### PR TITLE
[FIX] point_of_sale: better barcode scanning error handling

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -8815,6 +8815,18 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
+msgid "This barcode is not compatible with the GS1 standard. Consider configuring a fallback barcode parser from the PoS settings."
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
+msgid "Unsupported Barcode Format"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/hooks/hooks.js:0
 #: code:addons/point_of_sale/static/src/app/utils/error_handlers.js:0
 msgid "Unknown Error"

--- a/addons/point_of_sale/static/src/app/services/barcode_reader_service.js
+++ b/addons/point_of_sale/static/src/app/services/barcode_reader_service.js
@@ -62,8 +62,13 @@ export class BarcodeReader {
                 throw new GS1BarcodeError("The GS1 barcode must contain a product.");
             }
         } catch (error) {
-            if (this.fallbackParser && error instanceof GS1BarcodeError) {
-                parseBarcode = this.fallbackParser.parse_barcode(code);
+            if (error instanceof GS1BarcodeError) {
+                if (this.fallbackParser) {
+                    parseBarcode = this.fallbackParser.parse_barcode(code);
+                } else {
+                    this.showGS1IncompatibleBarcodeWarning();
+                    return;
+                }
             } else {
                 throw error;
             }
@@ -98,6 +103,18 @@ export class BarcodeReader {
         } else {
             return parsedBarcode.code;
         }
+    }
+
+    showGS1IncompatibleBarcodeWarning() {
+        this.notification.add(
+            _t(
+                "This barcode is not compatible with the GS1 standard. Consider configuring a fallback barcode parser from the PoS settings."
+            ),
+            {
+                type: "warning",
+                title: _t("Unsupported Barcode Format"),
+            }
+        );
     }
 
     // the barcode scanner will listen on the hw_proxy/scanner interface for


### PR DESCRIPTION
Steps to reproduce
------------------
1. Set the default barcode parser to GS1 nomenclature
2. Don't set a fallback parser
3. Scan a non-GS1 compatible barcode

Observation: A traceback!

Improvement in this PR
----------------------
Instead of the not-much-useful traceback, we show a warning message asking the user to try setting a fallback parser from PoS settings.

opw-4739161