### PR TITLE
[FIX] point_of_sale: display due date on invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 from functools import partial
 from itertools import groupby
 from markupsafe import Markup
@@ -673,6 +673,7 @@ class PosOrder(models.Model):
             'currency_id': self.currency_id.id,
             'invoice_user_id': self.user_id.id,
             'invoice_date': invoice_date.astimezone(timezone).date(),
+            'invoice_date_due': invoice_date.astimezone(timezone).date() + timedelta(days=max(self.partner_id.property_payment_term_id.line_ids.mapped('nb_days'), default=0)),
             'fiscal_position_id': self.fiscal_position_id.id,
             'invoice_line_ids': self._prepare_invoice_lines(),
             'invoice_payment_term_id': False,


### PR DESCRIPTION
**Problem:**
When making an invoice for a customer that has a Payment Term set in
their Contact file, the due date for the invoice was not taken into
account. It will display the date of the invoice as the due date,
even if the Payment Term of the client was set to something else.

**Steps to reproduce:**
- Go to Contacts and set a Payment term for the Contact you will use (Sales and Purchase tab)
- Open the Point of Sale, chose a product and the contact you set a Payment Term for
- Pay for the order and make sur to click the Invoice button
- You can either check the invoice that was downloaded or go to accounting to check the invoice
- The due date is the same as the invoice's date and not what we set as the Payment Term

**Why the fix:**
The due date for the invoice is now set. The best way to do it would
be to set it with the invoice's *invoice_payment_term_id*, but  the
Point of Sale does not support the discount given by the
payment terms, leading to other errors. This is all explained in this
commit: https://github.com/odoo/odoo/pull/199385
This commit will still allow the user to see what the due date of the
invoice is. In the case of a complex Payment Term, that has multiple
steps to pay, the chosen date will be the one that is the furthest in
the future, as it is done when creating an invoice in the accounting
module.

opw-4680526