### PR TITLE
[FIX] website: send form with hidden date field


### DIFF
--- a/addons/website/static/src/snippets/s_website_form/form.js
+++ b/addons/website/static/src/snippets/s_website_form/form.js
@@ -338,7 +338,7 @@ export class Form extends Interaction {
                 const inputEl = dateEl.querySelector("input");
                 const { value } = inputEl;
                 if (!value) {
-                    return;
+                    continue;
                 }
 
                 formValues[inputEl.getAttribute("name")] = dateEl.matches(".s_website_form_date")


### PR DESCRIPTION
Scenario: add a form with existing date field (for "Send an E-mail" form
the field "Scheduled Send Date" for example) and make it hidden. Fill
and send the form.

Issue: the form is not send and it spin without end

Reason: in b9b3a605e0f4c5da3a258c980107d6162da7f44f the code for fixing
date format was rewritten as for loop without nested function. But the
return that was used to get to next loop iteration, was not converted to
a continue, so if there was a date / datetime widget unfilled (eg. if it
is hidden in the form) we would unexpectedly exit the function Form.send
without sending the form or enabling the button.

opw-4699541
opw-4746416