### PR TITLE
[FIX] website_partner: avoid slug error while creating new partner record

### DIFF
--- a/addons/website_partner/models/res_partner.py
+++ b/addons/website_partner/models/res_partner.py
@@ -14,4 +14,5 @@ class ResPartner(models.Model):
     def _compute_website_url(self):
         super()._compute_website_url()
         for partner in self:
-            partner.website_url = "/partners/%s" % self.env['ir.http']._slug(partner)
+            if partner.id:
+                partner.website_url = "/partners/%s" % self.env['ir.http']._slug(partner)


### PR DESCRIPTION
**Description**

- In Saas 18.2, the '[website_url](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_partner/models/res_partner.py#L14)' field in the res.partner is a computed field.  However, when a new contact is created via the form view, as the field does not have dependencies so it won’t be automatically calculated. From odoo/odoo@40e0216, computed fields without dependencies are now computed during onchange() instead of returning an initial False value. During the creation process, especially within onchange triggers [here](https://github.com/odoo/odoo/commit/40e0216656a6bffaff5b36e413aff23603cc8e72) , while creating a new contact, this can lead to an error if the computation tries to perform a slug operation on a record that hasn’t been saved yet.

- This PR ensures that it gets properly computed by ensuring via condition to avoid performing a slug on a not yet saved record in case of an onchange.

**Steps to Reproduce:(V18.2)**

1. Install the 'website_partner', 'contacts' application in saas-18.2
2. Add 'website_url' field in form view of res.partner
3. Try to create new record in contacts[res.partner].

Reference commits - odoo/odoo@40e0216 , [odoo/odoo@7ba64a8](https://github.com/odoo/odoo/commit/7ba64a8c51f2888b301ee6feae140b02ca4b1b95#diff-4c7613a9ea8e1131502ede128b264e908fd6b074bf886ac475fc73833c8a71a8L16-R19)

similar example for other model livechat - [V18.0](https://github.com/odoo/odoo/blob/18.0/addons/website_livechat/models/im_livechat.py#L13 ),  [V18.2](https://github.com/odoo/odoo/blob/saas-18.2/addons/website_livechat/models/im_livechat.py#L16) 

**Traceback -**

```
  File "/home/odoo/src/odoo/saas-18.2/addons/web/models/models.py", line 1559, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "/home/odoo/src/odoo/saas-18.2/addons/web/models/models.py", line 1645, in __init__
    self.fetch(name)
  File "/home/odoo/src/odoo/saas-18.2/addons/web/models/models.py", line 1660, in fetch
    self[field_name] = self.record[field_name]
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 6349, in __getitem__
    return self._fields[key].__get__(self)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/fields.py", line 1437, in __get__
    self.compute_value(recs)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/fields.py", line 1603, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/saas-18.2/addons/mail/models/mail_thread.py", line 474, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 4570, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/fields.py", line 69, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/saas-18.2/addons/website_partner/models/res_partner.py", line 18, in _compute_website_url
    partner.website_url = "/partners/%s" % self.env['ir.http']._slug(partner)
  File "/home/odoo/src/odoo/saas-18.2/addons/website/models/ir_http.py", line 76, in _slug
    return super()._slug(value)
  File "/home/odoo/src/odoo/saas-18.2/addons/http_routing/models/ir_http.py", line 62, in _slug
    raise ValueError("Cannot slug non-existent record %s" % value)
ValueError: Cannot slug non-existent record res.partner(<NewId 0x7466e37336c0>,)
```
![Runbot saas-18 2](https://github.com/user-attachments/assets/ef447230-9d23-4ca1-862c-c9326b5551da)


opw - [4709146](https://www.odoo.com/odoo/project/70/tasks/4709146)
upg - [2724009](https://upgrade.odoo.com/web#id=2724009&cids=1&menu_id=107&action=150&model=upgrade.request&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
