### PR TITLE
[IMP] mail,*: chatter live update

### DIFF
--- a/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
+++ b/addons/bus/static/tests/mock_server/mock_models/ir_websocket.js
@@ -27,6 +27,20 @@ export class IrWebSocket extends models.ServerModel {
         if (authenticatedPartner) {
             channels.push(authenticatedPartner);
         }
-        return channels;
+        return channels.map((c) => {
+            if (typeof c !== "string") {
+                return c;
+            }
+            const match = c.match(/^model-([-_\w.]+)_(\d+)$/);
+            if (!match) {
+                return c;
+            }
+            const [, modelName, id] = match;
+            const model = this.env[modelName];
+            if (!model) {
+                console.error(`Model ${modelName} not found`);
+            }
+            return model.search_read([["id", "=", Number(id)]])[0];
+        });
     }
 }

--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -31,7 +31,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=471):  # crm 605 / com 605 / ent 605
+        with self.assertQueryCount(user_sales_manager=523):  # crm 605 / com 605 / ent 605
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=False)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert | self.sales_team_1)
@@ -49,7 +49,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
         with self.assertQueryCount(user_sales_manager=0):
             test_leads = self.env['crm.lead'].browse(test_leads.ids)
 
-        with self.assertQueryCount(user_sales_manager=450):  # crm 544 / com 546 / ent 585
+        with self.assertQueryCount(user_sales_manager=477):  # crm 544 / com 546 / ent 585
             test_leads._handle_salesmen_assignment(user_ids=user_ids, team_id=team_id)
 
         self.assertEqual(test_leads.team_id, self.sales_team_convert)

--- a/addons/hr_holidays/tests/test_res_partner.py
+++ b/addons/hr_holidays/tests/test_res_partner.py
@@ -59,6 +59,7 @@ class TestPartner(TransactionCase):
     @freeze_time('2024-06-04')
     def test_res_partner_to_store(self):
         self.leaves.write({'state': 'validate'})
+        self.env.invalidate_all()  # No dependencies on hr.leave in res.partner, so we need to invalidate the cache manually
         self.assertEqual(
             Store(self.partner).get_result()["res.partner"][0]["leave_date_to"],
             fields.Date.to_string(self.today + relativedelta(days=2)),

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -48,7 +48,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
     @users('__system__', 'admin')
     @warmup
     def test_performance_leave_create(self):
-        with self.assertQueryCount(__system__=53, admin=53):
+        with self.assertQueryCount(__system__=60, admin=60):
             leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
         leave.action_refuse()
 

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -82,4 +82,7 @@ patch(Thread.prototype, {
         }
         return super.getPersonaName(persona);
     },
+    get subscribeToBusOnDisplay() {
+        return this.channel_type !== "livechat" && super.subscribeToBusOnDisplay;
+    },
 });

--- a/addons/mail/models/__init__.py
+++ b/addons/mail/models/__init__.py
@@ -1,5 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 # core models (required for mixins)
 from . import mail_alias
 from . import mail_alias_domain

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -386,7 +386,7 @@ class MailActivityMixin(models.AbstractModel):
 
         return self.env['mail.activity'].search(domain)
 
-    def activity_schedule(self, act_type_xmlid='', date_deadline=None, summary='', note='', **act_values):
+    def activity_schedule(self, act_type_xmlid='', date_deadline=None, summary='', note='', to_be_done=False, **act_values):
         """ Schedule an activity on each record of the current record set.
         This method allow to provide as parameter act_type_xmlid. This is an
         xml_id of activity type instead of directly giving an activity_type_id.
@@ -432,7 +432,10 @@ class MailActivityMixin(models.AbstractModel):
             if not create_vals.get('user_id') and activity_type.default_user_id:
                 create_vals['user_id'] = activity_type.default_user_id.id
             create_vals_list.append(create_vals)
-        return self.env['mail.activity'].create(create_vals_list)
+        activities = self.env['mail.activity'].create(create_vals_list)
+        if not to_be_done:
+            activities._notify_activity_thread(unlink=False)
+        return activities
 
     def _activity_schedule_with_view(self, act_type_xmlid='', date_deadline=None, summary='', views_or_xmlid='', render_context=None, **act_values):
         """ Helper method: Schedule an activity on each record of the current record set.

--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -481,6 +481,7 @@ GROUP BY fol.id%s%s""" % (
             ])
         for fol_id, values in upd.items():
             sudo_self.browse(fol_id).write(values)
+        return new
 
     def _add_default_followers(self, res_model, res_ids, partner_ids, customer_ids=None,
                                check_existing=True, existing_policy='skip'):

--- a/addons/mail/models/mail_link_preview.py
+++ b/addons/mail/models/mail_link_preview.py
@@ -96,7 +96,7 @@ class MailLinkPreview(models.Model):
             ]
         )
         (message.sudo().message_link_preview_ids - message_link_previews_ok)._unlink_and_notify()
-        message._bus_send_store(message, "message_link_preview_ids")
+        self.env.user._bus_send_store(message, "message_link_preview_ids")
 
     @api.model
     def _is_link_preview_enabled(self):

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -13,7 +13,7 @@ class ResPartner(models.Model):
     """ Update partner to add a field about notification preferences. Add a generic opt-out field that can be used
        to restrict usage of automatic email templates. """
     _name = 'res.partner'
-    _inherit = ['res.partner', 'mail.activity.mixin', 'mail.thread.blacklist']
+    _inherit = ['mail.thread.blacklist', 'res.partner', 'mail.activity.mixin']
     _mail_flat_thread = False
 
     # override to add and order tracking

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -4,6 +4,7 @@ import { Thread } from "@mail/core/common/thread";
 import {
     Component,
     onMounted,
+    onWillDestroy,
     onWillUpdateProps,
     useChildSubEnv,
     useRef,
@@ -51,6 +52,9 @@ export class Chatter extends Component {
                 this.load(this.state.thread, this.requestList);
             }
         });
+        onWillDestroy(() => {
+            this.cleanDisplayed();
+        });
     }
 
     get afterPostRequestList() {
@@ -69,7 +73,14 @@ export class Chatter extends Component {
         return [];
     }
 
+    cleanDisplayed() {
+        if (this.state.thread) {
+            this.state.thread.chatterDisplayed = false;
+        }
+    }
+
     changeThread(threadModel, threadId) {
+        this.cleanDisplayed();
         this.state.thread = this.store.Thread.insert({ model: threadModel, id: threadId });
         if (threadId === false) {
             if (this.state.thread.messages.length === 0) {
@@ -85,6 +96,7 @@ export class Chatter extends Component {
                 });
             }
         }
+        this.state.thread.chatterDisplayed = true;
     }
 
     /**
@@ -115,8 +127,6 @@ export class Chatter extends Component {
 
     onPostCallback() {
         this.state.jumpThreadPresent++;
-        // Load new messages to fetch potential new messages from other users (useful due to lack of auto-sync in chatter).
-        this.load(this.state.thread, this.afterPostRequestList);
     }
 
     onScroll() {

--- a/addons/mail/static/src/core/web/mail_core_common_service_patch.js
+++ b/addons/mail/static/src/core/web/mail_core_common_service_patch.js
@@ -2,6 +2,11 @@ import { patch } from "@web/core/utils/patch";
 import { MailCoreCommon } from "@mail/core/common/mail_core_common_service";
 
 patch(MailCoreCommon.prototype, {
+    async _handleNotificationNewMessage(...args) {
+        // initChannelsUnreadCounter becomes unreliable
+        await this.store.channels.fetch();
+        return super._handleNotificationNewMessage(...args);
+    },
     _handleNotificationToggleStar(payload, metadata) {
         super._handleNotificationToggleStar(payload, metadata);
         const { id: notifId } = metadata;

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -237,6 +237,15 @@ const threadPatch = {
     get showCorrespondentCountry() {
         return false;
     },
+    get busChannel() {
+        if (this.model === "discuss.channel") {
+            return `discuss.channel_${this.id}`;
+        }
+        return super.busChannel;
+    },
+    get subscribeToBusOnDisplay() {
+        return this.model !== "discuss.channel" && super.subscribeToBusOnDisplay;
+    },
     /** @returns {import("models").ChannelMember} */
     computeCorrespondent() {
         if (this.channel_type === "channel") {

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -474,6 +474,22 @@ export class MailThread extends models.ServerModel {
                     );
                 }
             }
+        } else {
+            // chatter notification
+            const threads = this.env[this._name].browse(message.res_id);
+            for (const thread of threads) {
+                notifications.push([
+                    thread,
+                    "mail.message/new",
+                    {
+                        data: new mailDataHelpers.Store(
+                            MailMessage.browse(message_id)
+                        ).get_result(),
+                        id: thread.id,
+                        temporary_id,
+                    },
+                ]);
+            }
         }
         if (message.partner_ids) {
             for (const partner_id of message.partner_ids) {

--- a/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
+++ b/addons/mail/static/tests/scheduled_message/scheduled_message.test.js
@@ -2,7 +2,6 @@ import {
     click,
     contains,
     defineMailModels,
-    insertText,
     openFormView,
     start,
     startServer,
@@ -282,29 +281,6 @@ test("Scheduling a message", async () => {
     await click(".o-mail-Composer button[title='Open Full Composer']");
     await contains(".o-mail-Scheduled-Message");
     await contains(".o-mail-Message-body", { text: "New scheduled message" });
-});
-
-test("New scheduled message is loaded when sending a message", async () => {
-    const pyEnv = await startServer();
-    const partnerId = pyEnv.user.partner_id;
-    await start();
-    await openFormView("res.partner", partnerId);
-    await contains(".o-mail-Chatter");
-    await contains(".o-mail-ScheduledMessagesList", { count: 0 });
-    pyEnv["mail.scheduled.message"].create({
-        author_id: pyEnv["res.partner"].create({ name: "Julien Dragoul" }),
-        body: "Hello",
-        model: "res.partner",
-        res_id: partnerId,
-        scheduled_date: "2024-10-20 12:00:00",
-    });
-    await click(".o-mail-Chatter-logNote");
-    await contains(".o-mail-Composer");
-    await insertText(".o-mail-Composer-input", "Bloups");
-    await click(".o-mail-Composer button", { text: "Log" });
-    await contains(".o-mail-ScheduledMessagesList");
-    await contains(".o-mail-Message-author", { text: "Julien Dragoul" });
-    await contains(".o-mail-Message-body", { text: "Hello" });
 });
 
 test("Scheduled messages are updated when switching records", async () => {

--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -382,9 +382,9 @@ class MailActivitySchedule(models.TransientModel):
         self._action_schedule_activities()
 
     def action_schedule_activities_done(self):
-        self._action_schedule_activities().action_done()
+        self._action_schedule_activities(to_be_done=True).action_done()
 
-    def _action_schedule_activities(self):
+    def _action_schedule_activities(self, to_be_done=False):
         if not self.res_model:
             return self._action_schedule_activities_personal()
         return self._get_applied_on_records().activity_schedule(
@@ -393,7 +393,8 @@ class MailActivitySchedule(models.TransientModel):
             summary=self.summary,
             note=self.note,
             user_id=self.activity_user_id.id,
-            date_deadline=self.date_deadline
+            date_deadline=self.date_deadline,
+            to_be_done=to_be_done,
         )
 
     def _action_schedule_activities_personal(self):

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -545,7 +545,7 @@ class TestCommon(HttpCase):
         for k, v in dict1.items():
             self.assertEqual(v, dict2.get(k), f"'{k}' mismatch")
 
-    def call_post_commit_hooks(self):
+    def call_post_commit_hooks(self, skip_notify=False):
         """
         manually calls postcommit hooks defined with the decorator @after_commit
         """
@@ -555,4 +555,6 @@ class TestCommon(HttpCase):
         funcs = self.env.cr.postcommit._funcs.copy()
         while funcs:
             func = funcs.popleft()
+            if skip_notify and func.__name__ == "notify":
+                continue
             func()

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -368,7 +368,7 @@ class TestCreateEvents(TestCommon):
             self.organizer_user.with_user(self.organizer_user).sudo().restart_microsoft_synchronization()
             # Sync microsoft calendar, considering that ten minutes were passed after the event creation.
             self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
-            self.call_post_commit_hooks()
+            self.call_post_commit_hooks(skip_notify=True)
             event.invalidate_recordset()
 
             # Assert that insert function was not called and check last_sync_date variable value.
@@ -389,7 +389,7 @@ class TestCreateEvents(TestCommon):
         event.write({
             "name": "New event name"
         })
-        self.call_post_commit_hooks()
+        self.call_post_commit_hooks(skip_notify=True)
 
         # Prepare mock for new synchronization.
         event_id = "123"
@@ -399,7 +399,7 @@ class TestCreateEvents(TestCommon):
 
         # Synchronize local event with Outlook after updating it locally.
         self.organizer_user.with_user(self.organizer_user).sudo()._sync_microsoft_calendar()
-        self.call_post_commit_hooks()
+        self.call_post_commit_hooks(skip_notify=True)
         event.invalidate_recordset()
 
         # Assert that the event got synchronized with Microsoft (through mock).

--- a/addons/test_mail/tests/__init__.py
+++ b/addons/test_mail/tests/__init__.py
@@ -14,6 +14,7 @@ from . import test_mail_composer_mixin
 from . import test_mail_followers
 from . import test_mail_gateway
 from . import test_mail_flow
+from . import test_mail_ir_websocket
 from . import test_mail_mail
 from . import test_mail_management
 from . import test_mail_message

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -65,6 +65,9 @@ class TestActivityRights(TestActivityCommon):
             with self.subTest(user=activity.user_id.name, creator=activity.create_uid.name):
                 # no document access -> based on create_uid / user_id
                 with patch.object(MailTestActivity, '_check_access', autospec=True, side_effect=_employee_crash):
+                    # invalidate model to force _check_access
+                    # otherwise some residual access rights are kept in cache from the setup
+                    activity.invalidate_model()
                     activity = activity.with_user(self.user_employee)
                     self.assertEqual(activity.can_write, can_write)
                     if can_write:

--- a/addons/test_mail/tests/test_mail_ir_websocket.py
+++ b/addons/test_mail/tests/test_mail_ir_websocket.py
@@ -1,0 +1,67 @@
+import json
+from odoo.tests import new_test_user, tagged
+from odoo.addons.bus.tests.common import WebsocketCase
+from odoo.addons.bus.models.bus import channel_with_db, json_dump
+
+
+@tagged("-at_install", "post_install")
+class TestIrWebsocket(WebsocketCase):
+    def test_chatter_channel_list(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        session = self.authenticate("bob_user", "bob_user")
+        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
+        test_mail = self.env["mail.test.simple"].create({
+            "name": "Test",
+            "email_from": "tutu@test.com",
+        })
+        self.subscribe(
+            websocket,
+            [f"model-{test_mail._name}_{test_mail.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        test_mail.message_post(
+            body="Test message",
+            message_type="comment",
+            subtype_id=self.env.ref("mail.mt_comment").id,
+            author_id=bob.partner_id.id,
+        )
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.trigger_notification_dispatching([(test_mail, "thread"), (test_mail, "thread-internal")])
+        notifications = json.loads(websocket.recv())
+        message_notifications = [notification for notification in notifications if notification["message"]["type"] == "mail.message/new"]
+        self.assertEqual(len(message_notifications), 1)
+        notification = message_notifications[0]
+        self._close_websockets()
+        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
+        self.assertEqual(bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, (test_mail, "thread"))))
+        self.assertEqual(notification["message"]["type"], "mail.message/new")
+
+    def test_chatter_channel_list_internal(self):
+        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
+        session = self.authenticate("bob_user", "bob_user")
+        websocket = self.websocket_connect(cookie=f"session_id={session.sid};")
+        test_mail = self.env["mail.test.simple"].create({
+            "name": "Test",
+            "email_from": "tutu@test.com",
+        })
+        self.subscribe(
+            websocket,
+            [f"model-{test_mail._name}_{test_mail.id}"],
+            self.env["bus.bus"]._bus_last_id(),
+        )
+        test_mail.message_post(
+            body="Test message",
+            message_type="comment",
+            subtype_id=self.env.ref("mail.mt_note").id,
+            author_id=bob.partner_id.id,
+        )
+        self.env.cr.precommit.run()  # trigger the creation of bus.bus records
+        self.trigger_notification_dispatching([(test_mail, "thread"), (test_mail, "thread-internal")])
+        notifications = json.loads(websocket.recv())
+        message_notifications = [notification for notification in notifications if notification["message"]["type"] == "mail.message/new"]
+        self.assertEqual(len(message_notifications), 1)
+        notification = message_notifications[0]
+        self._close_websockets()
+        bus_record = self.env["bus.bus"].search([("id", "=", int(notification["id"]))])
+        self.assertEqual(bus_record.channel, json_dump(channel_with_db(self.env.cr.dbname, (test_mail, "thread-internal"))))
+        self.assertEqual(notification["message"]["type"], "mail.message/new")

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -258,7 +258,11 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
         """Test mentioning a partner with no common company."""
         test_records_mc_c2 = self.test_records_mc[1]
         self._reset_bus()
-        with self.assertBus([(self.cr.dbname, "res.partner", self.user_employee_c3.partner_id.id)]):
+        with self.assertBus([
+            (self.cr.dbname, "mail.test.multi.company", test_records_mc_c2.id, "thread-internal"),  # update followers in thread
+            (self.cr.dbname, "mail.test.multi.company", test_records_mc_c2.id, "thread"),  # add message to thread
+            (self.cr.dbname, "res.partner", self.user_employee_c3.partner_id.id)  # add message to inbox per user
+        ]):
             test_records_mc_c2.with_user(self.user_employee_c2).with_context(
                 allowed_company_ids=self.company_2.ids
             ).message_post(

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -1132,6 +1132,30 @@ class TestChatterTweaks(ThreadRecipients):
 
 
 @tagged('mail_thread')
+class TestChatterBus(MailCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_portal = cls._create_portal_user()
+        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+
+    def test_sync_chatter_receive_message_by_bus(self):
+        with self.assertBus([(self.cr.dbname, "mail.test.simple", self.test_record.id, "thread")]):
+            self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_comment')
+
+    def test_sync_chatter_note_no_external_notification(self):
+        with self.assertNotInBus([(self.cr.dbname, "mail.test.simple", self.test_record.id, "thread")]):
+            self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_note')
+
+    def test_sync_chatter_receive_note_by_bus(self):
+        with self.assertBus(
+            [(self.cr.dbname, "mail.test.simple", self.test_record.id, "thread-internal")],
+        ):
+            self.test_record.message_post(body='Test', message_type='comment', subtype_xmlid='mail.mt_note')
+
+
+@tagged('mail_thread')
 class TestDiscuss(MailCommon, TestRecipients):
 
     @classmethod

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -962,8 +962,8 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
                 partner_ids=[self.partner_employee_2.id],
             )
 
-        self.assertEqual(mock_compute_subject.call_count, 1,
-                         'Should call model-based subject computation for outgoing emails')
+        self.assertEqual(mock_compute_subject.call_count, 2,
+                         'Should call model-based subject computation for outgoing emails and bus notifications')
         self.assertEqual(mock_notify_headers.call_count, 1,
                          'Should call model-based headers computation for outgoing emails')
         self.assertEqual(mock_notify_mailvals.call_count, 1,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -343,8 +343,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             # voip module read activity_type during create leading to one less query in enterprise on action_feedback
             _category = activity.activity_type_id.category
 
-        with self.assertQueryCount(admin=9, employee=8):  # tm: 6 / 6
-
+        with self.assertQueryCount(admin=18, employee=17):  # tm: 10 / 10
             activity.action_feedback(feedback='Zizisse Done !')
 
     @warmup
@@ -371,7 +370,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_activity_mixin(self):
         record = self.env['mail.test.activity'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=15, employee=13):
             activity = record.action_start('Test Start')
             # read activity_type to normalize cache between enterprise and community
             # voip module read activity_type during create leading to one less query in enterprise on action_close
@@ -379,7 +378,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=10, employee=9):  # tm: 7 / 7
+        with self.assertQueryCount(admin=16, employee=15):  # tm: 11 / 11
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])
@@ -397,7 +396,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             for values in self.test_attachments_vals
         ])
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=15, employee=13):
             activity = record.action_start('Test Start')
             #read activity_type to normalize cache between enterprise and community
             #voip module read activity_type during create leading to one less query in enterprise on action_close
@@ -405,7 +404,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        with self.assertQueryCount(admin=12, employee=11):  # tm: 9 / 9
+        with self.assertQueryCount(admin=19, employee=18):  # tm 12 / 12
             record.action_close('Dupe feedback', attachment_ids=attachments.ids)
 
         # notifications
@@ -431,7 +430,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=33, employee=33):
+        with self.assertQueryCount(admin=42, employee=40):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -452,7 +451,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer.id)],
             })
 
-        with self.assertQueryCount(admin=35, employee=35):
+        with self.assertQueryCount(admin=44, employee=42):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -476,7 +475,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 composer_form.attachment_ids.add(attachment)
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=51, employee=51):  # tm 50/50
+        with self.assertQueryCount(admin=60, employee=58):  # tm 50/50
             composer._action_send_mail()
 
         # notifications
@@ -521,7 +520,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'partner_ids': [(4, customer_id)],
             })
 
-        with self.assertQueryCount(admin=33, employee=33):
+        with self.assertQueryCount(admin=42, employee=40):
             composer._action_send_mail()
 
     @users('admin', 'employee')
@@ -539,7 +538,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=34, employee=34):
+        with self.assertQueryCount(admin=43, employee=41):
             composer._action_send_mail()
 
         # notifications
@@ -566,7 +565,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=44, employee=44):
+        with self.assertQueryCount(admin=53, employee=51):
             composer._action_send_mail()
 
         # notifications
@@ -598,7 +597,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=47, employee=47):
+        with self.assertQueryCount(admin=57, employee=55):
             composer._action_send_mail()
 
         # notifications
@@ -628,7 +627,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             )
             composer = composer_form.save()
 
-        with self.assertQueryCount(admin=67, employee=67):
+        with self.assertQueryCount(admin=77, employee=75):
             composer._action_send_mail()
 
         # notifications
@@ -655,7 +654,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=39, employee=38):
+        with self.assertQueryCount(admin=43, employee=42):
             record.write({
                 'user_id': self.user_emp_email.id,
             })
@@ -664,7 +663,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=20, employee=19):
+        with self.assertQueryCount(admin=22, employee=21):
             record.write({
                 'user_id': self.user_emp_inbox.id,
             })
@@ -714,7 +713,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_log_with_post(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=11, employee=11):
             record.message_post(
                 body=Markup('<p>Test message_post as log</p>'),
                 subtype_xmlid='mail.mt_note',
@@ -725,7 +724,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_no_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=13, employee=13):
             record.message_post(
                 body=Markup('<p>Test Post Performances basic</p>'),
                 partner_ids=[],
@@ -738,7 +737,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_one_email_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=29, employee=29):
+        with self.assertQueryCount(admin=33, employee=33):
             record.message_post(
                 body=Markup('<p>Test Post Performances with an email ping</p>'),
                 partner_ids=self.customer.ids,
@@ -750,7 +749,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_post_one_inbox_notification(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=17, employee=17):
+        with self.assertQueryCount(admin=19, employee=19):
             record.message_post(
                 body=Markup('<p>Test Post Performances with an inbox ping</p>'),
                 partner_ids=self.user_emp_inbox.partner_id.ids,
@@ -763,10 +762,10 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_message_subscribe_default(self):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
 
-        with self.assertQueryCount(admin=6, employee=6):
+        with self.assertQueryCount(admin=14, employee=14):
             record.message_subscribe(partner_ids=self.user_emp_inbox.partner_id.ids)
 
-        with self.assertQueryCount(admin=3, employee=3):
+        with self.assertQueryCount(admin=6, employee=6):
             record.message_subscribe(partner_ids=self.user_emp_inbox.partner_id.ids)
 
     @mute_logger('odoo.models.unlink')
@@ -776,10 +775,10 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         record = self.env['mail.test.simple'].create({'name': 'Test'})
         subtype_ids = (self.env.ref('test_mail.st_mail_test_simple_external') | self.env.ref('mail.mt_comment')).ids
 
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=13, employee=13):
             record.message_subscribe(partner_ids=self.user_emp_inbox.partner_id.ids, subtype_ids=subtype_ids)
 
-        with self.assertQueryCount(admin=2, employee=2):
+        with self.assertQueryCount(admin=5, employee=5):
             record.message_subscribe(partner_ids=self.user_emp_inbox.partner_id.ids, subtype_ids=subtype_ids)
 
     @mute_logger('odoo.models.unlink')
@@ -1019,7 +1018,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         record = self.container.with_user(self.env.user)
 
         # about 20 (19?) queries per additional customer group
-        with self.assertQueryCount(admin=52, employee=51):
+        with self.assertQueryCount(admin=54, employee=55):
             record.message_post(
                 body=Markup('<p>Test Post Performances</p>'),
                 message_type='comment',
@@ -1037,7 +1036,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=66, employee=65):
+        with self.assertQueryCount(admin=67, employee=68):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -1062,7 +1061,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
                 'default_template_id': test_template.id,
             }).create({})
 
-        with self.assertQueryCount(admin=92, employee=92):
+        with self.assertQueryCount(admin=112, employee=112):
             messages_as_sudo = test_records.message_post_with_source(
                 'test_mail.mail_template_simple_test',
                 render_values={'partner': self.user_emp_inbox.partner_id},
@@ -1089,7 +1088,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id)
 
         # subscribe new followers with forced given subtypes
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=10, employee=10):
             rec.message_subscribe(
                 partner_ids=pids[:4],
                 subtype_ids=subtype_ids
@@ -1098,7 +1097,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:4])
 
         # subscribe existing and new followers with force=False, meaning only some new followers will be added
-        with self.assertQueryCount(admin=5, employee=5):
+        with self.assertQueryCount(admin=11, employee=11):
             rec.message_subscribe(
                 partner_ids=pids[:6],
                 subtype_ids=None
@@ -1107,7 +1106,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.env.user.partner_id | self.user_portal.partner_id | self.partners[:6])
 
         # subscribe existing and new followers with force=True, meaning all will have the same subtypes
-        with self.assertQueryCount(admin=4, employee=4):
+        with self.assertQueryCount(admin=10, employee=10):
             rec.message_subscribe(
                 partner_ids=pids,
                 subtype_ids=subtype_ids
@@ -1152,7 +1151,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=41, employee=41):
+        with self.assertQueryCount(admin=45, employee=45):
             rec.write({'user_id': self.user_portal.id})
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
         # write tracking message
@@ -1172,7 +1171,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         customer_id = self.customer.id
         user_id = self.user_portal.id
 
-        with self.assertQueryCount(admin=90, employee=90):
+        with self.assertQueryCount(admin=97, employee=97):
             rec = self.env['mail.test.ticket'].create({
                 'name': 'Test',
                 'container_id': container_id,
@@ -1202,7 +1201,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
         self.assertEqual(len(rec1.message_ids), 1)
 
-        with self.assertQueryCount(admin=56, employee=56):
+        with self.assertQueryCount(admin=60, employee=60):
             rec.write({
                 'name': 'Test2',
                 'container_id': self.container.id,
@@ -1239,7 +1238,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.user_portal.partner_id | self.env.user.partner_id)
 
-        with self.assertQueryCount(admin=62, employee=62):
+        with self.assertQueryCount(admin=66, employee=66):
             rec.write({
                 'name': 'Test2',
                 'container_id': container_id,
@@ -1502,10 +1501,79 @@ class TestMessageToStorePerformance(BaseMailPerformance):
             )
             return (
                 [
+                    (self.cr.dbname, "mail.test.simple", record.id, "thread"),
                     (self.cr.dbname, "res.partner", self.user_emp_inbox.partner_id.id),
                     (self.cr.dbname, "res.partner", self.user_follower_emp_inbox.partner_id.id),
                 ],
                 [
+                    {
+                        "type": "mail.message/new",
+                        "payload": {
+                            "id": record.id,
+                            "data": {
+                                "mail.message": self._filter_messages_fields(
+                                    {
+                                        "attachment_ids": [],
+                                        "author_id": {
+                                            "id": self.env.user.partner_id.id,
+                                            "type": "partner",
+                                        },
+                                        "author_guest_id": False,
+                                        "body": [
+                                            "markup",
+                                            "<p>Test Post Performances with multiple inbox ping!</p>",
+                                        ],
+                                        "create_date": fields.Datetime.to_string(message.create_date),
+                                        "date": fields.Datetime.to_string(message.date),
+                                        "default_subject": "Test",
+                                        "email_from": '"OdooBot" <odoobot@example.com>',
+                                        "id": message.id,
+                                        "incoming_email_cc": False,
+                                        "incoming_email_to": False,
+                                        "message_link_preview_ids": [],
+                                        "message_type": "comment",
+                                        "model": "mail.test.simple",
+                                        "notification_ids": [],
+                                        "partner_ids": [],
+                                        "pinned_at": False,
+                                        "rating_id": False,
+                                        "reactions": [],
+                                        "record_name": "Test",
+                                        "res_id": record.id,
+                                        "scheduledDatetime": False,
+                                        "subject": False,
+                                        "subtype_id": self.env.ref("mail.mt_comment").id,
+                                        "thread": {"id": record.id, "model": "mail.test.simple"},
+                                        "write_date": fields.Datetime.to_string(message.write_date),
+                                    },
+                                ),
+                                "mail.message.subtype": [
+                                    {"description": False, "id": self.env.ref("mail.mt_comment").id},
+                                ],
+                                "mail.thread": self._filter_threads_fields(
+                                    {
+                                        "display_name": "Test",
+                                        "id": record.id,
+                                        "model": "mail.test.simple",
+                                        "module_icon": "/base/static/description/icon.png",
+                                    },
+                                ),
+                                "res.partner": self._filter_partners_fields(
+                                    {
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
+                                        "id": self.env.user.partner_id.id,
+                                        "isInternalUser": True,
+                                        "is_company": False,
+                                        "name": "OdooBot",
+                                        "userId": self.env.user.id,
+                                        "write_date": fields.Datetime.to_string(
+                                            self.env.user.partner_id.write_date
+                                        ),
+                                    },
+                                ),
+                            },
+                        },
+                    },
                     {
                         "type": "mail.message/inbox",
                         "payload": {
@@ -1738,7 +1806,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
         self._reset_bus()
         self.env.invalidate_all()
         with self.assertBus(get_params=get_bus_params):
-            with self.assertQueryCount(17):
+            with self.assertQueryCount(19):
                 record.message_post(
                     body=Markup("<p>Test Post Performances with multiple inbox ping!</p>"),
                     message_type="comment",
@@ -1831,7 +1899,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=77):  # tm: 77
+        with self.assertQueryCount(employee=82):
             ticket.message_post(
                 attachments=attachments_vals,
                 attachment_ids=attachments.ids,
@@ -1876,7 +1944,7 @@ class TestPerformance(BaseMailPostPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=770):  # tm: 761
+        with self.assertQueryCount(employee=838):  # tm: 761
             for ticket, attachments in zip(tickets, attachments_all, strict=True):
                 ticket.message_post(
                     attachments=attachments_vals,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -75,7 +75,7 @@ class TestMailPerformance(FullBaseMailPerformance):
         self.push_to_end_point_mocked.reset_mock()  # reset as executed twice
         self.flush_tracking()
 
-        with self.assertQueryCount(employee=101):  # tmf: 98
+        with self.assertQueryCount(employee=108):
             new_message = record_ticket.message_post(
                 attachment_ids=attachments.ids,
                 body=Markup('<p>Test Content</p>'),
@@ -400,25 +400,25 @@ class TestRatingPerformance(FullBaseMailPerformance):
     @users('employee')
     @warmup
     def test_rating_last_value_perfs(self):
-        with self.assertQueryCount(employee=254):  # tmf: 254
+        with self.assertQueryCount(employee=294):  # tmf: 233
             self.create_ratings('mail.test.rating.thread')
 
-        with self.assertQueryCount(employee=283):  # tmf: 283
+        with self.assertQueryCount(employee=323):  # tmf: 263
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=242):  # tmf: 242
+        with self.assertQueryCount(employee=282):  # tmf: 222
             self.apply_ratings(5)
 
     @users('employee')
     @warmup
     def test_rating_last_value_perfs_with_rating_mixin(self):
-        with self.assertQueryCount(employee=277):  # tmf: 277
+        with self.assertQueryCount(employee=317):  # tmf: 256
             self.create_ratings('mail.test.rating')
 
-        with self.assertQueryCount(employee=305):  # tmf: 305
+        with self.assertQueryCount(employee=345):  # tmf: 285
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=284):  # tmf: 284
+        with self.assertQueryCount(employee=324):  # tmf: 264
             self.apply_ratings(5)
 
         with self.assertQueryCount(employee=1):

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -36,7 +36,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_1_partner(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.customer.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=32):  # tms: 32
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=35):  # tms: 31
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -51,7 +51,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def test_message_sms_record_10_partners(self):
         record = self.test_record.with_user(self.env.user)
         pids = self.partners.ids
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=32):  # tms: 32
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=35):  # tms: 31
             messages = record._message_sms(
                 body='Performance Test',
                 partner_ids=pids,
@@ -65,7 +65,7 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     @warmup
     def test_message_sms_record_default(self):
         record = self.test_record.with_user(self.env.user)
-        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=33):  # tms: 33
+        with self.subTest("QueryCount"), self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=36):  # tms: 32
             messages = record._message_sms(
                 body='Performance Test',
             )

--- a/addons/website_slides/tests/test_gamification_karma.py
+++ b/addons/website_slides/tests/test_gamification_karma.py
@@ -147,7 +147,7 @@ class TestKarmaGain(common.SlidesCase):
             self.assertEqual(user_trackings[1].origin_ref, self.channel)
 
         # now, remove the membership in batch, on multiple users - karma should not move as we only archive membership
-        with self.assertQueryCount(8):
+        with self.assertQueryCount(11):
             (self.channel | self.channel_2)._remove_membership(users.partner_id.ids)
 
         for user in users:


### PR DESCRIPTION
The point of this commit is to have a live chatter. Therefore you will receive new messages/followers update/attachments/activities directly in your chatter without refreshing the page or doing an action yourself, allowing you to have a more lively discussion with people connected to the same chatter.

This is mainly done by inheriting `bus.listener.mixin` in `mail.thread` which allows to send bus notification to all clients listening to one of the subchannels of the model.

The discuss app (which was already supporting those bus features) is relieved of some actions that are now
delegated to the mail.thread directly.

In more detail, each model inheriting from `mail.thread` has a
corresponding channel to subscribe to (i.e.
`thread-{model_name}_{model_id}`). On top of that an `internal`
subchannel is automatically assigned to the user depending on whether
the user is internal or not. This allows safe sharing of `Log Notes` as
well as some other internal notifications not shared with the external
world.

The user is subscribed to the channel whenever the chatter is mounted in
the DOM or when the thread is changed.

task-3660221

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
