### PR TITLE
[FIX] point_of_sale: missing attribute name

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -343,7 +343,7 @@ export class PosOrder extends Base {
                         product_id: line.get_product().id,
                         name: line.get_full_product_name(),
                         basic_name: line.get_product().name,
-                        display_name: line.get_product().name,
+                        display_name: line.get_product().display_name,
                         note: line.getNote(),
                         quantity: line.get_quantity(),
                     };


### PR DESCRIPTION
Steps to reproduce:
------------------------
- Install POS & setup kitchen printer.
- Open session and make an order with instant creation mode attribute product.
- Cancel the order.

Issue:
-------
- In the cancel KOT the attribute name wasn't visible.

Cause:
---------
- Wrong value passed for display name just simple name was passed instead of display name containing the attribute.

FIX:
------
- Corrected the value passed for the display name.

Task: 4720599
