### PR TITLE
[FIX] mail: no fake textarea in long page with comments


### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -141,7 +141,9 @@
 
 .o-mail-Composer-fake {
     height: 0;
+    left: -10000px;
     top: -10000px;
+    visibility: hidden;
 }
 
 .o-mail-Composer-bg {


### PR DESCRIPTION

Scenario: create a long blog page article and enable comments

Result: there is a grey unusable textarea with o-mail-Composer-fake
over the blog content.

Issue: in 7710c3331ebd22f8396870bd0731f8c1152d9c41 the fake textarea
used to compute the height of the real textarea, had a position of
-10000px, which make sense in the backend to make it hidden. But in
18.0 with 368eb78a9cedfce0802b64fd2782e1c018541e40 we use the backend
composer on portal, where a page could be higher than 10000px and the
fake textarea can be shown.

Fix: hide it better (also to the left, and in case there was a
10000x10000 pixels page with comment at the bottom right, make it
invisible).

opw-4719975
