### PR TITLE
[IMP] web, *: render web client without waiting for translations.

### DIFF
--- a/addons/http_routing/controllers/main.py
+++ b/addons/http_routing/controllers/main.py
@@ -9,13 +9,13 @@ from odoo.addons.web.controllers.webclient import WebClient
 
 class Routing(Home):
 
-    @http.route('/website/translations/<string:unique>', type='http', auth="public", website=True, readonly=True)
-    def get_website_translations(self, unique, lang=None, mods=None):
+    @http.route('/website/translations', type='http', auth="public", website=True, readonly=True, sitemap=False)
+    def get_website_translations(self, hash=None, lang=None, mods=None):
         IrHttp = request.env['ir.http'].sudo()
         modules = IrHttp.get_translation_frontend_modules()
         if mods:
             modules += mods.split(',')
-        return WebClient().translations(unique, mods=','.join(modules), lang=lang)
+        return WebClient().translations(hash, mods=','.join(modules), lang=lang)
 
 
 class SessionWebsite(Session):

--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -265,17 +265,8 @@ class IrHttp(models.AbstractModel):
     def get_frontend_session_info(self) -> dict:
         session_info = super(IrHttp, self).get_frontend_session_info()
 
-        IrHttpModel = request.env['ir.http'].sudo()
-        modules = IrHttpModel.get_translation_frontend_modules()
-        user_context = request.session.context if request.session.uid else {}
-        lang = user_context.get('lang')
-        translation_hash = request.env['ir.http'].get_web_translations_hash(modules, lang)
-
         session_info.update({
             'translationURL': '/website/translations',
-            'cache_hashes': {
-                'translations': translation_hash,
-            },
         })
         return session_info
 

--- a/addons/mail/models/ir_http.py
+++ b/addons/mail/models/ir_http.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import odoo
 from odoo import models
 from odoo.http import request
 from odoo.addons.mail.tools.discuss import Store
@@ -25,9 +24,5 @@ class IrHttp(models.AbstractModel):
         guest = self.env['mail.guest']._get_guest_from_context()
         if not request.session.uid and guest:
             user_context = {'lang': guest.lang}
-            mods = odoo.tools.config['server_wide_modules']
-            lang = user_context.get("lang")
-            translation_hash = self.env['ir.http'].sudo().get_web_translations_hash(mods, lang)
-            result['cache_hashes']['translations'] = translation_hash
             result["user_context"] = user_context
         return result

--- a/addons/mail/views/discuss_public_templates.xml
+++ b/addons/mail/views/discuss_public_templates.xml
@@ -15,10 +15,6 @@
                         debug: "<t t-out="debug"/>",
                         discuss_data: <t t-out="json.dumps(data)"/>
                     };
-                    {
-                        const { user_context,  cache_hashes } = odoo.__session_info__;
-                        fetch(`/web/webclient/translations/${cache_hashes.translations}?lang=${user_context.lang}`);
-                    }
                 </script>
                 <t t-call-assets="mail.assets_public"/>
                 <t t-call-assets="mail.assets_discuss_public_test_tours" t-if="'tests' in debug or test_mode_enabled"/>

--- a/addons/mrp_subcontracting/controllers/portal.py
+++ b/addons/mrp_subcontracting/controllers/portal.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from odoo import http, _
 from odoo.http import request
 from odoo.exceptions import AccessError, MissingError
-from odoo.tools import config
 from odoo.addons.portal.controllers import portal
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 
@@ -90,16 +89,8 @@ class CustomerPortal(portal.CustomerPortal):
         except (AccessError, MissingError):
             raise werkzeug.exceptions.NotFound
         session_info = request.env['ir.http'].session_info()
-        user_context = dict(request.env.context) if request.session.uid else {}
-        mods = config['server_wide_modules']
-        lang = user_context.get("lang")
-        translation_hash = request.env['ir.http'].get_web_translations_hash(mods, lang)
-        cache_hashes = {
-            "translations": translation_hash,
-        }
         production_company = picking.company_id
         session_info.update(
-            cache_hashes=cache_hashes,
             action_name='mrp_subcontracting.subcontracting_portal_view_production_action',
             picking_id=picking.id,
             user_companies={

--- a/addons/point_of_sale/static/src/app/main.js
+++ b/addons/point_of_sale/static/src/app/main.js
@@ -8,7 +8,6 @@ import { user } from "@web/core/user";
 import { session } from "@web/session";
 import { mountComponent } from "@web/env";
 import { Chrome } from "@point_of_sale/app/pos_app";
-import { jsToPyLocale } from "@web/core/l10n/utils";
 
 const loader = reactive({ isShown: true });
 whenReady(() => {
@@ -60,11 +59,7 @@ whenReady(() => {
 function registerServiceWorker() {
     // Register the service worker for the POS
     const urlsToCache = JSON.parse(odoo.urls_to_cache);
-    const translationsHash = session.cache_hashes?.translations;
-    const lang = jsToPyLocale(user.lang || document.documentElement.getAttribute("lang"));
-    const translationURL = session.translationURL || "/web/webclient/translations";
-    const url = `${translationURL}/${translationsHash}?lang=${lang}`;
-    urlsToCache.push(...[url, "/web/static/lib/zxing-library/zxing-library.js"]);
+    urlsToCache.push("/web/static/lib/zxing-library/zxing-library.js");
 
     navigator.serviceWorker?.register("/pos/service-worker.js").then((registration) => {
         const worker = registration.installing || registration.waiting || registration.active;

--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -11,7 +11,7 @@ from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.osv.expression import AND, FALSE_DOMAIN
-from odoo.tools import config, groupby as groupbyelem
+from odoo.tools import groupby as groupbyelem
 
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 
@@ -128,22 +128,16 @@ class ProjectCustomerPortal(CustomerPortal):
     def _prepare_project_sharing_session_info(self, project):
         session_info = request.env['ir.http'].session_info()
         user_context = dict(request.env.context) if request.session.uid else {}
-        mods = config['server_wide_modules']
         if request.env.lang:
             lang = request.env.lang
             session_info['user_context']['lang'] = lang
             # Update Cache
             user_context['lang'] = lang
         lang = user_context.get("lang")
-        translation_hash = request.env['ir.http'].get_web_translations_hash(mods, lang)
-        cache_hashes = {
-            "translations": translation_hash,
-        }
 
         project_company = self._get_project_sharing_company(project)
 
         session_info.update(
-            cache_hashes=cache_hashes,
             action_name="project.project_sharing_project_task_action",
             project_id=project.id,
             project_name=project.name,

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -91,9 +91,6 @@ class IrHttp(models.AbstractModel):
             'web.max_file_upload_size',
             default=DEFAULT_MAX_CONTENT_LENGTH,
         ))
-        mods = odoo.tools.config['server_wide_modules']
-        if request.db:
-            mods = list(request.registry._init_modules) + mods
         is_internal_user = user._is_internal()
         session_info = {
             "uid": session_uid,
@@ -120,11 +117,6 @@ class IrHttp(models.AbstractModel):
             'profile_params': request.session.get('profile_params'),
             "max_file_upload_size": max_file_upload_size,
             "home_action_id": user.action_id.id,
-            "cache_hashes": {
-                "translations": self.env['ir.http'].sudo().get_web_translations_hash(
-                    mods, request.session.context['lang']
-                ) if session_uid else None,
-            },
             "currencies": self.env['res.currency'].get_all_currencies(),
             'bundle_params': {
                 'lang': request.session.context['lang'],
@@ -181,6 +173,7 @@ class IrHttp(models.AbstractModel):
             "is_internal_user": user._is_internal(),
             'is_website_user': user._is_public() if session_uid else False,
             'uid': session_uid,
+            "registry_hash": hmac(self.env(su=True), "webclient-cache", self.env.registry.registry_sequence),
             'is_frontend': True,
             'profile_session': request.session.get('profile_session'),
             'profile_collectors': request.session.get('profile_collectors'),

--- a/addons/web/static/tests/_framework/mock_session.hoot.js
+++ b/addons/web/static/tests/_framework/mock_session.hoot.js
@@ -26,9 +26,6 @@ const makeSession = ({
         debug: new URLSearchParams(location.search).get("debug"),
         lang,
     },
-    cache_hashes: {
-        translations: "f17c8e4bb0fd4d5db2615d28713486df97853a8f",
-    },
     can_insert_in_spreadsheet: true,
     db,
     registry_hash: "05500d71e084497829aa807e3caa2e7e9782ff702c15b2f57f87f2d64d049bd0",

--- a/addons/web/static/tests/core/l10n/translation.test.js
+++ b/addons/web/static/tests/core/l10n/translation.test.js
@@ -1,3 +1,4 @@
+/* eslint no-restricted-syntax: 0 */
 import { after, describe, expect, test } from "@odoo/hoot";
 import {
     defineParams,
@@ -10,13 +11,25 @@ import {
 } from "@web/../tests/web_test_helpers";
 import { _t, translatedTerms, translationLoaded } from "@web/core/l10n/translation";
 import { session } from "@web/session";
+import { IndexedDB } from "@web/core/utils/indexed_db";
+import { animationFrame, Deferred } from "@odoo/hoot-mock";
 
 import { Component, markup, xml } from "@odoo/owl";
 const { DateTime } = luxon;
 
+let id = 0;
+
 const frenchTerms = { Hello: "Bonjour" };
 class TestComponent extends Component {
-    static template = "";
+    // For performance reasons, HOOT caches the compiled templates
+    // (with the terms already translated).
+    // In this test suite, since the translations are being tested,
+    // we need that each template to be unique (to avoid using a cached template).
+    // To do this, we create a unique empty node in each template.
+    static get template() {
+        return xml`${this._template}<div id="${id++}"/>`;
+    }
+    static _template = "";
     static props = ["*"];
 }
 
@@ -32,7 +45,7 @@ async function mockLang(lang) {
 }
 
 test("lang is given by the user context", async () => {
-    onRpc("/web/webclient/translations/*", (request) => {
+    onRpc("/web/webclient/translations", (request) => {
         const urlParams = new URLSearchParams(new URL(request.url).search);
         expect.step(urlParams.get("lang"));
     });
@@ -42,7 +55,7 @@ test("lang is given by the user context", async () => {
 
 test("lang is given by an attribute on the DOM root node", async () => {
     serverState.lang = null;
-    onRpc("/web/webclient/translations/*", (request) => {
+    onRpc("/web/webclient/translations", (request) => {
         const urlParams = new URLSearchParams(new URL(request.url).search);
         expect.step(urlParams.get("lang"));
     });
@@ -60,10 +73,10 @@ test("url is given by the session", async () => {
         translationURL: "/get_translations",
     });
     onRpc(
-        "/get_translations/*",
+        "/get_translations",
         function (request) {
-            expect(request.url).toInclude("/get_translations/");
-            return this.loadTranslations();
+            expect(request.url).toInclude("/get_translations");
+            return this.loadTranslations(request);
         },
         { pure: true }
     );
@@ -71,7 +84,7 @@ test("url is given by the session", async () => {
 });
 
 test("can translate a text node", async () => {
-    TestComponent.template = xml`<div id="main">Hello</div>`;
+    TestComponent._template = `<div id="main">Hello</div>`;
     defineParams({
         translations: frenchTerms,
     });
@@ -79,10 +92,243 @@ test("can translate a text node", async () => {
     expect("#main").toHaveText("Bonjour");
 });
 
+test("[cache] write into the cache", async () => {
+    patchWithCleanup(IndexedDB.prototype, {
+        write(table, key, value) {
+            expect.step(`table: ${table}`);
+            expect.step(`key: ${key}`);
+            expect.step(`value: ${JSON.stringify(value)}`);
+        },
+    });
+    onRpc("/web/webclient/translations", (request) => {
+        expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
+    });
+    TestComponent._template = `<div id="main">Hello</div>`;
+    defineParams({
+        translations: frenchTerms,
+    });
+    await mountWithCleanup(TestComponent);
+    expect("#main").toHaveText("Bonjour");
+    const expectedValue = {
+        lang: "en",
+        lang_parameters: {
+            date_format: "%m/%d/%Y",
+            decimal_point: ".",
+            direction: "ltr",
+            grouping: "[3,0]",
+            time_format: "%H:%M:%S",
+            short_time_format: "%H:%M",
+            thousands_sep: ",",
+            week_start: 7,
+        },
+        modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } },
+        multi_lang: false,
+        hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001",
+    };
+    expect.verifySteps([
+        "hash: ",
+        "table: /web/webclient/translations",
+        'key: {"lang":"en"}',
+        `value: ${JSON.stringify(expectedValue)}`,
+    ]);
+});
+
+test("[cache] read from cache, and don't wait to render", async () => {
+    patchWithCleanup(IndexedDB.prototype, {
+        read() {
+            return {
+                lang: "en",
+                lang_parameters: {
+                    date_format: "%m/%d/%Y",
+                    decimal_point: ".",
+                    direction: "ltr",
+                    grouping: "[3,0]",
+                    time_format: "%H:%M:%S",
+                    short_time_format: "%H:%M",
+                    thousands_sep: ",",
+                    week_start: 7,
+                },
+                modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } },
+                multi_lang: false,
+                hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001",
+            };
+        },
+    });
+    const def = new Deferred();
+    onRpc("/web/webclient/translations", async (request) => {
+        await def;
+        expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
+    });
+    TestComponent._template = `<div id="main">Hello</div>`;
+    defineParams({
+        translations: frenchTerms,
+    });
+    await mountWithCleanup(TestComponent);
+    expect("#main").toHaveText("Bonjour"); //Don't wait the end of the fetch to render
+    def.resolve();
+    await animationFrame();
+    expect.verifySteps(["hash: 5d62e6f31a2e19f1f128bd7f56d11088a746e001"]); //Fetch with the hash of the translation in cache
+});
+
+test("[cache] update the cache if hash are different - template", async () => {
+    patchWithCleanup(IndexedDB.prototype, {
+        read() {
+            return {
+                lang: "en",
+                lang_parameters: {
+                    date_format: "%m/%d/%Y",
+                    decimal_point: ".",
+                    direction: "ltr",
+                    grouping: "[3,0]",
+                    time_format: "%H:%M:%S",
+                    short_time_format: "%H:%M",
+                    thousands_sep: ",",
+                    week_start: 7,
+                },
+                modules: { web: { messages: [{ id: "Hello", string: "Different Bonjour" }] } },
+                multi_lang: false,
+                hash: "5d62e6f31a2e",
+            };
+        },
+        write(table, key, value) {
+            expect.step(`table: ${table}`);
+            expect.step(`key: ${key}`);
+            expect.step(`value: ${JSON.stringify(value)}`);
+        },
+    });
+    const def = new Deferred();
+    onRpc("/web/webclient/translations", async (request) => {
+        await def;
+        expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
+    });
+    TestComponent._template = `<div id="main">Hello</div>`;
+    defineParams({
+        translations: frenchTerms,
+    });
+    const component = await mountWithCleanup(TestComponent);
+    expect("#main").toHaveText("Different Bonjour"); //Value came from the cache!
+    def.resolve();
+    await animationFrame();
+    const expectedValue = {
+        lang: "en",
+        lang_parameters: {
+            date_format: "%m/%d/%Y",
+            decimal_point: ".",
+            direction: "ltr",
+            grouping: "[3,0]",
+            time_format: "%H:%M:%S",
+            short_time_format: "%H:%M",
+            thousands_sep: ",",
+            week_start: 7,
+        },
+        modules: { web: { messages: [{ id: "Hello", string: "Bonjour" }] } }, // value was updated in the cache
+        multi_lang: false,
+        hash: "5d62e6f31a2e19f1f128bd7f56d11088a746e001", // hash was updated in the cache
+    };
+    expect.verifySteps([
+        "hash: 5d62e6f31a2e", //Fetch with the hash of the translation in cache
+        "table: /web/webclient/translations",
+        'key: {"lang":"en"}',
+        `value: ${JSON.stringify(expectedValue)}`,
+    ]);
+
+    component.render();
+    await animationFrame();
+    // The value hasn't been updated with the new translation, this is because owl caches the translated templates for performance reasons.
+    // This is a known limitation.
+    expect("#main").toHaveText("Different Bonjour");
+});
+
+test("[cache] update the cache if hash are different - js", async () => {
+    patchWithCleanup(IndexedDB.prototype, {
+        read() {
+            return {
+                lang: "en",
+                lang_parameters: {
+                    date_format: "%m/%d/%Y",
+                    decimal_point: ".",
+                    direction: "ltr",
+                    grouping: "[3,0]",
+                    time_format: "%H:%M:%S",
+                    short_time_format: "%H:%M",
+                    thousands_sep: ",",
+                    week_start: 7,
+                },
+                modules: {
+                    web: {
+                        messages: [{ id: "Hi", string: "Different Salut" }],
+                    },
+                },
+                multi_lang: false,
+                hash: "5d62e6f31a2e",
+            };
+        },
+        write(table, key, value) {
+            expect.step(`table: ${table}`);
+            expect.step(`key: ${key}`);
+            expect.step(`value: ${JSON.stringify(value)}`);
+        },
+    });
+    const def = new Deferred();
+    onRpc("/web/webclient/translations", async (request) => {
+        await def;
+        expect.step(`hash: ${new URL(request.url).searchParams.get("hash")}`);
+    });
+    class MyTestComponent extends Component {
+        static template = xml`<div id="main"><t t-esc="otherText"/></div>`;
+        static props = ["*"];
+
+        get otherText() {
+            return _t("Hi");
+        }
+    }
+
+    defineParams({
+        translations: { Hi: "Salut" },
+    });
+    const component = await mountWithCleanup(MyTestComponent);
+    // The cached translated terms are used
+    expect("#main").toHaveText("Different Salut");
+
+    def.resolve();
+    await animationFrame();
+    const expectedValue = {
+        lang: "en",
+        lang_parameters: {
+            date_format: "%m/%d/%Y",
+            decimal_point: ".",
+            direction: "ltr",
+            grouping: "[3,0]",
+            time_format: "%H:%M:%S",
+            short_time_format: "%H:%M",
+            thousands_sep: ",",
+            week_start: 7,
+        },
+        modules: {
+            web: {
+                messages: [{ id: "Hi", string: "Salut" }],
+            },
+        }, // value was updated in the cache
+        multi_lang: false,
+        hash: "267b5f5848b78a58ff6f57530b5f6fcdc46ecad0", // hash was updated in the cache
+    };
+    expect.verifySteps([
+        "hash: 5d62e6f31a2e", //Fetch with the hash of the translation in cache
+        "table: /web/webclient/translations",
+        'key: {"lang":"en"}',
+        `value: ${JSON.stringify(expectedValue)}`,
+    ]);
+
+    component.render();
+    await animationFrame();
+    // Using the updated translated terms
+    expect("#main").toHaveText("Salut");
+});
+
 test("can lazy translate", async () => {
     // Can't use patchWithCleanup cause it doesn't support Symbol
     translatedTerms[translationLoaded] = false;
-    TestComponent.template = xml`<div id="main"><t t-esc="constructor.someLazyText" /></div>`;
+    TestComponent._template = `<div id="main"><t t-esc="constructor.someLazyText" /></div>`;
     TestComponent.someLazyText = _t("Hello");
     expect(() => TestComponent.someLazyText.toString()).toThrow();
     expect(() => TestComponent.someLazyText.valueOf()).toThrow();
@@ -158,7 +404,10 @@ test("_t fills the format specifiers in translated terms with formatted lists", 
     });
     await mockLang("fr_FR");
     const translatedStr1 = _t("Due in %s days", ["30", "60", "90"]);
-    const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {due_dates: ["30", "60", "90"], user: "Mitchell"});
+    const translatedStr2 = _t("Due in %(due_dates)s days for %(user)s", {
+        due_dates: ["30", "60", "90"],
+        user: "Mitchell",
+    });
     expect(translatedStr1).toBe("Échéance dans 30, 60 et 90 jours");
     expect(translatedStr2).toBe("Échéance dans 30, 60 et 90 jours pour Mitchell");
 });

--- a/addons/web/static/tests/legacy/setup.js
+++ b/addons/web/static/tests/legacy/setup.js
@@ -230,9 +230,6 @@ function cleanLoadedLanguages() {
 
 function patchSessionInfo() {
     patchWithCleanup(sessionInfo, {
-        cache_hashes: {
-            translations: "314159",
-        },
         qweb: "owl",
         // Commit: 3e847fc8f499c96b8f2d072ab19f35e105fd7749
         // to see what user_companies is

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -843,6 +843,7 @@ test("should wait label promises for one2many search defaults", async () => {
         searchViewId: false,
         context: { search_default_company: 1 },
     });
+    await animationFrame();
     expect(`.o_cp_searchview`).toHaveCount(0);
 
     def.resolve();

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -278,7 +278,7 @@
                     // Block to avoid leaking variables in the script scope
                     {
                         odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
-                        const { user_context,  cache_hashes } = odoo.__session_info__;
+                        const { user_context } = odoo.__session_info__;
                         const lang = new URLSearchParams(document.location.search).get("lang");
                         let menuURL = `/web/webclient/load_menus?unique=${new Date().getTime().toString()}`;
                         if (lang) {
@@ -287,9 +287,6 @@
                         }
                         odoo.reloadMenus = () => fetch(menuURL).then(res => res.json());
                         odoo.loadMenusPromise = odoo.reloadMenus();
-                        // Prefetch translations to speedup webclient. This is done in JS because link rel="prefetch"
-                        // is not yet supported on safari.
-                        fetch(`/web/webclient/translations/${cache_hashes.translations}?lang=${user_context.lang}`);
                     }
                 </script>
                 <t t-call-assets="web.assets_web_print" media="print" t-js="false"/>

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -442,6 +442,9 @@ class IrHttp(models.AbstractModel):
             'lang': lang,
             'multi_lang': len(self.env['res.lang'].sudo().get_installed()) > 1,
         }
+        if self.env.context.get('cache_translation_data'):
+            # put in the transactional cache
+            self.env.cr.cache['translation_data'] = translation_cache
         return hashlib.sha1(json.dumps(translation_cache, sort_keys=True, default=json_default).encode()).hexdigest()
 
     @classmethod


### PR DESCRIPTION
Before this commit, a "translation hash" was calculated and added to the
session_info. The method used to compute the hash needs to compute the
translations, which can be slow, and only the hash is cached. This hash is then
used by the client to fetch the translations twice. Once directly in the page
template, and once in the localization service. This is done to get the
translations as quickly as possible. Normally, the browser cache should prevent
from the second request from being made (since the hash is the same), but this
doesn't always seem to work as expected, as all requests are started as soon as
possible, so if there is a small delay in the first request the second is also
be made. So in the worst case scenario, translations are calculated 3 times by
the server, and the web client waits for them to finish before rendering.

Now, a translation hash is no longer calculated to be placed in session_info,
speeding up session_info and the page. The translation hash is sent to the web client
with the translations themselves.

Only the first time, the web client will waits for the translations to be
rendered. The next time the user accesses the web client, the cached
translations are used. Each time the user accesses the web client, the
translations are fetched. If a cached translation exists, the hash of the
cached translation is used to fetch the translations. The new route computes
the current hash of the translations, compares it with the one it received and
if it's the same simply replies that there has been no change; if the hash is
different, it replies with the computed translations and the new hash.
Note that when the hash is computed, the translations are kept in a cache to
avoid having to compute the translations twice.

opw-4737228

Co-authored-by: Rémy Voet <ryv@odoo.com>