### PR TITLE
[FIX] website: fixes translation issues

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -217,6 +217,7 @@ class Website(models.Model):
         websites.company_id._compute_website_id()
         for website in websites:
             website._bootstrap_homepage()
+            website._bootstrap_contactus()
 
         if not self.env.user.has_group('website.group_multi_website') and self.search_count([]) > 1:
             all_user_groups = 'base.group_portal,base.group_user,base.group_public'
@@ -837,6 +838,31 @@ class Website(models.Model):
         self.copy_menu_hierarchy(default_menu)
         home_menu = self.env['website.menu'].search([('website_id', '=', self.id), ('url', '=', '/')])
         home_menu.page_id = homepage_page
+
+    def _bootstrap_contactus(self):
+        Page = self.env['website.page']
+        standard_contactus = self.env.ref('website.contactus', raise_if_not_found=False)
+        if not standard_contactus:
+            return
+
+        new_contactus_view = self.env.ref('website.contactus').arch_db
+        standard_contactus.with_context(website_id=self.id).arch_db = new_contactus_view
+
+        contactus_page = Page.search([
+            ('website_id', '=', self.id),
+            ('key', '=', standard_contactus.key),
+        ], limit=1)
+        if not contactus_page:
+            contactus_page = Page.create({
+                'website_published': True,
+                'url': '/contactus',
+                'view_id': self.with_context(website_id=self.id).viewref('website.contactus').id,
+            })
+
+        contactus_page.url = '/contactus'
+
+        home_menu = self.env['website.menu'].search([('website_id', '=', self.id), ('url', '=', '/contactus')])
+        home_menu.page_id = contactus_page
 
     def copy_menu_hierarchy(self, top_menu):
         def copy_menu(menu, t_menu):


### PR DESCRIPTION
Issue: Tooltip not retaining translations

Steps to Reproduce :

- Have a website with English as main lang and French as second lang.
- Drop an image block and set a tooltip on it
- Save and translate the tooltip in French
- In english, save the block with the image
(to be able to reuse it elsewhere)
- When you drop the block in a website pages or event pages, the
tooltip keeps its translation, but if you drop it in the
/contactus page, the tooltip has no translation.

Before this PR:

- A saved custom snippet would not retain its translations when dropped
for the first time on the "Contact Us" page.

- This occurred because the `ir.ui.view` model had only one record for
`website.contactus` with `website_id=NULL`. When the snippet was
dropped, a new `ir.ui.view` record was created for `website_id=1`
(or the current website). During this process, only the English `jsonb`
content of the snippet was added to the `arch_db` field of `ir.ui.view`.

After this PR:

- The saved custom snippet now retains its translations when dropped
for the first time on the "Contact Us" page.

Task-4543654

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
