### PR TITLE
[IMP] account*: use Domain

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 
 from odoo import _, fields, http
 from odoo.exceptions import AccessError, MissingError
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 
 from odoo.addons.account.controllers.download_docs import _build_zip_from_data, _get_headers
 from odoo.addons.portal.controllers.portal import CustomerPortal
@@ -52,7 +52,7 @@ class PortalAccount(CustomerPortal):
             move_type = [m_type+move for move in ('_invoice', '_refund', '_receipt')]
         else:
             move_type = ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
-        return [('state', 'not in', ('cancel', 'draft')), ('move_type', 'in', move_type)]
+        return Domain('state', 'not in', ('cancel', 'draft')) & Domain('move_type', 'in', move_type)
 
     def _get_overdue_invoices_domain(self, partner_id=None):
         return [
@@ -100,10 +100,7 @@ class PortalAccount(CustomerPortal):
         values = self._prepare_portal_layout_values()
         AccountInvoice = request.env['account.move']
 
-        domain = expression.AND([
-            domain or [],
-            self._get_invoices_domain(),
-        ])
+        domain = Domain(domain or Domain.TRUE) & self._get_invoices_domain()
 
         searchbar_sortings = self._get_account_searchbar_sortings()
         # default sort by order

--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -1,6 +1,5 @@
 from bisect import bisect_left
 from collections import defaultdict
-from collections.abc import Iterable
 import contextlib
 import itertools
 import re
@@ -8,7 +7,6 @@ import json
 
 from odoo import api, fields, models, _, Command
 from odoo.fields import Domain
-from odoo.osv import expression
 from odoo.exceptions import UserError, ValidationError, RedirectWarning
 from odoo.tools import SQL, Query
 
@@ -687,10 +685,10 @@ class AccountAccount(models.Model):
     def _search_internal_group(self, operator, value):
         if operator != 'in':
             return NotImplemented
-        return expression.OR([
-            [('account_type', '=like', self._get_internal_group(v) + '%')]
+        return Domain.OR(
+            Domain('account_type', '=like', self._get_internal_group(v) + '%')
             for v in value
-        ])
+        )
 
     @api.depends('account_type')
     def _compute_reconcile(self):
@@ -865,7 +863,7 @@ class AccountAccount(models.Model):
 
     @api.model
     def _search_display_name(self, operator, value):
-        if operator in expression.NEGATIVE_TERM_OPERATORS:
+        if Domain.is_negative_operator(operator):
             return NotImplemented
         if operator == 'in':
             names = value
@@ -1547,7 +1545,7 @@ class AccountGroup(models.Model):
 
     @api.model
     def _search_display_name(self, operator, value):
-        if operator in expression.NEGATIVE_TERM_OPERATORS:
+        if Domain.is_negative_operator(operator):
             return NotImplemented
         if operator == 'in':
             return [

--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 from odoo import api, fields, models, _
-from odoo import osv
+from odoo.fields import Domain
 from odoo.tools.sql import SQL
 from odoo.exceptions import UserError
 
@@ -75,7 +74,7 @@ class AccountAccountTag(models.Model):
             ]
             or_domains.append(expr_domain)
 
-        domain = osv.expression.AND([[('engine', '=', 'tax_tags')], osv.expression.OR(or_domains)])
+        domain = Domain('engine', '=', 'tax_tags') & Domain.OR(or_domains)
         return self.env['account.report.expression'].search(domain)
 
     @api.ondelete(at_uninstall=False)

--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -1,6 +1,6 @@
-from odoo import api, Command, fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.osv import expression
+from odoo.fields import Command, Domain
 
 from xmlrpc.client import MAXINT
 
@@ -507,7 +507,7 @@ class AccountBankStatementLine(models.Model):
             # Set if bank recon will display draft invoices/bills that have a partner.
             # Usually not applied when used by bank recon models (no suggestions & auto matching for draft entries)
             partnered_drafts_domain = [('parent_state', '=', 'draft'), ('partner_id', '!=', False)]
-            state_domain = expression.OR([state_domain, partnered_drafts_domain])
+            state_domain = Domain.OR([state_domain, partnered_drafts_domain])
         return state_domain + [
             # Base domain.
             ('display_type', 'not in', ('line_section', 'line_note')),

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -14,11 +14,11 @@ import re
 import os
 from textwrap import shorten
 
-from odoo import api, fields, models, _, Command, modules
+from odoo import api, fields, models, _, modules
 from odoo.tools.sql import column_exists, create_column
 from odoo.addons.account.tools import format_structured_reference_iso
 from odoo.exceptions import UserError, ValidationError, AccessError, RedirectWarning
-from odoo.osv import expression
+from odoo.fields import Command, Domain
 from odoo.tools.misc import clean_context
 from odoo.tools import (
     date_utils,
@@ -2534,12 +2534,13 @@ class AccountMove(models.Model):
         return res
 
     def _get_product_catalog_domain(self):
+        domain = super()._get_product_catalog_domain()
         if self.is_sale_document():
-            return expression.AND([super()._get_product_catalog_domain(), [('sale_ok', '=', True)]])
+            return domain & Domain('sale_ok', '=', True)
         elif self.is_purchase_document():
-            return expression.AND([super()._get_product_catalog_domain(), [('purchase_ok', '=', True)]])
+            return domain & Domain('purchase_ok', '=', True)
         else:  # In case of an entry
-            return super()._get_product_catalog_domain()
+            return domain
 
     def _default_order_line_values(self, child_field=False):
         default_data = super()._default_order_line_values(child_field)
@@ -4107,16 +4108,10 @@ class AccountMove(models.Model):
         :param common_domain: a search domain that will be included in the returned domain in any case
         :param force_hash: if True, we'll check all moves posted, independently of journal settings
         """
-        common_domain = expression.AND([
-            common_domain or [],
-            [('state', '=', 'posted')],
-        ])
+        domain = Domain(common_domain or Domain.TRUE) & Domain('state', '=', 'posted')
         if force_hash:
-            return common_domain
-        return expression.AND([
-            common_domain,
-            [('restrict_mode_hash_table', '=', True)],
-        ])
+            return domain
+        return domain & Domain('restrict_mode_hash_table', '=', True)
 
     @api.model
     def _is_move_restricted(self, move, force_hash=False):
@@ -4167,7 +4162,7 @@ class AccountMove(models.Model):
         ], force_hash=True)
         if last_move_hashed and not include_pre_last_hash:
             # Hash moves only after the last hashed move, not the ones that may have been posted before the journal was set on restrict mode
-            domain.extend([('sequence_number', '>', last_move_hashed.sequence_number)])
+            domain &= Domain('sequence_number', '>', last_move_hashed.sequence_number)
 
         # On the accounting dashboard, we are only interested on whether there are documents to hash or not
         # so we can stop the computation early if we find at least one document to hash

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -4,9 +4,9 @@ from datetime import date
 import logging
 import re
 
-from odoo import api, fields, models, Command, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError, RedirectWarning
-from odoo.fields import Domain
+from odoo.fields import Command, Domain
 from odoo.tools import frozendict, float_compare, Query, SQL, OrderedSet
 from odoo.addons.web.controllers.utils import clean_action
 
@@ -3137,7 +3137,7 @@ class AccountMoveLine(models.Model):
         """ Returns a domain to be used to identify the move lines that are allowed
         to be taken into account in the tax report.
         """
-        return [
+        return Domain([
             # Lines on moves without any payable or receivable line are always exigible
             '|', ('move_id.always_tax_exigible', '=', True),
 
@@ -3150,7 +3150,7 @@ class AccountMoveLine(models.Model):
             # Lines from non-CABA taxes are always exigible
             '|', ('tax_line_id.tax_exigibility', '!=', 'on_payment'),
             ('tax_ids.tax_exigibility', '!=', 'on_payment'), # So: exigible if at least one tax from tax_ids isn't on_payment
-        ]
+        ])
 
     def _get_invoiced_qty_per_product(self):
         qties = defaultdict(float)

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ast
 import re
 from collections import defaultdict
 
-from odoo import models, fields, api, _, osv, Command
+from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError, UserError
+from odoo.fields import Command, Domain
 
 FIGURE_TYPE_SELECTION_VALUES = [
     ('monetary', "Monetary"),
@@ -806,7 +806,7 @@ class AccountReportExpression(models.Model):
                         domains.append(dependency_domain)
 
             if domains:
-                sub_expressions |= self.env['account.report.expression'].search(osv.expression.OR(domains))
+                sub_expressions |= self.env['account.report.expression'].search(Domain.OR(domains))
 
             to_expand = sub_expressions.filtered(lambda x: x.engine == 'aggregation' and x not in result)
             result |= sub_expressions
@@ -850,7 +850,7 @@ class AccountReportExpression(models.Model):
             country = tag_expression.report_line_id.report_id.country_id
             or_domains.append(self.env['account.account.tag']._get_tax_tags_domain(tag_expression.formula, country.id, sign))
 
-        return self.env['account.account.tag'].with_context(active_test=False, lang='en_US').search(osv.expression.OR(or_domains))
+        return self.env['account.account.tag'].with_context(active_test=False, lang='en_US').search(Domain.OR(or_domains))
 
     @api.model
     def _get_tags_create_vals(self, tag_name, country_id, existing_tag=None):

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-from odoo import api, fields, models, _, Command
-from odoo.osv import expression
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.fields import Domain
+from odoo.fields import Command, Domain
 from odoo.tools import frozendict, groupby, html2plaintext, is_html_empty, split_every, SQL
 from odoo.tools.float_utils import float_repr, float_round, float_compare
 from odoo.tools.misc import clean_context, formatLang
@@ -246,7 +244,7 @@ class AccountTax(models.Model):
                         ('country_id', '=', tax.country_id.id),
                         ('id', '!=', tax.id),
                     ])
-            if duplicates := self.search(expression.OR(domains)):
+            if duplicates := self.search(Domain.OR(domains)):
                 raise ValidationError(
                     self.env._(
                         "Tax names must be unique!\n%(taxes)s",

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -7,10 +7,9 @@ from collections import defaultdict
 from psycopg2 import errors as pgerrors
 
 from odoo import _, api, fields, models
-from odoo.exceptions import LockError, UserError, ValidationError
-from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, SQL, mute_logger, unique
-
+from odoo.exceptions import UserError, ValidationError
+from odoo.fields import Domain
+from odoo.tools import SQL, unique
 from odoo.addons.account.models.account_move import BYPASS_LOCK_CHECK
 from odoo.addons.base_vat.models.res_partner import _ref_vat
 
@@ -707,7 +706,7 @@ class ResPartner(models.Model):
     def _has_invoice(self, partner_domain):
         self.ensure_one()
         invoice = self.env['account.move'].sudo().search(
-            expression.AND([
+            Domain.AND([
                 partner_domain,
                 [
                     ('move_type', 'in', ['out_invoice', 'out_refund']),
@@ -929,9 +928,9 @@ class ResPartner(models.Model):
         if not domains:
             return None
 
-        domain = expression.OR(domains)
+        domain = Domain.OR(domains)
         if extra_domain:
-            domain = expression.AND([domain, extra_domain])
+            domain &= Domain(extra_domain)
         return self.env['res.partner'].search(domain, limit=2)
 
     @api.model

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -1,8 +1,6 @@
-# -*- coding: utf-8 -*-
-
-from odoo import api, Command, fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.tools import format_amount
 
 ACCOUNT_DOMAIN = "[('account_type', 'not in', ('asset_receivable','liability_payable','asset_cash','liability_credit_card','off_balance'))]"
@@ -289,11 +287,11 @@ class ProductProduct(models.Model):
             name = name.split('\n')[0]
         domains = []
         if barcode:
-            domains.append([('barcode', '=', barcode)])
+            domains.append(Domain('barcode', '=', barcode))
         if default_code:
-            domains.append([('default_code', '=', default_code)])
+            domains.append(Domain('default_code', '=', default_code))
         if name:
-            domains += [[('name', '=', name)], [('name', 'ilike', name)]]
+            domains += [Domain('name', '=', name), Domain('name', 'ilike', name)]
 
         company = company or self.env.company
         for company_domain in (
@@ -301,10 +299,10 @@ class ProductProduct(models.Model):
             [('company_id', '=', False)],
         ):
             products = self.env['product.product'].search(
-                expression.AND([
-                    expression.OR(domains),
+                Domain.AND([
+                    Domain.OR(domains),
                     company_domain,
-                    extra_domain or [],
+                    extra_domain or Domain.TRUE,
                 ]),
             )
             for domain in domains:

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # pylint: disable=bad-whitespace
 from freezegun import freeze_time
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import Form, tagged
-from odoo import fields, Command
-from odoo.osv import expression
+from odoo import fields
+from odoo.fields import Command, Domain
 from odoo.exceptions import ValidationError, UserError
 from datetime import date
 
@@ -2292,7 +2291,7 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
     def _assert_payment_move_state(self, move_type, amount, counterpart_values_list, payment_state, post_move=True):
         def assert_partial(line1, line2):
-            partial = self.env['account.partial.reconcile'].search(expression.OR([
+            partial = self.env['account.partial.reconcile'].search(Domain.OR([
                 [('debit_move_id', '=', line1.id), ('credit_move_id', '=', line2.id)],
                 [('debit_move_id', '=', line2.id), ('credit_move_id', '=', line1.id)],
             ]), limit=1)

--- a/addons/account/wizard/account_secure_entries_wizard.py
+++ b/addons/account/wizard/account_secure_entries_wizard.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
-from odoo import Command, api, fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Command, Domain
 
 
 class AccountSecureEntriesWizard(models.TransientModel):
@@ -186,7 +186,7 @@ class AccountSecureEntriesWizard(models.TransientModel):
                         ('sequence_number', '<=', last_move.sequence_number),
                         ('sequence_number', '>=', first_move.sequence_number),
                     ])
-                domain = expression.OR(OR_domains)
+                domain = Domain.OR(OR_domains)
                 warnings['account_sequence_gap'] = {
                     'message': _("Securing these entries will create at least one gap in the sequence."),
                     'action_text': _("Review"),
@@ -214,14 +214,14 @@ class AccountSecureEntriesWizard(models.TransientModel):
         :return a search domain
         """
         if not (company_id and hash_date):
-            return [(0, '=', 1)]
-        return expression.AND([
+            return Domain.FALSE
+        return Domain.AND([
             [
                 ('date', '<=', fields.Date.to_string(hash_date)),
                 ('company_id', 'child_of', company_id.id),
                 ('inalterable_hash', '=', False),
             ],
-            domain or [],
+            domain or Domain.TRUE,
         ])
 
     def _get_draft_moves_in_hashed_period_domain(self):

--- a/addons/account_edi/models/account_edi_format.py
+++ b/addons/account_edi/models/account_edi_format.py
@@ -1,21 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields, api, _
-from odoo.tools.pdf import OdooPdfFileReader
-from odoo.osv import expression
+from odoo import api, fields, models
 from odoo.tools import html_escape
-from odoo.exceptions import RedirectWarning
-
-from lxml import etree
-from struct import error as StructError
-import base64
-import io
-import logging
-import pathlib
-import re
-
-_logger = logging.getLogger(__name__)
 
 
 class AccountEdiFormat(models.Model):

--- a/addons/account_payment/models/account_payment_method_line.py
+++ b/addons/account_payment/models/account_payment_method_line.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.osv import expression
 
 
 class AccountPaymentMethodLine(models.Model):

--- a/addons/event_booth_sale/models/sale_order.py
+++ b/addons/event_booth_sale/models/sale_order.py
@@ -39,10 +39,4 @@ class SaleOrder(models.Model):
         return action
 
     def _get_product_catalog_domain(self):
-        """Override of `_get_product_catalog_domain` to extend the domain.
-
-        :returns: A list of tuples that represents a domain.
-        :rtype: list
-        """
-        domain = super()._get_product_catalog_domain()
-        return Domain.AND([domain, [('service_tracking', '!=', 'event_booth')]])
+        return super()._get_product_catalog_domain() & Domain('service_tracking', '!=', 'event_booth')

--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -56,10 +56,4 @@ class SaleOrder(models.Model):
             sale_order.attendee_count = attendee_count_data.get(sale_order.id, 0)
 
     def _get_product_catalog_domain(self):
-        """Override of `_get_product_catalog_domain` to extend the domain.
-
-        :returns: A list of tuples that represents a domain.
-        :rtype: list
-        """
-        domain = super()._get_product_catalog_domain()
-        return Domain.AND([domain, [('service_tracking', '!=', 'event')]])
+        return super()._get_product_catalog_domain() & Domain('service_tracking', '!=', 'event')

--- a/addons/l10n_account_withholding_tax/models/account_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/models/account_withholding_line.py
@@ -1,9 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
 
-from odoo import Command, api, fields, models
+from odoo import api, fields, models
 from odoo.exceptions import UserError
-from odoo.osv import expression
+from odoo.fields import Command, Domain
 from odoo.tools.misc import frozendict
 
 
@@ -424,7 +424,7 @@ class AccountWithholdingLine(models.AbstractModel):
         """ Construct and return a domain that will filter withholding taxes available for this company and payment type. """
         filter_domain = models.check_company_domain_parent_of(self, company)
         payment_type = 'purchase' if payment_type == 'outbound' else 'sale'
-        return expression.AND([filter_domain, [('type_tax_use', '=', payment_type), ('is_withholding_tax_on_payment', '=', True)]])
+        return Domain.AND([filter_domain, Domain('type_tax_use', '=', payment_type), Domain('is_withholding_tax_on_payment', '=', True)])
 
     def _need_update_withholding_lines_placeholder(self):
         """ Determines if the lines' placeholders needs update or not. """

--- a/addons/l10n_cn/models/account_move.py
+++ b/addons/l10n_cn/models/account_move.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 try:
     from cn2an import an2cn
@@ -41,4 +40,4 @@ class AccountMove(models.Model):
             domains.append([('res_model', '=', 'account.bank.statement'), ('res_id', 'in', statement_ids.ids)])
         if payment_ids:
             domains.append([('res_model', '=', 'account.payment'), ('res_id', 'in', payment_ids.ids)])
-        return self.env['ir.attachment'].search_count(expression.OR(domains))
+        return self.env['ir.attachment'].search_count(Domain.OR(domains))

--- a/addons/l10n_latam_base/models/l10n_latam_identification_type.py
+++ b/addons/l10n_latam_base/models/l10n_latam_identification_type.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields, api
-from odoo.osv import expression
 
 
 class L10n_LatamIdentificationType(models.Model):

--- a/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
+++ b/addons/l10n_latam_invoice_document/models/l10n_latam_document_type.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import fields, models, api
-from odoo.osv import expression
 
 
 class L10n_LatamDocumentType(models.Model):

--- a/addons/l10n_vn/migrations/17.0.2.0.2/post-migration.py
+++ b/addons/l10n_vn/migrations/17.0.2.0.2/post-migration.py
@@ -1,5 +1,5 @@
 from odoo import api, SUPERUSER_ID
-from odoo.osv import expression
+from odoo.fields import Domain
 from odoo.release import version
 from odoo.tools import parse_version
 
@@ -16,9 +16,9 @@ def _fix_accounts_type(env):
                 company_domain = [('company_ids', 'in', company.ids), ('account_type', '!=', correct_account_type)]
             else:
                 company_domain = [('company_id', '=', company.id), ('account_type', '!=', correct_account_type)]
-            doamin = expression.AND([company_domain, expression.OR([[('code', 'like', f'{code}%')] for code in accounts_code])])
+            doamin = Domain.AND([company_domain, Domain.OR([[('code', 'like', f'{code}%')] for code in accounts_code])])
             domains_per_company.append(doamin)
-        accounts = env['account.account'].search(expression.OR(domains_per_company))
+        accounts = env['account.account'].search(Domain.OR(domains_per_company))
         accounts.account_type = correct_account_type
 
 

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, models
+from odoo.fields import Domain
 
 
 class ProductCatalogMixin(models.AbstractModel):
@@ -33,15 +34,16 @@ class ProductCatalogMixin(models.AbstractModel):
             'readOnly': self._is_readonly() if self else False,
         }
 
-    def _get_product_catalog_domain(self):
+    def _get_product_catalog_domain(self) -> Domain:
         """Get the domain to search for products in the catalog.
 
         For a model that uses products that has to be hidden in the catalog, it
         must override this method and extend the appropriate domain.
-        :returns: A list of tuples that represents a domain.
-        :rtype: list
+        :returns: A domain.
         """
-        return ['|', ('company_id', '=', False), ('company_id', 'parent_of', self.company_id.id), ('type', '!=', 'combo')]
+        return (
+            Domain('company_id', '=', False) | Domain('company_id', 'parent_of', self.company_id.id)
+         ) & Domain('type', '!=', 'combo')
 
     def _get_product_catalog_record_lines(self, product_ids, **kwargs):
         """ Returns the record's lines grouped by product.

--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
 from odoo.exceptions import RedirectWarning, UserError
-from odoo.osv import expression
+from odoo.fields import Domain
 
 
 class AccountAnalyticLine(models.Model):
@@ -51,7 +50,8 @@ class AccountAnalyticLine(models.Model):
         return  super()._check_can_create()
 
     def _get_favorite_project_id_domain(self, employee_id=False):
-        return expression.AND([
+        return Domain.AND([
             super()._get_favorite_project_id_domain(employee_id),
-            [('holiday_id', '=', False), ('global_leave_id', '=', False)],
+            Domain('holiday_id', '=', False),
+            Domain('global_leave_id', '=', False),
         ])

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1121,7 +1121,7 @@ class PurchaseOrder(models.Model):
         }
 
     def _get_product_catalog_domain(self):
-        return Domain.AND([super()._get_product_catalog_domain(), [('purchase_ok', '=', True)]])
+        return super()._get_product_catalog_domain() & Domain('purchase_ok', '=', True)
 
     def _get_product_catalog_order_data(self, products, **kwargs):
         res = super()._get_product_catalog_order_data(products, **kwargs)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1325,7 +1325,7 @@ class SaleOrder(models.Model):
         }
 
     def _get_product_catalog_domain(self):
-        return Domain.AND([super()._get_product_catalog_domain(), [('sale_ok', '=', True)]])
+        return super()._get_product_catalog_domain() & Domain('sale_ok', '=', True)
 
     @api.readonly
     def action_open_business_doc(self):

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -166,9 +166,9 @@ class ResUsers(models.Model):
 
     def _check_company_domain(self, companies):
         if not companies:
-            return []
+            return Domain.TRUE
         company_ids = companies if isinstance(companies, str) else models.to_record_ids(companies)
-        return [('company_ids', 'in', company_ids)]
+        return Domain('company_ids', 'in', company_ids)
 
     @property
     def SELF_READABLE_FIELDS(self):

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3656,17 +3656,17 @@ class BaseModel(metaclass=MetaModel):
             raise ValueError("Expected singleton or no record: %s" % self)
         return self.env['ir.config_parameter'].sudo().get_param('web.base.url')
 
-    def _check_company_domain(self, companies):
+    def _check_company_domain(self, companies) -> Domain:
         """Domain to be used for company consistency between records regarding this model.
 
         :param companies: the allowed companies for the related record
         :type companies: BaseModel or list or tuple or int or unquote
         """
         if not companies:
-            return [('company_id', '=', False)]
+            return Domain('company_id', '=', False)
         if isinstance(companies, unquote):
-            return [('company_id', 'in', unquote(f'{companies} + [False]'))]
-        return [('company_id', 'in', to_record_ids(companies) + [False])]
+            return Domain('company_id', 'in', unquote(f'{companies} + [False]'))
+        return Domain('company_id', 'in', to_record_ids(companies) + [False])
 
     def _check_company(self, fnames=None):
         """ Check the companies of the values of the given field names.


### PR DESCRIPTION
In order to deprecate `odoo.osv`, we must first stop using it and replace it with `Domain`. This covers most of usages in account.

task-4280707
odoo/enterprise#83887



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
