### PR TITLE
[FIX] mail,hr: auto-subscribe users present in sub-departments

### DIFF
--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -130,7 +130,12 @@ class Department(models.Model):
             self.message_unsubscribe(partner_ids=list(manager_to_unsubscribe))
             # set the employees's parent to the new manager
             self._update_employee_manager(manager_id)
-        return super(Department, self).write(vals)
+        departments = super(Department, self).write(vals)
+        if "parent_id" in vals:
+            self.env["discuss.channel"].sudo().search([
+                ("subscription_department_ids", "parent_of", vals["parent_id"])
+            ])._subscribe_users_automatically()
+        return departments
 
     def _update_employee_manager(self, manager_id):
         employees = self.env['hr.employee']

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -517,7 +517,7 @@ We can redirect you to the public employee list."""
         employee_departments = employees.department_id
         if employee_departments:
             self.env['discuss.channel'].sudo().search([
-                ('subscription_department_ids', 'in', employee_departments.ids)
+                ('subscription_department_ids', 'parent_of', employee_departments.ids)
             ])._subscribe_users_automatically()
         onboarding_notes_bodies = {}
         hr_root_menu = self.env.ref('hr.menu_hr_root')
@@ -555,9 +555,10 @@ We can redirect you to the public employee list."""
         if vals.get('department_id') or vals.get('user_id'):
             department_id = vals['department_id'] if vals.get('department_id') else self[:1].department_id.id
             # When added to a department or changing user, subscribe to the channels auto-subscribed by department
-            self.env['discuss.channel'].sudo().search([
-                ('subscription_department_ids', 'in', department_id)
-            ])._subscribe_users_automatically()
+            if department_id:
+                self.env['discuss.channel'].sudo().search([
+                    ('subscription_department_ids', 'parent_of', department_id)
+                ])._subscribe_users_automatically()
         if vals.get('departure_description'):
             for employee in self:
                 employee.message_post(body=_(

--- a/addons/hr/tests/test_channel.py
+++ b/addons/hr/tests/test_channel.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.fields import Command
 
 from odoo.addons.hr.tests.common import TestHrCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.tests.common import tagged
 
 
@@ -29,3 +31,125 @@ class TestChannel(TestHrCommon):
         })
 
         self.assertEqual(self.channel.channel_partner_ids, self.department.mapped('member_ids.user_id.partner_id'))
+
+    def test_auto_subscribe_child_department_when_adding_parent(self):
+        self.assertEqual(self.channel.channel_partner_ids, self.env["res.partner"])
+        user1 = mail_new_test_user(
+            self.env,
+            login="user1",
+            groups="base.group_user,hr.group_hr_user",
+            name="User 1",
+            email="user1@example.com",
+        )
+        emp1 = self.env["hr.employee"].create({"user_id": user1.id})
+        self.env["hr.department"].create(
+            {
+                "parent_id": self.department.id,
+                "name": "Child Department",
+                "member_ids": [Command.link(emp1.id)],
+            }
+        )
+
+        self.channel.write({"subscription_department_ids": [Command.link(self.department.id)]})
+
+        self.assertEqual(
+            self.channel.channel_partner_ids,
+            self.department.mapped("member_ids.user_id.partner_id") | emp1.user_id.partner_id,
+        )
+
+    def test_auto_subscribe_multi_level_child_department_when_adding_parent(self):
+        self.assertEqual(self.channel.channel_partner_ids, self.env["res.partner"])
+        user1 = mail_new_test_user(
+            self.env,
+            login="user1",
+            groups="base.group_user,hr.group_hr_user",
+            name="User 1",
+            email="user1@example.com",
+        )
+        emp1 = self.env["hr.employee"].create({"user_id": user1.id})
+        child_level_1 = self.env["hr.department"].create(
+            {
+                "parent_id": self.department.id,
+                "name": "Child Department",
+            }
+        )
+        self.env["hr.department"].create(
+            {
+                "parent_id": child_level_1.id,
+                "name": "Child Department Level 2",
+                "member_ids": [Command.link(emp1.id)],
+            }
+        )
+
+        self.channel.write({"subscription_department_ids": [Command.link(self.department.id)]})
+
+        self.assertEqual(
+            self.channel.channel_partner_ids,
+            self.department.mapped("member_ids.user_id.partner_id") | emp1.user_id.partner_id,
+        )
+
+    def test_auto_subscribe_child_department_when_creating_employee(self):
+        self.assertEqual(self.channel.channel_partner_ids, self.env["res.partner"])
+        user1 = mail_new_test_user(
+            self.env,
+            login="user1",
+            groups="base.group_user,hr.group_hr_user",
+            name="User 1",
+            email="user1@example.com",
+        )
+        child_department = self.env["hr.department"].create(
+            {
+                "parent_id": self.department.id,
+                "name": "Child Department",
+            }
+        )
+
+        self.channel.write({"subscription_department_ids": [Command.link(self.department.id)]})
+        emp1 = self.env["hr.employee"].create(
+            {
+                "user_id": user1.id,
+                "department_id": child_department.id,
+            }
+        )
+
+        self.assertEqual(
+            self.channel.channel_partner_ids,
+            self.department.mapped("member_ids.user_id.partner_id") | emp1.user_id.partner_id,
+        )
+
+    def test_auto_subscribe_department_when_changing_parent(self):
+        self.assertEqual(self.channel.channel_partner_ids, self.env["res.partner"])
+        user1 = mail_new_test_user(
+            self.env,
+            login="user1",
+            groups="base.group_user,hr.group_hr_user",
+            name="User 1",
+            email="user1@example.com",
+        )
+        previous_department = self.env["hr.department"].create(
+            {
+                "name": "Previous Department",
+            }
+        )
+        child_department = self.env["hr.department"].create(
+            {
+                "parent_id": previous_department.id,
+                "name": "Child Department",
+            }
+        )
+        self.channel.write({"subscription_department_ids": [Command.link(self.department.id)]})
+        emp1 = self.env["hr.employee"].create(
+            {
+                "user_id": user1.id,
+                "department_id": child_department.id,
+            }
+        )
+        self.assertEqual(
+            self.channel.channel_partner_ids,
+            self.department.mapped("member_ids.user_id.partner_id"),
+        )
+        child_department.parent_id = self.department.id
+        self.assertEqual(
+            self.channel.channel_partner_ids,
+            self.department.mapped("member_ids.user_id.partner_id") | emp1.user_id.partner_id,
+        )


### PR DESCRIPTION
Currently only the users that are present in the departments given in the auto-subscribe-departments are subscribed automatically. This PR solves this in 2 passes, by checking all the parent departments of the user when it is changed so it targets all those for the auto-subscription and the channel checks all the children members of this parent department when asked to refresh its list

task-3142162



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
