### PR TITLE
[FIX] hw_drivers: remove Adam scale support

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -13,7 +13,6 @@ from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.iot_handlers.drivers.SerialBaseDriver import SerialDriver, SerialProtocol, serial_connection
 
-
 _logger = logging.getLogger(__name__)
 
 # Only needed to ensure compatibility with older versions of Odoo
@@ -48,35 +47,6 @@ Toledo8217Protocol = ScaleProtocol(
     clearCommand=b'C',
     emptyAnswerValid=False,
     autoResetWeight=False,
-)
-
-# The ADAM scales have their own RS232 protocol, usually documented in the scale's manual
-#   e.g at https://www.adamequipment.com/media/docs/Print%20Publications/Manuals/PDF/AZEXTRA/AZEXTRA-UM.pdf
-#          https://www.manualslib.com/manual/879782/Adam-Equipment-Cbd-4.html?page=32#manual
-# Only the baudrate and label format seem to be configurable in the AZExtra series.
-ADAMEquipmentProtocol = ScaleProtocol(
-    name='Adam Equipment',
-    baudrate=4800,
-    bytesize=serial.EIGHTBITS,
-    stopbits=serial.STOPBITS_ONE,
-    parity=serial.PARITY_NONE,
-    timeout=0.2,
-    writeTimeout=0.2,
-    measureRegexp=br"\s*([0-9.]+)kg",  # LABEL format 3 + KG in the scale settings, but Label 1/2 should work
-    statusRegexp=None,
-    commandTerminator=b"\r\n",
-    commandDelay=0.2,
-    measureDelay=0.5,
-    # AZExtra beeps every time you ask for a weight that was previously returned!
-    # Adding an extra delay gives the operator a chance to remove the products
-    # before the scale starts beeping. Could not find a way to disable the beeps.
-    newMeasureDelay=5,
-    measureCommand=b'P',
-    zeroCommand=b'Z',
-    tareCommand=b'T',
-    clearCommand=None,  # No clear command -> Tare again
-    emptyAnswerValid=True,  # AZExtra does not answer unless a new non-zero weight has been detected
-    autoResetWeight=True,  # AZExtra will not return 0 after removing products
 )
 
 
@@ -234,81 +204,6 @@ class Toledo8217Driver(ScaleDriver):
                 if answer == b'\x02E\rhello':
                     connection.write(b'F' + protocol.commandTerminator)
                     return True
-        except serial.serialutil.SerialTimeoutException:
-            pass
-        except Exception:
-            _logger.exception('Error while probing %s with protocol %s' % (device, protocol.name))
-        return False
-
-
-class AdamEquipmentDriver(ScaleDriver):
-    """Driver for the Adam Equipment serial scale."""
-
-    _protocol = ADAMEquipmentProtocol
-    priority = 0  # Test the supported method of this driver last, after all other serial drivers
-
-    def __init__(self, identifier, device):
-        super(AdamEquipmentDriver, self).__init__(identifier, device)
-        self._is_reading = False
-        self._last_weight_time = 0
-        self.device_manufacturer = 'Adam'
-
-    def _check_last_weight_time(self):
-        """The ADAM doesn't make the difference between a value of 0 and "the same value as last time":
-        in both cases it returns an empty string.
-        With this, unless the weight changes, we give the user `TIME_WEIGHT_KEPT` seconds to log the new weight,
-        then change it back to zero to avoid keeping it indefinetely, which could cause issues.
-        In any case the ADAM must always go back to zero before it can weight again.
-        """
-
-        TIME_WEIGHT_KEPT = 10
-
-        if self.data['value'] is None:
-            if time.time() - self._last_weight_time > TIME_WEIGHT_KEPT:
-                self.data['value'] = 0
-        else:
-            self._last_weight_time = time.time()
-
-    def _take_measure(self):
-        """Reads the device's weight value, and pushes that value to the frontend."""
-
-        if self._is_reading:
-            with self._device_lock:
-                self._read_weight()
-                self._check_last_weight_time()
-                if self.data['value'] != self.last_sent_value or self._status['status'] == self.STATUS_ERROR:
-                    self.last_sent_value = self.data['value']
-                    event_manager.device_changed(self)
-        else:
-            time.sleep(0.5)
-
-    # Ensures compatibility with older versions of Odoo
-    def _scale_read_old_route(self):
-        """Used when the iot app is not installed"""
-
-        time.sleep(3)
-        with self._device_lock:
-            self._read_weight()
-            self._check_last_weight_time()
-        return self.data['value']
-
-    @classmethod
-    def supported(cls, device):
-        """Checks whether the device at `device` is supported by the driver.
-
-        :param device: path to the device
-        :type device: str
-        :return: whether the device is supported by the driver
-        :rtype: bool
-        """
-
-        protocol = cls._protocol
-
-        try:
-            with serial_connection(device['identifier'], protocol, is_probing=True) as connection:
-                connection.write(protocol.measureCommand + protocol.commandTerminator)
-                # Checking whether writing to the serial port using the Adam protocol raises a timeout exception is about the only thing we can do.
-                return True
         except serial.serialutil.SerialTimeoutException:
             pass
         except Exception:


### PR DESCRIPTION
This PR removes the code responsible for the detection and communication with Adam scales.
These scales had no reliable way of detecting them as such, with the code always detecting every single serial connection as an Adam scale. Since Adam scales have been added to Odoo years agom there are 0 existing (even archived) tickets in support concerning them, we are recommending Mettler Toledo scales to our clients and most importantly they interfere with the detection of belgian blackboxes we delete the problematic code and thus the support of these unused scales.

@mobt-odoo @adgu-odoo 
