### PR TITLE
[FIX] reCaptcha, turnstile: disable both protection on neutralize

### DIFF
--- a/addons/google_recaptcha/data/neutralize.sql
+++ b/addons/google_recaptcha/data/neutralize.sql
@@ -1,0 +1,4 @@
+-- disable reCAPTCHA
+UPDATE ir_config_parameter
+SET value = ''
+WHERE key IN ('recaptcha_public_key', 'recaptcha_private_key');


### PR DESCRIPTION
This commit disable both protection upon neutralizing a db by removing the tokens.
Version 16.0 : only reCaptcha
Version 17.0+: both

opw-4734555
upg-2759374

