### PR TITLE
[FIX} website: fix mega menu styling issue in vertical navbars

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1696,6 +1696,63 @@ header {
     }
 }
 
+// Mega menu templates adjusted in order to fit the vertically aligned header template.
+.o_header_sidebar,
+.o_header_navbar_hamburger {
+
+    .s_mega_menu_menu_image_menu,
+    .s_mega_menu_little_icons,
+    .s_mega_menu_big_icons_subtitles,
+    .s_mega_menu_images_subtitles,
+    .s_mega_menu_menus_logos,
+    .s_mega_menu_thumbnails,
+    .s_mega_menu_cards {
+        > .container .row div {
+            width: 100% !important;
+        }
+    }
+
+    .s_mega_menu_odoo_menu,
+    .s_mega_menu_multi_menus {
+        > .container .row div {
+            width: 50% !important;
+        }
+    }
+
+    // removes extra decorative element which is not to be shown in this header template
+    .s_mega_menu_big_icons_subtitles{
+        .o_we_shape{
+            display: none;
+        }
+    }
+
+    .s_mega_menu_menus_logos .s_mega_menu_menus_logos_wrapper {
+        .row {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            justify-items: center;
+
+            div {
+                width: 100% !important;
+            }
+        }
+    }
+
+    .s_mega_menu_thumbnails .container .container .row div.col-6 {
+        width: 50% !important;
+    }
+    .s_mega_menu_thumbnails .container .container .row div:not(.col-6) {
+        display: none !important;
+    }
+    .s_mega_menu_thumbnails .s_mega_menu_thumbnails_footer .container{
+        flex-direction: column;
+        div{
+            width: 100% !important;
+        }
+    }
+
+}
+
 // Navbar Links Styles
 @if index(('block', 'border-bottom'), o-website-value('header-links-style')) {
     @include media-breakpoint-up(md) {

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -560,7 +560,7 @@
             <t t-set="_navbar_classes" t-valuef="d-none d-lg-block shadow-sm"/>
             <t t-set="_navbar_expand_class" t-valuef=""/>
 
-            <div id="o_main_nav" class="o_main_nav container d-grid py-0 o_grid_header_3_cols">
+            <div id="o_main_nav" class="o_main_nav container d-grid py-0 o_grid_header_3_cols o_header_navbar_hamburger">
                 <!-- Nav Toggler -->
                 <t t-call="website.navbar_toggler">
                     <t t-set="_toggler_class" t-valuef="btn me-auto p-2"/>


### PR DESCRIPTION
Steps to Reproduce :
1. Add a Mega Menu through Menu Editor
2. Switch the header template to Sidebar
3. Once done --> Open the mega menu; it will overlap with one another.

Issue:
Vertically aligned navbars like the sidebar and hamburger navbar, have styling issues with the mega menu. The mega menu is designed according to the full width of the screen, which leads to not look good mega menu when opened in a limited-spaced navbar.

Fix:
This commit adds the style particularly to vertical navbars, such that the styling of the mega menu is proper even in these navbars.

Task: 4684074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
