### PR TITLE
[FIX] survey: fix confirmation in live session

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -260,8 +260,8 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
             this._submitForm({ previousPageId: parseInt(target.dataset['previousPageId']) });
         } else if (target.value === 'next_skipped') {
             this._submitForm({ nextSkipped: true });
-        } else if (target.value === 'finish') {
-            // Adding pop-up before the survey is submitted
+        } else if (target.value === 'finish' && !this.options.sessionInProgress) {
+            // Adding pop-up before the survey is submitted when not in live session
             this.call("dialog", "add", ConfirmationDialog, {
                 title: _t("Submit confirmation"),
                 body: _t("Are you sure you want to submit the survey?"),
@@ -271,6 +271,8 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
                 },
                 cancel: () => {},
             });
+        } else if (target.value === 'finish') {
+            this._submitForm({ isFinish: true });
         } else {
             this._submitForm({});
         }


### PR DESCRIPTION
Purpose
=======
Fix the confirmation request popup which is displayed after each question in a live session.

Specification
=============
In a live session answers cannot be edited after each question so every time an attendee submit an answer the form is considered as finished. This triggers the confirmation popup everytime.

The confirmation popup is only relevant outside of live sessions to prevent the user doing a certification with only 1 attempt to mistakenly end the survey. Also in live sessions the survey flow is handled by the host and not the attendees.
=> Removing the confirmation popup for live sessions

related: odoo/odoo#176612

Task-4743653

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
