### PR TITLE
[FIX] html_editor: extend wait timeout in table dimension reset test

### DIFF
--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1117,7 +1117,7 @@ test("reset row size to remove custom height", async () => {
     expect("[data-type='row'].o-we-table-menu").toHaveCount(1);
 
     await click("[data-type='row'].o-we-table-menu");
-    await waitFor(".dropdown-menu");
+    await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_row_size']"));
     expect(getContent(el)).toBe(
         unformat(`
@@ -1172,7 +1172,7 @@ test("should redistribute excess width from current column to smaller columns", 
     expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
 
     await click("[data-type='column'].o-we-table-menu");
-    await waitFor(".dropdown-menu");
+    await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
         unformat(`
@@ -1230,7 +1230,7 @@ test("should redistribute excess width from larger columns to current column", a
     expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
 
     await click("[data-type='column'].o-we-table-menu");
-    await waitFor(".dropdown-menu");
+    await waitFor(".dropdown-menu", { timeout: 1000 });
     await click(queryOne(".dropdown-menu [name='reset_column_size']"));
     expect(getContent(el)).toBe(
         unformat(`


### PR DESCRIPTION
Purpose of this PR:

- Extended the waitFor timeout to 1000ms to prevent test failures on slower environments like runbot. This ensures the table menu has enough time to appear before assertions.

Related to PR: https://github.com/odoo/odoo/pull/193185

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
