### PR TITLE
[FIX] iot_base: for longpolling port to 8069 locally

### DIFF
--- a/addons/iot_base/static/src/network_utils/http.js
+++ b/addons/iot_base/static/src/network_utils/http.js
@@ -27,6 +27,7 @@ export function formatEndpoint(ip, route) {
     url.search = "";
     url.hostname = ip;
     url.pathname = route;
+    if (url.port) url.port = "8069";
     return url.toString();
 }
 


### PR DESCRIPTION
Currently, if one runs an odoo instance on a different port than 8069, the longpolling can't contact an IoT Box as it can only run on port 8069.

This commit ensures that, if the IoT Box is reached through http (so it needs to specify the port), the port is set to 8069.
