### PR TITLE
 [FIX] html_editor: close popover and refocus editor on escape

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -496,6 +496,7 @@ export class LinkPlugin extends Plugin {
             onClose: () => {
                 this.linkInDocument = null;
                 this.overlay.close();
+                this.dependencies.selection.focusEditable();
             },
             getInternalMetaData: this.getInternalMetaData,
             getExternalMetaData: this.getExternalMetaData,

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -142,6 +142,7 @@ export class LinkPopover extends Component {
     onKeydown(ev) {
         if (ev.key === "Escape") {
             ev.preventDefault();
+            ev.stopImmediatePropagation();
             this.props.onClose();
         }
     }

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -82,7 +82,7 @@ export class PowerButtonsPlugin extends Plugin {
             } else {
                 const span = this.document.createElement("span");
                 span.textContent = text;
-                span.className = "d-flex align-items-center";
+                span.className = "d-flex align-items-center text-nowrap";
                 span.style.height = "1em";
                 btn.append(span);
             }

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -218,6 +218,7 @@ export class PowerboxPlugin extends Plugin {
         const key = ev.key;
         switch (key) {
             case "Escape":
+                ev.stopImmediatePropagation();
                 this.closePowerbox();
                 break;
             case "Enter":

--- a/addons/html_editor/static/src/main/table/table_picker.js
+++ b/addons/html_editor/static/src/main/table/table_picker.js
@@ -55,6 +55,7 @@ export class TablePicker extends Component {
                     }
                     break;
                 default:
+                    ev.stopImmediatePropagation();
                     this.props.overlay.close();
                     break;
             }


### PR DESCRIPTION
### Steps to reproduce:

- Open an app (e.g., Calendar) where the editor is instantiated into a dialog.
- Focus on the text area in the editor.
- Open a popover (e.g., powerbox, table popover, link popover).
- Press the `<Escape>` key.
- Observe that the modal closes and the focus is lost from the text area.

### Description of the issue/feature this PR addresses:

- Pressing `<Escape>` closes both the popover and the modal dialog at once.
- The "AI" text in power button appeared vertically (with "A" on one line and "I" on the next).

### Desired behavior after PR is merged:

- The first `<Escape>` press only closes the popover and focuses the editor.
- A subsequent `<Escape>` press (with no popover open) will close the modal.
- The "AI" label is now properly constrained to a single line using `text-nowrap`.

task-4737716

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
