### PR TITLE
[FIX] sale_project: Fix tour for project sale orderline

### DIFF
--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -44,7 +44,17 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         content: "Create an Sales Order Item in the autocomplete dropdown.",
         run: "click",
     }, {
-        trigger: ".o_form_button_save",
+        trigger: "#product_id_0",
+        content: "Fill the Sales Order Item name.",
+        run: "click",
+    },
+    {
+        trigger:"#product_id_0_0_0",
+        content: "Select the Product in the autocomplete dropdown.",
+        run: "click",
+    },
+    {
+        trigger: ".modal-footer .o_form_button_save",
         content: "Save project",
         run: "click",
     },


### PR DESCRIPTION
the tour was not working because the sale order item wasn't being selected in the modal
and the save button was not being selected because (It is not allowed to do action on an element that's below a modal).

build_error-163102

