### PR TITLE
[FIX] pos*: too much lines sent to kitchen

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -435,10 +435,13 @@ export class PosStore extends Reactive {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (
                     typeof order.id === "number" &&
-                    Object.keys(order.last_order_preparation_change.lines).length > 0
+                    Object.keys(order.last_order_preparation_change.lines).length > 0 &&
+                    !this.doNotSendOrderInPreparation
                 ) {
                     await this.sendOrderInPreparation(order, true);
                 }
+
+                this.doNotSendOrderInPreparation = false;
 
                 const cancelled = this.removeOrder(order, false);
                 this.removePendingOrder(order);


### PR DESCRIPTION
  Before this commit, when I Link  2 tables, add item on the new
  grouped tables and order it, I get duplicate preparation card.

  When we create a new product card, we need to ensure that only t
  items (not sent) are actually sent as new items to prepare.

  Do not bother by cancelling items from the previous preparation
  Think at it as if it was a preparation ticket in paper

task-id: 4735631

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
