### PR TITLE
[ADD] sms_twilio: new SMS provider

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1936,6 +1936,15 @@ resource_name          = sms
 replace_edited_strings = false
 keep_translations      = false
 
+[o:odoo:p:odoo-17:r:sms_twilio]
+file_filter            = addons/sms_twilio/i18n/<lang>.po
+source_file            = addons/sms_twilio/i18n/sms_twilio.pot
+type                   = PO
+minimum_perc           = 0
+resource_name          = sms_twilio
+replace_edited_strings = false
+keep_translations      = false
+
 [o:odoo:p:odoo-17:r:snailmail]
 file_filter            = addons/snailmail/i18n/<lang>.po
 source_file            = addons/snailmail/i18n/snailmail.pot

--- a/addons/mass_mailing_sms/models/sms_tracker.py
+++ b/addons/mass_mailing_sms/models/sms_tracker.py
@@ -43,6 +43,7 @@ class SmsTracker(models.Model):
         }[trace_status]
         traces = self.mailing_trace_id.filtered(lambda t: t.trace_status not in statuses_to_ignore)
         if traces:
+            # TDE note: check to use set_sent / ... tools updating marketing automation bits
             traces_values = {
                 'trace_status': trace_status,
                 'failure_type': failure_type,

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test.py
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test.py
@@ -5,7 +5,6 @@ from markupsafe import Markup
 from werkzeug.urls import url_join
 
 from odoo import fields, models, _
-from odoo.addons.sms.tools.sms_api import SmsApi
 
 
 class MassSMSTest(models.TransientModel):
@@ -24,6 +23,7 @@ class MassSMSTest(models.TransientModel):
 
         numbers = [number.strip() for number in self.numbers.splitlines()]
         sanitized_numbers = [self.env.user._phone_format(number=number) for number in numbers]
+        valid_numbers = [number for sanitized, number in zip(sanitized_numbers, numbers) if sanitized]
         invalid_numbers = [number for sanitized, number in zip(sanitized_numbers, numbers) if not sanitized]
 
         record = self.env[self.mailing_id.mailing_model_real].search([], limit=1)
@@ -32,32 +32,32 @@ class MassSMSTest(models.TransientModel):
             # Returns a proper error if there is a syntax error with qweb
             body = self.env['mail.render.mixin']._render_template(body, self.mailing_id.mailing_model_real, record.ids)[record.id]
 
-        new_sms_messages_sudo = self.env['sms.sms'].sudo().create([{'body': body, 'number': number} for number in sanitized_numbers])
-        sms_api = SmsApi(self.env)
+        new_sms_messages_sudo = self.env['sms.sms'].sudo().create([{'body': body, 'number': number} for number in valid_numbers])
+        sms_api = self.env.company._get_sms_api_class()(self.env)
         sent_sms_list = sms_api._send_sms_batch([{
             'content': body,
             'numbers': [{'number': sms_id.number, 'uuid': sms_id.uuid} for sms_id in new_sms_messages_sudo],
         }], delivery_reports_url=url_join(self[0].get_base_url(), '/sms/status'))
-
-        error_messages = {}
-        if any(sent_sms.get('state') != 'success' for sent_sms in sent_sms_list):
-            error_messages = sms_api._get_sms_api_error_messages()
 
         notification_messages = []
         if invalid_numbers:
             notification_messages.append(_('The following numbers are not correctly encoded: %s',
                 ', '.join(invalid_numbers)))
 
-        for sent_sms in sent_sms_list:
+        for sent_sms, db_sms in zip(sent_sms_list, new_sms_messages_sudo):
+            recipient = db_sms.number or sent_sms.get('res_id')
             if sent_sms.get('state') == 'success':
                 notification_messages.append(
-                    _('Test SMS successfully sent to %s', sent_sms.get('res_id')))
+                    _('Test SMS successfully sent to %s', recipient))
             elif sent_sms.get('state'):
-                notification_messages.append(
-                    _('Test SMS could not be sent to %s: %s',
-                    sent_sms.get('res_id'),
-                    error_messages.get(sent_sms['state'], _("An error occurred.")))
+                failure_reason = sent_sms.get('failure_reason')
+                message = _('Test SMS could not be sent to %s: %s',
+                    recipient,
+                    sms_api._get_sms_api_error_messages().get(sent_sms['state']),
                 )
+                if failure_reason:
+                    message += ' %s' % failure_reason
+                notification_messages.append(message)
 
         if notification_messages:
             message_body = Markup(

--- a/addons/phone_validation/tools/phone_validation.py
+++ b/addons/phone_validation/tools/phone_validation.py
@@ -89,6 +89,10 @@ try:
             phone_fmt = phonenumbers.PhoneNumberFormat.NATIONAL
         return phonenumbers.format_number(phone_nbr, phone_fmt)
 
+    def phone_get_country_code_for_number(number):
+        region_data = phone_get_region_data_for_number(number)
+        return region_data['code']
+
     def phone_get_region_data_for_number(number):
         try:
             phone_obj = phone_parse(number, None)
@@ -118,6 +122,9 @@ except ImportError:
             )
             _phonenumbers_lib_warning = True
         return number
+
+    def phone_get_country_code_for_number(number):
+        return ''
 
     def phone_get_region_code_for_number(number):
         return {

--- a/addons/sms/models/__init__.py
+++ b/addons/sms/models/__init__.py
@@ -8,6 +8,7 @@ from . import mail_message
 from . import mail_notification
 from . import mail_thread
 from . import models
+from . import res_company
 from . import res_partner
 from . import sms_sms
 from . import sms_template

--- a/addons/sms/models/res_company.py
+++ b/addons/sms/models/res_company.py
@@ -1,0 +1,11 @@
+from odoo import models
+
+from odoo.addons.sms.tools.sms_api import SmsApi
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    def _get_sms_api_class(self):
+        self.ensure_one()
+        return SmsApi

--- a/addons/sms/models/sms_tracker.py
+++ b/addons/sms/models/sms_tracker.py
@@ -41,12 +41,12 @@ class SmsTracker(models.Model):
             If provided, notification values will be derived from it.
             (see ``_get_tracker_values_from_provider_error``)
         """
-        failure_reason = False
+        failure_reason = self.env.context.get("sms_known_failure_reason")  # TODO RIGR in master: pass as param instead of context
         failure_type = f'sms_{provider_error}'
         error_status = None
         if failure_type not in self.env['sms.sms'].DELIVERY_ERRORS:
             failure_type = 'unknown'
-            failure_reason = provider_error
+            failure_reason = failure_reason or provider_error
         elif failure_type in self.env['sms.sms'].BOUNCE_DELIVERY_ERRORS:
             error_status = "bounce"
 

--- a/addons/sms/tools/sms_api.py
+++ b/addons/sms/tools/sms_api.py
@@ -5,11 +5,35 @@ from odoo import _, exceptions
 from odoo.addons.iap.tools import iap_tools
 
 
-class SmsApi:
-    DEFAULT_ENDPOINT = 'https://sms.api.odoo.com'
+class SmsApiBase:
+    PROVIDER_TO_SMS_FAILURE_TYPE = {
+        'server_error': 'sms_server',
+        'sms_number_missing': 'sms_number_missing',
+        'wrong_number_format': 'sms_number_format',
+    }
 
     def __init__(self, env):
         self.env = env
+        self.company = env.company
+
+    def _get_sms_api_error_messages(self):
+        """Return a mapping of `_send_sms_batch` errors to an error message."""
+        raise NotImplementedError()
+
+    def _send_sms_batch(self, messages, delivery_reports_url=False):
+        raise NotImplementedError()
+
+    def _set_company(self, company):
+        self.company = company
+
+
+class SmsApi(SmsApiBase):  # TODO RIGR in master: rename SmsApi to SmsApiIAP, and  SmsApiBase to SmsApi
+    DEFAULT_ENDPOINT = 'https://sms.api.odoo.com'
+    PROVIDER_TO_SMS_FAILURE_TYPE = SmsApiBase.PROVIDER_TO_SMS_FAILURE_TYPE | {
+        'insufficient_credit': 'sms_credit',
+        'country_not_supported': 'sms_country_not_supported',
+        'unregistered': 'sms_acc',
+    }
 
     def _contact_iap(self, local_endpoint, params, timeout=15):
         if not self.env.registry.ready:  # Don't reach IAP servers during module installation
@@ -20,7 +44,7 @@ class SmsApi:
         endpoint = self.env['ir.config_parameter'].sudo().get_param('sms.endpoint', self.DEFAULT_ENDPOINT)
         return iap_tools.iap_jsonrpc(endpoint + local_endpoint, params=params, timeout=timeout)
 
-    def _send_sms_batch(self, messages, delivery_reports_url=False):
+    def _send_sms_batch(self, messages, delivery_reports_url=False):  # TODO RIGR: switch to kwargs in master
         """ Send SMS using IAP in batch mode
 
         :param list messages: list of SMS (grouped by content) to send:
@@ -34,7 +58,7 @@ class SmsApi:
                   ]
               }, ...
           ]```
-        :param str delivery_reports_url: url to route receiving delivery reports
+        :param str delivery_reports_url: url to route receiving delivery reports. Deprecated  # TODO RIGR: remove in master
         :return: response from the endpoint called, which is a list of results
           formatted as ```[
               {

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -212,8 +212,9 @@ class SendSMS(models.TransientModel):
                 self.sanitized_numbers.split(',') if self.sanitized_numbers else [self.recipient_single_number_itf or self.recipient_single_number or '']
             )
         ]
-        self.env['sms.sms'].sudo().create(sms_values).send()
-        return True
+        sms_su = self.env['sms.sms'].sudo().create(sms_values)
+        sms_su.send()
+        return sms_su
 
     def _action_send_sms_comment_single(self, records=None):
         # If we have a recipient_single_original number, it's possible this number has been corrected in the popup

--- a/addons/sms_twilio/__init__.py
+++ b/addons/sms_twilio/__init__.py
@@ -1,0 +1,3 @@
+from . import controllers
+from . import models
+from . import wizard

--- a/addons/sms_twilio/__manifest__.py
+++ b/addons/sms_twilio/__manifest__.py
@@ -1,0 +1,22 @@
+{
+    'name': 'Twilio SMS',
+    'version': '1.0',
+    'summary': 'Send SMS messages using Twilio',
+    'category': 'Hidden/Tools',
+    'description': """
+This module allows using Twilio as a provider for SMS messaging.
+The user has to create an account on twilio.com and top
+up their account to start sending SMS messages.
+""",
+    'depends': [
+        'sms',
+    ],
+    'data': [
+        'views/res_config_settings_views.xml',
+        'views/sms_sms_views.xml',
+        'wizard/sms_twilio_account_manage_views.xml',
+        'security/ir.model.access.csv'
+    ],
+    'installable': True,
+    'license': 'LGPL-3',
+}

--- a/addons/sms_twilio/controllers/__init__.py
+++ b/addons/sms_twilio/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/addons/sms_twilio/controllers/controllers.py
+++ b/addons/sms_twilio/controllers/controllers.py
@@ -1,0 +1,74 @@
+import hmac
+import logging
+import re
+
+from odoo.addons.sms_twilio.tools.sms_twilio import generate_twilio_sms_callback_signature
+from odoo.http import Controller, request, route
+
+
+TWILIO_TO_SMS_STATE_ERRORS = {
+    'failed': 'error',
+    'undelivered': 'error',
+}
+
+TWILIO_TO_SMS_STATE = {
+    # https://www.twilio.com/docs/messaging/api/message-resource#message-status-values
+    'queued': 'outgoing',
+    'sending': 'process',
+    'sent': 'pending',
+    'delivered': 'sent',
+    'receiving': 'process',
+    'received': 'pending',
+    'accepted': 'outgoing',
+    'scheduled': 'outgoing',
+    'canceled': 'canceled',
+    **TWILIO_TO_SMS_STATE_ERRORS,
+}
+
+_logger = logging.getLogger(__name__)
+
+
+class SmsTwilioController(Controller):
+
+    @route('/sms_twilio/status/<string:uuid>', type='http', auth='public', methods=['POST'], csrf=False)
+    def update_sms_status(self, uuid, SmsStatus=None, ErrorCode=None, ErrorMessage=None, **kwargs):
+        # Verify Odoo Sms Uuid Validity
+        if not re.match(r'^[0-9a-f]{32}$', uuid):
+            _logger.warning("Twilio SMS: update_sms_status received a non-valid uuid='%s'", uuid)
+            raise request.not_found()
+
+        # Verify Twilio Status
+        if SmsStatus not in TWILIO_TO_SMS_STATE:
+            _logger.warning("Twilio SMS: update_sms_status received unknown twilio_status='%s'", SmsStatus)
+            raise request.not_found()
+
+        # Verify Twilio Signature
+        if not self._validate_twilio_signature(request, uuid):
+            _logger.warning("Twilio SMS: update_sms_status could not validate Twilio signature with uuid='%s'", uuid)
+            raise request.not_found()
+
+        # Update the tracker with the state
+        sms_tracker_sudo = request.env['sms.tracker'].sudo().search([('sms_uuid', '=', uuid)])
+        if not sms_tracker_sudo:
+            _logger.warning("Twilio SMS: update_sms_status could not find a matching SMS tracker for sms_uuid=%s", uuid)
+            return
+
+        if SmsStatus in TWILIO_TO_SMS_STATE_ERRORS:
+            sms_tracker_sudo._action_update_from_twilio_error(SmsStatus, ErrorCode, ErrorMessage)
+        else:
+            sms_tracker_sudo._action_update_from_sms_state(TWILIO_TO_SMS_STATE[SmsStatus])
+
+        # Mark Sms as to be deleted
+        request.env['sms.sms'].sudo().search([('uuid', '=', uuid), ('to_delete', '=', False)]).to_delete = True
+
+        return "OK"
+
+    def _validate_twilio_signature(self, request, uuid):
+        company_sudo = request.env['sms.sms'].sudo().search([('uuid', '=', uuid)])._get_sms_company().sudo()
+        computed_signature = generate_twilio_sms_callback_signature(
+            company_sudo,
+            uuid,
+            request.httprequest.form.to_dict()
+        )
+        x_twilio_signature = request.httprequest.headers.get('X-Twilio-Signature', '')
+        return hmac.compare_digest(computed_signature, x_twilio_signature)

--- a/addons/sms_twilio/data/neutralize.sql
+++ b/addons/sms_twilio/data/neutralize.sql
@@ -1,0 +1,2 @@
+UPDATE res_company
+   SET sms_twilio_auth_token = 'dummytoken';

--- a/addons/sms_twilio/i18n/sms_twilio.pot
+++ b/addons/sms_twilio/i18n/sms_twilio.pot
@@ -1,0 +1,349 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* sms_twilio
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-16 12:28+0000\n"
+"PO-Revision-Date: 2025-05-16 12:28+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "+1 555-123-4567"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "ACabcde12345abcde12345abcde12345ab"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_res_company__sms_twilio_account_sid
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_account_sid
+msgid "Account SID"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid ""
+"Any number here that is not on Twilio will be deleted and the ordering will "
+"be reset to Twilio's."
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_res_company__sms_twilio_auth_token
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_auth_token
+msgid "Auth Token"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields.selection,name:sms_twilio.selection__sms_sms__failure_type__sms_twilio_authentication
+msgid "Authentication error"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Cancel"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__company_id
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__company_id
+msgid "Company"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__country_id
+msgid "Country"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__country_code
+msgid "Country Code"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__create_uid
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__create_date
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Credentials"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Delete"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__display_name
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_error_msg
+msgid "Error message"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_sms__failure_type
+msgid "Failure Type"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_mail_notification__failure_type
+msgid "Failure type"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__id
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__id
+msgid "ID"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/models/res_company.py:0
+#, python-format
+msgid ""
+"Invalid Twilio Account SID: must only contain alphanumeric characters after "
+"'AC'."
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/models/res_company.py:0
+#, python-format
+msgid ""
+"Invalid Twilio Account SID: must start with 'AC' and be 34 characters long."
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__write_uid
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__write_date
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_sms_tracker
+msgid "Link SMS to mailing/sms tracking models"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.res_config_settings_view_form
+msgid "Manage Twilio Connection"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/models/res_company.py:0
+#, python-format
+msgid "Manage Twilio SMS"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_mail_notification
+msgid "Message Notifications"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_res_company__sms_twilio_number_ids
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_number_ids
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Numbers"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields.selection,name:sms_twilio.selection__res_company__sms_provider__iap
+msgid "Odoo IAP"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_sms_sms
+msgid "Outgoing SMS"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/wizard/manage_connection_wizard.py:0
+#, python-format
+msgid "Please set the number to which you want to send a test SMS."
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Reload Numbers from Twilio"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_res_company__sms_provider
+#: model:ir.model.fields,field_description:sms_twilio.field_res_config_settings__sms_provider
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_provider
+msgid "SMS Provider"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_sms_twilio_manage_connection_wizard
+msgid "SMS Twilio Connection Wizard"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Save"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Send test SMS"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_success_msg
+msgid "Success message"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Testing"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,help:sms_twilio.field_sms_twilio_number__country_code
+msgid ""
+"The ISO country code in two chars. \n"
+"You can use this field for quick search."
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/wizard/manage_connection_wizard.py:0
+#, python-format
+msgid "The SMS has been sent from %s"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/tools/sms_api.py:0
+#, python-format
+msgid "The Twilio StatusCallback URL is incorrect"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/tools/sms_api.py:0
+#, python-format
+msgid "The number you're trying to reach is not correctly formatted."
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/wizard/manage_connection_wizard.py:0
+#, python-format
+msgid "This is a test SMS from Odoo"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_manage_connection_wizard__sms_twilio_to_number
+msgid "To Number"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields.selection,name:sms_twilio.selection__res_company__sms_provider__twilio
+msgid "Twilio"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/tools/sms_api.py:0
+#: model:ir.model.fields.selection,name:sms_twilio.selection__mail_notification__failure_type__sms_twilio_authentication
+#, python-format
+msgid "Twilio Authentication Error"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model,name:sms_twilio.model_sms_twilio_number
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_twilio_number__number
+msgid "Twilio Number"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "Twilio SMS Manage Connection"
+msgstr ""
+
+#. module: sms_twilio
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_sms__sms_twilio_sid
+#: model:ir.model.fields,field_description:sms_twilio.field_sms_tracker__sms_twilio_sid
+msgid "Twilio SMS SID"
+msgstr ""
+
+#. module: sms_twilio
+#. odoo-python
+#: code:addons/sms_twilio/tools/sms_api.py:0
+#, python-format
+msgid "Unknown error, please contact Odoo support"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid ""
+"When sending an SMS to a partner, Odoo will pick the first number available\n"
+"                        from the same country as the recipient. If no number exists for this country,\n"
+"                        Odoo will use the first one available."
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "You can access the documentation"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid "abcde12345abcde12345abcde12345ab"
+msgstr ""
+
+#. module: sms_twilio
+#: model_terms:ir.ui.view,arch_db:sms_twilio.manage_connection_wizard_view
+msgid ""
+"by clicking here\n"
+"                        <i class=\"fa fa-external-link\" aria-hidden=\"true\"/>"
+msgstr ""

--- a/addons/sms_twilio/models/__init__.py
+++ b/addons/sms_twilio/models/__init__.py
@@ -1,0 +1,6 @@
+from . import res_company
+from . import res_config_settings
+from . import sms_composer
+from . import sms_sms
+from . import sms_tracker
+from . import sms_twilio_number

--- a/addons/sms_twilio/models/res_company.py
+++ b/addons/sms_twilio/models/res_company.py
@@ -1,0 +1,48 @@
+import re
+
+from odoo import fields, models, _
+from odoo.exceptions import UserError
+
+from odoo.addons.sms_twilio.tools.sms_api import SmsApiTwilio
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    sms_provider = fields.Selection(
+        string='SMS Provider',
+        selection=[
+            ('iap', 'Send via Odoo'),
+            ('twilio', 'Send via Twilio'),
+        ],
+        default='iap',
+    )
+    sms_twilio_account_sid = fields.Char("Account SID", groups='base.group_system')
+    sms_twilio_auth_token = fields.Char("Auth Token", groups='base.group_system')
+    sms_twilio_number_ids = fields.One2many("sms.twilio.number", "company_id", "Numbers")
+
+    def _get_sms_api_class(self):
+        self.ensure_one()
+        if self.sms_provider == 'twilio':
+            return SmsApiTwilio
+        return super()._get_sms_api_class()
+
+    def _assert_twilio_sid(self):
+        self.ensure_one()
+        account_sid = self.sms_twilio_account_sid
+        if not account_sid or len(account_sid) != 34 or not account_sid.startswith('AC'):
+            raise UserError(_("Invalid Twilio Account SID: must start with 'AC' and be 34 characters long."))
+        if not re.match(r'^[A-Za-z0-9]{32}$', account_sid[2:]):
+            raise UserError(_("Invalid Twilio Account SID: must only contain alphanumeric characters after 'AC'."))
+
+    def _action_open_sms_twilio_account_manage(self):
+        return {
+            'name': _('Manage Twilio SMS'),
+            'res_model': 'sms.twilio.account.manage',
+            'res_id': False,
+            'context': self.env.context,
+            'type': 'ir.actions.act_window',
+            'views': [(False, 'form')],
+            'view_mode': 'form',
+            'target': 'new',
+        }

--- a/addons/sms_twilio/models/res_config_settings.py
+++ b/addons/sms_twilio/models/res_config_settings.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    sms_provider = fields.Selection(related='company_id.sms_provider', required=True, readonly=False)
+
+    def action_open_sms_twilio_account_manage(self):
+        return self.company_id._action_open_sms_twilio_account_manage()

--- a/addons/sms_twilio/models/sms_composer.py
+++ b/addons/sms_twilio/models/sms_composer.py
@@ -1,0 +1,16 @@
+from odoo import models
+
+
+class SendSMS(models.TransientModel):
+    _inherit = 'sms.composer'
+
+    def _prepare_mass_sms_values(self, records):
+        results = super()._prepare_mass_sms_values(records)
+        for record, result in zip(records, results):
+            company = self.env.company
+            if "company_id" in record._fields:
+                company = record.company_id
+            elif "record_company_id" in record._fields:
+                company = record.record_company_id
+            results[record.id]["record_company_id"] = company.id
+        return results

--- a/addons/sms_twilio/models/sms_sms.py
+++ b/addons/sms_twilio/models/sms_sms.py
@@ -1,0 +1,71 @@
+from collections import defaultdict
+
+from odoo import fields, models, api
+
+
+class SmsSms(models.Model):
+    _inherit = 'sms.sms'
+
+    sms_twilio_sid = fields.Char(related="sms_tracker_id.sms_twilio_sid", depends=['sms_tracker_id'])
+    record_company_id = fields.Many2one('res.company', 'Company', ondelete='set null')
+    failure_type = fields.Selection(
+        selection_add=[
+            ('twilio_authentication', 'Authentication Error"'),
+            ('twilio_callback', 'Incorrect callback URL'),
+        ],
+    )
+
+    # CRUD
+    # ------------------------------------------------------------
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            vals['record_company_id'] = vals.get('record_company_id') or self.env.company.id  # TODO RIGR in master: move this field to SmsSms, and populate it via vals_list from all flows
+        return super().create(vals_list)
+
+    # SEND
+    # ------------------------------------------------------------
+
+    def _split_by_api(self):
+        # override to handle twilio or IAP choice, which is company dependent
+        # even twilio accounts may differ between companies
+        sms_by_company = defaultdict(lambda: self.env['sms.sms'])  # TODO RIGR: in master, let's be smarter and group by provider/twilio account (e.g.: IAP/twilio1/twilio2)
+        todo_via_super = self.browse()
+        for sms in self:
+            sms_by_company[sms._get_sms_company()] += sms
+        for company, company_sms in sms_by_company.items():
+            if company.sms_provider == "twilio":
+                sms_api = company._get_sms_api_class()(self.env)
+                sms_api._set_company(company)
+                yield sms_api, company_sms
+            else:
+                todo_via_super += company_sms
+        if todo_via_super:
+            yield from super(SmsSms, todo_via_super)._split_by_api()
+
+    def _get_sms_company(self):
+        return self.mail_message_id.record_company_id or self.record_company_id or super()._get_sms_company()
+
+    def _get_batch_size(self):
+        companies = self._get_sms_company()
+        if companies and any(company.sms_provider == 'twilio' for company in companies):
+            return int(self.env['ir.config_parameter'].sudo().get_param('sms_twilio.session.batch.size', 10))
+        return super()._get_batch_size()
+
+    def _handle_call_result_hook(self, results):
+        """
+        Store the sid of Twilio on the SMS tracking record (as SMS will be deleted)
+        :param results: a list of dict in the form [{
+            'uuid': Odoo's id of the SMS,
+            'state': State of the SMS in Odoo,
+            'sms_twilio_sid': Twilio's id of the SMS,
+        }, ...]
+        """
+        twilio_sms = self.filtered(lambda s: s._get_sms_company().sms_provider == 'twilio')
+        grouped_twilio_sms = twilio_sms.grouped("uuid")
+        for result in results:
+            sms = grouped_twilio_sms.get(result.get('uuid'))
+            if sms and sms.sms_tracker_id and result.get('sms_twilio_sid'):
+                sms.sms_tracker_id.sms_twilio_sid = result['sms_twilio_sid']
+        super(SmsSms, self - twilio_sms)._handle_call_result_hook(results)

--- a/addons/sms_twilio/models/sms_tracker.py
+++ b/addons/sms_twilio/models/sms_tracker.py
@@ -1,0 +1,26 @@
+from odoo import models, fields
+
+TWILIO_CODE_TO_FAILURE_TYPE = {
+    # https://www.twilio.com/docs/messaging/guides/debugging-tools#error-codes
+    '30002': "expired",  # Account suspended
+    '30003': "invalid_destination",  # Unreachable destination handset
+    '30004': "rejected",  # Message blocked
+    '30005': "invalid_destination",  # Unknown destination handset
+    '30006': "not_allowed",  # Landline or unreachable carrier
+    '30007': "rejected",  # Carrier violation
+    '30008': "not_delivered",  # Unknown error
+}
+
+
+class SmsTracker(models.Model):
+    _inherit = 'sms.tracker'
+
+    sms_twilio_sid = fields.Char(string='Twilio SMS SID', readonly=True)
+
+    def _action_update_from_twilio_error(self, sms_status, error_code, error_message):
+        """Update the SMS tracker with the Twilio Status and Error code/msg"""
+        failure_type = (
+            TWILIO_CODE_TO_FAILURE_TYPE.get(error_code)
+            or (None if sms_status == "failed" else "not_delivered")
+        )
+        return self.with_context(sms_known_failure_reason=error_message)._action_update_from_provider_error(failure_type)

--- a/addons/sms_twilio/models/sms_twilio_number.py
+++ b/addons/sms_twilio/models/sms_twilio_number.py
@@ -1,0 +1,23 @@
+from odoo import models, fields
+
+
+class SmsTwilioNumber(models.Model):
+    _name = 'sms.twilio.number'
+    _description = 'Twilio Number'
+    _order = 'sequence'
+
+    company_id = fields.Many2one('res.company', string='Company', default=lambda self: self.env.company)
+    sequence = fields.Integer(default=1)
+    number = fields.Char(string='Twilio Number', required=True)
+    country_id = fields.Many2one("res.country", string='Country', required=True)
+    country_code = fields.Char(related='country_id.code', string='Country Code')
+
+    def _compute_display_name(self):
+        for record in self:
+            record.display_name = f"{record.number} ({record.country_id.name})"
+
+    def action_unlink(self):
+        # First create the action while self exists as it's going to be unlink right after
+        action = self.company_id._action_open_sms_twilio_account_manage()
+        self.unlink()
+        return action

--- a/addons/sms_twilio/security/ir.model.access.csv
+++ b/addons/sms_twilio/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_sms_twilio_number_system,access_sms_twilio_number_system,sms_twilio.model_sms_twilio_number,base.group_system,1,1,1,1
+access_sms_twilio_account_manage_system,access_sms_twilio_account_manage_system,sms_twilio.model_sms_twilio_account_manage,base.group_system,1,1,1,0

--- a/addons/sms_twilio/tests/__init__.py
+++ b/addons/sms_twilio/tests/__init__.py
@@ -1,0 +1,3 @@
+from . import test_sms_twilio
+from . import test_sms_twilio_controller
+from . import test_twilio_account_manage

--- a/addons/sms_twilio/tests/common.py
+++ b/addons/sms_twilio/tests/common.py
@@ -1,0 +1,200 @@
+import re
+
+from contextlib import contextmanager
+from requests import Response
+from unittest.mock import patch
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.sms.models.sms_sms import SmsSms
+from odoo.addons.sms.tests.common import SMSCase
+from odoo.addons.sms_twilio.tools import sms_twilio as twilio_tools
+from odoo.addons.sms_twilio.tools.sms_api import SmsApiTwilio
+from odoo.tests.common import TransactionCase
+
+
+class MockSmsTwilioApi(SMSCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # some test data
+        cls.twilio_valid_phone_number = "+12202154155"
+        cls.twilio_invalid_phone_number = "+3212312312"
+
+        # mock control
+        cls.mock_ok = True
+        cls.mock_body = False
+        cls.mock_number = False
+
+        # find details of outgoing requests
+        cls.twilio_request_re = re.compile(r"https://api.twilio.com/2010-04-01/Accounts/(AC[\d]{32})/(.*)")
+
+        # typical / expected responses
+        cls.webhook_ok_response = {
+            'AccountSid': 'ACfake',
+            'ApiVersion': '2010-04-01',
+            'From': '+12212341234',
+            'MessageSid': 'SMfake',
+            'MessageStatus': 'delivered',
+            'RawDlrDoneDate': '2504241615',
+            'SmsSid': 'SMfake',
+            'SmsStatus': 'delivered',
+            'To': '+32486321321',
+        }
+        cls.request_send_ok_json = {
+            "account_sid": "AC12345678987654321234567898765432",
+            "api_version": "2010-04-01",
+            "date_created": "Mon, 14 Apr 2025 09:27:41 +0000",
+            "date_sent": None,
+            "date_updated": "Mon, 14 Apr 2025 09:27:41 +0000",
+            "direction": "outbound-api",
+            "error_code": None,
+            "error_message": None,
+            "from": "+12212341234",
+            "messaging_service_sid": None,
+            "num_media": "0",
+            "num_segments": "1",
+            "price": None,
+            "price_unit": "USD",
+            "sid": "SMfake",
+            "status": "queued",
+            "subresource_uris": {
+                "media": "/2010-04-01/Accounts/ACfake/Messages/SMfake/Media.json"
+            },
+            "uri": "/2010-04-01/Accounts/ACfake/Messages/SMfake.json",
+        }
+        cls.request_send_nok_json = {
+            'code': 21211,
+            'message': "Invalid 'To' Phone Number: +324863XXXX",
+            'more_info': 'https://www.twilio.com/docs/errors/21211',
+            'status': 400,
+        }
+
+    @classmethod
+    def _request_handler(cls, session, request, **kwargs):
+        url = request.url
+        matching = cls.twilio_request_re.match(url)
+        if matching:
+            _sid = matching.group(1)
+            right_part = matching.group(2)
+            response = Response()
+            response.status_code = 200
+            if right_part == "IncomingPhoneNumbers.json":
+                response.json = lambda: {
+                    'incoming_phone_numbers': [
+                        {'phone_number': '+32455998877'},
+                        {'phone_number': '+32455665544'},
+                    ],
+                }
+                return response
+            elif right_part == "Messages.json":
+                if cls.mock_ok:
+                    request_send_ok_json = cls.request_send_ok_json.copy()
+                    request_send_ok_json['body'] = cls.mock_body or 'body'
+                    request_send_ok_json['sid'] = f'twilio_{cls.mock_company.name}_{cls.mock_sms_uuid}' if cls.mock_sms_uuid else 'SMFake'
+                    request_send_ok_json['to_number'] = cls.mock_number or 'to_number'
+                    response.json = lambda: request_send_ok_json
+                else:
+                    request_send_nok_json = cls.request_send_nok_json.copy()
+                    request_send_nok_json['body'] = cls.mock_body or 'body'
+                    request_send_nok_json['to_number'] = cls.mock_number or 'to_number'
+                    response.json = lambda: request_send_nok_json
+                    response.status_code = 400
+                return response
+        return super()._request_handler(session, request, **kwargs)
+
+    @classmethod
+    def _setup_sms_twilio(cls, company):
+        company.sudo().write({
+            "sms_provider": "twilio",
+            "sms_twilio_account_sid": "AC12345678987654321234567898765432",
+            "sms_twilio_auth_token": "grimgorironhide",
+        })
+
+    @classmethod
+    def _update_mock(cls, mock_ok, mock_body, mock_number, mock_sms_uuid, mock_company):
+        cls.mock_ok = mock_ok
+        # various data, used notably to forge better simulated responses
+        cls.mock_body = mock_body
+        cls.mock_company = mock_company
+        cls.mock_number = mock_number
+        cls.mock_sms_uuid = mock_sms_uuid or 'NA'
+
+    @contextmanager
+    def mock_sms_twilio_send(self, ok=True):
+        self._clear_sms_sent()
+        self._update_mock(ok, False, False, False, False)
+        sms_twilio_send_request_origin = SmsApiTwilio._sms_twilio_send_request
+
+        def _sms_api_twilio_sms_twilio_send_request(model, *args, **kwargs):
+            (_session, to_number, body, uuid) = args
+            self._update_mock(self.mock_ok, body, to_number, uuid, model.company)
+            res = sms_twilio_send_request_origin(model, *args, **kwargs)
+            self._sms += [{
+                'body': body,
+                'number': to_number,
+                'uuid': uuid,
+            }]
+            return res
+
+        with patch.object(SmsApiTwilio, '_sms_twilio_send_request', autospec=True, side_effect=_sms_api_twilio_sms_twilio_send_request) as _sms_twilio_send_mock:
+            self._sms_twilio_send_mock = _sms_twilio_send_mock
+            yield
+
+    @contextmanager
+    def mock_sms_twilio_gateway(self, ok=True):
+        self._clear_sms_sent()
+        sms_create_origin = SmsSms.create
+
+        def _sms_sms_create(model, *args, **kwargs):
+            res = sms_create_origin(model, *args, **kwargs)
+            self._new_sms += res.sudo()
+            return res
+
+        with (
+            patch.object(SmsSms, 'create', autospec=True, wraps=SmsSms, side_effect=_sms_sms_create),
+            self.mock_sms_twilio_send(ok=ok),
+        ):
+            yield
+
+    def simulate_sms_twilio_status(self, sms_batch, company):
+        """ Simulate callback webhook called by Twilio """
+        for sms in sms_batch:
+            expected_signature = twilio_tools.generate_twilio_sms_callback_signature(
+                self.user_admin.company_id,
+                sms.uuid,
+                self.webhook_ok_response,
+            )
+            _response = self.url_open(
+                f"/sms_twilio/status/{sms.uuid}", self.webhook_ok_response,
+                headers={
+                    "X-Twilio-Signature": expected_signature,
+                },
+            )
+
+
+class MockSmsTwilio(MockSmsTwilioApi, TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref('base.user_admin')
+        cls.company_admin = cls.user_admin.company_id
+        cls.basic_user = mail_new_test_user(
+            cls.env,
+            company_id=cls.company_admin.id,
+            country_id=cls.env.ref('base.be').id,
+            groups='base.group_user,base.group_partner_manager',
+            login='employee',
+        )
+
+        cls.valid_partner = cls.env['res.partner'].create({
+            'name': 'ValidPartner',
+            'phone': cls.twilio_valid_phone_number,
+        })
+        cls.invalid_partner = cls.env['res.partner'].create({
+            'name': 'InvalidPartner',
+            'phone': cls.twilio_invalid_phone_number,
+        })

--- a/addons/sms_twilio/tests/test_sms_twilio.py
+++ b/addons/sms_twilio/tests/test_sms_twilio.py
@@ -1,0 +1,168 @@
+from odoo.addons.sms_twilio.tests.common import MockSmsTwilio
+from odoo.tests import tagged, users
+
+
+@tagged('post_install', '-at_install', 'twilio')
+class TestSmsTwilio(MockSmsTwilio):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_sms_twilio(cls.user_admin.company_id)
+
+    def test_assert_initial_values(self):
+        self.assertEqual(self.valid_partner.phone, self.twilio_valid_phone_number)
+        self.assertEqual(self.invalid_partner.phone, self.twilio_invalid_phone_number)
+
+    @users('employee')
+    def test_send_sms_composer_number(self):
+        for number, expected_status, expected_failure_type, expected_to_delete in [
+            (self.twilio_valid_phone_number, "pending", False, True),
+            (self.twilio_invalid_phone_number, "error", "sms_number_format", False),
+        ]:
+            with self.subTest(number=number):
+                with self.mock_sms_twilio_gateway(ok=(number != self.twilio_invalid_phone_number)):
+                    body = f"Send SMS to {number}"
+                    composer = self.env['sms.composer'].create({
+                        'body': body,
+                        'composition_mode': 'numbers',
+                        'numbers': number,
+                    })
+                    composer._action_send_sms()
+                    self.assertSMS(
+                        self.env["res.partner"], number, expected_status,
+                        content=body,
+                        failure_type=expected_failure_type,
+                        fields_values={
+                            "to_delete": expected_to_delete,
+                        },
+                    )
+
+    @users('employee')
+    def test_send_sms_composer_partner(self):
+        for partner, expected_status, expected_failure_type, expected_to_delete in [
+            (self.valid_partner, "pending", False, True),
+            (self.invalid_partner, "error", "sms_number_format", False),
+        ]:
+            with self.subTest(partner=partner, number=partner.phone):
+                with self.mock_sms_twilio_gateway(ok=(partner != self.invalid_partner)):
+                    body = f"Send SMS to {partner.name}"
+                    composer = self.env['sms.composer'].with_context(
+                        active_model='res.partner',
+                        active_id=partner,
+                    ).create({'body': body})
+                    composer._action_send_sms()
+                    self.assertSMS(
+                        partner, partner.phone, expected_status,
+                        content=body,
+                        failure_type=expected_failure_type,
+                        fields_values={
+                            "to_delete": expected_to_delete,
+                        },
+                    )
+
+    @users('employee')
+    def test_send_with_multi_company(self):
+        """Test that in a multi company environment where each company decides
+        how it should send SMS that we respect this choice. """
+        company_twilio = self.env.company
+        company_twilio.sudo().write({
+            "name": "Company 1 (Twilio)",
+            "sms_provider": "twilio",
+        })
+        company_twilio_2 = self.env['res.company'].sudo().create({
+            "name": "Company 2 (Twilio)",
+            "sms_provider": "twilio",
+            "sms_twilio_account_sid": "AC11111222223333344444555556666677",
+            "sms_twilio_auth_token": "skarsnik",
+        })
+        company_iap = self.env['res.company'].sudo().create({
+            "name": "Company 3 (IAP)",
+            "sms_provider": "iap",
+        })
+        company_iap_2 = self.env['res.company'].sudo().create({
+            "name": "Company 4 (IAP)",
+            "sms_provider": "iap",
+        })
+        self.env.user.sudo().company_ids |= company_twilio_2 + company_iap + company_iap_2
+
+        partners_twilio = self.env['res.partner'].create([{
+            "name": f"Partner Twilio {i}",
+            "phone": f"+1220215411{i}",
+            "company_id": company_twilio.id
+        } for i in range(2)])
+
+        partners_twilio_2 = self.env['res.partner'].create([{
+            "name": f"Partner Twilio2 {i}",
+            "phone": f"+1220215422{i}",
+            "company_id": company_twilio_2.id
+        } for i in range(2)])
+
+        partners_iap = self.env['res.partner'].create([{
+            "name": f"Partner IAP {i}",
+            "phone": f"+1220215433{i}",
+            "company_id": company_iap.id
+        } for i in range(2)])
+
+        partners_iap_2 = self.env['res.partner'].create([{
+            "name": f"Partner IAP2 {i}",
+            "phone": f"+1220215444{i}",
+            "company_id": company_iap_2.id
+        } for i in range(2)])
+
+        with (
+            self.mockSMSGateway(),
+            self.mock_sms_twilio_send(),
+        ):
+            composer_twilio = self.env['sms.composer'].create({
+                "body": "Mixed SMS",
+                "composition_mode": 'mass',
+                "mass_force_send": True,
+                "res_ids": (partners_twilio + partners_twilio_2 + partners_iap + partners_iap_2).ids,
+                "res_model": "res.partner",
+            })
+            composer_twilio._action_send_sms()
+
+            # should call twilio 4 times (4 partners, one number at a time) and IAP 1 time (batch, even different companies)
+            self.assertEqual(self._sms_twilio_send_mock.call_count, 4)
+            self.assertEqual(self._sms_api_contact_iap_mock.call_count, 1)
+
+            # check SMS statuses
+            # TDE FIXME: in mass mode without mailing, no sms_tracker are created hence
+            # sms_twilio_sid is not stored ... meh
+            for partner in partners_twilio:
+                self.assertSMS(
+                    partner, partner.phone, "pending",
+                    content="Mixed SMS",
+                    failure_type=False,
+                    fields_values={
+                        "record_company_id": company_twilio,
+                    },
+                )
+            for partner in partners_twilio_2:
+                self.assertSMS(
+                    partner, partner.phone, "pending",
+                    content="Mixed SMS",
+                    failure_type=False,
+                    fields_values={
+                        "record_company_id": company_twilio_2,
+                    },
+                )
+            for partner in partners_iap:
+                self.assertSMS(
+                    partner, partner.phone, "pending",
+                    content="Mixed SMS",
+                    failure_type=False,
+                    fields_values={
+                        "record_company_id": company_iap,
+                    },
+                )
+            for partner in partners_iap_2:
+                self.assertSMS(
+                    partner, partner.phone, "pending",
+                    content="Mixed SMS",
+                    failure_type=False,
+                    fields_values={
+                        "record_company_id": company_iap_2,
+                    },
+                )

--- a/addons/sms_twilio/tests/test_sms_twilio_controller.py
+++ b/addons/sms_twilio/tests/test_sms_twilio_controller.py
@@ -1,0 +1,119 @@
+from odoo.addons.sms_twilio.tests.common import MockSmsTwilio
+from odoo.addons.sms_twilio.tools import sms_twilio as twilio_tools
+from odoo.tools import mute_logger
+from odoo.tests import tagged, users
+from odoo.tests.common import HttpCase
+
+
+@tagged('post_install', '-at_install', 'twilio', 'twilio_controller')
+class TestSmsTwilioController(MockSmsTwilio, HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_sms_twilio(cls.user_admin.company_id)
+
+    @mute_logger('odoo.addons.sms_twilio.controllers.controllers')
+    @users('employee')
+    def test_sms_twilio_controller_status(self):
+        """Test that the controller correctly processes the webhook calls we
+        receive from Twilio"""
+        # All good
+        ok = self.webhook_ok_response.copy()
+        # Handle known errors (the ones that we have already mapped)
+        invalid_destination = {
+            **self.webhook_ok_response,
+            "SmsStatus": "undelivered",
+            "ErrorCode": 30005,
+            "ErrorMessage": "Unknown destination handset",
+        }
+        # Handle unknown errors (the ones that we not have mapped)
+        unknown_error = {
+            **self.webhook_ok_response,
+            "SmsStatus": "failed",
+            "ErrorCode": 12345,
+            "ErrorMessage": "Unknown error",
+        }
+        # Unknown status -> no update
+        wrong_status = {
+            **self.webhook_ok_response,
+            "SmsStatus": "myfakestatus",
+            "ErrorCode": 12345,
+            "ErrorMessage": "Unknown error",
+        }
+        with self.mock_sms_twilio_gateway():
+            for call_params, expected_data in zip(
+                [ok, invalid_destination, unknown_error, wrong_status],
+                [{
+                    'failure_type': False,
+                    'failure_reason': False,
+                    'notification_status': 'sent',
+                }, {
+                    'failure_type': 'sms_invalid_destination',
+                    'failure_reason': "Unknown destination handset",
+                    'notification_status': 'bounce',
+                }, {
+                    'failure_type': 'unknown',
+                    'failure_reason': "Unknown error",
+                    'notification_status': 'exception',
+                }, {
+                    'failure_type': False,
+                    'failure_reason': False,
+                    'notification_status': 'pending',
+                },
+                ],
+                strict=True,
+            ):
+                with self.subTest(call_params=call_params):
+                    composer = self.env['sms.composer'].with_context(
+                        active_model='res.partner',
+                        active_id=self.valid_partner,
+                    ).create({'body': "SMS Body"})
+                    composer._action_send_sms()
+                    sms = self._new_sms[-1]
+
+                    expected_signature = twilio_tools.generate_twilio_sms_callback_signature(
+                        self.user_admin.company_id,
+                        sms.uuid,
+                        call_params,
+                    )
+                    # Simulate callback webhook called by Twilio
+                    _python_versionresponse = self.url_open(
+                        f"/sms_twilio/status/{sms.uuid}", call_params,
+                        headers={
+                            "X-Twilio-Signature": expected_signature,
+                        },
+                    )
+                    self.assertRecordValues(sms.sms_tracker_id.mail_notification_id, [{
+                        'notification_status': expected_data["notification_status"],
+                        'failure_type': expected_data["failure_type"],
+                        'failure_reason': expected_data["failure_reason"],
+                    }])
+
+    @mute_logger('odoo.addons.sms_twilio.controllers.controllers')
+    @users('employee')
+    def test_sms_twilio_controller_status_signature(self):
+        """ Check X-Twilio-Signature is effectively checked """
+        call_params = self.webhook_ok_response.copy()
+        with self.mock_sms_twilio_gateway():
+            composer = self.env['sms.composer'].with_context(
+                active_model='res.partner',
+                active_id=self.valid_partner,
+            ).create({'body': "Body msg"})
+            composer._action_send_sms()
+            sms = self._new_sms[-1]
+
+            # Simulate callback webhook called by Twilio
+            response = self.url_open(
+                f"/sms_twilio/status/{sms.uuid}", call_params,
+                headers={
+                    "X-Twilio-Signature": "WrongSignature",
+                },
+            )
+            self.assertEqual(response.status_code, 404)
+            # SMS not updated
+            self.assertRecordValues(sms.sms_tracker_id.mail_notification_id, [{
+                'notification_status': 'pending',
+                'failure_type': False,
+                'failure_reason': False,
+            }])

--- a/addons/sms_twilio/tests/test_twilio_account_manage.py
+++ b/addons/sms_twilio/tests/test_twilio_account_manage.py
@@ -1,0 +1,59 @@
+from odoo.addons.sms_twilio.tests.common import MockSmsTwilio
+from odoo.tests import tagged, users
+from odoo.tests.common import TransactionCase
+
+
+@tagged('post_install', '-at_install', 'twilio', 'twilio_manage')
+class TestSmsTwilio(MockSmsTwilio, TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.user_admin = cls.env.ref("base.user_admin")
+        cls._setup_sms_twilio(cls.user_admin.company_id)
+
+    @users('admin')
+    def test_manage_action_reload_numbers(self):
+        wizard = self.env["sms.twilio.account.manage"].create({})
+        action = wizard.action_reload_numbers()
+        self.assertDictEqual(action, {
+            'name': 'Manage Twilio SMS',
+            'res_model': wizard._name,
+            'res_id': wizard.id,
+            'context': self.env.context,
+            'type': 'ir.actions.act_window',
+            'views': [(False, 'form')],
+            'view_mode': 'form',
+            'target': 'new',
+        })
+
+    @users('admin')
+    def test_manage_action_send_test(self):
+        wizard = self.env["sms.twilio.account.manage"].create({
+            'test_number': '+32455001122',
+        })
+        for has_error, notif_params in zip(
+            (False, True),
+            ({}, {
+                'message': 'sms_number_format: None',
+                'type': 'danger',
+            }),
+            strict=True,
+        ):
+            with self.subTest(has_error=has_error):
+                with self.mock_sms_twilio_send(ok=not has_error):
+                    notif = wizard.action_send_test()
+                params = {
+                    'title': "Twilio SMS",
+                    # FIXME: check this
+                    'message': 'The SMS has been sent from False',
+                    'type': 'success',
+                    'sticky': False,
+                    **notif_params,
+                }
+                self.assertDictEqual(notif, {
+                    'type': 'ir.actions.client',
+                    'tag': 'display_notification',
+                    'params': params,
+                })

--- a/addons/sms_twilio/tools/__init__.py
+++ b/addons/sms_twilio/tools/__init__.py
@@ -1,0 +1,2 @@
+from . import sms_api
+from . import sms_twilio

--- a/addons/sms_twilio/tools/sms_api.py
+++ b/addons/sms_twilio/tools/sms_api.py
@@ -1,0 +1,98 @@
+import logging
+import requests
+
+from odoo import _
+from odoo.addons.sms.tools.sms_api import SmsApiBase
+from odoo.addons.sms_twilio.tools.sms_twilio import get_twilio_from_number, get_twilio_status_callback_url
+
+_logger = logging.getLogger(__name__)
+
+
+class SmsApiTwilio(SmsApiBase):
+    PROVIDER_TO_SMS_FAILURE_TYPE = SmsApiBase.PROVIDER_TO_SMS_FAILURE_TYPE | {
+        'twilio_authentication': 'sms_credit',
+        'twilio_callback': 'twilio_callback',
+    }
+
+    def _sms_twilio_send_request(self, session, to_number, body, uuid):
+        company_sudo = (self.company or self.env.company).sudo()
+        company_sudo._assert_twilio_sid()
+        from_number = get_twilio_from_number(company_sudo, to_number)
+        data = {
+            'From': from_number.number,
+            'To': to_number,
+            'Body': body,
+            'StatusCallback': get_twilio_status_callback_url(company_sudo, uuid),
+        }
+        try:
+            return session.post(
+                f'https://api.twilio.com/2010-04-01/Accounts/{company_sudo.sms_twilio_account_sid}/Messages.json',
+                data=data,
+                auth=(company_sudo.sms_twilio_account_sid, company_sudo.sms_twilio_auth_token),
+                timeout=5,
+            )
+        except requests.exceptions.RequestException as e:
+            _logger.warning('Twilio SMS API error: %s', str(e))
+        return None
+
+    def _send_sms_batch(self, messages, delivery_reports_url=False):
+        """ Send a batch of SMS using twilio.
+        See params and returns in original method sms/tools/sms_api.py
+        In addition to the uuid and state, we add the sms_twilio_sid to the returns (one per sms)
+        """
+        # Use a session as we have to sequentially call twilio, might save time
+        session = requests.Session()
+
+        res = []
+        for message in messages:
+            body = message.get('content') or ''
+            for number_info in message.get('numbers') or []:
+                uuid = number_info['uuid']
+                response = self._sms_twilio_send_request(session, number_info['number'], body, uuid)
+                fields_values = {
+                    'failure_reason':  _("Unknown failure at sending, please contact Odoo support"),
+                    'state': 'server_error',
+                    'uuid': uuid,
+                }
+                if response is not None:
+                    response_json = response.json()
+                    if not response.ok or response_json.get('error'):
+                        failure_type = self._twilio_error_code_to_odoo_state(response_json)
+                        error_message = response_json.get('message') or response_json.get('error_message') or self._get_sms_api_error_messages().get(failure_type)
+                        fields_values.update({
+                            'failure_reason': error_message,
+                            'failure_type': failure_type,
+                            'state': failure_type,
+                        })
+                    else:
+                        fields_values.update({
+                            'failure_reason': False,
+                            'failure_type': False,
+                            'sms_twilio_sid': response_json.get('sid'),
+                            'state': 'sent',
+                        })
+                res.append(fields_values)
+        return res
+
+    def _twilio_error_code_to_odoo_state(self, response_json):
+        error_code = response_json.get('code') or response_json.get('error_code')
+        if error_code in (21211, 21614, 21265):  # See https://www.twilio.com/docs/errors/xxxxx
+            return "wrong_number_format"
+        elif error_code == 21604:
+            # A "To" phone number is required
+            return "sms_number_missing"
+        elif error_code == 21609:
+            # Twilio StatusCallback URL is incorrect
+            return "twilio_callback"
+        _logger.warning('Twilio SMS: Unknown error "%s" (code: %s)', response_json.get('message'), error_code)
+        return "unknown"
+
+    def _get_sms_api_error_messages(self):
+        return {
+            'sms_number_missing': _("A 'To' phone number is required."),
+            'twilio_authentication': _("Twilio Authentication Error"),
+            'twilio_callback': _("Twilio StatusCallback URL is incorrect"),
+            'wrong_number_format': _("The number you're trying to reach is not correctly formatted."),
+            # fallback
+            'unknown': _("Unknown error, please contact Odoo support"),
+        }

--- a/addons/sms_twilio/tools/sms_twilio.py
+++ b/addons/sms_twilio/tools/sms_twilio.py
@@ -1,0 +1,40 @@
+import base64
+import hashlib
+import hmac
+
+from werkzeug.urls import url_join
+
+from odoo import fields
+from odoo.addons.phone_validation.tools import phone_validation
+
+
+def get_twilio_from_number(company, to_number):
+    """
+    :return: the Twilio number from which we'll send the SMS depending on the country of destination (to_number)
+    """
+    country_code = phone_validation.phone_get_country_code_for_number(to_number)
+    from_number = company.env['sms.twilio.number'].search([
+        ('company_id', '=', company.id),
+    ])
+    return fields.first(from_number.filtered(lambda n: n.country_code == country_code)) or fields.first(from_number)
+
+
+def get_twilio_status_callback_url(company, uuid):
+    base_url = company.get_base_url()  # When testing locally, this should be replaced by a real url (not localhost, e.g. with ngrok)
+    return url_join(base_url, f'/sms_twilio/status/{uuid}')
+
+
+def generate_twilio_sms_callback_signature(company, sms_uuid, callback_params):
+    url = get_twilio_status_callback_url(company, sms_uuid)
+    # Sort the POST parameters by key and concatenate them to URL
+    sorted_params = ''.join(f"{k}{v}" for k, v in sorted(callback_params.items()))
+    data = url + sorted_params
+
+    # Compute HMAC-SHA1 digest and then base64 encode
+    return base64.b64encode(
+        hmac.new(
+            company.sms_twilio_auth_token.encode(),
+            data.encode(),
+            hashlib.sha1
+        ).digest()
+    ).decode()

--- a/addons/sms_twilio/views/res_config_settings_views.xml
+++ b/addons/sms_twilio/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.sms.twilio</field>
+            <field name="model">res.config.settings</field>
+            <field name="priority" eval="0"/>
+            <field name="inherit_id" ref="sms.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//widget[@service_name='sms']" position="before">
+                    <field name="sms_provider" class="o_light_label" widget="radio" options="{'horizontal': true}" required="True"/>
+                    <div class="content-group" invisible="sms_provider != 'twilio'">
+                        <button name="action_open_sms_twilio_account_manage" icon="oi-arrow-right"
+                                type="object" class="btn-link"
+                                string="Configure Twilio Account"/>
+                    </div>
+                </xpath>
+                <xpath expr="//widget[@service_name='sms']" position="attributes">
+                    <attribute name="invisible">sms_provider == 'twilio'</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sms_twilio/views/sms_sms_views.xml
+++ b/addons/sms_twilio/views/sms_sms_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="sms_sms_view_form" model="ir.ui.view">
+            <field name="name">sms.sms.view.form.inherit.twilio</field>
+            <field name="model">sms.sms</field>
+            <field name="inherit_id" ref="sms.sms_tsms_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='failure_type']" position="after">
+                    <field name="sms_twilio_sid" invisible="not sms_twilio_sid"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/sms_twilio/wizard/__init__.py
+++ b/addons/sms_twilio/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import sms_twilio_account_manage

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage.py
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage.py
@@ -1,0 +1,112 @@
+import logging
+import requests
+
+from odoo import _, fields, models
+from odoo.addons.phone_validation.tools import phone_validation
+from odoo.addons.sms_twilio.tools.sms_twilio import get_twilio_from_number
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class SmsTwilioAccountManage(models.TransientModel):
+    _name = 'sms.twilio.account.manage'
+    _description = 'SMS Twilio Connection Wizard'
+
+    company_id = fields.Many2one(comodel_name='res.company', required=True, readonly=True, default=lambda self: self.env.company)
+    sms_provider = fields.Selection(related='company_id.sms_provider', readonly=False)
+    sms_twilio_account_sid = fields.Char(related='company_id.sms_twilio_account_sid', readonly=False)
+    sms_twilio_auth_token = fields.Char(related='company_id.sms_twilio_auth_token', readonly=False)
+    sms_twilio_number_ids = fields.One2many(related='company_id.sms_twilio_number_ids', readonly=False)
+    test_number = fields.Char("Test Number")
+
+    def action_reload_numbers(self):
+        """Fetch the available numbers from Twilio account"""
+        self.company_id._assert_twilio_sid()
+        try:
+            response = requests.get(
+                f'https://api.twilio.com/2010-04-01/Accounts/{self.company_id.sms_twilio_account_sid}/IncomingPhoneNumbers.json',
+                auth=(self.company_id.sms_twilio_account_sid, self.company_id.sms_twilio_auth_token),
+                timeout=5,
+            )
+        except requests.exceptions.RequestException as e:
+            _logger.warning('Twilio SMS API error: %s', str(e))
+            return self._display_notification(
+                notif_type='danger',
+                message=_("An error occurred while fetching the numbers."),
+            )
+
+        json_response = response.json()
+        if not response.ok:
+            _logger.warning('Twilio SMS API error: %s', json_response.get('code'))
+            return self._display_notification(
+                notif_type='danger',
+                message=_("Error: %s", json_response.get('message')),
+            )
+
+        self.sms_twilio_number_ids.unlink()
+        for twilio_number in json_response.get('incoming_phone_numbers', []):
+            country_code = phone_validation.phone_get_country_code_for_number(twilio_number.get('phone_number'))
+            country_id = self.env['res.country'].search([
+                ('code', '=', country_code)
+            ], limit=1)
+            if not self.env['sms.twilio.number'].search_count([
+                ('company_id', '=', self.company_id.id),
+                ('number', '=', twilio_number.get('phone_number')),
+                ('country_id', '=', country_id.id),
+            ], limit=1):
+                self.env['sms.twilio.number'].create({
+                    'company_id': self.company_id.id,
+                    'number': twilio_number.get('phone_number'),
+                    'country_id': country_id.id,
+                })
+        return {
+            'name': _('Manage Twilio SMS'),
+            'res_model': self._name,
+            'res_id': self.id,
+            'context': self.env.context,
+            'type': 'ir.actions.act_window',
+            'views': [(False, 'form')],
+            'view_mode': 'form',
+            'target': 'new',
+        }
+
+    def action_send_test(self):
+        if not self.test_number:
+            raise UserError(_("Please set the number to which you want to send a test SMS."))
+        composer = self.env['sms.composer'].create({
+            'body': _("This is a test SMS from Odoo"),
+            'composition_mode': 'numbers',
+        })
+        sms_su = composer._action_send_sms()[0]
+
+        has_error = bool(sms_su.failure_type)
+        if not has_error:
+            message = _("The SMS has been sent from %s", get_twilio_from_number(self.company_id, self.test_number).display_name)
+        elif sms_su.failure_type != "unknown":
+            sms_api = self.company_id._get_sms_api_class()(self.env)
+            message = _('%(failure_type)s: %(failure_reason)s',
+                         failure_type=sms_su.failure_type,
+                         failure_reason=sms_api._get_sms_api_error_messages().get(sms_su.failure_type),
+            )
+        else:
+            message = _("Error: %s", sms_su.failure_type)
+        return self._display_notification(
+            notif_type='danger' if has_error else 'success',
+            message=message,
+        )
+
+    def action_save(self):
+        return {'type': 'ir.actions.act_window_close'}
+
+    def _display_notification(self, notif_type, message):
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _("Twilio SMS"),
+                'message': message,
+                'type': notif_type,
+                'sticky': False,
+            }
+        }

--- a/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
+++ b/addons/sms_twilio/wizard/sms_twilio_account_manage_views.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="sms_twilio_account_manage_view_form" model="ir.ui.view">
+        <field name="name">sms.twilio.account.manage.view.form</field>
+        <field name="model">sms.twilio.account.manage</field>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <form string="Twilio SMS Manage Connection">
+                <group string="Credentials">
+                    <field name="company_id" invisible="1"/>
+                    <label for="sms_twilio_account_sid"/>
+                    <div class="d-flex align-items-center">
+                        <field name="sms_twilio_account_sid" placeholder="ACabcde12345abcde12345abcde12345ab"
+                            required="1"/>
+                        <a target="_blank" class="btn btn-link ms-1 w-25"
+                            role="button"
+                            href="https://www.odoo.com/documentation/17.0/applications/marketing/sms_marketing/twilio.html">
+                            Need help ?
+                            <i class="fa fa-external-link" aria-hidden="true"/>
+                        </a>
+                    </div>
+                    <field name="sms_twilio_auth_token" password="True" placeholder="abcde12345abcde12345abcde12345ab"
+                        required="1"/>
+                    <label for="test_number"/>
+                    <div class="d-flex align-items-center">
+                        <field name="test_number" placeholder="+1 555-123-4567"/>
+                        <button name="action_send_test" string="Send test SMS"
+                            icon="fa-send" type="object"
+                            class="btn btn-link w-25 ms-1"/>
+                    </div>
+                </group>
+                <group string="Phone Numbers">
+                    <button
+                        class="btn btn-secondary" colspan="2"
+                        type="object" name="action_reload_numbers"
+                        string="Reload Numbers from Twilio" icon="fa-refresh"/>
+                    <field name="sms_twilio_number_ids" colspan="2" nolabel="1">
+                        <tree editable="bottom" delete="0">
+                            <field name="sequence" widget="handle"/>
+                            <field name="country_id"/>
+                            <field name="number" placeholder="+1 555-123-4567"/>
+                            <button name="action_unlink" title="Delete" icon="fa-trash" type="object"/>
+                        </tree>
+                    </field>
+                </group>
+                <footer>
+                    <button string="Update Account" type="object" name="action_save" class="btn-primary" data-hotkey="q"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/test_mail_sms/__manifest__.py
+++ b/addons/test_mail_sms/__manifest__.py
@@ -12,6 +12,7 @@ tests independently to functional aspects of other models. """,
     'depends': [
         'mail',
         'sms',
+        'sms_twilio',
         'test_performance',
     ],
     'data': [

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -119,7 +119,7 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': False,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=56):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=57):
             composer.action_send_sms()
 
     @mute_logger('odoo.addons.sms.models.sms_sms')
@@ -135,5 +135,5 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': True,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=59):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=60):
             composer.action_send_sms()

--- a/addons/test_mass_mailing/__manifest__.py
+++ b/addons/test_mass_mailing/__manifest__.py
@@ -12,6 +12,7 @@ test_mail. """,
     'depends': [
         'mass_mailing',
         'mass_mailing_sms',
+        'sms_twilio',
         'test_mail',
         'test_mail_sms',
     ],

--- a/addons/test_mass_mailing/tests/test_mailing_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_sms.py
@@ -4,6 +4,7 @@
 from ast import literal_eval
 
 from odoo.addons.phone_validation.tools import phone_validation
+from odoo.addons.sms_twilio.tests.common import MockSmsTwilioApi
 from odoo.addons.test_mass_mailing.tests.common import TestMassSMSCommon
 from odoo import exceptions
 from odoo.tests import tagged
@@ -12,7 +13,7 @@ from odoo.tools import mute_logger
 
 
 @tagged('mass_mailing', 'mass_mailing_sms')
-class TestMassSMSInternals(TestMassSMSCommon):
+class TestMassSMSInternals(TestMassSMSCommon, MockSmsTwilioApi):
 
     @users('user_marketing')
     def test_mass_sms_domain(self):
@@ -283,6 +284,32 @@ class TestMassSMSInternals(TestMassSMSCommon):
             with self.mock_mail_gateway(), self.assertRaises(Exception):
                 mailing_test.action_send_sms()
 
+    def test_mass_sms_test_button_twilio(self):
+        """ Test the testing tool when twilio is activated on company """
+        self._setup_sms_twilio(self.user_marketing.company_id)
+
+        mailing = self.env['mailing.mailing'].create({
+            'name': 'TestButton',
+            'subject': 'Subject {{ object.name }}',
+            'preview': 'Preview {{ object.name }}',
+            'state': 'draft',
+            'mailing_type': 'sms',
+            'body_plaintext': 'Hello {{ object.name }}',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+        })
+        mailing_test = self.env['mailing.sms.test'].with_user(self.user_marketing).create({
+            'numbers': '+32456001122',
+            'mailing_id': mailing.id,
+        })
+
+        with self.with_user('user_marketing'):
+            with self.mock_sms_twilio_gateway():
+                mailing_test.action_send_sms()
+
+        self.assertSMS(
+            self.env["res.partner"], '+32456001122', 'outgoing',
+        )
+
 
 @tagged('mass_mailing', 'mass_mailing_sms')
 class TestMassSMS(TestMassSMSCommon):
@@ -424,3 +451,36 @@ class TestMassSMS(TestMassSMSCommon):
             mailing, recipients
         )
         self.assertEqual(mailing.canceled, 3)
+
+
+@tagged('mass_mailing', 'mass_mailing_sms', 'twilio')
+class TestMassSMSTwilio(TestMassSMSCommon, MockSmsTwilioApi):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_sms_twilio(cls.user_admin.company_id)
+
+    @users('user_marketing')
+    def test_mass_sms(self):
+        mailing = self.env['mailing.mailing'].browse(self.mailing_sms.ids)
+        mailing.write({
+            'body_plaintext': 'This is a mass SMS',
+            'sms_template_id': False,
+            'sms_force_send': True,
+            'sms_allow_unsubscribe': False,
+        })
+
+        with self.mock_sms_twilio_gateway():
+            mailing.action_send_sms()
+
+        self.assertSMSTraces(
+            [{
+                'partner': record.customer_id,
+                'number': self.records_numbers[i],
+                'trace_status': 'pending',
+                'content': 'This is a mass SMS',
+            } for i, record in enumerate(self.records)],
+            mailing,
+            self.records,
+        )


### PR DESCRIPTION
We provide a SMS service for our clients through an IAP service. It has almost no annoying configuration, the Odoo database sends stuff to an IAP proxy, that sends the SMS to our providers for them. Cool, easy, it's used quite a bit.

BUT for this to work, Odoo "registers" itself to our providers in the name of our clients. The problem is that the situation with Mobile operators in many countries is rapidly evolving, and more and more countries now require the clients themselves to submit an authorization request to be able to send SMS on their network. As such, Odoo is not supposed to register itself in place of its client. In some countries (and big ones, like USA, Australia, UK and soon France), this service is not working well, or at all, anymore.

The registration process is fastidious, and on top of them it changes from country to country. We do not want to start implementing registration processes by countries just for SMS sending.

For that reason, we will start to provide a new module where we remove the IAP part and connect directly to a new provider: Twilio. Clients will do all the registration themselves directly with the provider, and setup their account in Odoo to send those SMS. Twilio is a well known provider with extensive coverage, ideal for a global solution like Odoo.

task-4658352