### PR TITLE
[IMP] onboarding: use string instead of name to make title translatable

### DIFF
--- a/addons/onboarding/views/onboarding_views.xml
+++ b/addons/onboarding/views/onboarding_views.xml
@@ -73,12 +73,12 @@
                         <field name="is_per_company"/>
                     </group>
                     <notebook>
-                        <page name="Onboardings using this step">
+                        <page name="onboarding_using_this_step" string="Onboardings using this step">
                             <group string="Onboardings">
                                 <field name="onboarding_ids" nolabel="1"/>
                             </group>
                         </page>
-                        <page name="Step rendering">
+                        <page name="step_rendering" string="Step rendering">
                             <group>
                                 <field name="description"/>
                                 <field name="button_text"/>

--- a/doc/cla/individual/abbasebadian.md
+++ b/doc/cla/individual/abbasebadian.md
@@ -1,0 +1,11 @@
+Iran, 2025-04-19
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+ 
+Abbas Ebadian abbasebadiann@gmail.com https://github.com/abbasebadian


### PR DESCRIPTION
Since `name` attribute is not translatable in XML views and even can not be added to TRANSLATED_ATTRIBS, `string` must be used instead of `name` attribute,  in order to make the text exportable to `po` file.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
