### PR TITLE
[FIX] tests: catch chrome external requests

### DIFF
--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
 
 from lxml import html
 from werkzeug.urls import url_encode
@@ -8,9 +9,17 @@ from odoo.addons.website.tools import MockRequest, create_image_attachment
 from odoo.tests.common import HOST
 from odoo.tools import config
 
+_logger = logging.getLogger(__name__)
+
 
 @tagged('post_install', '-at_install', 'website_snippets')
 class TestSnippets(HttpCase):
+
+    def fetch_proxy(self, url):
+        if 'twitter.com' in url or 'youtube.com' in url:
+            _logger.info('External chrome request during tests: Sending dummy page for %s', url)
+            return self.make_fetch_proxy_response('<body>Dummy page</body>')
+        return super().fetch_proxy(url)
 
     def test_01_empty_parents_autoremove(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_empty_parent_autoremove', login='admin')

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import logging
 
 from dateutil.relativedelta import relativedelta
 
@@ -11,6 +12,7 @@ from odoo.fields import Command, Datetime
 from odoo.tools import mute_logger
 from odoo.tools.misc import file_open
 
+_logger = logging.getLogger(__name__)
 
 class TestUICommon(HttpCaseGamification, HttpCaseWithUserPortal):
 
@@ -224,6 +226,14 @@ class TestUi(TestUICommon):
 
 @tests.common.tagged('post_install', '-at_install')
 class TestUiPublisher(HttpCaseGamification):
+
+    def fetch_proxy(self, url):
+        if url.endswith('ThreeTimeAKCGoldWinnerPembrookeWelshCorgi.jpg'):
+            _logger.info('External chrome request during tests: Sending dummy image for %s', url)
+            with file_open('base/tests/odoo.jpg', 'rb') as f:
+                content = f.read()
+            return self.make_fetch_proxy_response(content)
+        return super().fetch_proxy(url)
 
     def test_course_publisher_elearning_manager(self):
         user_demo = self.user_demo


### PR DESCRIPTION
Accessing external resources in chrome can increase randomness in execution for multiple reasons:

- the external resource may temporary not be available
- the external resource may be faster-slower to load
- the external server could block some requests because of rate limiting
- the network may be unreachable.

Moreover, downloading fonts at every execution also slows down the tests

A possibility to solve the issue was to block the network on runbot, in the dockers. The main problem with this solution is that it wouldn't be the same behavior locally. It is also hard to adapt all versions at the same time.

This commit introduced another solution, using Fetch.enable in the chrome developers tools. This will allow to have a callback on every external request, allowing to enable/disable/give an alternate answer to the request.

All local request are allowed, all external request should be either
blocked or an alternative answer given.

This could be costly but at first glance it looks like it had no visible
negative impact on performances.

The first version was blocking all external requests, leading to a lot of failing tests, most of them already seen in nighties. It is hard to say since depending on when it happens it could create different error message, at least a few dozens of error related to this where found, maybe a few hundreds looking at the kind of patterns it can cause.  

Following this attempts a fix was to vendor all needed sources leading to ~130 cached url, with more than 100 fonts. This list was furthered reduced to have default fonts that would be returned reducing the load.

A test was made to return a 404 instead and it was actually enough, and it is the same for most requests (stripe, ayden, ...). Only a few of them needs a answer close to reality.

- The gooleapis css can be emty but not a 404 because it may make some of the css computation fail (website.backend_assets_all_wysiwyg.min.css) One of the failling test is TestCustomSnippet.test_01_run_tour

This final version returns a 404 for most resources.

A version returning 500 also works fine.

This pr could impact other cis (odoosh, other runbot) but the impact is expected to be slow wince only two tests needed to be adapted outside tests/common.py. It would be still possible to make Fetch.enable optional using an environment variable. 

Targeting 18.0 looks reasonable for a start, could be backported to 16.0 later

Note that this pr may make some random error more frequent, #207469 was needed to make this pr green. 
The assumption is that the speedup of the loading of some resources (or possible slowdown of local request) may change the timing of the execution revealing making some error more frequent.