### PR TITLE
[IMP] fleet: add engine option for bike-type vehicles

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -94,7 +94,7 @@ class FleetVehicle(models.Model):
         ('miles', 'mi')
         ], 'Odometer Unit', default='kilometers', required=True)
     transmission = fields.Selection(
-        [('manual', 'Manual'), ('automatic', 'Automatic')], 'Transmission',
+        [('manual', 'Manual'), ('semi_automatic', 'Semi-Automatic'), ('automatic', 'Automatic')], 'Transmission',
         compute='_compute_transmission', store=True, readonly=False)
     fuel_type = fields.Selection(FUEL_TYPES, 'Fuel Type', compute='_compute_fuel_type', store=True, readonly=False)
     power_unit = fields.Selection([
@@ -139,7 +139,9 @@ class FleetVehicle(models.Model):
         ('today', 'Today'),
     ], compute='_compute_service_activity')
     vehicle_properties = fields.Properties('Properties', definition='model_id.vehicle_properties_definition', copy=True)
-    vehicle_range = fields.Integer(string="Range")
+    vehicle_range = fields.Integer(string="Range",
+        help="Range represents the maximum distance a vehicle can travel on a full charge (for EVs) or \
+            a full tank (for fuel-powered vehicles)")
     range_unit = fields.Selection([('km', 'km'), ('mi', 'mi')],
         compute='_compute_range_unit', store=True, readonly=False, default="km", required=True)
 

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -36,7 +36,9 @@ class FleetVehicleModel(models.Model):
     image_128 = fields.Image(related='brand_id.image_128', readonly=True)
     active = fields.Boolean(default=True)
     vehicle_type = fields.Selection([('car', 'Car'), ('bike', 'Bike')], default='car', required=True, tracking=True)
-    transmission = fields.Selection([('manual', 'Manual'), ('automatic', 'Automatic')], 'Transmission', tracking=True)
+    transmission = fields.Selection(
+        selection=[('manual', 'Manual'), ('semi_automatic', 'Semi-Automatic'), ('automatic', 'Automatic')],
+        string='Transmission', tracking=True)
     vehicle_count = fields.Integer(compute='_compute_vehicle_count', search='_search_vehicle_count')
     model_year = fields.Selection(selection='_get_year_selection', tracking=True)
     color = fields.Char(tracking=True)
@@ -61,7 +63,9 @@ class FleetVehicleModel(models.Model):
         ('horsepower', 'Horsepower (hp)')
         ], 'Power Unit', default='power', required=True)
     vehicle_properties_definition = fields.PropertiesDefinition('Vehicle Properties')
-    vehicle_range = fields.Integer(string="Range")
+    vehicle_range = fields.Integer(string="Range",
+        help="Range represents the maximum distance a vehicle can travel on a full charge (for EVs) or \
+            a full tank (for fuel-powered vehicles)")
     range_unit = fields.Selection([('km', 'km'), ('mi', 'mi')], default="km", required=True)
     drive_type = fields.Selection([
         ('fwd', 'Front-Wheel Drive (FWD)'),

--- a/addons/fleet/views/fleet_vehicle_model_views.xml
+++ b/addons/fleet/views/fleet_vehicle_model_views.xml
@@ -48,10 +48,11 @@
                                     <field name="color"/>
                                     <field name="trailer_hook"/>
                                 </group>
-                                <group id="vehicle_information" string="Vehicle Information" invisible="vehicle_type != 'bike'">
+                                <group id="vehicle_information" string="Model" invisible="vehicle_type != 'bike'">
+                                    <field name="model_year"/>
                                     <field name="electric_assistance"/>
                                 </group>
-                                <group string="Engine" invisible="vehicle_type != 'car'" name="group_engine">
+                                <group string="Engine" name="group_engine">
                                     <field name="default_fuel_type" required="1"/>
                                     <field name="transmission"/>
                                     <field name="drive_type"/>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -148,9 +148,9 @@
                                     </div>
                                     <field name="electric_assistance" invisible="vehicle_type != 'bike'"/>
                                 </group>
-                                <group string="Engine" invisible="vehicle_type != 'car'">
+                                <group string="Engine">
                                     <field name="fuel_type"/>
-                                    <field name="transmission" invisible="vehicle_type != 'car'"/>
+                                    <field name="transmission"/>
                                     <label for="power" invisible="power_unit != 'power'"/>
                                     <div class="o_row" invisible="power_unit != 'power'">
                                         <field name="power"/>


### PR DESCRIPTION
Previously, bike-type vehicles in the fleet app did not support an engine option This has been updated to accommodate motorbikes, which require engine specifications.

task-4653379

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
