### PR TITLE
[FIX] html_editor: select entire cell when all content is selected

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -603,6 +603,7 @@ export class TablePlugin extends Plugin {
     }
 
     onMouseup(ev) {
+        delete this._mouseMovePositionWhenAllContentsSelected;
         this._currentMouseState = ev.type;
         this.editable.removeEventListener("mousemove", this.onMousemove);
     }
@@ -638,8 +639,6 @@ export class TablePlugin extends Plugin {
             return;
         }
         const selection = this.dependencies.selection.getEditableSelection();
-        const docSelection = this.document.getSelection();
-        const range = docSelection.rangeCount && docSelection.getRangeAt(0);
         const startTd = closestElement(selection.startContainer, "td");
         const endTd = closestElement(selection.endContainer, "td");
         if (startTd && startTd === endTd && !isProtected(startTd) && !isProtecting(startTd)) {
@@ -650,10 +649,12 @@ export class TablePlugin extends Plugin {
                 .every((child) => selectedNodes.includes(child));
             if (areCellContentsFullySelected) {
                 const SENSITIVITY = 5;
-                const rangeRect = range.getBoundingClientRect();
+                if (!this._mouseMovePositionWhenAllContentsSelected) {
+                    this._mouseMovePositionWhenAllContentsSelected = [ev.clientX, ev.clientY];
+                }
                 const isMovingAwayFromSelection =
-                    ev.clientX > rangeRect.x + rangeRect.width + SENSITIVITY || // moving right
-                    ev.clientX < rangeRect.x - SENSITIVITY; // moving left
+                    Math.abs(ev.clientX - this._mouseMovePositionWhenAllContentsSelected[0]) >=
+                    SENSITIVITY;
                 if (isMovingAwayFromSelection) {
                     // A cell is fully selected and the mouse is moving away
                     // from the selection, within said cell -> select the cell.


### PR DESCRIPTION
### Approach:

- When the entire content of a single table cell is selected, store the `ev.clientX` value once the cell content is fully selected. Afterward, if the mouse moves in the direction of the selection (left or right) by a sensitivity threshold of 5px, the entire cell is selected.

### Steps to Reproduce:

- Create a table (e.g., using /table).
- Add multiple blocks with varying text lengths inside a cell.
- Try selecting all the content inside the cell using the mouse.
- Observe that the cell does not get selected.

### Description of the issue/feature this PR addresses:

- The cell does not get selected when all content inside the cell is selected with the mouse.

### Desired behavior after PR is merged:

- The entire cell is selected when the content is fully selected.

task-4743170

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
