### PR TITLE
[IMP] hr_payroll: add rate and extra hours functionality in work entry type

### DIFF
--- a/addons/hr_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_holidays/data/hr_leave_type_data.xml
@@ -573,4 +573,16 @@
         <field name="company_id" eval="False"/>
         <field name="country_id" ref="base.sk"/>
     </record>
+
+<!-- PL : Poland -->
+    <record id="l10n_pl_leave_type_sick_leave" model="hr.leave.type">
+        <field name="name">PL Sick Leaves 80% </field>
+        <field name="requires_allocation">no</field>
+        <field name="request_unit">half_day</field>
+        <field name="support_document">True</field>
+        <field name="icon_id" ref="hr_holidays.icon_21"/>
+        <field name="color">6</field>
+        <field name="company_id" eval="False"/>
+        <field name="country_id" ref="base.pl"/>
+    </record>
 </data></odoo>

--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -809,6 +809,16 @@
         <field name="is_leave" eval="True"/>
     </record>
 
+<!-- PL : Poland -->
+    <record id="l10n_pl_work_entry_type_sick_leave" model="hr.work.entry.type">
+        <field name="name">Sick Time Off (Paid at 80%)</field>
+        <field name="color">4</field>
+        <field name="code">PLSICK3166</field>
+        <field name="country_id" ref="base.pl"/>
+        <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.8</field>
+    </record>
+
 <!-- SK : Slovakia -->
     <record id="l10n_sk_work_entry_type_sick_25" model="hr.work.entry.type">
         <field name="name">Sick Time Off Day 1-3 (Paid at 25%)</field>
@@ -816,6 +826,7 @@
         <field name="color">5</field>
         <field name="country_id" ref="base.sk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.25</field>
     </record>
 
     <record id="l10n_sk_work_entry_type_sick_55" model="hr.work.entry.type">
@@ -824,6 +835,7 @@
         <field name="color">5</field>
         <field name="country_id" ref="base.sk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.55</field>
     </record>
 
     <record id="l10n_sk_work_entry_type_sick_0" model="hr.work.entry.type">
@@ -832,6 +844,7 @@
         <field name="color">5</field>
         <field name="country_id" ref="base.sk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.0</field>
     </record>
 
     <record id="l10n_sk_work_entry_type_maternity" model="hr.work.entry.type">
@@ -840,6 +853,7 @@
         <field name="color">5</field>
         <field name="country_id" ref="base.sk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.75</field>
     </record>
 
     <record id="l10n_sk_work_entry_type_parental_time_off" model="hr.work.entry.type">
@@ -848,14 +862,24 @@
         <field name="color">8</field>
         <field name="country_id" ref="base.sk"/>
         <field name="is_leave" eval="True"/>
+        <field name="amount_rate">0.0</field>
     </record>
 
 <!-- US : United States -->
+    <record id="l10n_us_work_entry_type_overtime" model="hr.work.entry.type">
+        <field name="name">Overtime Hours (Paid at 150%)</field>
+        <field name="color">4</field>
+        <field name="code">USOVERTIME150</field>
+        <field name="country_id" ref="base.us"/>
+        <field name="amount_rate">1.5</field>
+    </record>
+
     <record id="l10n_us_work_entry_type_double" model="hr.work.entry.type">
         <field name="name">Double Time Hours</field>
         <field name="color">4</field>
         <field name="code">USDOUBLE</field>
         <field name="country_id" ref="base.us"/>
+        <field name="amount_rate">2.0</field>
     </record>
 
     <record id="l10n_us_work_entry_type_retro_overtime" model="hr.work.entry.type">
@@ -863,6 +887,7 @@
         <field name="color">4</field>
         <field name="code">USRETROOVERTIME</field>
         <field name="country_id" ref="base.us"/>
+        <field name="amount_rate">1.5</field>
     </record>
 
     <record id="l10n_us_work_entry_type_retro_regular" model="hr.work.entry.type">
@@ -871,4 +896,5 @@
         <field name="code">USRETROREGULAR</field>
         <field name="country_id" ref="base.us"/>
     </record>
+
 </data></odoo>

--- a/addons/hr_work_entry/models/hr_work_entry_type.py
+++ b/addons/hr_work_entry/models/hr_work_entry_type.py
@@ -27,6 +27,13 @@ class HrWorkEntryType(models.Model):
     is_work = fields.Boolean(
         compute='_compute_is_work', inverse='_inverse_is_work', string="Working Time", readonly=False,
         help="If checked, the work entry is counted as work time in the working schedule")
+    amount_rate = fields.Float(
+        string="Rate",
+        default=1.0,
+        help="If you want the hours should be paid double, the rate should be 200%.")
+    is_extra_hours = fields.Boolean(
+        string="Added to Monthly Pay",
+        help="Check this setting if you want the hours to be considered as extra time and added as a bonus to the basic salary.")
 
     @api.constrains('country_id')
     def _check_work_entry_type_country(self):

--- a/addons/hr_work_entry/views/hr_work_entry_views.xml
+++ b/addons/hr_work_entry/views/hr_work_entry_views.xml
@@ -222,6 +222,11 @@
                         </group>
                         <group>
                             <field name="country_id" options="{'no_create': True, 'no_open': True}"/>
+                            <label for="amount_rate"/>
+                            <div class="o_row mw-25" name="amount_rate">
+                                <field name="amount_rate" widget="percentage"/>
+                            </div>
+                            <field name="is_extra_hours"/>
                         </group>
                     </group>
                     <group name="other">

--- a/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
+++ b/addons/hr_work_entry_holidays/data/hr_leave_type_data.xml
@@ -211,4 +211,9 @@
     <record id="hr_holidays.l10n_sk_leave_type_maternity" model="hr.leave.type">
         <field name="work_entry_type_id" ref="hr_work_entry.l10n_sk_work_entry_type_maternity"/>
     </record>
+
+<!-- PL : Poland -->
+    <record id="hr_holidays.l10n_pl_leave_type_sick_leave" model="hr.leave.type">
+        <field name="work_entry_type_id" ref="hr_work_entry.l10n_pl_work_entry_type_sick_leave"/>
+    </record>
 </odoo>


### PR DESCRIPTION
_* = hr_holidays, hr_work_entry, hr_work_entry_contract, hr_work_entry_holidays

- The goal of this change is to improve the payroll system by providing a clearer and more flexible way to manage extra hours and overtime manually.
- This update introduces the ability to mark specific work entry types as extra hours and define a custom rate to be applied during payslip computation.
- HR managers can now manually configure both the extra hours flag and the associated rate on each work entry type.

This PR includes:

- Introduced a general rate field on work entry types to define the pay rate for any work entry.
- Added a checkbox to mark specific work entry types as extra hours, so they are paid on top of the regular wage.
- Updated the payslip logic to calculate the amount based on the defined rate for all work entry types.
- Added a checkbox to the work entry type to determine if the amount should be added on top of the regular salary, based on the rate.
- Updated the logic to handle all countries based on the new work entry type settings, allowing consistent rate application and extra work amount globally. (BE, HK, LU etc.)
- Removed overtime rule parameters and country-specific hardcoded logic to make the extra hours and rate calculation more flexible across all countries. (PL, US, SK etc.)
- Wrote upgrade scripts to handle old data and align it with new work entry type and rate logic across PL, SK, and US.
- Removed old overtime rule parameters and updated work entries and worked days to match the new setup.
- Wrote upgrade scripts to handle old data and align it with new work entry type and rate logic across PL, SK, and US.
- Removed old overtime rule parameters and updated work entries and worked days to match the new setup.

Related Upgrade PR - https://github.com/odoo/upgrade/pull/7364

Task - 4420535

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr