### PR TITLE
[IMP] im_livechat: introduce the agent's expertise field

### DIFF
--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -380,7 +380,10 @@ class ChatbotScriptStep(models.Model):
             # next, add the human_operator to the channel and post a "Operator invited to the channel" notification
             discuss_channel.sudo()._add_members(
                 users=human_operator,
-                create_member_params={"livechat_member_type": "agent"},
+                create_member_params={
+                    "livechat_member_type": "agent",
+                    "agent_expertise_ids": self.operator_expertise_ids.ids,
+                },
                 inviting_partner=self.chatbot_script_id.operator_partner_id,
             )
             # sudo - discuss.channel: let the chat bot proceed to the forward step (change channel operator, add human operator

--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -28,6 +28,9 @@ class ImLivechatChannelMemberHistory(models.Model):
     chatbot_script_id = fields.Many2one(
         "chatbot.script", compute="_compute_member_fields", index="btree_not_null", store=True
     )
+    agent_expertise_ids = fields.Many2many(
+        "im_livechat.expertise", compute="_compute_member_fields", store=True
+    )
 
     _member_id_unique = models.Constraint(
         "UNIQUE(member_id)", "Members can only be linked to one history"
@@ -57,3 +60,6 @@ class ImLivechatChannelMemberHistory(models.Model):
                 history.livechat_member_type or history.member_id.livechat_member_type
             )
             history.chatbot_script_id = history.chatbot_script_id or history.member_id.chatbot_script_id
+            history.agent_expertise_ids = (
+                history.agent_expertise_ids or history.member_id.agent_expertise_ids
+            )

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -82,8 +82,9 @@
                         <filter name="group_by_operator" string="Agent" domain="[]" context="{'group_by': 'partner_id'}"/>
                         <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
-                        <filter name="group_by_customer" domain="[]" context="{'group_by':'visitor_partner_id'}"/>
                         <filter name="group_by_chatbot" string="Chatbot" domain="[]" context="{'group_by':'chatbot_script_id'}"/>
+                        <filter name="group_by_expertise" string="Expertise" domain="[]" context="{'group_by':'session_expertises'}"/>
+                        <filter name="group_by_customer" domain="[]" context="{'group_by':'visitor_partner_id'}"/>
                         <separator orientation="vertical" />
                         <filter name="group_by_hour" string="Hour of Day" domain="[]" context="{'group_by':'start_date_hour'}"/>
                         <filter name="group_by_month" string="Date" domain="[]" context="{'group_by':'start_date:month'}" />


### PR DESCRIPTION
Purpose of this commit:
To introduce the agent's expertise field in order to enable grouping the session based on the agent's expertise.

part of task-4619177
