### PR TITLE
[FIX] mrp: use removal strategy when splitting MO

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -67,6 +67,10 @@ class MrpProductionSplit(models.TransientModel):
 
     def action_split(self):
         productions = self.production_id._split_productions({self.production_id: [detail.quantity for detail in self.production_detailed_vals_ids]})
+        # Reassign the raw moves to make sure that the lots are assigned based on the removal strategy
+        raw_moves = productions.mapped('move_raw_ids')
+        raw_moves._do_unreserve()
+        raw_moves._action_assign()
         for production, detail in zip(productions, self.production_detailed_vals_ids):
             production.user_id = detail.user_id
             production.date_start = detail.date


### PR DESCRIPTION
**Problem:**
When splitting a MO that has products with components tracked by
lots, the new MOs won't follow the removal strategy assigned to
said product. The first MO will have the first lot, and the
second MO will have the second lot, even if some products are still
available in the first lot. Once every lot has been used once,
the removal strategy is applied as intended on the remaining MOs.

**Steps to reproduce:**
- Make a product, that has a BoM with a component that is tracked by lots
- Make two lots for this components
- Set the removal strategy for this component to FIFO (or another one)
- Make a manufacturing order with quantity high enough to use multiple lots
- Confirm the MO and then split it in as much parts as components were used
- Look at the lot of the second MO, it is the second lot, even though there are still components available in the first lot

**Cause of the issue:**
The removal strategy was not taken into account as a whole
when splitting the MO. Thus resulting in values that seems
kind of random. As the components were assigned one at a time
to the backorders, they did not synchronize between
themselves before being assigned, which explains why they
did not have a correct lot assigned.

**Fix:**
As the components are assigned one at a time during the MO
splitting, it is not an option to try and sort them according
to the removal strategy during the assignation. We instead
wait for all of the components to be assigned (in a wrong way)
then unassign them all just to assign them the right way right
afterwards. This is done by calling *_action_assign* which takes
the removal strategy into account. This time around, all the
components are assigned at them same time, making the
removal strategy applicable.

opw-4678932