### PR TITLE
[FIX] mail: suppress push notifications only when conversation is fully focused

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -446,7 +446,27 @@ export class Store extends BaseStore {
     }
 
     /** Provides an override point for when the store service has started. */
-    onStarted() {}
+    onStarted() {
+        navigator.serviceWorker?.addEventListener("message", ({ data = {} }) => {
+            const { type, payload } = data;
+            if (type === "notification-display-request") {
+                const { correlationId, model, res_id } = payload;
+                const thread = this.Thread.get({ model, id: res_id });
+                let isTabFocused;
+                try {
+                    isTabFocused = parent.document.hasFocus();
+                } catch {
+                    // assumes tab not focused: parent.document from iframe triggers CORS error
+                }
+                if (isTabFocused && thread?.isDisplayed) {
+                    navigator.serviceWorker.controller.postMessage({
+                        type: "notification-display-response",
+                        payload: { correlationId },
+                    });
+                }
+            }
+        });
+    }
 
     /**
      * Search and fetch for a partner with a given user or partner id.


### PR DESCRIPTION
**Current behavior before PR:**

Push notifications are shown even when the user is already viewing the same
conversation in the Discuss app or in the ChatWindow. The Service Worker does
not currently check whether the conversation is focused, leading to redundant
and unnecessary notifications.

**Desired behavior after PR is merged:**

The Service Worker now intelligently checks the state of the Discuss and
ChatWindow before displaying push notifications. Notifications are only shown
when the user is not actively focused on the same conversation.
The updated logic ensures:

- Chat bubble minimized and tab focused → Show
- Chat window open, tab focused, but a conversation not focus → Suppress
- Chat window open, tab focused,  the conversation is focused → Suppress

This behavior is achieved by the Service Worker sending a message to the client
window to get the active thread and its focus status before deciding whether to
show a notification. This results in a cleaner user experience by avoiding
redundant alerts when they’re not needed.

task-[4582533](https://www.odoo.com/odoo/my-tasks/4582533)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
