### PR TITLE
[IMP] mail: improved email log lines

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -588,12 +588,17 @@ class MailMail(models.Model):
                 if res:  # mail has been sent at least once, no major exception occurred
                     mail.write({'state': 'sent', 'message_id': res, 'failure_reason': False})
                     _logger.info(
-                        "Mail with ID %r and Message-Id %r from %r to (redacted) %r successfully sent",
+                        "Mail (mail.mail) with ID %r and Message-Id %r from %r to (redacted) %s successfully sent",
                         mail.id,
                         mail.message_id,
-                        tools.email_normalize(msg['from']),
-                        tools.mail.email_anonymize(tools.email_normalize(msg['to']))
+                        tools.email_normalize(msg['from']),  # FROM should not change, so last msg good enough
+                        ', '.join(
+                            repr(tools.mail.email_anonymize(tools.email_normalize(m['email_to'])))
+                            for m in email_list
+                        ),
                     )
+                    _logger.info("Total emails tried by SMTP: %s", len(email_list))
+
                     # /!\ can't use mail.state here, as mail.refresh() will cause an error
                     # see revid:odo@openerp.com-20120622152536-42b2s28lvdv3odyr in 6.1
                 mail._postprocess_sent_message(success_pids=success_pids, failure_type=failure_type)


### PR DESCRIPTION
# Context

Building on a recent PR (https://github.com/odoo/odoo/pull/188697), we introduce multiple small tweaks to enhance the life of support agents and system admins that work a lot with the log files in the the context of email related issues.

# Changes

* A given `mail.mail` record being processed by the `_send` method can end up sending multiple emails under the hood ( if `recipient_ids` points to muliple ids). This means that the ratio between one `mail.mail` record and the number of email sent through SMTP is not always 1:1. We added a new log line that counts the total emails processed in the loop which should give a more precise estimation of the real number of emails attempted through SMTP

* Given the above, we the usual log line was not reporting all the (redacted) list of email addresses but only the `email_to` of the last `msg` value created during the inner loops. We now correctly show a comma seperated list of all recipients in a given batch.

* The historical log line `Sent batch %s emails via mail server ID #%s` could be missleading as it was not counting the number of emails but the number of `mail.mail` records processed. It was reformulated to account for this.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
