### PR TITLE
[FIX] web: invalidate persistent caches when database structure changes.

### DIFF
--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -6,7 +6,7 @@ import odoo
 from odoo import api, models, fields
 from odoo.http import request, DEFAULT_MAX_CONTENT_LENGTH
 from odoo.tools import config
-from odoo.tools.misc import str2bool
+from odoo.tools.misc import hmac, str2bool
 
 
 """
@@ -103,6 +103,7 @@ class IrHttp(models.AbstractModel):
             "is_internal_user": is_internal_user,
             "user_context": user_context,
             "db": self.env.cr.dbname,
+            "registry_hash": hmac(self.env(su=True), "webclient-cache", self.env.registry.registry_sequence),
             "user_settings": self.env['res.users.settings']._find_or_create_for_user(user)._res_users_settings_format(),
             "server_version": version_info.get('server_version'),
             "server_version_info": version_info.get('server_version_info'),

--- a/addons/web/static/src/start.js
+++ b/addons/web/static/src/start.js
@@ -24,7 +24,7 @@ export async function startWebClient(Webclient) {
     };
     odoo.isReady = false;
 
-    rpc.setCache(new PersistentCache("rpc", session.server_version));
+    rpc.setCache(new PersistentCache("rpc", session.registry_hash));
 
     await whenReady();
     const app = await mountComponent(Webclient, document.body, { name: "Odoo Web Client" });

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -1,3 +1,4 @@
+import { session } from "@web/session";
 import { browser } from "../../core/browser/browser";
 import { registry } from "../../core/registry";
 
@@ -23,7 +24,7 @@ export const menuService = {
         const storedMenus = browser.localStorage.getItem("webclient_menus");
         const storedMenusVersion = browser.localStorage.getItem("webclient_menus_version");
 
-        if (storedMenus && storedMenusVersion === odoo.info.server_version) {
+        if (storedMenus && storedMenusVersion === session.registry_hash) {
             fetchMenus().then((res) => {
                 if (res) {
                     const fetchedMenus = JSON.stringify(res);
@@ -38,7 +39,7 @@ export const menuService = {
         } else {
             menusData = await fetchMenus();
             if (menusData) {
-                browser.localStorage.setItem("webclient_menus_version", odoo.info.server_version);
+                browser.localStorage.setItem("webclient_menus_version", session.registry_hash);
                 browser.localStorage.setItem("webclient_menus", JSON.stringify(menusData));
             }
         }

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -31,6 +31,7 @@ const makeSession = ({
     },
     can_insert_in_spreadsheet: true,
     db,
+    registry_hash: "05500d71e084497829aa807e3caa2e7e9782ff702c15b2f57f87f2d64d049bd0",
     home_action_id: false,
     is_admin: true,
     is_internal_user: true,

--- a/addons/web/static/tests/legacy/setup.js
+++ b/addons/web/static/tests/legacy/setup.js
@@ -245,6 +245,7 @@ function patchSessionInfo() {
             tz: "taht",
         },
         db: "test",
+        registry_hash: "05500d71e084497829aa807e3caa2e7e9782ff702c15b2f57f87f2d64d049bd0",
         is_admin: true,
         is_system: true,
         username: "thewise@odoo.com",

--- a/addons/web/static/tests/webclient/menu_service.test.js
+++ b/addons/web/static/tests/webclient/menu_service.test.js
@@ -79,7 +79,8 @@ test(`use stored menus, and don't update on load_menus return (if identical)`, a
     onRpc("/web/webclient/load_menus", () => def);
 
     // Initial Stored values
-    browser.localStorage.webclient_menus_version = "1.0";
+    browser.localStorage.webclient_menus_version =
+        "05500d71e084497829aa807e3caa2e7e9782ff702c15b2f57f87f2d64d049bd0";
     browser.localStorage.webclient_menus = JSON.stringify({
         1: { appID: 1, children: [2, 3], name: "App1", id: 1, actionID: 666 },
         2: { appID: 1, children: [], name: "Test1", id: 2, actionID: 666 },
@@ -106,7 +107,8 @@ test(`use stored menus, and update on load_menus return`, async () => {
 
     // Initial Stored values
     // There is no menu "Test2" in the initial values
-    browser.localStorage.webclient_menus_version = "1.0";
+    browser.localStorage.webclient_menus_version =
+        "05500d71e084497829aa807e3caa2e7e9782ff702c15b2f57f87f2d64d049bd0";
     browser.localStorage.webclient_menus = JSON.stringify({
         1: { id: 1, children: [2], name: "App1", appID: 1, actionID: 666 },
         2: { id: 2, children: [], name: "Test1", appID: 1, actionID: 666 },


### PR DESCRIPTION
[FIX] web: invalidate persistent caches when database structure changes.

Before this commit, the persistent caches were not invalidated when the database structure changed (e.g.: installing/removing modules; adding/removing fields). The persistent caches will return old values, which could lead to errors. This can also happen when using a different database with the same URL (e.g.: in local when developing; or changing the database using `web/database/manager`; or changing the cli parameter `-d<database>,--database<database>`).

Now the persistent caches will be invalidated if the database structure is changed, or if a different database is used.

Co-authored-by: Rémy Voet <ryv@odoo.com>