### PR TITLE
[IMP] hr_holidays: remove custom hour limit for flex

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -440,7 +440,7 @@ class HrLeave(models.Model):
                     for holiday in public_holidays
                 )
                 days = days - excluded_days
-                hours = min(leave.request_hour_to - leave.request_hour_from, calendar.hours_per_day) if leave.request_unit_hours \
+                hours = (leave.request_hour_to - leave.request_hour_from) if leave.request_unit_hours \
                     else (days * calendar.hours_per_day)
                 result[leave.id] = (days, hours)
                 continue

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -491,7 +491,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_hour_to': 17,
         })
 
-        self.assertEqual(leave5.number_of_hours, 8)
+        self.assertEqual(leave5.number_of_hours, 10)
 
     def test_number_of_hours_display_global_leave(self):
         # Check that the field number_of_hours


### PR DESCRIPTION
- when an employss has a flex calendar the custom hours leaves should not be limited to the avg_hours_per_day

Task: 4744248

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
