### PR TITLE
[FIX] hw_drivers: incorrect rpc result browsing

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -338,15 +338,12 @@ def load_certificate():
     if response.status != 200:
         return "ERR_IOT_HTTPS_LOAD_REQUEST_STATUS %s\n\n%s" % (response.status, response.reason)
 
-    response = json.loads(response.data.decode())
-    error = response.get('error')
-    if error or not response.get('result'):
-        _logger.error(
-            "An error received from odoo.com while trying to get the certificate: %s", error or 'Empty response'
-        )
+    result = json.loads(response.data.decode()).get('result', {})
+    error = result.get('error')
+    if error:
+        _logger.error("An error received from odoo.com while trying to get the certificate: %s", error)
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
 
-    result = response['result']
     write_file('odoo-subject.conf', result['subject_cn'])
     if platform.system() == 'Linux':
         with writable():


### PR DESCRIPTION
Another check on the object received by the IoT Box containing certificate keys was always returning False,
resulting in the certificate never being applied to the box.

The object returned by odoo.com is a dictionary containing either:
- 'error': 'an error message',
- 'result': False (always False),
or:
- 'private_key_pem',
- 'x509_pem',
- 'subject_cn'.

So checking `response.get("result")` would always return `False`, even if the server returned a certificate.