### PR TITLE
[FIX] mail:tests: fix 'edited again (edited)' test

### DIFF
--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -203,6 +203,7 @@ test("Can edit message comment in chatter", async () => {
     // save without change should keep (edited)
     await click(".o-mail-Message [title='Expand']");
     await click(".o-mail-Message-moreMenu [title='Edit']");
+    await contains(".o-mail-Message .o-mail-Composer-input", { value: "edited again" });
     await contains(".o-mail-Message:contains('Escape to cancel, CTRL-Enter to save')");
     await triggerHotkey("control+Enter"); // somehow press doesn't work :(
     await contains(".o-mail-Message-content", { text: "edited again (edited)" });


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/204922

PR above improved visual of (edited) label so that this is inline to the message content. Due to implementation details, it adds new test coverage when saving an edited message without changes, which may not have (edited) label with a simpler fix and this would be obviously a bug.

The new steps to test may do `ctrl-ENTER` too soon, which would lead to not saving the message edition and instead the message is still being edited. As a result, this assertion would fail:

```
Failed to find 1 of ".o-mail-Message-content" with text "edited again (edited)" (Timeout of 3 seconds). Found 0 instead.
```

This commit fixes the issue by awaiting that the message being edited shows the input with message content in textarea, ensuring the user can actually edit the message and thus the ctrl-ENTER shortcut works and saves the message edition.

runbot-1629170