### PR TITLE
[IMP] point_of_sale: improve order picking

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -54,7 +54,9 @@
                                                 </div>
                                             </td>
                                             <td class="align-middle">
-                                                <div t-if="order.presetTime" t-attf-class="fs-6 badge rounded {{this.getPresetTimeColor(order)}}"><t t-esc="order.presetTime"/></div>
+                                                <div t-if="order.presetTime" t-attf-class="fs-6 badge rounded {{this.getPresetTimeColor(order)}}">
+                                                    <t t-esc="getPresetDatetimeString(order)"/>
+                                                </div>
                                             </td>
                                             <td t-if="showCardholderName()">
                                                 <div><t t-esc="getCardholderName(order)"></t></div>


### PR DESCRIPTION
Add "To pick" filter on ticketscreen. This filter will only display orders that are to be picked up by the customer in the future.

Improve preset_time display. Previously, preset time only displayed the time, not the date. This was difficult for the user to understand. Now, if the date is for tomorrow or later, the date will be displayed.

taskId: 4739045


