### PR TITLE
[FIX] website_slides: fix install app display issue

### DIFF
--- a/addons/website_slides/static/src/interactions/slide_upload.js
+++ b/addons/website_slides/static/src/interactions/slide_upload.js
@@ -30,7 +30,7 @@ export class SlideUpload extends Interaction {
             channelId: parseInt(data.channelId),
             canPublish: data.canPublish === "True",
             canUpload: data.canUpload === "True",
-            modulesToInstall: data.modulesToInstall || [],
+            modulesToInstall: data.modulesToInstall ? JSON.parse(data.modulesToInstall) : [],
             openModal: data.openModal,
         });
     }


### PR DESCRIPTION
Steps to reproduce
===================
Create a database with website_slides installed only. Go to Website > Courses > Create or choose a course > Course Page > Add Content

Technical
==========
Earlier, we were using the ```.data()``` function of jQuery, which parses the string  by default. During our recent interaction conversion https://github.com/odoo/odoo/commit/22e777c046521f3f89b62caa5876680beb7f5aba we started using the ```.dataset``` of JavaScript, which gives the data in the string form itself.

This commit addresses the issue and now we need to parse string data.

Task-4735297
