### PR TITLE
[FIX] html_editor: font size input not initialized properly in Firefox

### DIFF
--- a/addons/html_editor/static/src/main/font/font_size_selector.js
+++ b/addons/html_editor/static/src/main/font/font_size_selector.js
@@ -27,42 +27,72 @@ export class FontSizeSelector extends Component {
 
         onMounted(() => {
             const iframeEl = this.iframeContentRef.el;
-            const iframeDoc = iframeEl.contentWindow.document;
-            this.fontSizeInput = iframeDoc.createElement("input");
-            Object.assign(iframeDoc.body.style, {
-                padding: "0",
-                margin: "0",
-            });
-            Object.assign(this.fontSizeInput.style, {
-                width: "100%",
-                height: "100%",
-                border: "none",
-                outline: "none",
-                textAlign: "center",
-            });
-            this.fontSizeInput.type = "text";
-            this.fontSizeInput.name = "font-size-input";
-            this.fontSizeInput.autocomplete = "off";
-            iframeDoc.body.appendChild(this.fontSizeInput);
-            this.fontSizeInput.addEventListener("click", () => {
-                if (!this.dropdown.isOpen) {
-                    this.dropdown.open();
+
+            const initFontSizeInput = () => {
+                const iframeDoc = iframeEl.contentWindow.document;
+
+                // Skip if already initialized.
+                if (this.fontSizeInput || !iframeDoc.body) {
+                    return;
                 }
-            });
-            this.fontSizeInput.addEventListener("input", this.debouncedCustomFontSizeInput);
-            this.fontSizeInput.addEventListener("keydown", this.onKeyDownFontSizeInput.bind(this));
+
+                this.fontSizeInput = iframeDoc.createElement("input");
+                Object.assign(iframeDoc.body.style, {
+                    padding: "0",
+                    margin: "0",
+                });
+                Object.assign(this.fontSizeInput.style, {
+                    width: "100%",
+                    height: "100%",
+                    border: "none",
+                    outline: "none",
+                    textAlign: "center",
+                });
+                this.fontSizeInput.type = "text";
+                this.fontSizeInput.name = "font-size-input";
+                this.fontSizeInput.autocomplete = "off";
+                this.fontSizeInput.value = this.state.displayName;
+                iframeDoc.body.appendChild(this.fontSizeInput);
+                this.fontSizeInput.addEventListener("click", () => {
+                    if (!this.dropdown.isOpen) {
+                        this.dropdown.open();
+                    }
+                });
+                this.fontSizeInput.addEventListener("input", this.debouncedCustomFontSizeInput);
+                this.fontSizeInput.addEventListener(
+                    "keydown",
+                    this.onKeyDownFontSizeInput.bind(this)
+                );
+            };
+            if (iframeEl.contentDocument.readyState === "complete") {
+                initFontSizeInput();
+            } else {
+                // in firefox, iframe is not immediately available. we need to wait
+                // for it to be ready before mounting.
+                iframeEl.addEventListener(
+                    "load",
+                    () => {
+                        initFontSizeInput();
+                    },
+                    { once: true }
+                );
+            }
         });
         useEffect(
             () => {
-                // Update `fontSizeInputValue` whenever the font size changes.
-                this.fontSizeInput.value = this.state.displayName;
+                if (this.fontSizeInput) {
+                    // Update `fontSizeInputValue` whenever the font size changes.
+                    this.fontSizeInput.value = this.state.displayName;
+                }
             },
             () => [this.state.displayName]
         );
         useEffect(
             () => {
-                // Focus input on dropdown open, blur on close.
-                this.dropdown.isOpen ? this.fontSizeInput.select() : this.fontSizeInput.blur();
+                if (this.fontSizeInput) {
+                    // Focus input on dropdown open, blur on close.
+                    this.dropdown.isOpen ? this.fontSizeInput.select() : this.fontSizeInput.blur();
+                }
             },
             () => [this.dropdown.isOpen]
         );
@@ -79,6 +109,7 @@ export class FontSizeSelector extends Component {
                 this.fontSizeInput.value = this.state.displayName;
             }
         }
+        this.fontSizeInput.focus();
     }
 
     onKeyDownFontSizeInput(ev) {


### PR DESCRIPTION
### Browser: Firefox

### Steps to Reproduce:

- Go to To-Do
- Type something
- Select the typed text
- Font size is not visible and dropdown doesn't appear on single click

### Description of the issue/feature this PR addresses:

- Font size input inside the iframe was not properly initialized in Firefox due to delayed iframe load.
- Clicking once on the font size selector did not open the dropdown.

### Desired behavior after PR is merged:

- Font size input initialization is deferred until iframe is fully loaded.
- Dropdown now opens correctly on single click and displays current font size.

task-4735622

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
