### PR TITLE
[FIX] account: bank account editable again in draft

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1032,7 +1032,7 @@
                                        context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
                                        domain="[('partner_id', '=', bank_partner_id)]"
                                        invisible="move_type not in ('in_invoice', 'in_refund', 'in_receipt')"
-                                       readonly="is_move_sent"/>
+                                       readonly="is_move_sent and state != 'draft'"/>
 
                                 <!-- Invoice payment terms (only invoices) + due date (only invoices / receipts) -->
                                 <div class="o_td_label" invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')">
@@ -1409,7 +1409,7 @@
                                         <field name="partner_bank_id"
                                                context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"
                                                domain="[('partner_id.ref_company_ids', 'parent_of', company_id)]"
-                                               readonly="is_move_sent"/>
+                                               readonly="is_move_sent and state != 'draft'"/>
                                         <field name="payment_reference"
                                             invisible="move_type not in ('out_invoice', 'out_refund')"
                                             readonly="inalterable_hash"


### PR DESCRIPTION
Steps to reproduce
- Have a bank account in the accounting tab of the current company partner
- Create an invoice for a customer
- Confirm it
- Send&Print
- Reset the invoice to draft

Issue: In 'Other Info' tab, the Recipient Bank (`partner_bank_id`) is still red-only.

It occurs since 5c7eefed412e676c6ddf67f62bce514e5bade44c The bank account is now editable even when the invoice is posted but become readonly once the invoice is sent.
This means that if a wrong bank account has been set by mistake it is impossible to change it, and a credit note is needed.

opw-4683997
