### PR TITLE
[FIX] account: Expected singleton Error computing placeholder without…

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -912,7 +912,7 @@ class AccountMove(models.Model):
     @api.depends('date', 'journal_id', 'move_type', 'name', 'posted_before', 'sequence_number', 'sequence_prefix', 'state')
     def _compute_name_placeholder(self):
         for move in self:
-            if (not move.name or move.name == '/') and self.date and not move._get_last_sequence():
+            if (not move.name or move.name == '/') and move.date and not move._get_last_sequence():
                 sequence_format_string, sequence_format_values = move._get_next_sequence_format()
                 sequence_format_values['seq'] = sequence_format_values['seq'] + 1
                 move.name_placeholder = sequence_format_string.format(**sequence_format_values)

--- a/doc/cla/individual/saidkraim.md
+++ b/doc/cla/individual/saidkraim.md
@@ -1,0 +1,9 @@
+Algeria, 2025-04-17
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+
+Kraim Said dev.said.kraim@gmail.com https://github.com/saidkraim21dev


### PR DESCRIPTION
… 18/04/2025

Description of the issue/feature this PR addresses:
ERRER: File "/home/odoo/src/odoo/addons/account/models/account_move.py", line 915, in _compute_name_placeholder
if (not move.name or move.name == '/') and self.date and not move._get_last_sequence():
^^^^^^^^^
File "/home/odoo/src/odoo/odoo/fields.py", line 1232, in get
record.ensure_one()
File "/home/odoo/src/odoo/odoo/models.py", line 6255, in ensure_one
raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: account.move(2620, 2606, 2592, 2584, 2582, 2580, 2578, 2576, 2574, 2572, 2564, 2550, 2536)

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
