### PR TITLE
[REV] l10n_es: remove account 466 to common template

### DIFF
--- a/addons/l10n_es/data/account.account.template-common.csv
+++ b/addons/l10n_es/data/account.account.template-common.csv
@@ -222,7 +222,6 @@
 "account_common_449","Deudores por operaciones en común","449","asset_receivable","l10n_es.account_chart_template_common","True"
 "account_common_460","Anticipos de remuneraciones","460","asset_receivable","l10n_es.account_chart_template_common","True"
 "account_common_465","Remuneraciones pendientes de pago","465","liability_payable","l10n_es.account_chart_template_common","True"
-"account_common_466","Remuneraciones mediante sistemas de aportación definida pendientes de pago","466","liability_payable","l10n_es.account_chart_template_common","True"
 "account_common_4700","Hacienda Pública, deudora por IVA","4700","asset_current","l10n_es.account_chart_template_common","True"
 "account_common_4708","Hacienda Pública, deudora por subvenciones concedidas","4708","asset_current","l10n_es.account_chart_template_common","True"
 "account_common_4709","Hacienda Pública, deudora por devolución de impuestos","4709","asset_current","l10n_es.account_chart_template_common","True"

--- a/addons/l10n_es/data/account.account.template-full.csv
+++ b/addons/l10n_es/data/account.account.template-full.csv
@@ -35,6 +35,7 @@
 "account_full_2550","Activos por derivados financieros, cartera de negociación","2550","asset_fixed","l10n_es.account_chart_template_full","False"
 "account_full_2553","Activos por derivados financieros, instrumentos de cobertura","2553","asset_fixed","l10n_es.account_chart_template_full","False"
 "account_full_257","Derechos de reembolso derivados de contratos de seguro relativos a retribuciones al personal","257","asset_fixed","l10n_es.account_chart_template_full","False"
+"account_full_466","Remuneraciones mediante sistemas de aportación definida pendientes de pago","466","liability_payable","l10n_es.account_chart_template_full","True"
 "account_full_490","Deterioro de valor de créditos por operaciones comerciales","490","liability_current","l10n_es.account_chart_template_full","False"
 "account_full_501","Obligaciones y bonos convertibles a corto plazo","501","liability_current","l10n_es.account_chart_template_full","False"
 "account_full_5091","Obligaciones y bonos convertibles amortizados","5091","liability_current","l10n_es.account_chart_template_full","True"


### PR DESCRIPTION
This reverts commit a43d8b44405786023960a028aee7c5f79a1f0425.

What is being called the "full" COA is actually the general one (https://www.boe.es/biblioteca_juridica/abrir_pdf.php?id=PUB-PB-2024-227)

Whereas the "common" COA is the one of SMEs
(https://www.boe.es/biblioteca_juridica/abrir_pdf.php?id=PUB-PB-2021-228).

So there was a naming confusion in the reverted commit.

Entreprise PR: https://github.com/odoo/enterprise/pull/83892
