### PR TITLE
[IMP] l10n_ro_edi: move context variable to method parameter

### DIFF
--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -184,12 +184,11 @@ class AccountMove(models.Model):
             return
 
         self.env['res.company']._with_locked_records(self)
-        result = self.env['l10n_ro_edi.document']\
-                     .with_context(is_b2b=self.partner_id.commercial_partner_id.is_company)\
-                     ._request_ciusro_send_invoice(
+        result = self.env['l10n_ro_edi.document']._request_ciusro_send_invoice(
             company=self.company_id,
             xml_data=xml_data,
             move_type=self.move_type,
+            is_b2b=self.partner_id.commercial_partner_id.is_company,
         )
         result['attachment_raw'] = xml_data
         if 'error' in result:  # result == {'error': <str>, 'attachment_raw': <bytes>}

--- a/addons/l10n_ro_edi/models/ciusro_document.py
+++ b/addons/l10n_ro_edi/models/ciusro_document.py
@@ -73,7 +73,7 @@ class L10n_Ro_EdiDocument(models.Model):
     key_certificate = fields.Char()  # Received from a successful response: to be saved for government purposes
 
     @api.model
-    def _request_ciusro_send_invoice(self, company, xml_data, move_type='out_invoice'):
+    def _request_ciusro_send_invoice(self, company, xml_data, move_type='out_invoice', is_b2b=True):
         """
         This method makes an 'upload' request to send xml_data to Romanian SPV.Based on the result, it will then process
         the answer and return a dictionary, which may consist of either an 'error' or a 'key_loading' string.
@@ -86,7 +86,7 @@ class L10n_Ro_EdiDocument(models.Model):
         result = make_efactura_request(
             session=requests,
             company=company,
-            endpoint='upload' if self.env.context.get('is_b2b') else 'uploadb2c',  # TODO: change the context value into a method parameter in master
+            endpoint='upload' if is_b2b else 'uploadb2c',
             method='POST',
             params={'standard': 'UBL' if move_type == 'out_invoice' else 'CN',
                     'cif': company.vat.replace('RO', '')},


### PR DESCRIPTION
Move the `is_b2b` context parameter to a method parameter to simplify usage and debugging.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
