### PR TITLE
[IMP] l10n_in_stock: update module name

### DIFF
--- a/addons/l10n_in_stock/__manifest__.py
+++ b/addons/l10n_in_stock/__manifest__.py
@@ -2,9 +2,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 {
-    'name': 'Indian - Stock Report(GST)',
+    'name': 'Indian - Stock',
     'version': '1.0',
-    'description': """GST Stock Report""",
+    'description': """Indian - Stock""",
     'category': 'Accounting/Localizations',
     'depends': [
         'l10n_in',


### PR DESCRIPTION
The module name will be changed from 'Indian - Stock Report (GST)' to 'Indian - Stock'. This update aligns with the introduction of a new module, `l10n_in_reports_stock`, which will handle stock reporting independently.

task-4334089

