### PR TITLE
[FIX] discuss: fixes the size of overlay

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.dark.scss
+++ b/addons/mail/static/src/discuss/call/common/call.dark.scss
@@ -3,5 +3,5 @@
 // No CSS hacks, variables overrides only
 
 .o-discuss-Call {
-    --o-discuss-Call-bgColor: #{$o-gray-100};
+    --o-discuss-Call-bgColor: black;
 }

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -81,6 +81,12 @@ export class CallParticipantCard extends Component {
         );
     }
 
+    get isSmall() {
+        return Boolean(
+            this.props.isSidebarItem || this.ui.isSmall || this.props.minimized || this.props.inset
+        );
+    }
+
     get showLiveLabel() {
         if (this.props.isSidebarItem) {
             return false;

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.scss
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.scss
@@ -97,8 +97,12 @@
     &.o-proportional-container {
         container-type: inline-size;
         .o-proportional-text {
+            font-size: #{"min(1rem, 40cqw)"};
             &.o-video-text {
                 font-size: 5cqw;
+            }
+            &.o-discuss-CallParticipantCard-overlayBottomName {
+                font-size: #{"min(0.8rem, 40cqw)"};
             }
         }
     }

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -29,9 +29,9 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1">
-                    <span t-if="!props.minimized and !props.inset" class="px-1 rounded-1 text-truncate smaller opacity-75 w-100 o-discuss-CallParticipantCard-overlayBottomName" t-esc="name"/>
-                    <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
+                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden rounded-1" t-att-class="{ 'o-proportional-container w-50': isSmall }">
+                    <span t-if="!props.minimized and !props.inset" class="rounded-1 text-truncate opacity-75 w-100 o-proportional-text o-discuss-CallParticipantCard-overlayBottomName" t-att-class="{'o-minimized px-1': isSmall, 'p-0': !isSmall }" t-esc="name"/>
+                    <small t-if="rtcSession.is_screen_sharing_on and props.minimized and !isOfActiveCall" class="user-select-none o-proportional-text o-minimized rounded text-bg-danger d-flex align-items-center fw-bolder p-1" title="live" aria-label="live">
                         LIVE
                     </small>
                 </span>
@@ -41,21 +41,21 @@
                 <button t-if="popover.isOpen or (isContextMenuAvailable and ((!isMobileOS and rootHover.isHover) or (isMobileOS and !props.minimized)))" t-on-click="onContextMenu" class="o-discuss-CallParticipantCard-contextButton btn btn-secondary btn-sm rounded-circle position-absolute border-0 top-0 end-0 smaller p-1" title="Participant options" t-ref="contextMenuAnchor">
                     <i class="fa fa-chevron-down fa-fw"/>
                 </button>
-                <div class="o-discuss-CallParticipantCard-overlay position-absolute bottom-0 end-0 d-flex w-25 flex-row-reverse">
-                    <span t-if="hasRaisingHand" class="d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="raising hand" aria-label="raising hand">
+                <div class="o-discuss-CallParticipantCard-overlay position-absolute bottom-0 end-0 d-flex w-50 flex-row-reverse w-50" t-att-class="{ 'o-proportional-container': isSmall, 'mw-25': props.isSidebarItem or props.inset }">
+                    <span t-if="hasRaisingHand" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle bg-500" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="raising hand" aria-label="raising hand">
                         <i class="fa fa-hand-paper-o"/>
                     </span>
-                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="muted" aria-label="muted">
+                    <span t-if="rtcSession.is_muted and !rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="muted" aria-label="muted">
                         <i class="fa fa-microphone-slash"/>
                     </span>
-                    <span t-if="rtcSession.is_deaf" class="d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': props.minimized, 'p-2': !props.minimized }" title="deaf" aria-label="deaf">
+                    <span t-if="rtcSession.is_deaf" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="deaf" aria-label="deaf">
                         <i class="fa fa-deaf"/>
                     </span>
-                    <span t-if="hasMediaError" class="o-discuss-CallParticipantCard-overlay-replayButton d-flex flex-column justify-content-center me-1 p-2 rounded-circle" title="media player Error" t-on-click.stop="onClickReplay">
+                    <span t-if="hasMediaError" class="o-discuss-CallParticipantCard-overlay-replayButton o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" title="media player Error" t-on-click.stop="onClickReplay">
                         <i t-if="rootHover.isHover" class="fa fa-repeat text-danger"/>
                         <i t-else="" class="fa fa-exclamation-triangle text-danger"/>
                     </span>
-                    <span t-if="showConnectionState" class="d-flex flex-column justify-content-center me-1 p-2 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-title="rtcSession.connectionState">
+                    <span t-if="showConnectionState" class="o-proportional-text d-flex flex-column justify-content-center me-1 rounded-circle o-discuss-CallParticipantCard-iconBlackBg" t-att-class="{'o-minimized p-1': isSmall, 'p-2': !isSmall }" t-att-title="rtcSession.connectionState">
                         <i class="fa fa-exclamation-triangle text-warning"/>
                     </span>
                     <span t-if="showLiveLabel" class="user-select-none rounded o-proportional-text text-bg-danger d-flex align-items-center py-1 px-2 fw-bolder" title="live" aria-label="live">


### PR DESCRIPTION
Before this commit, in small call views, the overlay of participant
cards was taking too much space and made the UI feel too cluttered
while hiding the camera/screen of participants.

This commit fixes this issue by making the icons proportional to their
containers.

This commit also fixes an improper dynamic background color in dark
mode.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/d83a25ea-43ec-4d22-b3ad-ad613ee85727) | ![image](https://github.com/user-attachments/assets/b229e7a9-00cd-4422-97aa-dc9107f5f6ad) |
| ![image](https://github.com/user-attachments/assets/139521bd-a664-4dd1-97ae-926838e685f0) | ![image](https://github.com/user-attachments/assets/f8308b43-5057-4e27-8a72-fe3a3ca5dbf9) | 