### PR TITLE
[FIX] mail: format tracked floats with digits

### DIFF
--- a/addons/bus/static/tests/helpers/mock_python_environment.js
+++ b/addons/bus/static/tests/helpers/mock_python_environment.js
@@ -41,12 +41,13 @@ async function getModelDefinitions() {
 
     for (const [modelName, fields] of modelDefinitions) {
         // insert fields present in the fieldsToInsert registry : if the field
-        // exists, update its default value according to the one in the
+        // exists, update its default and digits value according to the one in the
         // registry; If it does not exist, add it to the model definition.
         const fieldNamesToFieldToInsert = fieldsToInsertRegistry.category(modelName).getEntries();
         for (const [fname, fieldToInsert] of fieldNamesToFieldToInsert) {
             if (fname in fields) {
                 fields[fname].default = fieldToInsert.default;
+                fields[fname].digits = fieldToInsert.digits;
             } else {
                 fields[fname] = fieldToInsert;
             }

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -141,7 +141,7 @@ class MailTracking(models.Model):
         # fetch model-based information
         if model:
             TrackedModel = self.env[model]
-            tracked_fields = TrackedModel.fields_get(self.field_id.mapped('name'), attributes={'string', 'type'})
+            tracked_fields = TrackedModel.fields_get(self.field_id.mapped('name'), attributes={'digits', 'string', 'type'})
             model_sequence_info = dict(TrackedModel._mail_track_order_fields(tracked_fields)) if model else {}
         else:
             tracked_fields, model_sequence_info = {}, {}
@@ -170,10 +170,12 @@ class MailTracking(models.Model):
                 'fieldType': col_info['type'],
                 'newValue': {
                     'currencyId': tracking.currency_id.id,
+                    'floatPrecision': col_info.get('digits'),
                     'value': tracking._format_display_value(col_info['type'], new=True)[0],
                 },
                 'oldValue': {
                     'currencyId': tracking.currency_id.id,
+                    'floatPrecision': col_info.get('digits'),
                     'value': tracking._format_display_value(col_info['type'], new=False)[0],
                 },
             }

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -87,7 +87,7 @@ patch(Message.prototype, {
                 return formatDateTime(value);
             }
             case "float":
-                return formatFloat(trackingValue.value);
+                return formatFloat(trackingValue.value, { digits: trackingValue.floatPrecision });
             case "integer":
                 return formatInteger(trackingValue.value);
             case "text":

--- a/addons/mail/static/tests/helpers/mock_server/models/mail_tracking_value.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/mail_tracking_value.js
@@ -43,7 +43,8 @@ patch(MockServer.prototype, {
         newValue,
         fieldName,
         field,
-        modelName
+        modelName,
+        record
     ) {
         let isTracked = true;
         const irField = this.models["ir.model.fields"].records.find(
@@ -71,10 +72,17 @@ patch(MockServer.prototype, {
                 values["old_value_integer"] = initialValue ? 1 : 0;
                 values["new_value_integer"] = newValue ? 1 : 0;
                 break;
-            case "monetary":
+            case "monetary": {
                 values[`old_value_float`] = initialValue;
                 values[`new_value_float`] = newValue;
+                let currencyField = field.currency_field;
+                // see get_currency_field in python fields
+                if (!currencyField && "currency_id" in record) {
+                    currencyField = "currency_id";
+                }
+                values[`currency_id`] = record[currencyField];
                 break;
+            }
             case "selection":
                 values["old_value_char"] = initialValue;
                 values["new_value_char"] = newValue;
@@ -113,9 +121,13 @@ patch(MockServer.prototype, {
                 fieldName: irField.name,
                 fieldType: irField.ttype,
                 newValue: {
+                    currencyId: tracking.currency_id,
+                    floatPrecision: this.models[irField.model].fields[irField.name].digits,
                     value: this._mockMailTrackingValue_FormatDisplayValue(tracking, "new"),
                 },
                 oldValue: {
+                    currencyId: tracking.currency_id,
+                    floatPrecision: this.models[irField.model].fields[irField.name].digits,
                     value: this._mockMailTrackingValue_FormatDisplayValue(tracking, "old"),
                 },
             };

--- a/addons/mail/static/tests/helpers/mock_server/models/models.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/models.js
@@ -30,7 +30,8 @@ patch(MockServer.prototype, {
                     newValue,
                     fname,
                     trackedFieldNamesToField[fname],
-                    model
+                    model,
+                    record
                 );
                 if (tracking) {
                     trackingValueIds.push(tracking);

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -121,6 +121,7 @@ class MailTestTrackAll(models.Model):
     date_field = fields.Date('Date', tracking=3)
     datetime_field = fields.Datetime('Datetime', tracking=4)
     float_field = fields.Float('Float', tracking=5)
+    float_field_with_digits = fields.Float('Precise Float', digits=(10, 8), tracking=5)
     html_field = fields.Html('Html', tracking=False)
     integer_field = fields.Integer('Integer', tracking=7)
     many2many_field = fields.Many2many(

--- a/addons/test_mail/static/tests/helpers/model_definitions_setup.js
+++ b/addons/test_mail/static/tests/helpers/model_definitions_setup.js
@@ -1,6 +1,9 @@
 /** @odoo-module **/
 
-import { addModelNamesToFetch } from "@bus/../tests/helpers/model_definitions_helpers";
+import {
+    addModelNamesToFetch,
+    insertModelFields,
+} from "@bus/../tests/helpers/model_definitions_helpers";
 
 addModelNamesToFetch([
     "mail.test.track.all",
@@ -9,4 +12,10 @@ addModelNamesToFetch([
     "mail.test.multi.company.read",
     "mail.test.properties",
     "mail.test.simple.main.attachment",
+    "res.currency",
 ]);
+
+insertModelFields("mail.test.track.all", {
+    float_field_with_digits: { digits: [10, 8] },
+});
+

--- a/addons/test_mail/static/tests/tracking_value_tests.js
+++ b/addons/test_mail/static/tests/tracking_value_tests.js
@@ -8,10 +8,12 @@ import {
     editSelect,
     selectDropdownItem,
     patchTimeZone,
+    patchWithCleanup,
     getFixture,
 } from "@web/../tests/helpers/utils";
 import testUtils from "@web/../tests/legacy/helpers/test_utils";
 import { click, contains, insertText } from "@web/../tests/utils";
+import { currencies } from "@web/core/currency";
 
 let target;
 
@@ -26,6 +28,7 @@ QUnit.module("tracking value", {
                         <field name="date_field"/>
                         <field name="datetime_field"/>
                         <field name="float_field"/>
+                        <field name="float_field_with_digits"/>
                         <field name="integer_field"/>
                         <field name="monetary_field"/>
                         <field name="many2one_field_id"/>
@@ -82,11 +85,24 @@ QUnit.test("rendering of tracked field of type float: from 0 to non-0", async fu
     const pyEnv = await startServer();
     const mailTestTrackAllId1 = pyEnv["mail.test.track.all"].create({
         float_field: 0,
+        float_field_with_digits: 0,
     });
     await this.start({ res_id: mailTestTrackAllId1 });
-    await insertText("div[name=float_field] input", "1", { replace: true });
+    await insertText("div[name=float_field] input", "1.01", { replace: true });
+    await insertText("div[name=float_field_with_digits] input", "1.0001", { replace: true });
     await click(".o_form_button_save");
-    await contains(".o-mail-Message-tracking", { text: "0.001.00(Float)" });
+    await contains(".o-mail-Message-tracking", { count: 2 });
+    const [defaultPrecisionLine, increasedPrecisionLine] =
+        target.getElementsByClassName("o-mail-Message-tracking");
+    const expectedText = [
+        [defaultPrecisionLine, ["0.00", "1.01", "(Float)"]],
+        [increasedPrecisionLine, ["0.00000000", "1.00010000", "(Float)"]],
+    ];
+    for (const [targetLine, [oldText, newText, fieldName]] of expectedText) {
+        await contains(".o-mail-Message-trackingOld", { target: targetLine, text: oldText });
+        await contains(".o-mail-Message-trackingNew", { target: targetLine, text: newText });
+        await contains(".o-mail-Message-trackingField", { target: targetLine, text: fieldName });
+    }
 });
 
 QUnit.test("rendering of tracked field of type integer: from non-0 to 0", async function () {
@@ -113,13 +129,21 @@ QUnit.test("rendering of tracked field of type integer: from 0 to non-0", async 
 
 QUnit.test("rendering of tracked field of type monetary: from non-0 to 0", async function () {
     const pyEnv = await startServer();
+
+    const testCurrencyId = pyEnv["res.currency"].create({ name: "ECU", symbol: "§" });
+    // need to patch currencies as they're passed via cookies, not through the orm
+    patchWithCleanup(currencies, {
+        [testCurrencyId]: { digits: [69, 2], position: "after", symbol: "§" },
+    });
+
     const mailTestTrackAllId1 = pyEnv["mail.test.track.all"].create({
+        currency_id: testCurrencyId,
         monetary_field: 1,
     });
     await this.start({ res_id: mailTestTrackAllId1 });
     await insertText("div[name=monetary_field] input", "0", { replace: true });
     await click(".o_form_button_save");
-    await contains(".o-mail-Message-tracking", { text: "1.000.00(Monetary)" });
+    await contains(".o-mail-Message-tracking", { text: "1.00 §0.00 §(Monetary)" });
 });
 
 QUnit.test("rendering of tracked field of type monetary: from 0 to non-0", async function () {

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -118,10 +118,12 @@ class TestTracking(MailCommon):
                 'id': message_1.tracking_value_ids.id,
                 'newValue': {
                     'currencyId': False,
+                    'floatPrecision': None,
                     'value': new_user.display_name,
                 },
                 'oldValue': {
                     'currencyId': False,
+                    'floatPrecision': None,
                     'value': original_user.display_name,
                 },
             })
@@ -534,6 +536,7 @@ class TestTrackingInternals(MailCommon):
             'date_field': today,
             'datetime_field': now,
             'float_field': 3.22,
+            'float_field_with_digits': 3.00001,
             'html_field': '<p>Html Value</p>',
             'integer_field': 42,
             'many2one_field_id': self.test_partner.id,
@@ -545,22 +548,30 @@ class TestTrackingInternals(MailCommon):
         new_message = test_record.message_ids - messages
         self.assertEqual(len(new_message), 1,
                          'Should have generated a tracking value')
-        self.assertTracking(
-            new_message,
-            [
-                ('boolean_field', 'boolean', 0, 1),
-                ('char_field', 'char', False, 'char_value'),
-                ('date_field', 'date', False, today_dt),
-                ('datetime_field', 'datetime', False, now),
-                ('float_field', 'float', 0, 3.22),
-                ('integer_field', 'integer', 0, 42),
-                ('many2one_field_id', 'many2one', self.env['res.partner'], self.test_partner),
-                ('monetary_field', 'monetary', False, (42.42, self.env.ref('base.USD'))),
-                ('selection_field', 'selection', '', 'FIRST'),
-                ('text_field', 'text', False, 'text_value'),
-            ],
-            strict=True
-        )
+        tracking_value_list = [
+            ('boolean_field', 'boolean', 0, 1),
+            ('char_field', 'char', False, 'char_value'),
+            ('date_field', 'date', False, today_dt),
+            ('datetime_field', 'datetime', False, now),
+            ('float_field', 'float', 0, 3.22),
+            ('float_field_with_digits', 'float', 0, 3.00001),
+            ('integer_field', 'integer', 0, 42),
+            ('many2one_field_id', 'many2one', self.env['res.partner'], self.test_partner),
+            ('monetary_field', 'monetary', False, (42.42, self.env.ref('base.USD'))),
+            ('selection_field', 'selection', '', 'FIRST'),
+            ('text_field', 'text', False, 'text_value'),
+        ]
+        self.assertTracking(new_message, tracking_value_list, strict=True)
+        # check formatting for all field types
+        formatted_values_all = new_message.message_format()[0]['trackingValues']
+        for (field_name, field_type, _, _), formatted_vals in zip(tracking_value_list, formatted_values_all):
+            currency = self.env.ref('base.USD').id if field_type == 'monetary' else False
+            precision = None if field_name != 'float_field_with_digits' else (10, 8)
+            with self.subTest(field_name=field_name):
+                self.assertEqual(formatted_vals['oldValue']['currencyId'], currency)
+                self.assertEqual(formatted_vals['newValue']['currencyId'], currency)
+                self.assertEqual(formatted_vals['oldValue']['floatPrecision'], precision)
+                self.assertEqual(formatted_vals['newValue']['floatPrecision'], precision)
 
     @users('employee')
     def test_mail_track_compute(self):
@@ -696,10 +707,12 @@ class TestTrackingInternals(MailCommon):
             'fieldType': 'char',
             'newValue': {
                 'currencyId': False,
+                'floatPrecision': None,
                 'value': 'X',
             },
             'oldValue': {
                 'currencyId': False,
+                'floatPrecision': None,
                 'value': False,
             },
         }]
@@ -807,22 +820,22 @@ class TestTrackingInternals(MailCommon):
                     'id': trackings[0].id,
                     'fieldName': 'secret',
                     'fieldType': 'char',
-                    'newValue': {'currencyId': False, 'value': 'secret'},
-                    'oldValue': {'currencyId': False, 'value': False}
+                    'newValue': {'currencyId': False, 'floatPrecision': None, 'value': 'secret'},
+                    'oldValue': {'currencyId': False, 'floatPrecision': None, 'value': False}
                 }, {
                     'changedField': 'Old integer',
                     'id': trackings[2].id,
                     'fieldName': 'Removed',
                     'fieldType': 'integer',
-                    'newValue': {'currencyId': False, 'value': 35},
-                    'oldValue': {'currencyId': False, 'value': 30}
+                    'newValue': {'currencyId': False, 'floatPrecision': None, 'value': 35},
+                    'oldValue': {'currencyId': False, 'floatPrecision': None, 'value': 30}
                 }, {
                     'changedField': 'Unknown',
                     'id': trackings[1].id,
                     'fieldName': 'unknown',
                     'fieldType': 'char',
-                    'newValue': {'currencyId': False, 'value': False},
-                    'oldValue': {'currencyId': False, 'value': False}
+                    'newValue': {'currencyId': False, 'floatPrecision': None, 'value': False},
+                    'oldValue': {'currencyId': False, 'floatPrecision': None, 'value': False}
                 }
             ]
         )
@@ -984,10 +997,12 @@ class TestTrackingInternals(MailCommon):
                     'fieldType': field_info[1],
                     'newValue': {
                         'currencyId': False,
+                        'floatPrecision': None,
                         'value': values[1],
                     },
                     'oldValue': {
                         'currencyId': False,
+                        'floatPrecision': None,
                         'value': values[0],
                     },
                 }
@@ -1015,10 +1030,12 @@ class TestTrackingInternals(MailCommon):
                     'fieldType': field_info[1],
                     'newValue': {
                         'currencyId': False,
+                        'floatPrecision': None,
                         'value': values[1],
                     },
                     'oldValue': {
                         'currencyId': False,
+                        'floatPrecision': None,
                         'value': values[0],
                     },
                 }


### PR DESCRIPTION
Currently all floats are formatted with the default of 2 in the chatter.
Instead if "digits" is specified for the field we should display the
field with that precision.

Formatting tests were updated, which required adding the option to set
the "digits" field value for fields on models that are fetched from
back-end definitions. As that info is only stored in python and is not
transmitted to the test framework, similarly to "default".

task-4746268