### PR TITLE
[IMP] l10n_in_edi: log message on retry

### DIFF
--- a/addons/l10n_in_edi/i18n/l10n_in_edi.pot
+++ b/addons/l10n_in_edi/i18n/l10n_in_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-03 05:48+0000\n"
-"PO-Revision-Date: 2025-04-03 05:48+0000\n"
+"POT-Creation-Date: 2025-08-20 11:49+0000\n"
+"PO-Revision-Date: 2025-08-20 11:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -312,6 +312,13 @@ msgstr ""
 #. module: l10n_in_edi
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi.res_config_settings_view_form_inherit_l10n_in_edi
 msgid "Production Environment"
+msgstr ""
+
+#. module: l10n_in_edi
+#. odoo-python
+#: code:addons/l10n_in_edi/models/account_move.py:0
+#, python-format
+msgid "Retrying EDI processing for the following documents:%s"
 msgstr ""
 
 #. module: l10n_in_edi

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -3,6 +3,8 @@
 
 import json
 
+from markupsafe import Markup
+
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
@@ -26,6 +28,20 @@ class AccountMove(models.Model):
                 lambda i: i.edi_format_id.code == "in_einvoice_1_03"
                 and i.state in ("sent", "to_cancel", "cancelled")
             ))
+
+    def action_retry_edi_documents_error(self):
+        for move in self:
+            if move.country_code == 'IN':
+                move.message_post(body=_(
+                    "Retrying EDI processing for the following documents: %(breakline)s %(edi_codes)s",
+                    breakline=Markup("<br/>"),
+                    edi_codes=Markup("<br/>").join(
+                        move.edi_document_ids
+                        .filtered(lambda doc: doc.blocking_level == "error")
+                        .mapped("edi_format_name")
+                    )
+                ))
+        return super().action_retry_edi_documents_error()
 
     def button_cancel_posted_moves(self):
         """Mark the edi.document related to this move to be canceled."""


### PR DESCRIPTION
Following the implementation of [Black list request by GST](https://github.com/odoo/iap-apps/pull/1039)
the users are blocked for 24 hours on generating too many request. When processing through EDI there is no log when clicked on the retry button, Which is more essentially needed now to know by which user the EDI was retried and we logged the same on the move



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
