### PR TITLE
[FIX] mrp: compute json based on set dates

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -176,8 +176,10 @@ class MrpWorkorder(models.Model):
                 continue
             if wo.state in ('pending', 'waiting', 'ready'):
                 previous_wos = wo.blocked_by_workorder_ids
-                prev_start = min([workorder.date_start for workorder in previous_wos]) if previous_wos else False
-                prev_finished = max([workorder.date_finished for workorder in previous_wos]) if previous_wos else False
+                previous_starts = previous_wos.filtered('date_start').mapped('date_start')
+                previous_finished = previous_wos.filtered('date_finished').mapped('date_finished')
+                prev_start = min(previous_starts) if previous_starts else False
+                prev_finished = max(previous_finished) if previous_finished else False
                 if wo.state == 'pending' and prev_start and not (prev_start > wo.date_start):
                     infos.append({
                         'color': 'text-primary',

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -4652,6 +4652,31 @@ class TestMrpOrder(TestMrpCommon):
             production_form.date_start = original_start_date
         self.assertEqual(mo.date_start, original_start_date)
 
+    def test_json_popover_with_workorder_dependence(self):
+        """
+        Check that json_popover is correctly computed for workorders with dependencies
+        """
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'normal',
+            'allow_operation_dependencies': True,
+            'operation_ids': [
+                Command.create({'name': 'Super op 1', 'workcenter_id': self.workcenter_2.id, 'sequence': 1}),
+                Command.create({'name': 'Super op 2', 'workcenter_id': self.workcenter_2.id, 'sequence': 2}),
+                Command.create({'name': 'Super op 3', 'workcenter_id': self.workcenter_2.id, 'sequence': 2}),
+            ]
+        })
+        bom.operation_ids[-1].blocked_by_operation_ids = bom.operation_ids[:2]
+        mo = self.env['mrp.production'].create({'bom_id': bom.id})
+        mo.action_confirm()
+        date_start = fields.Date.today()
+        date_finished = fields.Date.today() + timedelta(days=5)
+        wos_to_set = mo.workorder_ids - mo.workorder_ids[1]
+        wos_to_set.write({'date_start': date_start, 'date_finished': date_finished})
+        self.assertTrue(mo.workorder_ids[-1].show_json_popover)
+
+
 @tagged('post_install', '-at_install')
 class TestMrpSynchronization(HttpCase):
 


### PR DESCRIPTION
### Issue:

The compute method of the json_popover raises a traceback if dates are not uniformly set on blocking operations.

### Steps to reproduce:

- Create a bom for a product with 3 operations.
- Allow operation dependancies and set op3 to be bloqued by op1 and op2.
- Create an MO using that bom and confirm.
- Try to set the date_start and date_finished on both op1 and op3 but not op2
- Save
#### > Traceback: TypeError: '<' not supported between instances of 'bool' and 'datetime.datetime'

#### Cause of the issue:

The min and max call are simply performed by comparing boolean values with dates.

This is a backport of 1278404cd6d5f9b6d7f8c510f168e77a870ba6ca

opw-4511050
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
