### PR TITLE
[FIX] mass_mailing: unable to edit field source_id

### DIFF
--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -351,7 +351,6 @@
                                              attrs="{'readonly': [('state', 'in', ('sending', 'done'))]}"/>
                                         <field name="source_id"
                                             string="Source"
-                                            readonly="1"
                                             required="False"
                                             class="o_text_overflow"
                                             groups="base.group_no_one"


### PR DESCRIPTION
The field was assigned an unnecessary fixed readonly attribute, so it could not be edited


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
