### PR TITLE
[FIX] stock: test_picking_tours without demo

### DIFF
--- a/addons/stock/tests/test_picking_tours.py
+++ b/addons/stock/tests/test_picking_tours.py
@@ -6,6 +6,11 @@ from odoo.tests import HttpCase, tagged
 @tagged('-at_install', 'post_install')
 class TestStockPickingTour(HttpCase):
     def setUp(self):
+        config = self.env['res.config.settings'].create({
+            'group_stock_production_lot': True
+        })
+        config.execute()
+
         self.receipt = self.env['stock.picking'].create({
             'picking_type_id': self.env.ref('stock.picking_type_in').id,
             'location_id': self.env.ref('stock.stock_location_suppliers').id,


### PR DESCRIPTION
The tours test_generate_serial_1 and test_generate_serial_2 were broken because the demo data is no longer used in the tests.
Using demo data, the option "Lots & Serial Numbers" is enabled by default. This option have to be enabled for the test.

[Runbot error 160956](https://runbot.odoo.com/odoo/error/160956)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
