### PR TITLE
[FIX] mail: ensure all companies context when archiving user activities

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -143,7 +143,7 @@ class Users(models.Model):
         return write_res
 
     def action_archive(self):
-        activities_to_delete = self.env['mail.activity'].search([('user_id', 'in', self.ids)])
+        activities_to_delete = self.env['mail.activity'].sudo().search([('user_id', 'in', self.ids)])
         activities_to_delete.unlink()
         return super(Users, self).action_archive()
 

--- a/addons/test_mail/models/test_mail_models.py
+++ b/addons/test_mail/models/test_mail_models.py
@@ -178,6 +178,7 @@ class MailTestActivity(models.Model):
     date = fields.Date()
     email_from = fields.Char()
     active = fields.Boolean(default=True)
+    company_id = fields.Many2one('res.company')
 
     def action_start(self, action_summary):
         return self.activity_schedule(


### PR DESCRIPTION
**Steps to reproduce:**
- Set up one user with a new company
- With this user :
    - Create sale order
    - Create activity on the new sale order
- Go back to the admin user
- Disable the new company in the top right menu
- Archive the user
- Activities of the user are still present

**Issue:**
In `activities_to_delete = self.env['mail.activity'].search([('user_id', 'in', self.ids)])`, the access rights of the records used in the activities are checked, which means that the sale order domains are applied. If the given domain doesn't match (for example `('company_id', 'in', company_ids)` when the company_id is manually disabled), the search can miss the activity to unlink.

**Fix:**
Added `.sudo()` to ensure all of the user's activities of any company
are considered, overwriting the current company context.

opw-4716031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
