### PR TITLE
[FIX] web, html_editor: traceback when navigating in custom colorpicker

### DIFF
--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -613,6 +613,34 @@ test("solid tab color navigation using keys", async () => {
     expect(getContent(el)).toBe(`<p><font style="color: rgb(0, 0, 0);">[test]</font></p>`);
 });
 
+test("custom tab color navigation using keys", async () => {
+    const { el } = await setupEditor("<p>[test]</p>");
+    await expandToolbar();
+    await click(".o-we-toolbar .o-select-color-foreground");
+    await animationFrame();
+    await press("Tab");
+    expect(getActiveElement()).toBe(queryFirst('.o_font_color_selector button:contains("Custom")'));
+    await press("Enter");
+    await animationFrame();
+    expect(".btn:contains('Custom')").toHaveClass("active");
+    await press("Tab");
+    await press("Tab");
+    await press("Tab");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="#374151"]')
+    );
+    await press("ArrowDown");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="black"]')
+    );
+    await press("ArrowDown");
+    expect(getActiveElement()).toBe(
+        queryFirst('.o_font_color_selector button[data-color="black"]') // Should do nothing
+    );
+    await press("Enter");
+    expect(getContent(el)).toBe(`<p><font class="text-black">[test]</font></p>`);
+});
+
 describe.tags("desktop");
 describe("color preview", () => {
     test("preview color should work and be reverted", async () => {

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -146,9 +146,9 @@ export class ColorPicker extends Component {
                 key === "ArrowUp"
                     ? target.parentElement.previousElementSibling
                     : target.parentElement.nextElementSibling;
-            targetBtn =
-                row?.matches(".o_color_section, .o_colorpicker_section") &&
-                row.children[buttonIndex];
+            if (row?.matches(".o_color_section, .o_colorpicker_section")) {
+                targetBtn = row.children[buttonIndex];
+            }
         }
         if (targetBtn?.classList.contains("o_color_button")) {
             targetBtn.focus();


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Select some text.
- Open colorpicker from toolbar, switch to custom colorpicker.
- Press tab 3 times to focus a color button.
- Pressing ArrowDown twice leads to traceback.

The issue happens because in `colorPickerNavigation` method, targetBtn assigns `false` value when row doesn't match the selector. As a result, accessing `targetBtn?.classList.contains` because `false` is not a valid value for optional chaining.

**Desired behaviour after PR is merged:**

Now, If no valid target button is found, focus remains on the current button and no error occurs.

task-4743633



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
