### PR TITLE
[IMP] hw_drivers: disable linux routes on virtual iot boxes

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -99,7 +99,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully cleared credentials',
         })
 
-    @route.iot_route('/hw_posbox_homepage/wifi_clear', type='http', cors='*')
+    @route.iot_route('/hw_posbox_homepage/wifi_clear', type='http', cors='*', linux_only=True)
     def clear_wifi_configuration(self):
         helpers.update_conf({'wifi_ssid': '', 'wifi_password': ''})
         wifi.disconnect()
@@ -183,14 +183,14 @@ class IotBoxOwlHomePage(http.Controller):
             'qr_code_url' : network_qr_codes.get('qr_url'),
         })
 
-    @route.iot_route('/hw_posbox_homepage/wifi', type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/wifi', type="http", cors='*', linux_only=True)
     def get_available_wifi(self):
         return json.dumps({
             'currentWiFi': wifi.get_current(),
             'availableWiFi': wifi.get_available_ssids(),
         })
 
-    @route.iot_route('/hw_posbox_homepage/version_info', type="http", cors='*')
+    @route.iot_route('/hw_posbox_homepage/version_info', type="http", cors='*', linux_only=True)
     def get_version_info(self):
         git = ["git", "--work-tree=/home/pi/odoo/", "--git-dir=/home/pi/odoo/.git"]
         # Check branch name and last commit hash on IoT Box
@@ -277,7 +277,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Successfully saved credentials',
         }
 
-    @route.iot_route('/hw_posbox_homepage/update_wifi', type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_wifi', type="jsonrpc", methods=['POST'], cors='*', linux_only=True)
     def update_wifi(self, essid, password):
         if wifi.reconnect(essid, password, force_update=True):
             helpers.update_conf({'wifi_ssid': essid, 'wifi_password': password})
@@ -299,13 +299,15 @@ class IotBoxOwlHomePage(http.Controller):
 
         return res_payload
 
-    @route.iot_route('/hw_posbox_homepage/generate_password', type="jsonrpc", methods=["POST"], cors='*', sign=True)
+    @route.iot_route(
+        '/hw_posbox_homepage/generate_password', type="jsonrpc", methods=["POST"], cors='*', sign=True, linux_only=True
+    )
     def generate_password(self):
         return {
             'password': helpers.generate_password(),
         }
 
-    @route.iot_route('/hw_posbox_homepage/enable_ngrok', type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/enable_ngrok', type="jsonrpc", methods=['POST'], cors='*', linux_only=True)
     def enable_remote_connection(self, auth_token):
         if subprocess.call(['pgrep', 'ngrok']) == 1:
             subprocess.Popen(['sudo', 'systemd-run', 'ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
@@ -316,7 +318,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Ngrok tunnel is now enabled',
         }
 
-    @route.iot_route('/hw_posbox_homepage/update_hostname', type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_hostname', type="jsonrpc", methods=['POST'], cors='*', linux_only=True)
     def update_hostname(self, hostname):
         """Update the hostname of the IoT Box.
 
@@ -412,7 +414,7 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'Logger level updated',
         }
 
-    @route.iot_route('/hw_posbox_homepage/update_git_tree', type="jsonrpc", methods=['POST'], cors='*')
+    @route.iot_route('/hw_posbox_homepage/update_git_tree', type="jsonrpc", methods=['POST'], cors='*', linux_only=True)
     def update_git_tree(self):
         helpers.check_git_branch()
         return {

--- a/addons/hw_posbox_homepage/controllers/main.py
+++ b/addons/hw_posbox_homepage/controllers/main.py
@@ -20,7 +20,7 @@ class IoTboxHomepage(Home):
     def clean_partition(self):
         subprocess.check_call(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; cleanup'])
 
-    @route.iot_route('/hw_proxy/perform_upgrade', type='http')
+    @route.iot_route('/hw_proxy/perform_upgrade', type='http', linux_only=True)
     def perform_upgrade(self):
         self.updating.acquire()
         os.system('/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh')
@@ -31,7 +31,7 @@ class IoTboxHomepage(Home):
     def check_version(self):
         return helpers.get_version()
 
-    @route.iot_route('/hw_proxy/perform_flashing_create_partition', type='http')
+    @route.iot_route('/hw_proxy/perform_flashing_create_partition', type='http', linux_only=True)
     def perform_flashing_create_partition(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; create_partition']).decode().split('\n')[-2]
@@ -44,7 +44,7 @@ class IoTboxHomepage(Home):
             _logger.exception("Flashing create partition failed")
             return Response(str(e), status=500)
 
-    @route.iot_route('/hw_proxy/perform_flashing_download_raspios', type='http')
+    @route.iot_route('/hw_proxy/perform_flashing_download_raspios', type='http', linux_only=True)
     def perform_flashing_download_raspios(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; download_raspios']).decode().split('\n')[-2]
@@ -58,7 +58,7 @@ class IoTboxHomepage(Home):
             _logger.exception("Flashing download raspios failed")
             return Response(str(e), status=500)
 
-    @route.iot_route('/hw_proxy/perform_flashing_copy_raspios', type='http')
+    @route.iot_route('/hw_proxy/perform_flashing_copy_raspios', type='http', linux_only=True)
     def perform_flashing_copy_raspios(self):
         try:
             response = subprocess.check_output(['sudo', 'bash', '-c', '. /home/pi/odoo/addons/iot_box_image/configuration/upgrade.sh; copy_raspios']).decode().split('\n')[-2]


### PR DESCRIPTION
This commit adds a new parameter (`linux_only`) for `iot_route`, to disallow an endpoint on Virtual IoT Boxes. If the route is linux-only but called on a Windows machine, it will now return a 403 (Forbidden) error.

Task: 4717189
