### PR TITLE
[IMP] website: allow facebook and instagram as inner snippets and bui…

### DIFF
--- a/addons/website/views/snippets/s_facebook_page.xml
+++ b/addons/website/views/snippets/s_facebook_page.xml
@@ -3,9 +3,9 @@
 
 <!-- Snippet template -->
 <template id="s_facebook_page" name="Facebook">
-    <div class="o_facebook_page o_not_editable">
+    <section class="o_facebook_page o_container_small pt48 pb48">
         <iframe class="mw-100 o_facebook_page_preview" src="https://www.facebook.com/plugins/page.php?height=70&amp;hide_cover=true&amp;href=https%3A%2F%2Fwww.facebook.com%2FOdoo&amp;show_facepile=false&amp;small_header=true&amp;tabs=&amp;width=500" style="width: 500px; height: 70px; border: medium none; overflow: hidden;" aria-label="Facebook"/>
-    </div>
+    </section>
 </template>
 
 <!-- Snippet options-->

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -414,6 +414,10 @@
                     t-image-preview="/website/static/src/img/snippets_previews/s_instagram_preview.jpg">
                     <keywords>social media, ig, feed</keywords>
                 </t>
+                <t t-snippet="website.s_facebook_page" string="Facebook Page" group="social"
+                    t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg">
+                    <keywords>social media, ig, feed</keywords>
+                </t>
                 <!-- TODO: remove 'snippet_google_map_hook', it does not seem to be used -->
                 <t id="snippet_google_map_hook"/>
                 <t t-set="google_maps_api_key" t-value="request.env['website'].get_current_website().google_maps_api_key"/>
@@ -445,6 +449,7 @@
                 <t t-snippet="website.s_share" string="Share" t-thumbnail="/website/static/src/img/snippets_thumbs/s_share.svg"/>
                 <t t-snippet="website.s_social_media" string="Social Media" t-thumbnail="/website/static/src/img/snippets_thumbs/s_social_media.svg"/>
                 <t t-snippet="website.s_facebook_page" string="Facebook" t-thumbnail="/website/static/src/img/snippets_thumbs/s_facebook_page.svg"/>
+                <t t-snippet="website.s_instagram_page" string="Instagram" t-thumbnail="/website/static/src/img/snippets_thumbs/s_instagram_page.svg"/>
                 <t t-snippet="website.s_searchbar_input" string="Search" t-thumbnail="/website/static/src/img/snippets_thumbs/s_searchbar_inline.svg" t-forbid-sanitize="form"/>
                 <t id="mass_mailing_newsletter_hook"/>
                 <t id="mail_group_hook"/>
@@ -1158,7 +1163,7 @@
         <!-- TODO should be improved -->
 
     <t t-set="so_content_addition_selector" t-translation="off">
-        blockquote, .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating,
+        blockquote, .s_alert, .o_facebook_page, .s_share, .s_social_media, .s_rating, .s_instagram_page,
         .s_hr, .s_google_map, .s_map, .s_countdown, .s_chart, .s_text_highlight, .s_progress_bar, .s_badge,
         .s_embed_code, .s_donation, .s_add_to_cart, .s_online_appointment, .o_snippet_drop_in_only, .s_image, .s_cta_badge, .s_accordion
     </t>


### PR DESCRIPTION
…lding block

added Facebook to the social group and Instagram to the inner content category. users can insert facebook and instagram either as inner snippets or as building blocks, similar to the countdown snippet.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
