### PR TITLE
[IMP] l10n_in: block invoice if fiscal country mismatches localization

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -1,13 +1,14 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* l10n_in
+# 	* accountant
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.2a1+e\n"
+"Project-Id-Version: Odoo Server 18.3a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-13 10:29+0000\n"
-"PO-Revision-Date: 2025-02-13 10:29+0000\n"
+"POT-Creation-Date: 2025-05-01 10:19+0000\n"
+"PO-Revision-Date: 2025-05-01 10:19+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -95,6 +96,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in
+#: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
+msgid ""
+"<span>The Fiscal Localization does not match the Fiscal Country, so it's "
+"recommended to</span>"
+msgstr ""
+
+#. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "<strong>PAYMENT QR CODE</strong>"
 msgstr ""
@@ -108,6 +116,19 @@ msgstr ""
 #. module: l10n_in
 #: model:ir.model,name:l10n_in.model_account_chart_template
 msgid "Account Chart Template"
+msgstr ""
+
+#. module: accountant
+#: model:ir.ui.menu,name:accountant.menu_accounting
+#: model_terms:ir.ui.view,arch_db:accountant.res_config_settings_view_form
+#: model_terms:ir.ui.view,arch_db:accountant.res_partner_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Accounting Settings"
 msgstr ""
 
 #. module: l10n_in
@@ -171,6 +192,11 @@ msgstr ""
 msgid ""
 "As the Partner's PAN missing/invalid, it's advisable to apply TDS at the "
 "higher rate."
+msgstr ""
+
+#. module: accountant
+#: model:ir.ui.menu,name:accountant.account_assets_liabilities_menu
+msgid "Assets & Liabilities"
 msgstr ""
 
 #. module: l10n_in
@@ -775,6 +801,11 @@ msgid "India"
 msgstr ""
 
 #. module: l10n_in
+#: model:res.country.group,name:l10n_in.inter_state_group
+msgid "India Inter-State Group"
+msgstr ""
+
+#. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_form_view
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_search_view
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_tree_view
@@ -784,11 +815,6 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 msgid "India TDS Control:"
-msgstr ""
-
-#. module: l10n_in
-#: model:res.country.group,name:l10n_in.inter_state_group
-msgid "India inter-state group"
 msgstr ""
 
 #. module: l10n_in
@@ -936,6 +962,11 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.view_move_line_list_l10n_in_withholding
 msgid "Journal items"
+msgstr ""
+
+#. module: l10n_in
+#: model:ir.model.fields,field_description:l10n_in.field_res_config_settings__l10n_in_fiscal_country_warning
+msgid "L10N In Fiscal Country Warning"
 msgstr ""
 
 #. module: l10n_in
@@ -1942,6 +1973,14 @@ msgid "Technical field to identify Indian withholding entry"
 msgstr ""
 
 #. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid ""
+"The Fiscal country and your fiscal localization's country do not match.\n"
+"Please change it from your Account's configuration."
+msgstr ""
+
+#. module: l10n_in
 #: model:ir.model.constraint,message:l10n_in.constraint_l10n_in_port_code_code_uniq
 msgid "The Port Code must be unique!"
 msgstr ""
@@ -2206,6 +2245,7 @@ msgstr ""
 
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_view_partner_form
+#: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.view_company_form
 msgid "update it"
 msgstr ""

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -541,7 +541,16 @@ class AccountMove(models.Model):
         return super()._get_name_invoice_report()
 
     def _post(self, soft=True):
-        """Use journal type to define document type because not miss state in any entry including POS entry"""
+        if any(move.company_id.chart_template == 'in' and move.country_code != 'IN' for move in self):
+            _ = self.env._
+            raise RedirectWarning(
+                message=_(
+                    "The Fiscal country and your fiscal localization's country do not match.\n"
+                    "Please change it from your Account's configuration.",
+                ),
+                action=self.env.ref('account.action_account_config').id,
+                button_text=_("Accounting Settings"),
+            )
         posted = super()._post(soft)
         gst_treatment_name_mapping = {k: v for k, v in
                              self._fields['l10n_in_gst_treatment']._description_selection(self.env)}

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -10,6 +10,12 @@
                     <field name="group_l10n_in_reseller"/>
                 </setting>
             </block>
+            <xpath expr="//block[@name='fiscal_localization_setting_container']" position="before">
+                <div class="alert alert-warning" role="alert" invisible="not l10n_in_fiscal_country_warning">
+                    <span>The Fiscal Localization does not match the Fiscal Country, so it's recommended to</span>
+                    <button class="oe_link p-0 ms-1" type="object" name="action_l10n_in_update_fiscal_country">update it</button>
+                </div>
+            </xpath>
             <xpath expr="//block[@name='fiscal_localization_setting_container']" position="after">
                 <div id="india_integration_section">
                     <block title="Indian Integration" id="india_localization" invisible="country_code != 'IN'">


### PR DESCRIPTION
PURPOSE
 -  If India fiscal is loaded in company and fiscal country is other then India then block user to post invoice. because we compute many things base on this.

SPECIFICATION
 - Raise Warning in settings menu if Selected fiscal country is different then Fiscal Localization country.
 - Raised Validation Error in Invoice section if there mismatch in Fiscal country  and Localization country.

TASK ID:4644866