### PR TITLE
[FIX] l10n_ch: Use same address in text as in QR code

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -52,10 +52,10 @@
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
                                 <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
-                                <span t-field="o.company_id.street"/><br/>
-                                <span t-field="o.company_id.country_id.code"/>
-                                <span t-field="o.company_id.zip"/>
-                                <span t-field="o.company_id.city"/><br/>
+                                <span t-field="o.partner_bank_id.partner_id.street"/><br/>
+                                <span t-field="o.partner_bank_id.partner_id.country_id.code"/>
+                                <span t-field="o.partner_bank_id.partner_id.zip"/>
+                                <span t-field="o.partner_bank_id.partner_id.city"/><br/>
                                 <br/>
                             </div>
 
@@ -164,10 +164,10 @@
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
                                 <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
-                                <span t-field="o.company_id.street"/><br/>
-                                <span t-field="o.company_id.country_id.code"/>
-                                <span t-field="o.company_id.zip"/>
-                                <span t-field="o.company_id.city"/><br/>
+                                <span t-field="o.partner_bank_id.partner_id.street"/><br/>
+                                <span t-field="o.partner_bank_id.partner_id.country_id.code"/>
+                                <span t-field="o.partner_bank_id.partner_id.zip"/>
+                                <span t-field="o.partner_bank_id.partner_id.city"/><br/>
                                 <br/>
                             </div>
 

--- a/doc/cla/corporate/exelen.md
+++ b/doc/cla/corporate/exelen.md
@@ -1,0 +1,15 @@
+Switzerland, 24th-Apr-2025
+
+Exelen GmbH agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Olivier Hochreutiner olivier.hochreutiner@exelen.ch https://github.com/ohoc
+
+List of contributors:
+
+Olivier Hochreutiner olivier.hochreutiner@exelen.ch https://github.com/ohoc


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong address/zip/city in Swiss QR bill template.

Current behavior before PR:
The template for Swiss QR bills uses the company address, zip code and city.

Desired behavior after PR is merged:
The template for Swiss QR bills uses the address/zip/city of the creditor's bank account.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
