### PR TITLE
[FIX] tools: update email local-part for RFC 5322

### DIFF
--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -564,10 +564,10 @@ def prepend_html_content(html_body, html_content):
 #----------------------------------------------------------
 
 # matches any email in a body of text
-email_re = re.compile(r"""([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63})""", re.VERBOSE)
+email_re = re.compile(r"""([a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63})""", re.VERBOSE)
 
 # matches a string containing only one email
-single_email_re = re.compile(r"""^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$""", re.VERBOSE)
+single_email_re = re.compile(r"""^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$""", re.VERBOSE)
 
 mail_header_msgid_re = re.compile('<[^<>]+>')
 


### PR DESCRIPTION
### Issue:
Certain `atext` characters are allowed in the `local-part` of emails per RFC 5322, which we already use when validating mail aliases. However, the `email_re` and `single_email_re` regex were not updated. This leads to unintended behavior when creating `res.user` records, eventually preventing password reset emails from being sent.

### Steps to Reproduce:
1) Create a new `res.user` and set the `login` field to `t'1@example.com`. 2) The `on_change_login` method will fail outdated regex, leaving the `email` field as `False`.
3) Try action to `Send Password Reset Instructions`. 4) Receive error since no `email` is set on the user.

### Solution:
Update the email regex to meet RFC 5322 compliance like we did for mail aliases.

RFC 5322
https://datatracker.ietf.org/doc/html/rfc5322#section-3.4

opw-4713241