### PR TITLE
[FIX] test_performance: non-deterministic results

### DIFF
--- a/odoo/addons/test_performance/tests/test_timeit.py
+++ b/odoo/addons/test_performance/tests/test_timeit.py
@@ -94,7 +94,7 @@ class TestPerformanceTimeit(TransactionCase):
         code: str, *,
         record_list: list[BaseModel] | None = None,
         relative_size: list[int] | None = None,
-        check_type: Literal['linear', 'maybe-linear', None] = 'linear',
+        check_type: Literal['linear', 'maybe-linear'] | None = 'linear',
         number: int = 4,
         repeat: int = 3,
         **kw,
@@ -157,7 +157,7 @@ class TestPerformanceTimeit(TransactionCase):
             p.with_context(active_test=True)
             for p in self.get_parents()
         ]
-        self.launch_perf_set("records.child_ids", record_list=record_list)
+        self.launch_perf_set("records.child_ids", record_list=record_list, check_type='maybe-linear')
 
     def test_perf_access_iter(self):
         self.launch_perf_set("list(records)")
@@ -166,7 +166,7 @@ class TestPerformanceTimeit(TransactionCase):
         self.launch_perf_set("records._as_query()", number=100)
 
     def test_perf_exists(self):
-        self.launch_perf_set("records.exists()")
+        self.launch_perf_set("records.exists()", check_type='maybe-linear')
 
     def test_perf_search_query(self):
         self.launch_perf("records._search([])", self.Model)
@@ -181,7 +181,7 @@ class TestPerformanceTimeit(TransactionCase):
 
     def test_perf_domain_filtered(self):
         for domain in self.example_domains:
-            self.launch_perf_set(f"records.filtered_domain({domain!r})", repeat=2)
+            self.launch_perf_set(f"records.filtered_domain({domain!r})", repeat=2, check_type='maybe-linear')
 
     def test_perf_xxlarge_domain(self):
 


### PR DESCRIPTION
Some of the tests are not deterministic on the runbot. Avoid raising errors in these cases.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
