### PR TITLE
[FIX] hr_holidays: User unable to cancel the taken leave on mandatory days

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -782,7 +782,7 @@ Versions:
                 if previous_emp_data != emp_data and len(emp_data) >= len(previous_emp_data):
                     raise ValidationError(_("There is no valid allocation to cover that request."))
         is_leave_user = self.env.user.has_group('hr_holidays.group_hr_holidays_user')
-        if not is_leave_user and any(leave.has_mandatory_day for leave in self):
+        if not is_leave_user and any(leave.has_mandatory_day for leave in self if leave.state not in ('cancel', 'refuse')):
             raise ValidationError(_('You are not allowed to request time off on a Mandatory Day'))
 
     ####################################################


### PR DESCRIPTION
### Steps to Reproduce:
- Apply for leave on non-mandatory days (as a demo user) and get it approved.
- Admin marks one of those days as a mandatory day.
- Now, attempt to cancel the approved leave (as a demo user).

### Before:
- User wasn't able to cancel or refuse a leave if a mandatory days added later in leave life cycle.

### After:
- We will skip mandatory days check while doing operation refuse/cancel.

Task: 4736952

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
