### PR TITLE
[IMP] hw_drivers: notify event also via websocket

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import logging
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
+from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.tools.helpers import toggleable
+
+_logger = logging.getLogger(__name__)
 
 
 class Driver(Thread):
@@ -44,9 +47,17 @@ class Driver(Thread):
     def action(self, data):
         """Helper function that calls a specific action method on the device.
 
-        :param dict data: the `_actions` key mapped to the action method we want to call
+        :param dict data: the action method name and the parameters to be passed to it
+        :return: the result of the action method
         """
-        self._actions[data.get('action', '')](data)
+        action = data.get('action', '')
+        try:
+            response = {'status': 'success', 'result': self._actions[action](data), 'action_args': {**data}}
+        except Exception as e:
+            _logger.exception("Error while executing action %s with params %s", action, data)
+            response = {'status': 'error', 'result': str(e), 'action_args': {**data}}
+
+        event_manager.device_changed(self, response)  # Make response available to /event route or websocket
 
     def disconnect(self):
         self._stopped.set()

--- a/addons/hw_drivers/event_manager.py
+++ b/addons/hw_drivers/event_manager.py
@@ -6,45 +6,69 @@ from threading import Event
 import time
 
 from odoo.http import request
+from odoo.addons.hw_drivers.tools import helpers
+from odoo.addons.hw_drivers.websocket_client import send_to_controller
 
 class EventManager(object):
     def __init__(self):
         self.events = []
         self.sessions = {}
 
-    def _delete_expired_sessions(self, max_time=70):
-        '''
-        Clears sessions that are no longer called.
+    def _delete_expired_sessions(self, ttl=70):
+        """Clear sessions that are no longer called.
 
-        :param max_time: time a session can stay unused before being deleted
-        '''
-        now = time.time()
-        expired_sessions = [
-            session
+        :param int ttl: time a session can stay unused before being deleted
+        """
+        self.sessions = {
+            session: self.sessions[session]
             for session in self.sessions
-            if now - self.sessions[session]['time_request'] > max_time
-        ]
-        for session in expired_sessions:
-            del self.sessions[session]
+            if self.sessions[session]['time_request'] + ttl < time.time()
+        }
 
     def add_request(self, listener):
-        self.session = {
-            'session_id': listener['session_id'],
+        """Create a new session for the listener.
+        :param dict listener: listener id and devices
+        :return: the session created
+        """
+        session_id = listener['session_id']
+        session = {
+            'session_id': session_id,
             'devices': listener['devices'],
             'event': Event(),
             'result': {},
             'time_request': time.time(),
         }
         self._delete_expired_sessions()
-        self.sessions[listener['session_id']] = self.session
-        return self.sessions[listener['session_id']]
 
-    def device_changed(self, device):
+        self.sessions[session_id] = session
+        return session
+
+    def device_changed(self, device, data=None):
+        """Register a new event.
+
+        If ``data`` is provided, it means that the caller is the action method,
+        it will be used as the event data (instead of the one provided by the request).
+
+        :param Driver device: actual device class
+        :param dict data: data returned by the device (optional)
+        """
+        if data:
+            # Notify via websocket
+            send_to_controller({
+                'session_id': data.get('action_args', {}).get('session_id', ''),
+                'iot_box_identifier': helpers.get_mac_address(),
+                'device_identifier': device.device_identifier,
+                **data,
+            })
+        else:
+            data = json.loads(request.params['data']) if request and 'data' in request.params else {}
+
+        # Make notification available to longpolling event route
         event = {
             **device.data,
             'device_identifier': device.device_identifier,
             'time': time.time(),
-            'request_data': json.loads(request.params['data']) if request and 'data' in request.params else None,
+            **data,
         }
         self.events.append(event)
         for session in self.sessions:
@@ -54,7 +78,7 @@ class EventManager(object):
                 and not self.sessions[session]['event'].is_set()
             ):
                 if device.device_type in session_devices:
-                    event['device_identifier'] = device.device_type  # allow to use device type as identifier
+                    event['device_identifier'] = device.device_type  # allow device type as identifier (longpolling)
                 self.sessions[session]['result'] = event
                 self.sessions[session]['event'].set()
 

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -12,7 +12,6 @@ import werkzeug
 from odoo import http
 from odoo.addons.hw_drivers.browser import Browser, BrowserState
 from odoo.addons.hw_drivers.driver import Driver
-from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers, route
 from odoo.addons.hw_drivers.tools.helpers import Orientation
@@ -118,7 +117,6 @@ class DisplayDriver(Driver):
 
         orientation = data.get('orientation', 'NORMAL').upper()
         self.set_orientation(Orientation[orientation])
-        event_manager.device_changed(self)
 
     def _action_open_customer_display(self, data):
         if self.device_identifier == 'distant_display' or not data.get('pos_id') or not data.get('access_token'):

--- a/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/KeyboardUSBDriver_L.py
@@ -7,7 +7,6 @@ import json
 import logging
 from lxml import etree
 import os
-from pathlib import Path
 from queue import Queue, Empty
 import re
 import requests
@@ -215,7 +214,6 @@ class KeyboardUSBDriver(Driver):
 
     def _action_default(self, data):
         self.data['value'] = ''
-        event_manager.device_changed(self)
 
     def _is_scanner(self):
         """Read the device type from the saved filed and set it as current type.

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -19,7 +19,6 @@ from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.iot_handlers.interfaces.PrinterInterface_L import PPDs, conn, cups_lock
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers, wifi, route
-from odoo.addons.hw_drivers.websocket_client import send_to_controller
 
 _logger = logging.getLogger(__name__)
 
@@ -357,7 +356,6 @@ class PrinterDriver(Driver):
         else:
             title, body = self._printer_status_content()
             self.print_raw(title + b'\r\n' + body.decode().replace('\n', '\r\n').encode())
-        event_manager.device_changed(self)
 
     def print_status_receipt(self):
         """Prints the status ticket of the IoT Box on the current printer."""
@@ -442,8 +440,7 @@ class PrinterDriver(Driver):
     def _action_default(self, data):
         _logger.debug("_action_default called for printer %s", self.device_name)
         self.print_raw(b64decode(data['document']))
-        event_manager.device_changed(self)
-        send_to_controller(self.connection_type, {'print_id': data['print_id'], 'device_identifier': self.device_identifier})
+        return {'print_id': data['print_id']}
 
 
 class PrinterController(http.Controller):

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -14,7 +14,6 @@ from odoo.addons.hw_drivers.event_manager import event_manager
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers
 from odoo.tools.mimetypes import guess_mimetype
-from odoo.addons.hw_drivers.websocket_client import send_to_controller
 
 _logger = logging.getLogger(__name__)
 
@@ -187,9 +186,8 @@ class PrinterDriver(Driver):
             self.print_report(document)
         else:
             self.print_raw(document)
-        event_manager.device_changed(self)
-        send_to_controller(self.connection_type, {'print_id': data['print_id'], 'device_identifier': self.device_identifier})
         _logger.debug("_action_default finished with mimetype %s for printer %s", mimetype, self.device_name)
+        return {'print_id': data['print_id']}
 
 
     def print_status(self, _data=None):
@@ -204,7 +202,6 @@ class PrinterDriver(Driver):
             self.print_raw("^XA^CI28 ^FT35,40 ^A0N,30 ^FDIoT Box Test Label^FS^XZ".encode())
         else:
             self.print_raw("IoT Box Test Page".encode())
-        event_manager.device_changed(self)
 
 
 proxy_drivers['printer'] = PrinterDriver

--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -81,7 +81,6 @@ class SerialDriver(Driver):
         """Updates the current status and pushes it to the frontend."""
 
         self.data['status'] = self._status
-        event_manager.device_changed(self)
 
     def _set_name(self):
         """Tries to build the device's name based on its type and protocol name but falls back on a default name if that doesn't work."""

--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -123,7 +123,6 @@ class ScaleDriver(SerialDriver):
 
         self._read_weight()
         self.last_sent_value = self.data['value']
-        event_manager.device_changed(self)
 
     @staticmethod
     def _get_raw_response(connection):

--- a/addons/hw_drivers/websocket_client.py
+++ b/addons/hw_drivers/websocket_client.py
@@ -17,20 +17,15 @@ websocket.enableTrace(True, level=logging.getLevelName(_logger.getEffectiveLevel
 
 
 @helpers.require_db
-def send_to_controller(device_type, params, server_url=None):
+def send_to_controller(params, server_url=None):
     """Confirm the operation's completion by sending a response back to the Odoo server
 
-    :param device_type: the type of device that the operation was performed on
     :param params: the parameters to send back to the server
     :param server_url: URL of the Odoo server (provided by decorator).
     """
-    routes = {
-        "printer": "/iot/printer/status",
-    }
     params['iot_mac'] = helpers.get_mac_address()
-    server_url += routes[device_type]
     try:
-        response = requests.post(server_url, json={'params': params}, timeout=5)
+        response = requests.post(server_url + "/iot/box/send_websocket", json={'params': params}, timeout=5)
         response.raise_for_status()
     except requests.exceptions.RequestException:
         _logger.exception('Could not reach confirmation status URL: %s', server_url)
@@ -62,7 +57,7 @@ def on_message(ws, messages):
             if iot_mac in payload['iotIdentifiers']:
                 helpers.disconnect_from_server()
                 close_server_log_sender_handler()
-        elif message_type not in ['print_confirmation', 'bundle_changed']:  # intended to be ignored
+        elif message_type not in ['operation_confirmation', 'bundle_changed']:  # intended to be ignored
             _logger.warning("message type not supported: %s", message_type)
 
 


### PR DESCRIPTION
Before this commit, every action called through websocket between a db and an IoT Box had its response available only though the longpolling `event` route.

Now, every event is also sent through websocket.

Additionally, every action now registers an event to check (at least) if the operation has completed.

Enterprise PR: [https://github.com/odoo/enterprise/pull/83843](https://github.com/odoo/enterprise/pull/83843)
