### PR TITLE
[FIX] mail, *: enable shared methods overrides through inheritance

### DIFF
--- a/addons/im_livechat/controllers/attachment.py
+++ b/addons/im_livechat/controllers/attachment.py
@@ -6,7 +6,6 @@ from odoo import _
 from odoo.http import route, request
 from odoo.exceptions import AccessError
 from odoo.addons.mail.controllers.attachment import AttachmentController
-from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.mail.tools.discuss import add_guest_to_context
 
 
@@ -14,7 +13,9 @@ class LivechatAttachmentController(AttachmentController):
     @route()
     @add_guest_to_context
     def mail_attachment_upload(self, ufile, thread_id, thread_model, is_pending=False, **kwargs):
-        thread = ThreadController._get_thread_with_access(thread_model, thread_id, mode=request.env[thread_model]._mail_post_access, **kwargs)
+        thread = self._get_thread_with_access(
+            thread_model, thread_id, mode=request.env[thread_model]._mail_post_access, **kwargs
+        )
         if not thread:
             raise NotFound()
         if (

--- a/addons/mail/controllers/message_reaction.py
+++ b/addons/mail/controllers/message_reaction.py
@@ -8,11 +8,11 @@ from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
 
 
-class MessageReactionController(http.Controller):
+class MessageReactionController(ThreadController):
     @http.route("/mail/message/reaction", methods=["POST"], type="jsonrpc", auth="public")
     @add_guest_to_context
     def mail_message_reaction(self, message_id, content, action, **kwargs):
-        message = ThreadController._get_message_with_access(int(message_id), mode="create", **kwargs)
+        message = self._get_message_with_access(int(message_id), mode="create", **kwargs)
         if not message:
             raise NotFound()
         partner, guest = self._get_reaction_author(message, **kwargs)

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -6,7 +6,7 @@ from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.mail.tools.discuss import add_guest_to_context, Store
 
 
-class WebclientController(http.Controller):
+class WebclientController(ThreadController):
     """Routes for the web client."""
 
     @http.route("/mail/action", methods=["POST"], type="jsonrpc", auth="public")
@@ -47,7 +47,7 @@ class WebclientController(http.Controller):
                 user = request.env.user.sudo(False)
                 user._init_messaging(store)
         if name == "mail.thread":
-            thread = ThreadController._get_thread_with_access(
+            thread = self._get_thread_with_access(
                 params["thread_model"],
                 params["thread_id"],
                 mode="read",

--- a/addons/mail/tests/common_controllers.py
+++ b/addons/mail/tests/common_controllers.py
@@ -3,7 +3,7 @@ import json
 from markupsafe import Markup
 from requests.exceptions import HTTPError
 
-from odoo import fields
+from odoo import Command, fields
 from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.http import Request
@@ -86,7 +86,12 @@ class MailControllerCommon(HttpCase, MailCommon):
 
 class MailControllerAttachmentCommon(MailControllerCommon):
 
-    def _execute_subtests(self, document, subtests):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.WITH_TOKEN, cls.NO_TOKEN = True, False
+
+    def _execute_subtests_upload(self, document, subtests):
         for data_user, allowed, *args in subtests:
             route_kw = args[0] if args else {}
             user, guest = self._authenticate_pseudo_user(data_user)
@@ -95,13 +100,41 @@ class MailControllerAttachmentCommon(MailControllerCommon):
                     attachment_id = self._upload_attachment(document, route_kw)
                     attachment = self.env["ir.attachment"].sudo().search([("id", "=", attachment_id)])
                     self.assertTrue(attachment)
-                    self._delete_attachment(attachment, route_kw)
-                    self.assertFalse(attachment.exists())
                 else:
                     with self.assertRaises(
                         HTTPError, msg="upload attachment should raise NotFound"
                     ):
                         self._upload_attachment(document, route_kw)
+
+    def _execute_subtests_delete(self, subtests, allowed, message=None, thread=None):
+        for data_user, token, *args in subtests:
+            extra_params = args[0] if args else {}
+            route_kw = extra_params.get("route_kw", {})
+            author = extra_params.get("author")
+            user, guest = self._authenticate_pseudo_user(data_user)
+            with self.subTest(user=user.name, guest=guest.name, token=token, route_kw=route_kw):
+                attachment = self.env["ir.attachment"].create({"name": "sample attachment"})
+                if token:
+                    attachment.generate_access_token()
+                if thread:
+                    message and message.write({"res_id": thread.id, "model": thread._name})
+                    attachment.write({"res_model": thread._name, "res_id": thread.id})
+                if message:
+                    message.write({"attachment_ids": [Command.LINK, attachment.id]})
+                    if author:
+                        if isinstance(author, str) and author == "self_author":
+                            author = guest.id if guest else user.partner_id
+                        message.author_guest_id = author if guest else False
+                        message.author_id = author if not guest else False
+                if allowed:
+                    self._delete_attachment(attachment, token, route_kw)
+                    self.assertFalse(attachment.exists())
+                else:
+                    with self.assertRaises(JsonRpcException, msg="Wrong access token"):
+                        self._delete_attachment(attachment, token, route_kw)
+                if message:
+                    message.author_guest_id = False
+                    message.author_id = False
 
     def _upload_attachment(self, document, route_kw):
         with mute_logger("odoo.http"), file_open("addons/web/__init__.py") as file:
@@ -119,15 +152,16 @@ class MailControllerAttachmentCommon(MailControllerCommon):
             res.raise_for_status()
             return json.loads(res.content.decode("utf-8"))["data"]["ir.attachment"][0]["id"]
 
-    def _delete_attachment(self, attachment, route_kw):
-        self.make_jsonrpc_request(
-            route="/mail/attachment/delete",
-            params={
-                "attachment_id": attachment.id,
-                "access_token": attachment.access_token,
-                **route_kw,
-            },
-        )
+    def _delete_attachment(self, attachment, token, route_kw):
+        with mute_logger("odoo.http"):
+            self.make_jsonrpc_request(
+                route="/mail/attachment/delete",
+                params={
+                    "attachment_id": attachment.id,
+                    "access_token": attachment.access_token if token else None,
+                    **route_kw,
+                },
+            )
 
 
 class MailControllerBinaryCommon(MailControllerCommon):

--- a/addons/mail/tests/discuss/test_discuss_attachment_controller.py
+++ b/addons/mail/tests/discuss/test_discuss_attachment_controller.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from itertools import product
 
 import odoo
 from odoo.addons.mail.tests.common_controllers import MailControllerAttachmentCommon
@@ -13,7 +14,7 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
         )
         channel.add_members(guest_ids=[self.guest.id])
         channel.env.context = {**channel.env.context, "guest": self.guest}
-        self._execute_subtests(
+        self._execute_subtests_upload(
             channel,
             (
                 (self.guest, True),
@@ -22,4 +23,43 @@ class TestDiscussAttachmentController(MailControllerAttachmentCommon):
                 (self.user_portal, True),
                 (self.user_public, True),
             ),
+        )
+
+    def test_attachment_delete_linked_to_public_channel(self):
+        """Test access to delete an attachment associated with a public channel"""
+        channel = self.env["discuss.channel"].create({"name": "public channel"})
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=False,
+            thread=channel,
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.user_admin, self.user_employee),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=True,
+            thread=channel,
+        )
+
+    def test_attachment_delete_linked_to_private_channel(self):
+        """Test access to delete an attachment associated with a private channel"""
+        channel = self.env["discuss.channel"].create(
+            {"name": "Private Channel", "channel_type": "group"}
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_employee, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=False,
+            thread=channel,
+        )
+        self._execute_subtests_delete(
+            product(self.user_admin, (self.WITH_TOKEN, self.NO_TOKEN)),
+            allowed=True,
+            thread=channel,
         )

--- a/addons/portal/controllers/portal_thread.py
+++ b/addons/portal/controllers/portal_thread.py
@@ -8,14 +8,14 @@ from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.portal.utils import get_portal_partner
 
 
-class PortalChatter(http.Controller):
+class PortalChatter(ThreadController):
 
     @http.route('/mail/avatar/mail.message/<int:res_id>/author_avatar/<int:width>x<int:height>', type='http', auth='public')
     def portal_avatar(self, res_id=None, height=50, width=50, access_token=None, _hash=None, pid=None):
         """Get the avatar image in the chatter of the portal"""
         if access_token or (_hash and pid):
             message_su = request.env["mail.message"].browse(int(res_id)).exists().sudo()
-            thread = ThreadController._get_thread_with_access(
+            thread = self._get_thread_with_access(
                 message_su.model, message_su.res_id,
                 token=access_token, hash=_hash, pid=pid and int(pid)
             )
@@ -31,11 +31,11 @@ class PortalChatter(http.Controller):
     @http.route("/portal/chatter_init", type="jsonrpc", auth="public", website=True)
     def portal_chatter_init(self, thread_model, thread_id, **kwargs):
         store = Store()
-        thread = ThreadController._get_thread_with_access(thread_model, thread_id, **kwargs)
+        thread = self._get_thread_with_access(thread_model, thread_id, **kwargs)
         partner = request.env.user.partner_id
         if thread:
             mode = request.env[thread_model]._get_mail_message_access([thread_id], "create")
-            has_react_access = ThreadController._get_thread_with_access(thread_model, thread_id, mode, **kwargs)
+            has_react_access = self._get_thread_with_access(thread_model, thread_id, mode, **kwargs)
             can_react = has_react_access
             if request.env.user._is_public():
                 portal_partner = get_portal_partner(
@@ -67,7 +67,7 @@ class PortalChatter(http.Controller):
         # Check access
         Message = request.env['mail.message']
         if kw.get('token'):
-            access_as_sudo = ThreadController._get_thread_with_access(
+            access_as_sudo = self._get_thread_with_access(
                 thread_model, thread_id, token=kw.get("token"),
             )
             if not access_as_sudo:  # if token is not correct, raise Forbidden

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_controller_attachment
 from . import test_controller_binary
 from . import test_controller_thread
 from . import test_invite

--- a/addons/test_mail/tests/test_controller_attachment.py
+++ b/addons/test_mail/tests/test_controller_attachment.py
@@ -1,0 +1,105 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from itertools import product
+
+import odoo
+from odoo.addons.mail.tests.common_controllers import MailControllerAttachmentCommon
+
+
+@odoo.tests.tagged("-at_install", "post_install", "mail_controller")
+class TestAttachmentController(MailControllerAttachmentCommon):
+    def test_independent_attachment_delete(self):
+        """Test access to delete an attachment"""
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_employee, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=False,
+        )
+        self._execute_subtests_delete(
+            product(self.user_admin, (self.WITH_TOKEN, self.NO_TOKEN)),
+            allowed=True,
+        )
+
+    def test_attachment_delete_linked_to_public_thread(self):
+        """Test access to delete an attachment associated with a public thread"""
+        thread = self.env["mail.test.access.public"].create({"name": "Test"})
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=False,
+            thread=thread,
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.user_admin, self.user_employee),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=True,
+            thread=thread,
+        )
+
+    def test_attachment_delete_linked_to_non_accessible_thread(self):
+        """Test access to delete an attachment associated with a non-accessible thread"""
+        thread = self.env["mail.test.access"].create({"access": "admin", "name": "Test"})
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_employee, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+            ),
+            allowed=False,
+            thread=thread,
+        )
+        self._execute_subtests_delete(
+            product(self.user_admin, (self.WITH_TOKEN, self.NO_TOKEN)),
+            allowed=True,
+            thread=thread,
+        )
+
+    def test_attachment_delete_linked_to_message(self):
+        """Test access to delete an attachment associated with a message"""
+        message = self.env["mail.message"].create({"body": "Test"})
+        # Subtest format: (user, token, {"author": message author})
+        author, no_author = {"author": "self_author"}, {}
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_employee, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                (author, no_author),
+            ),
+            allowed=False,
+            message=message,
+        )
+        self._execute_subtests_delete(
+            product(
+                self.user_admin,
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                (author, no_author),
+            ),
+            allowed=True,
+            message=message,
+        )
+
+    def test_attachment_delete_linked_to_message_in_thread(self):
+        """Test access to delete an attachment associated with a message in an accessible thread"""
+        message = self.env["mail.message"].create({"body": "Test"})
+        thread = self.env["mail.test.access.public"].create({"name": "Test"})
+        author, no_author = {"author": "self_author"}, {}
+        # (user(s), author or not, expected result)
+        test_cases = [
+            ((self.user_admin, self.user_employee), (author, no_author), True),
+            ((self.guest, self.user_portal), (author,), True),
+            ((self.guest, self.user_portal), (no_author,), False),
+            (self.user_public, (author, no_author), False),
+        ]
+
+        for users, author_config, allowed in test_cases:
+            # Subtest format: (user, token, {"author": message author})
+            self._execute_subtests_delete(
+                product(users, (self.WITH_TOKEN, self.NO_TOKEN), author_config),
+                allowed=allowed,
+                message=message,
+                thread=thread,
+            )

--- a/addons/test_mail_full/tests/test_controller_attachment.py
+++ b/addons/test_mail_full/tests/test_controller_attachment.py
@@ -1,3 +1,5 @@
+from itertools import product
+
 import odoo
 from odoo.addons.mail.tests.common_controllers import MailControllerAttachmentCommon
 
@@ -9,7 +11,7 @@ class TestPortalAttachmentController(MailControllerAttachmentCommon):
         """Test access to upload an attachment on portal"""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
         token, bad_token, sign, bad_sign, _ = self._get_sign_token_params(record)
-        self._execute_subtests(
+        self._execute_subtests_upload(
             record,
             (
                 (self.user_public, False),
@@ -35,3 +37,132 @@ class TestPortalAttachmentController(MailControllerAttachmentCommon):
                 (self.user_admin, True, sign),
             ),
         )
+
+    def test_independent_attachment_delete_portal(self):
+        """Test access to delete an attachment on portal"""
+        # Subtest format: (user, token, {"route_kw": security params})
+        record = self.env["mail.test.portal"].create({"name": "Test"})
+        token, bad_token, sign, bad_sign, _ = self._get_sign_token_params(record)
+        route_kws = (
+            {"route_kw": token},
+            {"route_kw": sign},
+            {"route_kw": bad_token},
+            {"route_kw": bad_sign},
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_employee, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                route_kws,
+            ),
+            allowed=False,
+        )
+        self._execute_subtests_delete(
+            product(self.user_admin, (self.WITH_TOKEN, self.NO_TOKEN), route_kws),
+            allowed=True,
+        )
+
+    def test_attachment_delete_portal_linked_to_thread(self):
+        """Test access to delete an attachment on portal associated with a thread"""
+        record = self.env["mail.test.portal"].create({"name": "Test"})
+        token, bad_token, sign, bad_sign, _ = self._get_sign_token_params(record)
+        # Subtest format: (user, token, {"route_kw": security params})
+        route_kws = (
+            {},
+            {"route_kw": token},
+            {"route_kw": sign},
+            {"route_kw": bad_token},
+            {"route_kw": bad_sign},
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.guest, self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                route_kws,
+            ),
+            allowed=False,
+            thread=record,
+        )
+        self._execute_subtests_delete(
+            product(
+                (self.user_admin, self.user_employee),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                route_kws,
+            ),
+            allowed=True,
+            thread=record,
+        )
+
+    def test_attachment_delete_portal_no_partner(self):
+        """Test access to delete an attachment on a portal document without partner which is
+        associated with a message"""
+        record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})
+        message = self.env["mail.message"].create({"model": record._name, "res_id": record.id})
+        sign_token_params = self._get_sign_token_params(record)
+        allowed_subtests, forbidden_subtests = self._get_delete_attachment_subtests(
+            sign_token_params, False
+        )
+        self._execute_subtests_delete(
+            allowed_subtests,
+            allowed=True,
+            message=message,
+        )
+        self._execute_subtests_delete(
+            forbidden_subtests,
+            allowed=False,
+            message=message,
+        )
+
+    def test_attachment_delete_portal_assigned_partner(self):
+        """Test access to delete an attachment on a portal document with a partner which is
+        associated with a message"""
+        record = self.env["mail.test.portal"].create({"name": "Test"})
+        sign_token_params = self._get_sign_token_params(record)
+        record.partner_id = sign_token_params[-1]
+        message = self.env["mail.message"].create({"model": record._name, "res_id": record.id})
+        allowed_subtests, forbidden_subtests = self._get_delete_attachment_subtests(
+            sign_token_params, True
+        )
+        self._execute_subtests_delete(
+            allowed_subtests,
+            allowed=True,
+            message=message,
+        )
+        self._execute_subtests_delete(
+            forbidden_subtests,
+            allowed=False,
+            message=message,
+        )
+
+    def _get_delete_attachment_subtests(self, sign_token_params, specific_partner_result):
+        token, bad_token, sign, bad_sign, doc_partner = sign_token_params
+        # Subtest format: (user, token, {"author": message author, "route_kw": security params})
+        portal_partner = self.user_portal.partner_id
+        allowed_subtests = [
+            (self.user_portal, self.NO_TOKEN, {"author": portal_partner, "route_kw": token}),
+            (self.user_portal, self.WITH_TOKEN, {"author": portal_partner, "route_kw": token}),
+            (self.user_portal, self.NO_TOKEN, {"author": portal_partner, "route_kw": sign}),
+            (self.user_portal, self.WITH_TOKEN, {"author": portal_partner, "route_kw": sign}),
+            (self.user_public, self.NO_TOKEN, {"author": doc_partner, "route_kw": sign}),
+            (self.user_public, self.WITH_TOKEN, {"author": doc_partner, "route_kw": sign}),
+        ]
+        if specific_partner_result:
+            allowed_subtests.extend(
+                [
+                    (self.user_public, self.NO_TOKEN, {"author": doc_partner, "route_kw": token}),
+                    (self.user_public, self.WITH_TOKEN, {"author": doc_partner, "route_kw": token}),
+                ]
+            )
+        forbidden_subtests = filter(
+            lambda subtest: subtest not in allowed_subtests,
+            product(
+                (self.user_portal, self.user_public),
+                (self.WITH_TOKEN, self.NO_TOKEN),
+                [
+                    {"author": author, "route_kw": route_kw}
+                    for author in (None, portal_partner, doc_partner)
+                    for route_kw in ({}, token, sign, bad_token, bad_sign)
+                ],
+            ),
+        )
+        return allowed_subtests, forbidden_subtests


### PR DESCRIPTION
*: im_livechat, portal, test_mail, test_mail_full

Steps to reproduce:
- Install a module with portal mixin
- From a portal document (not logged in) try to delete an attachment of a
message
- The override of `_can_edit_message` is never called and the attachment is not
deleted

With this commit, any controller that needs the shared method of
`ThreadController` controller inherits that control. Direct calls to imported
controller methods could bypass overrides.