### PR TITLE
[FIX] mail: prevent error while loading progress bar in CRM pipeline

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -256,6 +256,11 @@ class MailActivityMixin(models.AbstractModel):
             return super()._read_group_groupby(groupby_spec, query)
         self._check_field_access(self._fields['activity_state'], 'read')
 
+        # if already grouped by activity_state, do not add the join again
+        alias = query.make_alias(self._table, 'last_activity_state')
+        if alias in query._joins:
+            return SQL.identifier(alias, 'activity_state')
+
         self.env['mail.activity'].flush_model(['res_model', 'res_id', 'user_id', 'date_deadline'])
         self.env['res.users'].flush_model(['partner_id'])
         self.env['res.partner'].flush_model(['tz'])


### PR DESCRIPTION
Currently, an error occurs when users attempt to group by records by **Activity State** in the CRM pipeline kanban view.

**Steps to reproduce:**
- Install the `crm` module.
- Open the CRM pipeline kanban view.
- Group records by Activity State.
- Observe the error.

**Error:** `AssertionError`

The issue occurs when attempting to add a  LEFT JOIN on an SQL query without verifying whether it has already been included. - [1]

The method `_read_group_groupby` is called twice because the `activity_state` field is used both as a progress bar field at [2] and as a manual group by option in the Kanban view by the user.

[1] - https://github.com/odoo/odoo/blob/6edf0ba80818fc23b8daf46d694d201e0efee133/addons/mail/models/mail_activity_mixin.py#L284

[2] - https://github.com/odoo/odoo/blob/5c4e0826528ec88ea7a180a3598e7f225346bc49/addons/crm/views/crm_lead_views.xml#L505-L507

This commit adds a check to ensure that the join is only added once, preventing redundant joins.

Sentry - 6545651193