### PR TITLE
[FIX] l10n_in_stock: fix printing of picking operation

### DIFF
--- a/addons/l10n_in_stock/views/report_stockpicking_operations.xml
+++ b/addons/l10n_in_stock/views/report_stockpicking_operations.xml
@@ -3,7 +3,9 @@
 
     <template id="gst_report_picking_inherit" inherit_id="stock.report_picking">
         <xpath expr="//span[@t-field='move.description_picking']" position="after">
-            <t t-if="move.product_id and move.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'"><h6><strong class="ml16">HSN/SAC Code:</strong> <span t-field="ml.product_id.l10n_in_hsn_code"/></h6></t>
+            <h6 t-if="move.product_id and move.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'">
+                <strong class="ml16">HSN/SAC Code:</strong> <span t-field="move.product_id.l10n_in_hsn_code"/>
+            </h6>
         </xpath>
     </template>
 


### PR DESCRIPTION
### Before this commit:
A traceback occurred when trying to print the picking distribution from a `stock.picking` record. This was due to a typo in a variable name introduced in a update to the `stock.picking` module.

Issue caused by: https://github.com/odoo/odoo/commit/381615636185b88585e5ca112e43b6a7d81e1895

### After this commit:
The typo has been corrected by replacing the incorrect variable name with the correct one, resolving the traceback issue during the picking distribution print.

> Task-4737536




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
