### PR TITLE
[FIX] point_of_sale: account for local timezone in orders report

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -429,7 +429,10 @@ export class TicketScreen extends Component {
     }
     getDate(order) {
         const todayTs = DateTime.now().startOf("day").ts;
-        if (DateTime.fromSQL(order.date_order).startOf("day").ts === todayTs) {
+        if (
+            DateTime.fromSQL(order.date_order, { zone: "utc" }).toLocal().startOf("day").ts ===
+            todayTs
+        ) {
             return _t("Today");
         } else {
             return formatDateTime(parseUTCString(order.date_order), {

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -766,7 +766,7 @@ export function addDiscount(discount) {
 
 export function setTimeZone(testTimeZone) {
     return {
-        content: "Set test time zone to a non UTC time zone",
+        content: `Set test time zone to ${testTimeZone}`,
         trigger: "body",
         run: function () {
             luxon.Settings.defaultZone = testTimeZone;


### PR DESCRIPTION
Steps:
-----
1. Make an order from a time zone such that does not have the same local date as UTC. For instance, from Mexico at 23h.

The next day, the order date will say "Today" instead of yesterday's date.

Reason:
-------
We were not taking into consideration the current timezone when checking if the UTC date corresponds to the local today's date.

Fix:
----
Convert the UTC date to a local date before proceeding with our conditional checks.

opw-4699263