### PR TITLE
[FIX] l10n_es_edi_sii: fix "CuotaRecargoEquivalencia" in json sent to SII

### DIFF
--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -6,6 +6,7 @@ import json
 from freezegun import freeze_time
 from unittest.mock import patch
 
+from odoo import Command
 from odoo.tests import tagged
 
 
@@ -161,11 +162,15 @@ class TestEdiXmls(TestEsEdiCommon):
                 invoice_line_ids=[
                     {
                         'price_unit': 100.0,
-                        'tax_ids': [(6, 0, (self._get_tax_by_xml_id('s_iva10b') + self._get_tax_by_xml_id('s_req014')).ids)],
+                        'tax_ids': [Command.set((self._get_tax_by_xml_id('s_iva10b') + self._get_tax_by_xml_id('s_req014')).ids)],
+                    },
+                    {
+                        'price_unit': 50.0,
+                        'tax_ids': [Command.set((self._get_tax_by_xml_id('s_iva10b') + self._get_tax_by_xml_id('s_req014')).ids)],
                     },
                     {
                         'price_unit': 200.0,
-                        'tax_ids': [(6, 0, (self._get_tax_by_xml_id('s_iva21s') + self._get_tax_by_xml_id('s_req52')).ids)],
+                        'tax_ids': [Command.set((self._get_tax_by_xml_id('s_iva21s') + self._get_tax_by_xml_id('s_req52')).ids)],
                     },
                 ],
             )
@@ -214,9 +219,9 @@ class TestEdiXmls(TestEsEdiCommon):
                                             'DetalleIVA': [
                                                 {
                                                     'TipoImpositivo': 10.0,
-                                                    'BaseImponible': 100.0,
-                                                    'CuotaRepercutida': 10.0,
-                                                    'CuotaRecargoEquivalencia': 1.4,
+                                                    'BaseImponible': 150.0,
+                                                    'CuotaRepercutida': 15.0,
+                                                    'CuotaRecargoEquivalencia': 2.1,
                                                     'TipoRecargoEquivalencia': 1.4
                                                 }
                                             ]
@@ -226,7 +231,7 @@ class TestEdiXmls(TestEsEdiCommon):
                             }
                         }
                     },
-                    'ImporteTotal': 363.8,
+                    'ImporteTotal': 419.5,
                     'Contraparte': {
                         'IDOtro': {'ID': 'BE0477472701', 'IDType': '02'},
                         'NombreRazon': 'partner_a',


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_es_edi_sii
- Switch to a Spanish company (e.g. ES Company)
- Create an invoice:
  * Customer: [a Spanish customer] (e.g. Ayuntamiento De Bilbao)
  * 1 invoice line with a "Sujeto" type tax (e.g. "4% G") and a "Recargo de Equivalencia" type tax (e.g. "0.5% SE")
  * another invoice line with the same taxes
- Confirm the invoice
- Send the invoice to "SII IVA Llevanza de libros registro (ES)"
- Check the sent "jsondump.json" file in the attachments

**Issue:**
Value of "CuotaRecargoEquivalencia" in the json is incorrect. It only contains the tax amount of the "Recargo de Equivalencia" tax (i.e. "0.5% SE") of the second line, instead of the sum of the tax amount from both lines.

**Cause:**
When computing the details for the "Recargo de Equivalencia" taxes, each invoice line is grouped by their combination of taxes.
For each combination, we keep the tax details of the recargo tax of one line (the latest one) overriding the previous values, instead of summing them.

**Solution:**
Sum the tax amount for each group of taxes.

opw-4650892




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
