### PR TITLE
[FIX] point_of_sale: long press on product image should show info dialog

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -92,6 +92,7 @@
             'point_of_sale/static/tests/pos/tours/**/*',
             'point_of_sale/static/tests/generic_helpers/**/*',
             'point_of_sale/static/tests/customer_display/**/*',
+            'point_of_sale/static/src/utils.js'
         ],
         'web.assets_unit_tests': [
             # for the related_models.test.js

--- a/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/components/product_card/product_card.xml
@@ -9,7 +9,7 @@
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
             <div t-if="props.imageUrl" class="product-img ratio ratio-4x3 rounded-top rounded-3">
-                <img class="w-100 o_object_fit_cover bg-200" t-att-src="props.imageUrl" t-att-alt="props.name" draggable="false"/>
+                <img class="w-100 o_object_fit_cover bg-200 pe-none" t-att-src="props.imageUrl" t-att-alt="props.name" draggable="false"/>
             </div>
             <div class="product-content h-100 px-2 rounded-bottom-3 flex-shrink-1"
                 t-att-class="{'d-flex' : !props.isComboPopup, 'my-1': !(props.isComboPopup and !props.imageUrl)}">

--- a/addons/point_of_sale/static/src/app/hooks/long_press_hook.js
+++ b/addons/point_of_sale/static/src/app/hooks/long_press_hook.js
@@ -1,4 +1,6 @@
-export function useLongPress(callback, delay = 1000) {
+import { LONG_PRESS_DURATION } from "@point_of_sale/utils";
+
+export function useLongPress(callback, delay = LONG_PRESS_DURATION) {
     let timer = null;
 
     function startLongPress(params) {

--- a/addons/point_of_sale/static/src/utils.js
+++ b/addons/point_of_sale/static/src/utils.js
@@ -1,3 +1,5 @@
+import { session } from "@web/session";
+
 /*
  * comes from o_spreadsheet.js
  * https://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
@@ -142,3 +144,5 @@ export class Counter {
 export function isValidEmail(email) {
     return email && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
+
+export const LONG_PRESS_DURATION = session.test_mode ? 100 : 1000;

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -685,3 +685,14 @@ registry.category("web_tour.tours").add("test_fiscal_position_tax_group_labels",
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_product_long_press", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.longPressProduct("Test Product"),
+            Dialog.is(),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -5,6 +5,7 @@ import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_li
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import { LONG_PRESS_DURATION } from "@point_of_sale/utils";
 
 export function firstProductIsFavorite(name) {
     return [
@@ -843,4 +844,21 @@ export function createProductFromFrontend(name, barcode, list_price, category) {
 
 export function editProductFromFrontend(name, barcode, list_price) {
     return productInputSteps(name, barcode, list_price);
+}
+
+export function longPressProduct(productName) {
+    return [
+        {
+            content: `Long pressing product "${productName}"...`,
+            trigger: `.product-name:contains("${productName}")`,
+            run: async () => {
+                const el = document.querySelector(".product-name");
+                const mouseDown = new MouseEvent("mousedown", { bubbles: true });
+                const mouseUp = new MouseEvent("mouseup", { bubbles: true });
+                el.dispatchEvent(mouseDown);
+                await new Promise((resolve) => setTimeout(resolve, LONG_PRESS_DURATION + 50));
+                el.dispatchEvent(mouseUp);
+            },
+        },
+    ];
 }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1891,6 +1891,18 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_fiscal_position_tax_group_labels', login="pos_user")
 
+    def test_product_long_press(self):
+        """ Test the long press on product to open the product info """
+        archive_products(self.env)
+        self.env['product.product'].create({
+            'name': 'Test Product',
+            'list_price': 100,
+            'taxes_id': False,
+            'available_in_pos': True,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_product_long_press', login="pos_user")
+
 # This class just runs the same tests as above but with mobile emulation
 class MobileTestUi(TestUi):
     browser_size = '375x667'


### PR DESCRIPTION
Steps:
===
- Open PoS.
- Long press on the product card (specifically on the image).

Issue:
===
- Long pressing on the product image in iOS was triggering a download prompt
instead of opening the product info dialog.

Cause:
===
- By default, image elements are interactive in browsers. On iOS, long-pressing
such elements prompts the user to download the image.

FIX:
===
- Added the `pe-none` class to the product image to disable pointer events,
ensuring the long-press action is handled by the product card and not
intercepted by the image.
- Also included a tour test to validate the long-press behavior.

task-4735484
