### PR TITLE
[IMP] purchase: reload purchase dashboard on list view actions

### DIFF
--- a/addons/purchase/static/src/views/purchase_dashboard.js
+++ b/addons/purchase/static/src/views/purchase_dashboard.js
@@ -1,16 +1,22 @@
 import { useService } from "@web/core/utils/hooks";
-import { Component, onWillStart } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
 
 export class PurchaseDashBoard extends Component {
     static template = "purchase.PurchaseDashboard";
-    static props = {};
+    static props = { list: { type: Object, optional: true } };
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
 
         onWillStart(async () => {
-            this.purchaseData = await this.orm.call("purchase.order", "retrieve_dashboard");
+            await this.updateDashboardState();
         });
+        onWillUpdateProps(async () => {
+            await this.updateDashboardState();
+        });
+    }
+    async updateDashboardState() {
+        this.purchaseData = await this.orm.call("purchase.order", "retrieve_dashboard");
     }
 
     /**

--- a/addons/purchase/static/src/views/purchase_dashboard.js
+++ b/addons/purchase/static/src/views/purchase_dashboard.js
@@ -17,6 +17,7 @@ export class PurchaseDashBoard extends Component {
     }
     async updateDashboardState() {
         this.purchaseData = await this.orm.call("purchase.order", "retrieve_dashboard");
+        this.multiuser = JSON.stringify(this.purchaseData.global) !== JSON.stringify(this.purchaseData.my);
     }
 
     /**

--- a/addons/purchase/static/src/views/purchase_dashboard.scss
+++ b/addons/purchase/static/src/views/purchase_dashboard.scss
@@ -8,6 +8,10 @@
             &.o_purchase_dashboard_card_bottom {
                 --btn-border-radius: 0 0 #{$btn-border-radius} #{$btn-border-radius};
             }
+
+            &.o_purchase_dashboard_card_sole {
+                --btn-border-radius: #{$btn-border-radius};
+            }
         }
 
         width: 100%;

--- a/addons/purchase/static/src/views/purchase_dashboard.xml
+++ b/addons/purchase/static/src/views/purchase_dashboard.xml
@@ -6,12 +6,15 @@
                 <div class="col-12 col-lg-8 flex-grow-1 flex-lg-grow-0 flex-shrink-0">
                     <div class="grid gap-1 gap-lg-4">
                         <div class="g-col-12 g-col-lg-1 d-flex align-items-center pt-2 pb-lg-2 justify-content-lg-end text-break">
-                            All
+                            <t t-if="multiuser">All</t>
                         </div>
                         <div class="g-col-12 g-col-lg-11 grid gap-1" style="--columns: 61">
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Draft RFQs" filter_name="draft_rfqs">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
-                                    t-attf-class="{{ purchaseData['global']['draft']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
+                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                   t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
+                                       {{ purchaseData['global']['draft']['all'] == 0
+                                          ? 'bg-secondary-subtle text-secondary-emphasis'
+                                          : 'bg-info-subtle text-info-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['draft']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['draft']['priority']">
@@ -21,7 +24,8 @@
                                 </a>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Sent RFQs" filter_name="waiting_rfqs">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap">
+                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 bg-secondary-subtle text-secondary-emphasis text-truncate text-wrap"
+                                   t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['sent']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['sent']['priority']">
@@ -31,8 +35,11 @@
                                 </a>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late RFQs" filter_name="late">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
-                                    t-attf-class="{{ purchaseData['global']['late']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-warning-subtle text-warning-emphasis' }}">
+                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                   t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
+                                       {{ purchaseData['global']['late']['all'] == 0
+                                          ? 'bg-secondary-subtle text-secondary-emphasis'
+                                          : 'bg-warning-subtle text-warning-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['late']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['late']['priority']">
@@ -43,8 +50,11 @@
                             </div>
                             <div class="g-col-1"/>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Not Acknowledged POs" filter_name="not_acknowledged">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
-                                    t-attf-class="{{ purchaseData['global']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
+                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                   t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
+                                       {{ purchaseData['global']['not_acknowledged']['all'] == 0
+                                          ? 'bg-secondary-subtle text-secondary-emphasis'
+                                          : 'bg-info-subtle text-info-emphasis' }}">
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['not_acknowledged']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['not_acknowledged']['priority']">
@@ -54,8 +64,12 @@
                                 </a>
                             </div>
                             <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late Receipt POs" filter_name="late_receipt">
-                                <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
-                                    t-attf-class="{{ purchaseData['global']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
+                                <a href="#" class="btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
+                                   t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
+                                       {{ purchaseData['global']['late_receipt']['all'] == 0
+                                          ? 'bg-secondary-subtle text-secondary-emphasis'
+                                          : 'bg-danger-subtle text-danger-emphasis' }}">
+
                                     <div class="fs-2">
                                         <span t-out="purchaseData['global']['late_receipt']['all']"/>
                                         <span class="ps-4" t-if="purchaseData['global']['late_receipt']['priority']">
@@ -66,7 +80,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="grid gap-1 gap-lg-4">
+                    <div t-if="multiuser" class="grid gap-1 gap-lg-4">
                         <div class="g-col-12 g-col-lg-1 d-flex align-items-center pt-2 pb-lg-2 justify-content-lg-end text-break">
                             My
                         </div>
@@ -137,23 +151,24 @@
                         <div class="g-col-12 g-col-lg-12 grid gap-1">
                             <div class="d-none d-lg-block g-col-6 p-0" id="left_grid_top"/>
                             <div class="g-col-6 p-0" title="All Days to Order">
-                                <div class="o_purchase_dashboard_card_top purchase-dashboard-card o_no_hover p-1 p-lg-2 text-truncate text-wrap"
-                                    t-attf-class="{{
-                                        purchaseData['days_to_purchase'] and
-                                        purchaseData['global']['days_to_order'] > purchaseData['days_to_purchase']
-                                        ? 'btn btn-warning' : 'bg-100 text-center' }}">
+                                <div class="purchase-dashboard-card o_no_hover p-1 p-lg-2 text-truncate text-wrap"
+                                     t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}
+                                         {{ purchaseData['days_to_purchase'] and
+                                            purchaseData['global']['days_to_order'] > purchaseData['days_to_purchase']
+                                            ? 'btn btn-warning'
+                                            : 'bg-100 text-center' }}">
                                     <div class="fs-2" t-out="purchaseData['global']['days_to_order']"/>Days to Order
                                 </div>
                             </div>
                         </div>
                     </div>
-                    <div class="grid gap-1 gap-lg-4 pt-0 pt-lg-1">
+                    <div t-if="multiuser" class="grid gap-1 gap-lg-4 pt-0 pt-lg-1">
                         <div class="d-lg-none g-col-12 d-flex align-items-center pt-2 pb-lg-2 justify-content-lg-end text-break">
                             My
                         </div>
                         <div class="g-col-12 g-col-lg-12 grid gap-1">
                             <div class="d-none d-lg-block g-col-6 p-0" id="left_grid_bottom"/>
-                            <div class="g-col-6 p-0" title="All Days to Order">
+                            <div class="g-col-6 p-0" title="My Days to Order">
                                 <div class="o_purchase_dashboard_card_bottom purchase-dashboard-card o_no_hover p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{
                                         purchaseData['days_to_purchase'] and

--- a/addons/purchase/static/src/views/purchase_listview.xml
+++ b/addons/purchase/static/src/views/purchase_listview.xml
@@ -1,7 +1,7 @@
 <templates>
     <t t-name="purchase.ListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
         <xpath expr="//div[hasclass('o_list_renderer')]" position="before">
-            <PurchaseDashBoard />
+            <PurchaseDashBoard list="props.list"/>
         </xpath>
     </t>
 

--- a/addons/purchase_stock/static/src/purchase_dashboard/purchase_dashboard.xml
+++ b/addons/purchase_stock/static/src/purchase_dashboard/purchase_dashboard.xml
@@ -3,13 +3,14 @@
     <t t-name="purchase_stock.PurchaseDashboard" t-inherit="purchase.PurchaseDashboard" t-inherit-mode="extension">
         <xpath expr="//div[@id='left_grid_top']" position="replace">
         <div class="g-col-6 p-0" title="OTD">
-            <div class="o_purchase_dashboard_card_top purchase-dashboard-card o_no_hover p-1 p-lg-2 bg-100 text-center text-truncate text-wrap">
+            <div class="purchase-dashboard-card o_no_hover p-1 p-lg-2 bg-100 text-center text-truncate text-wrap"
+                 t-attf-class="o_purchase_dashboard_card_{{ multiuser ? 'top' : 'sole' }}">
                 <div class="fs-2" t-out="purchaseData['global']['otd']"/>OTD
             </div>
         </div>
         </xpath>
         <xpath expr="//div[@id='left_grid_bottom']" position="replace">
-        <div class="g-col-6 p-0" title="OTD">
+        <div t-if="multiuser" class="g-col-6 p-0" title="OTD">
             <div class="o_purchase_dashboard_card_bottom purchase-dashboard-card o_no_hover p-1 p-lg-2 bg-100 text-center text-truncate text-wrap">
                 <div t-out="purchaseData['my']['otd']"/>
             </div>


### PR DESCRIPTION
The dashboard content is generated in the backend upon page load, which means it's dynamic and not responsive to the actions on the purchase orders in the list view. Here we make the actions trigger soft reloads to force the dashboard regeneration.

The cancel action triggers `afterExecuteActionButton()` but the custom `ir.actions.server` actions don't trigger any list controller hooks and must be given an `ir.actions.client` action to force the reload

The only use case not covered is that the duplicate action doesn't trigger the `{before,after}ExecuteActionButton()` hooks, as no static action button does. We can override the static action button list accessor to crudely wrap each callback with a reload on exit, but it's very inelegant.

Secondly, the 'my' row should be hidden if all the extant POs were created by the current user. (ie my POs = all POs)

Task ID: [4576029](https://www.odoo.com/odoo/project/966/tasks/4576029)
