### PR TITLE
[FIX] digest: fix view inheritence

### DIFF
--- a/addons/digest/views/res_config_settings_views.xml
+++ b/addons/digest/views/res_config_settings_views.xml
@@ -3,7 +3,7 @@
     <record id="res_config_settings_view_form" model="ir.ui.view">
         <field name="name">res.config.settings.view.form.inherit.digest</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
+        <field name="inherit_id" ref="mail.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='restrict_template_rendering_setting']" position="before">
                 <setting id="digest" string="Digest Email" help="Add new users as recipient of a periodic email with key metrics" documentation="/applications/general/digest_emails.html" title="New users are automatically added as recipient of the following digest email." name="digest_email_setting_container">


### PR DESCRIPTION
The view `digest.res_config_settings_view_form` uses the field `restrict_template_rendering_setting` from the [mail](https://github.com/odoo/odoo/blob/2987eea19f375191250ac9306f6b9d3b831ade08/addons/mail/views/res_config_settings_views.xml#L58) module in an xpath, while it inherits the view in `base_setup`. The order of the inheritence can load the digest view before the mail view and the field in the xpath will not be found.

affects many upgrades

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
