### PR TITLE
[FIX] sale_stock: change MO packaging upon SOL qty update

### DIFF
--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -195,13 +195,17 @@ class SaleOrderLine(models.Model):
         if 'product_uom_qty' in values:
             lines = self.filtered(lambda r: r.state == 'sale' and not r.is_expense)
 
-        if 'product_packaging_id' in values:
-            self.move_ids.filtered(
-                lambda m: m.state not in ['cancel', 'done']
-            ).product_packaging_id = values['product_packaging_id']
+        old_packaging = {sol: sol.product_packaging_id for sol in self}
 
         previous_product_uom_qty = {line.id: line.product_uom_qty for line in lines}
         res = super(SaleOrderLine, self).write(values)
+
+        for sol in self:
+            if sol.product_packaging_id != old_packaging[sol]:
+                sol.move_ids.filtered(
+                    lambda m: m.state not in ['cancel', 'done']
+                ).product_packaging_id = sol.product_packaging_id
+
         if lines:
             lines._action_launch_stock_rule(previous_product_uom_qty)
         return res

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1984,3 +1984,45 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertEqual(so.picking_ids[0].state, 'done')
         self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[0].location_dest_id, child_location_1)
         self.assertEqual(so.picking_ids[1].move_ids.move_line_ids[1].location_dest_id, child_location_2)
+
+    def test_update_sol_quantity_without_packaging(self):
+        """
+        Test updating a SOL quantity without specifying a packaging (eg through catalog).
+        Ensure both the move's quantity & packaging are correctly updated.
+        """
+        wh = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        wh.delivery_steps = 'pick_pack_ship'
+
+        pack3, pack6 = self.env['product.packaging'].create([{
+            'name': 'Pack Of %s' % qty,
+            'product_id': self.product_a.id,
+            'qty': qty,
+        } for qty in [3, 6]])
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {
+                'product_id': self.product_a.id,
+                'product_uom_qty': 1,
+                'product_uom': self.product_a.uom_id.id,
+            })],
+        })
+        so.action_confirm()
+        self.assertFalse(so.order_line.product_packaging_id)
+
+        so.order_line.product_uom_qty = 12
+        self.assertEqual(so.order_line.product_packaging_id, pack6)
+        moves = so.procurement_group_id.stock_move_ids
+        self.assertRecordValues(moves, [
+            {'product_uom_qty': 12, 'product_packaging_qty': 2, 'product_packaging_id': pack6.id},
+            {'product_uom_qty': 12, 'product_packaging_qty': 2, 'product_packaging_id': pack6.id},
+            {'product_uom_qty': 12, 'product_packaging_qty': 2, 'product_packaging_id': pack6.id},
+        ])
+
+        pick_sm = moves.filtered(lambda sm: sm.location_id == wh.lot_stock_id)
+        pick_sm.product_packaging_id = pack3
+        self.assertRecordValues(moves, [
+            {'product_uom_qty': 12, 'product_packaging_qty': 4, 'product_packaging_id': pack3.id},
+            {'product_uom_qty': 12, 'product_packaging_qty': 4, 'product_packaging_id': pack3.id},
+            {'product_uom_qty': 12, 'product_packaging_qty': 4, 'product_packaging_id': pack3.id},
+        ])


### PR DESCRIPTION
Issue
-----
In a SO, changing the quantity for a product with packagings through the catalog correctly updates the SOL's packaging but not the move's. Instead, it creates a new move for the difference in quantity (with the correct new packaging) while
leaving the existing one unchanged. The user ends up with 2 moves with different packagings.

Steps to reproduce
-----
- Install both Sale and Stock
- Enable "Product Packagings" under Settings > Sales
- Create a new product with a custom packaging for 2 units (inventory tab)
- Create a SO
- Add the product to the SO
- Confirm SO
- Open product catalog
- Update the product quantity to 4
- Go back to the SO
- Go to the linked delivery

-> The delivery has 2 lines instead of 1

Cause
-----
The logic flow is different between when in form or catalog view.

When changing the quantity of a sale line through the form, the quantity update is done on a temporary record. This triggers a change of the packaging through

https://github.com/odoo/odoo/blob/0a0dc2f1bd54f44356a5959b8bcd52aaddcf1261/addons/sale/models/sale_order_line.py#L649-L650

When saving the changes, both the quantity and packaging are present in the write `values` as both fields have to be updated on the real record. This allows to enter the following block, which updates the packaging on the existing move.

https://github.com/odoo/odoo/blob/0a0dc2f1bd54f44356a5959b8bcd52aaddcf1261/addons/sale_stock/models/sale_order_line.py#L198-L201

Later on in the write, we trigger a replenishment.

https://github.com/odoo/odoo/blob/0a0dc2f1bd54f44356a5959b8bcd52aaddcf1261/addons/sale_stock/models/sale_order_line.py#L205-L206

This replenishment creates a new move for the rdifference in quantities, using the SOL's new packaging. Since both the new and existing line have the same packaging, they are merged together. Everything works as expected.

When making changes through the catalog, we are directly writing the new quantity on the existing SOL. We directly enter the SOL's `write` method with only the new quantity in `values`.

This means we don't update the packaging on the existing move since `product_packaging_id` is not in `values` so we can't enter the block

https://github.com/odoo/odoo/blob/0a0dc2f1bd54f44356a5959b8bcd52aaddcf1261/addons/sale_stock/models/sale_order_line.py#L198-L201

The write then goes on to trigger a replenishment. When preparing to create the procurement, we access the SOL's `product_packaging_id`

https://github.com/odoo/odoo/blob/0a0dc2f1bd54f44356a5959b8bcd52aaddcf1261/addons/sale_stock/models/sale_order_line.py#L248

Since it's dependency (the quantity) changed, the compute is triggered. The SOL packaging is updated and the newly computed packaging is used to create the procurement (and subsequent move).

We end up with two moves with different packagings,
- the existing move with the old packaging
- the new move with the new (correct) packaging
They can not be merged together because their packagings differ -> bug.

Version constraint
-----
The bug is only present in 17.X versions, as packagings have been deprecated in 18.0.

Making the field computed
-----
We could make the move's packaging a *computed* field. This seems like the most logical and practical solution. However, this approach has some problems:

- the field is used for both sales and purchases so we'd have to adapt the  behaviour there as well.
- we have to consider multi step routes. In such cases, the moves are linked  between themselves but not to the SOL. This means we can't make the dependence be on the SOL packaging, we have to make it on the other move's. So we would have to make the field recursive, so that an update on the first move's packaging can propagate along the chain.
- adding onto the previous point, sale and purchase multi step routes use different rules, so we would depend on the origin's product_packaging_id in one and on the destintation's in the other.

This leads to us propagating changes both ways across move chains, so we don't know whether the origin or the destination has the correct packaging.

Solution
-----
Update the packaging of existing moves through the SOL's write method before it launches the replenishment.

Why this works
-----
We first store the existing packaging (or lack thereof) of the SOL

> old_packaging = {sol: sol.product_packaging_id for sol in self}

We then write the content of `values` on the record.

> res = super(SaleOrderLine, self).write(values)

This only updates the quantity of the SOL.

We then force the recomputation of the SOL's packaging

> if sol.product_packaging_id != old_packaging[sol]:

If the new packaging differs from the previous, we update the existing move(s) so that they use the new packaging of the line

> sol.move_ids.filtered(
> 	lambda m: m.state not in ['cancel', 'done']
> ).product_packaging_id = sol.product_packaging_id

Only then does the write launch the replenishment

> lines._action_launch_stock_rule(previous_product_uom_qty)

Since the existing moves' packaging has been updated, they will correctly be merged with the new ones.

-----
Ticket:
opw-4603600