### PR TITLE
[FIX] l10n_lv: remove unused data file

### DIFF
--- a/addons/l10n_lv/data/menuitem_data.xml
+++ b/addons/l10n_lv/data/menuitem_data.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<odoo>
-    <menuitem id="account_reports_lv_statements_menu" name="Latvia" parent="account.menu_finance_reports" sequence="5" groups="account.group_account_readonly"/>
-</odoo>


### PR DESCRIPTION
In commit aca36072a8adcdc2263f5dcc12a3c9fb374a025e a new data file was created but not included in the manifest. So it is never loaded.

This commit removes the file (since it is not used anyway).

task: None