### PR TITLE
[FIX] pos_self_order: fix product variants price preicision

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -134,7 +134,7 @@ export class AttributeSelection extends Component {
 
     shouldShowPriceExtra(value) {
         const priceExtra = value.price_extra;
-        return !floatIsZero(priceExtra, this.selfOrder.config.currency_decimals);
+        return !floatIsZero(priceExtra, this.selfOrder.currency.decimal_places);
     }
 
     getfPriceExtra(value) {

--- a/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_attribute_tour.js
@@ -8,6 +8,7 @@ registry.category("web_tour.tours").add("self_attribute_selector", {
     steps: () => [
         Utils.clickBtn("Order Now"),
         ProductPage.clickProduct("Desk Organizer"),
+        ProductPage.checkAttributePrice("Size", "S", "$ 0.25"),
         ...ProductPage.setupAttribute([
             { name: "Size", value: "M" },
             { name: "Fabric", value: "Leather" },

--- a/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/product_page_util.js
@@ -36,6 +36,13 @@ export function clickDiscard() {
     };
 }
 
+export function checkAttributePrice(name, value, price) {
+    return {
+        content: `Check product price ${price} for variant ${name}: ${value}`,
+        trigger: `div.attribute-row h2:contains('${name}') + div.row div.col label div.name span:contains('${value}') + span:contains('${price}')`,
+    };
+}
+
 export function setupAttribute(attributes, addToCart = true) {
     const steps = [];
     if (addToCart) {

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -17,7 +17,7 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
         })
 
         product = self.env['product.product'].search([('name', '=', 'Desk Organizer')])[0]
-        product.attribute_line_ids[0].product_template_value_ids[0].price_extra = 0.0
+        product.attribute_line_ids[0].product_template_value_ids[0].price_extra = 0.25
         product.attribute_line_ids[0].product_template_value_ids[1].price_extra = 1.0
         product.attribute_line_ids[0].product_template_value_ids[2].price_extra = 2.0
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Create a PoS product with variants, one of the variant with a `price_extra` less than 0.5
2. Activate self ordering and open that interface
3. Choose the product we created in step 1

Observation: the variant that have an `price_extra` less than 0.5 does not show that price different.

Reason:
-------
We are using the config `decimal_places`, which existed prior to version 17.4, but it has since been removed in 17.4+, but we still reference this config field in pos_self_order !!

Fix:
----
Use the precision field from `currency.decimal_places` instead.

opw-4706506
opw-4721090