### PR TITLE
[IMP] point_of_sale: add product tag description

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -54,7 +54,8 @@
         'views/res_config_settings_views.xml',
         'views/customer_display_index.xml',
         'views/account_move_views.xml',
-        'views/pos_session_sales_details.xml'
+        'views/pos_session_sales_details.xml',
+        'views/product_tag_views.xml'
     ],
     'demo': [
         'data/demo_data.xml',

--- a/addons/point_of_sale/models/product_tag.py
+++ b/addons/point_of_sale/models/product_tag.py
@@ -1,11 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import models, api
+from odoo import api, fields, models
+from odoo.tools import is_html_empty
 
 
 class ProductTag(models.Model):
     _name = 'product.tag'
     _inherit = ['product.tag', 'pos.load.mixin']
 
+    pos_description = fields.Html(string='Description', translate=True)
+
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['name']
+        return ['name', 'pos_description']
+
+    def write(self, vals):
+        if vals.get('pos_description') and is_html_empty(vals['pos_description']):
+            vals['pos_description'] = ''
+        return super().write(vals)

--- a/addons/point_of_sale/views/point_of_sale_dashboard.xml
+++ b/addons/point_of_sale/views/point_of_sale_dashboard.xml
@@ -107,7 +107,7 @@
                             </div>
                         </div>
                         <div class="row g-0 pb-4 ms-2 mt-auto">
-                            <div name="card_left" class="col-6">
+                            <div name="card_left" class="col-6 d-flex flex-wrap align-items-center gap-2">
                                 <button t-if="record.current_session_state.raw_value != 'closing_control'" class="btn btn-primary" name="open_ui" type="object">
                                     <t t-if="record.current_session_state.raw_value === 'opened'">Continue Selling</t>
                                     <t t-else="">Open Register</t>

--- a/addons/point_of_sale/views/product_tag_views.xml
+++ b/addons/point_of_sale/views/product_tag_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <!-- Product Tags -->
+    <record id="product_tag_form_view_inherit_point_of_sale" model="ir.ui.view">
+        <field name="name">product.tag.form.inherit.point.of.sale</field>
+        <field name="model">product.tag</field>
+        <field name="inherit_id" ref="product.product_tag_form_view"/>
+        <field name="priority" eval="100"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form/sheet/group" position="after">
+                <group name="pos" string="Point of Sale">
+                    <field name="pos_description"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+    <menuitem id="pos_menu_products_tag_action" action="product.product_tag_action"
+              parent="point_of_sale.pos_menu_products_configuration" sequence="3"/>
+
+</odoo>

--- a/addons/pos_self_order/views/point_of_sale_dashboard.xml
+++ b/addons/pos_self_order/views/point_of_sale_dashboard.xml
@@ -24,18 +24,12 @@
         <field name="model">pos.config</field>
         <field name="inherit_id" ref="point_of_sale.view_pos_config_kanban" />
         <field name="arch" type="xml">
-            <xpath
-                expr="//div[hasclass('dropdown-pos-config')]/div/div[hasclass('o_kanban_manage_view')]"
-                position="inside">
+            <xpath expr="//div[@name='card_left']" position="inside">
                 <field name="self_ordering_mode" invisible="1" />
-                <div role="menuitem">
-                    <a name="preview_self_order_app"
-                        type="object"
-                        style="white-space: nowrap;"
-                        invisible="not self_ordering_mode == 'mobile'">
+                 <button invisible="not self_ordering_mode == 'mobile' and not self_ordering_mode == 'consultation'"
+                         class="btn btn-secondary" name="preview_self_order_app" type="object">
                         Mobile Menu
-                    </a>
-                </div>
+                 </button>
             </xpath>
             <xpath expr="//field[@name='name']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
@@ -47,14 +41,14 @@
             <xpath expr="//div[@name='card_left']" position="after">
                 <field name="self_ordering_mode" invisible="1" />
                 <field name="current_session_id" invisible="1" />
-                <div class="col-6 d-flex flex-column align-items-start" invisible="not self_ordering_mode == 'kiosk'">
+                <div class="col-6 d-flex flex-wrap align-items-center gap-2" invisible="not self_ordering_mode == 'kiosk'">
                     <button t-if="!record.current_session_id.raw_value" class="btn btn-primary pos_open_session_btn" name="action_open_wizard" type="object">
                         Start Kiosk
                     </button>
                     <button t-else="" name="action_close_kiosk_session" class="btn btn-secondary" type="object">
                         Close Session
                     </button>
-                    <button t-if="record.current_session_id.raw_value" class="btn-link mt-2" name="action_open_wizard" type="object">
+                    <button t-if="record.current_session_id.raw_value" class="btn btn-secondary" name="action_open_wizard" type="object">
                         Open Kiosk
                     </button>
                 </div>


### PR DESCRIPTION
This commit adds an description field to product tags to allow displaying additional information in Self and Kiosk. 
It also introduces secondary buttons (“Mobile Menu” and “Open Kiosk”) on the dashboard for improved navigation.

Task: 4724527

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
