### PR TITLE
[IMP] web, account: Allow resequencing across groups in list view

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
@@ -38,16 +38,20 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
         return super.processAllColumn(allColumns, list);
     }
 
-    getActiveColumns(list) {
-        let activeColumns = super.getActiveColumns(list);
+    getActiveColumns() {
+        let activeColumns = super.getActiveColumns();
         const productCol = activeColumns.find((col) => this.productColumns.includes(col.name));
         const labelCol = activeColumns.find((col) => col.name === "name");
 
         if (productCol) {
             if (labelCol) {
-                list.records.forEach((record) => (record.columnIsProductAndLabel = true));
+                this.props.list.records.forEach(
+                    (record) => (record.columnIsProductAndLabel = true)
+                );
             } else {
-                list.records.forEach((record) => (record.columnIsProductAndLabel = false));
+                this.props.list.records.forEach(
+                    (record) => (record.columnIsProductAndLabel = false)
+                );
             }
             activeColumns = activeColumns.filter((col) => col.name !== "name");
             this.titleField = productCol.name;

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -28,8 +28,8 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
         super.getCellTitle(column, record);
     }
 
-    getActiveColumns(list) {
-        let activeColumns = super.getActiveColumns(list);
+    getActiveColumns() {
+        let activeColumns = super.getActiveColumns();
         let productTmplCol = activeColumns.find((col) => col.name === 'product_template_id');
         let productCol = activeColumns.find((col) => col.name === 'product_id');
 

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -157,6 +157,7 @@
                 <t t-if="!group.isFolded">
                     <t t-call="{{ constructor.rowsTemplate }}">
                         <t t-set="list" t-value="group.list"/>
+                        <t t-set="groupId" t-value="group.id"/>
                     </t>
                     <tr t-if="!group.list.isGrouped and props.editable and canCreate">
                         <td t-if="hasSelectors"/>
@@ -179,7 +180,8 @@
     </t>
 
     <t t-name="web.ListRenderer.GroupRow">
-        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer"
+        <tr t-attf-class="{{group.count > 0 ? 'o_group_has_content' : ''}} o_group_header {{!group.isFolded ? 'o_group_open' : ''}} cursor-pointer {{ canResequenceRows and group_index > 0 ? 'o_row_draggable' : '' }}"
+            t-att-data-group-id="group.id"
             t-on-click="(ev) => this.onGroupHeaderClicked(ev, group)"
         >
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)"
@@ -229,6 +231,7 @@
         <tr class="o_data_row"
             t-att-class="getRowClass(record)"
             t-att-data-id="record.id"
+            t-att-data-group-id="groupId"
             t-on-click.capture="(ev) => this.onClickCapture(record, ev)"
             t-on-mouseover.capture="(ev) => this.ignoreEventInSelectionMode(ev)"
             t-on-mouseout.capture="(ev) => this.ignoreEventInSelectionMode(ev)"


### PR DESCRIPTION
This commit enables users to resequence records between groups in grouped list views, similar to the behavior in ungrouped lists.

- The resequencing logic mirrors the approach already used in Kanban views.
- To support this feature, handle fields are now retained in grouped views instead of being removed.

Part of task-4613142

