### PR TITLE
[REF] point_of_sale: refactor of the tests' parent class

### DIFF
--- a/addons/l10n_es_edi_tbai/tests/common.py
+++ b/addons/l10n_es_edi_tbai/tests/common.py
@@ -2,11 +2,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import requests
+
 from pytz import timezone
 from datetime import date, datetime
-import requests
 from unittest.mock import Mock
+from dateutil.relativedelta import relativedelta
 
+from odoo import fields
 from odoo.tools import file_open
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.account.tests.test_account_move_send import TestAccountMoveSendCommon
@@ -71,6 +74,9 @@ class TestEsEdiTbaiCommon(TestAccountMoveSendCommon):
             'scope': 'tbai',
             'company_id': cls.company_data['company'].id,
         })
+
+        # Prevent certificate expiration in tests
+        cls.certificate.date_end = fields.Datetime.now() + relativedelta(days=2)
         cls.company_data['company'].write({
             'l10n_es_tbai_tax_agency': agency,
             'l10n_es_tbai_certificate_id': cls.certificate.id,

--- a/addons/l10n_es_edi_tbai_pos/tests/__init__.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tbai_pos
+from . import common

--- a/addons/l10n_es_edi_tbai_pos/tests/common.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/common.py
@@ -1,0 +1,23 @@
+from odoo.addons.point_of_sale.tests.common import CommonPosTest
+
+
+class CommonPosEsEdiTest(CommonPosTest):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+
+        self.env.user.group_ids += self.env.ref('account.group_account_manager')
+        self.es_edi_edit_partner(self)
+        self.es_edi_edit_product_templates(self)
+
+    def es_edi_edit_partner(self):
+        self.partner_lowe.write({
+            'vat': 'ESF35999705',
+            'country_id': self.env.ref('base.es').id,
+            'invoice_edi_format': None,
+        })
+
+    def es_edi_edit_product_templates(self):
+        self.ten_dollars_with_10_incl.write({
+            'taxes_id': self._get_tax_by_xml_id('s_iva21b').ids
+        })

--- a/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
+++ b/addons/l10n_es_edi_tbai_pos/tests/test_tbai_pos.py
@@ -1,101 +1,71 @@
 from unittest.mock import patch
 
-from odoo import Command
 from odoo.addons.l10n_es_edi_tbai.tests.common import TestEsEdiTbaiCommonGipuzkoa
-from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.addons.l10n_es_edi_tbai_pos.tests.common import CommonPosEsEdiTest
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
 @tagged('post_install_l10n', 'post_install', '-at_install')
-class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
-
+class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, CommonPosEsEdiTest):
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.partner_es = cls.env['res.partner'].create({
-            'name': 'ES Partner',
-            'vat': 'ESF35999705',
-            'country_id': cls.env.ref('base.es').id,
-            'invoice_edi_format': None,
-        })
-
-    @classmethod
-    def create_pos_order(cls, session, price_unit):
-        return cls.PosOrder.create({
-            'session_id': session.id,
-            'lines': [
-                Command.create({
-                    'product_id': cls.product_a.id,
-                    'price_unit': price_unit,
-                    'qty': 1,
-                    'tax_ids': cls._get_tax_by_xml_id('s_iva21b').ids,
-                    'price_subtotal': price_unit,
-                    'price_subtotal_incl': price_unit * 1.21,
-                }),
-            ],
-            'amount_tax': 0.21 * price_unit,
-            'amount_total': 1.21 * price_unit,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-        })
-
-    @classmethod
-    def pay_pos_order(cls, pos_order):
+    def pay_pos_order(self, pos_order):
         context_make_payment = {
             'active_ids': pos_order.ids,
             'active_id': pos_order.id,
         }
-        pos_make_payment = cls.PosMakePayment.with_context(context_make_payment).create({
+        pos_make_payment = self.env['pos.make.payment'].with_context(context_make_payment).create({
             'amount': pos_order.amount_total,
         })
         with patch(
             'odoo.addons.l10n_es_edi_tbai.models.l10n_es_edi_tbai_document.requests.Session.request',
-            return_value=cls.mock_response_post_invoice_success,
+            return_value=self.mock_response_post_invoice_success,
         ):
             pos_make_payment.with_context(context_make_payment).check()
 
     def test_tbai_pos_order(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        pos_order = self.create_pos_order(current_session, 100.0)
-        self.pay_pos_order(pos_order)
-
-        self.assertEqual(pos_order.state, 'paid')
-        self.assertEqual(pos_order.l10n_es_tbai_state, 'sent')
+        self.ten_dollars_with_10_incl.product_variant_id.lst_price = 100
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id}
+            ],
+        })
+        self.pay_pos_order(order)
+        self.assertEqual(order.state, 'paid')
+        self.assertEqual(order.l10n_es_tbai_state, 'sent')
 
     def test_tbai_pos_order_to_invoice(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        pos_order = self.create_pos_order(current_session, 500.0)
+        self.ten_dollars_with_10_incl.product_variant_id.lst_price = 500
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id}
+            ],
+        })
 
         # The amount is above 400 (default simplified invoice limit) so an error should be raised if it's not invoiced
         with self.assertRaises(UserError):
-            self.pay_pos_order(pos_order)
+            self.pay_pos_order(order)
 
-        # Now with the pos order invoiced
-        pos_order.partner_id = self.partner_es
-        pos_order.to_invoice = True
-        self.pay_pos_order(pos_order)
+        order.partner_id = self.partner_lowe
+        order.to_invoice = True
+        self.pay_pos_order(order)
 
-        self.assertTrue(pos_order.account_move)
+        self.assertTrue(order.account_move)
         # The edi is handled by the invoice
-        self.assertFalse(pos_order.l10n_es_tbai_state)
+        self.assertFalse(order.l10n_es_tbai_state)
 
     def test_tbai_refund_pos_order(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # Create and pay a pos order not invoiced
-        pos_order = self.create_pos_order(current_session, 100.0)
-        self.pay_pos_order(pos_order)
+        self.ten_dollars_with_10_incl.product_variant_id.lst_price = 100
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id}
+            ],
+        })
+        self.pay_pos_order(order)
 
         # Create the refund
-        refund_action = pos_order.refund()
-        pos_refund = self.PosOrder.browse(refund_action['res_id'])
+        refund_action = order.refund()
+        pos_refund = self.env['pos.order'].browse(refund_action['res_id'])
 
         # An error is raised if the refund is invoiced
         pos_refund.to_invoice = True
@@ -110,18 +80,19 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
         self.assertEqual(pos_refund.l10n_es_tbai_state, 'sent')
 
     def test_tbai_refund_invoiced_pos_order(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # Create and pay a pos order not invoiced
-        pos_order = self.create_pos_order(current_session, 500.0)
-        pos_order.partner_id = self.partner_es
-        pos_order.to_invoice = True
-        self.pay_pos_order(pos_order)
-
-        # Create the refund
-        refund_action = pos_order.refund()
-        pos_refund = self.PosOrder.browse(refund_action['res_id'])
+        self.ten_dollars_with_10_incl.product_variant_id.lst_price = 100
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_lowe.id,
+                'to_invoice': True,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id}
+            ],
+        })
+        self.pay_pos_order(order)
+        refund_action = order.refund()
+        pos_refund = self.env['pos.order'].browse(refund_action['res_id'])
 
         # An error is raised if the refund is not invoiced
         with self.assertRaises(UserError):
@@ -130,6 +101,5 @@ class TestPosEdi(TestEsEdiTbaiCommonGipuzkoa, TestPointOfSaleCommon):
         # Now works with the refund invoiced
         pos_refund.to_invoice = True
         self.pay_pos_order(pos_refund)
-
         self.assertTrue(pos_refund.account_move)
         self.assertFalse(pos_refund.l10n_es_tbai_state)

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -165,7 +165,10 @@ registry.category("web_tour.tours").add("test_tracking_number_closing_session", 
             ProductScreen.clickDisplayedProduct("Desk Pad", true, "1.0"),
             ProductScreen.clickPayButton(),
             PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.enterPaymentLineAmount("Bank", "20"),
             PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });
 

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -268,6 +268,8 @@ registry.category("web_tour.tours").add("LotTour", {
                     }),
                 ].flat()
             ),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Partner Test 1"),
             ProductScreen.clickDisplayedProduct("Product A"),
             ProductScreen.enterLotNumber("3"),
             ProductScreen.selectedOrderlineHas("Product A", "3"),
@@ -289,5 +291,22 @@ registry.category("web_tour.tours").add("LotTour", {
             inLeftSide({
                 trigger: ".info-list:contains('Lot Number 1001')",
             }),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
+            ...ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("002"),
+            inLeftSide(
+                [Numpad.click("1"), ProductScreen.clickLine("Product B"), Numpad.click("1")].flat()
+            ),
+            TicketScreen.confirmRefund(),
+            { ...ProductScreen.back(), isActive: ["mobile"] },
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            ReceiptScreen.clickNextOrder(),
         ].flat(),
 });

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
+import logging
+
 from random import randint
 from datetime import datetime
-
 from odoo import fields, tools
-from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+from odoo.fields import Command
 from odoo.tests import Form
-
-import logging
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
 
 _logger = logging.getLogger(__name__)
 
@@ -16,127 +15,349 @@ def archive_products(env):
     tip = env.ref('point_of_sale.product_product_tip').product_tmpl_id
     (all_pos_product - tip)._write({'active': False})
 
-class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
 
+class CommonPosTest(ValuationReconciliationTestCommon):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(self):
         super().setUpClass()
-        cls.env.user.group_ids |= cls.env.ref('point_of_sale.group_pos_manager')
-        cls.company_data_2 = cls.setup_other_company()
+        archive_products(self.env)
 
-        cls.company_data['company'].write({
-            'point_of_sale_update_stock_quantities': 'real',
+        self.env.user.group_ids += self.env.ref('point_of_sale.group_pos_manager')
+        self.env.ref('base.EUR').active = True
+        self.env.ref('base.USD').active = True
+
+        self.create_res_partners(self)
+        self.create_account_cash_rounding(self)
+        self.create_pos_categories(self)
+        self.create_account_taxes(self)
+        self.create_product_templates(self)
+        self.create_payment_methods(self)
+        self.create_pos_configs(self)
+
+    def create_pos_configs(self):
+        sale_journal_eur = self.env['account.journal'].create({
+            'name': 'PoS Sale EUR',
+            'type': 'sale',
+            'code': 'POSE',
+            'company_id': self.company.id,
+            'sequence': 12,
+            'currency_id': self.env.ref('base.EUR').id,
+        })
+        self.pricelist_eur = self.env['product.pricelist'].create({
+            'name': 'Test EUR Pricelist',
+            'currency_id': self.env.ref('base.EUR').id
+        })
+        self.pos_config_eur = self.env['pos.config'].create({
+            'name': 'PoS Config EUR',
+            'journal_id': sale_journal_eur.id,
+            'use_pricelist': True,
+            'available_pricelist_ids': [(6, 0, self.pricelist_eur.ids)],
+            'pricelist_id': self.pricelist_eur.id,
+            'payment_method_ids': [(6, 0, self.bank_payment_method.ids)]
+        })
+        self.pos_config_usd = self.env['pos.config'].create({
+            'name': 'PoS Config USD',
+            'journal_id': self.company_data['default_journal_sale'].id,
+            'invoice_journal_id': self.company_data['default_journal_sale'].id,
+            'payment_method_ids': [
+                (4, self.credit_payment_method.id),
+                (4, self.bank_payment_method.id),
+                (4, self.cash_payment_method.id),
+            ]
         })
 
-        cls.AccountBankStatement = cls.env['account.bank.statement']
-        cls.AccountBankStatementLine = cls.env['account.bank.statement.line']
-        cls.PosMakePayment = cls.env['pos.make.payment']
-        cls.PosOrder = cls.env['pos.order']
-        cls.PosSession = cls.env['pos.session']
-        cls.company = cls.company_data['company']
-        cls.product3 = cls.env['product.product'].create({
-            'name': 'Product 3',
-            'list_price': 450,
+    def create_res_partners(self):
+        self.partner_mobt = self.env['res.partner'].create({
+            'name': 'MOBT',
         })
-        cls.product4 = cls.env['product.product'].create({
-            'name': 'Product 4',
-            'list_price': 750,
+        self.partner_adgu = self.env['res.partner'].create({
+            'name': 'ADGU',
         })
-        cls.partner1 = cls.env['res.partner'].create({'name': 'Partner 1'})
-        cls.partner4 = cls.env['res.partner'].create({'name': 'Partner 4'})
-        cls.pos_config = cls.env['pos.config'].create({
-            'name': 'Main',
-            'journal_id': cls.company_data['default_journal_sale'].id,
-            'invoice_journal_id': cls.company_data['default_journal_sale'].id,
+        self.partner_lowe = self.env['res.partner'].create({
+            'name': 'LOWE',
         })
-        cls.led_lamp = cls.env['product.product'].create({
-            'name': 'LED Lamp',
-            'available_in_pos': True,
-            'list_price': 0.90,
+        self.partner_jcb = self.env['res.partner'].create({
+            'name': 'JCB',
         })
-        cls.whiteboard_pen = cls.env['product.product'].create({
-            'name': 'Whiteboard Pen',
-            'available_in_pos': True,
-            'list_price': 1.20,
+        self.partner_moda = self.env['res.partner'].create({
+            'name': 'MODA',
         })
-        cls.newspaper_rack = cls.env['product.product'].create({
-            'name': 'Newspaper Rack',
-            'available_in_pos': True,
-            'list_price': 1.28,
+        self.partner_stva = self.env['res.partner'].create({
+            'name': 'STVA',
         })
-        cls.company_data['default_journal_cash'].pos_payment_method_ids.unlink()
-        cls.cash_payment_method = cls.env['pos.payment.method'].create({
+        self.partner_manv = self.env['res.partner'].create({
+            'name': 'MANV',
+        })
+        self.partner_vlst = self.env['res.partner'].create({
+            'name': 'VLST',
+        })
+
+    def create_account_cash_rounding(self):
+        self.account_cash_rounding_down = self.env['account.cash.rounding'].create({
+            'name': 'Rounding down',
+            'rounding': 0.05,
+            'rounding_method': 'DOWN',
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+        self.account_cash_rounding_up = self.env['account.cash.rounding'].create({
+            'name': 'Rounding up',
+            'rounding': 0.05,
+            'rounding_method': 'UP',
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+        self.account_cash_rounding_half = self.env['account.cash.rounding'].create({
+            'name': 'Rounding half',
+            'rounding': 0.05,
+            'profit_account_id': self.company_data['default_account_revenue'].id,
+            'loss_account_id': self.company_data['default_account_expense'].id,
+        })
+
+    def create_payment_methods(self):
+        self.cash_payment_method = self.env['pos.payment.method'].create({
             'name': 'Cash',
-            'receivable_account_id': cls.company_data['default_account_receivable'].id,
-            'journal_id': cls.company_data['default_journal_cash'].id,
-            'company_id': cls.env.company.id,
+            'receivable_account_id': self.company_data['default_account_receivable'].id,
+            'journal_id': self.company_data['default_journal_cash'].id,
         })
-        cls.bank_payment_method = cls.env['pos.payment.method'].create({
+        self.bank_payment_method = self.env['pos.payment.method'].create({
             'name': 'Bank',
-            'journal_id': cls.company_data['default_journal_bank'].id,
-            'receivable_account_id': cls.company_data['default_account_receivable'].id,
-            'company_id': cls.env.company.id,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'receivable_account_id': self.company_data['default_account_receivable'].id,
         })
-        cls.credit_payment_method = cls.env['pos.payment.method'].create({
+        self.credit_payment_method = self.env['pos.payment.method'].create({
             'name': 'Credit',
-            'receivable_account_id': cls.company_data['default_account_receivable'].id,
+            'receivable_account_id': self.company_data['default_account_receivable'].id,
             'split_transactions': True,
-            'company_id': cls.env.company.id,
-        })
-        cls.pos_config.write({'payment_method_ids': [(4, cls.credit_payment_method.id), (4, cls.bank_payment_method.id), (4, cls.cash_payment_method.id)]})
-
-        # Create POS journal
-        cls.pos_config.journal_id = cls.env['account.journal'].create({
-            'type': 'general',
-            'name': 'Point of Sale - Test',
-            'code': 'POSS - Test',
-            'company_id': cls.env.company.id,
-            'sequence': 20
         })
 
-        # create a VAT tax of 10%, included in the public price
-        Tax = cls.env['account.tax']
-        account_tax_10_incl = Tax.create({
-            'name': 'VAT 10 perc Incl',
-            'amount_type': 'percent',
-            'amount': 10.0,
+    def create_pos_categories(self):
+        self.cat_no_tax = self.env['pos.category'].create({
+            'name': 'No tax',
+            'sequence': 0,
+        })
+        self.cat_tax_five_incl = self.env['pos.category'].create({
+            'name': 'Tax five incl',
+            'sequence': 1,
+        })
+        self.cat_tax_ten_incl = self.env['pos.category'].create({
+            'name': 'Tax ten incl',
+            'sequence': 2,
+        })
+        self.cat_tax_fiften_incl = self.env['pos.category'].create({
+            'name': 'Tax fifteen incl',
+            'sequence': 3,
+        })
+        self.cat_tax_five_excl = self.env['pos.category'].create({
+            'name': 'Tax five excl',
+            'sequence': 4,
+        })
+        self.cat_tax_ten_excl = self.env['pos.category'].create({
+            'name': 'Tax ten excl',
+            'sequence': 5,
+        })
+        self.cat_tax_fiften_excl = self.env['pos.category'].create({
+            'name': 'Tax fifteen excl',
+            'sequence': 6,
+        })
+
+    def create_account_taxes(self):
+        self.tax_five_incl = self.env['account.tax'].create({
+            'name': 'Tax five incl',
+            'amount': 5,
             'price_include_override': 'tax_included',
         })
-
-        # assign this 10 percent tax on the [PCSC234] PC Assemble SC234 product
-        # as a sale tax
-        cls.product3.taxes_id = [(6, 0, [account_tax_10_incl.id])]
-
-        # create a VAT tax of 5%, which is added to the public price
-        account_tax_05_incl = Tax.create({
-            'name': 'VAT 5 perc Incl',
-            'amount_type': 'percent',
-            'amount': 5.0,
-            'price_include_override': 'tax_excluded',
+        self.tax_ten_incl = self.env['account.tax'].create({
+            'name': 'Tax ten incl',
+            'amount': 10,
+            'price_include_override': 'tax_included',
+        })
+        self.tax_fiften_incl = self.env['account.tax'].create({
+            'name': 'Tax fifteen incl',
+            'amount': 15,
+            'price_include_override': 'tax_included',
+        })
+        self.tax_five_excl = self.env['account.tax'].create({
+            'name': 'Tax five excl',
+            'amount': 5,
+        })
+        self.tax_ten_excl = self.env['account.tax'].create({
+            'name': 'Tax ten excl',
+            'amount': 10,
+        })
+        self.tax_fiften_excl = self.env['account.tax'].create({
+            'name': 'Tax fifteen excl',
+            'amount': 15,
         })
 
-        # create a second VAT tax of 5% but this time for a child company, to
-        # ensure that only product taxes of the current session's company are considered
-        #(this tax should be ignore when computing order's taxes in following tests)
-        account_tax_05_incl_chicago = Tax.create({
-            'name': 'VAT 05 perc Excl (US)',
-            'amount_type': 'percent',
-            'amount': 5.0,
-            'price_include_override': 'tax_excluded',
-            'company_id': cls.company_data_2['company'].id,
+    def create_product_templates(self):
+        self.ten_dollars_no_tax = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars no tax',
+            'list_price': 10.0,
+            'pos_categ_ids': [(6, 0, [self.cat_no_tax.id])],
+            'taxes_id': [(5, 0)],
+        })
+        self.twenty_dollars_no_tax = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars no tax',
+            'list_price': 20.0,
+            'pos_categ_ids': [(6, 0, [self.cat_no_tax.id])],
+            'taxes_id': [(5, 0)],
+        })
+        self.ten_dollars_with_5_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 5 included',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_five_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_five_incl.id])],
+        })
+        self.twenty_dollars_with_5_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 5 included',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_five_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_five_incl.id])],
+        })
+        self.ten_dollars_with_10_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 10 included',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_ten_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_ten_incl.id])],
+        })
+        self.twenty_dollars_with_10_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 10 included',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_ten_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_ten_incl.id])],
+        })
+        self.ten_dollars_with_15_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 15 included',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_fiften_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_fiften_incl.id])],
+        })
+        self.twenty_dollars_with_15_incl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 15 included',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_fiften_incl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_fiften_incl.id])],
+        })
+        self.ten_dollars_with_5_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 5 excluded',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_five_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_five_excl.id])],
+        })
+        self.twenty_dollars_with_5_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 5 excluded',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_five_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_five_excl.id])],
+        })
+        self.ten_dollars_with_10_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 10 excluded',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_ten_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_ten_excl.id])],
+        })
+        self.twenty_dollars_with_10_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 10 excluded',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_ten_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_ten_excl.id])],
+        })
+        self.ten_dollars_with_15_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Ten dollars with 15 excluded',
+            'list_price': 10.0,
+            'taxes_id': [(6, 0, [self.tax_fiften_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_fiften_excl.id])],
+        })
+        self.twenty_dollars_with_15_excl = self.env['product.template'].create({
+            'available_in_pos': True,
+            'name': 'Twenty dollars with 15 excluded',
+            'list_price': 20.0,
+            'taxes_id': [(6, 0, [self.tax_fiften_excl.id])],
+            'pos_categ_ids': [(6, 0, [self.cat_tax_fiften_excl.id])],
         })
 
-        cls.product4.company_id = False
-        # I assign those 5 percent taxes on the PCSC349 product as a sale taxes
-        cls.product4.write(
-            {'taxes_id': [(6, 0, [account_tax_05_incl.id, account_tax_05_incl_chicago.id])]})
+    def create_backend_pos_order(self, data):
+        pos_config = data.get('pos_config', self.pos_config_usd)
+        order_data = data.get('order_data', {})
+        line_product_ids = [line_data['product_id'] for line_data in data.get('line_data', [])]
+        product_by_id = {p.id: p for p in self.env['product.product'].browse(line_product_ids)}
+        refund = False
 
-        # Set account_id in the generated repartition lines. Automatically, nothing is set.
-        invoice_rep_lines = (account_tax_05_incl | account_tax_10_incl).mapped('invoice_repartition_line_ids')
-        refund_rep_lines = (account_tax_05_incl | account_tax_10_incl).mapped('refund_repartition_line_ids')
+        if not pos_config.current_session_id:
+            pos_config.open_ui()
 
-        # Expense account, should just be something else than receivable/payable
-        (invoice_rep_lines | refund_rep_lines).write({'account_id': cls.company_data['default_account_tax_sale'].id})
+        order = self.env['pos.order'].create({
+            'amount_total': 0,
+            'amount_paid': 0,
+            'amount_tax': 0,
+            'amount_return': 0,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'company_id': self.env.company.id,
+            'session_id': pos_config.current_session_id.id,
+            'lines': [
+                Command.create({
+                    'price_unit': product_by_id[line_data['product_id']].lst_price,
+                    'price_subtotal': product_by_id[line_data['product_id']].lst_price,
+                    'tax_ids': [(6, 0, product_by_id[line_data['product_id']].taxes_id.ids)],
+                    'price_subtotal_incl': 0,
+                    **line_data,
+                }) for line_data in data.get('line_data', [])
+            ],
+            **order_data,
+        })
+
+        # Re-trigger prices computation
+        order.lines._onchange_amount_line_all()
+        order._compute_prices()
+
+        if data.get('payment_data'):
+            payment_context = {"active_ids": order.ids, "active_id": order.id}
+            for payment in data['payment_data']:
+                make_payment = {'payment_method_id': payment['payment_method_id']}
+                if payment.get('amount'):
+                    make_payment['amount'] = payment['amount']
+                order_payment = self.env['pos.make.payment'].with_context(**payment_context).create(make_payment)
+                order_payment.with_context(**payment_context).check()
+
+        if data.get('refund_data'):
+            refund_action = order.refund()
+            refund = self.env['pos.order'].browse(refund_action['res_id'])
+            payment_context = {"active_ids": refund.ids, "active_id": refund.id}
+
+            if data.get('order_data') and data['order_data'].get('to_invoice', False):
+                refund.to_invoice = True
+
+            for refund_data in data['refund_data']:
+                make_refund = {'payment_method_id': refund_data['payment_method_id']}
+                if refund_data.get('amount'):
+                    make_refund['amount'] = refund_data['amount']
+                refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create(make_refund)
+                refund_payment.with_context(**payment_context).check()
+
+        return order, refund
+
+    def compute_tax(self, product, price, qty=1, taxes=None, pos_config=None):
+        config = pos_config or self.pos_config_usd
+        if not taxes:
+            taxes = product.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id)
+        currency = config.currency_id
+        res = taxes.compute_all(price, currency, qty, product=product)
+        untax = res['total_excluded']
+        return untax, sum(tax.get('amount', 0.0) for tax in res['taxes'])
 
 
 class TestPoSCommon(ValuationReconciliationTestCommon):

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1,440 +1,151 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import time
-from freezegun import freeze_time
-from datetime import datetime
-
 import odoo
-from odoo import fields, tools
+
+from freezegun import freeze_time
+from odoo import fields
 from odoo.fields import Command
-from odoo.tools import float_compare, mute_logger, test_reports
 from odoo.tests import Form
-from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
-from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
+from odoo.addons.point_of_sale.tests.common import CommonPosTest
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestPointOfSaleFlow(TestPointOfSaleCommon):
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.other_currency = cls.setup_other_currency('GBP')
-
-    def compute_tax(self, product, price, qty=1, taxes=None):
-        if not taxes:
-            taxes = product.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id)
-        currency = self.pos_config.currency_id
-        res = taxes.compute_all(price, currency, qty, product=product)
-        untax = res['total_excluded']
-        return untax, sum(tax.get('amount', 0.0) for tax in res['taxes'])
-
-    def _create_pos_order_for_postponed_invoicing(self):
-        # Create the order on the first of january.
-        with freeze_time('2020-01-01'):
-            product = self.env['product.product'].create({
-                'name': 'Dummy product',
-                'is_storable': True,
-                'taxes_id': self.tax_sale_a.ids,
-            })
-            self.pos_config.open_ui()
-            pos_session = self.pos_config.current_session_id
-            untax, atax = self.compute_tax(product, 500, 1)
-            pos_order_data = {
-                'amount_paid': untax + atax,
-                'amount_return': 0,
-                'amount_tax': atax,
-                'amount_total': untax + atax,
-                'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-                'fiscal_position_id': False,
-                'lines': [(0, 0, {
-                    'discount': 0,
-                    'id': 42,
-                    'pack_lot_ids': [],
-                    'price_unit': 500.0,
-                    'product_id': product.id,
-                    'price_subtotal': 500.0,
-                    'price_subtotal_incl': 575.0,
-                    'qty': 1,
-                    'tax_ids': [(6, 0, product.taxes_id.ids)]
-                })],
-                'partner_id': False,
-                'session_id': pos_session.id,
-                'payment_ids': [(0, 0, {
-                    'amount': untax + atax,
-                    'name': fields.Datetime.now(),
-                    'payment_method_id': self.cash_payment_method.id
-                })],
-                'last_order_preparation_change': '{}',
-                'user_id': self.env.uid
-            }
-            pos_order_id = self.PosOrder.sync_from_ui([pos_order_data])['pos.order'][0]['id']
-            pos_order = self.env['pos.order'].browse(pos_order_id)
-            # End the session. The order has been created without any invoice.
-            self.pos_config.current_session_id.action_pos_session_closing_control()
-        return pos_order
-
+class TestPointOfSaleFlow(CommonPosTest):
     def test_order_refund(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        # I create a new PoS order with 2 lines
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 5.0,
-                'qty': 2.0,
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': 450 * (1 - 5/100.0) * 2,
-                'price_subtotal_incl': 450 * (1 - 5/100.0) * 2,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 5.0,
-                'qty': 3.0,
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': 300 * (1 - 5/100.0) * 3,
-                'price_subtotal_incl': 300 * (1 - 5/100.0) * 3,
-            })],
-            'amount_total': 1710.0,
-            'amount_tax': 0.0,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-            'last_order_preparation_change': '{}'
+        self.pos_config_usd.open_ui()
+
+        # The amount_total will be 30 with 3.52 taxes included
+        order, refund = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 10},
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 20},
+            ],
+            'refund_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': -30},
+            ]
         })
 
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.assertAlmostEqual(order.amount_total, order.amount_paid, msg='Order should be fully paid.')
-
-        # I create a refund
-        refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
-
-        self.assertEqual(order.amount_total, -1*refund.amount_total,
-            "The refund does not cancel the order (%s and %s)" % (order.amount_total, refund.amount_total))
-
-        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': refund.amount_total,
-            'payment_method_id': self.cash_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        refund_payment.with_context(**payment_context).check()
-
+        self.assertAlmostEqual(order.amount_total, order.amount_paid)
         self.assertEqual(refund.state, 'paid', "The refund is not marked as paid")
-        self.assertTrue(refund.payment_ids.payment_method_id.is_cash_count, msg='There should only be one payment and paid in cash.')
+        self.assertTrue(refund.payment_ids.payment_method_id.is_cash_count)
 
-        total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
+        current_session = self.pos_config_usd.current_session_id
+        total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(
+            lambda payment: payment.payment_method_id.type == 'cash').mapped('amount')
+        )
         current_session.post_closing_cash_details(total_cash_payment)
         current_session.close_session_from_ui()
-        self.assertEqual(current_session.state, 'closed', msg='State of current session should be closed.')
+        self.assertEqual(current_session.state, 'closed')
 
     def test_refund_multiple_payment_rounding(self):
-        """This test makes sure that the refund amount always correspond to what has been paid in the original order.
-           In this example we have a rounding, so we pay 55 in bank that is not rounded, then we pay the rest in cash
-           that is rounded. This sum up to 130 paid, so the refund should be 130."""
-        rouding_method = self.env['account.cash.rounding'].create({
-            'name': 'Rounding down',
-            'rounding': 5.0,
-            'rounding_method': 'DOWN',
-            'profit_account_id': self.company_data['default_account_revenue'].id,
-            'loss_account_id': self.company_data['default_account_expense'].id,
-        })
-
-        self.pos_config.write({
-            'rounding_method': rouding_method.id,
+        """
+            This test makes sure that the refund amount always correspond to what
+            has been paid in the original order. In this example we have a
+            rounding, so we pay 5 in bank that is not rounded, then we pay the
+            rest in cash that is rounded. This sum up to 10 paid, so the refund
+            should be 10.
+        """
+        self.account_cash_rounding_down.rounding = 5.0
+        self.pos_config_usd.write({
+            'rounding_method': self.account_cash_rounding_down.id,
             'cash_rounding': True,
         })
 
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'qty': 1,
-                    'price_subtotal': 134.38,
-                    'price_subtotal_incl': 134.38,
-                }),
+        self.pos_config_usd.open_ui()
+        # order total will be 11.5 with 1.5 taxes excluded, with rounding 10 should be paid
+        order, refund = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_15_excl.product_variant_id.id},
             ],
-            'amount_tax': 0.0,
-            'amount_total': 134.38,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 5},
+                {'payment_method_id': self.cash_payment_method.id},
+            ],
+            'refund_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': -10},
+            ]
         })
 
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': 55,
-            'payment_method_id': self.bank_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.assertEqual(order.amount_paid, 130.0)
+        self.assertEqual(order.amount_paid, 10.0)
         self.assertEqual(order.state, 'paid')
-
-        refund_order = self.env['pos.order'].browse(order.refund()['res_id'])
-        payment = self.env['pos.make.payment'].with_context(active_id=refund_order.id).create({
-            'payment_method_id': self.pos_config.payment_method_ids[0].id,
-        })
-        self.assertEqual(payment.amount, -130.0)
-        payment.check()
-        self.assertEqual(refund_order.amount_paid, -130.0)
-        self.assertEqual(refund_order.state, 'paid')
+        self.assertEqual(refund.amount_paid, -10.0)
+        self.assertEqual(refund.state, 'paid')
 
     def test_order_partial_refund_rounding(self):
         """ This test ensures that the refund amound of a partial order corresponds to
         the price of the item, without rounding. """
-        rouding_method = self.env['account.cash.rounding'].create({
-            'name': 'Rounding down',
-            'rounding': 5.0,
-            'rounding_method': 'DOWN',
-            'profit_account_id': self.company_data['default_account_revenue'].id,
-            'loss_account_id': self.company_data['default_account_expense'].id,
-        })
-
-        self.pos_config.write({
-            'rounding_method': rouding_method.id,
+        self.account_cash_rounding_down.rounding = 5.0
+        self.pos_config_usd.write({
+            'rounding_method': self.account_cash_rounding_down.id,
             'cash_rounding': True,
         })
 
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
 
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'qty': 1,
-                    'price_subtotal': 12.0,
-                    'price_subtotal_incl': 12.0,
-                    'price_unit': 12.0,
-                }),
-                Command.create({
-                    'product_id': self.product_b.id,
-                    'qty': 1,
-                    'price_subtotal': 16.0,
-                    'price_subtotal_incl': 16.0,
-                    'price_unit': 16.0,
-                }),
+        # order total will be 34.5 with 4.5 taxes excluded, with rounding 10 should be paid
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_15_excl.product_variant_id.id, 'qty': 3},
             ],
-            'amount_tax': 0.0,
-            'amount_total': 28.0,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 34.5},
+            ],
         })
 
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': 28,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
         self.assertEqual(order._get_rounded_amount(order.amount_total), order.amount_paid)
-
         refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
+        refund = self.env['pos.order'].browse(refund_action['res_id'])
 
         with Form(refund) as refund_form:
             with refund_form.lines.edit(0) as line:
-                line.qty = 0
+                line.qty = 1
         refund = refund_form.save()
 
-        self.assertEqual(refund.amount_total, -15.0)
-
+        self.assertEqual(refund.amount_total, 10.0)
         payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
+        refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
             'amount': refund.amount_total,
             'payment_method_id': self.cash_payment_method.id,
         })
         refund_payment.with_context(**payment_context).check()
-
         self.assertEqual(refund.state, 'paid')
         current_session.action_pos_session_closing_control()
         self.assertEqual(current_session.state, 'closed')
-
-    def test_order_refund_lots(self):
-        # open pos session
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # set up product iwith SN tracing and create two lots (1001, 1002)
-        self.stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.product2 = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
-            'tracking': 'serial',
-        })
-
-        lot1 = self.env['stock.lot'].create({
-            'name': '1001',
-            'product_id': self.product2.id,
-        })
-        lot2 = self.env['stock.lot'].create({
-            'name': '1002',
-            'product_id': self.product2.id,
-        })
-
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product2.id,
-            'inventory_quantity': 1,
-            'location_id': self.stock_location.id,
-            'lot_id': lot1.id
-        }).action_apply_inventory()
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product2.id,
-            'inventory_quantity': 1,
-            'location_id': self.stock_location.id,
-            'lot_id': lot2.id
-        }).action_apply_inventory()
-
-        # create pos order with the two SN created before
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 2,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 12,
-                'price_subtotal_incl': 12,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '1001'}],
-                    [0, 0, {'lot_name': '1002'}],
-                ]
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 12.0,
-            'amount_total': 12.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-            })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        # I create a refund
-        refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
-
-        order_lot_id = [lot_id.lot_name for lot_id in order.lines.pack_lot_ids]
-        refund_lot_id = [lot_id.lot_name for lot_id in refund.lines.pack_lot_ids]
-        self.assertEqual(
-            order_lot_id,
-            refund_lot_id,
-            "In the refund we should find the same lot as in the original order")
-
-        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': refund.amount_total,
-            'payment_method_id': self.cash_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        refund_payment.with_context(**payment_context).check()
-
-        self.assertEqual(refund.state, 'paid', "The refund is not marked as paid")
-        current_session.action_pos_session_closing_control()
 
     def test_order_partial_refund(self):
         """ The purpose of this test is to make a partial refund of a pos order.
         The amount to refund should depend on the article returned and once the
         payment made, the refund order should be marked as paid."""
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
 
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [
-                Command.create({
-                    'product_id': self.product_a.id,
-                    'price_unit': 10,
-                    'qty': 1,
-                    'price_subtotal': 10,
-                    'price_subtotal_incl': 10,
-                }),
-                Command.create({
-                    'product_id': self.product_b.id,
-                    'price_unit': 15,
-                    'qty': 1,
-                    'price_subtotal': 15,
-                    'price_subtotal_incl': 15,
-                }),
-                Command.create({
-                    'product_id': self.product3.id,
-                    'price_unit': 20,
-                    'qty': 1,
-                    'price_subtotal': 20,
-                    'price_subtotal_incl': 20,
-                })
+        # order total will be 30 with 3.52 taxes included
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
             ],
-            'amount_total': 45.0,
-            'amount_tax': 0.0,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 10},
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 20},
+            ]
         })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.assertEqual(order.amount_total, order.amount_paid)
 
         refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
+        refund = self.env['pos.order'].browse(refund_action['res_id'])
 
         with Form(refund) as refund_form:
             with refund_form.lines.edit(0) as line:
                 line.qty = 0
-            with refund_form.lines.edit(1) as line_2:
-                line_2.qty = 0
         refund = refund_form.save()
 
         self.assertEqual(refund.amount_total, -20.0)
 
         payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
+        refund_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
             'amount': refund.amount_total,
             'payment_method_id': self.cash_payment_method.id,
         })
@@ -446,389 +157,144 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
     def test_order_to_picking(self):
         """
-            In order to test the Point of Sale in module, I will do three orders from the sale to the payment,
-            invoicing + picking, but will only check the picking consistency in the end.
+            In order to test the Point of Sale in module, I will do three orders
+            from the sale to the payment, invoicing + picking, but will only
+            check the picking consistency in the end.
 
-            TODO: Check the negative picking after changing the picking relation to One2many (also for a mixed use case),
-            check the quantity, the locations and return picking logic
+            TODO: Check the negative picking after changing the picking relation
+            to One2many (also for a mixed use case), check the quantity, the
+            locations and return picking logic
         """
-
-        # I click on create a new session button
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # I create a PoS order with 2 units of PCSC234 at 450 EUR
-        # and 3 units of PCSC349 at 300 EUR.
-        untax1, atax1 = self.compute_tax(self.product3, 450, 2)
-        untax2, atax2 = self.compute_tax(self.product4, 300, 3)
-        self.pos_order_pos1 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 0.0,
-                'qty': 2.0,
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax1,
-                'price_subtotal_incl': untax1 + atax1,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 0.0,
-                'qty': 3.0,
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax2,
-                'price_subtotal_incl': untax2 + atax2,
-            })],
-            'amount_tax': atax1 + atax2,
-            'amount_total': untax1 + untax2 + atax1 + atax2,
-            'amount_paid': 0,
-            'amount_return': 0,
-            'last_order_preparation_change': '{}'
+        order_1, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_jcb.id,
+                'pricelist_id': self.partner_jcb.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.credit_payment_method.id, 'amount': 30},
+            ],
+        })
+        order_2, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_lowe.id,
+                'pricelist_id': self.partner_lowe.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.credit_payment_method.id, 'amount': 30},
+            ],
+        })
+        order_3, order_refund_3 = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_vlst.id,
+                'pricelist_id': self.partner_vlst.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 30},
+            ],
+            'refund_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': -30},
+            ],
         })
 
-        context_make_payment = {
-            "active_ids": [self.pos_order_pos1.id],
-            "active_id": self.pos_order_pos1.id
-        }
-        self.pos_make_payment_2 = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': untax1 + untax2 + atax1 + atax2
-        })
+        self.assertEqual(order_1.state, 'paid', 'Order should be in paid state.')
+        self.assertEqual(order_1.picking_ids[0].state, 'done')
+        self.assertEqual(order_1.picking_ids[0].move_ids.mapped('state'), ['done', 'done'])
+        self.assertEqual(order_2.state, 'paid', 'Order should be in paid state.')
+        self.assertEqual(order_2.picking_ids[0].state, 'done')
+        self.assertEqual(order_2.picking_ids[0].move_ids.mapped('state'), ['done', 'done'])
+        self.assertEqual(order_3.state, 'paid', 'Order should be in paid state.')
+        self.assertEqual(order_3.picking_ids[0].state, 'done')
+        self.assertEqual(order_3.picking_ids[0].move_ids.mapped('state'), ['done', 'done'])
 
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos1.id}
-
-        self.pos_make_payment_2.with_context(context_payment).check()
-        # I check that the order is marked as paid
-        self.assertEqual(
-            self.pos_order_pos1.state,
-            'paid',
-            'Order should be in paid state.'
-        )
-
-        # I test that the pickings are created as expected during payment
-        # One picking attached and having all the positive move lines in the correct state
-        self.assertEqual(
-            self.pos_order_pos1.picking_ids[0].state,
-            'done',
-            'Picking should be in done state.'
-        )
-        self.assertEqual(
-            self.pos_order_pos1.picking_ids[0].move_ids.mapped('state'),
-            ['done', 'done'],
-            'Move Lines should be in done state.'
-        )
-
-        # I create a second order
-        untax1, atax1 = self.compute_tax(self.product3, 450, -2)
-        untax2, atax2 = self.compute_tax(self.product4, 300, -3)
-        self.pos_order_pos2 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0003",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 0.0,
-                'qty': (-2.0),
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax1,
-                'price_subtotal_incl': untax1 + atax1,
-            }), (0, 0, {
-                'name': "OL/0004",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 0.0,
-                'qty': (-3.0),
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax2,
-                'price_subtotal_incl': untax2 + atax2,
-            })],
-            'amount_tax': atax1 + atax2,
-            'amount_total': untax1 + untax2 + atax1 + atax2,
-            'amount_paid': 0,
-            'amount_return': 0,
-            'last_order_preparation_change': '{}'
-        })
-
-        context_make_payment = {
-            "active_ids": [self.pos_order_pos2.id],
-            "active_id": self.pos_order_pos2.id
-        }
-        self.pos_make_payment_3 = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': untax1 + untax2 + atax1 + atax2
-        })
-
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos2.id}
-        self.pos_make_payment_3.with_context(context_payment).check()
-
-        # I check that the order is marked as paid
-        self.assertEqual(
-            self.pos_order_pos2.state,
-            'paid',
-            'Order should be in paid state.'
-        )
-
-        # I test that the pickings are created as expected
-        # One picking attached and having all the positive move lines in the correct state
-        self.assertEqual(
-            self.pos_order_pos2.picking_ids[0].state,
-            'done',
-            'Picking should be in done state.'
-        )
-        self.assertEqual(
-            self.pos_order_pos2.picking_ids[0].move_ids.mapped('state'),
-            ['done', 'done'],
-            'Move Lines should be in done state.'
-        )
-
-        untax1, atax1 = self.compute_tax(self.product3, 450, -2)
-        untax2, atax2 = self.compute_tax(self.product4, 300, 3)
-        self.pos_order_pos3 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0005",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 0.0,
-                'qty': (-2.0),
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax1,
-                'price_subtotal_incl': untax1 + atax1,
-            }), (0, 0, {
-                'name': "OL/0006",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 0.0,
-                'qty': 3.0,
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax2,
-                'price_subtotal_incl': untax2 + atax2,
-            })],
-            'amount_tax': atax1 + atax2,
-            'amount_total': untax1 + untax2 + atax1 + atax2,
-            'amount_paid': 0,
-            'amount_return': 0,
-            'last_order_preparation_change': '{}'
-        })
-
-        context_make_payment = {
-            "active_ids": [self.pos_order_pos3.id],
-            "active_id": self.pos_order_pos3.id
-        }
-        self.pos_make_payment_4 = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': untax1 + untax2 + atax1 + atax2,
-        })
-
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos3.id}
-        self.pos_make_payment_4.with_context(context_payment).check()
-
-        # I check that the order is marked as paid
-        self.assertEqual(
-            self.pos_order_pos3.state,
-            'paid',
-            'Order should be in paid state.'
-        )
-
-        # I test that the pickings are created as expected
-        # One picking attached and having all the positive move lines in the correct state
-        self.assertEqual(
-            self.pos_order_pos3.picking_ids[0].state,
-            'done',
-            'Picking should be in done state.'
-        )
-        self.assertEqual(
-            self.pos_order_pos3.picking_ids[0].move_ids.mapped('state'),
-            ['done'],
-            'Move Lines should be in done state.'
-        )
-        # I close the session to generate the journal entries
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        order_refund_3.action_pos_order_invoice()
+        invoice_pdf_content = str(order_refund_3.account_move._get_invoice_legal_documents(
+            'pdf', allow_fallback=True).get('content'))
+        self.assertTrue("using Cash" in invoice_pdf_content)
+        self.assertEqual(order_refund_3.picking_count, 1)
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
     def test_order_to_picking02(self):
-        """ This test is similar to test_order_to_picking except that this time, there are two products:
-            - One tracked by lot
-            - One untracked
-            - Both are in a sublocation of the main warehouse
         """
-        tracked_product, untracked_product = self.env['product.product'].create([{
-            'name': 'SuperProduct Tracked',
-            'is_storable': True,
-            'tracking': 'lot',
-            'available_in_pos': True,
-        }, {
-            'name': 'SuperProduct Untracked',
-            'is_storable': True,
-            'available_in_pos': True,
-        }])
+            This test is similar to test_order_to_picking except that this time,
+            there are two products:
+                - One tracked by lot (ten_dollars_with_10_incl)
+                - One untracked (twenty_dollars_with_15_incl)
+                - Both are in a sublocation of the main warehouse
+        """
         wh_location = self.company_data['default_warehouse'].lot_stock_id
         shelf1_location = self.env['stock.location'].create({
             'name': 'shelf1',
             'usage': 'internal',
             'location_id': wh_location.id,
         })
+        self.ten_dollars_with_10_incl.product_variant_id.write({
+            'tracking': 'lot',
+            'is_storable': True,
+        })
+        self.twenty_dollars_with_15_incl.product_variant_id.write({
+            'tracking': 'none',
+            'is_storable': True,
+        })
         lot = self.env['stock.lot'].create({
             'name': 'SuperLot',
-            'product_id': tracked_product.id,
-        })
-        qty = 2
-        self.env['stock.quant']._update_available_quantity(tracked_product, shelf1_location, qty, lot_id=lot)
-        self.env['stock.quant']._update_available_quantity(untracked_product, shelf1_location, qty)
-
-        self.pos_config.open_ui()
-        self.pos_config.current_session_id.update_stock_at_closing = False
-
-        untax, atax = self.compute_tax(tracked_product, 1.15, 1)
-
-        for _i in range(qty):
-            pos_order = self.PosOrder.create({
-                'company_id': self.env.company.id,
-                'session_id': self.pos_config.current_session_id.id,
-                'pricelist_id': self.partner1.property_product_pricelist.id,
-                'partner_id': self.partner1.id,
-                'lines': [(0, 0, {
-                    'name': "OL/0001",
-                    'product_id': tracked_product.id,
-                    'price_unit': 1.15,
-                    'discount': 0.0,
-                    'qty': 1.0,
-                    'tax_ids': [(6, 0, tracked_product.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                    'price_subtotal': untax,
-                    'price_subtotal_incl': untax + atax,
-                    'pack_lot_ids': [[0, 0, {'lot_name': lot.name}]],
-                }), (0, 0, {
-                    'name': "OL/0002",
-                    'product_id': untracked_product.id,
-                    'price_unit': 1.15,
-                    'discount': 0.0,
-                    'qty': 1.0,
-                    'tax_ids': [(6, 0, untracked_product.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                    'price_subtotal': untax,
-                    'price_subtotal_incl': untax + atax,
-                })],
-                'amount_tax': 2 * atax,
-                'amount_total': 2 * (untax + atax),
-                'amount_paid': 0,
-                'amount_return': 0,
-                'last_order_preparation_change': '{}'
-            })
-
-            context_make_payment = {
-                "active_ids": [pos_order.id],
-                "active_id": pos_order.id,
-            }
-            pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
-                'amount': 2 * (untax + atax),
-            })
-            context_payment = {'active_id': pos_order.id}
-            pos_make_payment.with_context(context_payment).check()
-
-            self.assertEqual(pos_order.state, 'paid')
-            tracked_line = pos_order.picking_ids.move_line_ids.filtered(lambda ml: ml.product_id.id == tracked_product.id)
-            untracked_line = pos_order.picking_ids.move_line_ids - tracked_line
-            self.assertEqual(tracked_line.lot_id, lot)
-            self.assertFalse(untracked_line.lot_id)
-            self.assertEqual(tracked_line.location_id, shelf1_location)
-            self.assertEqual(untracked_line.location_id, shelf1_location)
-
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-
-    def test_order_to_invoice(self):
-
-        invoice_partner_address = self.env["res.partner"].create({
-            'name': "Test invoice address",
-            'street': "Invoice Street",
-            'type': 'invoice',
-            'parent_id': self.partner1.id,
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
         })
 
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
+        quantity_1 = self.env['stock.quant']._update_available_quantity(
+            self.ten_dollars_with_10_incl.product_variant_id, shelf1_location, 2, lot_id=lot)
+        quantity_2 = self.env['stock.quant']._update_available_quantity(
+            self.twenty_dollars_with_15_incl.product_variant_id, shelf1_location, 2)
 
-        untax1, atax1 = self.compute_tax(self.product3, 450*0.95, 2)
-        untax2, atax2 = self.compute_tax(self.product4, 300*0.95, 3)
-        # I create a new PoS order with 2 units of PC1 at 450 EUR (Tax Incl) and 3 units of PCSC349 at 300 EUR. (Tax Excl)
-        self.pos_order_pos1 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 5.0,
-                'qty': 2.0,
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax1,
-                'price_subtotal_incl': untax1 + atax1,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 5.0,
-                'qty': 3.0,
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)],
-                'price_subtotal': untax2,
-                'price_subtotal_incl': untax2 + atax2,
-            })],
-            'amount_tax': atax1 + atax2,
-            'amount_total': untax1 + untax2 + atax1 + atax2,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-            'last_order_preparation_change': '{}'
+        self.assertEqual(quantity_1[0], 2)
+        self.assertEqual(quantity_2[0], 2)
+        self.pos_config_usd.open_ui()
+        self.pos_config_usd.current_session_id.update_stock_at_closing = False
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_manv.id,
+                'pricelist_id': self.partner_manv.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 30},
+            ],
         })
 
-        # I click on the "Make Payment" wizard to pay the PoS order
-        context_make_payment = {"active_ids": [self.pos_order_pos1.id], "active_id": self.pos_order_pos1.id}
-        self.pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': untax1 + untax2 + atax1 + atax2,
-        })
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos1.id}
-        self.pos_make_payment.with_context(context_payment).check()
+        self.assertEqual(order.state, 'paid')
+        tracked_line = self.env['stock.move.line'].search(
+            [('product_id', '=', self.ten_dollars_with_10_incl.product_variant_id.id)])
+        untracked_line = order.picking_ids.move_line_ids - tracked_line
+        self.assertEqual(tracked_line.lot_id, lot)
+        self.assertFalse(untracked_line.lot_id)
+        self.assertEqual(tracked_line.location_id, shelf1_location)
+        self.assertEqual(untracked_line.location_id, shelf1_location)
 
-        # I check that the order is marked as paid and there is no invoice
-        # attached to it
-        self.assertEqual(self.pos_order_pos1.state, 'paid', "Order should be in paid state.")
-        self.assertFalse(self.pos_order_pos1.account_move, 'Invoice should not be attached to order.')
-
-        # I generate an invoice from the order
-        res = self.pos_order_pos1.action_pos_order_invoice()
-        self.assertIn('res_id', res, "Invoice should be created")
-        self.assertEqual(self.pos_order_pos1.account_move.partner_id.id, invoice_partner_address.id, "Invoice address should be used")
-
-        # I test that the total of the attached invoice is correct
-        invoice = self.env['account.move'].browse(res['res_id'])
-        if invoice.state != 'posted':
-            invoice.action_post()
-        self.assertAlmostEqual(
-            invoice.amount_total, self.pos_order_pos1.amount_total, places=2, msg="Invoice not correct")
-
-        # I close the session to generate the journal entries
-        current_session.action_pos_session_closing_control()
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
     def test_order_to_payment_currency(self):
         """
-            In order to test the Point of Sale in module, I will do a full flow from the sale to the payment and invoicing.
-            I will use two products, one with price including a 10% tax, the other one with 5% tax excluded from the price.
+            In order to test the Point of Sale in module, I will do a full flow
+            from the sale to the payment and invoicing. I will use two products,
+            one with price including a 10% tax, the other one with 5% tax
+            excluded from the price.
+
             The order will be in a different currency than the company currency.
         """
-        # Make sure the company is in USD
-        self.env.ref('base.USD').active = True
-        self.env.ref('base.EUR').active = True
         self.env.cr.execute(
             "UPDATE res_company SET currency_id = %s WHERE id = %s",
             [self.env.ref('base.USD').id, self.env.company.id])
@@ -841,467 +307,209 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'currency_id': self.env.ref('base.EUR').id,
         })
 
-        # make a config that has currency different from the company
-        eur_pricelist = self.env['product.pricelist'].create({'name': 'Test EUR Pricelist', 'currency_id': self.env.ref('base.EUR').id})
-        sale_journal = self.env['account.journal'].create({
-            'name': 'PoS Sale EUR',
-            'type': 'sale',
-            'code': 'POSE',
-            'company_id': self.company.id,
-            'sequence': 12,
-            'currency_id': self.env.ref('base.EUR').id
-        })
-        eur_config = self.pos_config.create({
-            'name': 'Shop EUR Test',
-            'journal_id': sale_journal.id,
-            'use_pricelist': True,
-            'available_pricelist_ids': [(6, 0, eur_pricelist.ids)],
-            'pricelist_id': eur_pricelist.id,
-            'payment_method_ids': [(6, 0, self.bank_payment_method.ids)]
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_mobt.id,
+                'pricelist_id': self.partner_mobt.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_no_tax.product_variant_id.id},
+                {'product_id': self.twenty_dollars_no_tax.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 10},
+                {'payment_method_id': self.bank_payment_method.id},
+            ],
+            'pos_config': self.pos_config_eur,
         })
 
-        # I click on create a new session button
-        eur_config.open_ui()
-        current_session = eur_config.current_session_id
-
-        # I create a PoS order with 2 units of PCSC234 at 450 EUR (Tax Incl)
-        # and 3 units of PCSC349 at 300 EUR. (Tax Excl)
-
-        untax1, atax1 = self.compute_tax(self.product3, 450, 2)
-        untax2, atax2 = self.compute_tax(self.product4, 300, 3)
-        self.pos_order_pos0 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'pricelist_id': eur_pricelist.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 0.0,
-                'qty': 2.0,
-                'tax_ids': [(6, 0, self.product3.taxes_id.filtered(lambda t: t.company_id == self.env.company).ids)],
-                'price_subtotal': untax1,
-                'price_subtotal_incl': untax1 + atax1,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 0.0,
-                'qty': 3.0,
-                'tax_ids': [(6, 0, self.product4.taxes_id.filtered(lambda t: t.company_id == self.env.company).ids)],
-                'price_subtotal': untax2,
-                'price_subtotal_incl': untax2 + atax2,
-            })],
-            'amount_tax': atax1 + atax2,
-            'amount_total': untax1 + untax2 + atax1 + atax2,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-            'last_order_preparation_change': '{}'
-        })
-
-        # I check that the total of the order is now equal to (450*2 +
-        # 300*3*1.05)*0.95
-        self.assertLess(
-            abs(self.pos_order_pos0.amount_total - (450 * 2 + 300 * 3 * 1.05)),
-            0.01, 'The order has a wrong total including tax and discounts')
-
-        # I click on the "Make Payment" wizard to pay the PoS order with a
-        # partial amount of 100.0 EUR
-        context_make_payment = {"active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
-        self.pos_make_payment_0 = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': 100.0,
-            'payment_method_id': self.bank_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos0.id}
-        self.pos_make_payment_0.with_context(context_payment).check()
-
-        # I check that the order is not marked as paid yet
-        self.assertEqual(self.pos_order_pos0.state, 'draft', 'Order should be in draft state.')
-
-        # On the second payment proposition, I check that it proposes me the
-        # remaining balance which is 1790.0 EUR
-        defs = self.pos_make_payment_0.with_context({'active_id': self.pos_order_pos0.id}).default_get(['amount'])
-
-        self.assertLess(
-            abs(defs['amount'] - ((450 * 2 + 300 * 3 * 1.05) - 100.0)), 0.01, "The remaining balance is incorrect.")
-
-        #'I pay the remaining balance.
-        context_make_payment = {
-            "active_ids": [self.pos_order_pos0.id], "active_id": self.pos_order_pos0.id}
-
-        self.pos_make_payment_1 = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': (450 * 2 + 300 * 3 * 1.05) - 100.0,
-            'payment_method_id': self.bank_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        self.pos_make_payment_1.with_context(context_make_payment).check()
-
-        # I check that the order is marked as paid
-        self.assertEqual(self.pos_order_pos0.state, 'paid', 'Order should be in paid state.')
-
-        # I generate the journal entries
+        self.assertEqual(order.amount_total, 30)
+        self.assertEqual(order.amount_paid, 30)
+        self.assertEqual(order.state, 'paid')
+        current_session = self.pos_config_eur.current_session_id
         current_session.action_pos_session_validate()
-
-        # I test that the generated journal entry is attached to the PoS order
-        self.assertTrue(current_session.move_id, "Journal entry should have been attached to the session.")
-
-        # Check the amounts
+        self.assertTrue(current_session.move_id)
         debit_lines = current_session.move_id.mapped('line_ids.debit')
         credit_lines = current_session.move_id.mapped('line_ids.credit')
         amount_currency_lines = current_session.move_id.mapped('line_ids.amount_currency')
-        for a, b in zip(sorted(debit_lines), [0.0, 0.0, 0.0, 0.0, 922.5]):
+        for a, b in zip(sorted(debit_lines), [0.0, 15.0]):
             self.assertAlmostEqual(a, b)
-        for a, b in zip(sorted(credit_lines), [0.0, 22.5, 40.91, 409.09, 450]):
+        for a, b in zip(sorted(credit_lines), [0.0, 15.0]):
             self.assertAlmostEqual(a, b)
-        for a, b in zip(sorted(amount_currency_lines), [-900, -818.18, -81.82, -45, 1845]):
+        for a, b in zip(sorted(amount_currency_lines), [-30, 30]):
             self.assertAlmostEqual(a, b)
 
     def test_order_to_invoice_no_tax(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # I create a new PoS order with 2 units of PC1 at 450 EUR (Tax Incl) and 3 units of PCSC349 at 300 EUR. (Tax Excl)
-        self.pos_order_pos1 = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 5.0,
-                'qty': 2.0,
-                'price_subtotal': 855,
-                'price_subtotal_incl': 855,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product4.id,
-                'price_unit': 300,
-                'discount': 5.0,
-                'qty': 3.0,
-                'price_subtotal': 855,
-                'price_subtotal_incl': 855,
-            })],
-            'amount_tax': 855 * 2,
-            'amount_total': 855 * 2,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-            'last_order_preparation_change': '{}'
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_mobt.id,
+                'pricelist_id': self.partner_mobt.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_no_tax.product_variant_id.id},
+                {'product_id': self.twenty_dollars_no_tax.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 30},
+            ],
         })
+        self.assertEqual(order.state, 'paid', "Order should be in paid state.")
+        self.assertFalse(order.account_move, 'Invoice should not be attached to order yet.')
 
-        # I click on the "Make Payment" wizard to pay the PoS order
-        context_make_payment = {"active_ids": [self.pos_order_pos1.id], "active_id": self.pos_order_pos1.id}
-        self.pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': 855 * 2,
-        })
-        # I click on the validate button to register the payment.
-        context_payment = {'active_id': self.pos_order_pos1.id}
-        self.pos_make_payment.with_context(context_payment).check()
-
-        # I check that the order is marked as paid and there is no invoice
-        # attached to it
-        self.assertEqual(self.pos_order_pos1.state, 'paid', "Order should be in paid state.")
-        self.assertFalse(self.pos_order_pos1.account_move, 'Invoice should not be attached to order yet.')
-
-        # I generate an invoice from the order
-        res = self.pos_order_pos1.action_pos_order_invoice()
+        res = order.action_pos_order_invoice()
         self.assertIn('res_id', res, "No invoice created")
 
         # I test that the total of the attached invoice is correct
         invoice = self.env['account.move'].browse(res['res_id'])
         if invoice.state != 'posted':
             invoice.action_post()
-        self.assertAlmostEqual(
-            invoice.amount_total, self.pos_order_pos1.amount_total, places=2, msg="Invoice not correct")
+        self.assertAlmostEqual(invoice.amount_total, order.amount_total, places=2)
 
         for iline in invoice.invoice_line_ids:
             self.assertFalse(iline.tax_ids)
 
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
     def test_order_with_deleted_tax(self):
-        # create tax
-        dummy_50_perc_tax = self.env['account.tax'].create({
-            'name': 'Tax 50%',
-            'amount_type': 'percent',
-            'amount': 50.0,
-            'price_include_override': 'tax_excluded',
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_excl.product_variant_id.id},
+            ],
         })
 
-        # set tax to product
-        product5 = self.env['product.product'].create({
-            'name': 'product5',
-            'is_storable': True,
-            'taxes_id': dummy_50_perc_tax.ids
+        untax, atax = self.compute_tax(self.ten_dollars_with_10_excl.product_variant_id, 10.0)
+        self.ten_dollars_with_10_excl.taxes_id.unlink()
+        current_session = self.pos_config_usd.current_session_id
+        payment = self.env['pos.make.payment'].create({
+            'config_id': self.pos_config_usd.id,
+            'amount': untax + atax,
+            'payment_method_id': self.cash_payment_method.id,
         })
+        payment.with_context(active_ids=order.ids, active_id=order.id).check()
+        self.assertEqual(order.state, 'paid', "Order should be in paid state.")
 
-        # sell product thru pos
-        self.pos_config.open_ui()
-        pos_session = self.pos_config.current_session_id
-        untax, atax = self.compute_tax(product5, 10.0)
-        product5_order = {
-            'amount_paid': untax + atax,
-            'amount_return': 0,
-            'amount_tax': atax,
-            'amount_total': untax + atax,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'lines': [[0,
-                0,
-                {'discount': 0,
-                'pack_lot_ids': [],
-                'price_unit': 10.0,
-                'product_id': product5.id,
-                'price_subtotal': 10.0,
-                'price_subtotal_incl': 15.0,
-                'qty': 1,
-                'tax_ids': [(6, 0, product5.taxes_id.ids)]}]],
-            'partner_id': False,
-            'session_id': pos_session.id,
-            'payment_ids': [[0,
-                0,
-                {'amount': untax + atax,
-                'name': fields.Datetime.now(),
-                'payment_method_id': self.cash_payment_method.id}]],
-            'last_order_preparation_change': '{}',
-            'user_id': self.env.uid
-        }
-        self.PosOrder.sync_from_ui([product5_order])
-
-        # delete tax
-        dummy_50_perc_tax.unlink()
-
-        total_cash_payment = sum(pos_session.mapped('order_ids.payment_ids').filtered(lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
-        pos_session.post_closing_cash_details(total_cash_payment)
+        total_cash_payment = sum(current_session.mapped('order_ids.payment_ids').filtered(
+            lambda payment: payment.payment_method_id.type == 'cash').mapped('amount'))
+        current_session.post_closing_cash_details(total_cash_payment)
 
         # close session (should not fail here)
         # We don't call `action_pos_session_closing_control` to force the failed
         # closing which will return the action because the internal rollback call messes
         # with the rollback of the test runner. So instead, we directly call the method
         # that returns the action by specifying the imbalance amount.
-        action = pos_session._close_session_action(5.0)
+        action = current_session._close_session_action(1.0)
         wizard = self.env['pos.close.session.wizard'].browse(action['res_id'])
         wizard.with_context(action['context']).close_session()
 
-        # check the difference line
-        diff_line = pos_session.move_id.line_ids.filtered(lambda line: line.name == 'Difference at closing PoS session')
-        self.assertAlmostEqual(diff_line.credit, 5.0, msg="Missing amount of 5.0")
+        diff_line = current_session.move_id.line_ids.filtered(
+            lambda line: line.name == 'Difference at closing PoS session')
+        self.assertAlmostEqual(diff_line.credit, 1.0, msg="Missing amount of 1.0")
 
     def test_order_multi_step_route(self):
-        """ Test that orders in sessions with "Ship Later" enabled and "Specific Route" set to a
-            multi-step (2/3) route can be validated. This config implies multiple picking types
-            and multiple move_lines.
         """
-        tracked_product = self.env['product.product'].create({
-            'name': 'SuperProduct Tracked',
-            'is_storable': True,
+            Test that orders in sessions with "Ship Later" enabled and
+            "Specific Route" set to a multi-step (2/3) route can be validated.
+            This config implies multiple picking types and multiple move_lines.
+        """
+        self.ten_dollars_with_10_incl.product_variant_id.write({
             'tracking': 'lot',
-            'available_in_pos': True
-        })
-        tracked_product_2 = self.env['product.product'].create({
-            'name': 'SuperProduct Tracked 2',
             'is_storable': True,
-            'tracking': 'lot',
-            'available_in_pos': True
         })
-        tracked_product_2_lot = self.env['stock.lot'].create({
+        self.twenty_dollars_with_10_incl.product_variant_id.write({
+            'tracking': 'lot',
+            'is_storable': True,
+        })
+        twenty_dollars_lot = self.env['stock.lot'].create({
             'name': '80085',
-            'product_id': tracked_product_2.id,
+            'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id,
         })
         stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': tracked_product_2.id,
+        stock_quantity = self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id,
             'inventory_quantity': 1,
             'location_id': stock_location.id,
-            'lot_id': tracked_product_2_lot.id
-        }).action_apply_inventory()
+            'lot_id': twenty_dollars_lot.id
+        })
+        stock_quantity.action_apply_inventory()
         warehouse_id = self.company_data['default_warehouse']
         warehouse_id.delivery_steps = 'pick_ship'
 
-        self.pos_config.ship_later = True
-        self.pos_config.warehouse_id = warehouse_id
-        self.pos_config.route_id = warehouse_id.route_ids[-1]
-        self.pos_config.open_ui()
-        self.pos_config.current_session_id.update_stock_at_closing = False
-
-        untax, tax = self.compute_tax(tracked_product, 1.15, 1)
-
-        pos_order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': self.pos_config.current_session_id.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': tracked_product.id,
-                'price_unit': 1.15,
-                'qty': 1.0,
-                'price_subtotal': untax,
-                'price_subtotal_incl': untax + tax,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '80085'}],
-                ]
-            }),
-                (0, 0, {
-                    'name': "OL/0002",
-                    'product_id': tracked_product_2.id,
-                    'price_unit': 1.15,
-                    'qty': 1.0,
-                    'price_subtotal': untax,
-                    'price_subtotal_incl': untax + tax,
-                    'pack_lot_ids': [
-                        [0, 0, {'lot_name': '80085'}],
-                    ]
-            })],
-            'amount_tax': tax,
-            'amount_total': untax+tax,
-            'amount_paid': 0,
-            'amount_return': 0,
-            'shipping_date': fields.Date.today(),
-            'last_order_preparation_change': '{}'
+        self.pos_config_usd.write({
+            'ship_later': True,
+            'warehouse_id': warehouse_id.id,
+            'route_id': warehouse_id.route_ids[-1].id,
         })
 
-        context_make_payment = {
-            "active_ids": [pos_order.id],
-            "active_id": pos_order.id,
-        }
-        pos_make_payment = self.PosMakePayment.with_context(context_make_payment).create({
-            'amount': untax+tax,
+        self.pos_config_usd.open_ui()
+        self.pos_config_usd.current_session_id.update_stock_at_closing = False
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'shipping_date': fields.Date.today(),
+                'partner_id': self.partner_mobt.id,
+                'pricelist_id': self.partner_mobt.property_product_pricelist.id,
+            },
+            'line_data': [
+                {
+                    'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
+                    'pack_lot_ids': [[0, 0, {'lot_name': '80085'}]],
+                },
+                {
+                    'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id,
+                    'pack_lot_ids': [[0, 0, {'lot_name': '80085'}]],
+                },
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 30},
+            ],
         })
-        context_payment = {'active_id': pos_order.id}
-        pos_make_payment.with_context(context_payment).check()
-        pickings = pos_order.picking_ids
-        picking_mls_no_stock = pickings.move_line_ids.filtered(lambda l: l.product_id.id == tracked_product.id)
-        picking_mls_stock = pickings.move_line_ids.filtered(lambda l: l.product_id.id == tracked_product_2.id)
-        self.assertEqual(pos_order.state, 'paid')
+        picking_mls_no_stock = order.picking_ids.move_line_ids.filtered(
+            lambda l: l.product_id.id == self.ten_dollars_with_10_incl.product_variant_id.id)
+        picking_mls_stock = order.picking_ids.move_line_ids.filtered(
+            lambda l: l.product_id.id == self.twenty_dollars_with_10_incl.product_variant_id.id)
+        self.assertEqual(order.state, 'paid')
         self.assertEqual(len(picking_mls_no_stock), 0)
         self.assertEqual(len(picking_mls_stock), 1)
-        self.assertEqual(len(pickings.picking_type_id), 1)
-
-    def test_order_refund_picking(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        current_session.update_stock_at_closing = True
-        # I create a new PoS order with 1 line
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 5.0,
-                'qty': 2.0,
-                'tax_ids': [(6, 0, self.product3.taxes_id.ids)],
-                'price_subtotal': 450 * (1 - 5/100.0) * 2,
-                'price_subtotal_incl': 450 * (1 - 5/100.0) * 2,
-            })],
-            'amount_total': 1710.0,
-            'amount_tax': 0.0,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': True,
-            'last_order_preparation_change': '{}'
-        })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        # Make sure the invoice contains the payment method used
-        # TODO: We might want to test the whole PDF content in another test
-        invoice_pdf_content = str(order.account_move._get_invoice_legal_documents('pdf', allow_fallback=True).get('content'))
-        self.assertTrue("using Cash" in invoice_pdf_content)
-
-        # I create a refund
-        refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
-
-        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': refund.amount_total,
-            'payment_method_id': self.cash_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        refund_payment.with_context(**payment_context).check()
-
-        refund.action_pos_order_invoice()
-        self.assertEqual(refund.picking_count, 1)
+        self.assertEqual(len(order.picking_ids.picking_type_id), 1)
 
     def test_order_with_different_payments_and_refund(self):
         """
-        Test that all the payments are correctly taken into account when the order contains multiple payments and money refund.
+        Test that all the payments are correctly taken into account when the order
+        contains multiple payments and money refund.
         In this example, we create an order with two payments for a product of 750$:
             - one payment of $300 with customer account
             - one payment of $460 with cash
         Then, we refund the order with $10, and check that the amount still due is 300$.
         """
-
-        product5 = self.env['product.product'].create({
-            'name': 'product5',
+        self.twenty_dollars_no_tax.product_variant_id.write({
             'is_storable': True,
         })
-
-        # sell product thru pos
-        self.pos_config.open_ui()
-        pos_session = self.pos_config.current_session_id
-        product5_order = {
-            'amount_paid': 750,
-            'amount_return': 10,
-            'amount_tax': 0,
-            'amount_total': 750,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'lines': [[0, 0, {
-                    'discount': 0,
-                    'pack_lot_ids': [],
-                    'price_unit': 750.0,
-                    'product_id': product5.id,
-                    'price_subtotal': 750.0,
-                    'price_subtotal_incl': 750.0,
-                    'tax_ids': [[6, False, []]],
-                    'qty': 1,
-                }]],
-            'partner_id': self.partner1.id,
-            'session_id': pos_session.id,
-            'payment_ids': [[0, 0, {
-                    'amount': 460,
-                    'name': fields.Datetime.now(),
-                    'payment_method_id': self.cash_payment_method.id
-                }], [0, 0, {
-                    'amount': 300,
-                    'name': fields.Datetime.now(),
-                    'payment_method_id': self.credit_payment_method.id
-                }]],
-            'user_id': self.env.uid,
-            'last_order_preparation_change': '{}',
-            'to_invoice': True
-        }
-
-        pos_order_id = self.PosOrder.sync_from_ui([product5_order])['pos.order'][0]['id']
-        pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
-        #assert account_move amount_residual is 300
-        self.assertEqual(pos_order.account_move.amount_residual, 300)
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_adgu.id,
+                'to_invoice': True,
+            },
+            'line_data': [
+                {'product_id': self.twenty_dollars_no_tax.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 10},
+                {'payment_method_id': self.credit_payment_method.id, 'amount': 20},
+                {'payment_method_id': self.cash_payment_method.id, 'amount': -10},
+            ],
+        })
+        self.assertEqual(order.account_move.amount_residual, 20)
 
     def test_sale_order_postponed_invoicing(self):
-        """ Test the flow of creating an invoice later, after the POS session has been closed and everything has been processed.
-        The process should:
-           - Create a new misc entry, that will revert part of the POS closing entry.
-           - Create the move and associating payment(s) entry, as it would do when closing with invoice.
-           - Reconcile the receivable lines from the created misc entry with the ones from the created payment(s)
         """
-        # Extra setup for tax tags
+            Test the flow of creating an invoice later, after the POS session
+            has been closed and everything has been processed. Process should:
+                - Create a new misc entry, that will revert part of the POS
+                    closing entry.
+                - Create the move and associating payment(s) entry, as it would
+                    do when closing with invoice.
+                - Reconcile the receivable lines from the created misc entry
+                    with the ones from the created payment(s)
+        """
         tags = self.env['account.account.tag'].create([
             {
                 'name': f"tag{i}",
@@ -1311,25 +519,55 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             for i in range(1, 5)
         ])
 
-        self.tax_sale_a.invoice_repartition_line_ids.filtered(lambda l: l.repartition_type == 'base').write({'tag_ids': tags[0].ids})
-        self.tax_sale_a.invoice_repartition_line_ids.filtered(lambda l: l.repartition_type == 'tax').write({'tag_ids': tags[1].ids})
-        self.tax_sale_a.refund_repartition_line_ids.filtered(lambda l: l.repartition_type == 'base').write({'tag_ids': tags[2].ids})
-        self.tax_sale_a.refund_repartition_line_ids.filtered(lambda l: l.repartition_type == 'tax').write({'tag_ids': tags[3].ids})
+        self.twenty_dollars_with_15_excl.taxes_id = [Command.set(self.tax_sale_a.ids)]
+        self.tax_sale_a.invoice_repartition_line_ids.filtered(
+            lambda l: l.repartition_type == 'base').write({'tag_ids': tags[0].ids})
+        self.tax_sale_a.invoice_repartition_line_ids.filtered(
+            lambda l: l.repartition_type == 'tax').write({'tag_ids': tags[1].ids})
+        self.tax_sale_a.refund_repartition_line_ids.filtered(
+            lambda l: l.repartition_type == 'base').write({'tag_ids': tags[2].ids})
+        self.tax_sale_a.refund_repartition_line_ids.filtered(
+            lambda l: l.repartition_type == 'tax').write({'tag_ids': tags[3].ids})
 
-        pos_order = self._create_pos_order_for_postponed_invoicing()
+        with freeze_time('2020-01-01'):
+            order, _ = self.create_backend_pos_order({
+                'line_data': [
+                    {'product_id': self.twenty_dollars_with_15_excl.product_variant_id.id},
+                ],
+                'payment_data': [
+                    {'payment_method_id': self.bank_payment_method.id, 'amount': 23.0},
+                ],
+            })
+            self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
-        # Check the closing entry.
-        closing_entry = pos_order.session_move_id
-        self.assertRecordValues(closing_entry.line_ids.sorted(), [
-            {'balance': -75.0,      'account_id': self.company_data['default_account_tax_sale'].id,     'tax_ids': [],                  'tax_tag_ids': tags[1].ids, 'tax_tag_invert': True,     'reconciled': False},
-            {'balance': -500.0,     'account_id': self.company_data['default_account_revenue'].id,      'tax_ids': self.tax_sale_a.ids, 'tax_tag_ids': tags[0].ids, 'tax_tag_invert': True,     'reconciled': False},
-            {'balance': 575.0,      'account_id': self.company_data['default_account_receivable'].id,   'tax_ids': [],                  'tax_tag_ids': [],          'tax_tag_invert': False,    'reconciled': True},
-        ])
+            # Check the closing entry.
+            closing_entry = order.session_move_id
+            self.assertRecordValues(closing_entry.line_ids.sorted(), [{
+                    'balance': -3.0,
+                    'account_id': self.company_data['default_account_tax_sale'].id,
+                    'tax_ids': [],
+                    'tax_tag_ids': tags[1].ids,
+                    'tax_tag_invert': True,
+                    'reconciled': False
+                }, {
+                    'balance': -20.0,
+                    'account_id': self.company_data['default_account_revenue'].id,
+                    'tax_ids': self.tax_sale_a.ids,
+                    'tax_tag_ids': tags[0].ids,
+                    'tax_tag_invert': True,
+                    'reconciled': False
+                }, {
+                    'balance': 23.0,
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'tax_ids': [],
+                    'tax_tag_ids': [],
+                    'tax_tag_invert': False,
+                    'reconciled': True
+            }])
 
-        # Client is back on the 3rd, asks for an invoice.
         with freeze_time('2020-01-03'):
-            pos_order.partner_id = self.partner1.id
-            pos_order.action_pos_order_invoice()
+            order.partner_id = self.partner_adgu.id
+            order.action_pos_order_invoice()
 
         # Check the reverse moves, one for the closing entry, one for the statement lines.
         reverse_closing_entries = self.env['account.move'].search([
@@ -1339,15 +577,43 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             ('move_type', '=', 'entry'),
             ('state', '=', 'posted'),
         ])
-        self.assertRecordValues(reverse_closing_entries[0].line_ids.sorted(), [
-            {'balance': 75.0,       'account_id': self.company_data['default_account_tax_sale'].id,     'tax_ids': [],                  'tax_tag_ids': tags[1].ids, 'tax_tag_invert': True,     'reconciled': False},
-            {'balance': 500.0,      'account_id': self.company_data['default_account_revenue'].id,      'tax_ids': self.tax_sale_a.ids, 'tax_tag_ids': tags[0].ids, 'tax_tag_invert': True,     'reconciled': False},
-            {'balance': -575.0,     'account_id': self.company_data['default_account_receivable'].id,   'tax_ids': [],                  'tax_tag_ids': [],          'tax_tag_invert': False,    'reconciled': True},
-        ])
-        self.assertRecordValues(reverse_closing_entries[1].line_ids.sorted(), [
-            {'balance': -575.0,     'account_id': self.company_data['default_account_receivable'].id,   'tax_ids': [],                  'tax_tag_ids': [],          'tax_tag_invert': False,    'reconciled': True},
-            {'balance': 575.0,      'account_id': self.company_data['default_account_receivable'].id,   'tax_ids': [],                  'tax_tag_ids': [],          'tax_tag_invert': False,    'reconciled': True},
-        ])
+        self.assertRecordValues(reverse_closing_entries[0].line_ids.sorted(), [{
+                'balance': 3.0,
+                'account_id': self.company_data['default_account_tax_sale'].id,
+                'tax_ids': [],
+                'tax_tag_ids': tags[1].ids,
+                'tax_tag_invert': True,
+                'reconciled': False
+            }, {
+                'balance': 20.0,
+                'account_id': self.company_data['default_account_revenue'].id,
+                'tax_ids': self.tax_sale_a.ids,
+                'tax_tag_ids': tags[0].ids,
+                'tax_tag_invert': True,
+                'reconciled': False
+            }, {
+                'balance': -23.0,
+                'account_id': self.company_data['default_account_receivable'].id,
+                'tax_ids': [],
+                'tax_tag_ids': [],
+                'tax_tag_invert': False,
+                'reconciled': True
+        }])
+        self.assertRecordValues(reverse_closing_entries[2].line_ids.sorted(), [{
+                'balance': -23.0,
+                'account_id': self.company_data['default_account_receivable'].id,
+                'tax_ids': [],
+                'tax_tag_ids': [],
+                'tax_tag_invert': False,
+                'reconciled': True
+            }, {
+                'balance': 23.0,
+                'account_id': self.company_data['default_account_receivable'].id,
+                'tax_ids': [],
+                'tax_tag_ids': [],
+                'tax_tag_invert': False,
+                'reconciled': True
+        }])
 
     def test_sale_order_postponed_invoicing_anglosaxon(self):
         """ Test the flow of creating an invoice later, after the POS session has been closed and everything has been processed
@@ -1355,135 +621,55 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         """
         self.env.company.anglo_saxon_accounting = True
         self.env.company.point_of_sale_update_stock_quantities = 'closing'
-        pos_order = self._create_pos_order_for_postponed_invoicing()
-
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 20.0},
+            ],
+        })
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
         with freeze_time('2020-01-03'):
-            # We set the partner on the order
-            pos_order.partner_id = self.partner1.id
-            pos_order.action_pos_order_invoice()
+            order.partner_id = self.partner_stva.id
+            order.action_pos_order_invoice()
 
-        picking_ids = pos_order.session_id.picking_ids
-        # only one product is leaving stock
+        picking_ids = order.session_id.picking_ids
         self.assertEqual(sum(picking_ids.move_line_ids.mapped('quantity')), 1)
 
     def test_order_pos_tax_same_as_company(self):
-        """Test that when the default_pos_receivable_account and the partner account_receivable are the same,
-            payment are correctly reconciled and the invoice is correctly marked as paid.
         """
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        current_session.company_id.account_default_pos_receivable_account_id = self.partner1.property_account_receivable_id
+            Test that when the default_pos_receivable_account and the partner
+            account_receivable are the same, payment are correctly reconciled
+            and the invoice is correctly marked as paid.
+        """
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
+        account = self.partner_jcb.property_account_receivable_id
+        current_session.company_id.account_default_pos_receivable_account_id = account
 
-        product5_order = {
-            'amount_paid': 750,
-            'amount_tax': 0,
-            'amount_return':0,
-            'amount_total': 750,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'lines': [[0, 0, {
-                    'discount': 0,
-                    'pack_lot_ids': [],
-                    'price_unit': 750.0,
-                    'product_id': self.product3.id,
-                    'price_subtotal': 750.0,
-                    'price_subtotal_incl': 750.0,
-                    'tax_ids': [[6, False, []]],
-                    'qty': 1,
-                }]],
-            'partner_id': self.partner1.id,
-            'session_id': current_session.id,
-            'payment_ids': [[0, 0, {
-                    'amount': 450,
-                    'name': fields.Datetime.now(),
-                    'payment_method_id': self.cash_payment_method.id
-                }], [0, 0, {
-                    'amount': 300,
-                    'name': fields.Datetime.now(),
-                    'payment_method_id': self.bank_payment_method.id
-                }]],
-            'last_order_preparation_change': '{}',
-            'user_id': self.env.uid,
-            'to_invoice': True
-        }
-
-        pos_order_id = self.PosOrder.sync_from_ui([product5_order])['pos.order'][0]['id']
-        pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
-        self.assertEqual(pos_order.account_move.amount_residual, 0)
-
-    def test_order_refund_with_owner(self):
-        # open pos session
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # set up product iwith SN tracing and create two lots (1001, 1002)
-        self.stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.product2 = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_jcb.id,
+                'to_invoice': True,
+                'pricelist_id': self.partner_jcb.property_product_pricelist.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 30},
+            ],
         })
 
-        self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product2.id,
-            'inventory_quantity': 1,
-            'location_id': self.stock_location.id,
-            'owner_id': self.partner1.id
-        }).action_apply_inventory()
-
-        # create pos order with the two SN created before
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 6,
-                'price_subtotal_incl': 6,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 6.0,
-            'amount_total': 6.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-            })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        # I create a refund
-        refund_action = order.refund()
-        refund = self.PosOrder.browse(refund_action['res_id'])
-
-        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': refund.amount_total,
-            'payment_method_id': self.cash_payment_method.id,
-        })
-
-        # I click on the validate button to register the payment.
-        refund_payment.with_context(**payment_context).check()
-        current_session.action_pos_session_closing_control()
-        self.assertEqual(refund.picking_ids.move_line_ids_without_package.owner_id.id, order.picking_ids.move_line_ids_without_package.owner_id.id, "The owner of the refund is not the same as the owner of the original order")
+        self.assertEqual(order.account_move.amount_residual, 0)
 
     def test_journal_entries_category_without_account(self):
         # Set company's default accounts to false
         self.env.company.income_account_id = False
         self.env.company.expense_account_id = False
-        product = self.env['product.product'].create({
-            'name': 'Product with category without account',
-            'is_storable': True,
+        self.twenty_dollars_with_10_incl.write({
             'property_account_income_id': False,
             'property_account_expense_id': False,
         })
@@ -1492,149 +678,76 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'code': 'X1111',
         })
 
-        self.pos_config.journal_id.default_account_id = account.id
-        #create a new pos order with the product
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': product.id,
-                'price_unit': 10,
-                'discount': 0.0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 10,
-                'price_subtotal_incl': 10,
-            })],
-            'amount_total': 10,
-            'amount_tax': 0.0,
-            'amount_paid': 10,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
+        self.pos_config_usd.journal_id.default_account_id = account.id
+        self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.twenty_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 20},
+            ],
         })
-        #create a payment
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
+        current_session = self.pos_config_usd.current_session_id
         current_session.action_pos_session_closing_control()
         self.assertEqual(current_session.move_id.line_ids[0].account_id.id, account.id)
 
     def test_tracked_product_with_owner(self):
-        # open pos session
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # set up product iwith SN tracing and create two lots (1001, 1002)
         self.stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.product2 = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
+        self.ten_dollars_with_10_incl.product_variant_id.write({
             'tracking': 'serial',
+            'is_storable': True,
         })
-
         lot1 = self.env['stock.lot'].create({
             'name': '1001',
-            'product_id': self.product2.id,
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
         })
-
-        self.env['stock.quant']._update_available_quantity(self.product2, self.stock_location, 1, lot_id=lot1, owner_id=self.partner1)
+        self.env['stock.quant']._update_available_quantity(
+            self.ten_dollars_with_10_incl.product_variant_id,
+            self.stock_location,
+            1, lot_id=lot1, owner_id=self.partner_adgu)
 
 
         # create pos order with the two SN created before
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'id': 1,
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 6,
-                'price_subtotal_incl': 6,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '1001'}],
-                ]
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 6.0,
-            'amount_total': 6.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-            })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
+        self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_adgu.id,
+                'pricelist_id': self.pos_config_usd.pricelist_id.id,
+            },
+            'line_data': [
+                {
+                    'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
+                    'pack_lot_ids': [[0, 0, {'lot_name': lot1.name}]],
+                },
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 10},
+            ],
         })
-        order_payment.with_context(**payment_context).check()
+        current_session = self.pos_config_usd.current_session_id
         current_session.action_pos_session_closing_control()
-        self.assertEqual(current_session.picking_ids.move_line_ids.owner_id.id, self.partner1.id)
+        self.assertEqual(current_session.picking_ids.move_line_ids.owner_id.id, self.partner_adgu.id)
 
     def test_order_refund_with_invoice(self):
         """This test make sure that credit notes of pos orders are correctly
            linked to the original invoice."""
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        order_data = {
-            'amount_paid': 450,
-            'amount_tax': 0,
-            'amount_return': 0,
-            'amount_total': 450,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'lines': [[0, 0, {
-                'discount': 0,
-                'pack_lot_ids': [],
-                'price_unit': 450.0,
-                'product_id': self.product3.id,
-                'price_subtotal': 450.0,
-                'price_subtotal_incl': 450.0,
-                'tax_ids': [[6, False, []]],
-                'qty': 1,
-            }]],
-            'partner_id': self.partner1.id,
-            'session_id': current_session.id,
-            'payment_ids': [[0, 0, {
-                'amount': 450,
-                'name': fields.Datetime.now(),
-                'payment_method_id': self.cash_payment_method.id
-            }]],
-            'last_order_preparation_change': '{}',
-            'user_id': self.env.uid,
-            'to_invoice': True
-        }
-
-        order = self.PosOrder.sync_from_ui([order_data])
-        order = self.PosOrder.browse(order['pos.order'][0]['id'])
-
-        refund_id = order.refund()['res_id']
-        refund = self.PosOrder.browse(refund_id)
-        context_payment = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**context_payment).create({
-            'amount': refund.amount_total,
-            'payment_method_id': self.cash_payment_method.id
+        self.pos_config_usd.open_ui()
+        current_session = self.pos_config_usd.current_session_id
+        self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_adgu.id,
+                'to_invoice': True,
+            },
+            'line_data': [
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id}
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 20}
+            ],
+            'refund_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': -20}
+            ]
         })
-        refund_payment.with_context(**context_payment).check()
-        refund.action_pos_order_invoice()
-        #get last invoice created
+
         current_session.action_pos_session_closing_control()
         invoices = self.env['account.move'].search([('move_type', '=', 'out_invoice')], order='id desc', limit=1)
         credit_notes = self.env['account.move'].search([('move_type', '=', 'out_refund')], order='id desc', limit=1)
@@ -1642,16 +755,12 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(credit_notes.reversed_entry_id.id, invoices.id)
 
     def test_multi_exp_account_real_time(self):
-
-        #Create a real time valuation product category
         self.real_time_categ = self.env['product.category'].create({
             'name': 'test category',
             'parent_id': False,
             'property_cost_method': 'fifo',
             'property_valuation': 'real_time',
         })
-
-        #Create 2 accounts to be used for each product
         self.account1 = self.env['account.account'].create({
             'name': 'Account 1',
             'code': 'AC1',
@@ -1659,73 +768,41 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'account_type': 'expense',
         })
         self.account2 = self.env['account.account'].create({
-            'name': 'Account 1',
+            'name': 'Account 2',
             'code': 'AC2',
             'reconcile': True,
             'account_type': 'expense',
         })
-
-        self.product_a = self.env['product.product'].create({
-            'name': 'Product A',
+        self.ten_dollars_with_15_incl.write({
             'is_storable': True,
             'categ_id': self.real_time_categ.id,
             'property_account_expense_id': self.account1.id,
             'property_account_income_id': self.account1.id,
         })
-        self.product_b = self.env['product.product'].create({
-            'name': 'Product B',
+        self.twenty_dollars_with_15_incl.write({
             'is_storable': True,
             'categ_id': self.real_time_categ.id,
             'property_account_expense_id': self.account2.id,
             'property_account_income_id': self.account2.id,
         })
-
-        #Create an order with the 2 products
-        self.pos_config.open_ui()
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': self.pos_config.current_session_id.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product_a.id,
-                'price_unit': 100,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 100,
-                'price_subtotal_incl': 100,
-            }), (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product_b.id,
-                'price_unit': 100,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 100,
-                'price_subtotal_incl': 100,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 200.0,
-            'amount_total': 200.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}',
-            'shipping_date': fields.Date.today(),
-            })
-        #make payment
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'pricelist_id': self.pos_config_usd.pricelist_id.id,
+                'partner_id': self.partner_adgu.id,
+                'shipping_date': fields.Date.today(),
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_15_incl.product_variant_id.id},
+                {'product_id': self.twenty_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 30},
+            ],
         })
-        order_payment.with_context(**payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-        order.picking_ids._action_done()
 
-        moves = self.env['account.move'].search([('ref', '=', f'pos_order_{order.id}')])
-        self.assertEqual(len(moves), 2)
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
+        order.picking_ids._action_done()
+        self.assertEqual(len(order.picking_ids.move_ids), 2)
 
     def test_no_default_pricelist(self):
         """Should not have default_pricelist if use_pricelist is false."""
@@ -1733,261 +810,163 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         pricelist = self.env['product.pricelist'].create({
             'name': 'Test Pricelist',
         })
-        self.pos_config.write({
+        self.pos_config_usd.write({
             'pricelist_id': pricelist.id,
             'use_pricelist': False,
         })
-        self.pos_config.open_ui()
-        loaded_data = self.pos_config.current_session_id.load_data([])
+        self.pos_config_usd.open_ui()
+        loaded_data = self.pos_config_usd.current_session_id.load_data([])
 
         self.assertFalse(loaded_data['pos.config'][0]['pricelist_id'], False)
 
     def test_refund_rounding_backend(self):
-        rouding_method = self.env['account.cash.rounding'].create({
-            'name': 'Rounding up',
-            'rounding': 0.05,
-            'rounding_method': 'UP',
-        })
-
-        self.env['product.product'].create({
-            'name': 'Product Test',
-            'available_in_pos': True,
-            'list_price': 49.99,
-            'taxes_id': False,
-        })
-
-        self.pos_config.write({
-            'rounding_method': rouding_method.id,
+        self.account_cash_rounding_up.rounding = 5.0
+        self.pos_config_usd.write({
+            'rounding_method': self.account_cash_rounding_up.id,
             'cash_rounding': True,
             'only_round_cash_method': True,
         })
+        _, refund = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.twenty_dollars_with_15_excl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 23.0}
+            ],
+            'refund_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
+        })
 
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': False,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.env['product.product'].search([('available_in_pos', '=', True)], limit=1).id,
-                'price_unit': 49.99,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [],
-                'price_subtotal': 49.99,
-                'price_subtotal_incl': 49.99,
-            })],
-            'pricelist_id': False,
-            'amount_paid': 50.0,
-            'amount_total': 49.99,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-        })
-        #make payment
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        refund = order.refund()
-        refund = self.PosOrder.browse(refund['res_id'])
-        payment_context = {"active_ids": refund.ids, "active_id": refund.id}
-        refund_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'payment_method_id': self.cash_payment_method.id
-        })
-        self.assertEqual(refund_payment.amount, -50.0)
-        refund_payment.with_context(**payment_context).check()
+        current_session = self.pos_config_usd.current_session_id
         current_session.action_pos_session_closing_control()
-        self.assertEqual(refund.amount_total, -49.99)
-        self.assertEqual(refund.amount_paid, -50.0)
+        refund_payment = refund.payment_ids[0]
+        self.assertEqual(refund_payment.amount, -25.0)
+        self.assertEqual(refund.amount_total, -23.00)
+        self.assertEqual(refund.amount_paid, -25.0)
         self.assertEqual(current_session.state, 'closed')
+
     def test_order_different_lots(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
+        self.pos_config_usd.open_ui()
         self.stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.product2 = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
+        self.ten_dollars_with_10_incl.product_variant_id.write({
             'tracking': 'lot',
+            'is_storable': True,
         })
 
-        lot1 = self.env['stock.lot'].create({
+        lot_1 = self.env['stock.lot'].create({
             'name': '1001',
-            'product_id': self.product2.id,
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
         })
-        lot2 = self.env['stock.lot'].create({
+        lot_2 = self.env['stock.lot'].create({
             'name': '1002',
-            'product_id': self.product2.id,
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
         })
 
-        quant1 = self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product2.id,
+        stock_quant_1 = self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
             'inventory_quantity': 5,
             'location_id': self.stock_location.id,
-            'lot_id': lot1.id
+            'lot_id': lot_1.id
         })
-        quant1.action_apply_inventory()
-        quant2 = self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product2.id,
+        stock_quant_1.action_apply_inventory()
+        stock_quant_2 = self.env['stock.quant'].with_context(inventory_mode=True).create({
+            'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
             'inventory_quantity': 5,
             'location_id': self.stock_location.id,
-            'lot_id': lot2.id
+            'lot_id': lot_2.id
         })
-        quant2.action_apply_inventory()
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 2,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 12,
-                'price_subtotal_incl': 12,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '1001'}],
-                ]
-            }),
-            (0, 0, {
-                'name': "OL/0002",
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 6,
-                'price_subtotal_incl': 6,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '1002'}],
-                ]
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 18.0,
-            'amount_total': 18.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-            })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.bank_payment_method.id
+        stock_quant_2.action_apply_inventory()
+        self.assertEqual(stock_quant_1.quantity, 5)
+        self.assertEqual(stock_quant_2.quantity, 5)
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_adgu.id,
+                'pricelist_id': self.pos_config_usd.pricelist_id.id,
+            },
+            'line_data': [{
+                    'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
+                    'pack_lot_ids': [[0, 0, {'lot_name': '1001'}]],
+                    'qty': 1,
+                }, {
+                    'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
+                    'pack_lot_ids': [[0, 0, {'lot_name': '1002'}]],
+                    'qty': 2,
+                },
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 30},
+            ],
         })
-        order_payment.with_context(**payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-        self.assertEqual(quant2.quantity, 4)
-        self.assertEqual(quant1.quantity, 3)
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
+        self.assertEqual(order.state, 'done')
+
+        # Quantity decreased because from the same location
+        self.assertEqual(stock_quant_1.quantity, 4)
+        self.assertEqual(stock_quant_2.quantity, 3)
 
     def test_pos_branch_account(self):
         branch = self.env['res.company'].create({
-            'name': 'Branch 1',
+            'name': 'Sub Company',
             'parent_id': self.env.company.id,
             'chart_template': self.env.company.chart_template,
         })
-
         self.env.cr.precommit.run()
-
+        self.env.user.group_ids += self.env.ref('point_of_sale.group_pos_manager')
         bank_payment_method = self.bank_payment_method.copy()
         bank_payment_method.company_id = branch.id
-
-        b_pos_config = self.env['pos.config'].with_company(branch).create({
+        sub_pos_config = self.env['pos.config'].with_company(branch).create({
             'name': 'Main',
             'journal_id': self.company_data['default_journal_sale'].id,
             'invoice_journal_id': self.company_data['default_journal_sale'].id,
             'payment_method_ids': [(4, bank_payment_method.id)],
         })
 
-        b_pos_config.open_ui()
-        current_session = b_pos_config.current_session_id
-
-        order = self.PosOrder.create({
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product3.id,
-                'price_unit': 450,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 450,
-                'price_subtotal_incl': 450,
-            })],
-            'pricelist_id': b_pos_config.pricelist_id.id,
-            'amount_paid': 450.0,
-            'amount_total': 450.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
+        sub_pos_config.open_ui()
+        current_session = sub_pos_config.current_session_id
+        self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_moda.id,
+                'pricelist_id': sub_pos_config.pricelist_id.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': bank_payment_method.id},
+            ],
+            'pos_config': sub_pos_config,
         })
 
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': bank_payment_method.id,
-        })
-        order_payment.with_context(payment_context).check()
-        b_pos_config.current_session_id.action_pos_session_closing_control()
-
+        current_session = sub_pos_config.current_session_id
+        sub_pos_config.current_session_id.action_pos_session_closing_control()
         self.assertEqual(current_session.state, 'closed', msg='State of current session should be closed.')
 
     def test_order_unexisting_lots(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        self.product2 = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
+        self.ten_dollars_with_10_incl.product_variant_id.write({
             'tracking': 'lot',
+            'is_storable': True,
         })
 
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product2.id,
-                'price_unit': 6,
-                'discount': 0,
-                'qty': 2,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 12,
-                'price_subtotal_incl': 12,
-                'pack_lot_ids': [
-                    [0, 0, {'lot_name': '1001'}],
-                ]
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 12.0,
-            'amount_total': 12.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
+        order, _ = self.create_backend_pos_order({
+            'line_data': [{
+                'product_id': self.ten_dollars_with_10_incl.product_variant_id.id,
+                'pack_lot_ids': [[0, 0, {'lot_name': '1001'}]],
+            }],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id, 'amount': 10},
+            ],
         })
 
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.bank_payment_method.id,
-        })
-        order_payment.with_context(payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
         order_lot_id = order.picking_ids.move_line_ids_without_package.lot_id
         self.assertEqual(order_lot_id.name, '1001')
-        self.assertTrue(all([quant.lot_id == order_lot_id for quant in self.env['stock.quant'].search([('product_id', '=', self.product2.id)])]))
+        self.assertTrue(all(
+            quant.lot_id == order_lot_id
+            for quant in self.env['stock.quant'].search([
+                ('product_id', '=', self.ten_dollars_with_10_incl.product_variant_id.id)
+            ])
+        ))
 
     def test_pos_creation_in_branch(self):
         branch = self.env['res.company'].create({
@@ -2003,166 +982,49 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
     def test_reordering_rules_triggered_closing_pos(self):
         if self.env['ir.module.module']._get('purchase').state != 'installed':
             self.skipTest("Purchase module is required for this test to run")
-        vendor = self.env['res.partner'].create({'name': 'Vendor'})
-        product = self.env['product.product'].create({
-            'name': 'Product Test',
-            'lst_price': 1,
-            'is_storable': 'True',
-            'seller_ids': [(0, 0, {
-                'partner_id': vendor.id,
+
+        self.ten_dollars_with_15_incl.write({
+            'seller_ids': [Command.create({
+                'partner_id': self.partner_stva.id,
                 'min_qty': 1.0,
-                'price': 1.0,
+                'price': 10.0,
             })]
         })
 
         self.env['stock.warehouse.orderpoint'].create({
-            'product_id': product.id,
-            'location_id': self.pos_config.picking_type_id.default_location_src_id.id,
+            'product_id': self.ten_dollars_with_15_incl.product_variant_id.id,
+            'location_id': self.pos_config_usd.picking_type_id.default_location_src_id.id,
             'product_min_qty': 1.0,
             'product_max_qty': 1.0,
         })
 
-        self.pos_config.open_ui()
-
-        order = self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': self.pos_config.current_session_id.id,
-            'partner_id': vendor.id,
-            'lines': [Command.create({
-                'name': "OL/0001",
-                'product_id': product.id,
-                'price_unit': 1,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': 1,
-                'price_subtotal_incl': 1,
-                'pack_lot_ids': []
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 1.0,
-            'amount_total': 1.0,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
+        self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_stva.id,
+                'pricelist_id': self.pos_config_usd.pricelist_id.id,
+            },
+            'line_data': [
+                {'product_id': self.ten_dollars_with_15_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 10},
+            ],
         })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.bank_payment_method.id,
-        })
-        order_payment.with_context(payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
         purchase_order = self.env['purchase.order'].search([], limit=1)
-        self.assertEqual(purchase_order.order_line.product_id.id, product.id)
-        self.assertEqual(purchase_order.order_line.product_qty, 2)
+        self.assertEqual(purchase_order.order_line.product_qty, 1)
+        self.assertEqual(purchase_order.order_line.product_id.id,
+                        self.ten_dollars_with_15_incl.product_variant_id.id)
 
     def test_state_when_closing_register(self):
-        product = self.env['product.product'].create({
-            'name': 'Product A',
-            'is_storable': True,
+        self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.ten_dollars_with_10_incl.product_variant_id.id},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.bank_payment_method.id, 'amount': 10},
+            ],
         })
-
-        self.pos_config.open_ui()
-        session_id = self.pos_config.current_session_id
-
-        order = self.env['pos.order'].create({
-            'company_id': self.env.company.id,
-            'session_id': session_id.id,
-            'partner_id': False,
-            'lines': [(0, 0, {
-                'name': 'OL/0001',
-                'product_id': product.id,
-                'price_unit': 10.00,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': False,
-                'price_subtotal': 10.00,
-                'price_subtotal_incl': 10.00,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': 10.00,
-            'amount_total': 10.00,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-        })
-
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.bank_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        session_id.action_pos_session_closing_control(bank_payment_method_diffs={self.bank_payment_method.id: 5.00})
-        self.assertEqual(session_id.state, 'closed')
-
-    def test_product_combo_creation(self):
-        setup_product_combo_items(self)
-        """We check that combo products are created without taxes."""
-        # Test product combo creation
-        product_form = Form(self.env['product.product'])
-        product_form.name = "Test Combo Product"
-        product_form.lst_price = 100
-        product_form.type = "combo"
-        product_form.combo_ids = self.desk_accessories_combo
-        product = product_form.save()
-        self.assertTrue(product.combo_ids)
-
-        product_form.type = "consu"
-        product = product_form.save()
-        self.assertFalse(product.combo_ids)
-
-    def test_change_is_deducted_from_cash(self):
-        self.pos_config.open_ui()
-        pos_session = self.pos_config.current_session_id
-        cash_payment_method = pos_session.payment_method_ids.filtered('is_cash_count')[:1]
-        product_order = {
-           'amount_paid': 450,
-           'amount_return': 50,
-           'amount_tax': 0,
-           'amount_total': 450,
-           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-           'fiscal_position_id': False,
-           'pricelist_id': self.pos_config.pricelist_id.id,
-           'lines': [[0, 0, {
-                'discount': 0,
-                'pack_lot_ids': [],
-                'price_unit': 450.0,
-                'product_id': self.product3.id,
-                'price_subtotal': 450.0,
-                'price_subtotal_incl': 450.0,
-                'tax_ids': [[6, False, []]],
-                'qty': 1,
-            }]],
-           'name': 'Order 12346-123-1234',
-           'partner_id': self.partner1.id,
-           'session_id': pos_session.id,
-           'sequence_number': 2,
-           'payment_ids': [[0, 0, {
-                'amount': 400,
-                'name': fields.Datetime.now(),
-                'payment_method_id': self.bank_payment_method.id
-            }], [0, 0, {
-                'amount': 100,
-                'name': fields.Datetime.now(),
-                'payment_method_id': cash_payment_method.id
-            }]],
-           'uuid': '12345-123-1234',
-           'user_id': self.env.uid,
-           'to_invoice': True
-        }
-
-        pos_order_id = self.PosOrder.sync_from_ui([product_order])['pos.order'][0]['id']
-        pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
-        payments = pos_order.payment_ids
-        self.assertRecordValues(payments.sorted(), [
-            {'amount': -50, 'payment_method_id': cash_payment_method.id, 'is_change': True},
-            {'amount': 100, 'payment_method_id': cash_payment_method.id, 'is_change': False},
-            {'amount': 400, 'payment_method_id': self.bank_payment_method.id, 'is_change': False},
-        ])
-        account_moves = self.env['account.move'].search([('pos_payment_ids', 'in', pos_order.payment_ids.ids)])
-        self.assertEqual(sum(account_moves.mapped('amount_total')), pos_order.amount_total)
+        current_session = self.pos_config_usd.current_session_id
+        current_session.action_pos_session_closing_control(bank_payment_method_diffs={self.bank_payment_method.id: 5.00})
+        self.assertEqual(current_session.state, 'closed')

--- a/addons/pos_loyalty/tests/__init__.py
+++ b/addons/pos_loyalty/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_frontend
 from . import test_loyalty_history
 from . import test_unlink_reward
+from . import common

--- a/addons/pos_loyalty/tests/common.py
+++ b/addons/pos_loyalty/tests/common.py
@@ -1,0 +1,33 @@
+from odoo.addons.point_of_sale.tests.common import CommonPosTest
+from odoo.fields import Command
+
+
+class CommonPosLoyaltyTest(CommonPosTest):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+
+        self.loyalty_create_programs(self)
+        self.loyalty_create_rewards(self)
+
+    def loyalty_create_programs(self):
+        self.four_20_dollars_one_free_program = self.env['loyalty.program'].create({
+            'name': 'Buy 4 20 dollars Take 1 20 dollars',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [Command.create({
+                'product_ids': self.twenty_dollars_no_tax.product_variant_id.ids,
+                'reward_point_mode': 'unit',
+                'minimum_qty': 1,
+            })],
+        })
+
+    def loyalty_create_rewards(self):
+        self.twenty_dollars_reward = self.env['loyalty.reward'].create({
+            'program_id': self.four_20_dollars_one_free_program.id,
+            'reward_type': 'product',
+            'reward_product_id': self.twenty_dollars_no_tax.product_variant_id.id,
+            'reward_product_qty': 1,
+            'required_points': 4,
+        })

--- a/addons/pos_loyalty/tests/test_unlink_reward.py
+++ b/addons/pos_loyalty/tests/test_unlink_reward.py
@@ -1,62 +1,24 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
-from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.addons.pos_loyalty.tests.common import CommonPosLoyaltyTest
 from odoo.tests.common import tagged
 
 
 @tagged('-at_install', 'post_install')
-class TestUnlinkReward(TestPointOfSaleCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # Create a loyalty program
-        cls.loyalty_program = cls.env['loyalty.program'].create({
-            'name': 'Buy 4 whiteboard_pen, Take 1 whiteboard_pen',
-            'program_type': 'loyalty',
-            'trigger': 'auto',
-            'applies_on': 'both',
-            'rule_ids': [Command.create({
-                'product_ids': cls.whiteboard_pen.ids,
-                'reward_point_mode': 'unit',
-                'minimum_qty': 1,
-            })],
-        })
-
-        # Create a reward
-        cls.reward = cls.env['loyalty.reward'].create({
-            'program_id': cls.loyalty_program.id,
-            'reward_type': 'product',
-            'reward_product_id': cls.whiteboard_pen.id,
-            'reward_product_qty': 1,
-            'required_points': 4,
-        })
-
+class TestUnlinkReward(CommonPosLoyaltyTest):
     def test_pos_unlink_reward(self):
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-        self.PosOrder.create({
-            'company_id': self.env.company.id,
-            'session_id': current_session.id,
-            'partner_id': self.partner1.id,
-            'pricelist_id': self.partner1.property_product_pricelist.id,
-            'lines': [
-                Command.create({
-                    'product_id': self.whiteboard_pen.id,
-                    'qty': 5,
-                    'price_subtotal': 12.0,
-                    'price_subtotal_incl': 12.0,
-                    'reward_id': self.reward.id,
-                })
-            ],
-            'amount_tax': 0.0,
-            'amount_total': 134.38,
-            'amount_paid': 0.0,
-            'amount_return': 0.0,
+        self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_lowe.id,
+                'pricelist_id': self.partner_lowe.property_product_pricelist.id,
+            },
+            'line_data': [{
+                'qty': 5,
+                'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
+                'reward_id': self.twenty_dollars_reward.id,
+            }],
         })
-        # Attempt to delete the reward
-        self.reward.unlink()
-
         # Ensure the reward is archived and not deleted
-        self.assertTrue(self.reward.exists())
-        self.assertFalse(self.reward.active)
+        self.twenty_dollars_reward.unlink()
+        self.assertTrue(self.twenty_dollars_reward.exists())
+        self.assertFalse(self.twenty_dollars_reward.active)

--- a/addons/pos_mrp/tests/__init__.py
+++ b/addons/pos_mrp/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import common
 from . import test_frontend
 from . import test_pos_mrp_flow

--- a/addons/pos_mrp/tests/common.py
+++ b/addons/pos_mrp/tests/common.py
@@ -1,0 +1,123 @@
+from odoo.addons.point_of_sale.tests.common import CommonPosTest
+from odoo.fields import Command
+
+
+class CommonPosMrpTest(CommonPosTest):
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+
+        self.mrp_create_product_category(self)
+        self.mrp_edit_product_template(self)
+        self.mrp_create_bom(self)
+
+    def mrp_edit_product_template(self):
+        self.product_product_kit_one = self.ten_dollars_no_tax.product_variant_id
+        self.product_product_kit_two = self.twenty_dollars_no_tax.product_variant_id
+        self.product_product_kit_three = self.product_product_kit_two.copy()
+        self.product_product_kit_four = self.product_product_kit_two.copy()
+        self.product_product_comp_one = self.ten_dollars_with_10_incl.product_variant_id
+        self.product_product_comp_two = self.ten_dollars_with_15_incl.product_variant_id
+        self.product_product_comp_three = self.twenty_dollars_with_10_incl.product_variant_id
+        self.product_product_comp_four = self.twenty_dollars_with_15_incl.product_variant_id
+        self.product_product_kit_one.write({
+            'is_storable': True,
+            'categ_id': self.category_fifo.id,
+        })
+        self.product_product_kit_two.write({
+            'is_storable': True,
+            'categ_id': self.category_fifo.id,
+        })
+        self.product_product_kit_three.write({
+            'is_storable': True,
+            'categ_id': self.category_fifo.id,
+        })
+        self.product_product_kit_four.write({
+            'is_storable': True,
+            'categ_id': self.category_fifo.id,
+        })
+        self.product_product_comp_one.product_tmpl_id.write({
+            'standard_price': 10,
+        })
+        self.product_product_comp_two.product_tmpl_id.write({
+            'standard_price': 10,
+        })
+        self.product_product_comp_three.product_tmpl_id.write({
+            'standard_price': 10,
+        })
+        self.product_product_comp_four.product_tmpl_id.write({
+            'standard_price': 10,
+        })
+
+    def mrp_create_product_category(self):
+        self.category_average = self.env['product.category'].create({
+            'name': 'Category for average cost',
+            'property_cost_method': 'average',
+        })
+        self.category_fifo = self.env['product.category'].create({
+            'name': 'Category for kit',
+            'property_cost_method': 'fifo',
+        })
+        self.category_fifo_realtime = self.env['product.category'].create({
+            'name': 'Category for kit',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+
+    def mrp_create_bom(self):
+        self.bom_one_line = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_product_kit_one.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_product_comp_one.id,
+                    'product_qty': 1
+                }),
+            ],
+        })
+        self.bom_two_lines = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_product_kit_two.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_product_comp_one.id,
+                    'product_qty': 1
+                }),
+                Command.create({
+                    'product_id': self.product_product_comp_two.id,
+                    'product_qty': 1
+                }),
+            ],
+        })
+        self.bom_two_lines_of_kits = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_product_kit_three.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_product_kit_one.id,
+                    'product_qty': 1
+                }),
+                Command.create({
+                    'product_id': self.product_product_kit_two.id,
+                    'product_qty': 1
+                }),
+            ],
+        })
+        self.bom_two_lines_of_kits_with_qty = self.env['mrp.bom'].create({
+            'product_tmpl_id': self.product_product_kit_four.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': self.product_product_kit_one.id,
+                    'product_qty': 2
+                }),
+                Command.create({
+                    'product_id': self.product_product_kit_two.id,
+                    'product_qty': 3
+                }),
+            ],
+        })

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -1,541 +1,147 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import odoo
 
-from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
-from odoo import fields
-from odoo.tests import Form
+from odoo.addons.pos_mrp.tests.common import CommonPosMrpTest
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestPosMrp(TestPointOfSaleCommon):
+class TestPosMrp(CommonPosMrpTest):
     def test_bom_kit_order_total_cost(self):
-        #create a product category that use fifo
-        category = self.env['product.category'].create({
-            'name': 'Category for kit',
-            'property_cost_method': 'fifo',
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': self.product_product_kit_one.id}
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
         })
 
-        self.kit = self.env['product.product'].create({
-            'name': 'Kit Product',
-            'available_in_pos': True,
-            'is_storable': True,
-            'lst_price': 10.0,
-            'categ_id': category.id,
-        })
-
-        self.component_a = self.env['product.product'].create({
-            'name': 'Comp A',
-            'is_storable': True,
-            'available_in_pos': True,
-            'lst_price': 10.0,
-            'standard_price': 5.0,
-        })
-
-        self.component_b = self.env['product.product'].create({
-            'name': 'Comp B',
-            'is_storable': True,
-            'available_in_pos': True,
-            'lst_price': 10.0,
-            'standard_price': 10.0,
-        })
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_a
-            bom_line.product_qty = 1.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_b
-            bom_line.product_qty = 1.0
-        self.bom_a = bom_product_form.save()
-
-        self.pos_config.open_ui()
-        order = self.env['pos.order'].create({
-            'session_id': self.pos_config.current_session_id.id,
-            'lines': [(0, 0, {
-                'name': self.kit.name,
-                'product_id': self.kit.id,
-                'price_unit': self.kit.lst_price,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': self.kit.lst_price,
-                'price_subtotal_incl': self.kit.lst_price,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': self.kit.lst_price,
-            'amount_total': self.kit.lst_price,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-            'last_order_preparation_change': '{}'
-        })
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
-        self.assertEqual(pos_order.lines[0].total_cost, 15.0)
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
+        self.assertEqual(order.lines[0].total_cost, 10.0)
 
     def test_bom_kit_with_kit_invoice_valuation(self):
-        # create a product category that use fifo
-        category = self.env['product.category'].create({
-            'name': 'Category for kit',
-            'property_cost_method': 'fifo',
-            'property_valuation': 'real_time',
+        self.product_product_kit_one.categ_id = self.category_fifo_realtime
+        self.product_product_kit_two.categ_id = self.category_fifo_realtime
+        self.product_product_kit_three.categ_id = self.category_fifo_realtime
+        self.product_product_kit_four.categ_id = self.category_fifo_realtime
+
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'to_invoice': True,
+                'partner_id': self.partner_moda.id,
+            },
+            'line_data': [
+                {'product_id': self.product_product_kit_three.id},
+                {'product_id': self.product_product_kit_four.id}
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
         })
 
-        self.kit = self.env['product.product'].create({
-            'name': 'Final Kit',
-            'available_in_pos': True,
-            'categ_id': category.id,
-            'taxes_id': False,
-            'is_storable': True,
-        })
-
-        self.kit_2 = self.env['product.product'].create({
-            'name': 'Final Kit 2',
-            'available_in_pos': True,
-            'categ_id': category.id,
-            'taxes_id': False,
-            'is_storable': True,
-        })
-
-        self.subkit1 = self.env['product.product'].create({
-            'name': 'Subkit 1',
-            'available_in_pos': True,
-            'categ_id': category.id,
-            'taxes_id': False,
-        })
-
-        self.subkit2 = self.env['product.product'].create({
-            'name': 'Subkit 2',
-            'available_in_pos': True,
-            'categ_id': category.id,
-            'taxes_id': False,
-        })
-
-        self.component_a = self.env['product.product'].create({
-            'name': 'Comp A',
-            'available_in_pos': True,
-            'standard_price': 5.0,
-            'categ_id': category.id,
-            'taxes_id': False,
-        })
-
-        self.component_b = self.env['product.product'].create({
-            'name': 'Comp B',
-            'available_in_pos': True,
-            'standard_price': 5.0,
-            'categ_id': category.id,
-            'taxes_id': False,
-        })
-
-        self.component_c = self.env['product.product'].create({
-            'name': 'Comp C',
-            'available_in_pos': True,
-            'standard_price': 5.0,
-            'categ_id': category.id,
-            'taxes_id': False,
-        })
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.subkit1.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_a
-            bom_line.product_qty = 1.0
-        self.bom_a = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.subkit2.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_b
-            bom_line.product_qty = 1.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_c
-            bom_line.product_qty = 1.0
-        self.bom_b = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.subkit1
-            bom_line.product_qty = 1.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.subkit2
-            bom_line.product_qty = 1.0
-        self.final_bom = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.kit_2.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.subkit1
-            bom_line.product_qty = 2.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.subkit2
-            bom_line.product_qty = 3.0
-        self.final_bom = bom_product_form.save()
-
-        self.pos_config.open_ui()
-        order_data = {
-            'to_invoice': True,
-            'amount_paid': 2.0,
-            'amount_return': 0,
-            'amount_tax': 0,
-            'amount_total': 2.0,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'lines': [[0, 0, {
-                'discount': 0,
-                'pack_lot_ids': [],
-                'price_unit': 2,
-                'product_id': self.kit.id,
-                'price_subtotal': 2,
-                'price_subtotal_incl': 2,
-                'qty': 1,
-                'tax_ids': [(6, 0, self.kit.taxes_id.ids)]}], [0, 0, {
-                    'discount': 0,
-                    'pack_lot_ids': [],
-                    'price_unit': 2,
-                    'product_id': self.kit_2.id,
-                    'price_subtotal': 2,
-                    'price_subtotal_incl': 2,
-                    'qty': 1,
-                    'tax_ids': [(6, 0, self.kit_2.taxes_id.ids)]}
-            ]],
-            'partner_id': self.partner1.id,
-            'session_id': self.pos_config.current_session_id.id,
-            'payment_ids': [[0, 0, {
-                'amount': 2.0,
-                'name': fields.Datetime.now(),
-                'payment_method_id': self.cash_payment_method.id}
-            ]],
-            'user_id': self.env.uid
-        }
-        order = self.env['pos.order'].sync_from_ui([order_data])
-        order = self.env['pos.order'].browse(order['pos.order'][0]['id'])
-        self.assertEqual(order.lines.filtered(lambda l: l.product_id == self.kit).total_cost, 15.0)
-        accounts = self.kit.product_tmpl_id.get_product_accounts()
+        self.assertEqual(order.lines.filtered(
+            lambda l: l.product_id == self.product_product_kit_three).total_cost, 30.0)
+        accounts = self.product_product_kit_three.product_tmpl_id.get_product_accounts()
         debit_interim_account = accounts['stock_output']
         credit_expense_account = accounts['expense']
         invoice_accounts = order.account_move.line_ids.mapped('account_id.id')
         self.assertTrue(debit_interim_account.id in invoice_accounts)
         self.assertTrue(credit_expense_account.id in invoice_accounts)
         expense_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == credit_expense_account.id)
-        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).credit, 0.0)
-        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 15.0)
+        self.assertEqual(expense_line.filtered(
+            lambda l: l.product_id == self.product_product_kit_three).credit, 0.0)
+        self.assertEqual(expense_line.filtered(
+            lambda l: l.product_id == self.product_product_kit_three).debit, 30.0)
         interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == debit_interim_account.id)
-        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 15.0)
-        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).debit, 0.0)
-        self.pos_config.current_session_id.action_pos_session_closing_control()
+        self.assertEqual(interim_line.filtered(
+            lambda l: l.product_id == self.product_product_kit_three).credit, 30.0)
+        self.assertEqual(interim_line.filtered(
+            lambda l: l.product_id == self.product_product_kit_three).debit, 0.0)
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
 
     def test_bom_kit_different_uom_invoice_valuation(self):
         """This test make sure that when a kit is made of product using UoM A but the bom line uses UoM B
            the price unit is correctly computed on the invoice lines.
         """
         self.env.user.group_ids += self.env.ref('uom.group_uom')
-        category = self.env['product.category'].create({
-            'name': 'Category for kit',
-            'property_cost_method': 'fifo',
-            'property_valuation': 'real_time',
+
+        # Edit kit product and component product
+        self.product_product_kit_one.categ_id = self.category_fifo_realtime
+        self.product_product_comp_one.standard_price = 12000
+        self.product_product_comp_one.uom_id = self.env.ref('uom.product_uom_dozen').id
+
+        # Edit kit product quantity
+        self.bom_one_line.bom_line_ids[0].product_qty = 6.0
+        self.bom_one_line.bom_line_ids[0].product_uom_id = self.env.ref('uom.product_uom_unit').id
+        self.bom_one_line.product_qty = 2.0
+
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'to_invoice': True,
+                'partner_id': self.partner_moda.id,
+            },
+            'line_data': [
+                {'product_id': self.product_product_kit_one.id, 'qty': 2},
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
         })
 
-        self.kit = self.env['product.product'].create({
-            'name': 'Final Kit',
-            'available_in_pos': True,
-            'categ_id': category.id,
-            'taxes_id': False,
-            'is_storable': True,
-        })
+        accounts = self.product_product_kit_one.product_tmpl_id.get_product_accounts()
+        expense_line = order.account_move.line_ids.filtered(
+            lambda l: l.account_id.id == accounts['expense'].id)
+        interim_line = order.account_move.line_ids.filtered(
+            lambda l: l.account_id.id == accounts['stock_output'].id)
+        expense_line = expense_line.filtered(lambda l: l.product_id == self.product_product_kit_one)
+        interim_line = interim_line.filtered(lambda l: l.product_id == self.product_product_kit_one)
 
-        self.component_a = self.env['product.product'].create({
-            'name': 'Comp A',
-            'available_in_pos': True,
-            'standard_price': 12000.0,
-            'categ_id': category.id,
-            'taxes_id': False,
-            'uom_id': self.env.ref('uom.product_uom_dozen').id,
-        })
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
-        bom_product_form.product_qty = 2.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = self.component_a
-            bom_line.product_qty = 6.0
-            bom_line.product_uom_id = self.env.ref('uom.product_uom_unit')
-        self.bom_a = bom_product_form.save()
-
-        self.pos_config.open_ui()
-        order_data = {'to_invoice': True,
-            'amount_paid': 2.0,
-            'amount_return': 0,
-            'amount_tax': 0,
-            'amount_total': 2.0,
-            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-            'fiscal_position_id': False,
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'lines': [[0,
-                        0,
-                        {'discount': 0,
-                        'pack_lot_ids': [],
-                        'price_unit': 2,
-                        'product_id': self.kit.id,
-                        'price_subtotal': 2,
-                        'price_subtotal_incl': 2,
-                        'qty': 2,
-                        'tax_ids': []}],
-                        ],
-                'partner_id': self.partner1.id,
-                'session_id': self.pos_config.current_session_id.id,
-                'payment_ids': [[0,
-                                    0,
-                                    {'amount': 2.0,
-                                    'name': fields.Datetime.now(),
-                                    'payment_method_id': self.cash_payment_method.id}]],
-                'user_id': self.env.uid}
-        order = self.env['pos.order'].sync_from_ui([order_data])
-        order = self.env['pos.order'].browse(order['pos.order'][0]['id'])
-        accounts = self.kit.product_tmpl_id.get_product_accounts()
-        expense_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['expense'].id)
-        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 6000.0)
-        interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['stock_output'].id)
-        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 6000.0)
+        self.assertEqual(expense_line.debit, 6000.0)
+        self.assertEqual(interim_line.credit, 6000.0)
 
     def test_bom_kit_order_total_cost_with_shared_component(self):
-        category = self.env['product.category'].create({
-            'name': 'Category for average cost',
-            'property_cost_method': 'average',
+        self.bom_one_line.product_tmpl_id.categ_id = self.category_average
+        self.bom_two_lines.product_tmpl_id.categ_id = self.category_average
+        kit_1 = self.bom_one_line.product_tmpl_id.product_variant_id
+        kit_2 = self.bom_two_lines.product_tmpl_id.product_variant_id
+
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': kit_1.id},
+                {'product_id': kit_2.id}
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
         })
 
-        kit_1 = self.env['product.product'].create({
-            'name': 'Kit Product 1',
-            'available_in_pos': True,
-            'is_storable': True,
-            'type': 'consu',
-            'lst_price': 30.0,
-            'categ_id': category.id,
-        })
-
-        kit_2 = self.env['product.product'].create({
-            'name': 'Kit Product 2',
-            'available_in_pos': True,
-            'is_storable': True,
-            'type': 'consu',
-            'lst_price': 200.0,
-            'categ_id': category.id,
-        })
-
-        shared_component_a = self.env['product.product'].create({
-            'name': 'Shared Comp A',
-            'is_storable': True,
-            'type': 'consu',
-            'available_in_pos': True,
-            'lst_price': 10.0,
-            'standard_price': 5.0,
-
-        })
-
-        other_component_a = self.env['product.product'].create({
-            'name': 'Other Comp A',
-            'is_storable': True,
-            'type': 'consu',
-            'available_in_pos': True,
-            'lst_price': 20.0,
-            'standard_price': 10.0,
-        })
-
-        other_component_b = self.env['product.product'].create({
-            'name': 'Other Comp B',
-            'is_storable': True,
-            'type': 'consu',
-            'available_in_pos': True,
-            'lst_price': 30.0,
-            'standard_price': 20.0,
-        })
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = shared_component_a
-            bom_line.product_qty = 1.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = other_component_a
-            bom_line.product_qty = 1.0
-        self.bom_a = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = shared_component_a
-            bom_line.product_qty = 10.0
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = other_component_b
-            bom_line.product_qty = 5.0
-        self.bom_b = bom_product_form.save()
-
-        self.pos_config.open_ui()
-        order = self.env['pos.order'].create({
-            'session_id': self.pos_config.current_session_id.id,
-            'lines': [(0, 0, {
-                'name': kit_1.name,
-                'product_id': kit_1.id,
-                'price_unit': kit_1.lst_price,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': kit_1.lst_price,
-                'price_subtotal_incl': kit_1.lst_price,
-            }), (0, 0, {
-                'name': kit_2.name,
-                'product_id': kit_2.id,
-                'price_unit': kit_2.lst_price,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': kit_2.lst_price,
-                'price_subtotal_incl': kit_2.lst_price,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': kit_1.lst_price + kit_2.lst_price,
-            'amount_total': kit_1.lst_price + kit_2.lst_price,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-        })
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
-        self.assertRecordValues(pos_order.lines, [
-            {'product_id': kit_1.id, 'total_cost': 15.0},
-            {'product_id': kit_2.id, 'total_cost': 150.0},
+        self.pos_config_usd.current_session_id.action_pos_session_closing_control()
+        self.assertRecordValues(order.lines, [
+            {'product_id': kit_1.id, 'total_cost': 10.0},
+            {'product_id': kit_2.id, 'total_cost': 20.0},
         ])
 
     def test_bom_nested_kit_order_total_cost_with_shared_component(self):
-        category = self.env['product.category'].create({
-            'name': 'Category for average cost',
-            'property_cost_method': 'average',
+        self.bom_one_line.product_tmpl_id.categ_id = self.category_average
+        self.bom_two_lines.product_tmpl_id.categ_id = self.category_average
+        self.ten_dollars_with_5_incl.standard_price = 30.0
+        self.twenty_dollars_with_5_incl.standard_price = 50.0
+        kit_1 = self.bom_one_line.copy()
+        kit_2 = self.bom_one_line.copy()
+        kit_2.product_tmpl_id = self.ten_dollars_with_5_incl
+        kit_3 = self.bom_one_line.copy()
+        kit_3.product_tmpl_id = self.twenty_dollars_with_5_incl
+        kit_3.bom_line_ids[0].product_id = kit_1.product_tmpl_id.product_variant_id
+
+        order, _ = self.create_backend_pos_order({
+            'line_data': [
+                {'product_id': kit_3.product_tmpl_id.product_variant_id.id},
+                {'product_id': kit_2.product_tmpl_id.product_variant_id.id}
+            ],
+            'payment_data': [
+                {'payment_method_id': self.cash_payment_method.id}
+            ]
         })
 
-        kit_1 = self.env['product.product'].create({
-            'name': 'Kit Product 1',
-            'available_in_pos': True,
-            'is_storable': True,
-            'lst_price': 30.0,
-            'categ_id': category.id,
-        })
-
-        kit_2 = self.env['product.product'].create({
-            'name': 'Kit Product 2',
-            'available_in_pos': True,
-            'is_storable': True,
-            'lst_price': 200.0,
-            'categ_id': category.id,
-        })
-
-        kit_3 = self.env['product.product'].create({
-            'name': 'Kit Product 3',
-            'available_in_pos': True,
-            'is_storable': True,
-            'lst_price': 200.0,
-            'categ_id': category.id,
-        })
-
-        shared_component_a = self.env['product.product'].create({
-            'name': 'Shared Comp A',
-            'available_in_pos': True,
-            'is_storable': True,
-            'lst_price': 10.0,
-            'standard_price': 100,
-        })
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = shared_component_a
-            bom_line.product_qty = 1.0
-        self.bom_a = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = shared_component_a
-            bom_line.product_qty = 1.0
-        self.bom_b = bom_product_form.save()
-
-        bom_product_form = Form(self.env['mrp.bom'])
-        bom_product_form.product_tmpl_id = kit_3.product_tmpl_id
-        bom_product_form.product_qty = 1.0
-        bom_product_form.type = 'phantom'
-        with bom_product_form.bom_line_ids.new() as bom_line:
-            bom_line.product_id = kit_1
-            bom_line.product_qty = 1.0
-        self.bom_b = bom_product_form.save()
-
-
-        self.pos_config.open_ui()
-        order = self.env['pos.order'].create({
-            'session_id': self.pos_config.current_session_id.id,
-            'lines': [(0, 0, {
-                'name': kit_3.name,
-                'product_id': kit_3.id,
-                'price_unit': kit_3.lst_price,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': kit_3.lst_price,
-                'price_subtotal_incl': kit_3.lst_price,
-            }), (0, 0, {
-                'name': kit_2.name,
-                'product_id': kit_2.id,
-                'price_unit': kit_2.lst_price,
-                'qty': 1,
-                'tax_ids': [[6, False, []]],
-                'price_subtotal': kit_2.lst_price,
-                'price_subtotal_incl': kit_2.lst_price,
-            })],
-            'pricelist_id': self.pos_config.pricelist_id.id,
-            'amount_paid': kit_3.lst_price + kit_2.lst_price,
-            'amount_total': kit_3.lst_price + kit_2.lst_price,
-            'amount_tax': 0.0,
-            'amount_return': 0.0,
-            'to_invoice': False,
-        })
-        payment_context = {"active_ids": order.ids, "active_id": order.id}
-        order_payment = self.PosMakePayment.with_context(**payment_context).create({
-            'amount': order.amount_total,
-            'payment_method_id': self.cash_payment_method.id
-        })
-        order_payment.with_context(**payment_context).check()
-        self.pos_config.current_session_id.action_pos_session_closing_control()
-        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
-        self.assertRecordValues(pos_order.lines, [
-            {'product_id': kit_3.id, 'total_cost': 100.0},
-            {'product_id': kit_2.id, 'total_cost': 100.0},
+        self.assertRecordValues(order.lines, [
+            {'product_id': kit_3.product_tmpl_id.product_variant_id.id, 'total_cost': 50.0},
+            {'product_id': kit_2.product_tmpl_id.product_variant_id.id, 'total_cost': 30.0},
         ])

--- a/addons/pos_sale/tests/test_pos_sale_lot.py
+++ b/addons/pos_sale/tests/test_pos_sale_lot.py
@@ -2,94 +2,65 @@
 
 import odoo
 from odoo import fields
-from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.addons.point_of_sale.tests.common import CommonPosTest
 
 
 @odoo.tests.tagged('post_install', '-at_install')
-class TestPointOfSaleFlow(TestPointOfSaleCommon):
+class TestPointOfSaleFlow(CommonPosTest):
     def test_ship_later_lots(self):
-        # open pos session
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        # set up product iwith SN tracing and create two lots (1001, 1002)
+        self.env.user.group_ids += self.env.ref('account.group_account_manager')
         self.stock_location = self.company_data['default_warehouse'].lot_stock_id
-        self.product = self.env['product.product'].create({
-            'name': 'Product A',
+        self.twenty_dollars_no_tax.product_variant_id.write({
             'tracking': 'serial',
             'is_storable': True,
-            'lst_price': 10,
+            'taxes_id': []
         })
-
-        lot1 = self.env['stock.lot'].create({
+        lot_1 = self.env['stock.lot'].create({
             'name': '1001',
-            'product_id': self.product.id,
+            'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
             'company_id': self.env.company.id,
         })
-        lot2 = self.env['stock.lot'].create({
+        lot_2 = self.env['stock.lot'].create({
             'name': '1002',
-            'product_id': self.product.id,
+            'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
             'company_id': self.env.company.id,
         })
-
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product.id,
             'inventory_quantity': 1,
+            'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
             'location_id': self.stock_location.id,
-            'lot_id': lot1.id
+            'lot_id': lot_1.id
         }).action_apply_inventory()
         self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product.id,
             'inventory_quantity': 1,
+            'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
             'location_id': self.stock_location.id,
-            'lot_id': lot2.id
+            'lot_id': lot_2.id
         }).action_apply_inventory()
-
-        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
 
         sale_order = self.env['sale.order'].sudo().create({
-            'partner_id': partner_test.id,
+            'partner_id': self.partner_stva.id,
             'order_line': [(0, 0, {
-                'product_id': self.product.id,
-                'name': self.product.name,
+                'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
+                'name': self.twenty_dollars_no_tax.product_variant_id.name,
+                'price_unit': self.twenty_dollars_no_tax.product_variant_id.lst_price,
                 'product_uom_qty': 2,
-                'price_unit': self.product.lst_price,
             })],
         })
         sale_order.action_confirm()
-        self.pos_config.open_ui()
-        current_session = self.pos_config.current_session_id
-
-        pos_order = {
-           'amount_paid': 10,
-           'amount_return': 0,
-           'amount_tax': 0,
-           'amount_total': 10,
-           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
-           'fiscal_position_id': False,
-           'to_invoice': True,
-           'partner_id': partner_test.id,
-           'lines': [[0,
-             0,
-             {'discount': 0,
-              'pack_lot_ids': [[0, 0, {'lot_name': lot1.name}]],
-              'price_unit': 10,
-              'product_id': self.product.id,
-              'price_subtotal': 10,
-              'price_subtotal_incl': 10,
-              'sale_order_line_id': sale_order.order_line[0].id,
-              'sale_order_origin_id': sale_order.id,
-              'qty': 1,
-              'tax_ids': []}]],
-           'session_id': current_session.id,
-           'shipping_date': fields.Date.today(),
-           'payment_ids': [[0,
-             0,
-             {'amount': 10,
-              'name': fields.Datetime.now(),
-              'payment_method_id': self.pos_config.payment_method_ids[0].id}]],
-           'last_order_preparation_change': '{}',
-           'user_id': self.env.uid}
-
-        order = self.env['pos.order'].sync_from_ui([pos_order])
-        self.assertEqual(self.env['pos.order'].browse(order['pos.order'][0]['id']).picking_ids.move_line_ids.lot_id, lot1)
+        order, _ = self.create_backend_pos_order({
+            'order_data': {
+                'partner_id': self.partner_stva.id,
+                'shipping_date': fields.Date.today(),
+            },
+            'line_data': [{
+                'product_id': self.twenty_dollars_no_tax.product_variant_id.id,
+                'pack_lot_ids': [[0, 0, {'lot_name': lot_1.name}]],
+                'sale_order_line_id': sale_order.order_line[0].id,
+                'sale_order_origin_id': sale_order.id,
+            }],
+            'payment_data': [
+                {'payment_method_id': self.pos_config_usd.payment_method_ids[0].id}
+            ]
+        })
+        self.assertEqual(order.picking_ids.move_line_ids.lot_id, lot_1)


### PR DESCRIPTION
*: pos_mrp, pos_sale

The aim of this commit is to make test writing easier, by choosing
easy-to-calculate prices with their corresponding taxes.

The products created have prices of 10 or 20 with taxes of 5, 10 or 15
percent.

A global class will be created and inherited by all Point of Sale tests,
with the aim of always using products already available. If a different
product is required in a specific test, existing products can be
modified.

---

Modification in `l10n_es_edi_tbai` module is done to ensure the validity
of test certificates. After creating the certificate the date_end is
overrided to be set 2 days from the test date. This is done to ensure
that the test certificate is valid and can be used for testing.

---

Test in file: `point_of_sale/tests/test_point_of_sale_flow.py`:

- Test `test_order_refund_lots` is removed and adapted in the frontend
tour `test_lot`

- Test `test_order_to_invoice` is removed because frontend is already
testing this behavior, related tests:
    - Test `test_02_pos_with_invoiced`
    - Test `test_order_and_invoice_amounts`
    - And more in submodules...

- Test `test_order_with_deleted_tax` is removed because it is using
`sync_from_ui` method which should not be used in the backend.
Frontend tours are already testing its behavior

- Test `test_order_refund_picking` is merged with `test_order_to_picking`

- Test `test_order_with_different_payments_and_refund` is removed
because its description don't correspond to the actual behavior of the
test. The goal of the test isn't clear.

- Test `test_product_combo_creation` is removed because its already
tested in owner module.

- Test `test_order_refund_with_owner` was merged with the frontend
test `test_lot`

- Test `test_change_is_deducted_from_cash` was merged with the frontend
test `test_tracking_number_closing_session`