### PR TITLE
[IMP] im_livechat: introduce chatbot_partner_id field

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -15,6 +15,7 @@
             <field name="channel_id" ref="livechat_channel_chatbot_session_1_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_guest_demo" model="mail.guest">
             <field name="name">Visitor #234</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -15,6 +15,7 @@
             <field name="channel_id" ref="livechat_channel_chatbot_session_2_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_guest_demo" model="mail.guest">
             <field name="name">Visitor #235</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -15,6 +15,7 @@
             <field name="channel_id" ref="livechat_channel_chatbot_session_3_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_welcome_bot_demo"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_guest_demo" model="mail.guest">
             <field name="name">Visitor #236</field>

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -334,7 +334,10 @@ class DiscussChannel(models.Model):
         )
 
     def _get_allowed_channel_member_create_params(self):
-        return super()._get_allowed_channel_member_create_params() + ["livechat_member_type"]
+        return super()._get_allowed_channel_member_create_params() + [
+            "chatbot_script_id",
+            "livechat_member_type",
+        ]
 
     def _types_allowing_seen_infos(self):
         return super()._types_allowing_seen_infos() + ["livechat"]

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -231,6 +231,7 @@ class Im_LivechatChannel(models.Model):
             Command.create(
                 {
                     "livechat_member_type": "agent" if user_operator else "bot",
+                    "chatbot_script_id": chatbot_script.id if not user_operator else False,
                     "partner_id": operator_partner_id,
                     "unpin_dt": fields.Datetime.now(),
                 }

--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -25,6 +25,9 @@ class ImLivechatChannelMemberHistory(models.Model):
     partner_id = fields.Many2one(
         "res.partner", compute="_compute_member_fields", index="btree_not_null", store=True
     )
+    chatbot_script_id = fields.Many2one(
+        "chatbot.script", compute="_compute_member_fields", index="btree_not_null", store=True
+    )
 
     _member_id_unique = models.Constraint(
         "UNIQUE(member_id)", "Members can only be linked to one history"
@@ -53,3 +56,4 @@ class ImLivechatChannelMemberHistory(models.Model):
             history.livechat_member_type = (
                 history.livechat_member_type or history.member_id.livechat_member_type
             )
+            history.chatbot_script_id = history.chatbot_script_id or history.member_id.chatbot_script_id

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -83,6 +83,7 @@
                         <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
                         <filter name="group_by_customer" domain="[]" context="{'group_by':'visitor_partner_id'}"/>
+                        <filter name="group_by_chatbot" string="Chatbot" domain="[]" context="{'group_by':'chatbot_script_id'}"/>
                         <separator orientation="vertical" />
                         <filter name="group_by_hour" string="Hour of Day" domain="[]" context="{'group_by':'start_date_hour'}"/>
                         <filter name="group_by_month" string="Date" domain="[]" context="{'group_by':'start_date:month'}" />

--- a/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_member_history_views.xml
@@ -8,6 +8,7 @@
                 <search string="Search History">
                     <field name="channel_id"/>
                     <field name="partner_id"/>
+                    <field name="chatbot_script_id"/>
                     <field name="guest_id"/>
                     <field name="livechat_member_type" string="Member Type"/>
                 </search>
@@ -21,6 +22,7 @@
                     <field name="create_date"/>
                     <field name="channel_id"/>
                     <field name="partner_id"/>
+                    <field name="chatbot_script_id"/>
                     <field name="guest_id"/>
                     <field name="livechat_member_type" string="Member Type"/>
                 </list>


### PR DESCRIPTION
Purpose of this commit:
Introduced the chatbot_partner_id field to group session records by the chatbot responsible for handling them, enabling improved session statistics. The handled_by_bot field was removed, as its purpose is now fulfilled by chatbot_partner_id.

part of task: 4619177
