### PR TITLE
[FIX] web: Chrome 135 + HOOT ; click or not click, that is the question

### DIFF
--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -12985,7 +12985,8 @@ test("Keep scrollTop when loading records with load more", async () => {
     const clickKanbanLoadMoreButton = queryFirst(".o_kanban_load_more button");
     clickKanbanLoadMoreButton.scrollIntoView();
     const previousScrollTop = queryOne(".o_content").scrollTop;
-    await contains(clickKanbanLoadMoreButton).click();
+    clickKanbanLoadMoreButton.click();
+    await animationFrame();
     expect(previousScrollTop).not.toBe(0, { message: "Should not have the scrollTop value at 0" });
     expect(queryOne(".o_content").scrollTop).toBe(previousScrollTop);
 });


### PR DESCRIPTION
Since Chrome 135, the "Keep scrollTop when loading records with load
more" unit test fails with a scrolling value way higher than expected.
In practice, the scroll in the test goes down to the "Load more" button
after it has been clicked instead of keeping scroll to the same value as
before the loading of the "more" items. Weirdly, it doesn't look to be
an actual issue when performed by the user, but only in the test suite.

This commit works around that issue by using `element.click()` followed
by waiting for an animation frame instead of using `contains().click()`,
because... well, the two helpers behave slightly differently. 🤷