### PR TITLE
[FIX] mail: block duplicate recipients and popover

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -13,7 +13,7 @@ import { RecipientsInput } from "@mail/core/web/recipients_input";
 import { SearchMessageInput } from "@mail/core/common/search_message_input";
 import { SearchMessageResult } from "@mail/core/common/search_message_result";
 import { Deferred, KeepLast } from "@web/core/utils/concurrency";
-import { onWillStart, status, useEffect } from "@odoo/owl";
+import { onWillStart, reactive, status, useEffect, useSubEnv } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
 import { browser } from "@web/core/browser/browser";
@@ -120,6 +120,9 @@ patch(Chatter.prototype, {
         this.followerListDropdown = useDropdownState();
         /** @type {number|null} */
         this.loadingAttachmentTimeout = null;
+        useSubEnv({
+            chatterState: reactive({ isFullComposerOpen: false }),
+        });
         useCustomDropzone(this.rootRef, MailAttachmentDropzone, {
             extraClass: "o-mail-Chatter-dropzone",
             /** @param {Event} ev */

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -113,7 +113,6 @@ export class Composer extends Component {
         this.pickerContainerRef = useRef("picker-container");
         this.state = useState({
             active: true,
-            isFullComposerOpen: false,
         });
         this.fullComposerBus = new EventBus();
         this.selection = useSelection({
@@ -614,7 +613,7 @@ export class Composer extends Component {
                 }
                 this.props.messageToReplyTo?.cancel();
                 this.onCloseFullComposerCallback(isDiscard);
-                this.state.isFullComposerOpen = false;
+                this.env.chatterState.isFullComposerOpen = false;
                 // Use another event bus so that no message is sent to the
                 // closed composer.
                 this.fullComposerBus = new EventBus();
@@ -624,7 +623,7 @@ export class Composer extends Component {
             },
         };
         await this.env.services.action.doAction(action, options);
-        this.state.isFullComposerOpen = true;
+        this.env.chatterState.isFullComposerOpen = true;
     }
 
     /**
@@ -824,7 +823,7 @@ export class Composer extends Component {
             };
             browser.localStorage.setItem(composer.localId, JSON.stringify(config));
         };
-        if (this.state.isFullComposerOpen) {
+        if (this.env.chatterState.isFullComposerOpen) {
             this.fullComposerBus.trigger("SAVE_CONTENT", {
                 onSaveContent: saveContentToLocalStorage,
             });

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -252,6 +252,15 @@ export class Thread extends Record {
                     ? { type: "partner", id: recipient.partner_id }
                     : false;
             }
+            const suggestedRecipientSet = new Set(
+                this.suggestedRecipients.map((recipient) =>
+                    [recipient.partner_id, recipient.email].join("@@")
+                )
+            );
+            this.additionalRecipients = this.additionalRecipients.filter(
+                (recipient) =>
+                    !suggestedRecipientSet.has([recipient.partner_id, recipient.email].join("@@"))
+            );
         },
     });
     hasLoadingFailed = false;


### PR DESCRIPTION
This commit fixes an issue with the newly introduced `RecipientsInputTagsListPopover` and the email-like system.

The issue is that, when you have a partner that doesn't have an email address, opening the full composer from the chatter tries to remove the recipient. But when you close the composer without changing anything to it, then when opening the chatter you'll see a duplicated recipient if it is a suggested recipient.

Plus, if you reopen the modal you'll see that the popover in the chatter still opens.

This commit fixes both issues:
 1. When the `suggestedRecipients` are updated we filter the `additionalRecipients` so that if we have the same partner_id in both they don't duplicate.
 2. When you open the full composer the tags list is aware of that and doesn't open additional popovers.

task-4747049

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
