### PR TITLE
[FIX] stock_account: avoid sorting by id in `_compute_average_price`

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -801,7 +801,8 @@ class ProductProduct(models.Model):
             candidates = candidates.with_prefetch(self.env.context.get('candidates_prefetch_ids'))
 
         if len(candidates) > 1:
-            candidates = candidates.sorted(lambda svl: (svl.create_date, svl.id))
+            # sort candidates by create_date > existing records by id > new records without origin
+            candidates = candidates.sorted(lambda svl: (svl.create_date, not bool(svl.ids), svl.ids[0] if svl.ids else 0))
 
         value_invoiced = self.env.context.get('value_invoiced', 0)
         if 'value_invoiced' in self.env.context:


### PR DESCRIPTION
### Issue:

The operator `<` is not supported between `New` records. However, the `_compute_average_price` sorts a record set by `id`: https://github.com/odoo/odoo/blob/61b20ddc1646b1a1d81d39bcde688f4e3d5d7425/addons/stock_account/models/product.py#L803-L804 This raises a traceback if these records are New.

### Steps to reproduce:
- Install stock_account, sale_stock, purchase
- Enable sale margins and dropshipping
- Create a storable product tracked by Serial numbers:
    - invoicing policy: delivered quantities
    - costing method of the product category: standard
    - Use the dropshipping route and a set a vendor
- Create and confirm a sale order for 1 unit
- Confirm the associated PO
- On the associated dropship add a new line with a demand of 0 for one more unit of your tracked product
- Assign a serial number on both moves
- Try to validate the dropship picking
#### > Traceback: `<` not supported between instnaces of `NewId` and `NewId`

### Fix:

We can not remove the lambda method used in the sorted here: https://github.com/odoo/odoo/blob/61b20ddc1646b1a1d81d39bcde688f4e3d5d7425/addons/stock_account/models/product.py#L803-L804 Because even if the `_order` of `stock.valuation.layer` model is `create_date, id`:
https://github.com/odoo/odoo/blob/61b20ddc1646b1a1d81d39bcde688f4e3d5d7425/addons/stock_account/models/stock_valuation_layer.py#L17 for real records, it and even if the `sorted` method relies on this order for real records: https://github.com/odoo/odoo/blob/19ae561098369739258a00af52582164551920ec/odoo/models.py#L6335-L6339 it is not supported for new records.

opw-4712087
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
