### PR TITLE
[FIX] iot_box_image: incorrect reset alias

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -73,7 +73,7 @@ odoo_dev() {
   sudo git config --global --add safe.directory /home/pi/odoo
   sudo git remote add dev https://github.com/odoo-dev/odoo.git
   sudo git fetch dev \$1 --depth=1 --prune
-  sudo git reset --hard dev/\$1
+  sudo git reset --hard FETCH_HEAD
   sudo chown -R odoo:odoo /home/pi/odoo
   cd \$pwd
 }
@@ -89,7 +89,7 @@ odoo_origin() {
   sudo git config --global --add safe.directory /home/pi/odoo
   sudo git remote set-url origin https://github.com/odoo/odoo.git  # ensure odoo repository
   sudo git fetch origin \$1 --depth=1 --prune
-  sudo git reset --hard origin/\$1
+  sudo git reset --hard FETCH_HEAD
   sudo chown -R odoo:odoo /home/pi/odoo
   cd \$pwd
 }


### PR DESCRIPTION
`odoo_origin` and `odoo_dev` aliases used to reset odoo code on a dev/origin branch were sometimes returning an error not finding the fetched branch. They are now resetting on FETCH_HEAD to ensure the reset on the latest fetched branch.
