### PR TITLE
[FIX] sale_mrp: return kit in custom 2-steps

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -67,7 +67,7 @@ class SaleOrderLine(models.Model):
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
                     filters = {
                         'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                        'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
+                        'outgoing_moves': lambda m: m.location_id.usage == 'customer' and m.to_refund
                     }
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)
                     qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)


### PR DESCRIPTION
When using an intermediate return location, the delivered qty of a 
returned kit is incorrect

To reproduce the issue:
1. In Settings, enable "Multi-Step Routes"
2. Create a location L:
   - Parent: WH
   - Type: Internal
   - Return location: True
3. Create a route:
   - Applicable on: Main warehouse
   - Add one rule:
     - Action: Push To
     - Operation Type: Internal
     - From: L
     - To: WH/Stock
4. Create a kit K
5. Sell and deliver 1 x K
6. Return it to L
   - It will create an internal transfer 
7. Process the internal transfer
8. Open the SO

Error: The delivered quantity of the kit is -1 instead of 0

Step 6, when returning the kit, the push rule is applied and create 
the SM from L to WH/Stock. Since we copy the SM from Customer to L, the
new SM also has the field `sale_line_id` defined.

As a result, step 7, since all SM are done, `moves` contain them 
(the delivery, the return and the internal transfer). We then filter 
them based on some criteria:
https://github.com/odoo/odoo/blob/9918e8f3d627f3c52238d6b04bcd15c05d34e40c/addons/sale_mrp/models/sale_order_line.py#L67-L73
But, for `outgoing_moves` (which is actually the incoming ones, the 
name is wrong), since we look at the destination location, both the 
return and the internal SM will match. That's why we will decrease 
twice the delivered quantity. Hence, the bug.

A fix could be to avoid copying the `sale_line_id` field. That being 
said, when looking `sale_stock` side (i.e., same flow with a classic 
product), we don't have any issue because the filters are slightly 
different:
https://github.com/odoo/odoo/blob/418dc0cc3b3aa1ee2abbdb4852d9cd24fba7636e/addons/sale_stock/models/sale_order_line.py#L274-L278
(Here, we need to look at the `incoming_moves`. Again: the name is just 
incorrect on mrp side...)
We see that, for `incoming_moves`, we actually look at the source 
location. This explains why we don't have any issue with a non-kit 
product.

Therefore, the best fix would be to use the same filters everywhere. 
Good news, such a method already exist:
https://github.com/odoo/odoo/blob/9918e8f3d627f3c52238d6b04bcd15c05d34e40c/addons/sale_mrp/models/sale_order_line.py#L115-L116
However, using this method might lead to some other issues (among them: 
the override in `sale_subscription_stock` reads a field although the 
method is an `api.model` one). So, let's minimize the diff on stable 
version and refactor the code (use the same filters everywhere) on 
master.

About the filter names, the confusion actually comes from:
https://github.com/odoo/odoo/blob/312572c7b8138a4800350cd7a524a37551a348ef/addons/mrp/models/stock_move.py#L624
There, we should rather talk about positive moves and negatives 
moves, since this method can be used either in a SO flow or in a PO 
one. This explains why, for now, SO sode, an "incoming move" is 
actually an outgoing one. So, on master, another commit will be 
added to also clean that part of the code:
\- Improve the expected filter names in `_compute_kit_quantities`
\- Fix the filter names in `_get_incoming_outgoing_moves_filter`

OPW-4625228
