### PR TITLE
[FIX] web: prevent error while changing the language

### DIFF
--- a/addons/web/controllers/action.py
+++ b/addons/web/controllers/action.py
@@ -86,7 +86,7 @@ class Action(Controller):
                         else:
                             display_names.append(act['display_name'])
                     else:
-                        if act['res_model'] and act['type'] != 'ir.actions.client':
+                        if act.get('res_model') and act['type'] != 'ir.actions.client':
                             request.env[act['res_model']].check_access_rights('read')
                             # action shouldn't be available on its own if it doesn't have multi-record views
                             name = act['display_name'] if any(view[1] != 'form' and view[1] != 'search' for view in act['views']) else None


### PR DESCRIPTION
When the user changes the language in My Profile and tries to save,
a traceback will appear.

Steps to reproduce the error:
- Install ``sign`` and ``hr`` module.
- Activate multi languages
- Go to Sign > Reports > Green Savings
- Click on the profile icon > My Profile > Change language > Save

Traceback:
```
File "/home/odoo/src/odoo/saas-18.2/addons/web/controllers/action.py", line 90, in load_breadcrumbs
    if act['res_model'] and act['type'] != 'ir.actions.client':
KeyError: 'res_model'
```

https://github.com/odoo/odoo/blob/e901707961cca623acf646f5272c156928125f43/addons/web/controllers/action.py#L89
Here, ``ir.actions.report`` action does not have ``res_model``.
So, it will lead to the above traceback.

sentry-6556212172

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
