### PR TITLE
[IMP] hr_skills_slides: avoid restore of resume line on course changes

### DIFF
--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from markupsafe import Markup
@@ -10,8 +9,10 @@ from odoo.tools import html2plaintext
 class SlideChannelPartner(models.Model):
     _inherit = 'slide.channel.partner'
 
-    def _recompute_completion(self):
-        res = super(SlideChannelPartner, self)._recompute_completion()
+    def _post_completion_update_hook(self, completed=True):
+        res = super()._post_completion_update_hook(completed)
+        if not completed:
+            return res
         completed_membership = self.filtered(lambda m: m.member_status == 'completed')
         if not completed_membership:
             return res

--- a/addons/hr_skills_slides/tests/__init__.py
+++ b/addons/hr_skills_slides/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_hr_skills_slides

--- a/addons/hr_skills_slides/tests/test_hr_skills_slides.py
+++ b/addons/hr_skills_slides/tests/test_hr_skills_slides.py
@@ -1,0 +1,74 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests.common import TransactionCase
+
+
+class TestHrSkillsSlides(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = mail_new_test_user(
+            cls.env,
+            email='officer@example.com',
+            groups='base.group_user,website_slides.group_website_slides_officer',
+            login='user_officer',
+            name='Ophélie Officer',
+            notification_type='email',
+        )
+        cls.employee = cls.env['hr.employee'].create([{
+            'name': 'Test employee',
+            'user_id': cls.user.id,
+        }])
+        cls.channel = cls.env['slide.channel'].with_user(cls.user).create({
+            'name': 'Test Channel',
+            'channel_type': 'documentation',
+            'promote_strategy': 'most_voted',
+            'enroll': 'public',
+            'visibility': 'public',
+            'is_published': True,
+            'karma_gen_channel_finish': 100,
+            'karma_gen_channel_rank': 10,
+        })
+        cls.slide = cls.env['slide.slide'].with_user(cls.user).create({
+            'name': 'How To Cook Humans',
+            'channel_id': cls.channel.id,
+            'slide_category': 'document',
+            'is_published': True,
+            'completion_time': 2.0,
+            'sequence': 1,
+        })
+
+    def test_add_resume_line_after_complete(self):
+        """
+        Ensure that a resume line is added after that a eLearning course has been completed.
+        """
+        self.channel.sudo()._action_add_members(self.user.partner_id)
+        self.env['slide.slide.partner'].create([{
+            'channel_id': self.channel.id,
+            'completed': True,
+            'partner_id': self.user.partner_id.id,
+            'slide_id': self.slide.id,
+        }])
+        self.assertEqual(len(self.employee.resume_line_ids), 2)  # Course line + current position
+        resume_line = self.employee.resume_line_ids.filtered(lambda rl: rl.channel_id)
+        self.assertEqual(resume_line.channel_id.id, self.channel.id)
+        self.assertEqual(resume_line.course_url, self.channel.website_absolute_url)
+
+    def test_remove_resume_line_no_readd(self):
+        """
+        Ensure that a eLearning resume line that is removed is not re-added when the course changes.
+        """
+        self.channel.sudo()._action_add_members(self.user.partner_id)
+        channel_partner = self.env['slide.slide.partner'].create([{
+            'channel_id': self.channel.id,
+            'completed': True,
+            'partner_id': self.user.partner_id.id,
+            'slide_id': self.slide.id,
+        }])
+        resume_line = self.employee.resume_line_ids.filtered(lambda rl: rl.channel_id)
+        self.assertEqual(resume_line.channel_id.id, self.channel.id)
+        resume_line.unlink()
+        channel_partner._recompute_completion()
+        self.assertEqual(len(self.employee.resume_line_ids), 1)  # Only current position


### PR DESCRIPTION
When an eLearning course is completed, a resume line for that course is added. Currently, the used method has no idea if the course was already completed or completed for the first time. This results in some situations where the resume line is re-added upon course changes (e.g. adding some content) even if the user deleted it beforehand.

To solve this issue, the method used is not the post completion update hook, which is only called the first time a course is completed. That way, the resume line will still be removed if the user decides to remove it, even if the course completion is recomputed.

task-4737314
