### PR TITLE
pos_printer_view : improve text

### DIFF
--- a/addons/point_of_sale/views/pos_printer_view.xml
+++ b/addons/point_of_sale/views/pos_printer_view.xml
@@ -23,15 +23,14 @@
         <field name="view_mode">list,kanban,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
-            Add a new restaurant order printer
+            Add a new preparation printer
             </p><p>
-            Order Printers are used by restaurants and bars to print the
-            order updates in the kitchen/bar when the waiter updates the order.
+            Preparation printers are typically used by restaurants and bars to print the
+            orders at the kitchen/bar when the waiter updates an order.
             </p><p>
-            Each Order Printer has an IP Address that defines the IoT Box/Hardware
-            Proxy where the printer can be found, and a list of product categories.
-            An Order Printer will only print updates for products belonging to one of
-            its categories.
+            Each printer can be configured to print products from a specific category.
+            The printer will then only print updates for products belonging to one of
+            its linked categories.
             </p>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Simplifying the text displayed on the empty screen

Current behavior before PR:
The text displayed on the empty screen is not easy to understand. 

Desired behavior after PR is merged:
Preparation printer explanation is easier to understand for our users

Task id : 4736135



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
