### PR TITLE
[IMP] point_of_sale: allow page refresh in offline mode

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1239,6 +1239,9 @@ export class PosStore extends WithLazyGetterTrap {
         );
 
         try {
+            if (this.data.network.offline) {
+                throw new ConnectionLostError();
+            }
             const orderIdsToDelete = this.getOrderIdsToDelete();
             if (orderIdsToDelete.length > 0) {
                 await this.deleteOrders([], orderIdsToDelete);
@@ -1293,7 +1296,7 @@ export class PosStore extends WithLazyGetterTrap {
                     .forEach((order) => (order.session_id = this.session));
             }
 
-            this.clearPendingOrder();
+            orders.forEach((o) => this.removePendingOrder(o));
             return newData["pos.order"];
         } catch (error) {
             if (options.throw) {

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -87,11 +87,17 @@ export default class DevicesSynchronisation {
         const serverOpenOrders = this.pos.getOpenOrders().filter((o) => typeof o.id === "number");
         const recordIds = this.getDynamicRecordServerIds();
         const domain = this.constructOrdersDomain(serverOpenOrders);
-        const response = await this.pos.data.call("pos.config", "read_config_open_orders", [
-            odoo.pos_config_id,
-            domain,
-            recordIds,
-        ]);
+        let response = {};
+        try {
+            response = await this.pos.data.call("pos.config", "read_config_open_orders", [
+                odoo.pos_config_id,
+                domain,
+                recordIds,
+            ]);
+        } catch (error) {
+            console.warn("Error while reading open orders data from server", error);
+            return;
+        }
 
         if (Object.keys(response.dynamic_records).length) {
             const missing = await this.pos.data.missingRecursive(response.dynamic_records);


### PR DESCRIPTION
Before this commit:
==========
- Refreshing the POS page while in offline mode would result in a black screen, making the system unusable until connectivity was restored.
- Offline orders are not synced with online orders. When synced on closing the register, it shows an error pop-up.

After this commit:
==========
- Refreshing the POS page in offline mode is now supported.
- The POS interface will reload correctly and continue to function in offline mode, ensuring uninterrupted usage.
- Offline orders will be perfectly synced with online orders.

task-4703192
