### PR TITLE
[FIX] calendar: ensure organizer receives invitation.ics attachment

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -99,7 +99,7 @@ class Attendee(models.Model):
     def _send_invitation_emails(self):
         """ Hook to be able to override the invitation email sending process.
          Notably inside appointment to use a different mail template from the appointment type. """
-        self._send_mail_to_attendees(
+        self.with_context(mail_notify_author=True)._send_mail_to_attendees(
             self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
         )
 

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -730,7 +730,7 @@ class Meeting(models.Model):
         current_attendees = self.filtered('active').attendee_ids
         if 'partner_ids' in values:
             # we send to all partners and not only the new ones
-            (current_attendees - previous_attendees)._send_mail_to_attendees(
+            (current_attendees - previous_attendees).with_context(mail_notify_author=True)._send_mail_to_attendees(
                 self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
             )
         if not self.env.context.get('is_calendar_event_new') and 'start' in values:
@@ -916,7 +916,7 @@ class Meeting(models.Model):
         email = self.env.user.email
         if email:
             for meeting in self:
-                meeting.attendee_ids._send_mail_to_attendees(
+                meeting.attendee_ids.with_context(mail_notify_author=True)._send_mail_to_attendees(
                     self.env.ref('calendar.calendar_template_meeting_invitation', raise_if_not_found=False)
                 )
         return True

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -544,6 +544,39 @@ class TestCalendar(SavepointCaseWithUserDemo):
         self.assertEqual(new_calendar_event.start_date, calendar_event.start_date, "Start date should match the original.")
         self.assertEqual(new_calendar_event.stop_date, calendar_event.stop_date, "Stop date should match the original.")
 
+    @freezegun.freeze_time('2025-04-16 10:00:00')
+    def test_event_creation_organizer_receives_ics(self):
+        """ Ensure that when the organizer is the only attendee, an .ics file is still sent via email """
+        internal_user = new_test_user(
+            self.env,
+            login='internal_organizer',
+            groups='base.group_user',
+            email='organizer@example.com'
+        )
+        organizer_partner = internal_user.partner_id
+
+        # Create the event as the internal user and make them the solo attendee
+        event = self.CalendarEvent.with_user(internal_user).create({
+            'name': 'Solo Organizer Event',
+            'start': '2025-04-20 10:00:00',
+            'stop': '2025-04-20 11:00:00',
+            'partner_ids': [(6, 0, [organizer_partner.id])],
+        })
+
+        # Find sent mail for the organizer-attendee
+        mail = self.env['mail.message'].sudo().search([
+            ('notified_partner_ids', 'in', organizer_partner.id),
+            ('model', '=', 'calendar.event'),
+            ('res_id', '=', event.id),
+        ], limit=1)
+
+        self.assertTrue(mail, "Expected a mail message to be sent to the organizer-attendee.")
+        self.assertEqual(mail.res_id, event.id, "The mail should be linked to the correct calendar event.")
+
+        ics_attachment = mail.attachment_ids.filtered(lambda a: a.name == 'invitation.ics')
+        self.assertTrue(ics_attachment, "Expected the email to include the 'invitation.ics' attachment.")
+
+
 @tagged('post_install', '-at_install')
 class TestCalendarTours(HttpCaseWithUserDemo):
     def test_calendar_month_view_start_hour_displayed(self):

--- a/addons/calendar/tests/test_event_notifications.py
+++ b/addons/calendar/tests/test_event_notifications.py
@@ -46,7 +46,10 @@ class TestEventNotifications(TransactionCase, MailCase, CronMixinCase):
 
 
     def test_message_invite_self(self):
-        with self.assertNoNotifications():
+        with self.assertSinglePostNotifications([{'partner': self.partner, 'type': 'inbox'}], {
+            'message_type': 'user_notification',
+            'subtype': 'mail.mt_note',
+        }):
             self.event.with_user(self.user).partner_ids = self.partner
 
     def test_message_inactive_invite(self):


### PR DESCRIPTION
Previously, when an internal user created a calendar event, the organizer
did not receive the `invitation.ics` file in the notification email.

This ensures that the `.ics` file is properly attached and accessible
to the organizer, improving the consistency of calendar invites and usability
for internal scheduling.

task-4573126


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
