### PR TITLE
[IMP] l10n_*_hr_payroll: Local banks in demo data.

### DIFF
--- a/addons/l10n_sa/demo/demo_company.xml
+++ b/addons/l10n_sa/demo/demo_company.xml
@@ -2,7 +2,6 @@
 <odoo>
     <record id="base.partner_demo_company_sa" model="res.partner" forcecreate="1">
         <field name="name">SA Company</field>
-        <field name="vat"/>
         <field name="street">Al Amir Mohammed Bin Abdul Aziz Street</field>
         <field name="city">المدينة المنورة</field>
         <field name="country_id" ref="base.sa"/>
@@ -16,7 +15,6 @@
 
     <record id="base.demo_company_sa" model="res.company" forcecreate="1">
         <field name="name">SA Company</field>
-        <field name="vat">310175397400003</field>
         <field name="partner_id" ref="base.partner_demo_company_sa"/>
         <field name="paperformat_id" ref="l10n_sa.paperformat_l10n_sa_a4"></field>
     </record>

--- a/addons/l10n_sa_edi/demo/demo_company.xml
+++ b/addons/l10n_sa_edi/demo/demo_company.xml
@@ -2,7 +2,6 @@
 <odoo>
 
     <record id="base.partner_demo_company_sa" model="res.partner">
-        <field name="vat">399999999900003</field>
         <field name="state_id" ref="base.state_sa_70"/>
         <field name="street2">Somewhere close to Mecca</field>
         <field name="l10n_sa_edi_building_number">1234</field>

--- a/addons/l10n_tr/demo/demo_company.xml
+++ b/addons/l10n_tr/demo/demo_company.xml
@@ -2,7 +2,6 @@
 <odoo>
     <record id="base.partner_demo_company_tr" model="res.partner" forcecreate="1">
         <field name="name">TR Company</field>
-        <field name="vat">3297552117</field>
         <field name="street">3281. Cadde</field>
         <field name="city">İç Anadolu Bölgesi</field>
         <field name="country_id" ref="base.tr"/>


### PR DESCRIPTION
* = ae, au, bd, eg, hk, id, jo, ke, lt, lu, ma, mx, nl, pk, pl, ro, sa, sk, tr, and us.

This PR improves the demo data for multiple l10n payroll modules by adding two banks (`res.bank`) with local bank names and BIC codes to each localization. Additionally, this PR also implements a baseline demo data experience for the payroll localizations. Every l10n now comes with 2 demo employees, each with a contract and most of their information filled out with data that fits the localization.

task-3969900
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
