### PR TITLE
[REF] hw_drivers: remove idempotency check on action call

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -46,14 +46,6 @@ class DriverController(http.Controller):
         iot_device.data['owner'] = session_id
         data = json.loads(data)
 
-        # Skip the request if it was already executed (duplicated action calls)
-        iot_idempotent_id = data.get("iot_idempotent_id")
-        if iot_idempotent_id:
-            idempotent_session = iot_device._check_idempotency(iot_idempotent_id, session_id)
-            if idempotent_session:
-                _logger.info("Ignored request from %s as iot_idempotent_id %s already received from session %s",
-                             session_id, iot_idempotent_id, idempotent_session)
-                return False
         _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
         iot_device.action(data)
         return True


### PR DESCRIPTION
Idempotency check on action calls was added as a workaround for messages received by the `delivery_iot` model as the server could not directly contact the iot box to print: the server then broadcasted on the client bus, waiting for one client to connect and perform the request through longpolling ([See](https://github.com/odoo/enterprise/pull/36904)).

Since we can use the websocket, we replaced this logic to directly print from the server.

Enterprise PR: [https://github.com/odoo/enterprise/pull/83835](https://github.com/odoo/enterprise/pull/83835)
Task: 4649328
