### PR TITLE
[FIX] tools: preserve missing text in template inheritance

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -22,7 +22,8 @@ def add_stripped_items_before(node, spec, extract):
         parent = node.getparent()
         result = parent.text and RSTRIP_REGEXP.search(parent.text)
         before_text = result.group(0) if result else ''
-        parent.text = (parent.text or '').rstrip() + text
+        fallback_text = None if spec.text is None else ''
+        parent.text = ((parent.text or '').rstrip() + text) or fallback_text
     else:
         result = prev.tail and RSTRIP_REGEXP.search(prev.tail)
         before_text = result.group(0) if result else ''


### PR DESCRIPTION
When calling apply_inheritance_specs and moving a node (before after or inside), we merge the text content of the adjacents nodes. If the parent and target node both have no text, we should not set the text to an empty string.

When a node has no text, it is serialized as follows:

`<node/>`

But if it has an empty string, it has the following representation:

`<node></node>`

In the linked PR, we now apply the studio inheritance manually, and since we use the resulting tree directly instead of parsing the result, the `remove_blank_text` option of the parser has no effect.

This causes existing tests to show some difference.

---

Backport of 44bf7be4cea403115d2d674b3fa0e7829ec7002d

opw-3819667

closes odoo/odoo#175867

Related: odoo/enterprise#67980


-----
*** Dependent PR https://github.com/odoo/enterprise/pull/83732


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
