### PR TITLE
[FIX] web: report background image not displaying correctly

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -102,8 +102,8 @@ li.oe-nested {
 }
 
 .o_report_layout_background {
-    background-size: contains;
-    background-position: center 300px;
+    background-size: contain;
+    background-position: center;
     background-repeat: no-repeat;
 }
 


### PR DESCRIPTION
Steps to reproduce:
1. Settings > Navigate to Configure Document Layout
2. Under Layout Background, select Custom and upload an image.

Issue:
Background image was being cut off at the end. The image was not covering the entire div.

Solution:
Updated the `.o_report_layout_background` CSS to use `background-size: contain`
and remove 300px from `background-position` to ensure the image scales
proportionally and stays centered.

opw : 4727408

Before FIX :
![image](https://github.com/user-attachments/assets/8c3c5cdc-8fad-4e25-8732-2cb2bbf3a44f)
After FIX :
![image](https://github.com/user-attachments/assets/97cc4364-73a4-4913-bda2-89805499bc0a)
