### PR TITLE
[FIX] web: fix properties fields discarding

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -216,8 +216,9 @@ export class PropertiesField extends Component {
      * @returns {array}
      */
     get propertiesList() {
-        const propertiesValues = this.props.record.data[this.props.name] || [];
-        return propertiesValues.filter((definition) => !definition.definition_deleted);
+        return (this.props.record.data[this.props.name] || [])
+            .filter((definition) => !definition.definition_deleted)
+            .map((definition) => ({ ...definition }));
     }
 
     /**

--- a/addons/web/static/tests/views/fields/properties_field_tests.js
+++ b/addons/web/static/tests/views/fields/properties_field_tests.js
@@ -2083,6 +2083,41 @@ QUnit.module("Fields", (hooks) => {
         }
     );
 
+    QUnit.test("properties: discard changes", async function (assert) {
+        async function mockRPC(route, { method, model, kwargs }) {
+            if (["check_access_rights", "check_access_rule"].includes(method)) {
+                return true;
+            }
+        }
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            resId: 1,
+            serverData,
+            arch: `
+            <form>
+                <field name="company_id"/>
+                <field name="properties" widget="properties"/>
+            </form>`,
+            mockRPC,
+            actionMenus: {},
+        });
+        assert.strictEqual(
+            target.querySelector(".o_property_field:first-child input").value,
+            "char value",
+        );
+        await editInput(target, ".o_property_field:first-child input", "char updated");
+        assert.strictEqual(
+            target.querySelector(".o_property_field:first-child input").value,
+            "char updated",
+        );
+        await clickDiscard(target);
+        assert.strictEqual(
+            target.querySelector(".o_property_field:first-child input").value,
+            "char value",
+        );
+    });
+
     // ---------------------------------------------------
     // Test the properties groups
     // ---------------------------------------------------


### PR DESCRIPTION
Purpose:
-------
Following the changes in [1], discarding the changes in a form view when a properties field has a change does not reset the field to its initial value (UI only issue: the change is not applied when reloading the view).

This issue arises because after the changes in [1], the properties are not deep copied anymore. Therefore, when a property is updated, the value inside the relational model's record data is updated.

The issue is fixed by returning a copy of the properties values again.

[1]: https://github.com/odoo/odoo/commit/8723f020c3587a900c811b8cc23f53fe34b98df3#diff-89ec9296feb48614f91829b8b732dca614359831967fa65a2126d6fe68c84450
