### PR TITLE
[FIX] purchase_stock: Add missing group permission for product_uom_id

### DIFF
--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -20,6 +20,7 @@ class TestReorderingRule(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super(TestReorderingRule, cls).setUpClass()
+        cls.env.user.groups_id += cls.env.ref('uom.group_uom')
         cls.partner = cls.env['res.partner'].create({
             'name': 'Smith'
         })


### PR DESCRIPTION
The `product_uom_id` field was causing test failures in `test_reordering_rule.py`
because it was not present in the `product.supplierinfo` form view .

This commit adds the group permission `uom.group_uom` to the user 
who is running the test, to ensure that the `product_uom_id` field is available
and preventing the test failure.


build_error-111983