### PR TITLE
[FIX] website_sale: fix combo product price issue

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1818,6 +1818,7 @@
                 <ul class="d-none js_add_cart_variants mb-0" t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"/>
                 <input type="hidden" class="product_template_id" name="product_template_id" t-att-value="product.id"/>
                 <input type="hidden" t-if="len(filtered_sorted_variants) == 1" class="product_id" name="product_id" t-att-value="filtered_sorted_variants[0].id"/>
+                <input type="hidden" name="product_type" t-att-value="product.type"/>
                 <t t-if="len(filtered_sorted_variants) &gt; 1">
                     <t t-set="template_combination_info" t-value="product._get_combination_info(only_template=True)"/>
                     <div class="mb-4">


### PR DESCRIPTION
Steps to reproduce:
-

1. Create a database on `saas~18.2`
2. Install `website_sale` module
3. Go to the shop on the website and select a combo product
4. From the editor>customize, select  variants(Products List)
5. Add the combo product to the cart You will notice that the product price becomes zero.

Issue:
-
- When the variants option is enabled, the view `List View of Variants` is activated.
- At that time [here](https://github.com/odoo/odoo/blob/6edf0ba80818fc23b8daf46d694d201e0efee133/addons/website_sale/static/src/js/website_sale.js#L498) the product type is not retrieved, due to this the product is considered to be `configured`, and it is added to the cart without its `sub-products`, result of product price is zero.

Solution:
-
- By adding the product type to the view `List View of Variants`, it correctly retrieves the product type and proceeds to configure the product.

OPW - [4686969](https://www.odoo.com/odoo/project/70/tasks/4686969?debug=1)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
