### PR TITLE
[FIX] l10n_in_ewaybill*: Prevent, if doc not in valid state or IRN missing

### DIFF
--- a/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
+++ b/addons/l10n_in_ewaybill/i18n/l10n_in_ewaybill.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-26 12:21+0000\n"
-"PO-Revision-Date: 2025-05-26 12:21+0000\n"
+"POT-Creation-Date: 2025-06-26 05:36+0000\n"
+"PO-Revision-Date: 2025-06-26 05:36+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -69,6 +69,7 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #. odoo-python
 #: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+#: code:addons/l10n_in_ewaybill/tests/test_ewaybill_json.py:0
 msgid "- Transporter %s does not have a GST Number"
 msgstr ""
 
@@ -214,6 +215,12 @@ msgstr ""
 #. module: l10n_in_ewaybill
 #: model:ir.model.fields,field_description:l10n_in_ewaybill.field_l10n_in_ewaybill_type__allowed_supply_type
 msgid "Allowed for supply type"
+msgstr ""
+
+#. module: l10n_in_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py:0
+msgid "An E-waybill cannot be generated for a %s move."
 msgstr ""
 
 #. module: l10n_in_ewaybill

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -327,6 +327,7 @@ class L10nInEwaybill(models.Model):
             self._check_lines,
             self._check_gst_treatment,
             self._check_transporter,
+            self._check_state,
         ]
         for get_error_message in methods_to_check:
             error_message.extend(get_error_message())
@@ -347,6 +348,15 @@ class L10nInEwaybill(models.Model):
         }
         for partner in partners:
             error_message += self._l10n_in_validate_partner(partner)
+        return error_message
+
+    def _check_state(self):
+        error_message = []
+        if self.account_move_id and self.account_move_id.state != 'posted':
+            error_message.append(_(
+                "An E-waybill cannot be generated for a %s move.",
+                dict(self.env['account.move']._fields['state']._description_selection(self.env))[self.account_move_id.state]
+            ))
         return error_message
 
     @api.model

--- a/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
+++ b/addons/l10n_in_ewaybill_irn/i18n/l10n_in_ewaybill_irn.pot
@@ -6,14 +6,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:20+0000\n"
-"PO-Revision-Date: 2025-01-22 06:20+0000\n"
+"POT-Creation-Date: 2025-06-26 05:34+0000\n"
+"PO-Revision-Date: 2025-06-26 05:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_in_ewaybill_irn
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
+msgid ""
+"As the related invoice is eligible for e-invoicing, please generate the "
+"e-invoice first. Only then can the e-way bill be generated."
+msgstr ""
 
 #. module: l10n_in_ewaybill_irn
 #: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__display_name
@@ -23,6 +31,11 @@ msgstr ""
 #. module: l10n_in_ewaybill_irn
 #: model:ir.model.fields,field_description:l10n_in_ewaybill_irn.field_l10n_in_ewaybill__id
 msgid "ID"
+msgstr ""
+
+#. module: l10n_in_ewaybill_irn
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_irn.report_ewaybill_inherit_irn
+msgid "IRN:"
 msgstr ""
 
 #. module: l10n_in_ewaybill_irn
@@ -47,10 +60,4 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
 msgid "generated"
-msgstr ""
-
-#. module: l10n_in_ewaybill_irn
-#. odoo-python
-#: code:addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py:0
-msgid "waiting For IRN generation To create E-waybill"
 msgstr ""

--- a/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
+++ b/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server saas~18.1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-26 12:22+0000\n"
-"PO-Revision-Date: 2025-05-26 12:22+0000\n"
+"POT-Creation-Date: 2025-06-26 05:37+0000\n"
+"PO-Revision-Date: 2025-06-26 05:37+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,6 +18,12 @@ msgstr ""
 #. module: l10n_in_ewaybill_stock
 #: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_picking_form_inherit_ewaybill
 msgid "<span class=\"o_stat_text\">e-Waybill / Challan</span>"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+msgid "An E-waybill cannot be generated for a %s document."
 msgstr ""
 
 #. module: l10n_in_ewaybill_stock

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -165,6 +165,18 @@ class L10nInEwaybill(models.Model):
             return error_message
         return super()._check_lines()
 
+    def _check_state(self):
+        error_message = super()._check_state()
+        if not self.picking_id:
+            return error_message
+        picking_state = self.picking_id.state
+        if (not self._is_incoming() and picking_state != 'done') or (self._is_incoming() and picking_state not in ('done', 'assigned')):
+            error_message.append(_(
+                "An E-waybill cannot be generated for a %s document.",
+                dict(self.env['stock.picking']._fields['state']._description_selection(self.env))[picking_state]
+            ))
+        return error_message
+
     def _l10n_in_tax_details_for_stock(self):
         tax_details = {
             'line_tax_details': defaultdict(dict),


### PR DESCRIPTION
In this commit:
---
- Introduced a check to raise a UserError when attempting
  to generate an E-way bill without a IRN from the E-invoice.
- Added state validations to ensure E-waybill is generated 
  only when the document is in the correct state.
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
