### PR TITLE
[FIX] web_editor: apply shape on manually cropped image

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6823,7 +6823,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         // If the shape needs the image to be square (1:1 ratio) and if not
         // already the case, crop the image before applying the shape.
         const isCropRequired = params.unstretch;
-        if ((isCropRequired && img.dataset.aspectRatio !== "1/1" && previewMode !== "reset")
+        if ((isCropRequired && img.dataset.isManualCrop !== "true" && img.dataset.aspectRatio !== "1/1" && previewMode !== "reset")
                 || this.hasCroppedPreview) {
             // Preserve the cursor to be able to replace the image afterwards.
             const restoreCursor = preserveCursor(this.$target[0].ownerDocument);

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -97,6 +97,8 @@ export class ImageCrop extends Component {
                 this.$cropperImage.cropper('setAspectRatio', this.aspectRatios[this.aspectRatio].value);
             }
             await this._save();
+            delete this.media.dataset.isManualCrop;
+            this.media.classList.remove("o_we_image_cropped");
         }
     }
 
@@ -234,8 +236,7 @@ export class ImageCrop extends Component {
         });
         delete this.media.dataset.resizeWidth;
         this.initialSrc = await applyModifications(this.media, {forceModification: true, mimetype: this.mimetype});
-        const cropped = this.aspectRatio !== "0/0";
-        this.media.classList.toggle('o_we_image_cropped', cropped);
+        this.media.classList.add("o_we_image_cropped");
         if(refreshOptions){
             this.$media.trigger('image_cropped');
         }
@@ -315,8 +316,10 @@ export class ImageCrop extends Component {
                 const amount = this.$cropperImage.cropper('getData')[scaleDirection] * -1;
                 return this.$cropperImage.cropper(scaleDirection, amount);
             }
-            case 'apply':
+            case 'apply': {
+                this.media.dataset.isManualCrop = "true";
                 return this._save();
+            }
             case 'discard':
                 return this._closeCropper();
         }

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -734,7 +734,7 @@
                 Reset
             </we-button>
             <we-button class="fa fa-fw fa-object-ungroup" data-name="image_transform_opt" data-transform="true" data-no-preview="true" title="Transform the picture"/>
-            <we-button class="ms-0 border-start-0" data-reset-transform="" data-no-preview="true" title="Reset transformation">
+            <we-button class="o_we_bg_danger ms-0 border-start-0" data-reset-transform="" data-no-preview="true" title="Reset transformation">
                 Reset
             </we-button>
         </we-row>


### PR DESCRIPTION
Steps to reproduce:
1. Upload an image and manually crop it.
2. Apply a shape to the image.
3. We can see the image is original, not the one we just cropped.

Issue:
As part of task [3678061](https://www.odoo.com/odoo/my-tasks/3678061), all shapes were applied using a 1:1 ratio for
better UI. However, we didn’t account for cases where the user had manually cropped the image. In such cases, the shape was being applied to the original image with forced 1:1 cropping, ignoring the user's manual crop.

Fix:
Previously, applying a shape always cropped the image to 1:1 if crop was required and the aspect ratio wasn't already 1:1. This caused the user's custom crop area to be discarded.
Now, a new `is-manual-crop` attribute is introduced. If present, the default 1:1 crop is skipped, preserving the user's manual crop.
Also, the reset button didn’t appear for flexible crops(not using fixed ratios like 1:1 or 2:3) due to aspect ratio being 0/0. We now add the `o_we_image_cropped` class on save and remove it on reset to properly show or hide the reset button.

After cropping, the reset button appears in red, while the transform reset button is grey. To maintain consistency, we are adding the `o_we_bg_danger` class to transformation button.

This PR aims to respect the user’s manual crop when applying shapes.

task-4718769