### PR TITLE
[FIX] hw_drivers: unsupported message type log fix

### DIFF
--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -64,7 +64,7 @@ def on_message(ws, messages):
             else:
                 # likely intended as IoT share the same channel
                 _logger.debug("message ignored due to different iot mac: %s", iot_mac)
-        elif message_type != 'print_confirmation':  # intended to be ignored
+        elif message_type not in ['print_confirmation', 'bundle_changed']:  # intended to be ignored
             _logger.warning("message type not supported: %s", message_type)
 
 


### PR DESCRIPTION
Currently the IoT Box are being infested with logs like 
`2025-04-17 11:30:46,925 13649 WARNING ? odoo.addons.hw_drivers.websocket_client: message type not supported: bundle_changed`

This PR removes them as they aren't useful information
task-4735615
