### PR TITLE
[FIX] mail: fix text color in customer review section(website shop)

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -41,7 +41,7 @@
                 >
                     <div class="position-relative flex-grow-1">
                         <t t-set="inputClasses" t-value="'o-mail-Composer-inputStyle form-control border-0 rounded-3'"/>
-                        <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto"
+                        <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto text-body"
                             t-att-class="inputClasses"
                             t-ref="textarea"
                             t-on-keydown="onKeydown"

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -67,7 +67,7 @@
                                     <t t-if="message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',


### PR DESCRIPTION
<b>Steps to reproduce:</b>

1. Website > shop > Open any product > Open Editor(Edit)
2. Customize → Navigate to Customer →  Click on Rating.
3. Theme →  Navigate to Colors → Navigate to Light & Dark > Choose Dark theme.

<b>Issue:</b>
Website Shop, when using a dark background, the text in write a message box and comment bubbles in reviews sections becomes white making it invisible.

<b>Cause:</b>
In light mode, the text appears black, making it easy to read. However, when switching to dark mode, the text changes to white, which makes it difficult to read against the light bubble background.

<b>Solution:</b>
This commit adds class text-black to the comment and description container to improve the visibility.

<b>opw : 4724764</b>

<b>BUG:</b>
![2025-04-22_11-38](https://github.com/user-attachments/assets/17b32ddb-b3f5-433d-84a6-05c39af34735)
![image](https://github.com/user-attachments/assets/4daff91d-67fe-4a8d-8483-04096827f9e7)
![image](https://github.com/user-attachments/assets/64b0cc3e-7bb3-439d-bbe5-221ae15aa398)


<b>FIX:</b>
![image](https://github.com/user-attachments/assets/b0a7d5f6-b3c5-4355-9b0a-44d7c91b0fdc)
![image](https://github.com/user-attachments/assets/dcd46bd9-d3fb-4fee-8dbb-f9a1002b2b8d)
![image](https://github.com/user-attachments/assets/a3718d1e-d059-47e5-b6b4-e49ee1f52216)



