### PR TITLE
[FIX] barcodes,barcodes_gs1_nomeclature: regex error due to false barcode

### DIFF
--- a/addons/barcodes/models/barcode_nomenclature.py
+++ b/addons/barcodes/models/barcode_nomenclature.py
@@ -83,6 +83,7 @@ class BarcodeNomenclature(models.Model):
         return match
 
     def parse_barcode(self, barcode):
+     if isinstance(barcode,str):   
         if re.match(r'^urn:', barcode):
             return self.parse_uri(barcode)
         return self.parse_nomenclature_barcode(barcode)

--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -188,7 +188,10 @@ class BarcodeNomenclature(models.Model):
 
                 # The barcode isn't a valid GS1 barcode, checks if it can be unpadded.
                 if not parsed_data:
-                    match = re.match('0+([0-9]+)$', value)
+                    try:
+                        match = re.match('0+([0-9]+)$', value)
+                    except TypeError:
+                        match = None
                     if match:
                         return Domain(field, replacing_operator, match.groups()[0])
                 return condition


### PR DESCRIPTION
The error is caused when the the barcode is `False` in the function `parse_barcode` when creating a new maintenance equipment after changing default barcode nomenclature to  `GS1 nomenclature`. `map_gs1_barcode` proceeds to throw same error when error handling is only done for `parse_barcode` hence we need to handle it as well.

**Steps to reproduce:**

* Install Maintenance and Inventory
* Inventory>Configuration>Settings>Barcode Nomenclature
* Set to `Default GS1 Nomenclature`
* Maintenance App>Equipment>New

`TypeError: expected string or bytes-like object`

**Solution:**
* Check if barcode is a string before proceeding in `parse_barcode` function for regex.
* Wrap `re.match` in try and except if it throws an type error set `match = None` and proceed as usual for `map_gs1_barcode` such that it does not throw error the same regex error.

Sentry-6552593535

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
