### PR TITLE
[FIX] base_import: better date format matching with datetime cells in XLS

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -478,9 +478,9 @@ class Base_ImportImport(models.TransientModel):
                     # emulate xldate_as_datetime for pre-0.9.3
                     dt = datetime.datetime(*xlrd.xldate.xldate_as_tuple(cell.value, book.datemode))
                     values.append(
-                        dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT)
+                        dt
                         if is_datetime
-                        else dt.strftime(DEFAULT_SERVER_DATE_FORMAT)
+                        else dt.date()
                     )
                 elif cell.ctype is xlrd.XL_CELL_BOOLEAN:
                     values.append(u'True' if cell.value else u'False')
@@ -494,7 +494,7 @@ class Base_ImportImport(models.TransientModel):
                     )
                 else:
                     values.append(cell.value)
-            if any(x for x in values if x.strip()):
+            if any(x and (not isinstance(x, str) or x.strip()) for x in values):
                 rows.append(values)
 
         # return the file length as first value
@@ -530,9 +530,9 @@ class Base_ImportImport(models.TransientModel):
                 elif cell.is_date:
                     d_fmt = styles.is_datetime(cell.number_format)
                     if d_fmt == "datetime":
-                        values.append(cell.value.strftime(DEFAULT_SERVER_DATETIME_FORMAT))
+                        values.append(cell.value)
                     elif d_fmt == "date":
-                        values.append(cell.value.strftime(DEFAULT_SERVER_DATE_FORMAT))
+                        values.append(cell.value.date())
                     else:
                         raise ValueError(
                         _("Invalid cell format at row %(row)s, column %(col)s: %(cell_value)s, with format: %(cell_format)s, as (%(format_type)s) formats are not supported.", row=rowx, col=colx, cell_value=cell.value, cell_format=cell.number_format, format_type=d_fmt)
@@ -540,7 +540,7 @@ class Base_ImportImport(models.TransientModel):
                 else:
                     values.append(str(cell.value))
 
-            if any(x.strip() for x in values):
+            if any(x and (not isinstance(x, str) or x.strip()) for x in values):
                 rows.append(values)
         return sheet.max_row, rows
 
@@ -639,66 +639,68 @@ class Base_ImportImport(models.TransientModel):
                                see :meth:`parse_preview` for more details.
         :param options: parsing options
         """
-        values = set(preview_values)
-        # If all values are empty in preview than can be any field
-        if values == {''}:
-            return ['all']
+        if all(isinstance(v, str) for v in preview_values):
+            preview_values = [v.strip() for v in preview_values]
+            values = set(preview_values)
+            # If all values are empty in preview than can be any field
+            if values == {''}:
+                return ['all']
 
-        # If all values starts with __export__ this is probably an id
-        if all(v.startswith('__export__') for v in values):
-            return ['id', 'many2many', 'many2one', 'one2many']
+            # If all values starts with __export__ this is probably an id
+            if all(v.startswith('__export__') for v in values):
+                return ['id', 'many2many', 'many2one', 'one2many']
 
-        # If all values can be cast to int type is either id, float or monetary
-        # Exception: if we only have 1 and 0, it can also be a boolean
-        if all(v.isdigit() for v in values if v):
-            field_type = ['integer', 'float', 'monetary']
-            if {'0', '1', ''}.issuperset(values):
-                field_type.append('boolean')
-            return field_type
+            # If all values can be cast to int type is either id, float or monetary
+            # Exception: if we only have 1 and 0, it can also be a boolean
+            if all(v.isdigit() for v in values if v):
+                field_type = ['integer', 'float', 'monetary']
+                if {'0', '1', ''}.issuperset(values):
+                    field_type.append('boolean')
+                return field_type
 
-        # If all values are either True or False, type is boolean
-        if all(val.lower() in ('true', 'false', 't', 'f', '') for val in preview_values):
-            return ['boolean']
+            # If all values are either True or False, type is boolean
+            if all(val.lower() in ('true', 'false', 't', 'f', '') for val in preview_values):
+                return ['boolean']
 
-        # If all values can be cast to float, type is either float or monetary
-        try:
-            thousand_separator = decimal_separator = False
-            for val in preview_values:
-                val = val.strip()
-                if not val:
-                    continue
-                # value might have the currency symbol left or right from the value
-                val = self._remove_currency_symbol(val)
-                if val:
-                    if options.get('float_thousand_separator') and options.get('float_decimal_separator'):
-                        if options['float_decimal_separator'] == '.' and val.count('.') > 1:
-                            # This is not a float so exit this try
-                            float('a')
-                        val = val.replace(options['float_thousand_separator'], '').replace(options['float_decimal_separator'], '.')
-                    # We are now sure that this is a float, but we still need to find the
-                    # thousand and decimal separator
+            # If all values can be cast to float, type is either float or monetary
+            try:
+                thousand_separator = decimal_separator = False
+                for val in preview_values:
+                    val = val.strip()
+                    if not val:
+                        continue
+                    # value might have the currency symbol left or right from the value
+                    val = self._remove_currency_symbol(val)
+                    if val:
+                        if options.get('float_thousand_separator') and options.get('float_decimal_separator'):
+                            if options['float_decimal_separator'] == '.' and val.count('.') > 1:
+                                # This is not a float so exit this try
+                                float('a')
+                            val = val.replace(options['float_thousand_separator'], '').replace(options['float_decimal_separator'], '.')
+                        # We are now sure that this is a float, but we still need to find the
+                        # thousand and decimal separator
+                        else:
+                            if val.count('.') > 1:
+                                options['float_thousand_separator'] = '.'
+                                options['float_decimal_separator'] = ','
+                            elif val.count(',') > 1:
+                                options['float_thousand_separator'] = ','
+                                options['float_decimal_separator'] = '.'
+                            elif val.find('.') > val.find(','):
+                                thousand_separator = ','
+                                decimal_separator = '.'
+                            elif val.find(',') > val.find('.'):
+                                thousand_separator = '.'
+                                decimal_separator = ','
                     else:
-                        if val.count('.') > 1:
-                            options['float_thousand_separator'] = '.'
-                            options['float_decimal_separator'] = ','
-                        elif val.count(',') > 1:
-                            options['float_thousand_separator'] = ','
-                            options['float_decimal_separator'] = '.'
-                        elif val.find('.') > val.find(','):
-                            thousand_separator = ','
-                            decimal_separator = '.'
-                        elif val.find(',') > val.find('.'):
-                            thousand_separator = '.'
-                            decimal_separator = ','
-                else:
-                    # This is not a float so exit this try
-                    float('a')
-            if thousand_separator and not options.get('float_decimal_separator'):
-                options['float_thousand_separator'] = thousand_separator
-                options['float_decimal_separator'] = decimal_separator
-            return ['float', 'monetary']  # Allow float to be mapped on a text field.
-        except ValueError:
-            pass
+                        # This is not a float so exit this try
+                        float('a')
+                if thousand_separator and not options.get('float_decimal_separator'):
+                    options['float_thousand_separator'] = thousand_separator
+                    options['float_decimal_separator'] = decimal_separator
+                return ['float', 'monetary']  # Allow float to be mapped on a text field.
+            except ValueError:
+                pass
 
         results = self._try_match_date_time(preview_values, options)
         if results:
@@ -761,7 +763,7 @@ class Base_ImportImport(models.TransientModel):
         """
         headers_types = {}
         for column_index, header_name in enumerate(headers):
-            preview_values = [record[column_index].strip() for record in preview]
+            preview_values = [record[column_index] for record in preview]
             type_field = self._extract_header_types(preview_values, options)
             headers_types[(column_index, header_name)] = type_field
         return headers_types
@@ -1083,8 +1085,13 @@ class Base_ImportImport(models.TransientModel):
             for column_index, _unused in enumerate(preview[0]):
                 vals = []
                 for record in preview:
-                    if record[column_index]:
+                    val = record[column_index]
+                    if val and isinstance(val, str):
                         vals.append("%s%s" % (record[column_index][:50], "..." if len(record[column_index]) > 50 else ""))
+                    elif isinstance(val, datetime.datetime):
+                        vals.append(val.strftime(options.get('datetime_format') or DEFAULT_SERVER_DATETIME_FORMAT))
+                    elif isinstance(val, datetime.date):
+                        vals.append(val.strftime(options.get('date_format') or DEFAULT_SERVER_DATE_FORMAT))
                     if len(vals) == 5:
                         break
                 column_example.append(
@@ -1322,7 +1329,7 @@ class Base_ImportImport(models.TransientModel):
         d_fmt = options.get('date_format') or DEFAULT_SERVER_DATE_FORMAT
         dt_fmt = options.get('datetime_format') or DEFAULT_SERVER_DATETIME_FORMAT
         for num, line in enumerate(data):
-            if not line[index]:
+            if not line[index] or isinstance(line[index], datetime.date):
                 continue
 
             v = line[index].strip()
@@ -1704,6 +1711,8 @@ def check_patterns(patterns, values):
     for pattern in patterns:
         p = to_re(pattern)
         for val in values:
+            if isinstance(val, datetime.date):
+                continue
             if val and not p.match(val):
                 break
 

--- a/addons/test_import_export/models/models_import.py
+++ b/addons/test_import_export/models/models_import.py
@@ -88,6 +88,8 @@ class ImportPreview(models.Model):
     name = fields.Char('Name')
     somevalue = fields.Integer(string='Some Value', required=True)
     othervalue = fields.Integer(string='Other Variable')
+    date = fields.Date(string='Date')
+    datetime = fields.Datetime(string='Datetime')
 
 
 class ImportFloat(models.Model):

--- a/addons/test_import_export/tests/test_import.py
+++ b/addons/test_import_export/tests/test_import.py
@@ -1,5 +1,6 @@
 import base64
 import csv
+import datetime
 import difflib
 import io
 import pprint
@@ -43,6 +44,77 @@ def sorted_fields(fields):
     """ recursively sort field lists to ease comparison """
     recursed = [dict(field, fields=sorted_fields(field['fields'])) for field in fields]
     return sorted(recursed, key=lambda field: field['id'])
+
+
+def generate_xls(data):
+    """
+    Generates an XLS file from the given data dictionary. Each key in the `data` dictionary represents a column header,
+    and its corresponding values are written as rows under that column.
+
+    Date and datetime objects in the values will automatically set the style of the cell to a date/datetime.
+
+    :param dict data: keys are column headers, values are rows.
+    :return bytes: the xls file as bytes.
+    """
+    import xlwt  # noqa: PLC0415
+
+    wb = xlwt.Workbook()
+    ws = wb.add_sheet('Sheet1')
+
+    default_style = xlwt.XFStyle()
+
+    date_style = xlwt.XFStyle()
+    date_style.num_format_str = 'yyyy-mm-dd'
+
+    datetime_style = xlwt.XFStyle()
+    datetime_style.num_format_str = 'yyyy-mm-dd hh:mm:ss'
+
+    for column, (key, values) in enumerate(data.items()):
+        ws.write(0, column, key, default_style)
+        for row, value in enumerate(values, 1):
+            style = default_style
+            if isinstance(value, datetime.datetime):
+                style = datetime_style
+            elif isinstance(value, datetime.date):
+                style = date_style
+            ws.write(row, column, value, style)
+
+    output = io.BytesIO()
+    wb.save(output)
+    return output.getvalue()
+
+
+def generate_xlsx(data):
+    """
+    Generates an XLSX file from the given data dictionary. Each key in the `data` dictionary represents a column header,
+    and its corresponding values are written as rows under that column.
+
+    Date and datetime objects in the values will automatically set the style of the cell to a date/datetime.
+
+    :param dict data: keys are column headers, values are rows.
+    :return bytes: the xls file as bytes.
+    """
+    import openpyxl  # noqa: PLC0415
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+
+    date_style = openpyxl.styles.NamedStyle(name="date", number_format='yyyy-mm-dd')
+    datetime_style = openpyxl.styles.NamedStyle(name="datetime", number_format='yyyy-mm-dd hh:mm:ss')
+
+    for column, (key, values) in enumerate(data.items(), 1):
+        ws.cell(row=1, column=column).value = key
+        for row, value in enumerate(values, 2):
+            cell = ws.cell(row=row, column=column)
+            cell.value = value
+            if isinstance(value, datetime.datetime):
+                cell.style = datetime_style
+            elif isinstance(value, datetime.date):
+                cell.style = date_style
+
+    output = io.BytesIO()
+    wb.save(output)
+    return output.getvalue()
 
 
 class BaseImportCase(TransactionCase):
@@ -381,7 +453,7 @@ class TestPreview(TransactionCase):
         self.assertEqual(result['matches'], {0: ['name'], 1: ['somevalue']})
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
         # Order depends on iteration order of fields_get
-        self.assertItemsEqual(result['fields'], [
+        self.assertItemsEqual(result['fields'][:4], [
             get_id_field('import.preview'),
             {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.preview'},
             {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer', 'model_name': 'import.preview'},
@@ -404,7 +476,7 @@ class TestPreview(TransactionCase):
         self.assertIsNone(result.get('error'))
         self.assertEqual(result['matches'], {0: ['name'], 1: ['somevalue']})
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
-        self.assertItemsEqual(result['fields'], [
+        self.assertItemsEqual(result['fields'][:4], [
             get_id_field('import.preview'),
             {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.preview'},
             {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer', 'model_name': 'import.preview'},
@@ -427,7 +499,7 @@ class TestPreview(TransactionCase):
         self.assertIsNone(result.get('error'))
         self.assertEqual(result['matches'], {0: ['name'], 1: ['somevalue']})
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
-        self.assertItemsEqual(result['fields'], [
+        self.assertItemsEqual(result['fields'][:4], [
             get_id_field('import.preview'),
             {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.preview'},
             {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer', 'model_name': 'import.preview'},
@@ -450,7 +522,7 @@ class TestPreview(TransactionCase):
         self.assertIsNone(result.get('error'))
         self.assertEqual(result['matches'], {0: ['name'], 1: ['somevalue']})
         self.assertEqual(result['headers'], ['name', 'Some Value', 'Counter'])
-        self.assertItemsEqual(result['fields'], [
+        self.assertItemsEqual(result['fields'][:4], [
             get_id_field('import.preview'),
             {'id': 'name', 'name': 'name', 'string': 'Name', 'required': False, 'fields': [], 'type': 'char', 'model_name': 'import.preview'},
             {'id': 'somevalue', 'name': 'somevalue', 'string': 'Some Value', 'required': True, 'fields': [], 'type': 'integer', 'model_name': 'import.preview'},
@@ -813,6 +885,80 @@ foo3,US,0,persons\n""",
         self.assertEqual(tag1 | tag2 | tag3, partners[0].category_id)
         self.assertEqual(tag3, partners[1].category_id)
         self.assertEqual(tag1 | tag3, partners[2].category_id)
+
+    @mute_logger('odoo.addons.base_import.models.base_import')
+    @unittest.skipUnless(can_import('xlwt') and can_import('openpyxl'), "xlwt/openpyxl not available")
+    def test_xls_datetime_values(self):
+        """ Test the support of having dates set as strings with the user format and date/datetime objects
+        in the same xls(x) file.
+
+        xls(x) allows to set a date/datetime format on a cell.
+        e.g.
+        foo,06/30/2025
+        bar,datetime.date(2025, 7, 1)
+
+        In particular, Google Spreadsheet tends to automatically convert cells to date/datetime when it detects
+        their value is a date.
+        e.g. create a new google spreadsheet
+        in the first cell, enter `foo`
+        in the second cell, enter `01/07/2025`.
+        Notice that the date has been aligned to the right of the cell, while foo remained on the left.
+        It's because the cell holding the date has been automatically converted into a date format.
+        In a third cell, enter `30/07/2025`. It's possible it stays aligned to the left,
+        because it wasn't converted automatically into the date format.
+        It's because the day is higher than 12, and Google spreadsheet didn't detect it was a date
+        because it was expecting the Americam date format `%d/%m/%Y`.
+
+        In such a case, you have a file with dates visually looking using the same format in the user interface,
+        but in reality some are stored as simple strings, some are stored as date objects within the xls(x) file.
+
+        Given how easy this is to land in such a situation using Google Spreadhseet, Odoo should support it.
+        """
+        for data, expected_preview in [
+            ({
+                'Some Value': [1, 2],
+                'Date': ['06/30/2025', datetime.date(2025, 7, 1)],
+                'Datetime': ['06/30/2025 13:37:42', datetime.datetime(2025, 7, 1, 9, 8, 7)],
+            }, [
+                ['1', '2'],
+                # /!\ American format, July 1st is 07/01
+                ['06/30/2025', '07/01/2025'],
+                ['06/30/2025 13:37:42', '07/01/2025 09:08:07'],
+            ]),
+            ({
+                'Some Value': [1, 2],
+                'Date': ['2025-06-30', datetime.date(2025, 7, 1)],
+                'Datetime': ['2025-06-30 13:37:42', datetime.datetime(2025, 7, 1, 9, 8, 7)],
+            }, [
+                ['1', '2'],
+                ['2025-06-30', '2025-07-01'],
+                ['2025-06-30 13:37:42', '2025-07-01 09:08:07'],
+            ])
+        ]:
+            for file_content, file_type in [
+                (generate_xls(data), 'application/vnd.ms-excel'),
+                (generate_xlsx(data), 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'),
+            ]:
+                import_wizard = self.env['base_import.import'].create({
+                    'res_model': 'import.preview',
+                    'file': file_content,
+                    'file_type': file_type,
+                })
+                result = import_wizard.parse_preview({'has_headers': True})
+
+                self.assertEqual(result['preview'], expected_preview)
+                options = result.get('options', {})
+
+                response = import_wizard.execute_import(
+                    ['somevalue', 'date', 'datetime'],
+                    ['Some Value', 'Date', 'Datetime'],
+                    {
+                        'has_headers': True, 'quoting': '"', 'separator': ',',
+                        'date_format': options.get('date_format'), 'datetime_format': options.get('datetime_format'),
+                    },
+                )
+
+                self.assertFalse(response.get('messages'))
 
 
 class TestBatching(TransactionCase):


### PR DESCRIPTION
XLS(X) allows to store in cells date/datetimes values as date/datetime objects. Meaning, instead of having a string with the date in some format, the cell value can hold an actual date/datetime object, which are automatically converted into the `datetime.date`/`datetime.datetime` when the xls(x) file is parsed in python.

When an xls(X) file contains at the same time date values under date/datetime objects and under strings with the user format `%d/%m/%Y` (rather than the server format `%Y-%m-%d`),
the import was failing with the error
`time data '06/30/2025' does not match format '%Y-%m-%d'`

This error normally happens when the user tries to do an import with different kind of date formats under strings in the same file e.g. `06/30/2025` and `2025-07-01`
and this is understandable that Odoo doesn't know what to do in such a case.
But, if you stick to the same format, either only `%d/%m/%Y` either only '%Y-%m-%d'`, Odoo supports it.

However the case here is trickier: it's when the file contains at the same time dates under a string format, e.g. `06/30/2025` and under date objects, e.g. `datetime.date(2025, 6, 30)`. Which can happen quite easily, as Google Spreadsheet for instance tends to automatically convert the cells holding a date value into date object. And it's then easy to have a file containing both date objects and strings for date, which looks visually the same in the Google Spreadsheet interface.

In addition Google Spreadsheet tends to convert automatically only dates below the 12 of the month because of the american format. e.g.
if you set `01/06/2025`, it gets converted into a datetime object if you set `13/06/2025`, it doesn't get converted into a datetime object, the value stays as a string.

The goal of this revision is to support to have the possibility of having date values under date objects and string in a user format

The problem lied in the fact, during the xls parsing, date objects were converted into strings using the server date format. And then you could finish with data containing both the user format and the server format.

The idea is to no longer automatically convert date objects and to support having date objects in the import parsing. And when trying to guess the date/datetime format of the file, date objects are simply ignored, as they do not need to be parsed.
