### PR TITLE
[FIX] l10n_es: always display B2B fields for Spanish companies

### DIFF
--- a/addons/l10n_es/controllers/portal.py
+++ b/addons/l10n_es/controllers/portal.py
@@ -7,6 +7,13 @@ from odoo.addons.account.controllers.portal import PortalAccount
 
 class L10nESPortalAccount(PortalAccount):
 
+    def _prepare_address_form_values(self, *args, **kwargs):
+        """Ensure B2B fields are always displayed on Spanish e-commerce."""
+        rendering_values = super()._prepare_address_form_values(*args, **kwargs)
+        if not rendering_values.get('display_b2b_fields'):
+            rendering_values['display_b2b_fields'] = request.env.company.country_code == 'ES'
+        return rendering_values
+
     def _get_mandatory_billing_address_fields(self, country_sudo):
         """Require VAT/NIF for Spanish customers in billing addresses on Spanish e-commerce."""
         field_names = super()._get_mandatory_billing_address_fields(country_sudo)


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Enable Spanish localization;
2. assign website to Spanish company;
3. disable B2B fields in checkout via website editor;
4. edit address in eCommerce as a Spanish customer.

Issue
-----
Impossible to proceed, as VAT is a required field, but isn't displayed.

Cause
-----
Commit 26df8d31ab94 fixed this issue in earlier versions, but wasn't adapted for changes in 18.2+ where 5a93da8e9220 refactored address management.

Solution
--------
Override `_prepare_address_form_values` to always render B2B fields when the current company is Spanish.

opw-4708230
