### PR TITLE
[IMP] website_sale: add new 'At The End' options for countdown snippet

### DIFF
--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -156,6 +156,7 @@
         ],
         'website.assets_wysiwyg': [
             'website_sale/static/src/scss/website_sale.editor.scss',
+            'website_sale/static/src/snippets/s_countdown/options.js',
             'website_sale/static/src/snippets/s_dynamic_snippet_products/options.js',
             'website_sale/static/src/snippets/s_add_to_cart/options.js',
             'website_sale/static/src/js/website_sale.editor.js',

--- a/addons/website_sale/controllers/product_configurator.py
+++ b/addons/website_sale/controllers/product_configurator.py
@@ -99,6 +99,40 @@ class WebsiteSaleProductConfiguratorController(SaleProductConfiguratorController
         self._populate_currency_and_pricelist(kwargs)
         return super().sale_product_configurator_get_optional_products(*args, **kwargs)
 
+    @route(
+        route='/website_sale/product_configurator/set_prevent_zero_price_sale',
+        type='jsonrpc',
+        auth='public',
+        website=True,
+        readonly=True,
+    )
+    def website_sale_product_configurator_set_prevent_zero_price_sale(self, *args, **kwargs):
+        """ Set prevent_zero_price_sale to True, to prevent selling zero priced products. """
+        website = request.env['website'].get_current_website()
+        if website.prevent_zero_price_sale:
+            return (website.id, website.prevent_zero_price_sale)
+        website.prevent_zero_price_sale = True
+        return (website.id, website.prevent_zero_price_sale)
+
+    @route(
+        route='/website_sale/product_configurator/set_hide_products',
+        type='jsonrpc',
+        auth='public',
+        website=True,
+        readonly=True,
+    )
+    def website_sale_product_configurator_set_products_unpublished(self, limit=None, search_domain=None):
+        """ Unpublish products matching the search domain. """
+        domain = search_domain or []
+        products = request.env['product.template'].search(domain, limit=limit)
+        products.write({'is_published': False})
+
+        return [{
+            'id': p.id,
+            'name': p.name,
+            'is_published': p.is_published,
+        } for p in products]
+
     def _get_basic_product_information(
         self, product_or_template, pricelist, combination, currency=None, date=None, **kwargs
     ):

--- a/addons/website_sale/static/src/snippets/s_countdown/countdown.js
+++ b/addons/website_sale/static/src/snippets/s_countdown/countdown.js
@@ -1,0 +1,65 @@
+import { Countdown } from "@website/snippets/s_countdown/countdown";
+import { registry } from "@web/core/registry";
+import { rpc } from '@web/core/network/rpc';
+
+export class ProductCountdown extends Countdown {
+    getPublishedSearchDomain() {
+        const searchDomain = [];
+        const hideProductNames = this.el.dataset.hideProductNames;
+
+        if (hideProductNames) {
+            const nameFragments = hideProductNames.split(",").map(s => s.trim()).filter(Boolean);
+            const orConditions = [];
+
+            for (const fragment of nameFragments) {
+                orConditions.push(
+                    ["name", "ilike", fragment],
+                    ["default_code", "=", fragment],
+                    ["barcode", "=", fragment]
+                );
+            }
+
+            // Combine into proper OR domain
+            // If we have n conditions, we need (n-1) ORs
+            if (orConditions.length > 1) {
+                const domain = [];
+                const ors = orConditions.length - 1;
+                for (let i = 0; i < ors; i++) {
+                    domain.push('|');
+                }
+                domain.push(...orConditions);
+                searchDomain.push(...domain);
+            } else {
+                searchDomain.push(...orConditions);
+            }
+            return searchDomain;
+        }
+    }
+    
+    async set_prevent_zero_price_sale(){
+        return rpc("/website_sale/product_configurator/set_prevent_zero_price_sale", {});
+    }
+
+    async hide_product(){
+        await this.waitFor(rpc(
+            "/website_sale/product_configurator/set_hide_products",
+            Object.assign({
+                "search_domain": this.getPublishedSearchDomain(),
+            })
+        ));
+    }
+
+    handleEndCountdownAction() {
+        if (this.endAction === "prevent_sale_zero_priced_product"){
+            this.set_prevent_zero_price_sale();
+        } else if (this.endAction === "hide_product") {
+            this.hide_product()
+        } else{
+            super.handleEndCountdownAction();
+        }
+    }
+}
+
+registry
+    .category("public.interactions")
+    .add("website.countdown", ProductCountdown, { force: true });

--- a/addons/website_sale/static/src/snippets/s_countdown/options.js
+++ b/addons/website_sale/static/src/snippets/s_countdown/options.js
@@ -1,0 +1,20 @@
+import options from "@web_editor/js/editor/snippets.options";
+
+options.registry.countdown = options.registry.countdown.extend({
+    /**
+     * Override UI visibility to handle new endAction values.
+     *
+     * @override
+     */
+    updateUIVisibility: async function () {
+        await this._super(...arguments);
+        const dataset = this.$target[0].dataset;
+
+        // End Action UI
+        this.$el.find('.toggle-edit-message')
+            .toggleClass('d-none', 
+                dataset.endAction === 'prevent_sale_zero_priced_product' ||
+                dataset.endAction === 'hide_product'
+            );
+    },
+});

--- a/addons/website_sale/views/snippets/snippets.xml
+++ b/addons/website_sale/views/snippets/snippets.xml
@@ -742,4 +742,15 @@
     </xpath>
 </template>
 
+<template id="product_s_countdown_options" inherit_id="website.s_countdown_options" name="product countdown snippet options">
+    <xpath expr="//div[@data-js='countdown']/we-row/we-select" position="inside">
+        <we-button data-end-action="prevent_sale_zero_priced_product" data-name="prevent_sale_opt">Prevent Sale of Zero Priced Product</we-button>
+        <we-button data-end-action="hide_product" data-name="hide_product_opt">Hide the product</we-button>
+    </xpath>
+    <xpath expr="//we-select[@data-attribute-name='size']" position="before">
+        <we-input string="Product Names" data-dependencies="hide_product_opt" class="o_we_large" data-name="hide_product_names_opt"
+            data-attribute-name="hideProductNames" data-no-preview="true" data-select-data-attribute=""
+            placeholder="e.g. lamp,bin" title="Comma-separated list of parts of product names, barcodes or internal reference"/>
+    </xpath>
+</template>
 </odoo>


### PR DESCRIPTION
In the Website Editor, the Countdown snippet includes an 'At The End'
section to define behavior once the countdown ends.
Previously, it had four options.

This commit adds two more:

Prevent Sale of Zero Priced Products: When selected, the
prevent_zero_price_sale is set to True.
Hide Product: When selected, the chosen products are unpublished.

task-4369631