### PR TITLE
[FIX] l10n_it_edi: don't round the converted unit-prices in XML

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -327,7 +327,7 @@ class AccountMove(models.Model):
             else:
                 it_values['prezzo_unitario'] = 0.0
             if base_line['currency_id'] != self.company_currency_id:
-                it_values['prezzo_unitario'] = base_line['currency_id']._convert(it_values['prezzo_unitario'], self.company_currency_id, date=self.date)
+                it_values['prezzo_unitario'] = it_values['prezzo_unitario'] / base_line['rate']
 
             # Discount.
             it_values['sconto_maggiorazione_list'] = []

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
@@ -66,7 +66,7 @@
         <NumeroLinea>1</NumeroLinea>
         <Descrizione>A productive product</Descrizione>
         <Quantita>1.00</Quantita>
-        <PrezzoUnitario>660.00000000</PrezzoUnitario>
+        <PrezzoUnitario>659.99629252</PrezzoUnitario>
         <PrezzoTotale>659.99629252</PrezzoTotale>
         <AliquotaIVA>0.00</AliquotaIVA>
         <Natura>N3.1</Natura>
@@ -85,7 +85,7 @@
         <NumeroLinea>2</NumeroLinea>
         <Descrizione>A global discount</Descrizione>
         <Quantita>1.00</Quantita>
-        <PrezzoUnitario>-185.37000000</PrezzoUnitario>
+        <PrezzoUnitario>-185.37399203</PrezzoUnitario>
         <PrezzoTotale>-185.37399203</PrezzoTotale>
         <AliquotaIVA>0.00</AliquotaIVA>
         <Natura>N3.1</Natura>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
@@ -67,7 +67,7 @@
         <NumeroLinea>1</NumeroLinea>
         <Descrizione>A productive product</Descrizione>
         <Quantita>1.00</Quantita>
-        <PrezzoUnitario>660.00000000</PrezzoUnitario>
+        <PrezzoUnitario>659.99629252</PrezzoUnitario>
         <ScontoMaggiorazione>
           <Tipo>SC</Tipo>
           <Percentuale>15.00</Percentuale>
@@ -90,7 +90,7 @@
         <NumeroLinea>2</NumeroLinea>
         <Descrizione>A global discount</Descrizione>
         <Quantita>1.00</Quantita>
-        <PrezzoUnitario>-92.69000000</PrezzoUnitario>
+        <PrezzoUnitario>-92.68699601</PrezzoUnitario>
         <PrezzoTotale>-92.68699601</PrezzoTotale>
         <AliquotaIVA>0.00</AliquotaIVA>
         <Natura>N3.1</Natura>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
@@ -66,7 +66,7 @@
         <NumeroLinea>1</NumeroLinea>
         <Descrizione>A productive product</Descrizione>
         <Quantita>1.00</Quantita>
-        <PrezzoUnitario>990.00000000</PrezzoUnitario>
+        <PrezzoUnitario>989.99907313</PrezzoUnitario>
         <ScontoMaggiorazione>
           <Tipo>SC</Tipo>
           <Percentuale>15.00</Percentuale>

--- a/addons/l10n_it_edi/tests/export_xmls/prezzio_unitario_converted_company_currency.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/prezzio_unitario_converted_company_currency.xml
@@ -70,8 +70,8 @@
                 <NumeroLinea>1</NumeroLinea>
                 <Descrizione>test line</Descrizione>
                 <Quantita>1.00</Quantita>
-                <PrezzoUnitario>50.00000000</PrezzoUnitario>
-                <PrezzoTotale>50.00000000</PrezzoTotale>
+                <PrezzoUnitario>64.66662579</PrezzoUnitario>
+                <PrezzoTotale>64.66662579</PrezzoTotale>
                 <AliquotaIVA>22.00</AliquotaIVA>
                 <AltriDatiGestionali>
                     <TipoDato>DIVISA</TipoDato>
@@ -80,14 +80,15 @@
                 </AltriDatiGestionali>
                 <AltriDatiGestionali>
                     <TipoDato>CAMBIO</TipoDato>
-                    <RiferimentoNumero>2.00000000</RiferimentoNumero>
+                    <RiferimentoNumero>1.54639273</RiferimentoNumero>
                     <RiferimentoData>2025-02-24</RiferimentoData>
                 </AltriDatiGestionali>
             </DettaglioLinee>
             <DatiRiepilogo>
                 <AliquotaIVA>22.00</AliquotaIVA>
-                <ImponibileImporto>50.00</ImponibileImporto>
-                <Imposta>11.00</Imposta>
+                <Arrotondamento>0.00337421</Arrotondamento>
+                <ImponibileImporto>64.67</ImponibileImporto>
+                <Imposta>14.23</Imposta>
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -507,7 +507,7 @@ class TestItEdiExport(TestItEdi):
         usd = self.env.ref('base.USD')
         self.env['res.currency.rate'].create({
             'name': '2025-01-01',
-            'rate': 2,
+            'rate': 1.54639273,
             'currency_id': usd.id,
             'company_id': self.company.id,
         })


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_it" and switch to an Italian company
- Change the currency exchange rate so USD and EUR are not equal
- Create a vendor bill or invoice in USD, with at least one product and a price higher than 0
- Confirm, send and inspect the XML generated for the SDI
- The value of PrezzoTotale is different than PrezzoUnitario*Quantita

### Cause:
"prezzo_unitario" is rounded during the currency conversion. ([see](https://github.com/odoo/odoo/blob/9a48804ed07779692da2952476d3906d1abfa302/addons/l10n_it_edi/models/account_move.py#L330)) But "prezzo_totale" is never rounded, it is taken directly from the tax details

### Solution:
When converting "prezzo_unitario" avoid the rounding by adding `round=False`.

opw-4720375