### PR TITLE
[FIX] l10n_ae: avoid duplicated "Invoice" title on invoice report

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -10,81 +10,45 @@
             </p>
         </xpath>
 
-        <t name="invoice_title" position="before">
-            <t name="tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Tax Invoice</t>
-        </t>
-        <t name="invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="draft_invoice_title" position="before">
-            <t name="draft_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Invoice</t>
-        </t>
-        <t name="draft_invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="cancelled_invoice_title" position="before">
-            <t name="cancelled_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Invoice</t>
-        </t>
-        <t name="cancelled_invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
+        <xpath expr="//t[@name='invoice_title']" position="replace">
+            <t name="invoice_title" t-if="o.company_id.country_id.code == 'AE'">Tax Invoice</t>
+        </xpath>
+        <xpath expr="//t[@name='draft_invoice_title']" position="replace">
+            <t name="draft_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Invoice</t>
+        </xpath>
+        <xpath expr="//t[@name='cancelled_invoice_title']" position="replace">
+            <t name="cancelled_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Invoice</t>
+        </xpath>
 
-        <t name="credit_note_title" position="before">
-            <t name="tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Tax Credit Note</t>
-        </t>
-        <t name="credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="draft_credit_note_title" position="before">
-            <t name="draft_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Credit Note</t>
-        </t>
-        <t name="draft_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="cancelled_credit_note_title" position="before">
-            <t name="cancelled_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Credit Note</t>
-        </t>
-        <t name="cancelled_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
+        <xpath expr="//t[@name='credit_note_title']" position="replace">
+            <t name="credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Tax Credit Note</t>
+        </xpath>
+        <xpath expr="//t[@name='draft_credit_note_title']" position="replace">
+            <t name="draft_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Tax Credit Note</t>
+        </xpath>
+        <xpath expr="//t[@name='cancelled_credit_note_title']" position="replace">
+            <t name="cancelled_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Tax Credit Note</t>
+        </xpath>
 
-        <t name="proforma_invoice_title" position="before">
-            <t name="proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Invoice</t>
-        </t>
-        <t name="proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="draft_proforma_invoice_title" position="before">
-            <t name="draft_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Invoice</t>
-        </t>
-        <t name="draft_proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="cancelled_proforma_invoice_title" position="before">
-            <t name="cancelled_proforma_tax_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Invoice</t>
-        </t>
-        <t name="cancelled_proforma_invoice_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
+        <xpath expr="//t[@name='proforma_invoice_title']" position="replace">
+            <t name="proforma_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Invoice</t>
+        </xpath>
+        <xpath expr="//t[@name='draft_proforma_invoice_title']" position="replace">
+            <t name="draft_proforma_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Invoice</t>
+        </xpath>
+        <xpath expr="//t[@name='cancelled_proforma_invoice_title']" position="replace">
+            <t name="cancelled_proforma_invoice_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Invoice</t>
+        </xpath>
 
-        <t name="proforma_credit_note_title" position="before">
-            <t name="proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Credit Note</t>
-        </t>
-        <t name="proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="draft_proforma_credit_note_title" position="before">
-            <t name="draft_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Credit Note</t>
-        </t>
-        <t name="draft_proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
-        <t name="cancelled_proforma_credit_note_title" position="before">
-            <t name="cancelled_proforma_tax_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Credit Note</t>
-        </t>
-        <t name="cancelled_proforma_credit_note_title" position="attributes">
-            <attribute name="t-else"/>
-        </t>
+        <xpath expr="//t[@name='proforma_credit_note_title']" position="replace">
+            <t name="proforma_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Proforma Tax Credit Note</t>
+        </xpath>
+        <xpath expr="//t[@name='draft_proforma_credit_note_title']" position="replace">
+            <t name="draft_proforma_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Draft Proforma Tax Credit Note</t>
+        </xpath>
+        <xpath expr="//t[@name='cancelled_proforma_credit_note_title']" position="replace">
+            <t name="cancelled_proforma_credit_note_title" t-if="o.company_id.country_id.code == 'AE'">Cancelled Proforma Tax Credit Note</t>
+        </xpath>
 
         <xpath expr="//thead//th[@name='th_taxes']" position="replace">
             <th name="th_taxes"


### PR DESCRIPTION
In a previous commit 1accf51091229811a0b0c1d2356a56e5f7fde44c, we were concatenating the invoice title instead of replacing it. This caused the word "Invoice" to appear twice on printed, previewed, or emailed invoice documents when using the UAE localization.

This commit correctly replaces the title using XPath. For companies based in the UAE, the title now shows as "Tax Invoice"
without duplication.

OPW-4722229

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
