### PR TITLE
[FIX] l10n_din5008: fix text overflow in company details footer

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -137,17 +137,17 @@
                     <div class="company_details">
                         <table class="table-borderless">
                             <tr>
-                                <td>
-                                    <ul class="list-inline text-nowrap">
+                                <td colspan="4">
+                                    <ul class="list-inline">
                                         <li t-if="company.company_details"><span t-field="company.company_details"/></li>
                                     </ul>
                                 </td>
-                                <td>
+                                <td colspan="4">
                                     <ul class="list-inline">
                                         <li t-if="company.report_footer"><span t-field="company.report_footer"/></li>
                                     </ul>
                                 </td>
-                                <td>
+                                <td colspan="2">
                                     <ul class="list-inline">
                                         <li t-if="company.vat"><t t-out="company.account_fiscal_country_id.vat_label or 'Tax ID'"/>:
                                             <span t-if="forced_vat" t-out="forced_vat"/>
@@ -156,7 +156,7 @@
                                         <li>HRB Nr: <span t-field="company.company_registry"/></li>
                                     </ul>
                                 </td>
-                                <td t-if="company.partner_id.bank_ids">
+                                <td colspan="2" t-if="company.partner_id.bank_ids">
                                     <ul class="list-inline">
                                         <t t-foreach="company.partner_id.bank_ids[:2]" t-as="bank">
                                             <li><span t-field="bank.bank_id.name"/></li>

--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -90,6 +90,7 @@
     &.footer {
         padding-left: 5mm;
         padding-right: 10mm;
+        font-size: 0.7em;
         .page_number {
             margin-top: 4.23mm;
             width: 100%;


### PR DESCRIPTION
<b>Steps to reproduce:</b>

1. Setting > Navigate to Configure Document layout > layout : DIN 5008.
2. Accounting > invoice > PDF without Payment.

Note :Ensure the address has at least 33 characters without spaces to trigger the issue.

<b>Issue:</b>
   The footer of the invoice is not displaying correctly — the company name in the
   bottom left corner is overlapping and not aligned properly.

<b>Cause:</b>
   An upstream PR modified the footer text sizing, leading to layout issues when
   fields contain long values.

<b>Solution:</b>
Removed the `text-nowrap` class from the company details in the footer section.
Improved section alignment using `colspan` and made minor adjustments to footer text sizing.
These changes prevent content overlap in the company information section of reports,
ensuring proper display regardless of content length.

<b>opw: 4731515</b>

Before changes applied:
![image](https://github.com/user-attachments/assets/cf00bda8-ffde-4ea4-b5ca-59a47df152bd)
After changes applied:
![image](https://github.com/user-attachments/assets/354bf1ba-43b1-4a1e-aa66-142c3c44b38d)
