### PR TITLE
[IMP] website*: use Domain

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -23,8 +23,8 @@ import odoo
 
 from odoo import http, models, fields, _
 from odoo.exceptions import AccessError, UserError
+from odoo.fields import Domain
 from odoo.http import request, SessionExpiredException
-from odoo.osv import expression
 from odoo.tools import OrderedSet, escape_psql, html_escape as escape, py_to_js_locale
 from odoo.addons.base.models.ir_http import EXTENSION_TO_WEB_MIMETYPES
 from odoo.addons.base.models.ir_qweb import QWebException
@@ -408,7 +408,7 @@ class Website(Home):
     @http.route('/website/snippet/filters', type='jsonrpc', auth='public', website=True, readonly=True)
     def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False, **custom_template_data):
         dynamic_filter = request.env['website.snippet.filter'].sudo().search(
-            [('id', '=', filter_id)] + request.website.website_domain()
+            Domain('id', '=', filter_id) & request.website.website_domain()
         )
         return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample, **custom_template_data) or []
 
@@ -418,13 +418,14 @@ class Website(Home):
             raise werkzeug.exceptions.NotFound()
         domain = request.website.website_domain()
         if search_domain:
-            assert all(leaf[0] in request.env['website.snippet.filter']._fields for leaf in search_domain)
-            domain = expression.AND([domain, search_domain])
+            search_domain = Domain(search_domain)
+            assert all(condition.field_expr in request.env['website.snippet.filter']._fields for condition in search_domain.iter_conditions())
+            domain &= search_domain
         if model_name:
-            domain = expression.AND([
-                domain,
-                ['|', ('filter_id.model_id', '=', model_name), ('action_server_id.model_id.model', '=', model_name)]
-            ])
+            domain &= (
+                Domain('filter_id.model_id', '=', model_name)
+                | Domain('action_server_id.model_id.model', '=', model_name)
+            )
         dynamic_filter = request.env['website.snippet.filter'].sudo().search_read(
             domain, ['id', 'name', 'limit', 'model_name', 'help'], order='id asc'
         )
@@ -983,7 +984,7 @@ class Website(Home):
     def _get_customize_data(self, keys, is_view_data):
         model = 'ir.ui.view' if is_view_data else 'ir.asset'
         Model = request.env[model].with_context(active_test=False)
-        domain = expression.AND([[("key", "in", keys)], request.website.website_domain()])
+        domain = Domain("key", "in", keys) & request.website.website_domain()
         return Model.search(domain).filter_duplicate()
 
     @http.route(['/website/theme_customize_data_get'], type='jsonrpc', auth='user', website=True, readonly=True)

--- a/addons/website/models/ir_asset.py
+++ b/addons/website/models/ir_asset.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.fields import Domain
 
 
 class IrAsset(models.Model):
@@ -24,7 +25,7 @@ class IrAsset(models.Model):
 
     def _get_related_assets(self, domain, *, website_id=None, **params):
         if website_id:
-            domain += self.env['website'].website_domain(website_id)
+            domain = Domain(domain) & self.env['website'].browse(website_id).website_domain()
         assets = super()._get_related_assets(domain, **params)
         return assets.filter_duplicate(website_id)
 

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -5,9 +5,8 @@ import uuid
 import werkzeug
 
 from odoo import api, fields, models
-from odoo.fields import Domain
 from odoo.exceptions import AccessError, MissingError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -324,8 +323,8 @@ class IrUiView(models.Model):
         # when rendering for the website we have to include inactive views
         # we will prefer inactive website-specific views over active generic ones
         if current_website:
-            domain = [leaf for leaf in domain if 'active' not in leaf]
-        return expression.AND([website_views_domain, domain])
+            domain = domain.map_conditions(lambda cond: cond if cond.field_expr != 'active' else Domain.TRUE)
+        return website_views_domain & domain
 
     @api.model
     def _get_inheriting_views(self):

--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -38,12 +38,12 @@ class ResUsers(models.Model):
     @api.model
     def _get_login_domain(self, login):
         website = self.env['website'].get_current_website()
-        return super(ResUsers, self)._get_login_domain(login) + website.website_domain()
+        return super()._get_login_domain(login) & website.website_domain()
 
     @api.model
     def _get_email_domain(self, email):
         website = self.env['website'].get_current_website()
-        return super()._get_email_domain(email) + website.website_domain()
+        return super()._get_email_domain(email) & website.website_domain()
 
     @api.model
     def _get_login_order(self):

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -22,11 +22,12 @@ from odoo.addons.website.tools import similarity_score, text_from_html, get_base
 from odoo.addons.portal.controllers.portal import pager
 from odoo.addons.iap.tools import iap_tools
 from odoo.exceptions import AccessError, UserError, ValidationError
+from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.module import get_manifest
-from odoo.osv.expression import AND, OR, FALSE_DOMAIN
-from odoo.tools import SQL, Query, sql as sqltools
+from odoo.tools import SQL, Query
 from odoo.tools.image import image_process
+from odoo.tools.sql import escape_psql
 from odoo.tools.translate import _, xml_translate
 
 logger = logging.getLogger(__name__)
@@ -98,9 +99,8 @@ class Website(models.Model):
     _description = "Website"
     _order = "sequence, id"
 
-    @api.model
-    def website_domain(self, website_id=False):
-        return [('website_id', 'in', (False, website_id or self.id))]
+    def website_domain(self):
+        return Domain('website_id', 'in', [False, *self.ids])
 
     def _active_languages(self):
         return self.env['res.lang'].search([]).ids
@@ -531,7 +531,7 @@ class Website(models.Model):
     def configurator_recommended_themes(self, industry_id, palette, result_nbr_max=3):
         Module = request.env['ir.module.module']
         domain = Module.get_themes_domain()
-        domain = AND([[('name', '!=', 'theme_default')], domain])
+        domain = Domain.AND([[('name', '!=', 'theme_default')], domain])
         client_themes = Module.search(domain).mapped('name')
         client_themes_img = {t: get_manifest(t).get('images_preview_theme', {}) for t in client_themes if get_manifest(t)}
         themes_suggested = self._website_api_rpc(
@@ -1323,12 +1323,12 @@ class Website(models.Model):
             # Generate the exact domain to search for the URL in this field
             domains = []
             for url, website_domain in search_criteria:
-                domains.append(AND([
+                domains.append(Domain.AND([
                     [(field_name, 'ilike', url)],
                     website_domain if hasattr(Model, 'website_id') else [],
                 ]))
 
-            dependency_records = Model.search(OR(domains))
+            dependency_records = Model.search(Domain.OR(domains))
             if model_name == 'ir.ui.view':
                 dependency_records = _handle_views_and_pages(dependency_records)
             if dependency_records:
@@ -1614,7 +1614,7 @@ class Website(models.Model):
                     if query:
                         r = "".join([x[1] for x in rule._trace[1:] if not x[0]])  # remove model converter from route
                         query = sitemap_qs2dom(query, r, self.env[converter.model]._rec_name)
-                        if query == FALSE_DOMAIN:
+                        if query.is_false():
                             continue
 
                     for rec in converter.generate(self.env, args=val, dom=query):
@@ -1644,9 +1644,9 @@ class Website(models.Model):
             # custos granting them read and/or write access on page.
             raise AccessError(_("Access Denied"))
 
-        domain = [('url', '!=', False)]
+        domain = Domain('url', '!=', False)
         if self:
-            domain = AND([domain, self.website_domain()])
+            domain &= self.website_domain()
         pages = self.env['website.page'].sudo().search(domain)
         if self:
             pages = pages.with_context(website_id=self.id)._get_most_specific_pages()
@@ -1654,9 +1654,7 @@ class Website(models.Model):
 
     def _get_website_pages(self, domain=None, order='name', limit=None):
         website = self.get_current_website()
-        if domain is None:
-            domain = []
-        domain += website.website_domain()
+        domain = Domain(domain or Domain.TRUE) & website.website_domain()
         pages = self.env['website.page'].sudo().search(domain, order=order, limit=limit)
         pages = pages.with_context(website_id=website.id)._get_most_specific_pages()
         return pages
@@ -1887,7 +1885,7 @@ class Website(models.Model):
                             old_blockquote_asset.active = True
         self.env['ir.asset'].flush_model()
 
-    def _search_build_domain(self, domain, search, fields, extra=None):
+    def _search_build_domain(self, domain_list, search, fields, extra=None):
         """
         Builds a search domain AND-combining a base domain with partial matches of each term in
         the search expression in any of the fields.
@@ -1899,16 +1897,15 @@ class Website(models.Model):
 
         :return: domain limited to the matches of the search expression
         """
-        domains = domain.copy()
+        # just like website.searchable.mixin
+        domain = Domain.AND(domain_list)
         if search:
             for search_term in search.split(' '):
-                subdomains = []
-                for field in fields:
-                    subdomains.append([(field, 'ilike', sqltools.escape_psql(search_term))])
+                subdomains = [Domain(field, 'ilike', escape_psql(search_term)) for field in fields]
                 if extra:
                     subdomains.append(extra(self.env, search_term))
-                domains.append(OR(subdomains))
-        return AND(domains)
+                domain &= Domain.OR(subdomains)
+        return domain
 
     def _search_text_from_html(self, html_fragment):
         """
@@ -2102,7 +2099,7 @@ class Website(models.Model):
             model = self.env[model_name]
             if search_detail.get('requires_sudo'):
                 model = model.sudo()
-            domain = search_detail['base_domain'].copy()
+            domain = Domain.AND(search_detail['base_domain'])
             direct_fields = set(fields).intersection(model._fields)
             indirect_fields = self._search_get_indirect_fields(fields, model)
 
@@ -2162,13 +2159,15 @@ class Website(models.Model):
 
             query.order = '_best_similarity desc'
             query.limit = 1000
-            self.env.cr.execute(query.select(
-                SQL.identifier(model._table, 'id'),
-                SQL('%s AS _best_similarity', best_similarity),
-            ))
-            ids = {row[0] for row in self.env.cr.fetchall() if row[1] and row[1] >= similarity_threshold}
-            domain.append([('id', 'in', list(ids))])
-            domain = AND(domain)
+            ids = [
+                id_
+                for id_, similarity in self.env.execute_query(query.select(
+                    SQL.identifier(model._table, 'id'),
+                    SQL('%s AS _best_similarity', best_similarity),
+                ))
+                if (similarity or 0) >= similarity_threshold
+            ]
+            domain &= Domain('id', 'in', ids)
             records = model.search_read(domain, direct_fields, limit=limit)
             for record in records:
                 for value in record.values():
@@ -2194,23 +2193,26 @@ class Website(models.Model):
         :return: yields words
         """
         match_pattern = r'[\w./-]{%s,}' % min(4, len(search) - 3)
-        first = sqltools.escape_psql(search[0])
+        first = escape_psql(search[0])
         for search_detail in search_details:
             model_name, fields = search_detail['model'], search_detail['search_fields']
             model = self.env[model_name]
             if search_detail.get('requires_sudo'):
                 model = model.sudo()
-            domain = search_detail['base_domain'].copy()
-            fields_domain = []
+            domain = Domain.AND(search_detail['base_domain'])
             direct_fields = set(fields).intersection(model._fields)
             indirect_fields = self._search_get_indirect_fields(fields, model)
             fields = direct_fields.union(indirect_fields)
-            for field in fields:
-                fields_domain.append([(field, '=ilike', '%s%%' % first)])
-                fields_domain.append([(field, '=ilike', '%% %s%%' % first)])
-                fields_domain.append([(field, '=ilike', '%%>%s%%' % first)])  # HTML
-            domain.append(OR(fields_domain))
-            domain = AND(domain)
+            fields_domain = Domain.OR(
+                Domain(field, '=ilike', pattern)
+                for field in fields
+                for pattern in (
+                    '%s%%' % first,
+                    '%% %s%%' % first,
+                    '%%>%s%%' % first,  # HTML
+                )
+            )
+            domain &= fields_domain
             perf_limit = 1000
             records = model.search_read(domain, direct_fields, limit=perf_limit)
             if len(records) == perf_limit:

--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -3,8 +3,8 @@
 from ast import literal_eval
 
 from odoo import models, fields, api, SUPERUSER_ID
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 
 
 class Website(models.Model):
@@ -110,7 +110,7 @@ class IrModel(models.Model):
                             if 'domain' in property_definition and isinstance(property_definition['domain'], str):
                                 property_definition['domain'] = literal_eval(property_definition['domain'])
                                 try:
-                                    property_definition['domain'] = expression.normalize_domain(property_definition['domain'])
+                                    property_definition['domain'] = list(Domain(property_definition['domain']))
                                 except Exception:
                                     # Ignore non-fully defined properties
                                     continue

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -7,7 +7,7 @@ from werkzeug.urls import url_parse
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.fields import Command
+from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools.translate import html_translate
 
@@ -278,11 +278,10 @@ class WebsiteMenu(models.Model):
                     referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
                     menu['url'] = referer_url + menu['url']
             else:
-                domain = self.env["website"].website_domain(website_id) + [
-                    "|",
-                    ("url", "=", menu["url"]),
-                    ("url", "=", "/" + menu["url"]),
-                ]
+                domain = self.env["website"].browse(website_id).website_domain() & (
+                    Domain("url", "=", menu["url"])
+                    | Domain("url", "=", "/" + menu["url"])
+                )
                 page = self.env["website.page"].search(domain, limit=1)
                 if page:
                     menu['page_id'] = page.id

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -8,10 +8,10 @@ import pytz
 from odoo import api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 from odoo.tools import _, SQL
 from odoo.tools.misc import _format_time_ago
 from odoo.http import request
-from odoo.osv import expression
 
 
 class WebsiteTrack(models.Model):
@@ -304,7 +304,7 @@ class WebsiteVisitor(models.Model):
 
     def _add_tracking(self, domain, website_track_values):
         """ Add the track and update the visitor"""
-        domain = expression.AND([domain, [('visitor_id', '=', self.id)]])
+        domain = Domain.AND([domain, Domain('visitor_id', '=', self.id)])
         last_view = self.env['website.track'].sudo().search(domain, limit=1)
         if not last_view or last_view.visit_datetime < datetime.now() - timedelta(minutes=30):
             website_track_values['visitor_id'] = self.id
@@ -357,7 +357,7 @@ class WebsiteVisitor(models.Model):
 
         delay_days = int(self.env['ir.config_parameter'].sudo().get_param('website.visitor.live.days', 60))
         deadline = datetime.now() - timedelta(days=delay_days)
-        return [('last_connection_datetime', '<', deadline), ('partner_id', '=', False)]
+        return Domain('last_connection_datetime', '<', deadline) & Domain('partner_id', '=', False)
 
     def _update_visitor_timezone(self, timezone):
         """ We need to do this part here to avoid concurrent updates error. """

--- a/addons/website_crm/models/website_visitor.py
+++ b/addons/website_crm/models/website_visitor.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class WebsiteVisitor(models.Model):
@@ -45,8 +44,7 @@ class WebsiteVisitor(models.Model):
 
     def _inactive_visitors_domain(self):
         """ Visitors tied to leads are considered always active and should not be deleted. """
-        domain = super()._inactive_visitors_domain()
-        return expression.AND([domain, [('lead_ids', '=', False)]])
+        return super()._inactive_visitors_domain() & Domain('lead_ids', '=', False)
 
     def _merge_visitor(self, target):
         """ Link the leads to the main visitor to avoid them being lost. """

--- a/addons/website_event/models/website_visitor.py
+++ b/addons/website_event/models/website_visitor.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.osv import expression
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 
 
 class WebsiteVisitor(models.Model):
@@ -77,8 +76,7 @@ class WebsiteVisitor(models.Model):
 
     def _inactive_visitors_domain(self):
         """ Visitors registered to events are considered always active and should not be deleted. """
-        domain = super()._inactive_visitors_domain()
-        return expression.AND([domain, [('event_registration_ids', '=', False)]])
+        return super()._inactive_visitors_domain() & Domain('event_registration_ids', '=', False)
 
     def _merge_visitor(self, target):
         """ Override linking process to link registrations to the final visitor. """

--- a/addons/website_event_exhibitor/controllers/exhibitor.py
+++ b/addons/website_event_exhibitor/controllers/exhibitor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
@@ -8,8 +7,8 @@ from werkzeug.exceptions import Forbidden
 
 from odoo import http
 from odoo.addons.website_event.controllers.main import WebsiteEventController
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.tools import format_duration
 
 
@@ -21,7 +20,7 @@ class ExhibitorController(WebsiteEventController):
             ('exhibitor_type', 'in', ['exhibitor', 'online']),
         ]
         if not request.env.user.has_group('event.group_event_registration_desk'):
-            search_domain_base = expression.AND([search_domain_base, [('is_published', '=', True)]])
+            search_domain_base = Domain.AND([search_domain_base, [('is_published', '=', True)]])
         return search_domain_base
 
     # ------------------------------------------------------------
@@ -50,7 +49,7 @@ class ExhibitorController(WebsiteEventController):
 
         # search on content
         if searches.get('search'):
-            search_domain = expression.AND([
+            search_domain = Domain.AND([
                 search_domain,
                 ['|', ('name', 'ilike', searches['search']), ('website_description', 'ilike', searches['search'])]
             ])
@@ -58,7 +57,7 @@ class ExhibitorController(WebsiteEventController):
         # search on countries
         search_countries = self._get_search_countries(searches['countries'])
         if search_countries:
-            search_domain = expression.AND([
+            search_domain = Domain.AND([
                 search_domain,
                 [('partner_id.country_id', 'in', search_countries.ids)]
             ])
@@ -66,7 +65,7 @@ class ExhibitorController(WebsiteEventController):
         # search on sponsor types
         search_sponsorships = self._get_search_sponsorships(searches['sponsorships'])
         if search_sponsorships:
-            search_domain = expression.AND([
+            search_domain = Domain.AND([
                 search_domain,
                 [('sponsor_type_id', 'in', search_sponsorships.ids)]
             ])
@@ -140,7 +139,7 @@ class ExhibitorController(WebsiteEventController):
     def _event_exhibitor_get_values(self, event, sponsor, **options):
         # search for exhibitor list
         search_domain_base = self._get_event_sponsors_base_domain(event)
-        search_domain_base = expression.AND([
+        search_domain_base = Domain.AND([
             search_domain_base,
             [('id', '!=', sponsor.id)]
         ])

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
@@ -15,8 +14,8 @@ import operator
 import pytz
 
 from odoo import http, fields, tools, _
+from odoo.fields import Domain
 from odoo.http import content_disposition, request
-from odoo.osv import expression
 from odoo.tools import is_html_empty, plaintext2html
 from odoo.tools.misc import babel_locale_parse
 
@@ -45,7 +44,7 @@ class EventTrackController(http.Controller):
         unpublished tracks from the search results."""
         search_domain_base = self._get_event_tracks_agenda_domain(event)
         if not request.env.user.has_group('event.group_event_registration_desk'):
-            search_domain_base = expression.AND([
+            search_domain_base = Domain.AND([
                 search_domain_base,
                 [('is_published', '=', True)]
             ])
@@ -96,7 +95,7 @@ class EventTrackController(http.Controller):
 
         # search on content
         if searches.get('search'):
-            search_domain = expression.AND([
+            search_domain = Domain.AND([
                 search_domain,
                 ['|', ('name', 'ilike', searches['search']), ('partner_name', 'ilike', searches['search'])]
             ])
@@ -117,7 +116,7 @@ class EventTrackController(http.Controller):
                 [('tag_ids', 'in', [tag.id for tag in grouped_tags[group]])]
                 for group in grouped_tags
             ]
-            search_domain = expression.AND([
+            search_domain = Domain.AND([
                 search_domain,
                 *search_domain_items
             ])
@@ -216,7 +215,7 @@ class EventTrackController(http.Controller):
         local_tz = pytz.timezone(event.date_tz or 'UTC')
         lang_code = request.env.context.get('lang')
 
-        base_track_domain = expression.AND([
+        base_track_domain = Domain.AND([
             self._get_event_tracks_agenda_domain(event),
             [('date', '!=', False)]
         ])

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
@@ -13,7 +12,7 @@ import werkzeug.urls
 
 from odoo import api, fields, models, tools
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools.mail import email_normalize, html_to_inner_content, is_html_empty
 from odoo.tools.translate import _, html_translate
 
@@ -348,7 +347,7 @@ class EventTrack(models.Model):
                 domain = [('partner_id', '=', self.env.user.partner_id.id)]
 
             event_track_visitors = self.env['event.track.visitor'].sudo().search_read(
-                expression.AND([
+                Domain.AND([
                     domain,
                     [('track_id', 'in', self.ids)]
                 ]), fields=['track_id', 'is_wishlisted', 'is_blacklisted']
@@ -612,7 +611,7 @@ class EventTrack(models.Model):
             domain = [('partner_id', '=', self.env.user.partner_id.id)]
 
         track_visitors = self.env['event.track.visitor'].sudo().search(
-            expression.AND([domain, [('track_id', 'in', self.ids)]])
+            Domain.AND([domain, [('track_id', 'in', self.ids)]])
         )
         missing = self - track_visitors.track_id
         if missing and force_create:
@@ -672,7 +671,7 @@ class EventTrack(models.Model):
             ('id', '!=', self.id),
         ]
         if restrict_domain:
-            base_domain = expression.AND([
+            base_domain = Domain.AND([
                 base_domain,
                 restrict_domain
             ])

--- a/addons/website_event_track/models/website_visitor.py
+++ b/addons/website_event_track/models/website_visitor.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class WebsiteVisitor(models.Model):
@@ -50,8 +49,7 @@ class WebsiteVisitor(models.Model):
     def _inactive_visitors_domain(self):
         """ Visitors registered to push subscriptions are considered always active and should not be
         deleted. """
-        domain = super()._inactive_visitors_domain()
-        return expression.AND([domain, [('event_track_visitor_ids', '=', False)]])
+        return super()._inactive_visitors_domain() & Domain('event_track_visitor_ids', '=', False)
 
     def _merge_visitor(self, target):
         """ Override linking process to link wishlist to the final visitor. """

--- a/addons/website_event_track_live/controllers/track_live.py
+++ b/addons/website_event_track_live/controllers/track_live.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
+from odoo.fields import Domain
 
 from odoo.addons.website_event_track.controllers.event_track import EventTrackController
-from odoo.osv import expression
+
 
 class EventTrackLiveController(EventTrackController):
 
@@ -12,9 +12,9 @@ class EventTrackLiveController(EventTrackController):
     def get_next_track_suggestion(self, track_id):
         track = self._fetch_track(track_id)
         track_suggestion = track._get_track_suggestions(
-            restrict_domain=expression.AND([
+            restrict_domain=Domain.AND([
                 self._get_event_tracks_domain(track.event_id),
-                [('youtube_video_url', '!=', False)]
+                Domain('youtube_video_url', '!=', False)
             ]), limit=1)
         if not track_suggestion:
             return False

--- a/addons/website_event_track_quiz/models/event_track.py
+++ b/addons/website_event_track_quiz/models/event_track.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class EventTrack(models.Model):
@@ -51,7 +50,7 @@ class EventTrack(models.Model):
                     domain = [('partner_id', '=', self.env.user.partner_id.id)]
 
                 event_track_visitors = self.env['event.track.visitor'].sudo().search_read(
-                    expression.AND([
+                    Domain.AND([
                         domain,
                         [('track_id', 'in', tracks_quiz.ids)]
                     ]), fields=['track_id', 'quiz_completed', 'quiz_points']

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -8,7 +7,7 @@ from datetime import datetime
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError, AccessError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import sql, SQL
 from odoo.tools.json import scriptsafe as json_safe
 
@@ -865,36 +864,36 @@ class ForumPost(models.Model):
         }
 
         domain = website.website_domain()
-        domain = expression.AND([domain, [('state', '=', 'active'), ('can_view', '=', True)]])
+        domain &= Domain('state', '=', 'active') & Domain('can_view', '=', True)
         include_answers = options.get('include_answers', False)
         if not include_answers:
-            domain = expression.AND([domain, [('parent_id', '=', False)]])
+            domain &= Domain('parent_id', '=', False)
         forum = options.get('forum')
         if forum:
-            domain = expression.AND([domain, [('forum_id', '=', self.env['ir.http']._unslug(forum)[1])]])
+            domain &= Domain('forum_id', '=', self.env['ir.http']._unslug(forum)[1])
         tags = options.get('tag')
         if tags:
-            domain = expression.AND([domain, [('tag_ids', 'in', [self.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')])]])
+            domain &= Domain('tag_ids', 'in', [self.env['ir.http']._unslug(tag)[1] for tag in tags.split(',')])
         filters = options.get('filters')
         if filters == 'unanswered':
-            domain = expression.AND([domain, [('child_ids', '=', False)]])
+            domain &= Domain('child_ids', '=', False)
         elif filters == 'solved':
-            domain = expression.AND([domain, [('has_validated_answer', '=', True)]])
+            domain &= Domain('has_validated_answer', '=', True)
         elif filters == 'unsolved':
-            domain = expression.AND([domain, [('has_validated_answer', '=', False)]])
+            domain &= Domain('has_validated_answer', '=', False)
         user = self.env.user
         my = options.get('my')
         create_uid = user.id if my == 'mine' else options.get('create_uid')
         if create_uid:
-            domain = expression.AND([domain, [('create_uid', '=', create_uid)]])
+            domain &= Domain('create_uid', '=', create_uid)
         if my == 'followed':
-            domain = expression.AND([domain, [('message_partner_ids', '=', user.partner_id.id)]])
+            domain &= Domain('message_partner_ids', '=', user.partner_id.id)
         elif my == 'tagged':
-            domain = expression.AND([domain, [('tag_ids.message_partner_ids', '=', user.partner_id.id)]])
+            domain &= Domain('tag_ids.message_partner_ids', '=', user.partner_id.id)
         elif my == 'favourites':
-            domain = expression.AND([domain, [('favourite_ids', '=', user.id)]])
+            domain &= Domain('favourite_ids', '=', user.id)
         elif my == 'upvoted':
-            domain = expression.AND([domain, [('vote_ids.user_id', '=', user.id)]])
+            domain &= Domain('vote_ids.user_id', '=', user.id)
 
         # 'sorting' from the form's "Order by" overrides order during auto-completion
         order = options.get('sorting', order)

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -7,14 +7,12 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from functools import partial
 from operator import itemgetter
-from werkzeug.urls import url_encode
 
 from odoo import http, _
 from odoo.addons.website.controllers.form import WebsiteForm
-from odoo.osv.expression import AND
+from odoo.fields import Domain
 from odoo.http import request
 from odoo.tools import email_normalize
-from odoo.tools.misc import groupby
 
 
 class WebsiteHrRecruitment(WebsiteForm):
@@ -114,10 +112,10 @@ class WebsiteHrRecruitment(WebsiteForm):
         if not (country or department or office or contract_type or all_countries) \
             and (code := request.geoip.country_code) \
                 and (country := env['res.country'].search([('code', '=', code)], limit=1)):
-            country_count = env['hr.job'].search_count(AND([
-                website.website_domain(),
-                [('address_id.country_id', '=', country.id)]
-            ]))
+            country_count = env['hr.job'].search_count(
+                website.website_domain()
+                & Domain('address_id.country_id', '=', country.id)
+            )
             if not country_count:
                 country = False
 
@@ -207,7 +205,7 @@ class WebsiteHrRecruitment(WebsiteForm):
             'linkedin': [('linkedin_profile', '=ilike', value)],
         }.get(field, [])
 
-        applications_by_status = http.request.env['hr.applicant'].sudo().search(AND([
+        applications_by_status = http.request.env['hr.applicant'].sudo().search(Domain.AND([
             field_domain,
             [
                 ('job_id.website_id', 'in', [http.request.website.id, False]),

--- a/addons/website_profile/controllers/main.py
+++ b/addons/website_profile/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import werkzeug
@@ -11,8 +10,8 @@ from dateutil.relativedelta import relativedelta
 from operator import itemgetter
 
 from odoo import _, fields, http, tools
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 
 
 class WebsiteProfile(http.Controller):
@@ -138,9 +137,9 @@ class WebsiteProfile(http.Controller):
         """
         Hook for other modules to restrict the badges showed on profile page, depending of the context
         """
-        domain = [('website_published', '=', True)]
+        domain = Domain('website_published', '=', True)
         if 'badge_category' in kwargs:
-            domain = expression.AND([[('challenge_ids.challenge_category', '=', kwargs.get('badge_category'))], domain])
+            domain = Domain('challenge_ids.challenge_category', '=', kwargs.get('badge_category')) & domain
         return domain
 
     def _prepare_ranks_badges_values(self, **kwargs):
@@ -196,7 +195,7 @@ class WebsiteProfile(http.Controller):
             'group_by': group_by or 'all',
         }
         if search_term:
-            dom = expression.AND([['|', ('name', 'ilike', search_term), ('partner_id.commercial_company_name', 'ilike', search_term)], dom])
+            dom = Domain.AND([['|', ('name', 'ilike', search_term), ('partner_id.commercial_company_name', 'ilike', search_term)], dom])
 
         user_count = User.sudo().search_count(dom)
         my_user = request.env.user
@@ -223,7 +222,7 @@ class WebsiteProfile(http.Controller):
 
             if my_user.website_published and my_user.karma and my_user.id not in users.ids:
                 # Need to keep the dom to search only for users that appear in the ranking page
-                current_user = User.sudo().search(expression.AND([[('id', '=', my_user.id)], dom]))
+                current_user = User.sudo().search(Domain.AND([[('id', '=', my_user.id)], dom]))
                 if current_user:
                     current_user_values = self._prepare_all_users_values(current_user)[0]
 

--- a/addons/website_sale/controllers/gmc.py
+++ b/addons/website_sale/controllers/gmc.py
@@ -3,8 +3,8 @@
 from urllib.parse import urljoin
 from werkzeug.exceptions import NotFound
 
+from odoo.fields import Domain
 from odoo.http import Controller, request, route
-from odoo.osv import expression
 
 
 class GoogleMerchantCenter(Controller):
@@ -37,8 +37,8 @@ class GoogleMerchantCenter(Controller):
         # Find the pricelist by name if specified.
         if pricelist_name_ilike is not None:
             pricelist_sudo = request.env['product.pricelist'].sudo().search(
-                expression.AND([
-                    [('name', 'ilike', pricelist_name_ilike)],
+                Domain.AND([
+                    Domain('name', 'ilike', pricelist_name_ilike),
                     request.env['product.pricelist']._get_website_pricelists_domain(website),
                 ]),
                 limit=1,
@@ -52,8 +52,9 @@ class GoogleMerchantCenter(Controller):
         website_homepage = website._get_website_pages(
             [('url', '=', homepage_url), ('website_id', '!=', False)], limit=1,
         )
-        products = request.env['product.product'].search(expression.AND([
-            [('is_published', '=', True), ('type', 'in', ('consu', 'combo'))],
+        products = request.env['product.product'].search(Domain.AND([
+            Domain('is_published', '=', True),
+            Domain('type', 'in', ('consu', 'combo')),
             website.website_domain(),
         ]))
         gmc_data = {

--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from odoo import _, api, fields, models
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.tools import float_is_zero, is_html_empty
 from odoo.tools.translate import html_translate
 
@@ -211,9 +210,9 @@ class ProductTemplate(models.Model):
         return variant_dict
 
     def _get_website_accessory_product(self):
-        domain = self.env['website'].sale_product_domain()
+        domain = Domain(self.env['website'].sale_product_domain())
         if not self.env.user._is_internal():
-            domain = expression.AND([domain, [('is_published', '=', True)]])
+            domain &= Domain('is_published', '=', True)
         return self.accessory_product_ids.filtered_domain(domain)
 
     def _get_website_alternative_product(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -12,7 +12,6 @@ from odoo.exceptions import AccessError
 
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 from odoo.tools import file_open, ormcache
 from odoo.tools.translate import LazyTranslate, _
 
@@ -491,12 +490,14 @@ class Website(models.Model):
 
     def sale_product_domain(self):
         website_domain = self.get_current_website().website_domain()
-        if not self.env.user._is_internal():
-            website_domain = expression.AND([website_domain, [
+        if self.env.user._is_internal():
+            user_domain = Domain.TRUE
+        else:
+            user_domain = [
                 ('is_published', '=', True),
                 ('service_tracking', 'in', self.env['product.template']._get_saleable_tracking_types()),
-            ]])
-        return expression.AND([self._product_domain(), website_domain])
+            ]
+        return Domain.AND([self._product_domain(), website_domain, user_domain])
 
     def _product_domain(self):
         return [('sale_ok', '=', True)]

--- a/addons/website_slides/models/res_partner.py
+++ b/addons/website_slides/models/res_partner.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class ResPartner(models.Model):
@@ -74,9 +73,9 @@ class ResPartner(models.Model):
         action['display_name'] = _('Courses')
         action['domain'] = [('member_status', '!=', 'invited')]
         if len(self) == 1 and self.is_company:
-            action['domain'] = expression.AND([action['domain'], [('partner_id', 'in', self.child_ids.ids)]])
+            action['domain'] = Domain.AND([action['domain'], [('partner_id', 'in', self.child_ids.ids)]])
         elif len(self) == 1:
             action['context'] = {'search_default_partner_id': self.id}
         else:
-            action['domain'] = expression.AND([action['domain'], [('partner_id', 'in', self.ids)]])
+            action['domain'] = Domain.AND([action['domain'], [('partner_id', 'in', self.ids)]])
         return action

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -11,7 +11,6 @@ from markupsafe import Markup
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
-from odoo.osv import expression
 from odoo.tools import is_html_empty
 
 _logger = logging.getLogger(__name__)
@@ -812,11 +811,11 @@ class SlideChannel(models.Model):
         if not partner_ids:
             raise ValueError("Do not use this method with an empty partner_id recordset")
 
-        removed_channel_partner_domain = expression.OR([
-            [('partner_id', 'in', partner_ids),
-             ('channel_id', '=', channel.id)]
+        removed_channel_partner_domain = Domain.OR(
+            Domain('partner_id', 'in', partner_ids)
+            & Domain('channel_id', '=', channel.id)
             for channel in self
-        ])
+        )
 
         self.message_unsubscribe(partner_ids=partner_ids)
         if self:
@@ -857,7 +856,7 @@ class SlideChannel(models.Model):
     def action_view_ratings(self):
         action = self.env["ir.actions.actions"]._for_xml_id("website_slides.rating_rating_action_slide_channel")
         action['name'] = _('Rating of %s', self.name)
-        action['domain'] = expression.AND([ast.literal_eval(action.get('domain', '[]')), [('res_id', 'in', self.ids)]])
+        action['domain'] = Domain.AND([ast.literal_eval(action.get('domain', '[]')), Domain('res_id', 'in', self.ids)])
         return action
 
     def action_request_access(self):

--- a/addons/website_slides/models/slide_channel_partner.py
+++ b/addons/website_slides/models/slide_channel_partner.py
@@ -1,5 +1,5 @@
 from odoo import api, fields, models, tools, _
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class SlideChannelPartner(models.Model):
@@ -141,11 +141,11 @@ class SlideChannelPartner(models.Model):
         """
         if self:
             # find all slide link to the channel and the partner
-            removed_slide_partner_domain = expression.OR([
-                [('partner_id', '=', channel_partner.partner_id.id),
-                 ('slide_id', 'in', channel_partner.channel_id.slide_ids.ids)]
+            removed_slide_partner_domain = Domain.OR(
+                Domain('partner_id', '=', channel_partner.partner_id.id)
+                & Domain('slide_id', 'in', channel_partner.channel_id.slide_ids.ids)
                 for channel_partner in self
-            ])
+            )
             self.env['slide.slide.partner'].search(removed_slide_partner_domain).unlink()
         return super().unlink()
 

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import werkzeug
@@ -8,8 +7,8 @@ import werkzeug.exceptions
 from odoo import _
 from odoo import http
 from odoo.exceptions import AccessError
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 
 from odoo.addons.website_slides.controllers.main import WebsiteSlides
 
@@ -136,7 +135,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
         values = super(WebsiteSlidesSurvey, self)._prepare_ranks_badges_values(**kwargs)
 
         # 1. Getting all certification badges, sorted by granted user desc
-        domain = expression.AND([[('survey_id', '!=', False)], self._prepare_badges_domain(**kwargs)])
+        domain = Domain.AND([[('survey_id', '!=', False)], self._prepare_badges_domain(**kwargs)])
         certification_badges = request.env['gamification.badge'].sudo().search(domain)
         # keep only the badge with challenge category = slides (the rest will be displayed under 'normal badges' section
         certification_badges = certification_badges.filtered(

--- a/addons/website_slides_survey/models/slide_channel.py
+++ b/addons/website_slides_survey/models/slide_channel.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
 
 from odoo import api, fields, models, _
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class SlideChannelPartner(models.Model):
@@ -27,10 +26,10 @@ class SlideChannel(models.Model):
         track of the current pool of attempts allowed since the user (last) joined
         the course, as only those will have a slide_partner_id."""
         if self:
-            removed_channel_partner_domain = expression.OR([
-                [('partner_id', 'in', partner_ids), ('channel_id', '=', channel.id)]
+            removed_channel_partner_domain = Domain.OR(
+                Domain('partner_id', 'in', partner_ids) & Domain('channel_id', '=', channel.id)
                 for channel in self
-            ])
+            )
             slide_partners_sudo = self.env['slide.slide.partner'].sudo().search(
                 removed_channel_partner_domain)
             slide_partners_sudo.user_input_ids.slide_partner_id = False

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class SlideSlidePartner(models.Model):
@@ -34,14 +33,13 @@ class SlideSlidePartner(models.Model):
         certification_success_slides = self.filtered(lambda slide: slide.survey_scoring_success)
         if not certification_success_slides:
             return
-        certified_channels_domain = expression.OR([
-            [('partner_id', '=', slide.partner_id.id), ('channel_id', '=', slide.channel_id.id)]
+        certified_channels_domain = Domain.OR(
+            Domain('partner_id', '=', slide.partner_id.id) & Domain('channel_id', '=', slide.channel_id.id)
             for slide in certification_success_slides
-        ])
-        self.env['slide.channel.partner'].search(expression.AND([
-            [("survey_certification_success", "=", False)],
-            certified_channels_domain]
-        )).survey_certification_success = True
+        )
+        self.env['slide.channel.partner'].search(
+            Domain("survey_certification_success", "=", False) & certified_channels_domain
+        ).survey_certification_success = True
 
 
 class SlideSlide(models.Model):

--- a/addons/website_slides_survey/models/survey_user.py
+++ b/addons/website_slides_survey/models/survey_user.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
-from odoo.osv import expression
 
 
 class SurveyUser_Input(models.Model):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -636,10 +636,10 @@ actual arch.
     def _get_inheriting_views_domain(self):
         """ Return a domain to filter the sub-views to inherit from. """
         tree_cut_off_view = self.env.context.get("ir_ui_view_tree_cut_off_view")
-        if not tree_cut_off_view:
-            return [('active', '=', True)]
-        else:
-            return ['|', ('active', '=', True), ('id','=', tree_cut_off_view.id)]
+        domain = Domain('active', '=', True)
+        if tree_cut_off_view:
+            return domain | Domain('id', '=', tree_cut_off_view.id)
+        return domain
 
     @api.model
     def _get_filter_xmlid_query(self):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -730,11 +730,11 @@ class ResUsers(models.Model):
 
     @api.model
     def _get_login_domain(self, login):
-        return [('login', '=', login)]
+        return Domain('login', '=', login)
 
     @api.model
     def _get_email_domain(self, email):
-        return [('email', '=', email)]
+        return Domain('email', '=', email)
 
     @api.model
     def _get_login_order(self):


### PR DESCRIPTION
In order to deprecate `odoo.osv`, we must first stop using it and replace it with `Domain`.

task-4280707
odoo/enterprise#83832



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
