### PR TITLE
[FIX] hr_holidays: fix date's error message constraint

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -143,10 +143,10 @@ class HrLeaveAccrualLevel(models.Model):
         for level in self:
             if level.frequency == 'weekly' and not level.week_day:
                 error_message = _("Weekday must be selected to use the frequency weekly")
-            elif level.frequency == 'bimonthly' and level.first_day >= level.second_day:
+            elif level.frequency == 'bimonthly' and int(level.first_day) >= int(level.second_day):
                 error_message = _("The first day must be lower than the second day.")
         if error_message:
-            raise error_message
+            raise ValidationError(error_message)
 
     @api.constrains('cap_accrued_time', 'maximum_leave')
     def _check_maximum_leave(self):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -3784,3 +3784,19 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time("2025-01-05"):
             allocation._update_accrual()
             self.assertEqual(allocation.number_of_days, 8, "The number of days should be updated successfully")
+
+    def test_accrual_allocation_constraint_1(self):
+        with self.assertRaises(ValidationError):
+            self.env['hr.leave.accrual.plan'].create({
+                'name': 'Accrual Plan with no carryover',
+                'accrued_gain_time': 'start',
+                'carryover_date': 'year_start',
+                'level_ids': [Command.create({
+                    'added_value': 8,
+                    'added_value_type': 'day',
+                    'action_with_unused_accruals': 'lost',
+                    'frequency': 'bimonthly',
+                    'first_day': '20',
+                    'second_day': '3',
+                })],
+            })


### PR DESCRIPTION
Before this commit, the error message was raised without calling an error wrapper. It's fixed in this commit.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
