### PR TITLE
[FIX] project_timesheet_holidays: dup leaves creation on emp. unarchive

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -21,20 +21,22 @@ class Employee(models.Model):
         return employees
 
     def write(self, vals):
+        if vals.get('active'):
+            inactive_emp = self.filtered(lambda e: not e.active)
         result = super(Employee, self).write(vals)
         self_company = self.with_context(allowed_company_ids=self.company_id.ids)
         if 'active' in vals:
             if vals.get('active'):
                 # Create future holiday timesheets
-                inactive_emp = self_company.filtered(lambda e: not e.active)
-                inactive_emp._create_future_public_holidays_timesheets(self)
+                inactive_emp = inactive_emp.with_env(self_company.env)
+                inactive_emp._create_future_public_holidays_timesheets(inactive_emp)
             else:
                 # Delete future holiday timesheets
                 self_company._delete_future_public_holidays_timesheets()
         elif 'resource_calendar_id' in vals:
             # Update future holiday timesheets
             self_company._delete_future_public_holidays_timesheets()
-            self_company._create_future_public_holidays_timesheets(self)
+            self_company._create_future_public_holidays_timesheets(self_company)
         return result
 
     def _delete_future_public_holidays_timesheets(self):

--- a/addons/project_timesheet_holidays/tests/test_employee.py
+++ b/addons/project_timesheet_holidays/tests/test_employee.py
@@ -103,6 +103,14 @@ class TestEmployee(TransactionCase):
         self.assertEqual(str(timesheet.date), '2020-01-01', 'The timesheet should be created for the correct date')
         self.assertEqual(timesheet.unit_amount, 8, 'The timesheet should be created for the correct duration')
 
+        # test unarchiving on an already active employee does not create duplicate public leaves
+        employee.write({'active': True})
+        timesheet = self.env['account.analytic.line'].search([
+            ('employee_id', '=', employee.id),
+            ('global_leave_id', '=', self.global_leave.id),
+        ])
+        self.assertEqual(len(timesheet), 1, 'We should not have created duplicate public holiday leaves')
+
         # simulate the company of the employee updated is not in the allowed_company_ids of the current user
         employee.with_company(self.env.company).write({'resource_calendar_id': self.company.resource_calendar_id.id})
         timesheet = self.env['account.analytic.line'].search([


### PR DESCRIPTION
To reproduce:

- Install both `hr_contract_salary` and `project_timesheet_holidays`
- Create a public holiday for the company (ex. on May 01)
- Create a employee => This create leaves for employee's company public holidays

- Create a contract for that employee
- Send a signing request to both employee and HR responsible
- The employee sign the document
- The responsible sign the document

=> At that time, we're going to update the contract after both parties signed the contract and force unarchiving the employee even if it's already active.

This commit ensure that unarchiving an already active employee does not create duplicate *future* public holidays.

opw-4134712

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
