### PR TITLE
[FIX] html_editor: don't remove empty inline embedded components

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/file/state_file_model.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/file/state_file_model.js
@@ -29,4 +29,19 @@ export class StateFileModel extends FileModel {
             });
         }
     }
+
+    /**
+     * For embedded files stored without an `id` (i.e. demo data or old
+     * knowledge embedded files converted from "Knowledge Behavior"), allow
+     * direct usage of the file `url` as an `urlRoute` for the fileViewer and
+     * download attempts.
+     *
+     * @override
+     */
+    get urlRoute() {
+        if (this.isUrl && !this.id) {
+            return this.url;
+        }
+        return super.urlRoute;
+    }
 }

--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -260,7 +260,8 @@ export function isVisible(node) {
             // @todo: handle it in resources?
             isMediaElement(node) ||
             hasVisibleContent(node) ||
-            isProtecting(node))
+            isProtecting(node) ||
+            isEmbeddedComponent(node))
     );
 }
 export function hasVisibleContent(node) {
@@ -431,6 +432,10 @@ export function containsAnyNonPhrasingContent(element) {
         child = child.nextSibling;
     }
     return false;
+}
+
+export function isEmbeddedComponent(node) {
+    return node.nodeType === Node.ELEMENT_NODE && node.matches("[data-embedded]");
 }
 
 /**

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -966,6 +966,16 @@ describe("In-editor manipulations", () => {
         const node = historyPlugin._unserializeNode(historyPlugin.serializeNode(el))[0];
         expect(getContent(node)).toBe(`<div data-embedded="unknown"><p>UNKNOWN</p></div>`);
     });
+
+    test("Don't remove empty inline-block data-embedded elements during initElementForEdition, but wrap them in div instead", async () => {
+        const { el } = await setupEditor(
+            `<div data-embedded="counter" style="display:inline-block;"></div>`,
+            { config: getConfig([embedding("counter", Counter)]) }
+        );
+        expect(getContent(el, { sortAttrs: true })).toBe(
+            `<div><div contenteditable="false" data-embedded="counter" data-oe-protected="true" style="display:inline-block;"><span class="counter">Counter:0</span></div></div>`
+        );
+    });
 });
 
 describe("editable descendants", () => {


### PR DESCRIPTION
Prior to this commit, if an inline embedded component block was put as a direct child of the editable, it was removed during `initElementForEdition`, because `isVisible` returned false. However at that point, the `embedded_component_plugin` did not yet have the opportunity to fill that embedded component.

Therefore, as a prevention measure, all elements with `data-embedded` attribute will always be considered `visible`, as their removal should be at the discretion of the `embedded_component_plugin`.

If they happen to have an `inline` style and they are direct children of the editable, they should be wrapped in a baseContainer `div` or `p`, but never removed.

Issues of the type were observed when loading a Knowledge template containing a `div` with `data-embedded="file"` since embedded files have since been refactored to use an `inline-block` display style which made them eligible to be removed by `initElementForEdition` prior to the changes introduced in this commit.

task-4745902
