### PR TITLE
[FIX] point_of_sale: prevent traceback select value from suggestion & autofill

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -58,9 +58,9 @@ export class Navbar extends Component {
     }
 
     handleKeydown(event) {
-        const isEndCharacter = event.key.match(/(Enter|Tab)/);
+        const isEndCharacter = event.key?.match(/(Enter|Tab)/);
         const isSpecialKey =
-            !["Control", "Alt"].includes(event.key) && (event.key.length > 1 || event.metaKey);
+            !["Control", "Alt"].includes(event.key) && (event.key?.length > 1 || event.metaKey);
 
         clearTimeout(this.timeout);
         if (isEndCharacter) {
@@ -86,7 +86,7 @@ export class Navbar extends Component {
             document.activeElement !== this.inputRef.el &&
             !this.pos.getOrder()?.getSelectedOrderline() &&
             this.noOpenDialogs() &&
-            event.key.length == 1 &&
+            event.key?.length == 1 &&
             this.bufferedInput.length < 3
         ) {
             this.inputRef.el.focus();

--- a/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/app/components/popups/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_loyalty.ManageGiftCardPopup">
         <Dialog title="props.title" size="'md'">
-            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" />
+            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" autocomplete="off" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" />
             <div class="mt-3 d-flex">
                 <div t-attf-class="col align-items-center d-flex {{!ui.isSmall? 'me-2 w-50': ''}}">
                     <div class="col-form-label text-center pe-0 me-4 fs-5">Amount</div>


### PR DESCRIPTION
Steps to reproduce:
---------------------------------------------------------------------------------------------------------------------
- Install the point_of_sale module.
- Enable Loyalty from configuration
- 1. Open Session and add a gift card product to the order.
     Enter a gift card number using a past suggestion (autocomplete).
- 2. Create a new partner from the frontend using autofill

Issue:
----------------------------------------------------------------------------------------------------------------------
- A traceback occurs when the gift card number is selected from the suggestion
 list & create partner using autofill

Cause:
----------------------------------------------------------------------------------------------------------------------
- The event key value is undefined when selecting from autocomplete
  suggestions, causing a crash in the keydown event handler.

Fix:
---------------------------------------------------------------------------------------------------------------------
- Gift card number field suggestion is unnecessary, so remove suggestion and 
  safely handled cases where event key is undefined during keydown events to 
  prevent crashes.
  
  Task:4743765