### PR TITLE
[IMP] l10n_jo_edi: Fixes and improvements

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -60,7 +60,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return self._round_max_dp(self._get_unit_price_jod(line)) * self._round_max_dp(line.quantity) - self._round_max_dp(self._get_line_discount_jod(line))
 
     def _get_payment_method_code(self, invoice):
-        return PAYMENT_CODES_MAP[invoice.company_id.l10n_jo_edi_taxpayer_type]['receivable']
+        return PAYMENT_CODES_MAP.get(invoice.company_id.l10n_jo_edi_taxpayer_type, {}).get('receivable', '')
 
     def _aggregate_totals(self, vals):
         """
@@ -149,7 +149,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             return [{
                 'payment_means_code': 10,
                 'payment_means_code_attrs': {'listID': "UN/ECE 4461"},
-                'instruction_note': invoice.ref.replace('/', '_') if invoice.ref else '',
+                'instruction_note': (invoice.ref or '').replace('/', '_'),
             }]
         else:
             return []
@@ -198,7 +198,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
 
     def _get_invoice_line_item_vals(self, line, taxes_vals):
         product = line.product_id
-        description = line.name and line.name.replace('\n', ', ')
+        description = (line.name or '').replace('\n', ', ')
         return {
             'name': product.name or description,
         }
@@ -345,7 +345,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             return {}
 
         return {
-            'id': invoice.reversed_entry_id.name.replace('/', '_'),
+            'id': (invoice.reversed_entry_id.name or '').replace('/', '_'),
             'uuid': invoice.reversed_entry_id.l10n_jo_edi_uuid,
             'document_description': self.format_float(abs(invoice.reversed_entry_id.amount_total_signed), self._get_currency_decimal_places()),
         }

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -22,6 +22,7 @@ class AccountMove(models.Model):
     l10n_jo_edi_state = fields.Selection(
         selection=[('to_send', 'To Send'), ('sent', 'Sent')],
         string="JoFotara State",
+        tracking=True,
         copy=False)
     l10n_jo_edi_error = fields.Text(
         string="JoFotara Error",

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -71,10 +71,14 @@ class AccountMove(models.Model):
             if invoice.l10n_jo_edi_is_needed and not invoice.l10n_jo_edi_uuid:
                 invoice.l10n_jo_edi_uuid = uuid.uuid4()
 
+    @api.depends("state", "l10n_jo_edi_is_needed")
     def _compute_l10n_jo_edi_computed_xml(self):
         for invoice in self:
-            xml_content = self.env['account.edi.xml.ubl_21.jo']._export_invoice(invoice)[0]
-            invoice.l10n_jo_edi_computed_xml = base64.b64encode(xml_content)
+            if invoice.state == 'posted' and invoice.l10n_jo_edi_is_needed:
+                xml_content = self.env['account.edi.xml.ubl_21.jo']._export_invoice(invoice)[0]
+                invoice.l10n_jo_edi_computed_xml = base64.b64encode(xml_content)
+            else:
+                invoice.l10n_jo_edi_computed_xml = False
 
     def download_l10n_jo_edi_computed_xml(self):
         if error_message := self._l10n_jo_validate_config() or self._l10n_jo_validate_fields():

--- a/addons/l10n_jo_edi/views/account_move_views.xml
+++ b/addons/l10n_jo_edi/views/account_move_views.xml
@@ -16,7 +16,8 @@
                     </div>
                 </xpath>
                 <xpath expr="//group[@name='sale_info_group']" position="inside">
-                    <field name="l10n_jo_edi_state" invisible="not l10n_jo_edi_state"/>
+                    <field name="l10n_jo_edi_qr" invisible="1"/>
+                    <field name="l10n_jo_edi_state" invisible="country_code != 'JO'" readonly="l10n_jo_edi_qr"/>
                     <field name="l10n_jo_edi_is_needed" invisible="1"/>
                     <field name="reversed_entry_id"
                         invisible="move_type != 'out_refund' or not l10n_jo_edi_is_needed"


### PR DESCRIPTION
1.Fix issue encountered in debug mode
Repro steps:
1. Install l10n_jo_edi module
2. Enter debug mode
3. Inside an invoice form view, attempt to view the raw record data
then you will get an error

2.Change l10n_jo_edi_state
The EDI state is not read-only (to give users flexibility in timeout scenarios), so we need to do the following:
Not hide it if it's false (because the user can set it to false) and only hide it in non-Jordanian companies
Make the field trackable (so it's more clear to the users when it changes)
Make it readonly in case the invoice has a QR code

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
