### PR TITLE
[FIX] html_editor: prevent traceback when changing font of a link

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -556,6 +556,11 @@ export class DomPlugin extends Plugin {
             this.copyAttributes(newCandidate, baseContainer);
             newCandidate = baseContainer;
         }
+        const { commonAncestorContainer } = this.dependencies.selection.getEditableSelection();
+        // Clean before preserving cursors otherwise the saved cursors might
+        // reference a node that will be removed when setTagName eventually
+        // calls clean of its own.
+        this.dispatchTo("clean_handlers", closestElement(commonAncestorContainer));
         const cursors = this.dependencies.selection.preserveSelection();
         const selectedBlocks = [...this.dependencies.selection.getTraversedBlocks()];
         const deepestSelectedBlocks = selectedBlocks.filter(

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -196,6 +196,21 @@ describe("to heading 1", () => {
             contentAfter: '<ul><li class="nav-item"><h1>[abcd]</h1></li></ul>',
         });
     });
+
+    test("should re-selects link correctly after changing font style", async () => {
+        const { editor, el } = await setupEditor(
+            `<div class="o-paragraph"><a href="http://test.com">te[]st.com</a></div>`
+        );
+        await press(["ctrl", "a"]);
+        expect(getContent(el)).toBe(
+            `<div class="o-paragraph">[\ufeff<a href="http://test.com" class="o_link_in_selection">\ufefftest.com\ufeff</a>\ufeff]</div>`
+        );
+
+        setTag("h1")(editor);
+        expect(getContent(el)).toBe(
+            `<h1>[\ufeff<a href="http://test.com">\ufefftest.com\ufeff</a>\ufeff]</h1>`
+        );
+    });
 });
 
 describe("to heading 2", () => {


### PR DESCRIPTION
Steps to Reproduce:

1. Go to the To-do module.
2. Create a link.
3. Select the entire content using Ctrl + A.
4. Change the font style from 'Normal' to another (e.g., 'Header 1').
5. A traceback is thrown, although the link’s font style is changed.

Description of the issue/feature this PR addresses:

- The issue was caused by the presence of a `FEFF` (zero-width no-break space) character inside the selected text. This caused a conflict during selection restoration after the font style change. The clean handler was being triggered after the font change attempt, which led to an invalid cursor state.

 Current behavior before PR:
- A Traceback occurred when changing the font style of a selected link text.

Desired behavior after PR is merged:

- The clean handler is now explicitly called before the font change tries to restore the cursor, avoiding the invalid range or selection error.

task-4743390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
