### PR TITLE
[FIX] account: singleton traceback in compute method

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -912,7 +912,7 @@ class AccountMove(models.Model):
     @api.depends('date', 'journal_id', 'move_type', 'name', 'posted_before', 'sequence_number', 'sequence_prefix', 'state')
     def _compute_name_placeholder(self):
         for move in self:
-            if (not move.name or move.name == '/') and self.date and not move._get_last_sequence():
+            if (not move.name or move.name == '/') and move.date and not move._get_last_sequence():
                 sequence_format_string, sequence_format_values = move._get_next_sequence_format()
                 sequence_format_values['seq'] = sequence_format_values['seq'] + 1
                 move.name_placeholder = sequence_format_string.format(**sequence_format_values)


### PR DESCRIPTION
In the _compute_name_placeholder method, self.date is used inside the for move in self loop which causes a singleton error when self is a multiple records recordset.

This commit replaces self by move to avoid the singleton error.

no-task

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr