### PR TITLE
[FIX] web: fix properties tags navigation

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -48,6 +48,7 @@ export class PropertiesField extends Component {
             onClose: () => this.onCloseCurrentPopover?.(),
             fixedPosition: true,
             arrow: false,
+            setActiveElement: false, // make tag navigation work when adding a tag property
         });
         this.propertiesRef = useRef("properties");
 

--- a/addons/web/static/tests/views/fields/properties_field.test.js
+++ b/addons/web/static/tests/views/fields/properties_field.test.js
@@ -890,6 +890,14 @@ test("properties: tags", async () => {
     expect(".o_property_field_value .o_tag").toHaveCount(1, {
         message: "Should have unselected the removed tag B",
     });
+
+    // Remove a tag by pressing backspace
+    await click(".o_property_field_value .o_input_dropdown input");
+    await press("backspace");
+    await animationFrame();
+    expect(".o_property_field_value .o_tag").toHaveCount(0, {
+        message: "Should have unselected the tag",
+    });
 });
 
 /**


### PR DESCRIPTION
Purpose:
--------
In a form view, when changing the type of a property to "tags", the tag navigation hook does not work in the new properties tag widget (but works when reloading the page).

The reason is that since commit 69f0a38, the tag navigation hook uses the hotkey service which registers the hotkeys using the activeElement and skips the registrations that are not linked to the current activeElement when dispatching a key.

When modifying a property definition, the property tags field is mounted in the form view while the activeElement is the properties definition popover, hence the hotkeys are skipped once the popover is closed.

Task-4742523
