### PR TITLE
[IMP] hw_drivers, iot: remove Adam scale support

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -43,31 +43,6 @@ Toledo8217Protocol = SerialProtocol(
     emptyAnswerValid=False,
 )
 
-# The ADAM scales have their own RS232 protocol, usually documented in the scale's manual
-#   e.g at https://www.adamequipment.com/media/docs/Print%20Publications/Manuals/PDF/AZEXTRA/AZEXTRA-UM.pdf
-#          https://www.manualslib.com/manual/879782/Adam-Equipment-Cbd-4.html?page=32#manual
-# Only the baudrate and label format seem to be configurable in the AZExtra series.
-ADAMEquipmentProtocol = SerialProtocol(
-    name='Adam Equipment',
-    baudrate=4800,
-    bytesize=serial.EIGHTBITS,
-    stopbits=serial.STOPBITS_ONE,
-    parity=serial.PARITY_NONE,
-    timeout=0.2,
-    writeTimeout=0.2,
-    measureRegexp=rb"\s*([0-9.]+)kg",  # LABEL format 3 + KG in the scale settings, but Label 1/2 should work
-    statusRegexp=None,
-    commandTerminator=b"\r\n",
-    commandDelay=0.2,
-    measureDelay=0.5,
-    # AZExtra beeps every time you ask for a weight that was previously returned!
-    # Adding an extra delay gives the operator a chance to remove the products
-    # before the scale starts beeping. Could not find a way to disable the beeps.
-    newMeasureDelay=5,
-    measureCommand=b'P',
-    emptyAnswerValid=True,  # AZExtra does not answer unless a new non-zero weight has been detected
-)
-
 
 # HW Proxy is used by Community edition
 class ScaleReadHardwareProxy(http.Controller):
@@ -202,81 +177,6 @@ class Toledo8217Driver(ScaleDriver):
                 if answer == b'\x02E\rhello':
                     connection.write(b'F' + protocol.commandTerminator)
                     return True
-        except serial.serialutil.SerialTimeoutException:
-            pass
-        except Exception:
-            _logger.exception('Error while probing %s with protocol %s' % (device, protocol.name))
-        return False
-
-
-class AdamEquipmentDriver(ScaleDriver):
-    """Driver for the Adam Equipment serial scale."""
-
-    _protocol = ADAMEquipmentProtocol
-    priority = 0  # Test the supported method of this driver last, after all other serial drivers
-
-    def __init__(self, identifier, device):
-        super(AdamEquipmentDriver, self).__init__(identifier, device)
-        self._is_reading = False
-        self._last_weight_time = 0
-        self.device_manufacturer = 'Adam'
-
-    def _check_last_weight_time(self):
-        """The ADAM doesn't make the difference between a value of 0 and "the same value as last time":
-        in both cases it returns an empty string.
-        With this, unless the weight changes, we give the user `TIME_WEIGHT_KEPT` seconds to log the new weight,
-        then change it back to zero to avoid keeping it indefinetely, which could cause issues.
-        In any case the ADAM must always go back to zero before it can weight again.
-        """
-
-        TIME_WEIGHT_KEPT = 10
-
-        if self.data['value'] is None:
-            if time.time() - self._last_weight_time > TIME_WEIGHT_KEPT:
-                self.data['value'] = 0
-        else:
-            self._last_weight_time = time.time()
-
-    def _take_measure(self):
-        """Reads the device's weight value, and pushes that value to the frontend."""
-
-        if self._is_reading:
-            with self._device_lock:
-                self._read_weight()
-                self._check_last_weight_time()
-                if self.data['value'] != self.last_sent_value or self._status['status'] == self.STATUS_ERROR:
-                    self.last_sent_value = self.data['value']
-                    event_manager.device_changed(self)
-        else:
-            time.sleep(0.5)
-
-    # Ensures compatibility with Community edition
-    def _scale_read_hw_proxy(self):
-        """Used when the iot app is not installed"""
-
-        time.sleep(3)
-        with self._device_lock:
-            self._read_weight()
-            self._check_last_weight_time()
-        return self.data['value']
-
-    @classmethod
-    def supported(cls, device):
-        """Checks whether the device at `device` is supported by the driver.
-
-        :param device: path to the device
-        :type device: str
-        :return: whether the device is supported by the driver
-        :rtype: bool
-        """
-
-        protocol = cls._protocol
-
-        try:
-            with serial_connection(device['identifier'], protocol, is_probing=True) as connection:
-                connection.write(protocol.measureCommand + protocol.commandTerminator)
-                # Checking whether writing to the serial port using the Adam protocol raises a timeout exception is about the only thing we can do.
-                return True
         except serial.serialutil.SerialTimeoutException:
             pass
         except Exception:

--- a/addons/iot_base/static/src/device_controller.js
+++ b/addons/iot_base/static/src/device_controller.js
@@ -6,13 +6,12 @@ import { uniqueId } from "@web/core/utils/functions";
 export class DeviceController {
     /**
      * @param {import("@iot_base/network_utils/longpolling").IoTLongpolling} iotLongpolling
-     * @param {{ iot_ip: string, identifier: string, manual_measurement: string }} deviceInfo - Representation of an iot device
+     * @param {{ iot_ip: string, identifier: string }} deviceInfo - Representation of an iot device
      */
     constructor(iotLongpolling, deviceInfo) {
         this.id = uniqueId('listener-');
         this.iotIp = deviceInfo.iot_ip;
         this.identifier = deviceInfo.identifier;
-        this.manual_measurement = deviceInfo.manual_measurement;
         this.iotLongpolling = iotLongpolling;
     }
 

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.xml
@@ -40,10 +40,6 @@
                 </div>
             </div>
             <t t-set-slot="footer">
-                <button class="btn btn-secondary mx-2 w-100" t-if="scale.isManualMeasurement" t-att-disabled="scale.loading" t-on-click="() => scale.readWeight()">
-                    <i t-if="scale.loading and !scale.tareRequested" class="fa fa-spinner fa-spin"/>
-                    <t t-else="">Get Weight</t>
-                </button>
                 <button class="buy-product btn btn-lg btn-primary d-flex align-items-center justify-content-center mx-2 mb-2 cursor-pointer w-100" t-on-click="confirm">
                     Order
                     <i class="fa fa-angle-double-right ms-2"/>

--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js
@@ -20,10 +20,8 @@ export class PosScaleService extends Reactive {
 
     start(errorCallback) {
         this.onError = errorCallback;
-        if (!this.isManualMeasurement) {
-            this.isMeasuring = true;
-            this._readWeightContinuously();
-        }
+        this.isMeasuring = true;
+        this._readWeightContinuously();
     }
 
     reset() {
@@ -80,17 +78,11 @@ export class PosScaleService extends Reactive {
 
     requestTare() {
         this.tareRequested = true;
-        if (this.isManualMeasurement && !this.loading) {
+        if (!this.loading) {
             this.readWeight();
         } else {
             setTimeout(() => this._setTareIfRequested(), TARE_TIMEOUT_MS);
         }
-    }
-
-    get isManualMeasurement() {
-        // In Community we don't know anything about the connected scale,
-        // so we assume automatic measurement.
-        return false;
     }
 
     get netWeight() {


### PR DESCRIPTION
This PR removes the code responsible for the detection and communication with Adam scales. These scales had no reliable way of detecting them as such, with the code always detecting every single serial connection as an Adam scale. Since Adam scales have been added to Odoo years agom there are 0 existing (even archived) tickets in support concerning them, we are recommending Mettler Toledo scales to our clients and most importantly they interfere with the detection of belgian blackboxes we delete the problematic code and thus the support of these unused scales.

It also removes the associated 'manual_measurement' field and all of the associated fields and methods

Associated Enterprise PR: https://github.com/odoo/enterprise/pull/83793
Associated upgrade PR: https://github.com/odoo/upgrade/pull/7589
