### PR TITLE
[IMP] base: create non-stored compute fields without depends

### DIFF
--- a/odoo/addons/base/views/ir_model_views.xml
+++ b/odoo/addons/base/views/ir_model_views.xml
@@ -325,7 +325,7 @@
                             <page name="compute" string="Compute" groups="base.group_no_one">
                                 <group>
                                     <field name="related"/>
-                                    <field name="depends" required="compute not in [False, '']"/>
+                                    <field name="depends" required="bool(compute) and store"/>
                                     <field name="compute" widget="code" options="{'mode': 'python'}"/>
                                 </group>
                                 <div>


### PR DESCRIPTION
Before this commit:
- User could not create a non-stored computed field without specifying dependencies.

After this commit:
- User can create a non-stored computed field without specifying dependencies.

task-4395689
