### PR TITLE
[FIX] point_of_sale: fix cogs duplicate backorder

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -125,12 +125,14 @@ class StockPicking(models.Model):
                 continue
             if rec.pos_order_id.shipping_date and not rec.pos_order_id.to_invoice:
                 cost_per_account = defaultdict(lambda: 0.0)
-                for line in rec.pos_order_id.lines:
+                for line in rec.move_line_ids:
                     if line.product_id.type != 'product' or line.product_id.valuation != 'real_time':
                         continue
                     out = line.product_id.categ_id.property_stock_account_output_categ_id
                     exp = line.product_id._get_product_accounts()['expense']
-                    cost_per_account[(out, exp)] += line.total_cost
+                    line_cost = line.move_id._get_price_unit() * line.quantity_product_uom
+                    if line_cost != 0:
+                        cost_per_account[out, exp] += line_cost
                 move_vals = []
                 for (out_acc, exp_acc), cost in cost_per_account.items():
                     move_vals.append({

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -398,3 +398,113 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
         self.assertEqual(product_line.discount, 5)  # Disount is reflected
         self.assertEqual(product_line.price_subtotal, 90.25)  # Discount applies on price_unit
         self.assertEqual(product_line.price_total, 103.79)  # Taxes applied with price_total
+
+    def test_cogs_with_ship_later_with_backorder(self):
+        # This test will check that the correct journal entries are created when 2 products are sold
+        # using the ship later option and one of them is processed in a backorder
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        self.cash_journal.loss_account_id = self.account
+        current_session.set_cashbox_pos(0, None)
+
+        # Create 2 product one with no cost and one with a cost of 20 EUR
+        self.product_2 = self.env['product.product'].create({
+            'name': 'New product 2',
+            'standard_price': 20,
+            'available_in_pos': True,
+            'type': 'product',
+            'categ_id': self.category.id,
+        })
+
+        self.product_1 = self.env['product.product'].create({
+            'name': 'New product 1',
+            'standard_price': 0,
+            'available_in_pos': True,
+            'type': 'product',
+            'categ_id': self.category.id,
+        })
+
+        # I create a PoS order with 1 unit of New product at 450 EUR
+        self.pos_order_pos0 = self.PosOrder.create({
+            'company_id': self.company.id,
+            'partner_id': self.partner.id,
+            'pricelist_id': self.company.partner_id.property_product_pricelist.id,
+            'session_id': self.pos_config.current_session_id.id,
+            'to_invoice': False,
+            'shipping_date': '2023-01-01',
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.product_1.id,
+                'price_unit': 100,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 100,
+                'price_subtotal_incl': 100,
+            }), (0, 0, {
+                'name': "OL/0002",
+                'product_id': self.product_2.id,
+                'price_unit': 200,
+                'discount': 0.0,
+                'qty': 1.0,
+                'price_subtotal': 200,
+                'price_subtotal_incl': 200,
+            })],
+            'amount_total': 300,
+            'amount_tax': 0,
+            'amount_paid': 0,
+            'amount_return': 0,
+            'last_order_preparation_change': '{}'
+        })
+
+        # I make a payment to fully pay the order
+        context_make_payment = {"active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
+        self.pos_make_payment_0 = self.PosMakePayment.with_context(context_make_payment).create({
+            'amount': 300.0,
+            'payment_method_id': self.cash_payment_method.id,
+        })
+
+        # I click on the validate button to register the payment.
+        context_payment = {'active_id': self.pos_order_pos0.id}
+        self.pos_make_payment_0.with_context(context_payment).check()
+
+        # I close the current session to generate the journal entries
+        current_session_id = self.pos_config.current_session_id
+        current_session_id.post_closing_cash_details(300.0)
+        current_session_id.close_session_from_ui()
+        self.assertEqual(current_session_id.state, 'closed', 'Check that session is closed')
+
+        current_session.picking_ids.move_ids_without_package.filtered(lambda m: m.product_id == self.product_2).write({'quantity': 1, 'picked': True})
+        res_dict = current_session.picking_ids.button_validate()
+        self.env['stock.backorder.confirmation'].with_context(res_dict['context']).process()
+
+        # I test that the generated journal entries are correct.
+        out = self.product_1.categ_id.property_stock_account_output_categ_id
+        exp = self.product_1._get_product_accounts()['expense']
+        aml = current_session._get_related_account_moves().line_ids
+        aml_output = aml.filtered(lambda l: l.account_id.id == out.id and l.journal_id == self.pos_config.journal_id)
+        aml_expense = aml.filtered(lambda l: l.account_id.id == exp.id and l.journal_id == self.pos_config.journal_id)
+
+        self.assertEqual(len(aml_expense), 1, "There should be 1 output account move lines")
+        self.assertEqual(aml_expense.debit, 20)
+        self.assertEqual(aml_expense.credit, 0)
+
+        self.assertEqual(len(aml_output), 1, "There should be 1 output account move lines")
+        self.assertEqual(aml_output.debit, 0)
+        self.assertEqual(aml_output.credit, 20)
+
+        backorder_picking = current_session.picking_ids.filtered(lambda p: p.state == 'confirmed')
+        backorder_picking.move_ids_without_package.write({'quantity': 1, 'picked': True})
+        backorder_picking.button_validate()
+
+        # As the second item has no cost, the account move line should be the same as before
+        aml = current_session._get_related_account_moves().line_ids
+        aml_output = aml.filtered(lambda l: l.account_id.id == out.id and l.journal_id == self.pos_config.journal_id)
+        aml_expense = aml.filtered(lambda l: l.account_id.id == exp.id and l.journal_id == self.pos_config.journal_id)
+
+        self.assertEqual(len(aml_expense), 1, "There should be 1 output account move lines")
+        self.assertEqual(aml_expense.debit, 20)
+        self.assertEqual(aml_expense.credit, 0)
+
+        self.assertEqual(len(aml_output), 1, "There should be 1 output account move lines")
+        self.assertEqual(aml_output.debit, 0)
+        self.assertEqual(aml_output.credit, 20)

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1912,6 +1912,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'categ_id': self.real_time_categ.id,
             'property_account_expense_id': self.account1.id,
             'property_account_income_id': self.account1.id,
+            'standard_price': 100,
         })
         self.product_b = self.env['product.product'].create({
             'name': 'Product B',
@@ -1919,51 +1920,54 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'categ_id': self.real_time_categ.id,
             'property_account_expense_id': self.account2.id,
             'property_account_income_id': self.account2.id,
+            'standard_price': 100,
         })
 
         #Create an order with the 2 products
         self.pos_config.open_ui()
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': self.pos_config.current_session_id.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product_a.id,
-                'price_unit': 100,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 100,
-                'price_subtotal_incl': 100,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product_b.id,
-                'price_unit': 100,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 100,
-                'price_subtotal_incl': 100,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 200.0,
-            'amount_total': 200.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}',
-            'shipping_date': fields.Date.today(),
-            })
-        #make payment
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        order_data = {'data':
+          {'amount_paid': 200,
+           'amount_return': 0,
+           'amount_tax': 200,
+           'amount_total': 200,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'partner_id': self.partner1.id,
+           'fiscal_position_id': False,
+           'lines': [[0, 0, {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 100,
+              'product_id': self.product_a.id,
+              'price_subtotal': 100,
+              'price_subtotal_incl': 100,
+              'qty': 1,
+              'tax_ids': []
+              }], [0, 0, {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 100,
+              'product_id': self.product_b.id,
+              'price_subtotal': 100,
+              'price_subtotal_incl': 100,
+              'qty': 1,
+              'tax_ids': []
+            }]],
+           'name': 'Order 00044-003-0014',
+           'pos_session_id': self.pos_config.current_session_id.id,
+           'sequence_number': self.pos_config.journal_id.id,
+           'shipping_date': fields.Date.today(),
+           'statement_ids': [[0,
+             0,
+             {'amount': 200,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.cash_payment_method.id}]],
+           'uid': '00044-003-0014',
+           'user_id': self.env.uid},
+          'to_invoice': False}
+
+        self.PosOrder.create_from_ui([order_data])
+        order = self.pos_config.current_session_id.order_ids[0]
+        order.picking_ids.move_ids.write({"quantity": 1, "picked": True})
         order.picking_ids._action_done()
+        self.pos_config.current_session_id.action_pos_session_closing_control()
 
         moves = self.env['account.move'].search([('ref', '=', f'pos_order_{order.id}')])
         self.assertEqual(len(moves), 2)


### PR DESCRIPTION
When using shiplater in PoS and creating a backorder from the original picking, the COGS would be duplicated when validating the backorder.

Steps to reproduce:
-------------------
* Create 2 products, one with a cost of 20 and one with a cost of 0
* Create a PoS order with 2 lines, one for each product
* Validate the order using the shiplater option
* Close the session and go to the picking created
* Validate the delivery only for the product with a cost of 20 and make a backorder for the product with a cost of 0
* Go to the session accounting entries and check the COGS entries, you should see one entry for the product we just processed
* Validate the backorder
> Observation: A second COGS entry is created for the product with a
  cost of 20

Why the fix:
------------
Instead of creating the COGS entries based on the PoS order lines, we now create them based on the stock move lines. This way, we only create the COGS entries for the stock move lines that are actually processed. We also avoid creating COGS entries for the stock move lines that have no cost.

opw-4597430