### PR TITLE
[IMP] mail: sfu/ice servers settings revamp

### DIFF
--- a/addons/mail/models/ir_config_parameter.py
+++ b/addons/mail/models/ir_config_parameter.py
@@ -71,7 +71,7 @@ class IrConfig_Parameter(models.Model):
     #     google translate;
     #   * 'mail.web_push_vapid_private_key' and 'mail.web_push_vapid_public_key':
     #     configuration parameters when using web push notifications;
-    #   * 'mail.use_twilio_rtc_servers', 'mail.sfu_server_url' and 'mail.
+    #   * 'mail.use_twilio_rtc_servers', 'mail.use_sfu_server', 'mail.sfu_server_url' and 'mail.
     #     sfu_server_key': rtc server usage and configuration;
     #   * 'discuss.tenor_api_key': used for gif fetch service;
     _inherit = 'ir.config_parameter'

--- a/addons/mail/models/res_config_settings.py
+++ b/addons/mail/models/res_config_settings.py
@@ -33,12 +33,17 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='mail.use_twilio_rtc_servers',
     )
     twilio_account_sid = fields.Char(
-        'Twilio Account SID',
+        'Account SID',
         config_parameter='mail.twilio_account_sid',
     )
     twilio_account_token = fields.Char(
-        'Twilio Account Auth Token',
+        'Account Auth Token',
         config_parameter='mail.twilio_account_token',
+    )
+    use_sfu_server = fields.Boolean(
+        'Use SFU server',
+        help="If you want to setup SFU server for large group calls.",
+        config_parameter="mail.use_sfu_server",
     )
     sfu_server_url = fields.Char("SFU Server URL", config_parameter="mail.sfu_server_url")
     sfu_server_key = fields.Char("SFU Server key", config_parameter="mail.sfu_server_key", help="Base64 encoded key")

--- a/addons/mail/tools/discuss.py
+++ b/addons/mail/tools/discuss.py
@@ -37,19 +37,23 @@ def add_guest_to_context(func):
 
     return wrapper
 
-def get_twilio_credentials(env) -> (str, str):
+
+def get_twilio_credentials(env) -> tuple[str | None, str | None]:
     """
     To be overridable if we need to obtain credentials from another source.
-    :return: tuple(account_sid: str, auth_token: str)
+    :return: tuple(account_sid: str, auth_token: str) or (None, None) if Twilio is disabled
     """
     params = env["ir.config_parameter"].sudo()
+    if not params.get_param("mail.use_twilio_rtc_servers"):
+        return None, None
     account_sid = params.get_param("mail.twilio_account_sid")
     auth_token = params.get_param("mail.twilio_account_token")
     return account_sid, auth_token
 
 
 def get_sfu_url(env) -> str | None:
-    sfu_url = env['ir.config_parameter'].sudo().get_param("mail.sfu_server_url")
+    params = env["ir.config_parameter"].sudo()
+    sfu_url = params.get_param("mail.sfu_server_url") if params.get_param("mail.use_sfu_server") else None
     if not sfu_url:
         sfu_url = os.getenv("ODOO_SFU_URL")
     if sfu_url:

--- a/addons/mail/views/mail_ice_server_views.xml
+++ b/addons/mail/views/mail_ice_server_views.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0"?>
 <odoo>
     <record id="action_ice_servers" model="ir.actions.act_window">
-         <field name="name">ICE servers</field>
+         <field name="name">ICE Servers</field>
          <field name="res_model">mail.ice.server</field>
-         <field name="view_mode">list,form</field>
+         <field name="view_mode">list,form,kanban</field>
+         <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">No ICE servers found. Let's create one!</p>
+            <p>Use your own servers for calls to manage heavy traffic and ensure reliability if Twilio is unavailable.</p>
+        </field>
     </record>
 
     <record model="ir.ui.view" id="view_ice_server_tree">
         <field name="name">mail.ice.server.list</field>
         <field name="model">mail.ice.server</field>
         <field name="arch" type="xml">
-            <list editable="bottom">
+            <list editable="bottom" sample="1">
                 <field colspan="1" name="server_type"/>
                 <field name="uri"/>
                 <field name="username"/>
@@ -23,20 +27,76 @@
         <field name="name">mail.ice.server.form</field>
         <field name="model">mail.ice.server</field>
         <field name="arch" type="xml">
-            <form string="ICE server">
+            <form string="ICE Server Configuration">
                 <sheet>
                     <group>
-                        <label for="uri"/>
-                        <div class="oe_inline" name="URI" style="display: inline;">
-                            <field name="server_type" class="oe_inline"/><field name="uri" class="oe_inline"/>
-                        </div>
+                        <field name="server_type" class="oe_inline"/>
+                        <field name="uri" placeholder="stun:stun.google.com:19302 or turn:turn.example.com:3478"/>
                     </group>
-                    <group>
+                    <group string="Authentication">
                         <field name="username"/>
                         <field name="credential"/>
                     </group>
                 </sheet>
             </form>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_ice_server_kanban">
+        <field name="name">mail.ice.server.kanban</field>
+        <field name="model">mail.ice.server</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile" sample="1">
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_global_click">
+                            <div class="oe_kanban_content p-2">
+                                <div class="d-flex align-items-center mb-2">
+                                    <span class="fw-bold me-1">Type:</span>
+                                    <span class="fw-bold">
+                                        <field name="server_type"/>
+                                    </span>
+                                </div>
+                                <div class="d-flex align-items-center mb-2">
+                                    <span class="fw-bold me-1">URI:</span>
+                                    <span class="text-primary fw-bold">
+                                        <field name="uri"/>
+                                    </span>
+                                </div>
+                                <t t-if="record.username.raw_value">
+                                    <div class="d-flex align-items-center mb-2">
+                                        <span class="fw-bold me-1">Username:</span>
+                                        <field name="username"/>
+                                    </div>
+                                </t>
+                                <t t-if="record.credential.raw_value">
+                                    <div class="d-flex align-items-center">
+                                        <span class="fw-bold me-1">Credential:</span>
+                                        <field name="credential"/>
+                                    </div>
+                                </t>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="view_ice_server_search" model="ir.ui.view" >
+        <field name="name">mail.ice.server.search</field>
+        <field name="model">mail.ice.server</field>
+        <field name="arch" type="xml">
+            <search string="Search ICE Servers">
+                <field name="uri"/>
+                <field name="username"/>
+                <field name="credential"/>
+                <filter string="STUN" name="stun" domain="[('server_type','=','stun')]"/>
+                <filter string="TURN" name="turn" domain="[('server_type','=','turn')]"/>
+                <group>
+                    <filter string="Server Type" name="group_by_server_type" context="{'group_by': 'server_type'}"/>
+                </group>
+            </search>
         </field>
     </record>
 </odoo>

--- a/addons/mail/views/mail_menus.xml
+++ b/addons/mail/views/mail_menus.xml
@@ -162,7 +162,7 @@
         parent="mail.mail_menu_technical"
         sequence="52"/>
     <menuitem id="mail.ice_servers_menu"
-        name="ICE servers"
+        name="ICE Servers"
         action="action_ice_servers"
         parent="mail.mail_menu_technical"
         sequence="53"/>

--- a/addons/mail/views/res_config_settings_views.xml
+++ b/addons/mail/views/res_config_settings_views.xml
@@ -67,21 +67,24 @@
                                 </div>
                             </div>
                         </setting>
-                        <setting help="Add your twilio credentials for ICE servers">
+                        <setting string="Custom ICE Server with Twilio"
+                                 help="Set up your own server for small group calls using peer-to-peer connections"
+                                 documentation="https://www.odoo.com/documentation/18.0/applications/productivity/discuss/ice_servers.html">
                             <field name="use_twilio_rtc_servers"/>
-                            <div class="content-group"  invisible="not use_twilio_rtc_servers">
+                            <div class="content-group" invisible="not use_twilio_rtc_servers">
                                 <div class="row mt16" id="mail_twilio_sid">
                                     <label for="twilio_account_sid" class="col-lg-3"/>
-                                    <field name="twilio_account_sid" placeholder="e.g. ACd5543a0b450ar4c7t95f1b6e8a39t543"/>
+                                    <field name="twilio_account_sid" string="Account SID" placeholder="e.g. ACd5543a0b450ar4c7t95f1b6e8a39t543"/>
                                 </div>
                                 <div class="row mt16" id="mail_twilio_auth_token">
                                     <label for="twilio_account_token" class="col-lg-3"/>
-                                    <field name="twilio_account_token" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
+                                    <field name="twilio_account_token" string="Account Auth Token" placeholder="e.g. 65ea4f9e948b693N5156F350256bd152"/>
                                 </div>
                             </div>
                         </setting>
-                        <setting string="SFU server">
-                            <div class="content-group">
+                        <setting string="Custom SFU Server" help="Set up your own server for large group calls by routing connections centrally">
+                            <field name="use_sfu_server"/>
+                            <div class="content-group" invisible="not use_sfu_server">
                                 <div class="row mt16">
                                     <label for="sfu_server_url" string="URL" class="col-lg-3"/>
                                     <field name="sfu_server_url"/>
@@ -92,12 +95,11 @@
                                 </div>
                             </div>
                         </setting>
-                        <setting string="Custom ICE server list" help="Configure your ICE server list for webRTC">
-                            <div class="content-group">
-                                <div class="row col-lg-4">
-                                    <button type="action" name="%(mail.action_ice_servers)d" string="ICE Servers" icon="oi-arrow-right" class="btn-link"/>
-                                </div>
-                            </div>
+                        <setting string="Custom ICE Servers" help="Use your own servers for calls to manage heavy traffic and ensure reliability if Twilio is unavailable"
+                                 documentation="https://www.odoo.com/documentation/18.0/applications/productivity/discuss/ice_servers.html#define-a-list-of-custom-ice-servers">
+                                 <div class="content-group">
+                                        <button type="action" name="%(mail.action_ice_servers)d" string="Configure ICE Servers" icon="oi-arrow-right" class="btn-link"/>
+                                 </div>
                         </setting>
                         <setting id="tenor_api_key" string="Tenor GIF API key" help="Add a Tenor GIF API key to enable GIFs support." documentation="https://developers.google.com/tenor/guides/quickstart#setup">
                             <field name="tenor_api_key" placeholder="Paste your API key"/>


### PR DESCRIPTION
**Purpose of this PR:**
- Previously, sfu/ice server configuration settings lacked clear options for custom servers and proper documentation links, potentially causing confusion for SaaS and on-premise users about required setup.

- This PR adds clearer labels, tooltips, and documentation links for ICE server configuration. It adds a new `use_sfu_server` field to provide custom server options that follow the same logic as `use_twilio_rtc_servers` disabled by default for SaaS 
(works out of the box) but available for on-premise deployments that require custom configuration. It also improves the UI with better search filters, kanban view, and helper messages.

- With this change, admins have clear custom server options that work consistently across SaaS and on-premise deployments without causing any confusion.

**Current behavior before PR:**

1. SFU and ICE server settings in `res_config_settings` had minimal labels and tooltips, with no direct links to documentation.
2. `mail.ice.server` lacked a search view with useful filters or grouping.
3. No action helper message was shown when no ICE servers were configured.

**Desired behavior after PR is merged:**

1. Revamped `res.config.settings` with improved labels, tooltips, and doclinks for SFU and Twilio ICE server options.
2. Add `use_sfu_server` field  to provide custom server options that follow the same logic as `use_twilio_rtc_servers`.
3. Add search view to `mail_ice_server_views` with filters (STUN, TURN), group by type, and quick search on URI, username, and credential.
4. Add action helper message to guide users when no ICE servers are configured.
5. Add mobile-friendly kanban view.

Task - 4661931