### PR TITLE
[FIX] website, website_sale: menu oriented enhancements

### DIFF
--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -39,7 +39,7 @@ class WebsiteMenu(models.Model):
                 menu.mega_menu_classes = False
 
     name = fields.Char('Menu', required=True, translate=True)
-    url = fields.Char("Url", compute="_compute_url", store=True, required=True, default="#", copy=True)
+    url = fields.Char("Url", compute="_compute_url", store=True, required=True, readonly=False, default="#", copy=True)
     page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade', index='btree_not_null')
     controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade', index='btree_not_null')
     new_window = fields.Boolean('New Window')

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -1,6 +1,7 @@
 /** @odoo-module */
 
 import { delay } from '@odoo/hoot-dom';
+import { registry } from "@web/core/registry";
 import {
     clickOnEditAndWaitEditMode,
     clickOnExtraMenuItem,
@@ -10,6 +11,65 @@ import {
     openLinkPopup,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
+
+registry.category("web_tour.tours").add("parent_child_menu", {
+    url: "/odoo/action-website.action_website_menu",
+    steps: () => [
+        {
+            content: "Open Menu Form View",
+            trigger: ".o_list_button_add",
+            run: "click",
+        },
+        {
+            content: "Insert Menu Name",
+            trigger: "input[id='name_0']",
+            run: "edit Parent",
+        },
+        {
+            content: "Insert Menu URL",
+            trigger: "input[id='url_0']",
+            run: "edit /parent",
+        },
+        {
+            content: "Click on Save Button",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Click on Add a line button",
+            trigger: "div[name='child_id'] td.o_field_x2many_list_row_add a",
+            run: "click",
+        },
+        {
+            content: "Insert Child Menu Name",
+            trigger: ".o_dialog input[id='name_0']",
+            run: "edit Child",
+        },
+        {
+            content: "Insert Child Menu URL",
+            trigger: ".o_dialog input[id='url_0']",
+            run: "edit /child",
+        },
+        {
+            content: "Click on Save & Close Button",
+            trigger: "button:contains(Save & Close)",
+            run: "click",
+        },
+        {
+            content: "Click on Save Button",
+            trigger: ".o_form_button_save",
+            run: "click",
+        },
+        {
+            content: "Check the Parent's URL",
+            trigger: "div[name='url']:contains('#')",
+        },
+        {
+            content: "Check the Child's URL",
+            trigger: "td[name='url']:contains('/child')",
+        },
+    ],
+});
 
 registerWebsitePreviewTour('edit_menus', {
     url: '/',

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -548,6 +548,13 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_32_website_background_colorpicker(self):
         self.start_tour(self.env['website'].get_client_action_url("/"), "website_background_colorpicker", login="admin")
 
+    def test_33_website_menus(self):
+        # Create a website to prevent auto-assignment of the default parent menu.
+        self.env['website'].create({
+            'name': 'Test Website',
+        })
+        self.start_tour("/odoo/action-website.action_website_menu", "parent_child_menu", login="admin")
+
     def test_website_media_dialog_image_shape(self):
         self.start_tour("/", 'website_media_dialog_image_shape', login='admin')
 

--- a/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
+++ b/addons/website/views/snippets/s_mega_menu_odoo_menu.xml
@@ -6,7 +6,7 @@
         <div class="container">
             <div class="row">
                 <div class="col-12 col-lg-3 pt16 pb24">
-                    <h4 class="text-uppercase h5 fw-bold mt-0">Computers &amp; Devices</h4>
+                    <h4 class="h5 fw-bold mt-0">Computers &amp; Devices</h4>
                     <div class="s_hr pt4 pb16">
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--primary);"/>
                     </div>
@@ -20,7 +20,7 @@
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
-                    <h4 class="text-uppercase h5 fw-bold mt-0">Monitors</h4>
+                    <h4 class="h5 fw-bold mt-0">Monitors</h4>
                     <div class="s_hr pt4 pb16">
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--secondary);"/>
                     </div>
@@ -31,7 +31,7 @@
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
-                    <h4 class="text-uppercase h5 fw-bold mt-0">Electronics</h4>
+                    <h4 class="h5 fw-bold mt-0">Electronics</h4>
                     <div class="s_hr pt4 pb16">
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--primary);"/>
                     </div>
@@ -44,7 +44,7 @@
                     </nav>
                 </div>
                 <div class="col-12 col-lg-3 pt16 pb24">
-                    <h4 class="text-uppercase h5 fw-bold mt-0">Promotions</h4>
+                    <h4 class="h5 fw-bold mt-0">Promotions</h4>
                     <div class="s_hr pt4 pb16">
                         <hr class="w-100 mx-auto" style="border-top-width: 2px; border-top-color: var(--secondary);"/>
                     </div>

--- a/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
+++ b/addons/website_sale/views/snippets/s_mega_menu/odoo_menu.xml
@@ -16,7 +16,7 @@
                         t-as="category"
                     >
                         <div class="col-12 col-lg-3 pt16 pb24">
-                            <h4 class="text-uppercase h5 fw-bold mt-0">
+                            <h4 class="h5 fw-bold mt-0">
                                 <a
                                     t-att-href="'/shop/category/%s' % category.id"
                                     class="nav-link p-0 text-black"


### PR DESCRIPTION
## 1. Preserve child menu URL on save [Commit 1]

### Steps to reproduce: 

- Enable Debug mode
- Go to Website → Configuration → Menus.
- Create a menu with a URL (e.g., /parent) and save.
- Add a child menu within current menu with its own URL (e.g., /child)  and save.

### Issue:
After saving, the child menu’s URL is overwritten with '#'.

### Cause:
The `url` field is a computed field, which makes it `readonly=True` by default. In the form view for parent menus, we explicitly add a `readonly` condition on the URL field. This overrides the model-level readonly setting, so the user input is sent to the backend and saved. However, for child menus, there is no explicit `readonly` condition in the view. As a result, the model’s `readonly=True` setting takes effect, and the user input for the URL is silently discarded.

### Solution:
Explicitly set `readonly=False` on the computed `url` field to ensure input is saved correctly.

## 2. Remove forced uppercase styling in mega menu headings [Commit 2]

All heading section in the mega menu appear in uppercase, regardless of how the user types them. This PR ensure that heading capitalization should now reflect the actual user input.

task-4689969