### PR TITLE
[FIX] purchase_stock: correct negative quantities with mutlicurrencies on RFQ's

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -307,7 +307,8 @@ class PurchaseOrderLine(models.Model):
     def _prepare_account_move_line(self, move=False):
         res = super()._prepare_account_move_line(move=move)
         if 'balance' not in res:
-            res['balance'] = self.currency_id._convert(
+            sign = -1 if self.product_qty < 0 else 1
+            res['balance'] = sign * self.currency_id._convert(
                 self.price_unit_discounted * (self.qty_received or 1),
                 self.company_id.currency_id,
                 round=False,


### PR DESCRIPTION
Issue:
When we try to confirm a RFQ with negative quantities in a different currency than our company's currency, we will receive an error because the line's amount currency is different sign than the line's balance. We will then fail the SQL constraint.

Steps to Reproduce on Runbot:
- confirm a RFQ with negative quantity and positive unit price.

Notes:
This issue is resolved in 18 because the during the tax line computations, we update the amount_currency and balance fields with correct sign direction.

opw-4728724

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
