### PR TITLE
[FIX] l10n_cl: vat format on invoice report

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -249,7 +249,7 @@ class AccountMove(models.Model):
                     'tax_ids': gd.tax_ids,
                 }
             )
-        values['vat_percent'] = '%.2f%%' % vat_percent if vat_percent > 0 else False
+        values['vat_percent'] = '%.2f' % vat_percent if vat_percent > 0 else False
         return values
 
     def _l10n_cl_get_withholdings(self):

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -251,7 +251,7 @@
             </t>
             <t t-if="subtotal_amounts['vat_amount'] != 0.0">
                 <tr>
-                    <td>VAT <t t-esc="subtotal_amounts['vat_percent']"/></td>
+                    <td>VAT <t t-esc="subtotal_amounts['vat_percent']"/>%</td>
                     <td class="text-end" t-out="subtotal_amounts['vat_amount']"
                         t-options="{'widget': 'monetary', 'display_currency': subtotal_amounts['main_currency']}"/></tr>
             </t>


### PR DESCRIPTION
This corrects 9f96aa7648ed4320849c6736e85b9cb6c988232c that was
impacting all xml files whereas it should only have had an impact
on the invoice report.

opw-4661577
