### PR TITLE
[FIX] mail: make discuss stylistically less flat

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -24,7 +24,7 @@
                      role="menuitem"
                 >
                     <img
-                        class="img img-fluid my-0 mx-auto rounded"
+                        class="img img-fluid my-0 mx-auto rounded o-shadow-sm-light"
                         t-att-class="{ 'opacity-25': attachment.uploading }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -138,7 +138,7 @@
 </t>
 
 <t t-name="mail.Composer.quickActions">
-    <div class="o-mail-Composer-quickActions o-mail-Composer-bg" t-attf-class="{{ actionsContainerClass }}" t-ref="quick-actions" t-att-class="{ 'pe-1': props.composer.message or !extended, 'pe-2': extended }">
+    <div class="o-mail-Composer-quickActions o-mail-Composer-bg o-shadow-sm-light" t-attf-class="{{ actionsContainerClass }}" t-ref="quick-actions" t-att-class="{ 'pe-1': props.composer.message or !extended, 'pe-2': extended }">
         <div class="o-mail-Composer-mainActions d-flex flex-grow-1 align-items-baseline">
             <t t-foreach="partitionedActions.quick" t-as="action" t-key="action.id">
                 <t t-call="mail.Composer.quickAction"/>

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -96,6 +96,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     text-decoration: underline;
 }
 
+.o-shadow-sm-light {
+    $box-shadow-sm: 0 .125rem .25rem rgba($o-white, .075) !default;
+}
+
 .o-text-white {
     color: #FFF !important;
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -108,6 +108,12 @@
     }
 }
 
+.o-mail-Message-bubbleContainer {
+    
+    border-bottom-left-radius: $border-radius - 0.025rem; // so that it follows bubble roundness
+    border-bottom-right-radius: $border-radius - 0.025rem;
+}
+
 .o-mail-ChatWindow .o-mail-Message.o-selfAuthored {
     flex-direction: row-reverse;
 

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -19,7 +19,7 @@
             >
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
-                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view rounded-3" t-att-class="getAvatarContainerAttClass()">
+                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view rounded-3 o-shadow-sm-light" t-att-class="getAvatarContainerAttClass()">
                             <img class="o-mail-Message-avatar w-100 h-100 rounded-3" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
                         </div>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
@@ -67,7 +67,7 @@
                                     <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing, 'o-mail-Message-bubbleContainer o-shadow-sm-light': message.bubbleColor }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -10,7 +10,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.button">
-        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-5 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-5 px-1 gap-1 align-items-center shadow-sm" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
             'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
             'bg-view border-secondary': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,


### PR DESCRIPTION
Discuss style was too flat, which makes it slightly impractical with the floating elements like message bubbles, message reactions, and composer bg.

This commit fixes the issue by using a `o-shadow-sm-light` that is a `.shadow-sm` half less harsh. This makes Discuss UI less flat without making the shadows too harsh due to the big amount of this UI elements on a single screen.