### PR TITLE
[FIX] mail: avoid trying to send scheduled notifications for deleted records

### DIFF
--- a/addons/mail/models/mail_message_schedule.py
+++ b/addons/mail/models/mail_message_schedule.py
@@ -63,7 +63,7 @@ class MailMessageSchedule(models.Model):
         """
         for model, schedules in self._group_by_model().items():
             if model:
-                records = self.env[model].browse(schedules.mapped('mail_message_id.res_id'))
+                records = self.env[model].browse(schedules.mapped('mail_message_id.res_id')).exists()
             else:
                 records = [self.env['mail.thread']] * len(schedules)
 


### PR DESCRIPTION
If you post a scheduled message on a record and delete it before it is sent, the notifications cron got blocked with `MissingError`:

```py
2025-04-22 09:08:16,948 1 INFO devel odoo.addons.test_mail.tests.test_message_post: Starting TestMessagePost.test_message_post_schedule_deleted ... 
2025-04-22 09:08:17,233 1 INFO devel odoo.addons.test_mail.tests.test_message_post: ====================================================================== 
2025-04-22 09:08:17,233 1 ERROR devel odoo.addons.test_mail.tests.test_message_post: ERROR: TestMessagePost.test_message_post_schedule_deleted
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1013, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1161, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1020, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'mail.test.simple(1,).display_name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1013, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1161, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1020, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'mail.test.simple(1,).name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1222, in __get__
    self.compute_value(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1404, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1553, in _compute_display_name
    names = dict(self.name_get())
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1576, in name_get
    result.append((record.id, convert(record[name], record) or ""))
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6007, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1191, in __get__
    raise MissingError("\n".join([
odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: mail.test.simple(1,), User: 1)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1013, in get
    cache_value = field_cache[record._ids[0]]
KeyError: 1

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1161, in __get__
    value = env.cache.get(record, self)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 1020, in get
    raise CacheMiss(record, field)
odoo.exceptions.CacheMiss: 'mail.test.simple(1,).name'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/misc.py", line 821, in deco
    return func(*args, **kwargs)
  File "/opt/odoo/auto/addons/test_mail/tests/test_message_post.py", line 984, in test_message_post_schedule_deleted
    self.env["mail.message.schedule"].sudo()._send_notifications_cron()
  File "/opt/odoo/auto/addons/mail/models/mail_message_schedule.py", line 51, in _send_notifications_cron
    messages_scheduled._send_notifications()
  File "/opt/odoo/auto/addons/mail/models/mail_message_schedule.py", line 80, in _send_notifications
    record._notify_thread(schedule.mail_message_id, msg_vals=False, **notify_kwargs)
  File "/opt/odoo/auto/addons/sms/models/mail_thread.py", line 139, in _notify_thread
    recipients_data = super(MailThread, self)._notify_thread(message, msg_vals=msg_vals, **kwargs)
  File "/opt/odoo/auto/addons/mail_mobile/models/mail_thread.py", line 25, in _notify_thread
    recipients_data = super(MailThread, self)._notify_thread(message, msg_vals=msg_vals, **kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2502, in _notify_thread
    self._notify_thread_by_inbox(message, recipients_data, msg_vals=msg_vals, **kwargs)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 2541, in _notify_thread_by_inbox
    message_format_values = message.message_format()[0]
  File "/opt/odoo/auto/addons/sms/models/mail_message.py", line 42, in message_format
    message_values = super(MailMessage, self).message_format(format_reply=format_reply)
  File "/opt/odoo/auto/addons/mail/models/mail_message.py", line 954, in message_format
    vals_list = self._message_format(self._get_message_format_fields(), format_reply=format_reply)
  File "/opt/odoo/auto/addons/mail/models/mail_message.py", line 861, in _message_format
    record_name = self.env[message_sudo.model].browse(message_sudo.res_id).sudo().with_prefetch(thread_ids_by_model_name[message_sudo.model]).display_name
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1224, in __get__
    self.compute_value(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1404, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4276, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 98, in determine
    return needle(*args)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1553, in _compute_display_name
    names = dict(self.name_get())
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 1576, in name_get
    result.append((record.id, convert(record[name], record) or ""))
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6007, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1191, in __get__
    raise MissingError("\n".join([
odoo.exceptions.MissingError: Record does not exist or has been deleted.
(Record: mail.test.simple(1,), User: 1)
```

Now, those notifications are simply skipped.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@moduon MT-7276
