### PR TITLE
[IMP] purchase: vendor currency on vendor pricerules

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -25,7 +25,7 @@ class ProductSupplierinfo(models.Model):
     product_uom_id = fields.Many2one(
         'uom.uom', 'Unit', compute='_compute_product_uom_id', store=True, readonly=False, required=True, precompute=True)
     min_qty = fields.Float(
-        'Quantity', default=0.0, required=True, digits="Product Unit",
+        'Quantity', default=1.0, required=True, digits="Product Unit",
         help="The quantity to purchase from this vendor to benefit from the unit price. If a vendor unit is set, quantity should be specified in this unit, otherwise it should be specified in the default unit of the product.")
     price = fields.Float(
         'Unit Price', digits='Product Price', default=0.0, help="The price to purchase a product")

--- a/addons/product/views/product_supplierinfo_views.xml
+++ b/addons/product/views/product_supplierinfo_views.xml
@@ -106,10 +106,10 @@
                 <field name="date_end" optional="hide"/>
                 <field name="company_id" readonly="1" groups="base.group_multi_company"/>
                 <field name="min_qty" optional="hide"/>
-                <field name="product_uom_id" groups="uom.group_uom" optional="show" options="{'no_quick_create': True}" context="{'product_id': product_id}" widget="many2one_uom"/>
-                <field name="price"/>
+                <field name="product_uom_id" groups="uom.group_uom" optional="show" options="{'no_quick_create': True, 'no_open': True}" context="{'product_id': product_id}" widget="many2one_uom"/>
+                <field name="price" widget="monetary"/>
                 <field name="discount" optional="hide"/>
-                <field name="currency_id" groups="base.group_multi_currency"/>
+                <field name="currency_id" groups="base.group_multi_currency" optional="hide"/>
                 <field name="delay" optional="show"/>
             </list>
         </field>

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -52,3 +52,9 @@ class ResPartner(models.Model):
             stat_info = {'iconClass': 'fa-credit-card', 'value': partner.purchase_order_count, 'label': _('Purchases')}
             data_list[partner.id].append(stat_info)
         return data_list
+
+    def write(self, vals):
+        res = super().write(vals)
+        if 'property_purchase_currency_id' in vals:
+            self.env['product.supplierinfo'].search([('partner_id', 'in', self.ids)]).currency_id = vals.get('property_purchase_currency_id')
+        return res


### PR DESCRIPTION
With this commit
================================

- Update existing vendor pricelist rules to match the vendor’s currency
  when the currency changes, ensuring consistency.
- Prevent clicking on the unit of measure field in vendor pricelist rules.
- Set the default value of the quantity field to 1 instead of 0.

Task: 4681118