### PR TITLE
[FIX] l10n_hu_edi: invoice spacing

### DIFF
--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -97,8 +97,7 @@
         <xpath expr="//td[@name='account_invoice_line_name']/span" position="after">
             <div t-if="line.product_id.l10n_hu_product_code_type and line.product_id.l10n_hu_product_code">
                 <span t-if="line.product_id.l10n_hu_product_code_type == 'OTHER'">Other Product Code</span>
-                <span t-else="else" t-out="line.product_id.l10n_hu_product_code_type"/>
-                :
+                <span t-else="else" t-out="line.product_id.l10n_hu_product_code_type"/>:
                 <span t-out="line.product_id.l10n_hu_product_code"/>
             </div>
         </xpath>


### PR DESCRIPTION
Changing the syntax of the product code line in the invoice to not have a space before the colon. 
Example: `VTSZ : 8604000` -> `VTSZ: 8604000`

task-4707459