### PR TITLE
[FIX] mail: call view external margin slightly reduced

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -64,9 +64,18 @@ $o-discuss-talkingColor: lighten($success, 10%);
     gap: map-get($spacers, 1) / 2;
 }
 
+.o-mx-0_5 {
+    margin-left: map-get($spacers, 1) / 2;
+    margin-right: map-get($spacers, 1) / 2;
+}
+
 .o-my-0_5 {
     margin-top: map-get($spacers, 1) / 2;
     margin-bottom: map-get($spacers, 1) / 2;
+}
+
+.o-mt-0_5 {
+    margin-top: map-get($spacers, 1) / 2;
 }
 
 .o-py-0_5 {

--- a/addons/mail/static/src/discuss/call/common/call.xml
+++ b/addons/mail/static/src/discuss/call/common/call.xml
@@ -7,7 +7,7 @@
             'o-fullscreen fixed-top vw-100 vh-100': state.isFullscreen,
             'o-compact': props.compact and !isMobileOs,
             'o-minimized': minimized,
-            'position-relative rounded-2 mx-1 mt-1 p-1': !state.isFullscreen,
+            'position-relative rounded-2 o-mx-0_5 o-mt-0_5 p-1': !state.isFullscreen,
         }">
             <div class="o-discuss-Call-main d-flex flex-grow-1 flex-column align-items-center justify-content-center position-relative overflow-auto" t-on-mouseleave="onMouseleaveMain">
                 <div


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/206260

PR above improve style of call view with some spacing around it which looks better. However, the spacing was too big even though it uses the minimum `.mx-1.mt-1` of 4px.

The 4px spacing is in many cases the minimum desired to see spacing between 2 elements, but here the intent is to give a container a slight visual floating effect. The 4px is appropriate to show item next to each other but 2px is best to simulate floating effect.

This commit improves by reducing the spacing by half their value.

Before
<img width="401" alt="Screenshot 2025-04-18 at 21 42 46" src="https://github.com/user-attachments/assets/5260080f-3759-4083-861d-ec6727800d0e" />
After
<img width="409" alt="Screenshot 2025-04-18 at 21 41 42" src="https://github.com/user-attachments/assets/2a90bd9f-9ed9-48b7-927b-a64812706fb7" />
