### PR TITLE
[FIX] mail: improved message edit style

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -126,7 +126,7 @@
     </t>
 
 <t t-name="mail.Message.edited">
-    <em class="smaller fw-bold text-500"> (edited)</em>
+    <span class="o-xsmaller opacity-50"> (edited)</span>
 </t>
 
 <t t-name="mail.Message.actions">


### PR DESCRIPTION
The message "(edited)" label had the following issues:
- it looked too similar to message text content, notably the font-size
- italics is harder to read and is prone to cut at end of text on Gecko rendering engine

This commit fixes the issue by reducing the size of this label, no italics, normal weight. Opacity matches with other items in message list of similar level of importance such as datetime.

Before / After
<img width="243" alt="Screenshot 2025-04-18 at 22 00 02" src="https://github.com/user-attachments/assets/26b104a1-8620-4406-b380-f8c0839547e8" /> <img width="236" alt="Screenshot 2025-04-18 at 22 00 27" src="https://github.com/user-attachments/assets/54268752-b2a8-40b0-8296-4d2cbc3bb173" />
