### PR TITLE
[FIX] account: Fix register payment with epd + cash rounding

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -502,7 +502,8 @@ class AccountPaymentRegister(models.TransientModel):
         moves = batch_result['lines'].mapped('move_id')
         for move in moves:
             if early_payment_discount and move._is_eligible_for_early_payment_discount(move.currency_id, self.payment_date):
-                amount -= move.direction_sign * move.invoice_payment_term_id._get_amount_due_after_discount(move.amount_total, move.amount_tax)
+                for aml in batch_result['lines'].filtered(lambda l: l.move_id.id == move.id):
+                    amount += aml.discount_amount_currency
                 mode = 'early_payment'
             else:
                 for aml in batch_result['lines'].filtered(lambda l: l.move_id.id == move.id):


### PR DESCRIPTION
Suppose an invoice line of 11.0 with 21% tax.
The total of the invoice is 13.31.
With a cash rounding of 0.05 UP, the total of the invoice becomes 13.35. If we apply an early payment discount of 2% on payments, we expect a discount of 0.25 because 13.35 * 0.98 = 13.08 but 13.10 with the cash rounding. 13.35 - 13.10 = 0.25
However, the cash rounding of the payment register wizard is computed from the total invoice instead of taking the amount stored on the accounting item. Then, he was computing an early payment of 13.35 * 0.02 = 0.27 instead. At the end, the invoice was still open with a residual amount of 0.02.

opw-4730764

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
