### PR TITLE
[FIX] test_performance: iteration (non-deterministic)

### DIFF
--- a/odoo/addons/test_performance/tests/test_timeit.py
+++ b/odoo/addons/test_performance/tests/test_timeit.py
@@ -160,7 +160,7 @@ class TestPerformanceTimeit(TransactionCase):
         self.launch_perf_set("records.child_ids", record_list=record_list)
 
     def test_perf_access_iter(self):
-        self.launch_perf_set("list(records)")
+        self.launch_perf_set("list(records)", number=100, check_type='maybe-linear')
 
     def test_perf_as_query(self):
         self.launch_perf_set("records._as_query()", number=100)


### PR DESCRIPTION
Avoid raising errors on performance of iterators. These have been optimized for smaller sets and thus may get a more skewed time progression resulting in a non-linear behaviour.
Therefore, we disable that behaviour and try with more iterations to have better stability in results.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
