### PR TITLE
[IMP] hw_drivers: set custom user agent for IoT Box

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from functools import wraps
+import requests
+
 from . import server_logger
 from . import connection_manager
 from . import controllers
@@ -12,3 +15,20 @@ from . import interface
 from . import main
 from . import websocket_client
 from . import led_manager_L
+
+_get = requests.get
+_post = requests.post
+
+
+def set_user_agent(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        headers = kwargs.pop('headers', {})
+        headers['User-Agent'] = 'OdooIoTBox/1.0'
+        return func(*args, headers=headers, **kwargs)
+
+    return wrapper
+
+
+requests.get = set_user_agent(_get)
+requests.post = set_user_agent(_post)


### PR DESCRIPTION
This commit patches the `requests` library to always set the User Agent in headers to `OdooIoTBox/1.0`. This way, a database can easily know who the request is coming from.

Task: 4600268