### PR TITLE
[IMP] mrp: resequence work orders on BoM update for confirmed MOs

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2620,6 +2620,9 @@ class MrpProduction(models.Model):
                     workorder.name = operation.name
             elif workorder.operation_id and workorder.operation_id not in operations_by_id:
                 workorders_to_unlink |= workorder
+        # Resequence of workorder as per the BOM operation sequance
+        if self.workorder_ids.operation_id.ids != self.bom_id.operation_ids.ids:
+            self._resequence_workorders()
         # Creates a workorder for each remaining operation.
         workorders_values = []
         for operation in operations_by_id.values():
@@ -3132,8 +3135,13 @@ class MrpProduction(models.Model):
             wo.sequence = index_wo
         offset = len(phantom_workorders)
         non_phantom_workorders = self.workorder_ids - phantom_workorders
+        operation_sequence_map = {op.id: index for index, op in enumerate(self.bom_id.operation_ids)}
         for index_wo, wo in enumerate(non_phantom_workorders):
-            wo.sequence = index_wo + offset
+            if wo.operation_id:
+                wo.sequence = operation_sequence_map.get(wo.operation_id.id, 0) + offset
+                wo.blocked_by_workorder_ids = [Command.clear()]
+            else:
+                wo.sequence = index_wo + offset
         return True
 
     def _track_get_fields(self):


### PR DESCRIPTION
Previously, when the operation sequence was changed in the BoM and the 'Update BoM' button was used on a confirmed Manufacturing Order, the corresponding work orders did not reflect the updated sequence, causing discrepancies in execution order.

With this improvement, confirmed MOs automatically resequence work orders to match the BoM's updated operation order.

Operation dependencies are recalculated dynamically to maintain accurate links while preventing cyclic dependencies.

This ensures work orders are executed in the correct order, reducing user confusion and avoiding execution errors on the shop floor.

Task ID: [4703274](https://www.odoo.com/odoo/project/966/tasks/4703274)