### PR TITLE
[FIX] pos, pos_loyalty: hide special products when no regular ones are available

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -2268,6 +2268,14 @@ export class PosStore extends WithLazyGetterTrap {
         ].filter(Boolean);
     }
 
+    areAllProductsSpecial(products) {
+        const specialDisplayProductIds = this.session._pos_special_display_products_ids || [];
+        return (
+            specialDisplayProductIds.length >= products.length &&
+            products.every((product) => specialDisplayProductIds.includes(product.id))
+        );
+    }
+
     get productsToDisplay() {
         const searchWord = this.searchProductWord.trim();
         const allProducts = this.models["product.template"].getAll();
@@ -2299,6 +2307,10 @@ export class PosStore extends WithLazyGetterTrap {
         list = list
             .filter((product) => !excludedProductIds.includes(product.id) && product.canBeDisplayed)
             .slice(0, 100);
+
+        if (this.areAllProductsSpecial(list)) {
+            return [];
+        }
 
         return searchWord !== ""
             ? list.sort((a, b) => b.is_favorite - a.is_favorite)

--- a/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/product_screen_util.js
@@ -875,3 +875,17 @@ export function longPressProduct(productName) {
         },
     ];
 }
+
+export function isEmpty() {
+    return {
+        content: "Verify that the Product Screen is empty",
+        trigger: ".product-screen:not(:has(.product-list))",
+    };
+}
+
+export function loadSampleButtonIsThere() {
+    return {
+        content: "Click Load Sample",
+        trigger: ".product-screen .o_nocontent_help button:contains('Load Sample')",
+    };
+}

--- a/addons/pos_loyalty/models/product_template.py
+++ b/addons/pos_loyalty/models/product_template.py
@@ -20,6 +20,20 @@ class ProductTemplate(models.Model):
         missing_product_templates = self.env['product.template'].browse(missing_product_tmpl_ids).read(fields=fields, load=False)
         product_ids_to_hide = reward_products.product_tmpl_id - self.env['product.template'].browse(already_loaded_product_tmpl_ids)
         data['pos.session'][0]['_pos_special_products_ids'] += product_ids_to_hide.product_variant_id.ids
+
+        # Identify special loyalty products (e.g., gift cards, e-wallets) to be displayed in the POS
+        loyality_products = config_id.get_record_by_ref([
+            'loyalty.gift_card_product_50',
+            'loyalty.ewallet_product_50',
+        ])
+        special_display_products = self.env['product.product'].browse(loyality_products)
+        # Include trigger products from loyalty programs of type 'gift_card' or 'ewallet'
+        special_display_products += self.env['loyalty.program'].search([
+            ('program_type', 'in', ['gift_card', 'ewallet']),
+            ('pos_config_ids', 'in', [False, config_id.id]),
+        ]).trigger_product_ids
+
+        data['pos.session'][0]['_pos_special_display_products_ids'] = special_display_products.product_tmpl_id.ids
         res.extend(missing_product_templates)
 
         return res

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -174,3 +174,13 @@ registry.category("web_tour.tours").add("test_physical_gift_card_invoiced", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("EmptyProductScreenTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.isEmpty(),
+            ProductScreen.loadSampleButtonIsThere(),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -7,6 +7,7 @@ from odoo.tests import tagged
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
+from odoo.addons.point_of_sale.tests.common import archive_products
 
 
 @tagged("post_install", "-at_install")
@@ -2691,3 +2692,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(len(gift_card_program.coupon_ids), 1, "Gift card not generated")
         self.assertEqual(gift_card_program.coupon_ids[0].code, "test-card-1234", "Gift card code not correct")
         self.assertEqual(gift_card_program.coupon_ids[0].partner_id, partner, "Gift card partner id not correct")
+
+    def test_empty_product_screen_when_no_regular_products(self):
+        """
+        Verify that the product screen remains empty when no regular products are available,
+        ensuring that special products are hidden.
+        """
+        archive_products(self.env)
+        self.env.ref('loyalty.gift_card_product_50').product_tmpl_id.write({'active': True})
+        self.create_programs([('Special Gift Card Program', 'gift_card')])
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("EmptyProductScreenTour")


### PR DESCRIPTION
**Before this commit:**
=======
In a non-demo db with the loyalty module, loading sample data was not possible. Only special products (e.g., gift card, top-up eWallet) were shown, which caused the "Load Sample Data" button to be hidden.
![image](https://github.com/user-attachments/assets/b933d1cc-ea5f-4623-b3e0-05c5b5b55fbb)

**After this commit:**
=======
Hide the special products when no regular products are available. allowing the "Load Sample Data" button to remain visible.
![image](https://github.com/user-attachments/assets/e6446b40-83e2-46d2-b857-c4348603d82f)

Task: 4743089
