### PR TITLE
[FIX] l10n_jo_edi: keep empty ID node and use correct country code

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -1,3 +1,4 @@
+from lxml import etree
 from types import SimpleNamespace
 
 from odoo import models
@@ -103,8 +104,8 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
 
     def _get_partner_party_identification_vals_list(self, partner):
         return [{
-            'id_attrs': {'schemeID': 'TN' if not partner.country_code or partner.country_code == 'JO' else 'PN'},
-            'id': partner.vat if partner.vat and partner.vat != '/' else '',
+            'id_attrs': {'schemeID': 'TN' if partner.country_code == 'JO' else 'PN'},
+            'id': partner.vat if partner.vat and partner.vat != '/' else 'NO_VAT',
         }]
 
     def _get_partner_address_vals(self, partner):
@@ -406,3 +407,17 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         self._aggregate_totals(vals['vals'])
 
         return vals
+
+    def _export_invoice(self, invoice):
+        # EXTENDS account.edi.xml.ubl_21
+        # _export_invoice normally cleans up the xml to remove empty nodes.
+        # However, in the JO UBL version, we always want the PartyIdentification with ID nodes, even if empty.
+        # We'll replace the empty value by a dummy one so that the node doesn't get cleaned up and remove its content after the file generation.
+        xml, errors = super()._export_invoice(invoice)
+        xml_root = etree.fromstring(xml)
+        party_identification_id_elements = xml_root.findall('.//cac:PartyIdentification/cbc:ID', namespaces=xml_root.nsmap)
+        for element in party_identification_id_elements:
+            if element.text == 'NO_VAT':
+                element.text = ''
+        # method='html' is used to keep the element un-shortened ("<a></a>" instead of <a/>)
+        return etree.tostring(xml_root, method='html'), errors

--- a/addons/l10n_jo_edi/tests/test_files/type_7.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_7.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EIN_998833_0</cbc:ID>
+    <cbc:UUID>___ignore___</cbc:UUID>
+    <cbc:IssueDate>2022-09-27</cbc:IssueDate>
+    <cbc:InvoiceTypeCode name="021">388</cbc:InvoiceTypeCode>
+    <cbc:Note>ملاحظات 2</cbc:Note>
+    <cbc:DocumentCurrencyCode>JOD</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>JOD</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>___ignore___</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cac:Country>
+                    <cbc:IdentificationCode>JO</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>8000514</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jordan Company</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="TN"></cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:PostalZone>94538</cbc:PostalZone>
+                <cbc:CountrySubentityCode>JO-AZ</cbc:CountrySubentityCode>
+                <cac:Country>
+                    <cbc:IdentificationCode>JO</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Ahmad</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+        <cac:AccountingContact>
+            <cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+        </cac:AccountingContact>
+    </cac:AccountingCustomerParty>
+    <cac:SellerSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID>4419618</cbc:ID>
+            </cac:PartyIdentification>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="JO">1.320</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:LegalMonetaryTotal>
+        <cbc:TaxExclusiveAmount currencyID="JO">132.000</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="JO">130.680</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="JO">1.320</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="JO">130.680</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">44.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="JO">130.680</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>product_a</cbc:Name>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="JO">3.000</cbc:PriceAmount>
+            <cac:AllowanceCharge>
+                <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+                <cbc:AllowanceChargeReason>DISCOUNT</cbc:AllowanceChargeReason>
+                <cbc:Amount currencyID="JO">1.320</cbc:Amount>
+            </cac:AllowanceCharge>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_jo_edi/tests/test_files/type_8.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_8.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Invoice
+    xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2">
+    <cbc:ProfileID>reporting:1.0</cbc:ProfileID>
+    <cbc:ID>EIN_998833_0</cbc:ID>
+    <cbc:UUID>___ignore___</cbc:UUID>
+    <cbc:IssueDate>2022-09-27</cbc:IssueDate>
+    <cbc:InvoiceTypeCode name="021">388</cbc:InvoiceTypeCode>
+    <cbc:Note>ملاحظات 2</cbc:Note>
+    <cbc:DocumentCurrencyCode>JOD</cbc:DocumentCurrencyCode>
+    <cbc:TaxCurrencyCode>JOD</cbc:TaxCurrencyCode>
+    <cac:AdditionalDocumentReference>
+        <cbc:ID>ICV</cbc:ID>
+        <cbc:UUID>___ignore___</cbc:UUID>
+    </cac:AdditionalDocumentReference>
+    <cac:AccountingSupplierParty>
+        <cac:Party>
+            <cac:PostalAddress>
+                <cac:Country>
+                    <cbc:IdentificationCode>JO</cbc:IdentificationCode>
+                </cac:Country>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>8000514</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Jordan Company</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+    </cac:AccountingSupplierParty>
+    <cac:AccountingCustomerParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID schemeID="PN">54321</cbc:ID>
+            </cac:PartyIdentification>
+            <cac:PostalAddress>
+                <cbc:PostalZone>94538</cbc:PostalZone>
+                <cbc:CountrySubentityCode>JO-AZ</cbc:CountrySubentityCode>
+            </cac:PostalAddress>
+            <cac:PartyTaxScheme>
+                <cbc:CompanyID>54321</cbc:CompanyID>
+                <cac:TaxScheme>
+                    <cbc:ID>VAT</cbc:ID>
+                </cac:TaxScheme>
+            </cac:PartyTaxScheme>
+            <cac:PartyLegalEntity>
+                <cbc:RegistrationName>Ahmad</cbc:RegistrationName>
+            </cac:PartyLegalEntity>
+        </cac:Party>
+        <cac:AccountingContact>
+            <cbc:Telephone>+962 795-5585-949</cbc:Telephone>
+        </cac:AccountingContact>
+    </cac:AccountingCustomerParty>
+    <cac:SellerSupplierParty>
+        <cac:Party>
+            <cac:PartyIdentification>
+                <cbc:ID>4419618</cbc:ID>
+            </cac:PartyIdentification>
+        </cac:Party>
+    </cac:SellerSupplierParty>
+    <cac:AllowanceCharge>
+        <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+        <cbc:AllowanceChargeReason>discount</cbc:AllowanceChargeReason>
+        <cbc:Amount currencyID="JO">1.320</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:LegalMonetaryTotal>
+        <cbc:TaxExclusiveAmount currencyID="JO">132.000</cbc:TaxExclusiveAmount>
+        <cbc:TaxInclusiveAmount currencyID="JO">130.680</cbc:TaxInclusiveAmount>
+        <cbc:AllowanceTotalAmount currencyID="JO">1.320</cbc:AllowanceTotalAmount>
+        <cbc:PayableAmount currencyID="JO">130.680</cbc:PayableAmount>
+    </cac:LegalMonetaryTotal>
+    <cac:InvoiceLine>
+        <cbc:ID>1</cbc:ID>
+        <cbc:InvoicedQuantity unitCode="PCE">44.0</cbc:InvoicedQuantity>
+        <cbc:LineExtensionAmount currencyID="JO">130.680</cbc:LineExtensionAmount>
+        <cac:Item>
+            <cbc:Name>product_a</cbc:Name>
+        </cac:Item>
+        <cac:Price>
+            <cbc:PriceAmount currencyID="JO">3.000</cbc:PriceAmount>
+            <cac:AllowanceCharge>
+                <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+                <cbc:AllowanceChargeReason>DISCOUNT</cbc:AllowanceChargeReason>
+                <cbc:Amount currencyID="JO">1.320</cbc:Amount>
+            </cac:AllowanceCharge>
+        </cac:Price>
+    </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_jo_edi/tests/test_jo_edi_types.py
+++ b/addons/l10n_jo_edi/tests/test_jo_edi_types.py
@@ -248,3 +248,57 @@ class TestJoEdiTypes(JoEdiCommon):
             self.get_xml_tree_from_string(generated_file),
             self.get_xml_tree_from_string(expected_file)
         )
+
+    def test_jo_no_vat_customer(self):
+        self.company.l10n_jo_edi_taxpayer_type = 'income'
+        self.company.l10n_jo_edi_sequence_income_source = '4419618'
+        self.partner_jo.vat = False
+
+        invoice = self._l10n_jo_create_invoice({
+            'name': 'EIN/998833/0',
+            'invoice_date': '2022-09-27',
+            'narration': 'ملاحظات 2',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 3,
+                    'quantity': 44,
+                    'discount': 1,
+                    'tax_ids': [Command.clear()],
+                }),
+            ],
+        })
+
+        expected_file = self._read_xml_test_file('type_7')
+        generated_file = self.env['account.edi.xml.ubl_21.jo']._export_invoice(invoice)[0]
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_file),
+            self.get_xml_tree_from_string(expected_file)
+        )
+
+    def test_jo_no_country_customer(self):
+        self.company.l10n_jo_edi_taxpayer_type = 'income'
+        self.company.l10n_jo_edi_sequence_income_source = '4419618'
+        self.partner_jo.country_id = False
+
+        invoice = self._l10n_jo_create_invoice({
+            'name': 'EIN/998833/0',
+            'invoice_date': '2022-09-27',
+            'narration': 'ملاحظات 2',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 3,
+                    'quantity': 44,
+                    'discount': 1,
+                    'tax_ids': [Command.clear()],
+                }),
+            ],
+        })
+
+        expected_file = self._read_xml_test_file('type_8')
+        generated_file = self.env['account.edi.xml.ubl_21.jo']._export_invoice(invoice)[0]
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_file),
+            self.get_xml_tree_from_string(expected_file)
+        )


### PR DESCRIPTION
When generating the JO UBL file, we want to keep the PartyIdentification and its ID node, even if the latter is empty.

Also, in the same file, the country code of a partner should be set to 'PN' if the partner doesn't have its country set.

task-4656827