### PR TITLE
[IMP] pos_discount: include global discount in refunds

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -24,6 +24,7 @@ import {
     ControlButtonsPopup,
 } from "@point_of_sale/app/screens/product_screen/control_buttons/control_buttons";
 import { BarcodeVideoScanner } from "@web/core/barcode/barcode_video_scanner";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { OptionalProductPopup } from "@point_of_sale/app/components/popups/optional_products_popup/optional_products_popup";
 import { useRouterParamsChecker } from "@point_of_sale/app/hooks/pos_router_hook";
 import { debounce } from "@web/core/utils/timing";
@@ -180,6 +181,12 @@ export class ProductScreen extends Component {
             this.numberBuffer.reset();
             this.pos.numpadMode = buttonValue;
             return;
+        }
+        if (this.pos.selectedOrder.isRefund && buttonValue !== "Backspace") {
+            return this.dialog.add(AlertDialog, {
+                title: _t("%s update not allowed", this.pos.numpadMode),
+                body: _t("You can not change the %s of the refund order.", this.pos.numpadMode),
+            });
         }
         this.numberBuffer.sendKey(buttonValue);
     }

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -134,22 +134,19 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
             inLeftSide([
                 ...ProductScreen.clickLine("Desk Pad"),
                 ...ProductScreen.selectedOrderlineHasDirect("Desk Pad", "-1"),
-                // Try changing the refund line to positive number.
+                // Try changing the refund line's qty, price, discount but altering of refund line not allowed.
                 // Error popup should show.
                 Numpad.click("2"),
                 Dialog.confirm(),
-                // Change the refund line quantity to -3 -- not allowed
-                // so error popup.
-                ...["+/-", "3"].map(Numpad.click),
+                ...["Price", "2"].map(Numpad.click),
                 Dialog.confirm(),
-                // Change the refund line quantity to -2 -- allowed.
-                ...["+/-", "2"].map(Numpad.click),
-                ...ProductScreen.selectedOrderlineHasDirect("Desk Pad", "-2"),
+                ...["%", "5"].map(Numpad.click),
+                Dialog.confirm(),
             ]),
             // Check if the amount being refunded changed to 2.
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("005"),
-            TicketScreen.toRefundTextContains("Refunding 2.00"),
+            TicketScreen.toRefundTextContains("Refunding 1.00"),
             Chrome.clickRegister(),
             { ...ProductScreen.back(), isActive: ["mobile"] },
             // Pay the refund order.
@@ -161,7 +158,7 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
             // Check refunded quantity.
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("005"),
-            TicketScreen.refundedNoteContains("2.00 Refunded"),
+            TicketScreen.refundedNoteContains("1.00 Refunded"),
         ].flat(),
 });
 

--- a/addons/pos_discount/static/src/app/models/pos_order.js
+++ b/addons/pos_discount/static/src/app/models/pos_order.js
@@ -1,0 +1,10 @@
+import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosOrder.prototype, {
+    getDiscountLine() {
+        return this.lines?.find(
+            (line) => line.product_id.id === this.config.discount_product_id?.id
+        );
+    },
+});

--- a/addons/pos_discount/static/src/app/models/pos_order_line.js
+++ b/addons/pos_discount/static/src/app/models/pos_order_line.js
@@ -8,7 +8,13 @@ patch(PosOrderline.prototype, {
      */
     isGlobalDiscountApplicable() {
         return !(
-            this.config.tip_product_id && this.product_id.id === this.config.tip_product_id?.id
+            // Ignore existing discount line as not removing it before adding new discount line successfully
+            (
+                (this.config.tip_product_id &&
+                    this.product_id.id === this.config.tip_product_id?.id) ||
+                (this.config.discount_product_id &&
+                    this.product_id.id === this.config.discount_product_id?.id)
+            )
         );
     },
 });

--- a/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
+++ b/addons/pos_discount/static/src/app/screens/product_screen/control_buttons/control_buttons.js
@@ -34,8 +34,7 @@ patch(ControlButtons.prototype, {
             });
             return;
         }
-        // Remove existing discounts
-        lines.filter((line) => line.getProduct() === product).forEach((line) => line.delete());
+        const tobeRemoved = order.getDiscountLine(); // remove once we successfully create new line
 
         const discountableLines = lines.filter((line) => line.isGlobalDiscountApplicable());
         const baseLines = discountableLines.map((line) =>
@@ -60,7 +59,7 @@ patch(ControlButtons.prototype, {
             }
         );
         for (const baseLine of globalDiscountBaseLines) {
-            await this.pos.addLineToCurrentOrder(
+            const line = await this.pos.addLineToCurrentOrder(
                 {
                     product_id: baseLine.product_id,
                     price_unit: baseLine.price_unit,
@@ -71,6 +70,9 @@ patch(ControlButtons.prototype, {
                 },
                 { merge: false }
             );
+            if (line) {
+                tobeRemoved?.delete();
+            }
         }
     },
 });

--- a/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/pos_discount/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -1,0 +1,39 @@
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+
+patch(TicketScreen.prototype, {
+    async onDoRefund() {
+        await super.onDoRefund(...arguments);
+        const order = this.getSelectedOrder();
+        const discountLine = order.getDiscountLine();
+        const destinationOrder = this.pos.getOrder();
+
+        if (discountLine && destinationOrder && !destinationOrder.getDiscountLine()) {
+            const globalDiscount = -discountLine.price_subtotal_incl;
+            this.pos.models["pos.order.line"].create({
+                qty: 1,
+                price_unit:
+                    (globalDiscount * destinationOrder.taxTotals.total_amount) /
+                        (order.amount_total + globalDiscount) || 1,
+                product_id: this.pos.config.discount_product_id,
+                order_id: destinationOrder,
+            });
+        }
+    },
+
+    _onUpdateSelectedOrderline() {
+        const selectedOrderlineId = this.getSelectedOrderlineId();
+        const orderline = this.getSelectedOrder().lines.find(
+            (line) => line.id == selectedOrderlineId
+        );
+        if (orderline.product_id.id === this.pos.config.discount_product_id?.id) {
+            return this.dialog.add(AlertDialog, {
+                title: _t("Error"),
+                body: _t("You cannot edit a discount line."),
+            });
+        }
+        return super._onUpdateSelectedOrderline(...arguments);
+    },
+});

--- a/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
+++ b/addons/pos_discount/static/tests/tours/test_taxes_global_discount.js
@@ -3,6 +3,7 @@ import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 import { escapeRegExp } from "@web/core/utils/strings";
 import { registry } from "@web/core/registry";
 
@@ -84,6 +85,13 @@ registry
                 ProductScreen.checkTotalAmount("30.04"),
                 ProductScreen.checkTaxAmount("3.98"),
                 ...payAndInvoice("30.04"),
+                // On refund, check if the global discount line is correctly prorated in the refund order
+                ...ProductScreen.clickRefund(),
+                TicketScreen.filterIs("Paid"),
+                TicketScreen.selectOrder("001"),
+                ProductScreen.clickNumpad("1"),
+                TicketScreen.confirmRefund(),
+                PaymentScreen.totalIs("-17.95"), // -18.32 (product_1_1) + 0.37 (discount)
             ].flat(),
     });
 


### PR DESCRIPTION
In this commit:
-------------------
- If we are refunding order having global discount we have given accessibility to users to accommodate discount price to be reversed based on the percentage of the global discount.
- When we already have a discount line and try to update it, the older discount line was deleted but the updated set of lines is not taken for counting discountable lines.

Task: 4738008