### PR TITLE
[IMP] account, account_edi_ubl_cii: search PO reference in descriptions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5307,8 +5307,10 @@ class AccountMove(models.Model):
 
     def _link_bill_origin_to_purchase_orders(self, timeout=10):
         for move in self.filtered(lambda m: m.move_type in self.get_purchase_types()):
-            references = [move.invoice_origin] if move.invoice_origin else []
+            references = move.invoice_origin.split() if move.invoice_origin else []
             move._find_and_set_purchase_orders(references, move.partner_id.id, move.amount_total, timeout=timeout)
+            if not any(line.purchase_order_id for line in move.line_ids):
+                move.invoice_origin = False
         return self
 
     def _autopost_bill(self):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -748,7 +748,11 @@ class AccountEdiXmlUbl_20(models.AbstractModel):
             invoice_values['name'] = ref
         elif ref:
             invoice_values['ref'] = ref
-        invoice_values['invoice_origin'] = tree.findtext('./{*}OrderReference/{*}ID')
+        invoice_values['invoice_origin'] = (
+            tree.findtext('./{*}OrderReference/{*}ID')
+            or ' '.join([desc.text for desc in tree.findall('.//{*}Item/{*}Description')])
+            or None
+        )
         invoice_values['narration'] = self._import_description(tree, xpaths=['./{*}Note', './{*}PaymentTerms/{*}Note'])
         invoice_values['payment_reference'] = tree.findtext('./{*}PaymentMeans/{*}PaymentID')
 

--- a/addons/purchase_edi_ubl_bis3/tests/__init__.py
+++ b/addons/purchase_edi_ubl_bis3/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_purchase_order_edi_gen
+from . import test_account_move_import

--- a/addons/purchase_edi_ubl_bis3/tests/test_account_move_import.py
+++ b/addons/purchase_edi_ubl_bis3/tests/test_account_move_import.py
@@ -1,0 +1,106 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, Command
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo.tools import file_open
+
+
+@tagged('post_install', '-at_install')
+class TestAccountMoveImport(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_open_wood = cls.env['res.partner'].create({
+            'name': 'openWood',
+            'country_id': cls.env.ref('base.be').id,
+        })
+
+        cls.product = cls.env['product.product'].create({
+            'name': 'Test Product',
+            'standard_price': 40.0,
+        })
+
+        cls.purchase_order = cls.env['purchase.order'].create({
+            'partner_id': cls.partner_open_wood.id,
+            'date_order': fields.Date.today(),
+            'name': 'test_purchase_order',
+            'order_line': [Command.create({
+                'product_id': cls.product.id,
+                'name': cls.product.name,
+                'product_qty': 1.0,
+            })],
+        })
+        cls.purchase_order.button_confirm()
+
+    def _create_bill_from_xml(self, xml_file_path):
+        file_path = f"{self.test_module}/tests/test_files/{xml_file_path}"
+        with file_open(file_path, 'rb') as file:
+            xml_attachment = self.env['ir.attachment'].create({
+                'mimetype': 'application/xml',
+                'name': 'test_bill.xml',
+                'raw': file.read(),
+            })
+        return self._import_attachment(xml_attachment)
+
+    def _import_attachment(self, attachment, journal=None):
+        journal = journal or self.company_data["default_journal_purchase"]
+        return self.env['account.journal'] \
+            .with_context(default_journal_id=journal.id) \
+            ._create_document_from_attachment(attachment.id)
+
+    def test_import_purchase_order_reference_from_provided_field(self):
+        """
+        This test will try to match a purchase order when the purchase reference is in the provided field
+        """
+        bill = self._create_bill_from_xml("ubl_bis3_PO.xml")
+        self.assertEqual(bill.invoice_origin, self.purchase_order.name)
+        # Checks if all lines referencing a PO reference the PO we created in setup.
+        # The 'or [False]' makes sure that there's at least one line referencing a PO.
+        self.assertTrue(all([line.purchase_order_id == self.purchase_order for line in bill.line_ids if line.purchase_order_id] or [False]))
+
+    def test_import_purchase_order_reference_from_lines_description(self):
+        """
+        This test will try to match a purchase order when the purchase reference is not
+        in the provided field but in the lines descriptions
+        """
+        bill = self._create_bill_from_xml("ubl_bis3_PO_description.xml")
+        self.assertEqual(bill.invoice_origin, self.purchase_order.name)
+        # Checks if all lines referencing a PO reference the PO we created in setup.
+        # The 'or [False]' makes sure that there's at least one line referencing a PO.
+        self.assertTrue(all([line.purchase_order_id == self.purchase_order for line in bill.line_ids if line.purchase_order_id] or [False]))
+
+    def test_multiple_purchase_order_references(self):
+        """
+        This test checks that we find the purchase_order_id when giving multiple possible
+        references in the 'invoice_origin' field
+        """
+        # Test with reference
+        bill = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_origin': 'TEST multiple references test_purchase_order and other refs',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1,
+                'price_unit': 40,
+            })]
+        })
+        bill._link_bill_origin_to_purchase_orders()
+        self.assertEqual(bill.invoice_origin, 'test_purchase_order')
+        self.assertTrue(all(line.purchase_order_id == self.purchase_order for line in bill.line_ids if line.purchase_order_id))
+
+        # Test without ref
+        bill_2 = self.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'invoice_origin': 'TEST multiple references and other refs',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [Command.create({
+                'quantity': 1,
+                'price_unit': 40,
+            })]
+        })
+        bill_2._link_bill_origin_to_purchase_orders()
+        self.assertFalse(bill_2.invoice_origin)
+        self.assertTrue(all(not line.purchase_order_id for line in bill_2.line_ids))

--- a/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO.xml
@@ -1,0 +1,156 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2025/00005</cbc:ID>
+  <cbc:IssueDate>2025-04-18</cbc:IssueDate>
+  <cbc:DueDate>2025-04-18</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>test_purchase_order</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0246697724</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>BE Company CoA</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>1021 Sint-Bernardsesteenweg</cbc:StreetName>
+        <cbc:CityName>Antwerpen</cbc:CityName>
+        <cbc:PostalZone>2660</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0246697724</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>BE Company CoA</cbc:RegistrationName>
+        <cbc:CompanyID>BE0246697724</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>BE Company CoA</cbc:Name>
+        <cbc:Telephone>+32 470 12 34 56</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.beexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>OpenWood</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Orval 1</cbc:StreetName>
+        <cbc:CityName>Florenville</cbc:CityName>
+        <cbc:PostalZone>6823</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:ID>0208</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>OpenWood</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>OpenWood</cbc:Name>
+        <cbc:Telephone>+32 987 65 43 21</cbc:Telephone>
+        <cbc:ElectronicMail>wow@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Orval 1</cbc:StreetName>
+        <cbc:CityName>Florenville</cbc:CityName>
+        <cbc:PostalZone>6823</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>+++000/0000/05959+++</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>BE76429468789995</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">10.25</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">48.80</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">10.25</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">48.80</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">48.80</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">59.05</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">59.05</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">30.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>[E-COM12] Conference Chair (Steel)</cbc:Description>
+      <cbc:Name>Conference Chair</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>E-COM12</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">30.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">10.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>[E-COM08] Storage Box</cbc:Description>
+      <cbc:Name>Storage Box</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>E-COM08</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">10.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO_description.xml
+++ b/addons/purchase_edi_ubl_bis3/tests/test_files/ubl_bis3_PO_description.xml
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#compliant#urn:fdc:peppol.eu:2017:poacc:billing:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2025/00005</cbc:ID>
+  <cbc:IssueDate>2025-04-18</cbc:IssueDate>
+  <cbc:DueDate>2025-04-18</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0208">0246697724</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>BE Company CoA</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>1021 Sint-Bernardsesteenweg</cbc:StreetName>
+        <cbc:CityName>Antwerpen</cbc:CityName>
+        <cbc:PostalZone>2660</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>BE0246697724</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>BE Company CoA</cbc:RegistrationName>
+        <cbc:CompanyID>BE0246697724</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>BE Company CoA</cbc:Name>
+        <cbc:Telephone>+32 470 12 34 56</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.beexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>OpenWood</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Orval 1</cbc:StreetName>
+        <cbc:CityName>Florenville</cbc:CityName>
+        <cbc:PostalZone>6823</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cac:TaxScheme>
+          <cbc:ID>0208</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>OpenWood</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>OpenWood</cbc:Name>
+        <cbc:Telephone>+32 987 65 43 21</cbc:Telephone>
+        <cbc:ElectronicMail>wow@example.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Orval 1</cbc:StreetName>
+        <cbc:CityName>Florenville</cbc:CityName>
+        <cbc:PostalZone>6823</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>BE</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>+++000/0000/05959+++</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>BE76429468789995</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">10.25</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">48.80</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">10.25</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">48.80</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">48.80</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">59.05</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">59.05</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">30.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>[E-COM12] Conference Chair (Steel) test_purchase_order</cbc:Description>
+      <cbc:Name>Conference Chair</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>E-COM12</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">30.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>2</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">10.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>[E-COM08] Storage Box</cbc:Description>
+      <cbc:Name>Storage Box</cbc:Name>
+      <cac:SellersItemIdentification>
+        <cbc:ID>E-COM08</cbc:ID>
+      </cac:SellersItemIdentification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>21.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">10.00</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>


### PR DESCRIPTION
When importing a vendor bill from a xml file, we currently search for a PO reference in the provided field. If no references is found there, no PO is linked to the bill. With this commit, if no reference is found in the field, we search for it in the descriptions of the lines.

Runbot: https://runbot.odoo.com/runbot/bundle/master-import-xml-po-detection-roto-364308
Task: https://www.odoo.com/odoo/project/967/tasks/4280095
