### PR TITLE
[FIX] crm: fix drag and drop in crm tour

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -48,7 +48,7 @@ registry.category("web_tour.tours").add('crm_tour', {
     trigger: ".o_opportunity_kanban",
 },
 {
-    trigger: ".o_opportunity_kanban .o_kanban_group:first-child .o_kanban_record:last-of-type",
+    trigger: ".o_opportunity_kanban:not(:has(.o_view_sample_data)) .o_kanban_group .o_kanban_record:last-of-type",
     content: markup(_t("<b>Drag &amp; drop opportunities</b> between columns as you progress in your sales cycle.")),
     tooltipPosition: "right",
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(2))",


### PR DESCRIPTION
Fix drag and drop in CRM tour because the tour bubble disappear if the record has not been dropped in the correct column.

Now the tour bubble will stay visible until the opportunity is dropped in the correct stage. Still taking the last record of first column first, then last of second column, etc ...

Task-4624497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
