### PR TITLE
[IMP] hw_drivers: show unsupported devices

### DIFF
--- a/addons/hw_drivers/interface.py
+++ b/addons/hw_drivers/interface.py
@@ -5,19 +5,20 @@ import logging
 from threading import Thread
 import time
 
-from odoo.addons.hw_drivers.main import drivers, interfaces, iot_devices
+from odoo.addons.hw_drivers.main import drivers, interfaces, iot_devices, unsupported_devices
 
 _logger = logging.getLogger(__name__)
 
 
 class Interface(Thread):
     _loop_delay = 3  # Delay (in seconds) between calls to get_devices or 0 if it should be called only once
-    _detected_devices = {}
     connection_type = ''
+    allow_unsupported = False
     daemon = True
 
     def __init__(self):
         super().__init__()
+        self._detected_devices = set()
         self.drivers = sorted([d for d in drivers if d.connection_type == self.connection_type], key=lambda d: d.priority, reverse=True)
 
     def __init_subclass__(cls):
@@ -37,34 +38,38 @@ class Interface(Thread):
 
         added = devices.keys() - self._detected_devices
         removed = self._detected_devices - devices.keys()
-        # keys() returns a dict_keys, and the values of that stay in sync with the
-        # original dictionary if it changes. This means that get_devices needs to return
-        # a newly created dictionary every time. If it doesn't do that and reuses the
-        # same dictionary, this logic won't detect any changes that are made. Could be
-        # avoided by converting the dict_keys into a regular dict. The current logic
-        # also can't detect if a device is replaced by a different one with the same
-        # key. Also, _detected_devices starts out as a class variable but gets turned
-        # into an instance variable here. It would be better if it was an instance
-        # variable from the start to avoid confusion.
-        self._detected_devices = devices.keys()
+        self._detected_devices = set(devices.keys())
 
         for identifier in removed:
             if identifier in iot_devices:
                 iot_devices[identifier].disconnect()
                 _logger.info('Device %s is now disconnected', identifier)
+            elif self.allow_unsupported and identifier in unsupported_devices:
+                del unsupported_devices[identifier]
+                _logger.info('Unsupported device %s is now disconnected', identifier)
 
         for identifier in added:
-            for driver in self.drivers:
-                if driver.supported(devices[identifier]):
-                    _logger.info('Device %s is now connected', identifier)
-                    d = driver(identifier, devices[identifier])
-                    iot_devices[identifier] = d
-                    # Start the thread after creating the iot_devices entry so the
-                    # thread can assume the iot_devices entry will exist while it's
-                    # running, at least until the `disconnect` above gets triggered
-                    # when `removed` is not empty.
-                    d.start()
-                    break
+            supported_driver = next(
+                (driver for driver in self.drivers if driver.supported(devices[identifier])),
+                None
+            )
+            if supported_driver:
+                _logger.info('Device %s is now connected', identifier)
+                d = supported_driver(identifier, devices[identifier])
+                iot_devices[identifier] = d
+                # Start the thread after creating the iot_devices entry so the
+                # thread can assume the iot_devices entry will exist while it's
+                # running, at least until the `disconnect` above gets triggered
+                # when `removed` is not empty.
+                d.start()
+            elif self.allow_unsupported:
+                _logger.info('Unsupported device %s is now connected', identifier)
+                unsupported_devices[identifier] = {
+                    'name': f'Unknown device ({self.connection_type})',
+                    'identifier': identifier,
+                    'type': 'unsupported',
+                    'connection': 'direct' if self.connection_type == 'usb' else self.connection_type,
+                }
 
     def get_devices(self):
         raise NotImplementedError()

--- a/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/SerialInterface.py
@@ -9,6 +9,7 @@ from odoo.addons.hw_drivers.interface import Interface
 
 class SerialInterface(Interface):
     connection_type = 'serial'
+    allow_unsupported = True
 
     def get_devices(self):
         serial_devices = {

--- a/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
@@ -8,6 +8,16 @@ from odoo.addons.hw_drivers.interface import Interface
 
 class USBInterface(Interface):
     connection_type = 'usb'
+    allow_unsupported = True
+
+    @staticmethod
+    def usb_matcher(dev):
+        # Ignore USB hubs
+        if dev.bDeviceClass == 9:
+            return False
+
+        # Ignore serial adapters
+        return dev.product != "USB2.0-Ser!"
 
     def get_devices(self):
         """
@@ -18,7 +28,7 @@ class USBInterface(Interface):
         will get the same identifiers after a reboot or a disconnect/reconnect.
         """
         usb_devices = {}
-        devs = core.find(find_all=True)
+        devs = core.find(find_all=True, custom_match=self.usb_matcher)
         cpt = 2
         for dev in devs:
             identifier = "usb_%04x:%04x" % (dev.idVendor, dev.idProduct)

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 from odoo import http
 from odoo.addons.hw_drivers.tools import certificate, helpers, route, wifi
-from odoo.addons.hw_drivers.main import iot_devices
+from odoo.addons.hw_drivers.main import iot_devices, unsupported_devices
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.tools.misc import file_path
 from odoo.addons.hw_drivers.server_logger import (
@@ -148,6 +148,8 @@ class IotBoxOwlHomePage(http.Controller):
             'identifier': device.device_identifier,
             'connection': device.device_connection,
         } for device in iot_devices.values()]
+        devices += list(unsupported_devices.values())
+
         device_type_key = lambda device: device['type']
         grouped_devices = {
             device_type: list(devices)

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/DeviceDialog.js
@@ -15,6 +15,7 @@ export const DEVICE_ICONS = {
     printer: "fa-print",
     scale: "fa-balance-scale",
     scanner: "fa-barcode",
+    unsupported: "fa-question",
 };
 
 export const CONNECTION_ICONS = {
@@ -38,7 +39,9 @@ export class DeviceDialog extends Component {
     formatDeviceType(deviceType, numDevices) {
         const formattedDeviceType =
             deviceType[0].toUpperCase() + deviceType.replaceAll("_", " ").slice(1);
-        return numDevices === 1 ? formattedDeviceType : `${formattedDeviceType}s`;
+        return numDevices === 1 || deviceType === "unsupported"
+            ? formattedDeviceType
+            : `${formattedDeviceType}s`;
     }
 
     get devices() {

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -149,7 +149,7 @@ class StatusPage extends Component {
                             <tr t-foreach="Object.keys(state.data.devices)" t-as="deviceType" t-key="deviceType">
                                 <td class="device-type col-3">
                                     <i t-att-class="'me-1 fa fa-fw fa- ' + icons[deviceType]"/>
-                                    <t t-out="deviceType.replaceAll('_', ' ') + 's'" />
+                                    <t t-out="deviceType.replaceAll('_', ' ') + (deviceType === 'unsupported' ? '' : 's')"/>
                                 </td>
                                 <td class="col-3">
                                     <ul>


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/83925

Before this commit, any devices that did not have a supported driver were just ignored.

After this commit, if the Interface class sets
`allow_unsupported = True`, then any devices found with no suitable driver will be added to a list of unsupported devices. This list is sent to both the IoT box homepage, as well as sent to the connected DB. This can help with debugging devices that are not being detected as expected (e.g. blackbox serial device).

task-4744357

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
