### PR TITLE
[IMP] safe_eval: simplify API

### DIFF
--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -144,13 +144,7 @@ class AccountTax(models.Model):
             'max': max,
         }
         try:
-            return safe_eval(
-                self.formula_decoded_info['py_formula'],
-                globals_dict=formula_context,
-                locals_dict={},
-                locals_builtins=False,
-                nocopy=True,
-            )
+            return safe_eval(self.formula_decoded_info['py_formula'], formula_context)
         except ZeroDivisionError:
             return 0.0
 

--- a/addons/account_test/report/report_account_test.py
+++ b/addons/account_test/report/report_account_test.py
@@ -35,7 +35,7 @@ class ReportAccount_TestReport_Accounttest(models.AbstractModel):
                 cols = list(item)
             return [(col, item.get(col)) for col in cols if col in item]
 
-        localdict = {
+        context = {
             'cr': self.env.cr,
             'uid': self.env.uid,
             'reconciled_inv': reconciled_inv,  # specific function used in different tests
@@ -43,9 +43,9 @@ class ReportAccount_TestReport_Accounttest(models.AbstractModel):
             'column_order': None,  # used to choose the display order of columns (in case you are returning a list of dict)
             '_': lambda *a, **kw: self.env._(*a, **kw),  # pylint: disable=E8502,
         }
-        safe_eval(code_exec, localdict, mode="exec", nocopy=True)
-        result = localdict['result']
-        column_order = localdict.get('column_order', None)
+        safe_eval(code_exec, context, mode="exec")
+        result = context['result']
+        column_order = context.get('column_order')
 
         if not isinstance(result, (tuple, list, set)):
             result = [result]

--- a/addons/gamification/models/gamification_goal.py
+++ b/addons/gamification/models/gamification_goal.py
@@ -163,7 +163,7 @@ class GamificationGoal(models.Model):
                         'time': time,
                     }
                     code = definition.compute_code.strip()
-                    safe_eval(code, cxt, mode="exec", nocopy=True)
+                    safe_eval(code, cxt, mode="exec")
                     # the result of the evaluated codeis put in the 'result' local variable, propagated to the context
                     result = cxt.get('result')
                     if isinstance(result, (float, int)):

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -907,7 +907,7 @@ class IrActionsServer(models.Model):
         return True
 
     def _run_action_code_multi(self, eval_context):
-        safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
+        safe_eval(self.code.strip(), eval_context, mode="exec", filename=str(self))
         return eval_context.get('action')
 
     def _run_action_multi(self, eval_context=None):

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -47,7 +47,8 @@ SAFE_EVAL_BASE = {
 
 def make_compute(text, deps):
     """ Return a compute function from its code body and dependencies. """
-    func = lambda self: safe_eval(text, SAFE_EVAL_BASE, {'self': self}, mode="exec")
+    def func(self):
+        return safe_eval(text, SAFE_EVAL_BASE | {'self': self}, mode="exec")
     deps = [arg.strip() for arg in deps.split(",")] if deps else []
     return api.depends(*deps)(func)
 

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -26,13 +26,9 @@ from .config import config
 from .misc import file_open, file_path, SKIPPED_ELEMENT_TYPES
 from odoo.exceptions import ValidationError
 
-from .safe_eval import safe_eval as s_eval, pytz, time
+from .safe_eval import safe_eval, pytz, time
 
 _logger = logging.getLogger(__name__)
-
-
-def safe_eval(expr, ctx={}):
-    return s_eval(expr, ctx, nocopy=True)
 
 
 class ParseError(Exception):


### PR DESCRIPTION
This PR simplifies `safe_eval` which, up until now, allowed passing global and local namespaces. There is no usecase for this anymore. We want safe_eval exec mode to behave like a top-level module scope.

`nocopy` is not needed anymore either. It's a relic of when the context could be dynamic (e.g. for already deleted `RecordDictWrapper` or `QWebContext`).

Passed in context is always a dict. It will always be mutated with the local eval namespace dict after evaluation.

This all makes `safe_eval` API less confusing.

See: https://github.com/odoo/enterprise/pull/83818
See: https://github.com/odoo/upgrade-util/pull/265

task-4378806