### PR TITLE
[FIX] base: prevent error when non-dict context is set in window actions

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -304,6 +304,8 @@ class IrActionsActWindow(models.Model):
                     eval_ctx = dict(self.env.context)
                     try:
                         ctx = safe_eval(values.get('context', '{}'), eval_ctx)
+                        if not isinstance(ctx, dict):
+                            ctx = {}
                     except:
                         ctx = {}
                     values['help'] = self.with_context(**ctx).env[model].get_empty_list_help(values.get('help', ''))


### PR DESCRIPTION
This error occurs when a user provides a `non-dictionary` value, such as list, in the `context` field of `window action`.

Steps to Reproduce:

 - Install the `base` module.
 - Navigate to `Settings` > `Technical` > `Actions` > `Window Actions`.
 - Edit any window action and set the `context` field to an `empty list`.
 - Save the changes.

`TypeError: odoo.orm.models.BaseModel.with_context() argument after ** must be a mapping, not list`

This error occurs when the system attempts to invoke the `with_context()` method with a non-dictionary value, which leads to a TypeError.

This commit ensures the context is a valid dictionary before usage. If the provided context is not a dictionary, it is replaced with an `empty dictionary` to maintain compatibility and prevent error.

Sentry-6558123477

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
