### PR TITLE
[REF] point_of_sale: longpolling to control customer display

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -7,7 +7,7 @@
     'category': 'Sales/Point of Sale',
     'sequence': 40,
     'summary': 'Handle checkouts and payments for shops and restaurants.',
-    'depends': ['resource', 'stock_account', 'barcodes', 'web_editor', 'digest', 'phone_validation', 'partner_autocomplete'],
+    'depends': ['resource', 'stock_account', 'barcodes', 'web_editor', 'digest', 'phone_validation', 'partner_autocomplete', 'iot_base'],
     'uninstall_hook': 'uninstall_hook',
     'data': [
         'security/point_of_sale_security.xml',
@@ -138,6 +138,8 @@
             'bus/static/src/bus_parameters_service.js',
             'bus/static/src/multi_tab_service.js',
             'bus/static/src/workers/*',
+            'iot_base/static/src/network_utils/*',
+            'iot_base/static/src/device_controller.js',
         ],
 
         # Main PoS assets, they are loaded in the PoS UI
@@ -210,6 +212,8 @@
             "barcodes/static/tests/legacy/helpers.js",
             "web/static/tests/legacy/helpers/utils.js",
             "web/static/tests/legacy/helpers/cleanup.js",
+            'iot_base/static/src/network_utils/*',
+            'iot_base/static/src/device_controller.js',
         ],
         # Bundle that starts the pos, loaded on /pos/ui
         'point_of_sale.assets_prod': [

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -133,12 +133,7 @@ export class Navbar extends Component {
     openCustomerDisplay() {
         const proxyIP = this.pos.getDisplayDeviceIP();
         if (proxyIP) {
-            openProxyCustomerDisplay(
-                proxyIP,
-                this.pos.config.access_token,
-                this.pos.config.id,
-                this.notification
-            );
+            openProxyCustomerDisplay(proxyIP, this.pos, this.notification);
         } else {
             const getDeviceUuid = () => {
                 if (!localStorage.getItem("device_uuid")) {

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -11,7 +11,6 @@ import { parseFloat } from "@web/views/fields/parsers";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 import { ask } from "@point_of_sale/app/utils/make_awaitable_dialog";
-import { deduceUrl } from "@point_of_sale/utils";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { PaymentMethodBreakdown } from "@point_of_sale/app/components/payment_method_breakdown/payment_method_breakdown";
 
@@ -194,16 +193,7 @@ export class ClosePosPopup extends Component {
         this.pos._resetConnectedCashier();
         const proxyIP = this.pos.getDisplayDeviceIP();
         if (proxyIP) {
-            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
-                method: "POST",
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({ params: { action: "close" } }),
-            }).catch(() => {
-                console.log("Failed to send data to customer display");
-            });
+            this.pos.hardwareProxy.deviceControllers.customerDisplay.action({ action: "close" });
         }
         // If there are orders in the db left unsynced, we try to sync.
         const syncSuccess = await this.pos.pushOrdersWithClosingPopup();

--- a/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
+++ b/addons/point_of_sale/static/src/app/customer_display/customer_display_adapter.js
@@ -1,5 +1,4 @@
 import { formatCurrency } from "@point_of_sale/app/models/utils/currency";
-import { deduceUrl } from "@point_of_sale/utils";
 
 /**
  * This module provides functions to format order and order line data for customer display.
@@ -19,20 +18,9 @@ export class CustomerDisplayPosAdapter {
     dispatch(pos) {
         const proxyIP = pos.getDisplayDeviceIP();
         if (proxyIP) {
-            fetch(`${deduceUrl(proxyIP)}/hw_proxy/customer_facing_display`, {
-                method: "POST",
-                headers: {
-                    Accept: "application/json",
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify({
-                    params: {
-                        action: "set",
-                        data: this.data,
-                    },
-                }),
-            }).catch(() => {
-                console.log("Failed to send data to customer display");
+            pos.hardwareProxy.deviceControllers.customerDisplay.action({
+                action: "set",
+                data: this.data,
             });
         } else {
             this.channel.postMessage(JSON.parse(JSON.stringify(this.data)));

--- a/addons/point_of_sale/static/src/app/services/hardware_proxy_service.js
+++ b/addons/point_of_sale/static/src/app/services/hardware_proxy_service.js
@@ -22,6 +22,7 @@ export class HardwareProxy extends EventBus {
         this.host = "";
         this.keptalive = false;
         this.connectionInfo = reactive({ status: "init", drivers: {} });
+        this.deviceControllers = {};
         effect(
             (info) => {
                 if (info.status === "connected" && this.printer) {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -61,6 +61,7 @@ export class PosStore extends WithLazyGetterTrap {
         "action",
         "alert",
         "mail.sound_effects",
+        "iot_longpolling",
     ];
     constructor({ traps, env, deps }) {
         super({ traps });
@@ -84,6 +85,7 @@ export class PosStore extends WithLazyGetterTrap {
             pos_scale,
             action,
             alert,
+            iot_longpolling,
         }
     ) {
         this.env = env;
@@ -127,6 +129,7 @@ export class PosStore extends WithLazyGetterTrap {
         };
 
         this.hardwareProxy = hardware_proxy;
+        this.iotLongpolling = iot_longpolling;
         this.selectedOrderUuid = null;
         this.selectedPartner = null;
         this.selectedCategory = null;
@@ -563,11 +566,7 @@ export class PosStore extends WithLazyGetterTrap {
         this.markReady();
         this.showScreen(this.firstScreen);
         await this.deviceSync.readDataFromServer();
-        openProxyCustomerDisplay(
-            this.getDisplayDeviceIP(),
-            this.config.access_token,
-            this.config.id
-        );
+        openProxyCustomerDisplay(this.getDisplayDeviceIP(), this);
     }
 
     get productListViewMode() {

--- a/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
+++ b/addons/point_of_sale/static/src/customer_display/customer_display_data_service.js
@@ -19,15 +19,11 @@ export const CustomerDisplayDataService = {
                                 Accept: "application/json",
                                 "Content-Type": "application/json",
                             },
-                            body: JSON.stringify({
-                                params: {
-                                    action: "get",
-                                },
-                            }),
+                            body: JSON.stringify({ params: {} }),
                         }
                     );
                     const payload = await response.json();
-                    Object.assign(data, payload.result.data);
+                    Object.assign(data, payload.result);
                 } catch (error) {
                     notification.add(
                         _t(

--- a/addons/point_of_sale/static/src/customer_display/utils.js
+++ b/addons/point_of_sale/static/src/customer_display/utils.js
@@ -1,35 +1,20 @@
-import { deduceUrl } from "@point_of_sale/utils";
+import { DeviceController } from "@iot_base/device_controller";
 import { _t } from "@web/core/l10n/translation";
 
-export function openProxyCustomerDisplay(
-    displayDeviceIp,
-    accessToken,
-    configId,
-    notificationService = undefined
-) {
+export function openProxyCustomerDisplay(displayDeviceIp, pos, notificationService = null) {
     if (!displayDeviceIp) {
         return;
     }
 
+    pos.hardwareProxy.deviceControllers.customerDisplay ??= new DeviceController(
+        pos.iotLongpolling,
+        { iot_ip: displayDeviceIp, identifier: "display" }
+    );
+
     notificationService?.add(_t("Connecting to the IoT Box"));
-    fetch(`${deduceUrl(displayDeviceIp)}/hw_proxy/customer_facing_display`, {
-        method: "POST",
-        headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-            params: {
-                action: "open",
-                access_token: accessToken,
-                pos_id: configId,
-            },
-        }),
-    })
-        .then(() => {
-            notificationService?.add(_t("Connection successful"), { type: "success" });
-        })
-        .catch(() => {
-            notificationService?.add(_t("Connection failed"), { type: "danger" });
-        });
+    pos.hardwareProxy.deviceControllers.customerDisplay.action({
+        action: "open",
+        access_token: pos.config.access_token,
+        pos_id: pos.config.id,
+    });
 }


### PR DESCRIPTION
As longpolling was originally reserved to Enterprise users, the PoS had to use standard requests to IoT Box controllers to update the customer display data.

Now that the longpolling is available to everyone, the PoS can use it to simplify the communication with IoT Boxes.

**Note:** We couldn't listen for longpolling events to update data sent from the PoS on the customer display itself
as it is running on an IoT Box and no Odoo session is connected: it is impossible to sign longpolling requests. 

Enterprise PR: [https://github.com/odoo/enterprise/pull/84097](https://github.com/odoo/enterprise/pull/84097)
Task: 4394403
