### PR TITLE
Fix/theme-crash-no-request

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -75,7 +75,7 @@ class IrModuleModule(models.Model):
 
                     -> We want to upgrade every website using this theme.
         """
-        if request and request.db and request.context.get('apply_new_theme'):
+        if request and request.db and hasattr(request, 'env') and request.env and hasattr(request, 'context') and request.context.get('apply_new_theme'):
             self = self.with_context(apply_new_theme=True)
 
         for module in self:


### PR DESCRIPTION
**Impacted versions:**
  - 16.0
  
**Description of the issue/feature this PR addresses:** 

When updating or installing modules via CLI or non-HTTP contexts (e.g. cron, tests), the `website `module attempts to access `request.context.get('apply_new_theme')`.
However, request is None outside of HTTP requests, which causes a crash with:
`AttributeError: 'NoneType' object has no attribute 'context'`

**Current behavior before PR:**
- Odoo crashes during CLI-based module updates when `website`is installed
- Affects any operation triggering `ir.module.module.write()`

**Desired behavior after PR is merged:**
- Safely checks for `request.context` only if `request `is available
- Prevents crashes during non-HTTP operations (e.g. `-u all`, cron jobs, testing)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

Signed-off-by: Yassine Naanani (k11e3r) xyassine1999@gmail.com
