### PR TITLE
[IMP] server: add a graceful reload option

### DIFF
--- a/odoo/addons/base/tests/config/cli
+++ b/odoo/addons/base/tests/config/cli
@@ -64,6 +64,7 @@
 --dev xml,reload
 --shell-interface ipython
 --stop-after-init
+--graceful-reload
 --osv-memory-count-limit 71
 --transient-age-limit 4
 --max-cron-threads 4

--- a/odoo/addons/base/tests/config/non_default.conf
+++ b/odoo/addons/base/tests/config/non_default.conf
@@ -89,6 +89,7 @@ list_db = False
 dev_mode = xml
 shell_interface = ipython
 stop_after_init = True
+graceful_reload = True
 osv_memory_count_limit = 71
 transient_age_limit = 4.0
 max_cron_threads = 4

--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -115,6 +115,7 @@ class TestConfigManager(TransactionCase):
             'dev_mode': [],
             'shell_interface': None,
             'stop_after_init': False,
+            'graceful_reload': False,
             'osv_memory_count_limit': 0,
             'transient_age_limit': 1.0,
             'max_cron_threads': 2,
@@ -236,6 +237,7 @@ class TestConfigManager(TransactionCase):
             'dev_mode': [],  # blacklist for save, ignored from the config file
             'shell_interface': 'ipython',  # blacklist for save, read from the config file
             'stop_after_init': True,  # blacklist for save, read from the config file
+            'graceful_reload': True,
             'osv_memory_count_limit': 71,
             'transient_age_limit': 4.0,
             'max_cron_threads': 4,
@@ -356,6 +358,7 @@ class TestConfigManager(TransactionCase):
             'save': None,
             'shell_interface': None,
             'stop_after_init': False,
+            'graceful_reload': False,
             'root_path': f'{ROOT_PATH}/odoo',
             'translate_in': '',
             'translate_out': '',
@@ -507,6 +510,7 @@ class TestConfigManager(TransactionCase):
             'dev_mode': ['xml', 'reload'],
             'shell_interface': 'ipython',
             'stop_after_init': True,
+            'graceful_reload': True,
             'osv_memory_count_limit': 71,
             'transient_age_limit': 4.0,
             'max_cron_threads': 4,

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -942,6 +942,11 @@ class PreforkServer(CommonServer):
             if self.graceful_reload and os.environ.get('ODOO_HTTP_SOCKET_FD'):
                 self.socket = socket.fromfd(int(os.environ['ODOO_HTTP_SOCKET_FD']), family, socket.SOCK_STREAM)
 
+            # systemd socket activation
+            elif os.environ.get('LISTEN_FDS') == '1' and os.environ.get('LISTEN_PID') == str(os.getpid()):
+                SD_LISTEN_FDS_START = 3
+                self.socket = socket.fromfd(SD_LISTEN_FDS_START, family, socket.SOCK_STREAM)
+
             # default
             else:
                 self.socket = socket.socket(family, socket.SOCK_STREAM)

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -367,6 +367,9 @@ class configmanager(object):
             group.add_option("--limit-request", dest="limit_request", my_default=2**16,
                              help="Maximum number of request to be processed per worker (default 65536).",
                              type="int")
+            group.add_option("--graceful-reload", dest="graceful_reload", action="store_true", my_default=False,
+                             help="Posix and Prefork mode only, enables a graceful reload option by sending SIGHUP "
+                                  "to the main server PID.")
             parser.add_option_group(group)
 
         # Copy all optparse options (i.e. MyOption) into self.options.
@@ -485,7 +488,7 @@ class configmanager(object):
                 'syslog', 'without_demo', 'screencasts', 'screenshots',
                 'dbfilter', 'log_level', 'log_db',
                 'log_db_level', 'geoip_city_db', 'geoip_country_db', 'dev_mode',
-                'shell_interface', 'limit_time_worker_cron',
+                'shell_interface', 'limit_time_worker_cron', 'graceful_reload',
         ]
 
         for arg in keys:


### PR DESCRIPTION
Before, the only reload option that existed was the `server_phoenix` mode that reexecuted the server upon receival of the SIGHUP signal. This came with a consequential downtime while the server was restarting.

We introduce the new flag

    --graceful-reload

when starting odoo-bin that allows to reload the server with no downtime. (POSIX + Prefork mode)

When this flag is set and a SIGHUP signal is sent to the main server, it will initiate the shutdown procedure in a separate process that will first wait until the main process has finished restarting and is ready to handle new incoming HTTP requests.

The reexecuted server will reuse the same socket to ensure no connections are dropped and notify its stopping fork with a SIGHUP signal, which will then proceed with the shutdown procedure. It will not be able to reap the children processes, so it will monitor them closely in a slightly different way. The newly restarted server will reap them without consequence.

Note: the gevent longpolling server is not handled gracefully and a very unlikely race condition could put a traceback in the logs should the longpolling server start before it's stopped (address already in use), but it'll retry to start it continuously so it won't cause any issue.

We also add support for systemd's socket activation with the prefork server.