### PR TITLE
[FIX] hr_recruitment: remove the restriction to show the chatter button

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -463,7 +463,7 @@ class Applicant(models.Model):
 
     @api.model
     def get_view(self, view_id=None, view_type='form', **options):
-        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer'):
+        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer, !hr_recruitment.group_hr_recruitment_manager, !hr_recruitment.group_hr_recruitment_user'):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
         return super().get_view(view_id, view_type, **options)
 

--- a/addons/hr_recruitment/static/src/views/form_view.js
+++ b/addons/hr_recruitment/static/src/views/form_view.js
@@ -14,11 +14,8 @@ export class InterviewerFormController extends FormController {
     get className() {
         const result = super.className;
         const root = this.model.root;
-        if (!root.data.interviewer_ids || !root.data.user_id) {
-            return result;
-        }
-        result["o_applicant_interviewer_form"] = root.data.interviewer_ids.records.findIndex(
-            interviewer => interviewer.data.id === session.uid) > -1;
+        if (!root.data.user_id || root.data.user_id[0] !== session.uid)
+            result["o_applicant_interviewer_form"] = true;
         return result;
     }
 }


### PR DESCRIPTION
**Problem:**
The chatter buttons 'Send Message' and 'Log Note' are not shown in some cases: 
In version 16:
- If a user has only recruitment interviewer rights, and an admin user is assigned to him as an interviewer in the application, then the interviewer user can't see the chatter button.(https://github.com/odoo/odoo/commit/73c7cbc45fe23f759907446fb4a67180ac9c00e2) 

In version 17+:
- In a recruitment application,  if the user is set as an interviewer and recruitment both, then the chatter button will disappear to show. (https://github.com/odoo/odoo/commit/9fea777691c9c80c86ecde769fe35d4d0e552655)

**Solution:**
- Removed all conditions to show 'Send Message' and 'Log Note' buttons.

opw-[4660071](https://www.odoo.com/odoo/project/49/tasks/4660071)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
