### PR TITLE
[FIX] web: fix undefined type when updating property definition

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -13,7 +13,6 @@ import { usePopover } from "@web/core/popover/popover_hook";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { reposition } from "@web/core/position_hook";
 import { archParseBoolean } from "@web/views/utils";
-import { pick } from "@web/core/utils/objects";
 import { useSortable } from "@web/core/utils/sortable_owl";
 import { useRecordObserver } from "@web/model/relational_model/utils";
 
@@ -532,14 +531,14 @@ export class PropertiesField extends Component {
     async onPropertyDefinitionChange(propertyDefinition) {
         propertyDefinition["definition_changed"] = true;
         if (propertyDefinition.type === "separator") {
-            // remove all other keys
-            propertyDefinition = pick(
-                propertyDefinition,
-                "name",
-                "string",
-                "definition_changed",
-                "type"
-            );
+            const separatorKeys = new Set(["name", "string", "definition_changed", "type"]);
+            // remove all other keys in place, since propertyDefinition instance
+            // will be used as a PropertyDefinition component state value.
+            for (const key in propertyDefinition) {
+                if (!separatorKeys.has(key)) {
+                    delete propertyDefinition[key];
+                }
+            }
         }
         const propertiesValues = this.propertiesList;
         const propertyIndex = this._getPropertyIndex(propertyDefinition.name);


### PR DESCRIPTION
There was an issue in the `PropertyDefinition:state.propertyDefinition`,
which could sometimes not be updated properly, resulting in a traceback after
multiple property definition changes.

### How to reproduce:
- Open a CRM Lead form view and add a property of type `tags`.
- Save and fully reload the form view.
- Change the property type to `separator`
- Change the property name to another value.
- Click outside the popover to close it.
=> Traceback
```
Cannot read properties of undefined (reading 'type')
at  PropertiesField.onPropertyDefinitionChange
```

### Technical explanation:
The `propertyDefinition` argument given to `onChange` props of
`PropertyDefinition` component is expected to be modified in place, since it is
used as the `propertyDefinition` state value.
`pick` function creates a shallow copy, therefore using it on
`propertyDefinition` in `PropertiesField:onPropertyDefinitionChange` and
applying changes on that copy (i.e. in `_regeneratePropertyName`) will prevent
these changes to be registered in the
`PropertyDefinition:state.propertyDefinition`, resulting in inconsistent values
with `PropertyField:propertyList`, which would manifest at the next definition
change, since `_getPropertyIndex` would not be able to find the index of the
now obsolete `propertyDefinition`.

task-4743860