### PR TITLE
[FIX] l10n_it_edi: export the payment method in the XML

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -662,7 +662,7 @@ class AccountMove(models.Model):
             'partner_bank': self.partner_bank_id,
             'formato_trasmissione': formato_trasmissione,
             'document_type': document_type,
-            'payment_method': 'MP05',
+            'payment_method': self.l10n_it_payment_method,
             'downpayment_moves': downpayment_moves,
             'reconciled_moves': self._get_reconciled_invoices(),
             'rc_refund': reverse_charge_refund,

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_lowercase_fields.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_lowercase_fields.xml
@@ -79,7 +79,7 @@
         <DatiPagamento>
             <CondizioniPagamento>TP02</CondizioniPagamento>
             <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
+                <ModalitaPagamento>MP15</ModalitaPagamento>
                 <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
                 <ImportoPagamento>976.49</ImportoPagamento>
                 <CodicePagamento>INV/2022/00001</CodicePagamento>

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -525,7 +525,7 @@ class TestItEdiExport(TestItEdi):
 
         self._assert_export_invoice(invoice, 'prezzio_unitario_converted_company_currency.xml')
 
-    def test_export_XML_lowercase_fields(self):
+    def test_export_XML_lowercase_fields_and_payment_method(self):
         partner = self.env['res.partner'].create({
             'name': 'Alessi',
             'l10n_it_codice_fiscale': 'Mrtmtt91d08f205j',
@@ -545,6 +545,7 @@ class TestItEdiExport(TestItEdi):
                     'tax_ids': [Command.set(self.default_tax.ids)],
                 }),
             ],
+            'l10n_it_payment_method': 'MP15',
         })
         invoice.action_post()
         self._assert_export_invoice(invoice, 'invoice_lowercase_fields.xml')


### PR DESCRIPTION
### Steps to reproduce:
- Create an invoice
- In the page "Electronic Invoicing" change the "Payment Method" to something different from "MP05"
- Send to tax Agency
- In the XML ModalitaPagamento is still "MP05"

### Cause:
This [commit](https://github.com/odoo/odoo/commit/277e0895efa4b110128b1029a5fe76283a094cde) added the possibility to choose the payment method on invoice. When exporting the value was always "MP05", it did not read the value of `l10n_it_payment_method` because this filed was in another module: `l10n_it_edi_ndd`.
This [commit](https://github.com/odoo/odoo/commit/dc0ab07465a3a9536bff1dc2a2f45814f69023fd) merged the two modules, but the exporting value is still always "MP05".

### Solution:
Give the value of `l10n_it_payment_method`.

opw-4724243