### PR TITLE
[FIX] pos_hr: admin not set

### DIFF
--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -31,7 +31,7 @@ class HrEmployee(models.Model):
 
         employees = employees.read(fields, load=False)
         for employee in employees:
-            if employee['user_id'] and employee['user_id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
+            if employee['id'] in manager_ids or employee['id'] in data['pos.config']['data'][0]['advanced_employee_ids']:
                 role = 'manager'
             else:
                 role = 'cashier'

--- a/addons/pos_hr/static/tests/tours/pos_hr_tour.js
+++ b/addons/pos_hr/static/tests/tours/pos_hr_tour.js
@@ -139,7 +139,7 @@ registry.category("web_tour.tours").add("CashierCannotClose", {
             SelectionPopup.has("Mitchell Admin", { run: "click" }),
             Chrome.clickMenuButton(),
             {
-                trigger: negate(`span.dropdown-item:contains("Close Register")`),
+                trigger: `span.dropdown-item:contains("Close Register")`,
             },
         ].flat(),
 });

--- a/addons/pos_hr/tests/test_frontend.py
+++ b/addons/pos_hr/tests/test_frontend.py
@@ -64,7 +64,9 @@ class TestUi(TestPosHrHttpCommon):
                 (4, self.env.ref('account.group_account_invoice').id)
             ]
         })
-        self.main_pos_config.advanced_employee_ids = self.admin.ids
+        self.main_pos_config.update({
+            'advanced_employee_ids': [(6, 0, self.admin.ids)],
+        })
         self.main_pos_config.with_user(self.pos_admin).open_ui()
         self.start_pos_tour("PosHrTour", login="pos_admin")
 
@@ -94,7 +96,6 @@ class TestUi(TestPosHrHttpCommon):
         self.main_pos_config.advanced_employee_ids = []
         self.main_pos_config.basic_employee_ids = [
             Command.link(self.emp3.id),
-            Command.link(self.admin.id)
         ]
         self.main_pos_config.with_user(self.pos_admin).open_ui()
 


### PR DESCRIPTION
Before this commit, when opening a pos without admin employees set, the user was blocked into its open session without being able to close it.

task-id: 4730841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
