### PR TITLE
[IMP] project: align sub-task order across form and kanban views

### DIFF
--- a/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
+++ b/addons/project/static/src/components/subtask_kanban_list/subtask_kanban_list.js
@@ -47,8 +47,7 @@ export class SubtaskKanbanList extends Component {
             this.state.prevSubtaskCount = currentCount;
             this.state.isLoad = false;
             this.state.subtasks = this.list.records
-                .filter((subtask) => !["1_done", "1_canceled"].includes(subtask.data.state))
-                .sort((a, b) => a.resId - b.resId);
+                .filter((subtask) => !["1_done", "1_canceled"].includes(subtask.data.state));
         }
         return this.state.subtasks;
     }
@@ -94,11 +93,15 @@ export class SubtaskKanbanList extends Component {
                 type: "danger",
             });
         } else {
+            const sequences = this.list.records.map(r => r.data.sequence);
+            const nextSequence = (sequences.length ? Math.max(...sequences) : 0) + 1;
+
             await this.orm.create("project.task", [{
                 display_name: name,
                 parent_id: this.props.record.resId,
                 project_id: this.props.record.data.project_id.id,
                 user_ids: this.props.record.data.user_ids.resIds,
+                sequence: nextSequence,
             }]);
             this.subtaskCreate.open = false;
             this.subtaskCreate.name = "";

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_model.js
@@ -17,7 +17,7 @@ export class ProjectTaskRecord extends Record {
     }
 
     async toggleSubtasksList() {
-        const { display_name, project_id, state, user_ids } = this.config.fields;
+        const { display_name, project_id, state, user_ids, sequence } = this.config.fields;
         const activeField = makeActiveField({ onChange: true });
         activeField.related = {
             activeFields: {
@@ -25,12 +25,14 @@ export class ProjectTaskRecord extends Record {
                 state: makeActiveField(),
                 user_ids: makeActiveField(),
                 project_id: makeActiveField(),
+                sequence: makeActiveField(),
             },
             fields: {
                 display_name,
                 project_id,
                 state,
                 user_ids,
+                sequence,
             },
         };
         await this._load({

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -70,6 +70,7 @@ export class ProjectTask extends models.Model {
         relation_field: "parent_id",
     });
     subtask_count = fields.Integer();
+    sequence = fields.Integer({ string: "Sequence", default: 10 });
     closed_subtask_count = fields.Integer();
     project_id = fields.Many2one({ relation: "project.project", falsy_value_label: "🔒 Private" });
     display_in_project = fields.Boolean({ default: true });

--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -93,6 +93,7 @@ beforeEach(() => {
                 <field name="project_id"/>
                 <field name="closed_subtask_count"/>
                 <field name="child_ids"/>
+                <field name="sequence"/>
                 <field name="user_ids"/>
                 <field name="state"/>
                 <templates>
@@ -216,13 +217,15 @@ test("project.task (kanban): check subtask creation", async () => {
             expect.step(`${model}/${method}`);
         }
         if (model === "project.task" && method === "create") {
-            const [{ display_name, parent_id }] = args[0];
+            const [{ display_name, parent_id, sequence }] = args[0];
             expect(display_name).toBe("New Subtask");
             expect(parent_id).toBe(1);
+            expect(sequence).toBe(11, { message: "Sequence should be 11" });
             const newSubtaskId = MockServer.env["project.task"].create({
                 name: display_name,
                 parent_id,
                 state: "01_in_progress",
+                sequence: sequence,
             });
             MockServer.env["project.task"].write(parent_id, {
                 child_ids: [Command.link(newSubtaskId)],


### PR DESCRIPTION
Issue:
---------
   Sub-tasks are not displayed in the same sequence in the Form and Kanban views.

Reason:
------
   1) When a sub-task is created from the Kanban view, it was being assigned the default sequence.
   2) Additionally, the Kanban view was sorting based on the res_id instead of the sequence field.

Steps to Reproduce:
-------------
   - Install the Project module.
  - Create a Project and a Task.
  - Open the Task Form View.
  - Navigate to the Sub-tasks tab.
  - Add two sub-tasks.
  - Manually change the sequence of the sub-tasks.
  - Return to the Kanban view.
  - Open the Sub-task List View.
  - Add a new sub-task from the Kanban view.

Fix:
-----
   We now set the maximum sequence when a new sub-task is created from the Kanban view, ensuring it appears at the end of the list. Also, we removed the sorting based on res_id to ensure consistency across views.

task-4572316