### PR TITLE
[ADD] l10n_ar: Fix translation term on PDF report

### DIFF
--- a/addons/l10n_ar/i18n/es.po
+++ b/addons/l10n_ar/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-12 13:15+0000\n"
-"PO-Revision-Date: 2025-03-12 13:15+0000\n"
+"POT-Creation-Date: 2025-04-22 12:27+0000\n"
+"PO-Revision-Date: 2025-04-22 12:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,6 +15,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "% VAT"
+msgstr "% IVA"
 
 #. module: l10n_ar
 #: model_terms:res.company,invoice_terms_html:l10n_ar.company_exento
@@ -184,11 +189,6 @@ msgid ""
 msgstr ""
 "<span groups=\"account.group_show_line_subtotals_tax_included\">Importe</"
 "span>"
-
-#. module: l10n_ar
-#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
-msgid "<span>% VAT</span>"
-msgstr "<span>% IVA</span>"
 
 #. module: l10n_ar
 #: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -6,14 +6,19 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-12 13:15+0000\n"
-"PO-Revision-Date: 2025-03-12 13:15+0000\n"
+"POT-Creation-Date: 2025-04-22 12:26+0000\n"
+"PO-Revision-Date: 2025-04-22 12:26+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_ar
+#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
+msgid "% VAT"
+msgstr ""
 
 #. module: l10n_ar
 #: model_terms:res.company,invoice_terms_html:l10n_ar.company_exento
@@ -163,11 +168,6 @@ msgstr ""
 msgid ""
 "<span "
 "groups=\"account.group_show_line_subtotals_tax_included\">Amount</span>"
-msgstr ""
-
-#. module: l10n_ar
-#: model_terms:ir.ui.view,arch_db:l10n_ar.report_invoice_document
-msgid "<span>% VAT</span>"
 msgstr ""
 
 #. module: l10n_ar


### PR DESCRIPTION
Before this change, the column % VAT in Argentinean Legal PDF translation to Spanish was not working (Was always showing "% VAT" column title)

With this change will show "% IVA" when printing in Spanish

### Description of the issue/feature this PR addresses:

Bad Spanish translation on the Column % VAT in the Argentinean Legal PDF Report

1. Install Argentinean - Accounting module
2. Install Spanish language
3. Log into to one of the demo Argentinean Companys : (AR) Responsable Inscripto
4. Go to the Cutomer invoices menu and select any of the invoices already created in demo data
5. Go to the partner and change the Languaje to Spanish
6. Return to the invoice and print the PDF

### Current behavior before PR:

All the other terms are translated, but not the % VAT column
![image](https://github.com/user-attachments/assets/ba727710-5b15-45ed-83b6-fd285cf37697)

### Desired behavior after PR is merged:

All the terms are correctly translated
![image](https://github.com/user-attachments/assets/233ab5de-f00f-43df-aa24-3517f40cd5c7)


References LATM 1343 | ADHOC 50766
 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
