### PR TITLE
[FIX] account_fleet: ACLs on test

### DIFF
--- a/addons/account_fleet/tests/test_account_fleet.py
+++ b/addons/account_fleet/tests/test_account_fleet.py
@@ -12,9 +12,10 @@ class TestAccountFleet(AccountTestInvoicingCommon):
 
     @freeze_time('2021-09-15')
     def test_transfer_wizard_vehicle_info_propagation(self):
-        brand = self.env["fleet.vehicle.model.brand"].sudo().create({
+        self.env.user.group_ids |= self.env.ref("fleet.fleet_group_manager")
+        brand = self.env["fleet.vehicle.model.brand"].create({
             "name": "Audi",
-        }).sudo(False)
+        })
         model = self.env["fleet.vehicle.model"].create({
             "brand_id": brand.id,
             "name": "A3",

--- a/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
+++ b/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
@@ -10,6 +10,7 @@ class TestFleetVehicleLogServices(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.env.user.group_ids |= cls.env.ref("fleet.fleet_group_manager")
         cls.vendor = cls.env['res.partner'].create({'name': "Vendor"})
         cls.purchaser = cls.env['res.partner'].create({'name': "Purchaser"})
         brand = cls.env["fleet.vehicle.model.brand"].create({


### PR DESCRIPTION
Creating the fleet objects requires being fleet admin or sudo, but as it turns out `bill.action_post()` also requires fleet admin so no point in bothering with sudo, just add the group to the current user.

https://runbot.odoo.com/odoo/error/181531
