### PR TITLE
[IMP] mail: avoid sending field info twice for track values

### DIFF
--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -84,9 +84,9 @@ class MailMessage(models.Model):
             audit_log_preview = (title or '') + '\n'
             audit_log_preview += "\n".join(
                 "%(old_value)s ⇨ %(new_value)s (%(field)s)" % {
-                    'old_value': fmt_vals['oldValue']['value'],
-                    'new_value': fmt_vals['newValue']['value'],
-                    'field': fmt_vals['changedField'],
+                    'old_value': fmt_vals['oldValue'],
+                    'new_value': fmt_vals['newValue'],
+                    'field': fmt_vals['fieldInfo']['changedField'],
                 }
                 for fmt_vals in tracking_value_ids._tracking_value_format()
             )

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3611,9 +3611,9 @@ class MailThread(models.AbstractModel):
                 tracking_values = record_wlang._track_filter_for_display(tracking_values)
             tracking = [
                 (
-                    fmt_vals['changedField'],
-                    fmt_vals['oldValue']['value'],
-                    fmt_vals['newValue']['value'],
+                    fmt_vals['fieldInfo']['changedField'],
+                    fmt_vals['oldValue'],
+                    fmt_vals['newValue'],
                 ) for fmt_vals in tracking_values._tracking_value_format()
             ]
 

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -86,10 +86,10 @@ patch(Message.prototype, {
     /**
      * @returns {string}
      */
-    formatTracking(trackingType, trackingValue) {
-        switch (trackingType) {
+    formatTracking(trackingFieldInfo, trackingValue) {
+        switch (trackingFieldInfo.fieldType) {
             case "boolean":
-                return trackingValue.value ? _t("Yes") : _t("No");
+                return trackingValue ? _t("Yes") : _t("No");
             /**
              * many2one formatter exists but is expecting id/display_name or data
              * object but only the target record name is known in this context.
@@ -100,39 +100,35 @@ patch(Message.prototype, {
             case "char":
             case "many2one":
             case "selection":
-                return formatChar(trackingValue.value);
+                return formatChar(trackingValue);
             case "date": {
-                const value = trackingValue.value
-                    ? deserializeDate(trackingValue.value)
-                    : trackingValue.value;
+                const value = trackingValue ? deserializeDate(trackingValue) : trackingValue;
                 return formatDate(value);
             }
             case "datetime": {
-                const value = trackingValue.value
-                    ? deserializeDateTime(trackingValue.value)
-                    : trackingValue.value;
+                const value = trackingValue ? deserializeDateTime(trackingValue) : trackingValue;
                 return formatDateTime(value);
             }
             case "float":
-                return formatFloat(trackingValue.value, { digits: trackingValue.floatPrecision });
+                return formatFloat(trackingValue, { digits: trackingFieldInfo.floatPrecision });
             case "integer":
-                return formatInteger(trackingValue.value);
+                return formatInteger(trackingValue);
             case "text":
-                return formatText(trackingValue.value);
+                return formatText(trackingValue);
             case "monetary":
-                return formatMonetary(trackingValue.value, {
-                    currencyId: trackingValue.currencyId,
+                return formatMonetary(trackingValue, {
+                    currencyId: trackingFieldInfo.currencyId,
                 });
             default:
-                return trackingValue.value;
+                return trackingValue;
         }
     },
 
     /**
      * @returns {string}
      */
-    formatTrackingOrNone(trackingType, trackingValue) {
-        const formattedValue = this.formatTracking(trackingType, trackingValue);
+    formatTrackingOrNone(trackingFieldInfo, trackingValue) {
+        const formattedValue = this.formatTracking(trackingFieldInfo, trackingValue);
         return formattedValue || _t("None");
     },
 });

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -13,10 +13,10 @@
                         <ul class="mb-0 ps-4">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.oldValue)"/>
+                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
                                     <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
-                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.newValue)"/>
-                                    <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
+                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
+                                    <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.fieldInfo.changedField"/>)</span>
                                 </li>
                             </t>
                         </ul>

--- a/addons/mail/static/tests/mock_server/mock_models/mail_tracking_value.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_tracking_value.js
@@ -120,20 +120,15 @@ export class MailTrackingValue extends models.ServerModel {
         return trackingValues.map((tracking) => {
             const irField = IrModelFields.find((field) => field.id === tracking.field_id);
             return {
-                changedField: capitalize(irField.ttype),
                 id: tracking.id,
-                fieldName: irField.name,
-                fieldType: irField.ttype,
-                newValue: {
+                fieldInfo: {
+                    changedField: capitalize(irField.ttype),
                     currencyId: tracking.currency_id,
+                    fieldType: irField.ttype,
                     floatPrecision: this.env[irField.model]._fields[irField.name].digits,
-                    value: this._format_display_value(tracking, "new"),
                 },
-                oldValue: {
-                    currencyId: tracking.currency_id,
-                    floatPrecision: this.env[irField.model]._fields[irField.name].digits,
-                    value: this._format_display_value(tracking, "old"),
-                },
+                newValue: this._format_display_value(tracking, "new"),
+                oldValue: this._format_display_value(tracking, "old"),
             };
         });
     }


### PR DESCRIPTION
`currencyId` is sent for both old and new values. This makes no sense as the track value does not keep track of changes in currency.

We now send all field-related info as a sub-object `fieldInfo`, and let the values just be values. Matching the actual modelling.

task-4746268
