### PR TITLE
[IMP] account,{_edi_ubl_cii,_peppol}: Add attachments in UBL/CII XMLs

### DIFF
--- a/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
+++ b/addons/account/static/src/components/mail_attachments/mail_attachments_selector.js
@@ -39,6 +39,7 @@ export class MailAttachments extends Component {
             mimetype: attachment.mimetype,
             placeholder: false,
             manual: true,
+            can_be_xml_embedded: true,
         };
         this.props.record.update({ [this.props.name]: this.attachments.concat([fileDict]) });
     }

--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -26,7 +26,7 @@
                 </group>
 
                 <!-- Mail composer -->
-                <div invisible="'email' not in sending_methods">
+                <div name="mail_div" invisible="'email' not in sending_methods">
                     <field name="model" invisible="1"/>
                     <field name="res_ids" invisible="1"/>
                     <field name="render_model" invisible="1"/>

--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -412,6 +412,40 @@
         </xpath>
     </template>
 
+    <template id="ubl_20_AttachmentType">
+        <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:EmbeddedDocumentBinaryObject
+                t-att="vals.get('embedded_document_binary_object_attrs', {})"
+                t-out="vals.get('embedded_document_binary_object')"/>
+        </t>
+    </template>
+
+    <template id="ubl_20_DocumentReferenceType">
+        <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+           xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+            <cbc:ID t-out="vals.get('id')"/>
+            <cbc:UUID t-out="vals.get('uuid')"/>
+            <cbc:IssueDate t-out="vals.get('issue_date')"/>
+            <cbc:DocumentTypeCode t-att="vals.get('document_type_code_attrs')" t-out="vals.get('document_type_code')"/>
+            <cbc:DocumentType t-out="vals.get('document_type')"/>
+            <cac:Attachment>
+                <t t-call="account_edi_ubl_cii.ubl_20_AttachmentType">
+                    <t t-set="vals" t-value="vals.get('attachment_vals', {})"/>
+                </t>
+            </cac:Attachment>
+        </t>
+    </template>
+
+    <template id="ubl_20_AdditionalDocumentReferences">
+        <cac:AdditionalDocumentReference
+            t-foreach="vals" t-as="foreach_vals"
+            xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+            <t t-call="{{DocumentReferenceType_template}}">
+                <t t-set="vals" t-value="foreach_vals"/>
+            </t>
+        </cac:AdditionalDocumentReference>
+    </template>
+
     <template id="ubl_20_CommonType">
         <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
            xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
@@ -458,14 +492,9 @@
                     <cbc:DocumentTypeCode t-out="billing_reference_vals.get('document_type_code')"/>
                 </cac:InvoiceDocumentReference>
             </cac:BillingReference>
-            <t t-foreach="vals.get('additional_document_reference_list', [])" t-as="foreach_vals">
-                <cac:AdditionalDocumentReference>
-                    <cbc:ID t-out="foreach_vals.get('id')"/>
-                    <cbc:IssueDate t-out="foreach_vals.get('issue_date')"/>
-                    <cbc:DocumentTypeCode t-out="foreach_vals.get('document_type_code')"/>
-                    <cbc:DocumentType t-out="foreach_vals.get('document_type')"/>
-                    <cbc:DocumentDescription t-out="foreach_vals.get('document_description')"/>
-                </cac:AdditionalDocumentReference>
+            <t t-call="account_edi_ubl_cii.ubl_20_AdditionalDocumentReferences">
+                <t t-set="vals"
+                   t-value="vals.get('additional_document_reference_list', [])"/>
             </t>
             <cac:Signature t-foreach="vals.get('signature_vals', [])" t-as="foreach_vals">
                 <t t-call="{{SignatureType_template}}">

--- a/addons/account_edi_ubl_cii/data/ubl_21_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_21_templates.xml
@@ -67,6 +67,14 @@
         </xpath>
     </template>
 
+    <template id="ubl_21_DocumentReferenceType" inherit_id="account_edi_ubl_cii.ubl_20_DocumentReferenceType">
+        <xpath expr="//*[local-name()='Attachment']" position="before">
+            <t xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+                <cbc:DocumentDescription t-out="vals.get('document_description')"/>
+            </t>
+        </xpath>
+    </template>
+
     <template id="ubl_21_InvoiceType" inherit_id="account_edi_ubl_cii.ubl_20_InvoiceType" primary="True">
         <xpath expr="//*[local-name()='ProfileID']" position="after">
             <cbc:ProfileExecutionID xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -593,6 +593,7 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
             'TaxCategoryType_template': 'account_edi_ubl_cii.ubl_20_TaxCategoryType',
             'TaxTotalType_template': 'account_edi_ubl_cii.ubl_20_TaxTotalType',
             'AllowanceChargeType_template': 'account_edi_ubl_cii.ubl_20_AllowanceChargeType',
+            'DocumentReferenceType_template': 'account_edi_ubl_cii.ubl_20_DocumentReferenceType',
             'SignatureType_template': 'account_edi_ubl_cii.ubl_20_SignatureType',
             'ResponseType_template': 'account_edi_ubl_cii.ubl_20_ResponseType',
             'DeliveryType_template': 'account_edi_ubl_cii.ubl_20_DeliveryType',

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_21.py
@@ -31,6 +31,7 @@ class AccountEdiXmlUbl_21(models.AbstractModel):
             'InvoiceLineType_template': 'account_edi_ubl_cii.ubl_21_InvoiceLineType',
             'CreditNoteLineType_template': 'account_edi_ubl_cii.ubl_21_CreditNoteLineType',
             'DebitNoteLineType_template': 'account_edi_ubl_cii.ubl_21_DebitNoteLineType',
+            'DocumentReferenceType_template': 'account_edi_ubl_cii.ubl_21_DocumentReferenceType',
             'InvoiceType_template': 'account_edi_ubl_cii.ubl_21_InvoiceType',
             'CreditNoteType_template': 'account_edi_ubl_cii.ubl_21_CreditNoteType',
             'DebitNoteType_template': 'account_edi_ubl_cii.ubl_21_DebitNoteType',

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -196,6 +196,14 @@ class AccountEdiXmlUbl_Bis3(models.AbstractModel):
 
         return vals_list
 
+    def _get_document_type_code_vals(self, invoice, invoice_data):
+        # EXTENDS 'account_edi_ubl_cii
+        vals = super()._get_document_type_code_vals(invoice, invoice_data)
+        # Code "130" MUST be used to indicate an invoice object reference. Not used for other additional documents
+        # We only use this function on the invoice object.
+        vals['value'] = '130'
+        return vals
+
     def _get_invoice_tax_totals_vals_list(self, invoice, taxes_vals):
         # EXTENDS account.edi.xml.ubl_21
         vals_list = super()._get_invoice_tax_totals_vals_list(invoice, taxes_vals)

--- a/addons/account_peppol/__manifest__.py
+++ b/addons/account_peppol/__manifest__.py
@@ -31,6 +31,7 @@
         'views/account_portal_templates.xml',
         'views/res_partner_views.xml',
         'views/res_config_settings_views.xml',
+        'wizard/account_move_send_wizard.xml',
         'wizard/peppol_registration_views.xml',
         'wizard/peppol_config_wizard.xml',
     ],

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -212,6 +212,14 @@ class AccountMoveSend(models.AbstractModel):
         if self._can_commit():
             self._cr.commit()
 
+    @api.model
+    def _get_attachments_widget(self, invoice, invoice_data):
+        # EXTENDS 'account_edi_ubl_cii'
+        attachments_widget = super()._get_attachments_widget(invoice, invoice_data)
+        if not attachments_widget and 'peppol' in invoice_data['sending_methods']:
+            attachments_widget += invoice_data.get('peppol_attachments_widget', [])
+        return attachments_widget
+
     def action_what_is_peppol_activate(self, moves):
         companies = moves.company_id
         can_send = self.env['account_edi_proxy_client.user']._get_can_send_domain()

--- a/addons/account_peppol/wizard/account_move_send_wizard.xml
+++ b/addons/account_peppol/wizard/account_move_send_wizard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="account_move_send_wizard_form_inherit_account_peppol" model="ir.ui.view">
+        <field name="name">account.move.send.wizard.form.inherit.account_peppol</field>
+        <field name="model">account.move.send.wizard</field>
+        <field name="inherit_id" ref="account.account_move_send_wizard_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='mail_div']" position="after">
+                <field name="peppol_attachments_widget"
+                       widget="mail_attachments"
+                       invisible="not display_peppol_attachments_widget"/>
+            </xpath>
+            <xpath expr="//field[@name='mail_attachments_widget' and @widget='mail_attachments_selector']" position="after">
+                <field name="peppol_attachments_widget"
+                       widget="mail_attachments_selector"
+                       help="Documents will be attached within the electronic file."
+                       invisible="not display_peppol_attachments_widget"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -1091,7 +1091,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
             'invoice_edi_format': 'ubl_bis3',
             'extra_edi_checkboxes': False,
         }])
-        self._assert_mail_attachments_widget(wizard, [
+        self._assert_attachments_widget(wizard, [
             {
                 'mimetype': 'application/pdf',
                 'name': 'INV_2017_00001.pdf',
@@ -1123,7 +1123,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
             'sending_methods': ['manual'],
             'invoice_edi_format': 'ubl_bis3',
         }])
-        self._assert_mail_attachments_widget(wizard, [
+        self._assert_attachments_widget(wizard, [
             {
                 'id': invoice.invoice_pdf_report_id.id,
                 'mimetype': 'application/pdf',

--- a/addons/l10n_jo_edi/data/ubl_jo_templates.xml
+++ b/addons/l10n_jo_edi/data/ubl_jo_templates.xml
@@ -7,12 +7,6 @@
                 t-out="billing_reference_vals.get('document_description')"/>
         </xpath>
 
-        <xpath expr="//*[local-name()='AdditionalDocumentReference']//*[local-name()='ID']" position="after">
-            <cbc:UUID
-                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
-                t-out="foreach_vals['uuid']"/>
-        </xpath>
-
         <xpath expr="//*[local-name()='AccountingCustomerParty']" position="inside">
             <cac:AccountingContact
                 xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"


### PR DESCRIPTION
Add the possibility to embbed documents within our XMLs generated within the Send wizard.

If we send an UBL/CII XML by email only, we will embbed all documents that are sent by email: the PDF of the invoice (that was already the case before), the mail template attachments, and manually added attachments. The same documents will be added to the XML if we send by Peppol AND by Email.

If we send by Peppol only, we won't attach documents related to the *mail* template.

task-4544834 (Part-of)