### PR TITLE
[FIX] account, purchase: display purchase checkbox in one-app free accounting

### DIFF
--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -49,6 +49,12 @@
             <field name="priority">5</field>
             <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
+                <div name="options" position='inside'>
+                    <span class="d-inline-flex" invisible="type == 'combo'">
+                        <field name="purchase_ok"/>
+                        <label for="purchase_ok"/>
+                    </span>
+                </div>
                 <xpath expr="//field[@name='company_id']" position="after">
                     <field name="fiscal_country_codes" invisible="1"/>
                 </xpath>

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -83,12 +83,6 @@
                         </group>
                     </group>
                 </group>
-                <div name="options" position='inside'>
-                    <span class="d-inline-flex" invisible="type == 'combo'">
-                        <field name="purchase_ok"/>
-                        <label for="purchase_ok"/>
-                    </span>
-                </div>
             </field>
         </record>
 


### PR DESCRIPTION
After 18.0, the Product form has changed and the Purchase taxes field was moved on the main tab. By doing so, we removed the "Purchase" checkbox (as the tab would have been empty), but by doing so we lost the ability to tell that a product can be purchased or not.

Now when account is installed we make the checkbox visible on the Product form even without the Purchase app, the tab will then only be visible if both the Purchase app is installed and the checkbox is ticked. 

task- 4742975