### PR TITLE
[FIX] account_edi: fix edi warning CSS

### DIFF
--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -103,16 +103,16 @@
                 <xpath expr="//header" position="after">
                     <field name="edi_blocking_level" invisible="1" />
                     <field name="edi_error_count" invisible="1" />
-                    <div class="d-flex alert alert-info justify-content-between" role="alert"
+                    <div class="alert alert-info d-flex justify-content-between align-items-center" role="alert"
                         invisible="edi_web_services_to_process in ['', False] or state == 'draft'">
                          <div>The invoice will soon be sent to
                              <field name="edi_web_services_to_process" class="w-auto"/>
                          </div>
-                         <button name="button_process_edi_web_services" type="object" class="oe_link ps-0 text-decoration-underline" string="Process now"/>
+                         <button name="button_process_edi_web_services" type="object" class="oe_link py-0 text-decoration-underline" string="Process now"/>
                     </div>
                     <div class="alert alert-danger" role="alert"
                         invisible="edi_error_count == 0 or edi_blocking_level != 'error'">
-                        <div class="o_row">
+                        <div class="o_row align-items-center">
                             <field name="edi_error_message" />
                             <button name="button_force_cancel"
                                 string="Force Cancel"


### PR DESCRIPTION
### Before this commit:
The warning message `Invoice will soon be sent to EDI` was not displayed correctly, resulting in a broken UI at the top of the invoice form.

- **UI before fix:** ![image](https://github.com/user-attachments/assets/4be4117a-dd5d-407f-a45d-d9db0ba1b795)

### After this commit:
The warning UI has been fixed by adding appropriate CSS classes, ensuring proper alignment and styling.

- **UI after fix:** ![image](https://github.com/user-attachments/assets/ed558f2b-12fb-4001-b0b1-ba2726c0926b)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
