### PR TITLE
[FIX] event_sale: better hook state for sending mails

### DIFF
--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -135,6 +135,17 @@ class EventRegistration(models.Model):
                 views_or_xmlid='event_sale.event_ticket_id_change_exception',
                 render_context=render_context)
 
+    def _compute_field_value(self, field):
+        if field.name != 'state':
+            return super()._compute_field_value(field)
+
+        unconfirmed = self.filtered(lambda reg: reg.ids and reg.state in {'draft', 'cancel'})
+        res = super()._compute_field_value(field)
+        confirmed = unconfirmed.filtered(lambda reg: reg.state == 'open')
+        if confirmed:
+            confirmed._update_mail_schedulers()
+        return res
+
     def _get_registration_summary(self):
         res = super(EventRegistration, self)._get_registration_summary()
         res.update({

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -23,11 +23,7 @@ class SaleOrder(models.Model):
         return result
 
     def action_confirm(self):
-        unconfirmed_registrations = self.order_line.registration_ids.filtered(
-            lambda reg: reg.state in ["draft", "cancel"]
-        )
         res = super(SaleOrder, self).action_confirm()
-        unconfirmed_registrations._update_mail_schedulers()
 
         for so in self:
             if not any(line.service_tracking == 'event' for line in so.order_line):

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -329,6 +329,8 @@ class TestEventSaleMail(TestEventFullCommon):
 
         with self.mock_mail_gateway():
             self.customer_so.action_confirm()
+            # mail send is done when writing state value, hence flushing for the test
+            registration.flush_recordset()
         self.assertEqual(self.customer_so.state, "sale")
         self.assertEqual(registration.state, "open")
 


### PR DESCRIPTION
Registration mails can be send when registration is confirmed. However when event_sale is installed state becomes a computed field depending on sale order status. This means write override is not called to send mails. A fix has been done in order to send mails at SO confirm but this is known to be error prone and may cause concurrent update errors.

Instead, correctly hook '_compute_field_value' so that state change is watched in order to trigger mails.

Note that pos_event does weird things in '_compute_registration_status' but state is not a compute field in that module. Probably to cleanup at some point.

Improved version of odoo/odoo#164430
