### PR TITLE
[FIX] base_automation: more coherent eval context

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -618,6 +618,11 @@ class BaseAutomation(models.Model):
             'datetime': safe_eval.datetime,
             'dateutil': safe_eval.dateutil,
             'time': safe_eval.time,
+            'context_today': safe_eval.datetime.date.now,
+            'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
+            'now': safe_eval.datetime.datetime.now().strftime(r'%Y-%m-%d %H:%M:%S'),
+            'today': safe_eval.datetime.date.now().strftime(r'%Y-%m-%d'),
+            'current_date': safe_eval.datetime.date.now().strftime(r'%Y-%m-%d'),  # deprecated: today should be prefered
             'uid': self.env.uid,
             'user': self.env.user,
             'model': model,


### PR DESCRIPTION
Before this commit, the eval context for base_automation was not aligned with the browser side py_builtin.js eval context.

After this commit, the eval context for base_automation is aligned with the browser side py_builtin.js eval context.

Task id: opw-4737292