### PR TITLE
[FIX] account: wrong conversion in invoice analysis values

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -108,11 +108,11 @@ class AccountInvoiceReport(models.Model):
                    0.0) * currency_table.rate                               AS price_average,
                 CASE
                     WHEN move.move_type NOT IN ('out_invoice', 'out_receipt', 'out_refund') THEN 0.0
-                    WHEN move.move_type = 'out_refund' THEN -line.balance * currency_table.rate + (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
-                    ELSE -line.balance * currency_table.rate - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0)
+                    WHEN move.move_type = 'out_refund' THEN currency_table.rate * (-line.balance + (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0))
+                    ELSE currency_table.rate * (-line.balance - (line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0)) * COALESCE(product_standard_price.value_float, 0.0))
                 END
                                                                             AS price_margin,
-                line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
+                currency_table.rate * line.quantity / NULLIF(COALESCE(uom_line.factor, 1) / COALESCE(uom_template.factor, 1), 0.0) * (CASE WHEN move.move_type IN ('out_invoice','in_refund','out_receipt') THEN -1 ELSE 1 END)
                     * product_standard_price.value_float                    AS inventory_value,
                 COALESCE(partner.country_id, commercial_partner.country_id) AS country_id,
                 line.currency_id                                            AS currency_id

--- a/addons/account/tests/test_account_invoice_report.py
+++ b/addons/account/tests/test_account_invoice_report.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
-from odoo import fields
+from odoo import Command, fields
 
 
 @tagged('post_install', '-at_install')
@@ -222,3 +222,39 @@ class TestAccountInvoiceReport(AccountTestInvoicingCommon):
 
         _apply_combination_on_report_pivot(['price_average:avg', 'price_subtotal:sum'])
         _apply_combination_on_report_pivot(['price_average:avg', 'quantity:sum'])
+
+    def test_inventory_margin_currency(self):
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 1,
+                    'price_unit': 750,
+                }),
+            ],
+        })
+        egy_company = self.env['res.company'].create({
+            'name': 'Egyptian Company',
+            'currency_id': self.env.ref('base.EGP').id,
+            'user_ids': [Command.set(self.env.user.ids)],
+        })
+        report = self.env['account.invoice.report'].search(
+            [('move_id', '=', invoice.id)],
+        )
+        self.assertEqual(report.inventory_value, -800)
+        self.assertEqual(report.price_margin, -50)
+        self.env['res.currency.rate'].create({
+            'name': '2017-11-03',
+            'rate': 2,
+            'currency_id': self.env.ref('base.EGP').id,
+            'company_id': egy_company.id,
+        })
+        self.env.flush_all()
+        self.env.user.company_id = egy_company
+        self.env['account.invoice.report'].invalidate_model()
+        report = self.env['account.invoice.report'].search(
+            [('move_id', '=', invoice.id)],
+        )
+        self.assertEqual(report.inventory_value, -1600)
+        self.assertEqual(report.price_margin, -100)


### PR DESCRIPTION
Steps to reproduce:
- Install accounting, Sales apps
- Setup two companies for the current user with two diff currencies
- In company A, make a SO on a product and create an invoice
- Validate and confirm the invoice.
- Go to accounting, reporting, invoice analysis, and add group for the product
- Select the report of that specific invoice posted
- Observe the values untaxed_total, avg_price, inventory_value and price_margin
- Switch to company B, and add a currency rate between both currencies to observe a difference
- Make sure that you are selecting both companies, but B as the main company
- Go again to the report of the same Invoice.
- Observe the values again.

Issue:
When changing the currency, the fields untaxed_total and
price_avg are updated using the currency rate of the current
main company. However, inventory_value is not updated.

This inconsistency affects the calculation of price_margin,
which relies on both untaxed_total and inventory_value.
As a result, price_margin is computed incorrectly.

opw-4582973
