### PR TITLE
[FIX] web: deepCopy supports `undefined`

### DIFF
--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -37,7 +37,7 @@ export const deepEqual = (obj1, obj2) => shallowEqual(obj1, obj2, deepEqual);
  * @return {T}
  */
 export function deepCopy(obj) {
-    return JSON.parse(JSON.stringify(obj));
+    return obj && JSON.parse(JSON.stringify(obj));
 }
 
 /**


### PR DESCRIPTION
The current implementation of deepCopy only supports fully JSON stringifiable objects but its behaviour was modified in later versions to support `undefined` as well.
This commit backports that change as it does not break the current behaviour and reduces the chances of an unfortunate error in bugfixes.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
