### PR TITLE
[FIX] web_editor: fix colorpicker and dark mode enabled

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -40,6 +40,15 @@ for (let i = 1; i <= 5; i++) {
 for (let i = 100; i <= 900; i += 100) {
     EDITOR_COLOR_CSS_VARIABLES.push(`${i}`);
 }
+
+// Black, white and their opacity variants.
+// These variables are necessary to prevent the colorpicker from being affected
+// by the backend "Dark Mode".
+EDITOR_COLOR_CSS_VARIABLES.push(
+    "black", "black-15", "black-25", "black-50", "black-75",
+    "white", "white-25", "white-50", "white-75", "white-85"
+);
+
 /**
  * window.getComputedStyle cannot work properly with CSS shortcuts (like
  * 'border-width' which is a shortcut for the top + right + bottom + left border


### PR DESCRIPTION
Steps to reproduce:

- Switch to Dark Mode (Version Enterprise).
- Go to Website --> Edit Mode.
- Drag and drop any snippet.
- Select the snippet --> background color --> Custom tab.
- Bug: The white color is dark, and the black is a white color.

This commit fixes the issue by copying the variables: Black, White, and their opacity variants from the website preview to the snippet menu, so they are used in the color picker instead of the backend ones.

Note that this commit also fixes another bug: the "bg-black-15" color was incorrect in the colorpicker before this commit because that class does not exist in the backend.

task-4690318
