### PR TITLE
[IMP] l10n_ro_efactura: Generate the xml by default when sending to SPV

### DIFF
--- a/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
+++ b/addons/l10n_ro_efactura/i18n/l10n_ro_efactura.pot
@@ -227,6 +227,13 @@ msgstr ""
 
 #. module: l10n_ro_efactura
 #. odoo-python
+#: code:addons/l10n_ro_efactura/wizard/account_move_send.py:0
+#, python-format
+msgid "Error when building the CIUS-RO E-Factura XML"
+msgstr ""
+
+#. module: l10n_ro_efactura
+#. odoo-python
 #: code:addons/l10n_ro_efactura/controllers/main.py:0
 #: code:addons/l10n_ro_efactura/models/res_company.py:0
 #, python-format
@@ -251,13 +258,6 @@ msgstr ""
 #: code:addons/l10n_ro_efactura/controllers/main.py:0
 #, python-format
 msgid "Error when processing the response: %s"
-msgstr ""
-
-#. module: l10n_ro_efactura
-#. odoo-python
-#: code:addons/l10n_ro_efactura/wizard/account_move_send.py:0
-#, python-format
-msgid "Error when rebuilding the CIUS-RO E-Factura XML"
 msgstr ""
 
 #. module: l10n_ro_efactura

--- a/addons/l10n_ro_efactura/wizard/account_move_send.py
+++ b/addons/l10n_ro_efactura/wizard/account_move_send.py
@@ -69,22 +69,24 @@ class AccountMoveSend(models.TransientModel):
 
         for invoice, invoice_data in invoices_data.items():
             if invoice_data.get('l10n_ro_edi_send') and not invoice.l10n_ro_edi_state:
+                build_errors = None
                 if invoice_data.get('ubl_cii_xml_attachment_values'):
                     xml_data = invoice_data['ubl_cii_xml_attachment_values']['raw']
                 elif invoice.l10n_ro_edi_document_ids:
                     # If a document is on the invoice but the invoice's l10n_ro_edi_state is False,
                     # this means that the previously sent XML are invalid and have to be rebuilt
                     xml_data, build_errors = self.env['account.edi.xml.ubl_ro']._export_invoice(invoice)
-                    if build_errors:
-                        invoice_data['error'] = {
-                            'error_title': _("Error when rebuilding the CIUS-RO E-Factura XML"),
-                            'errors': build_errors,
-                        }
-                        continue
                 elif invoice.ubl_cii_xml_id:
                     xml_data = invoice.ubl_cii_xml_id.raw
                 else:
-                    xml_data = None
+                    xml_data, build_errors = self.env['account.edi.xml.ubl_ro']._export_invoice(invoice)
+
+                if build_errors:
+                    invoice_data['error'] = {
+                        'error_title': _("Error when building the CIUS-RO E-Factura XML"),
+                        'errors': build_errors,
+                    }
+                    continue
 
                 invoice._l10n_ro_edi_send_invoice(xml_data)
                 active_document = invoice.l10n_ro_edi_document_ids.sorted()[0]


### PR DESCRIPTION
Problem
---------
SPV requires the CIUS-RO xml. However, when selecting the "sending to SPV" uniquely in the move send wizard, it fails becuase it's missing the XML.

Solution
---------
When sending to SPV, generate the XML by default instead of doing nothing if it's not present.

task-4720583

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
