### PR TITLE
[FIX] point_of_sale: fix archived product variants in configurator

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -3,6 +3,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import * as ProductConfigurator from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import { registry } from "@web/core/registry";
+import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 
 registry.category("web_tour.tours").add("ProductConfiguratorTour", {
     steps: () =>
@@ -92,5 +93,27 @@ registry.category("web_tour.tours").add("PosProductWithDynamicAttributes", {
             ProductConfigurator.pickRadio("Test 2"),
             Dialog.confirm(),
             ProductScreen.selectedOrderlineHas("Dynamic Product", "1", "12.65", "Test 2"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosProductWithRemovedAttribute", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("One Attribute Removed Product"),
+            Dialog.is("One Attribute Removed Product"),
+            ProductConfigurator.pickRadio("Value 2-A"),
+            ProductConfigurator.pickRadio("Value 3-A"),
+            {
+                trigger: negate(".o_dialog .alert-warning"),
+                content: "No warning banner should be present in the dialog",
+            },
+            ProductConfigurator.pickRadio("Value 2-B"),
+            ProductConfigurator.pickRadio("Value 3-B"),
+            {
+                trigger: ".o_dialog .alert-warning",
+                content: "A warning banner should be present in the dialog",
+            },
         ].flat(),
 });

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -40,10 +40,9 @@ class ProductTemplate(models.Model):
         return products
 
     def _process_pos_self_ui_products(self, products):
+        archived_combinations = self._get_archived_combinations_per_product_tmpl_id([p['id'] for p in products])
         for product in products:
-            product['_archived_combinations'] = []
-            for product_product in self.env['product.product'].with_context(active_test=False).search([('product_tmpl_id', '=', product['id']), ('active', '=', False)]):
-                product['_archived_combinations'].append(product_product.product_template_attribute_value_ids.ids)
+            product['_archived_combinations'] = archived_combinations.get(product['id'], [])
             product['image_128'] = bool(product['image_128'])
 
     @api.model

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -89,3 +89,30 @@ registry.category("web_tour.tours").add("self_order_product_info", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_archived_attribute", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("One Attribute Removed Product"),
+        ...ProductPage.setupAttribute(
+            [
+                { name: "Attribute 2", value: "Value 2-A" },
+                { name: "Attribute 3", value: "Value 3-A" },
+            ],
+            false
+        ),
+        {
+            trigger: "body:not(:has(.alert-warning))",
+        },
+        ...ProductPage.setupAttribute(
+            [
+                { name: "Attribute 2", value: "Value 2-B" },
+                { name: "Attribute 3", value: "Value 3-B" },
+            ],
+            false
+        ),
+        {
+            trigger: ".alert-warning:contains('This combination does not exist.')",
+        },
+    ],
+});

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -138,3 +138,100 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         self_route = self.pos_config._get_self_order_route()
 
         self.start_tour(self_route, "self_order_product_info")
+
+    def test_archive_variants_attributes(self):
+        """Test archiving of variants when an attribute is removed, and verify
+        the behavior in the POS UI product configurator.
+
+        The test validates two main scenarios:
+        1. Variants used in orders remain in DB when their attribute is removed
+        2. In the UI configurator (see PosProductWithRemovedAttribute tour):
+           - Selecting active variants shows no warning
+           - Selecting archived variants shows a warning banner
+        """
+
+        # Create 3 attributes with 2 values each
+        attributes = self.env['product.attribute'].create([{
+            'name': f'Attribute {i}',
+            'create_variant': 'always',
+            'value_ids': [
+                (0, 0, {'name': f'Value {i}-A'}),
+                (0, 0, {'name': f'Value {i}-B'})
+            ],
+        } for i in range(1, 4)])
+
+        # Create product template with these attributes
+        # This will create 8 variants (2^3 combinations)
+        template = self.env['product.template'].create({
+            'name': 'One Attribute Removed Product',
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': attribute.id,
+                'value_ids': [(6, 0, attribute.value_ids.ids)]
+            }) for attribute in attributes],
+            'available_in_pos': True,
+        })
+
+        # Get two variants that differ in the first attribute's value
+        # These will be used to test proper archiving after attribute removal
+        variants = template.product_variant_ids
+        variant1 = variants.filtered(lambda v: any(
+            ptav.attribute_id == attributes[0] and ptav.product_attribute_value_id == attributes[0].value_ids[0]
+            for ptav in v.product_template_attribute_value_ids
+        ))[0]
+        variant2 = variants.filtered(lambda v: any(
+            ptav.attribute_id == attributes[0] and ptav.product_attribute_value_id == attributes[0].value_ids[1]
+            for ptav in v.product_template_attribute_value_ids
+        ))[0]
+
+        # Create a POS order using both variants to ensure they can't be deleted
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.env['pos.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'session_id': self.pos_config.current_session_id.id,
+            'amount_tax': 0,
+            'amount_total': 1,
+            'amount_paid': 1,
+            "amount_return": 0,
+            'lines': [
+                (0, 0, {
+                    'product_id': variant1.id,
+                    'price_unit': variant1.lst_price,
+                    'qty': 1,
+                    'discount': 0.0,
+                    'tax_ids': False,
+                    'price_subtotal': variant1.lst_price,
+                    'price_subtotal_incl': variant1.lst_price,
+                }),
+                (0, 0, {
+                    'product_id': variant2.id,
+                    'price_unit': variant2.lst_price,
+                    'qty': 1,
+                    'discount': 0.0,
+                    'tax_ids': False,
+                    'price_subtotal': variant1.lst_price,
+                    'price_subtotal_incl': variant1.lst_price,
+                })
+            ]
+        })
+
+        # Store variant ids for later checking
+        variant_ids = [variant1.id, variant2.id]
+
+        # Remove first attribute - this should archive variants that differ only by this attribute
+        template.attribute_line_ids.filtered(lambda l: l.attribute_id == attributes[0]).unlink()
+
+        # Archive a specific variant to test UI warning in the product configurator
+        # This variant has Value 2-B and Value 3-B (see tour steps)
+        variant_to_archive = template.product_variant_ids.filtered(
+            lambda v: any(ptav.product_attribute_value_id == attributes[1].value_ids[1] for ptav in v.product_template_attribute_value_ids)
+                      and any(ptav.product_attribute_value_id == attributes[2].value_ids[1] for ptav in v.product_template_attribute_value_ids)
+        )
+        variant_to_archive.write({'active': False})
+
+        # Verify variants from order still exist but are archived
+        archived_variants = self.env['product.product'].with_context(active_test=False).browse(variant_ids)
+        self.assertTrue(archived_variants.exists(), "Variants used in sale order should still exist")
+        self.assertTrue(all(not active for active in archived_variants.mapped('active')), "Variants used in sale order should be archived")
+
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, "self_order_archived_attribute")


### PR DESCRIPTION
__Current behavior before commit:__
When removing an attribute from a product template, related variants
used in previous orders get archived.

In POS, the configurator dialog currently prevents adding variants that
have attribute values included in the archived variants although it
shouldn't.

__Description of the fix:__
- Use the same logic as [this commit in 18.0][1] to retrieve archived
combinations
- Add tests to ensure proper behavior in the configurator dialog.

__Steps to reproduce the issue on runbot:__
1. Create a product with multiple attributes and variants
2. Create an order using some variants (so they are not deleted at next
step)
3. Remove one of the attributes from the product template
4. Check that variants from previous orders still exist but are archived
5. Open product configurator
6. A warning banner appears saying: "This option or combination of
options is not available" although all combinations remaining have an
active variant

[1]: https://github.com/odoo/odoo/commit/b3a5fe0045b98a6b

opw-4725685