### PR TITLE
[FIX] stock: remove location final reach on push check

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1982,8 +1982,9 @@ Please change the quantity done or the rounding precision of your unit of measur
         return True
 
     def _skip_push(self):
-        return self.is_inventory or self.move_dest_ids and any(m.location_id._child_of(self.location_dest_id) for m in self.move_dest_ids) or\
-            self.location_final_id and self.location_final_id._child_of(self.location_dest_id)
+        return self.is_inventory or (
+            self.move_dest_ids and any(m.location_id._child_of(self.location_dest_id) for m in self.move_dest_ids)
+        )
 
     def _check_quantity(self):
         return self.env['stock.quant'].search([


### PR DESCRIPTION
Currently we block the push propagation when a move reach its final location. However it causes issue on some cases and it's not really helpful.

E.g.of blocked flow
- Special location in customer zone.
- PO (set the final loc to stock). Arrived in stock don't push to wanted location

