### PR TITLE
[FIX] l10n_it_stock_ddt: test ACL

### DIFF
--- a/addons/l10n_it_stock_ddt/tests/test_edi.py
+++ b/addons/l10n_it_stock_ddt/tests/test_edi.py
@@ -103,6 +103,7 @@ class TestItEdiDDT(TestItEdi):
         """ Create a sale order with multiple DDTs, and create an invoice with a later date.
             The export has to have the TipoDocumento TD24 for Deferred Invoice.
         """
+        self.env.user.groups_id |= self.env.ref("sales_team.group_sale_salesman")
         # Create sale order
         with freeze_time('2020-02-02 18:00'):
             self.sale_order = self.env['sale.order'].with_company(self.company).create({


### PR DESCRIPTION
`TestItEdiDDT.test_deferred_invoice` creates a sales order but does not ensure the user has the rights to create one.

https://runbot.odoo.com/odoo/error/163639
