### PR TITLE
[FIX] hr_holidays: test ACLs

### DIFF
--- a/addons/hr_holidays/tests/test_dashboard.py
+++ b/addons/hr_holidays/tests/test_dashboard.py
@@ -7,7 +7,7 @@ class TestDashboard(TestHrHolidaysCommon):
     def test_dashboard_special_days(self):
         self.env.user = self.user_hrmanager
         employee = self.env.user.employee_id
-        other_calendar = self.env['resource.calendar'].create({
+        other_calendar = self.env['resource.calendar'].sudo().create({
             'name': 'Other calendar',
         })
 


### PR DESCRIPTION
Creating a `resource.calendar` record requirest the settings group. This is only necessary for the setup of this test, so just create it in `sudo` (afterwards the calendar is only referenced to create events).

https://runbot.odoo.com/odoo/error/145744
