### PR TITLE
[FIX] google_address_autocomplete: re-enable placeholder support

### DIFF
--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -147,8 +147,9 @@ export const addressAutoComplete = {
             }
         })
     ],
-    extractProps: ({ attrs, options }) => {
-        const props = charField.extractProps({attrs, options});
+    extractProps: (fieldInfo, dynamicInfo) => {
+        const { options } = fieldInfo;
+        const props = charField.extractProps(fieldInfo, dynamicInfo);
         const addressFieldMap = {};
         Object.keys(standardAddressFields).forEach((fname) => {
             const optionValue = options[fname];


### PR DESCRIPTION
After commit 752d159aa7b79344ff7b513ec9838a902f08ce9d, the google_address_autocomplete field widget did not support placeholder anymore.

This commit fixes this.

opw-4713685

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
