### PR TITLE
[FIX] hr_expense: prevent error on opening module expenses

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -947,7 +947,7 @@ class HrExpense(models.Model):
     @api.model
     def _get_empty_list_mail_alias(self):
         use_mailgateway = self.env['ir.config_parameter'].sudo().get_param('hr_expense.use_mailgateway')
-        expense_alias = self.env.ref('hr_expense.mail_alias_expense') if use_mailgateway else False
+        expense_alias = self.env.ref('hr_expense.mail_alias_expense', raise_if_not_found=False) if use_mailgateway else False
         if expense_alias and expense_alias.alias_domain and expense_alias.alias_name:
             # encode, but force %20 encoding for space instead of a + (URL / mailto difference)
             params = werkzeug.urls.url_encode({'subject': _("Lunch with customer $12.32")}).replace('+', '%20')


### PR DESCRIPTION
This error occurs when the user deletes the email alias expense `hr_expense.mail_alias_expense`.

Steps to Reproduce:

1. Install the module `hr_expense`.
2. Go to Setting > Technical > Email > Aliases and delete `Expense`.
3. Open Expenses.

`ValueError: External ID not found in the system: hr_expense.mail_alias_expense`

This error occurs when the system is unable to fetch hr_expense.mail_alias_expense ID while opening the module `Expenses`.

This commit ensures that if the ID does not exist, the function will return None instead of raising an exception.

Sentry: 6559233309