### PR TITLE
[IMP] base: deprecate _notify_progress 

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -214,8 +214,11 @@ class MailMail(models.Model):
 
             def post_send_callback(ids):
                 """ Track mail ids that have been sent, and notify cron progress accordingly. """
-                ids_done.update(send_ids)
-                self.env['ir.cron']._notify_progress(done=len(ids_done), remaining=total - len(ids_done))
+                processed = set(ids) - ids_done
+                ids_done.update(processed)
+                if self.env.get('ir_cron'):
+                    # commit progress only when running from a cron job
+                    self.env['ir.cron']._commit_progress(len(processed), remaining=total - len(ids_done))
         else:
             send_ids = list(set(send_ids) & set(ids))
             post_send_callback = None

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -110,8 +110,13 @@ class MassMailCase(MailCase, MockLinkTracker):
             # check input
             invalid = set(recipient_info.keys()) - {
                 'content',
+                # email_to
                 'email', 'email_to_mail', 'email_to_recipients',
+                # mail.mail
                 'mail_values',
+                # email
+                'email_values',
+                # trace
                 'partner', 'record', 'trace_status',
                 'failure_type', 'failure_reason',
             }
@@ -164,6 +169,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                     author = self.env.user.partner_id
 
                 # mail.mail specific values to check
+                email_values = recipient_info.get('email_values', {})
                 fields_values = {'mailing_id': mailing}
                 if recipient_info.get('mail_values'):
                     fields_values.update(recipient_info['mail_values'])
@@ -187,6 +193,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                             content=content,
                             email_to_recipients=email_to_recipients,
                             fields_values=fields_values,
+                            email_values=email_values,
                         )
                 # specific if email is False -> could have troubles finding it if several falsy traces
                 elif not email and status in ('cancel', 'bounce'):
@@ -196,6 +203,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                         content=content,
                         email_to_recipients=email_to_recipients,
                         fields_values=fields_values,
+                        email_values=email_values,
                     )
                 else:
                     self.assertMailMailWEmails(
@@ -204,6 +212,7 @@ class MassMailCase(MailCase, MockLinkTracker):
                         content=content,
                         email_to_recipients=email_to_recipients,
                         fields_values=fields_values,
+                        email_values=email_values,
                     )
 
             if link_info and not mail_not_created:

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1963,16 +1963,10 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
-        super(ProcurementGroup, self)._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
+        super()._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         self.env['pos.session']._alert_old_session()
-        if 'scheduler_task_done' in self._context:
-            task_done = self._context.get('scheduler_task_done', {'task_done': 0})['task_done'] + 1
-            self._context['scheduler_task_done']['task_done'] = task_done
-        else:
-            task_done = self._get_scheduler_tasks_to_do()
         if use_new_cursor:
-            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
-            self.env.cr.commit()
+            self.env['ir.cron']._commit_progress(1)
 
     @api.model
     def _get_scheduler_tasks_to_do(self):

--- a/addons/product_expiry/models/production_lot.py
+++ b/addons/product_expiry/models/production_lot.py
@@ -95,17 +95,10 @@ class ProcurementGroup(models.Model):
 
     @api.model
     def _run_scheduler_tasks(self, use_new_cursor=False, company_id=False):
-        super(ProcurementGroup, self)._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
+        super()._run_scheduler_tasks(use_new_cursor=use_new_cursor, company_id=company_id)
         self.env['stock.lot']._alert_date_exceeded()
-        if 'scheduler_task_done' in self._context:
-            task_done = self._context.get('scheduler_task_done', {'task_done': 0})['task_done'] + 1
-            self._context['scheduler_task_done']['task_done'] = task_done
-        else:
-            task_done = self._get_scheduler_tasks_to_do()
-
         if use_new_cursor:
-            self.env['ir.cron']._notify_progress(done=task_done, remaining=self._get_scheduler_tasks_to_do() - task_done)
-            self.env.cr.commit()
+            self.env['ir.cron']._commit_progress(1)
 
     @api.model
     def _get_scheduler_tasks_to_do(self):

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -7,6 +7,7 @@ import os
 import psycopg2
 import psycopg2.errors
 import typing
+import warnings
 from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 
@@ -757,7 +758,7 @@ class IrCron(models.Model):
         :param int remaining: the number of tasks left to process
         :param bool deactivate: whether the cron will be deactivated
         """
-        # TODO deprecate in favor of the other method
+        warnings.warn("Since 19.0, use _commit_progress", DeprecationWarning)
         if not (progress_id := self.env.context.get('ir_cron_progress_id')):
             return
         if done < 0 or remaining < 0:

--- a/odoo/addons/base/tests/test_ir_cron.py
+++ b/odoo/addons/base/tests/test_ir_cron.py
@@ -225,8 +225,8 @@ class TestIrCron(TransactionCase, CronMixinCase):
             def f(self):
                 frozen_datetime.tick(delta=timedelta(seconds=1))
                 state['call_count'] += 1
-                self.env['ir.cron']._notify_progress(
-                    done=1,
+                self.env['ir.cron']._commit_progress(
+                    processed=1,
                     remaining=CALL_TARGET - state['call_count']
                 )
             return f, state
@@ -236,8 +236,8 @@ class TestIrCron(TransactionCase, CronMixinCase):
             CALL_TARGET = 5
             def f(self):
                 state['call_count'] += 1
-                self.env['ir.cron']._notify_progress(
-                    done=1,
+                self.env['ir.cron']._commit_progress(
+                    processed=1,
                     remaining=CALL_TARGET - state['call_count']
                 )
             return f, state
@@ -254,8 +254,8 @@ class TestIrCron(TransactionCase, CronMixinCase):
             CALL_TARGET = 5
             def f(self):
                 state['call_count'] += 1
-                self.env['ir.cron']._notify_progress(
-                    done=1,
+                self.env['ir.cron']._commit_progress(
+                    processed=1,
                     remaining=CALL_TARGET - state['call_count']
                 )
                 self.env.cr.commit()
@@ -266,7 +266,7 @@ class TestIrCron(TransactionCase, CronMixinCase):
             state = {'call_count': 0}
             def f(self):
                 state['call_count'] += 1
-                self.env['ir.cron']._notify_progress(done=1, remaining=0)
+                self.env['ir.cron']._commit_progress(1, remaining=0)
                 self.env.cr.commit()
                 raise ValueError
             return f, state
@@ -330,8 +330,8 @@ class TestIrCron(TransactionCase, CronMixinCase):
         def mocked_run(self):
             frozen_datetime.tick(delta=timedelta(seconds=mocked_run_state['duration']))
             mocked_run_state['call_count'] += 1
-            self.env['ir.cron']._notify_progress(
-                done=1,
+            self.env['ir.cron']._commit_progress(
+                processed=1,
                 remaining=CALL_TARGET - mocked_run_state['call_count'],
             )
 


### PR DESCRIPTION
The goal is now to use `_commit_progress` which have a simpler API.
Details in commit messages.
