### PR TITLE
[IMP] mail: single RPC when doing @ mentions

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -104,8 +104,3 @@ class WebclientController(http.Controller):
                 ("group_ids", "in", request.env.user.all_group_ids.ids),
             ]
             store.add(request.env["mail.canned.response"].search(domain))
-        if name == "res.role":
-            roles = request.env["res.role"].search(
-                [("name", "ilike", params.get("term", ""))], limit=params.get("limit", 8)
-            )
-            store.add(roles, "name")

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models
 from odoo.osv import expression
 from odoo.tools import SQL
 from odoo.addons.mail.tools.discuss import Store
-from odoo.fields import Domain
+from odoo.exceptions import AccessError
 
 class ResPartner(models.Model):
     _inherit = "res.partner"
@@ -112,4 +112,9 @@ class ResPartner(models.Model):
         if allowed_group:
             for p in partners:
                 store.add(p, {"group_ids": [("ADD", (allowed_group & p.user_ids.all_group_ids).ids)]})
+        try:
+            roles = self.env["res.role"].search([("name", "ilike", search)], limit=8)
+            store.add(roles, "name")
+        except AccessError:
+            pass
         return store.get_result()

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -6,6 +6,7 @@ from odoo import _, api, fields, models, tools
 from odoo.osv import expression
 from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
+from odoo.exceptions import AccessError
 
 
 class ResPartner(models.Model):
@@ -279,7 +280,13 @@ class ResPartner(models.Model):
         """
         domain = self._get_mention_suggestions_domain(search)
         partners = self._search_mention_suggestions(domain, limit)
-        return Store(partners).get_result()
+        store = Store(partners)
+        try:
+            roles = self.env["res.role"].search([("name", "ilike", search)], limit=8)
+            store.add(roles, "name")
+        except AccessError:
+            pass
+        return store.get_result()
 
     @api.model
     def _get_mention_suggestions_domain(self, search):

--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -35,13 +35,9 @@ export class SuggestionService {
     async fetchSuggestions({ delimiter, term }, { thread, abortSignal } = {}) {
         const cleanedSearchTerm = cleanTerm(term);
         switch (delimiter) {
-            case "@": {
-                await Promise.all([
-                    this.fetchPartners(cleanedSearchTerm, thread, { abortSignal }),
-                    this.store.fetchStoreData("res.role", { term: cleanedSearchTerm }),
-                ]);
+            case "@":
+                await this.fetchPartnersRoles(cleanedSearchTerm, thread, { abortSignal });
                 break;
-            }
             case "#":
                 await this.fetchThreads(cleanedSearchTerm, { abortSignal });
                 break;
@@ -87,7 +83,7 @@ export class SuggestionService {
      * @param {string} term
      * @param {import("models").Thread} [thread]
      */
-    async fetchPartners(term, thread, { abortSignal } = {}) {
+    async fetchPartnersRoles(term, thread, { abortSignal } = {}) {
         const kwargs = { search: term };
         if (thread?.model === "discuss.channel") {
             kwargs.channel_id = thread.id;

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -1074,13 +1074,6 @@ function _process_request_for_internal_user(store, name, params) {
         ];
         store.add(this.env["mail.canned.response"].search(domain));
     }
-    if (name === "res.role") {
-        const roleIds = this.env["res.role"].search(
-            [["name", "ilike", params.term || ""]],
-            makeKwArgs({ limit: params.limit || 8 })
-        );
-        store.add("res.role", this.env["res.role"]._read_format(roleIds, ["name"], false));
-    }
 }
 
 const ids_by_model = {

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -101,9 +101,17 @@ export class ResPartner extends webModels.ResPartner {
             const partners = this._filter([["id", "not in", mainMatchingPartnerIds]]);
             extraMatchingPartnerIds = mentionSuggestionsFilter(partners, search, remainingLimit);
         }
-        return new mailDataHelpers.Store(
+
+        const store = new mailDataHelpers.Store(
             this.browse(mainMatchingPartnerIds.concat(extraMatchingPartnerIds))
-        ).get_result();
+        );
+        const roleIds = this.env["res.role"].search(
+            [["name", "ilike", search || ""]],
+            makeKwArgs({ limit: limit || 8 })
+        );
+        store.add("res.role", this.env["res.role"]._read_format(roleIds, ["name"], false));
+
+        return store.get_result();
     }
 
     /**
@@ -171,6 +179,11 @@ export class ResPartner extends webModels.ResPartner {
             };
             store.add(this.browse(partnerId), data);
         }
+        const roleIds = this.env["res.role"].search(
+            [["name", "ilike", searchLower || ""]],
+            makeKwArgs({ limit: limit || 8 })
+        );
+        store.add("res.role", this.env["res.role"]._read_format(roleIds, ["name"], false));
         return store.get_result();
     }
 

--- a/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
@@ -3,7 +3,7 @@ import { SuggestionService } from "@mail/core/common/suggestion_service";
 import { patch } from "@web/core/utils/patch";
 
 patch(SuggestionService.prototype, {
-    async fetchPartners(term, thread, { abortSignal } = {}) {
+    async fetchPartnersRoles(term, thread, { abortSignal } = {}) {
         if (thread.model === "project.task") {
             const suggestedPartners = await this.makeOrmCall(
                 "project.task",
@@ -20,7 +20,7 @@ patch(SuggestionService.prototype, {
                 suggestedPartnersIds.includes(persona.id)
             );
         }
-        return super.fetchPartners(...arguments);
+        return super.fetchPartnersRoles(...arguments);
     },
 
     getPartnerSuggestions(thread) {


### PR DESCRIPTION
This commit changes the way we handle @ mentions in the mail module. Instead of sending multiple RPC calls for fetching partners and roles, we now return roles in the partners call.

This enhances performance and resolves the issue where the abortSignal in the suggestion service failed to function due to the roles RPC not being aborted.

task-4680864


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
