### PR TITLE
[FIX] point_of_sale: restore customer display QR code

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -8,6 +8,7 @@ import { renderToElement } from "@web/core/utils/render";
 import { floatIsZero, roundPrecision } from "@web/core/utils/numbers";
 import { computeComboLines } from "./utils/compute_combo_lines";
 import { changesToOrder } from "./utils/order_change";
+import { toRaw } from "@odoo/owl";
 
 const { DateTime } = luxon;
 const formatCurrency = registry.subRegistries.formatters.content.monetary[1];
@@ -1095,6 +1096,7 @@ export class PosOrder extends Base {
                 amount: formatCurrency(pl.get_amount()),
             })),
             change: this.get_change() && formatCurrency(this.get_change()),
+            qrPaymentData: toRaw(this.get_selected_paymentline()?.qrPaymentData),
         };
     }
     get hasItemsOrPayLater() {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1715,6 +1715,11 @@ export class PosStore extends Reactive {
                 return false;
             }
         }
+        payment.qrPaymentData = {
+            name: payment.payment_method_id.name,
+            amount: this.env.utils.formatCurrency(payment.amount),
+            qrCode: qr,
+        };
         return await ask(
             this.env.services.dialog,
             {
@@ -1725,7 +1730,10 @@ export class PosStore extends Reactive {
             },
             {},
             QRPopup
-        );
+        ).then((result) => {
+            payment.qrPaymentData = undefined;
+            return result;
+        });
     }
 
     get isTicketScreenShown() {

--- a/addons/point_of_sale/static/src/app/utils/qr_code_popup/qr_code_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/qr_code_popup/qr_code_popup.js
@@ -20,21 +20,5 @@ export class QRPopup extends ConfirmationDialog {
         super.setup();
         this.props.body = _t("Please scan the QR code with %s", this.props.title);
         this.amount = this.env.utils.formatCurrency(this.props.line.amount);
-        this.showCustomerScreen();
-    }
-
-    showCustomerScreen() {
-        this.props.order.uiState["PaymentScreen"] = {
-            qrPaymentData: {
-                name: this.props.title,
-                amount: this.amount,
-                qrCode: this.props.qrCode,
-            },
-        };
-    }
-
-    async execButton(callback) {
-        delete this.props.order.uiState.PaymentScreen.qrPaymentData;
-        return super.execButton(callback);
     }
 }

--- a/addons/point_of_sale/static/src/customer_display/customer_display.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display.js
@@ -1,4 +1,4 @@
-import { Component, useState, whenReady } from "@odoo/owl";
+import { Component, useEffect, useState, whenReady } from "@odoo/owl";
 import { OdooLogo } from "@point_of_sale/app/generic_components/odoo_logo/odoo_logo";
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
 import { Orderline } from "@point_of_sale/app/generic_components/orderline/orderline";
@@ -7,14 +7,49 @@ import { MainComponentsContainer } from "@web/core/main_components_container";
 import { session } from "@web/session";
 import { useService } from "@web/core/utils/hooks";
 import { mountComponent } from "@web/env";
+import { CustomerFacingQR } from "./customer_facing_qr";
+
+function useSingleDialog() {
+    let close = null;
+    const dialog = useService("dialog");
+    return {
+        open(dialogClass, props) {
+            // If the dialog is already open, we don't want to open a new one
+            if (!close) {
+                close = dialog.add(dialogClass, props, {
+                    onClose: () => {
+                        close = null;
+                    },
+                });
+            }
+        },
+        close() {
+            close?.();
+        },
+    };
+}
 
 export class CustomerDisplay extends Component {
     static template = "point_of_sale.CustomerDisplay";
     static components = { OdooLogo, OrderWidget, Orderline, CenteredIcon, MainComponentsContainer };
     static props = [];
+
     setup() {
         this.session = session;
         this.order = useState(useService("customer_display_data"));
+        const singleDialog = useSingleDialog();
+
+        useEffect(
+            (qrPaymentData) => {
+                if (qrPaymentData) {
+                    singleDialog.open(CustomerFacingQR, qrPaymentData);
+                } else {
+                    singleDialog.close();
+                }
+            },
+            () => [this.order.qrPaymentData]
+        );
     }
 }
+
 whenReady(() => mountComponent(CustomerDisplay, document.body));

--- a/addons/point_of_sale/static/src/customer_display/customer_facing_qr.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_facing_qr.js
@@ -1,0 +1,18 @@
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+import { _t } from "@web/core/l10n/translation";
+
+export class CustomerFacingQR extends Component {
+    static template = "point_of_sale.CustomerFacingQR";
+    static components = { Dialog };
+    static props = {
+        qrCode: String,
+        name: String,
+        amount: String,
+        close: Function,
+    };
+
+    setup() {
+        this.title = _t("Please scan the QR code with %s", this.props.name);
+    }
+}

--- a/addons/point_of_sale/static/src/customer_display/customer_facing_qr.xml
+++ b/addons/point_of_sale/static/src/customer_display/customer_facing_qr.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.CustomerFacingQR">
+        <Dialog
+            footer="false"
+            header="false"
+            bodyClass="'w-100 h-100 d-flex flex-column justify-content-center align-items-center'"
+        >
+            <div class="text-center">
+                <p t-out="title"/>
+                <img class="pos-customer_payment_qr_code my-1" t-att-src="props.qrCode" alt="QR Code"/>
+            </div>
+            <div class="text-center">
+                <div>
+                    <strong>Amount: </strong>
+                    <span t-esc="props.amount"/>
+                </div>
+            </div>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/tests/tours/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/tours/customer_display_tour.js
@@ -29,6 +29,65 @@ export const ORDER_IS_FINALIZED =
 export const NEW_ORDER =
     '{"lines":[],"finalized":false,"amount":"0.00","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 
+const QR_URL =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+const PAY_WITH_CARD = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {},
+    qrPaymentData: undefined,
+};
+
+const SEND_QR = {
+    lines: [
+        {
+            productName: "Letter Tray",
+            price: "$ 2,972.75",
+            qty: "1.00",
+            unit: "Units",
+            unitPrice: "$ 2,972.75",
+            oldUnitPrice: "",
+            customerNote: "",
+            internalNote: "",
+            comboParent: "",
+            packLotLines: [],
+            price_without_discount: "$ 2,972.75",
+            isSelected: true,
+            imageSrc: "/web/image/product.product/855/image_128",
+        },
+    ],
+    finalized: false,
+    amount: "2,972.75",
+    paymentLines: [{ name: "CARD", amount: "2,972.75" }],
+    change: 0,
+    onlinePaymentData: {},
+    qrPaymentData: {
+        amount: "$ 2,972.75",
+        name: "CARD",
+        qrCode: QR_URL,
+    },
+};
+
 registry.category("web_tour.tours").add("CustomerDisplayTour", {
     test: true,
     steps: () =>
@@ -56,5 +115,31 @@ registry.category("web_tour.tours").add("CustomerDisplayTour", {
             },
             Order.doesNotHaveLine({}),
             amountIs("Total", "0.00"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("CustomerDisplayTourWithQr", {
+    test: true,
+    steps: () =>
+        [
+            {
+                trigger: "div:contains('Start adding products')",
+                run: () => {
+                    window.customerDisplayChannel = new BroadcastChannel("UPDATE_CUSTOMER_DISPLAY");
+                    postMessage(ADD_PRODUCT, "add product").run();
+                },
+            },
+            Order.hasLine({ productName: "Letter Tray", price: "2,972.75" }),
+            amountIs("Total", "2,972.75"),
+            postMessage(PAY_WITH_CARD, "pay with card"),
+            postMessage(SEND_QR, "send qr code"),
+            { trigger: "img[alt='QR Code']" },
+            postMessage(PAY_WITH_CARD, "confirm payment"),
+            postMessage(ORDER_IS_FINALIZED, "order is finalized"),
+            {
+                content: "Check that we are now on the 'Thank you' screen",
+                trigger: "div i.fa-smile-o",
+                run: "click",
+            },
         ].flat(),
 });

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1385,6 +1385,9 @@ class TestUi(TestPointOfSaleHttpCommon):
     def test_customer_display(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTour', login="pos_user")
 
+    def test_customer_display_with_qr(self):
+        self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}", 'CustomerDisplayTourWithQr', login="pos_user")
+
     def test_refund_few_quantities(self):
         """ Test to check that refund works with quantities of less than 0.5 """
         self.env['product.product'].create({


### PR DESCRIPTION
Previously, when using a payment method integrated with the Bank App (QR code), a QR code was shown on the customer display.

This functionality was lost during the refactoring of the customer display into a standalone OWL app:
https://github.com/odoo/odoo/commit/acf78c27b12cf014cd80d20ea5853e63ab9ca03f

It was later removed entirely with the deletion of the point_of_sale.CustomerFacingQR template:
https://github.com/odoo/odoo/commit/49116abd0916ac835e0ad1f6ba1714b8e80c4272

This commit reintroduces the QR code on the customer display.