### PR TITLE
[FIX] html_editor: fix runbot error after link discard flow change

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -481,7 +481,7 @@ export class LinkPlugin extends Plugin {
             onChange: applyCallback,
             onDiscard: () => {
                 restoreSavePoint();
-                this.closeLinkTools();
+                this.openLinkTools(linkElement);
                 this.dependencies.selection.focusEditable();
             },
             onRemove: () => {

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -962,8 +962,7 @@ test("link preview in Link Popover", async () => {
     });
     // Click on Discard button to undo changes.
     await contains(".o-we-linkpopover .o_we_discard_link").click();
-    await waitForNone(".o-we-linkpopover", { root: document, timeout: 1500 });
-    expect(".o-we-linkpopover").toHaveCount(0);
+    await waitFor("a.o_we_edit_link");
     expect(".test_target a").toHaveText("This website");
 
     // Click on the edit link icon


### PR DESCRIPTION
Before this commit: The runbot failed at the "link preview in Link Popover" test due to recent changes in the discard flow of the link popover (e.g., https://github.com/odoo/odoo/pull/197862). Previously, discarding changes was done by clicking away, which closed the link popover. After the update, discarding is done by clicking a "Discard" button. Upon discarding, the selection inside the link element is restored, and the link popover remains open but switches to a non-editing mode.

After this commit: Since the discard flow no longer relies on selection changes and the popover should remain open, the test no longer checks if the popover is closed. Additionally, in the `onDiscard` function, the popover is reopened in non-editing mode instead of being closed then reopened on selection reset

runbot-163251



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
