### PR TITLE
[FIX] website: prevent upload if logo is too big in configurator

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -259,6 +259,16 @@ class PaletteSelectionScreen extends Component {
         if (logoSelectInput.files.length === 1) {
             const previousLogoAttachmentId = this.state.logoAttachmentId;
             const file = logoSelectInput.files[0];
+            if (file.size > 2500000) {
+                this.notification.add(
+                    _t("The logo is too large. Please upload a logo smaller than 2.5 MB."),
+                    {
+                        title: file.name,
+                        type: "warning",
+                    }
+                );
+                return;
+            }
             const data = await getDataURLFromFile(file);
             const attachment = await this.rpc('/web_editor/attachment/add_data', {
                 'name': 'logo',


### PR DESCRIPTION
Steps to reproduce the issue:

- Create a new website using the configurator.
- At the step where the color palette is defined, upload a large logo (e.g., 6 MB).
- A traceback occurs.

The issue comes from the fact that the logo is added to the browser's session storage, which has a 10 MB limit in most modern browsers. Before the logo upload, the session storage already contains some data, and adding a large file goes over the 10 MB limit, which causes the traceback.

This commit prevents users from uploading a logo larger than 2.5 MB, which is already a lot for a logo shown in a website header.

task-4742810
