### PR TITLE
[FIX] point_of_sale: revert modification commands if sync fails

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -104,7 +104,9 @@ class PosOrder(models.Model):
             # when vals change the state to 'paid'
             for field in ['lines', 'payment_ids']:
                 if order.get(field):
-                    pos_order.write({field: order.get(field)})
+                    existing_record_ids = self.env[pos_order[field]._name].browse([r[1] for r in order[field] if r[1] != 0]).exists().ids
+                    existing_records_vals = [r for r in order[field] if r[0] not in [1, 2, 3, 4] or r[1] in existing_record_ids]
+                    pos_order.write({field: existing_records_vals})
                     order[field] = []
 
             del order['uuid']

--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -258,12 +258,9 @@ export class Base {
                         })
                         .filter((s) => s);
 
-                    if (
-                        this.models.commands[params.model].unlink.has(name) ||
-                        this.models.commands[params.model].delete.has(name)
-                    ) {
-                        const unlinks = this.models.commands[params.model].unlink.get(name);
-                        const deletes = this.models.commands[params.model].delete.get(name);
+                    const unlinks = this.getCommand("unlink", name);
+                    const deletes = this.getCommand("delete", name);
+                    if (unlinks || deletes) {
                         for (const id of unlinks || []) {
                             serializedDataOrm[name].push([3, id]);
                         }
@@ -271,8 +268,8 @@ export class Base {
                             serializedDataOrm[name].push([2, id]);
                         }
                         if (clear) {
-                            this.models.commands[params.model].unlink.delete(name);
-                            this.models.commands[params.model].delete.delete(name);
+                            this.deleteCommand("unlink", name);
+                            this.deleteCommand("delete", name);
                         }
                     }
                 } else {
@@ -297,6 +294,40 @@ export class Base {
     }
     get raw() {
         return this.baseData[this.id];
+    }
+    getCommand(command, fieldName) {
+        const key = `${fieldName}_${this.id}`;
+        if (this.models.commands[this.model.modelName][command].has(key)) {
+            return this.models.commands[this.model.modelName][command].get(key);
+        }
+    }
+    deleteCommand(command, fieldName = "") {
+        if (command === "delete" || command === "unlink") {
+            const key = `${fieldName}_${this.id}`;
+            if (this.models.commands[this.model.modelName][command].has(key)) {
+                this.models.commands[this.model.modelName][command].delete(key);
+            }
+        } else if (command === "update") {
+            if (this.models.commands[this.model.modelName][command].has(this.id)) {
+                this.models.commands[this.model.modelName][command].delete(this.id);
+            }
+        }
+    }
+    clearCommands() {
+        this.deleteCommand("update");
+        for (const [name, params] of Object.entries(this.model.modelFields)) {
+            if (
+                !params.dummy &&
+                X2MANY_TYPES.has(params.type) &&
+                this._dynamicModels.includes(params.relation)
+            ) {
+                this.deleteCommand("unlink", name);
+                this.deleteCommand("delete", name);
+                for (const record of [...this[name]]) {
+                    record.clearCommands();
+                }
+            }
+        }
     }
 }
 
@@ -664,7 +695,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         }
 
         if (typeof record.id === "number" && !opts.silent) {
-            commands[model].update.add(record.id);
+            addToCommand(model, "update", record.id);
         }
     }
 
@@ -673,10 +704,13 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         const fields = getFields(model);
         const handleCommand = (inverse, field, record, backend = false) => {
             if (inverse && !inverse.dummy && !opts.silent && typeof id === "number") {
-                const modelCommands = commands[field.relation];
-                const map = backend ? modelCommands.delete : modelCommands.unlink;
-                const oldVal = map.get(inverse.name);
-                map.set(inverse.name, [...(oldVal || []), record.id]);
+                addToCommand(
+                    field.relation,
+                    backend ? "delete" : "unlink",
+                    id,
+                    inverse.name,
+                    record[field.name].id
+                );
             }
         };
 
@@ -709,6 +743,26 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
         }
 
         return id;
+    }
+
+    function addToCommand(model, command, recordId, fieldName, inverseId) {
+        if (!(model in commands)) {
+            throw new Error(`Model ${model} not found`);
+        }
+        if (!(command in commands[model])) {
+            throw new Error(`Command ${command} not found`);
+        }
+        if (typeof recordId !== "number") {
+            return;
+        }
+        const modelCommand = commands[model][command];
+        if (["delete", "unlink"].includes(command)) {
+            const key = `${fieldName}_${inverseId}`;
+            const oldVal = modelCommand.get(key);
+            modelCommand.set(key, [...(oldVal || []), recordId]);
+        } else if (command === "update") {
+            modelCommand.add(recordId);
+        }
     }
 
     function createCRUD(model, fields) {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1173,9 +1173,7 @@ export class PosStore extends Reactive {
                 order.recomputeOrderData();
             }
 
-            const serializedOrder = orders.map((order) =>
-                order.serialize({ orm: true, clear: true })
-            );
+            const serializedOrder = orders.map((order) => order.serialize({ orm: true }));
             const data = await this.data.call("pos.order", "sync_from_ui", [serializedOrder], {
                 context,
             });
@@ -1212,6 +1210,7 @@ export class PosStore extends Reactive {
 
             // Remove only synced orders from the pending orders
             orders.forEach((o) => this.removePendingOrder(o));
+            orders.map((order) => order.clearCommands());
             return newData["pos.order"];
         } catch (error) {
             if (options.throw) {


### PR DESCRIPTION
Before this commit, when an orderline was removed and the order failed to sync on the first attempt, the deletion command was already discarded. As a result, the order could be synced later with the previously deleted order line still present.

Additionally, if a record is removed from another device but the change has not yet been synced, attempting to remove or modify that record can result in a "missing record" error. This commit resolves the issue by checking for the record's existence before performing any write operations.

opw-4707596

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
