### PR TITLE
[FIX] project: fix wrong stage in template task test

### DIFF
--- a/addons/project/static/tests/tours/project_task_templates_tour.js
+++ b/addons/project/static/tests/tours/project_task_templates_tour.js
@@ -16,7 +16,7 @@ registry.category("web_tour.tours").add("project_task_templates_tour", {
         },
         {
             trigger: 'div.o_last_breadcrumb_item span:contains("Project with Task Template")',
-            content: "Wit for the kanban view to load",
+            content: "Wait for the kanban view to load",
         },
         {
             trigger: "a.o-kanban-button-new",

--- a/addons/project/tests/test_task_templates_ui.py
+++ b/addons/project/tests/test_task_templates_ui.py
@@ -9,14 +9,15 @@ class TestTaskTemplatesTour(HttpCase):
         super().setUpClass()
         cls.project_with_templates = cls.env["project.project"].create({
             "name": "Project with Task Template",
-            "type_ids": [Command.link(cls.env.ref("project.project_project_stage_0").id)],
+            "type_ids": [Command.create({
+                "name": "New",
+            })],
         })
         cls.template_task = cls.env["project.task"].create({
             "name": "Template",
             "project_id": cls.project_with_templates.id,
             "is_template": True,
             "description": "Template description",
-            "stage_id": cls.env.ref("project.project_project_stage_0").id,
         })
 
     def test_task_templates_tour(self):


### PR DESCRIPTION
This PR fixes a test that is erroneously using a project stage as a task stage
