### PR TITLE
[FIX] l10n_it_edi_sale: test ACLs

### DIFF
--- a/addons/l10n_it_edi_sale/tests/test_edi_sale_order_pa.py
+++ b/addons/l10n_it_edi_sale/tests/test_edi_sale_order_pa.py
@@ -21,6 +21,7 @@ class TestItEdiSaleOrderPa(TestItEdi):
         })
 
         cls.module = 'l10n_it_edi_sale'
+        cls.env.user.group_ids |= cls.env.ref('sales_team.group_sale_salesman')
 
     def get_sales_order_vals(self, **kwargs):
         return {


### PR DESCRIPTION
The appropriately named `test_edi_sale_order_pa.py` does a bunch of sales order tests, which requires creating them, which it does not ensure the current user can do.

https://runbot.odoo.com/odoo/error/163632
