### PR TITLE
[IMP] account: remove hr and plm managers from get_default_groups

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -178,7 +178,7 @@ class AccountChartTemplate(models.AbstractModel):
         # Ensure that the context is the correct one, even if not called by try_loading
         if not self.env.is_system():
             raise AccessError(_("Only administrators can install chart templates"))
-
+        self = self.sudo()  # noqa: PLW0642
         chart_template_mapping = self._get_chart_template_mapping()[template_code]
         if not company.country_id:
             company.country_id = chart_template_mapping.get('country_id')

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -264,25 +264,12 @@ class AccountTestInvoicingCommon(ProductCommon):
 
     @classmethod
     def get_default_groups(cls):
-        groups = super().get_default_groups()
-        groups |= cls.env['res.groups'].browse(
-            cls.env['ir.model.data'].search([
-                ('model', '=', 'res.groups'),
-                ('name', 'in', (
-                    # TODO: Progressively remove groups from this list, hopefully no groups share the same name.
-                    # This is a consequence of moving groups from data to demo data: https://github.com/odoo/odoo/pull/198078
-                    'group_hr_manager', # hr
-                    'group_mrp_manager', # mrp
-                    'group_purchase_manager', # purchase
-                    'group_stock_manager', # stock
-                    # enterprise groups
-                    'group_hr_payroll_manager', # hr_payroll
-                    'group_plm_manager', # mrp_plm
-                ))
-            ]).mapped('res_id')
-        )
+        no_group = cls.env['res.groups'].browse()
         return (
-            groups
+            super().get_default_groups()
+            | (cls.env.ref('mrp.group_mrp_manager', False) or no_group)
+            | (cls.env.ref('purchase.group_purchase_manager', False) or no_group)
+            | (cls.env.ref('stock.group_stock_manager', False) or no_group)
             | cls.quick_ref('account.group_account_manager')
             | cls.quick_ref('account.group_account_user')
             | cls.quick_ref('base.group_system')  # company creation during setups

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1470,18 +1470,18 @@ class HrExpense(models.Model):
         self.ensure_one()
         approver_group = 'hr_expense.group_hr_expense_team_approver'
 
-        employee = self.employee_id
+        employee = self.employee_id.sudo()
         expense_manager = employee.expense_manager_id - employee.user_id
         if expense_manager:
-            return expense_manager
+            return expense_manager.sudo(False)
 
         department_manager = employee.department_id.manager_id.user_id - employee.user_id
         if department_manager and department_manager.has_groups(approver_group):
-            return department_manager
+            return department_manager.sudo(False)
 
         employee_team_leader = employee.parent_id.user_id
         if employee_team_leader:
-            return employee_team_leader
+            return employee_team_leader.sudo(False)
 
         return self.env['res.users']
 

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -48,12 +48,12 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             company_ids=[Command.set(cls.env.companies.ids)],
         )
 
-        cls.expense_employee = cls.env['hr.employee'].create({
+        cls.expense_employee = cls.env['hr.employee'].sudo().create({
             'name': 'expense_employee',
             'user_id': cls.expense_user_employee.id,
             'expense_manager_id': cls.expense_user_manager.id,
             'work_contact_id': cls.expense_user_employee.partner_id.id,
-        })
+        }).sudo(False)
 
         # Allow the current accounting user to access the expenses.
         cls.env.user.group_ids |= group_expense_manager

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -794,7 +794,7 @@ class TestExpenses(TestExpenseCommon):
     def test_expense_multi_company(self):
         main_company = self.company_data['company']
         other_company = self.company_data_2['company']
-        self.expense_employee.company_id = other_company
+        self.expense_employee.sudo().company_id = other_company
 
         # The expense employee is able to create an expense for company_2.
         # product_a needs a standard_price in company_2

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -13,11 +13,11 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
     def test_expense_access_rights(self):
         """ The expense employee can't be able to create an expense for someone else. """
 
-        expense_employee_2 = self.env['hr.employee'].create({
+        expense_employee_2 = self.env['hr.employee'].sudo().create({
             'name': 'expense_employee_2',
             'user_id': self.env.user.id,
             'work_contact_id': self.env.user.partner_id.id,
-        })
+        }).sudo(False)
 
         with self.assertRaises(AccessError):
             self.env['hr.expense'].with_user(self.expense_user_employee).create({
@@ -32,13 +32,13 @@ class TestExpensesAccessRights(TestExpenseCommon, HttpCase):
         # The expense base user (without other rights) is able to create and read sheet
 
         user = new_test_user(self.env, login='test-expense', groups='base.group_user')
-        expense_employee = self.env['hr.employee'].create({
+        expense_employee = self.env['hr.employee'].sudo().create({
             'name': 'expense_employee_base_user',
             'user_id': user.id,
             'work_contact_id': user.partner_id.id,
             'expense_manager_id': self.expense_user_manager.id,
             'address_id': user.partner_id.id,
-        })
+        }).sudo(False)
 
         expense = self.env['hr.expense'].with_user(user).create({
             'name': 'First Expense for employee',

--- a/addons/hr_expense/tests/test_expenses_mail_import.py
+++ b/addons/hr_expense/tests/test_expenses_mail_import.py
@@ -49,12 +49,12 @@ class TestExpensesMailImport(TestExpenseCommon):
         user.company_id = company_2.id
 
         # Create a second employee linked to the user for another company
-        company_2_employee = self.env['hr.employee'].create({
+        company_2_employee = self.env['hr.employee'].sudo().create({
             'name': 'expense_employee_2',
             'company_id': company_2.id,
             'user_id': user.id,
             'work_email': user.email,
-        })
+        }).sudo(False)
 
         message_parsed = {
             'message_id': "the-world-is-a-ghetto",
@@ -72,7 +72,7 @@ class TestExpensesMailImport(TestExpenseCommon):
     def test_import_expense_from_email_employee_without_user(self):
         """ When an employee is not linked to a user, he has to be able to create expenses from email """
         employee = self.expense_employee
-        employee.user_id = False
+        employee.sudo().user_id = False
 
         message_parsed = {
             'message_id': "the-world-is-a-ghetto",

--- a/addons/hr_expense/tests/test_expenses_states.py
+++ b/addons/hr_expense/tests/test_expenses_states.py
@@ -189,8 +189,8 @@ class TestExpensesStates(TestExpenseCommon):
 
     def test_expense_state_autovalidation(self):
         """ Test the auto-validation flow skips 'submitted' state when there is no manager"""
-        self.expense_employee.expense_manager_id = False
-        self.expenses_all.manager_id = False
+        self.expense_employee.sudo().expense_manager_id = False
+        self.expenses_all.sudo().manager_id = False
         self.expenses_all.action_submit()
         self.assertSequenceEqual(['approved', 'approved'], self.expenses_all.mapped('state'))
 

--- a/addons/hr_expense/tests/test_ui.py
+++ b/addons/hr_expense/tests/test_ui.py
@@ -12,7 +12,7 @@ class TestUi(TestExpenseCommon, HttpCase):
         by using the usual form view, even if they do not have access rights to `hr.employee`
         """
         employee_1 = self.expense_employee
-        employee_2 = self.env['hr.employee'].create({'name': 'employee2'})
+        employee_2 = self.env['hr.employee'].sudo().create({'name': 'employee2'})
         expense = self.env['hr.expense'].create({
             'name': 'expense_for_tour_0',
             'employee_id': employee_2.id,

--- a/addons/project_hr_expense/tests/test_project_profitability.py
+++ b/addons/project_hr_expense/tests/test_project_profitability.py
@@ -31,7 +31,7 @@ class TestProjectHrExpenseProfitability(TestProjectProfitabilityCommon, TestProj
         # Create a new company with the foreign currency.
         foreign_company = self.company_data_2['company']
         foreign_company.currency_id = self.foreign_currency
-        foreign_employee = self.env['hr.employee'].create({
+        foreign_employee = self.env['hr.employee'].sudo().create({
             'name': 'Foreign employee',
             'company_id': foreign_company.id,
             'expense_manager_id': self.expense_user_manager.id,

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -18,6 +18,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids |= cls.env.ref('purchase.group_purchase_user')
         cls.company_data_2 = cls.setup_other_company()
 
     def _create_invoice_for_po(self, purchase_order):

--- a/addons/project_sale_expense/tests/test_project_profitability.py
+++ b/addons/project_sale_expense/tests/test_project_profitability.py
@@ -28,7 +28,7 @@ class TestProjectSaleExpenseProfitability(TestProjectProfitabilityCommon, TestPr
             'name': 'Foreign Employee address',
             'company_id': foreign_company.id,
         })
-        foreign_employee = self.env['hr.employee'].create({
+        foreign_employee = self.env['hr.employee'].sudo().create({
             'name': 'foreign_employee',
             'company_id': foreign_company.id,
             'expense_manager_id': self.expense_user_manager.id,

--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -69,7 +69,7 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
 
     def test_read_purchase_order(self):
         """ Check that a purchase user can read all purchase order and 'in' invoices"""
-        purchase_user_2 = self.purchase_user.copy({
+        purchase_user_2 = self.purchase_user.sudo().copy({
             'name': 'Purchase user 2',
             'login': 'purchaseUser2',
             'email': 'pu2@odoo.com',

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -10,6 +10,7 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids |= cls.env.ref('hr.group_hr_user')
         cls.company_data_2 = cls.setup_other_company()
 
         cls.user_employee_company_B = mail_new_test_user(
@@ -43,32 +44,28 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
             groups='project.group_project_manager,hr_timesheet.group_hr_timesheet_user',
         )
 
-        cls.employee_user = cls.env['hr.employee'].create({
-            'name': 'Employee User',
-            'hourly_cost': 15,
-        })
-        cls.employee_manager = cls.env['hr.employee'].create({
-            'name': 'Employee Manager',
-            'hourly_cost': 45,
-        })
-
-        cls.employee_company_B = cls.env['hr.employee'].create({
-            'name': 'Gregor Clegane',
-            'user_id': cls.user_employee_company_B.id,
-            'hourly_cost': 15,
-        })
-
-        cls.manager_company_B = cls.env['hr.employee'].create({
-            'name': 'Cersei Lannister',
-            'user_id': cls.user_manager_company_B.id,
-            'hourly_cost': 45,
-        })
-        
-        cls.employee_without_sales_access = cls.env['hr.employee'].create({
-            'name': 'Tyrion Lannister',
-            'user_id': cls.user_employee_without_sales_access.id,
-            'hourly_cost': 25,
-        })
+        cls.employee_user, cls.employee_manager, \
+        cls.employee_company_B, cls.manager_company_B, \
+        cls.employee_without_sales_access = \
+            cls.env['hr.employee'].create([{
+                'name': 'Employee User',
+                'hourly_cost': 15,
+            }, {
+                'name': 'Employee Manager',
+                'hourly_cost': 45,
+            }, {
+                'name': 'Gregor Clegane',
+                'user_id': cls.user_employee_company_B.id,
+                'hourly_cost': 15,
+            }, {
+                'name': 'Cersei Lannister',
+                'user_id': cls.user_manager_company_B.id,
+                'hourly_cost': 45,
+            }, {
+                'name': 'Tyrion Lannister',
+                'user_id': cls.user_employee_without_sales_access.id,
+                'hourly_cost': 25,
+            }])
 
         # Account and project
         cls.analytic_account_sale.name = 'Project for selling timesheet - AA'


### PR DESCRIPTION
This was punted on during the Great DeDemoIzation, but as it turns out there's a lot of tests which are basically high as kites, use account's utility thingies (often without the module depending on account), and will get the groups they implicitly depend on via `get_default_groups`. Leading to failures in single module tests but not when everything under the sun is installed.
