### PR TITLE
[FIX] website_slides: All Courses result dropdown below search


### DIFF
--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -251,7 +251,7 @@
                         </div>
                         <!-- Search box (desktop) -->
                         <t t-call="website.website_search_box_input">
-                            <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-flex"/>
+                            <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right d-none d-md-block"/>
                             <t t-set="search_type" t-valuef="slides"/>
                             <!-- No action: remain on same URL -->
                             <t t-set="display_description" t-valuef="true"/>


### PR DESCRIPTION

Scenario: go to homepage > Courses > one "View all" > type in search

Result: dropdown with result is shown over the search input

Issue: search form is in flex layout, but the dropdown is displayed
in absolute so it is outside of flex flow and is positionned at the
top-right of the form container.

History:

- before bootstrap 4 (odoo 15): the search form had a flex layout, but
  bootstrap dropdown used "top:100%" so were positionned at the bottom
  of it.

- as of bootstrap 5 (odoo 16): the form kept a flex layout, but
  bootstrap dropdown now used "position: absolute" with unset top
  putting them below the search item in a block container, but over
  it in a flex layout.

Fix: when the search bar is displayed, display it as block.

opw-4735257
