### PR TITLE
[FIX] core: --without-demo inverted

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -545,7 +545,7 @@ class configmanager(object):
 
         self.options['init'] = opt.init and dict.fromkeys(opt.init.split(','), 1) or {}
         self.options['without_demo'] = self.options['without_demo'] not in (False, '', 'False', 'false')
-        self.options['demo'] = (dict(self.options['init']) if self.options['without_demo'] else {})
+        self.options['demo'] = (dict(self.options['init']) if not self.options['without_demo'] else {})
         self.options['update'] = opt.update and dict.fromkeys(opt.update.split(','), 1) or {}
         self.options['translate_modules'] = opt.translate_modules and [m.strip() for m in opt.translate_modules.split(',')] or ['all']
         self.options['translate_modules'].sort()


### PR DESCRIPTION
There was a regression introduced in PR https://github.com/odoo/odoo/pull/205695.
The logic for setting `options['demo']` was reversed — the `not` operator was missing in the `if` condition.

cc @Xavier-Do, @Julien00859, @rvalyi 