### PR TITLE
[REF] account: Allow to override email template

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2884,12 +2884,15 @@ class AccountMove(models.Model):
     def button_cancel(self):
         self.write({'auto_post': False, 'state': 'cancel'})
 
+    def _get_mail_template(self):
+        return self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
+
     def action_invoice_sent(self):
         """ Open a window to compose an email, with the edi invoice template
             message loaded by default
         """
         self.ensure_one()
-        template = self.env.ref('account.email_template_edi_invoice', raise_if_not_found=False)
+        template = self._get_mail_template()
         lang = False
         if template:
             lang = template._render_lang(self.ids)[self.id]


### PR DESCRIPTION
Description of the issue this PR addresses:
1. Add `company_id` and multi-company access rules for email templates.
2. Assign the email template `account.email_template_edi_invoice` to a specific company.
3. Log in to another company.
4. From an invoice, send an email.

Current behavior before PR:
An `AccessError` is raised

Desired behavior after PR is merged:
An override of `_get_mail_template` allows to select the correct email template to be used, before any `AccessError` is raised.

Additional notes:
In more recent versions, this is already possible, see https://github.com/odoo/odoo/blob/b60152525133321699e3b9d45d3de98ff81399ad/addons/account/models/account_move.py#L5382

I know this version is no more supported, but we are still using it and this is where we need the patch; hopefully this will help others too.

---
I confirm I have signed the CLA in https://github.com/odoo/odoo/pull/206862 and read the PR guidelines at www.odoo.com/submit-pr
