### PR TITLE
[IMP] web: time_picker: resize time dropdown to fit content

### DIFF
--- a/addons/web/static/src/core/time_picker/time_picker.scss
+++ b/addons/web/static/src/core/time_picker/time_picker.scss
@@ -14,8 +14,8 @@
 }
 
 .o_time_picker_dropdown.o-dropdown--menu {
+    --dropdown-min-width: unset;
     max-height: 15rem;
-    max-width: 6rem;
 }
 
 .o_datetime_picker .o_time_picker {


### PR DESCRIPTION
Before this commit, the width of the time picker dropdown was too big. In this commit, we avoid the value defined by Bootstrap variables defined as following :
´$dropdown-min-width: 10rem !default;´

Now we have a min-width of 0.

task-4661489

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
