### PR TITLE
[IMP] web, *: Clean up and reorder cog menu items

### DIFF
--- a/addons/project/static/src/views/project_task_form/project_task_form_controller.js
+++ b/addons/project/static/src/views/project_task_form/project_task_form_controller.js
@@ -26,7 +26,7 @@ export class ProjectTaskFormController extends FormControllerWithHTMLExpander {
         return {
             ...super.getStaticActionMenuItems(),
             openHistoryDialog: {
-                sequence: 50,
+                sequence: 15,
                 icon: "fa fa-history",
                 description: _t("Version History"),
                 callback: () => this.openHistoryDialog(),

--- a/addons/project_todo/static/tests/todo_list_view.test.js
+++ b/addons/project_todo/static/tests/todo_list_view.test.js
@@ -28,9 +28,9 @@ test("Check that todo_list view is restricted to archive, unarchive, duplicate a
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     expect(queryAllTexts`.o_menu_item`).toEqual([
         "Export",
+        "Duplicate",
         "Archive",
         "Unarchive",
-        "Duplicate",
         "Delete",
     ]);
 });

--- a/addons/web/static/src/search/action_menus/action_menus.xml
+++ b/addons/web/static/src/search/action_menus/action_menus.xml
@@ -33,7 +33,7 @@
                                 <div role="separator" class="dropdown-divider"/>
                             </t>
                             <t t-if="item.Component" t-component="item.Component" t-props="item.props" />
-                            <DropdownItem t-else="" class="'o_menu_item'" onSelected="() => this.onItemSelected(item)">
+                            <DropdownItem t-else="" class="item.class ? item.class + ' o_menu_item' : 'o_menu_item'" onSelected="() => this.onItemSelected(item)">
                                 <i t-if="item.icon" t-att-class="item.icon + ' me-1 fa-fw oi-fw'"/>
                                 <t t-esc="item.description"/>
                             </DropdownItem>

--- a/addons/web/static/src/search/cog_menu/cog_menu.js
+++ b/addons/web/static/src/search/cog_menu/cog_menu.js
@@ -66,13 +66,9 @@ export class CogMenu extends ActionMenus {
     }
 
     get cogItems() {
-        return [...this.actionItems, ...this.registryItems].sort((item1, item2) => {
-            const grp = (item1.groupNumber || 0) - (item2.groupNumber || 0);
-            if (grp !== 0) {
-                return grp;
-            }
-            return (item1.sequence || 0) - (item2.sequence || 0);
-        });
+        return [...this.registryItems, ...this.actionItems].sort(
+            (item1, item2) => (item1.groupNumber || 0) - (item2.groupNumber || 0)
+        );
     }
 
     getPrintItemAriaLabel(item) {

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -42,7 +42,7 @@
 
                             <t t-if="item.Component" t-component="item.Component" t-props="item.props"/>
 
-                            <DropdownItem t-else="" class="'o_menu_item'" onSelected="() => this.onItemSelected(item)">
+                            <DropdownItem t-else="" class="item.class ? item.class + ' o_menu_item' : 'o_menu_item'" onSelected="() => this.onItemSelected(item)">
                                 <i t-if="item.icon" t-att-class="item.icon" class="fa-fw oi-fw me-1"/>
                                 <t t-esc="item.description"/>
                             </DropdownItem>

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -468,21 +468,12 @@ export class FormController extends Component {
     getStaticActionMenuItems() {
         const { activeActions } = this.archInfo;
         return {
-            archive: {
-                isAvailable: () => this.archiveEnabled && this.model.root.isActive,
+            addPropertyFieldValue: {
+                isAvailable: () => activeActions.addPropertyFieldValue,
                 sequence: 10,
-                description: _t("Archive"),
-                icon: "oi oi-archive",
-                callback: () => {
-                    this.dialogService.add(ConfirmationDialog, this.archiveDialogProps);
-                },
-            },
-            unarchive: {
-                isAvailable: () => this.archiveEnabled && !this.model.root.isActive,
-                sequence: 20,
-                icon: "oi oi-unarchive",
-                description: _t("Unarchive"),
-                callback: () => this.model.root.unarchive(),
+                icon: "fa fa-cogs",
+                description: _t("Edit Properties"),
+                callback: () => this.model.bus.trigger("PROPERTY_FIELD:EDIT"),
             },
             duplicate: {
                 isAvailable: () => activeActions.create && activeActions.duplicate,
@@ -491,20 +482,30 @@ export class FormController extends Component {
                 description: _t("Duplicate"),
                 callback: () => this.duplicateRecord(),
             },
+            archive: {
+                isAvailable: () => this.archiveEnabled && this.model.root.isActive,
+                sequence: 40,
+                description: _t("Archive"),
+                icon: "oi oi-archive",
+                callback: () => {
+                    this.dialogService.add(ConfirmationDialog, this.archiveDialogProps);
+                },
+            },
+            unarchive: {
+                isAvailable: () => this.archiveEnabled && !this.model.root.isActive,
+                sequence: 45,
+                icon: "oi oi-unarchive",
+                description: _t("Unarchive"),
+                callback: () => this.model.root.unarchive(),
+            },
             delete: {
                 isAvailable: () => activeActions.delete && !this.model.root.isNew,
-                sequence: 40,
+                sequence: 50,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),
+                class: "text-danger",
                 callback: () => this.deleteRecord(),
                 skipSave: true,
-            },
-            addPropertyFieldValue: {
-                isAvailable: () => activeActions.addPropertyFieldValue,
-                sequence: 50,
-                icon: "fa fa-cogs",
-                description: _t("Edit Properties"),
-                callback: () => this.model.bus.trigger("PROPERTY_FIELD:EDIT"),
             },
         };
     }

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -355,9 +355,16 @@ export class KanbanController extends Component {
                 description: _t("Export"),
                 callback: () => this.exportRecords(),
             },
+            duplicate: {
+                isAvailable: () => this.props.archInfo.activeActions.duplicate,
+                sequence: 30,
+                icon: "fa fa-clone",
+                description: _t("Duplicate"),
+                callback: () => this.model.root.duplicateRecords(),
+            },
             archive: {
                 isAvailable: () => this.archiveEnabled,
-                sequence: 20,
+                sequence: 40,
                 icon: "oi oi-archive",
                 description: _t("Archive"),
                 callback: () =>
@@ -365,23 +372,17 @@ export class KanbanController extends Component {
             },
             unarchive: {
                 isAvailable: () => this.archiveEnabled,
-                sequence: 30,
+                sequence: 45,
                 icon: "oi oi-unarchive",
                 description: _t("Unarchive"),
                 callback: () => this.model.root.toggleArchiveWithConfirmation(false),
             },
-            duplicate: {
-                isAvailable: () => this.props.archInfo.activeActions.duplicate,
-                sequence: 35,
-                icon: "fa fa-clone",
-                description: _t("Duplicate"),
-                callback: () => this.model.root.duplicateRecords(),
-            },
             delete: {
                 isAvailable: () => this.props.archInfo.activeActions.delete,
-                sequence: 40,
+                sequence: 50,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),
+                class: "text-danger",
                 callback: () =>
                     this.deleteRecordsWithConfirmation(this.deleteConfirmationDialogProps),
             },

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -398,9 +398,16 @@ export class ListController extends Component {
                 description: _t("Export"),
                 callback: () => this.exportRecords(),
             },
+            duplicate: {
+                isAvailable: () => this.activeActions.duplicate,
+                sequence: 30,
+                icon: "fa fa-clone",
+                description: _t("Duplicate"),
+                callback: () => this.model.root.duplicateRecords(),
+            },
             archive: {
                 isAvailable: () => this.archiveEnabled,
-                sequence: 20,
+                sequence: 40,
                 icon: "oi oi-archive",
                 description: _t("Archive"),
                 callback: () =>
@@ -408,23 +415,17 @@ export class ListController extends Component {
             },
             unarchive: {
                 isAvailable: () => this.archiveEnabled,
-                sequence: 30,
+                sequence: 45,
                 icon: "oi oi-unarchive",
                 description: _t("Unarchive"),
                 callback: () => this.model.root.toggleArchiveWithConfirmation(false),
             },
-            duplicate: {
-                isAvailable: () => this.activeActions.duplicate,
-                sequence: 35,
-                icon: "fa fa-clone",
-                description: _t("Duplicate"),
-                callback: () => this.model.root.duplicateRecords(),
-            },
             delete: {
                 isAvailable: () => this.activeActions.delete,
-                sequence: 40,
+                sequence: 50,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),
+                class: "text-danger",
                 callback: () => this.onDeleteSelectedRecords(),
             },
         };

--- a/addons/web/static/tests/search/action_menus.test.js
+++ b/addons/web/static/tests/search/action_menus.test.js
@@ -202,15 +202,13 @@ test("render ActionMenus in list view with extraPrintItems", async () => {
         get actionMenuProps() {
             return {
                 ...super.actionMenuProps,
-                loadExtraPrintItems: () => {
-                    return [
-                        {
-                            key: "extra_print_key",
-                            description: "Extra Print Item",
-                            class: "o_menu_item",
-                        },
-                    ];
-                },
+                loadExtraPrintItems: () => [
+                    {
+                        key: "extra_print_key",
+                        description: "Extra Print Item",
+                        class: "o_menu_item",
+                    },
+                ],
             };
         }
     }
@@ -268,4 +266,28 @@ test("render ActionMenus in list view with extraPrintItems", async () => {
     ]);
 
     expect.verifySteps(["get_valid_action_reports"]);
+});
+
+test("static action items are properly ordered and styled", async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        actionMenus: {
+            action: [],
+            print: [],
+        },
+        loadActionMenus: true,
+        arch: /* xml */ `
+              <list>
+                  <field name="value"/>
+              </list>
+         `,
+    });
+    // select all records
+    await contains(`thead .o_list_record_selector input`).click();
+    expect(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).toHaveCount(1);
+    await contains(`div.o_control_panel .o_cp_action_menus .dropdown-toggle`).click();
+
+    expect(queryAllTexts(`.o_menu_item`)).toEqual(["Export", "Duplicate", "Delete"]);
+    expect(`.o_menu_item:last`).toHaveClass("text-danger");
 });


### PR DESCRIPTION
This commit refactors and improves the cog menu behavior and structure:

- Refactors the cogItems getter to remove unnecessary sequence sorting (already handled by view controllers) and prioritizes registry items before action items.
- Adds support for custom CSS classes on action menu items and uses it to highlight the Delete option in red.
- Adjusts the sequence of static action menu items to consistently follow the order: Duplicate → Archive → Unarchive → Delete at the end of the list

task-4610825
