### PR TITLE
[IMP] pos_self_order: improve splash and background image loading

### DIFF
--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -21,13 +21,6 @@ patch(PaymentPage.prototype, {
             this.checkAndOpenPaymentPage(order);
         }
     },
-    get backgroundImage() {
-        const bgImage = this.selfOrder.config._self_ordering_image_background_ids[0];
-        if (bgImage) {
-            return `url(data:image/png;base64,${bgImage.data})`;
-        }
-        return "none";
-    },
     get selectedPaymentIsOnline() {
         const paymentMethods = this.selectedPaymentMethod;
         return paymentMethods && paymentMethods.is_online_payment;

--- a/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_online_payment_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_online_payment_self_order.PaymentPage" t-inherit="pos_self_order.PaymentPage" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('payment-state-container')]" position="after">
-            <div t-if="this.selectedPaymentIsOnline and !state.selection and selfOrder.config.self_ordering_mode === 'kiosk'" class="o_kiosk_payment_screen d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+            <div t-if="this.selectedPaymentIsOnline and !state.selection and selfOrder.config.self_ordering_mode === 'kiosk'" class="o_kiosk_payment_screen d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
                 <h1 class="fw-bolder mb-4">Scan the QR code to pay</h1>
                 <div class="qr-code d-inline-flex flex-column border rounded-4 p-0 bg-view mb-3">
                     <img t-att-src="state.qrImage" />

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -130,14 +130,6 @@ export class ConfirmationPage extends Component {
         }
     }
 
-    get backgroundImage() {
-        const bgImage = this.selfOrder.config._self_ordering_image_background_ids[0];
-        if (bgImage) {
-            return `url(data:image/png;base64,${bgImage.data})`;
-        }
-        return "none";
-    }
-
     get printOptions() {
         return {};
     }

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -8,7 +8,7 @@
                 </div>
             </div>
         </div>
-        <div t-else="" class="confirmation-page d-flex justify-content-center align-items-center flex-column h-100 p-3 text-center" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+        <div t-else="" class="confirmation-page d-flex justify-content-center align-items-center flex-column h-100 p-3 text-center" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
             <div class="d-flex flex-column align-items-center justify-content-center w-100 h-100">
                 <div class="mb-4">
                     <h1 t-if="state.payment and selfOrder.config.self_ordering_pay_after !== 'each'" class="fw-bold" style="text-wrap: pretty;">

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -28,12 +28,4 @@ export class EatingLocationPage extends Component {
     get presets() {
         return this.selfOrder.models["pos.preset"].getAll();
     }
-
-    get backgroundImage() {
-        const bgImage = this.selfOrder.config._self_ordering_image_background_ids[0];
-        if (bgImage) {
-            return `url(data:image/png;base64,${bgImage.data})`;
-        }
-        return "none";
-    }
 }

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve" >
     <t t-name="pos_self_order.EatingLocationPage">
         <t t-if="selfOrder.kioskMode">
-            <div class="o_kiosk_eating_location_box d-flex flex-column flex-grow-1 overflow-y-auto o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+            <div class="o_kiosk_eating_location_box d-flex flex-column flex-grow-1 overflow-y-auto o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
                 <div class="scroll_container d-flex flex-column flex-grow-1 overflow-y-auto justify-content-center my-auto">
                     <div class="title-container text-center mt-4">
                         <h1 class="px-5 header">Where do you want to eat?</h1>

--- a/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.KioskCartPage">
-        <div class=" d-flex flex-column vh-100 overflow-hidden o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+        <div class=" d-flex flex-column vh-100 overflow-hidden o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
             <div class="d-flex flex-column flex-grow-1 py-4 overflow-hidden">
                 <h1 class="attribute_name px-3 mx-3 mb-3 mt-auto">Your Order</h1>
                 <div class="d-flex flex-column mx-3 bg-white py-0 px-3 rounded-4 border border-light overflow-y-auto">

--- a/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve" >
     <t t-name="pos_self_order.KioskCategoryListPage">
-        <div class="o_kiosk_category_list_page d-flex flex-column vh-100 overflow-hidden o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size:cover; background-position:center;">
+        <div class="o_kiosk_category_list_page d-flex flex-column vh-100 overflow-hidden o_kiosk_background o_kiosk_fade" t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size:cover; background-position:center;">
             <div class="scroll_container position-relative d-flex flex-grow-1 overflow-y-auto justify-content-center my-auto">
                 <div class="o_kiosk_container d-grid gap-4 justify-content-center w-100 p-3 my-auto">
                     <button t-foreach="categories"

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -10,10 +10,10 @@
                 <div class="carousel-inner h-100 w-100">
                     <div
                         t-foreach="selfOrder.config._self_ordering_image_home_ids"
-                        t-as="image"
-                        t-key="image.id"
+                        t-as="imageId"
+                        t-key="imageId"
                         t-attf-class="carousel-item object-fit-cover h-100 w-100 {{activeImage}}"
-                        t-attf-style="background-image: url('data:image/png;base64,{{image.data}}'); background-size: cover; background-position: center;" />
+                        t-attf-style="background-image: url('/web/image/ir.attachment/{{imageId}}/raw'); background-size: cover; background-position: center;" />
                 </div>
             </div>
         </div>

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -44,10 +44,6 @@ export class PaymentPage extends Component {
         );
     }
 
-    get backgroundImage() {
-        return this.selfOrder.kioskBackgroundImage;
-    }
-
     // this function will be override by pos_online_payment_self_order module
     // in mobile is the only available payment method
     async startPayment() {

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.PaymentPage">
         <div class="d-flex flex-column flex-grow-1 overflow-y-auto o_kiosk_background o_kiosk_fade"
-        t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+        t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
             <div class="scroll_container d-flex flex-column flex-grow-1 overflow-y-auto justify-content-center my-auto">
                 <div t-if="state.selection" class="o_kiosk_container d-grid gap-4 align-items-center justify-content-center w-100 p-3 overflow-y-auto">
                     <button

--- a/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.StandNumberPage">
         <t t-if="selfOrder.kioskMode">
             <div class="kiosk_stand_page d-flex flex-column align-items-center flex-grow-1 o_kiosk_background overflow-y-auto text-center o_kiosk_fade"
-            t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
+            t-attf-style="background-image:#{selfOrder.kioskBackgroundImageUrl};background-size: cover; background-position: center;">
                 <div class="d-flex flex-column my-auto overflow-y-auto">
                     <h1 class="mb-4 m-0">Enter your tracker number</h1>
                     <div class="d-flex flex-column gap-4">

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -875,10 +875,10 @@ export class SelfOrder extends Reactive {
         return this.getAvailableCategories().length > 1;
     }
 
-    get kioskBackgroundImage() {
-        const bgImage = this.config._self_ordering_image_background_ids[0];
-        if (bgImage) {
-            return `url(data:image/png;base64,${bgImage.data})`;
+    get kioskBackgroundImageUrl() {
+        const imageId = this.config._self_ordering_image_background_ids[0];
+        if (imageId) {
+            return `url('/web/image/ir.attachment/${imageId}/raw')`;
         }
         return "none";
     }


### PR DESCRIPTION
Previously, splash and background images were embedded directly in the data response as base64-encoded strings, which increased the payload size. These images are now loaded via standard /web/image URLs, following the standard way of accessing images.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
