### PR TITLE
[FIX] pos_hr: allow price control when not explicitly restricted

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -18,7 +18,7 @@ export class ProductInfoPopup extends Component {
     }
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser = this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier().role === "manager";
+        const isCashierManager = this.pos.get_cashier()._role === "manager";
         return isAccessibleToEveryUser || isCashierManager;
     }
     editProduct() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -962,7 +962,7 @@ export class PosStore extends Reactive {
      * @returns {name: string, id: int, role: string}
      */
     get_cashier() {
-        this.user.role = this.user.raw.role;
+        this.user._role = this.user.raw.role;
         return this.user;
     }
     get_cashier_user_id() {

--- a/addons/pos_hr/static/src/overrides/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_hr/static/src/overrides/screens/product_screen/order_summary/order_summary.js
@@ -5,7 +5,7 @@ import { patch } from "@web/core/utils/patch";
 
 patch(OrderSummary.prototype, {
     async setLinePrice(line, price) {
-        if (!this.pos.config.module_pos_hr || this.pos.employeeIsAdmin) {
+        if (this.pos.cashierHasPriceControlRights()) {
             await super.setLinePrice(line, price);
             return;
         }

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -143,3 +143,15 @@ registry.category("web_tour.tours").add("CashierCannotClose", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_basic_user_can_change_price", {
+    steps: () =>
+        [
+            Chrome.clickBtn("Open Register"),
+            PosHr.loginScreenIsShown(),
+            PosHr.clickLoginButton(),
+            SelectionPopup.has("Test Employee 3", { run: "click" }),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1", "10", "10"),
+        ].flat(),
+});

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -103,3 +103,20 @@ class TestUi(TestPosHrHttpCommon):
             "CashierCannotClose",
             login="pos_user",
         )
+
+    def test_basic_user_can_change_price(self):
+        self.main_pos_config.advanced_employee_ids = []
+        self.main_pos_config.basic_employee_ids = [
+            Command.link(self.emp3.id),
+            Command.link(self.admin.id)
+        ]
+        self.main_pos_config.write({
+            "restrict_price_control": False,
+        })
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+
+        self.start_tour(
+            "/pos/ui?config_id=%d" % self.main_pos_config.id,
+            "test_basic_user_can_change_price",
+            login="pos_user",
+        )


### PR DESCRIPTION
Before this commit, non-manager cashiers were unable to modify product prices even when price control was not enabled, which was not the intended behavior.

Additionally, when `pos_hr` was not installed, the `get_cashier` method returned the user object with a `role` attribute. However, when `pos_hr` was installed, the returned cashier used `_role`, leading to inconsistencies and broken functionality depending on the module's presence.

opw-4726098

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
