### PR TITLE
[FIX] base: allow filtered_domain for properties field

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6595,6 +6595,8 @@ class BaseModel(metaclass=MetaModel):
                         # so that negations are applied on the result of 'any' instead
                         # of on the mapped value
                         key, comparator, value = fname, 'any', [(rest, comparator, value)]
+                    if field.type == 'properties':
+                        key = fname
                 else:
                     field = self._fields[key]
                     if key == 'id':
@@ -6666,6 +6668,9 @@ class BaseModel(metaclass=MetaModel):
                             data = data and data.ids or [False]
                     elif field.type in ('date', 'datetime'):
                         data = [Datetime.to_datetime(d) for d in data]
+
+                    if field and field.type == 'properties':
+                        data = data and [v for k, v in data[0].items() if k == rest]
 
                     if comparator == '=':
                         ok = value in data


### PR DESCRIPTION
The system gives an error if we set the filter in the relation of lead_properties.

Steps to Produce:
1. Install the `CRM` module.
2. CRM > Configuration > Settings.
3. Enable the `Rule-Based Assignment` and save the changes.
4. CRM > Reporting > Leads, then go to list view.
5. Click on NEW and add the required values.
6. From the gear icon, click on Add properties, set a random value, and then save.
7. CRM > Sales > Teams.
8. Click on the 3 dots of any team and click on Configuration.
9. Add the new salesperson and set the Lead Assignment Filter like Properties > Property 1(name of the property you added in lead form view) - is equal - demo (values of that property that you gave previously) and then save.
10. Click the gear icon and select the CRM: Lead Assignment.

Error:
`AttributeError: ' dict ' object has no attribute '_fields'`

Solution:
The code filters records based on complex domain conditions and combines matching IDs using logical operators. It also supports special fields like properties.

Sentry - 6544761414

