### PR TITLE
[FIX] mrp_subcontracting_account: No additional cost for OUT svl

### DIFF
--- a/addons/mrp_subcontracting_account/models/stock_move.py
+++ b/addons/mrp_subcontracting_account/models/stock_move.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models
+from odoo.tools import float_compare
 
 
 class StockMove(models.Model):
@@ -15,7 +16,8 @@ class StockMove(models.Model):
         rslt = super()._generate_valuation_lines_data(partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description)
 
         subcontract_production = self.production_id.filtered(lambda p: p.subcontractor_id)
-        if not subcontract_production:
+        rounding = self.product_id.uom_id.rounding
+        if not subcontract_production or float_compare(qty, 0, precision_rounding=rounding) < 0:
             return rslt
         # split the credit line to two, one for component cost, one for subcontracting service cost
         currency = self.company_id.currency_id

--- a/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
+++ b/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py
@@ -98,14 +98,14 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt._action_done()
 
-        mo = picking_receipt._get_subcontract_production()
+        mo1 = picking_receipt._get_subcontract_production()
         # Finished is made of 1 comp1 and 1 comp2.
         # Cost of comp1 = 10
         # Cost of comp2 = 20
         # --> Cost of finished = 10 + 20 = 30
         # Additionnal cost = 30 (from the purchase order line or directly set on the stock move here)
         # Total cost of subcontracting 1 unit of finished = 30 + 30 = 60
-        self.assertEqual(mo.move_finished_ids.stock_valuation_layer_ids.value, 60)
+        self.assertEqual(mo1.move_finished_ids.stock_valuation_layer_ids.value, 60)
         self.assertEqual(picking_receipt.move_ids.stock_valuation_layer_ids.value, 0)
         self.assertEqual(picking_receipt.move_ids.product_id.value_svl, 60)
 
@@ -139,13 +139,14 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt._action_done()
 
-        mo = picking_receipt._get_subcontract_production()
+        mo2 = picking_receipt._get_subcontract_production()
         # In this case, since there isn't any additionnal cost, the total cost of the subcontracting
         # is the sum of the components' costs: 10 + 20 = 30
-        self.assertEqual(mo.move_finished_ids.stock_valuation_layer_ids.value, 30)
+        self.assertEqual(mo2.move_finished_ids.stock_valuation_layer_ids.value, 30)
         self.assertEqual(picking_receipt.move_ids.product_id.value_svl, 90)
 
         amls = self.env['account.move.line'].search([('id', 'not in', all_amls_ids)])
+        all_amls_ids += amls.ids
         self.assertRecordValues(amls, [
             # Receipt from subcontractor
             {'account_id': stock_cop_acc_id,     'product_id': self.finished.id,    'debit': 0.0,   'credit': 30.0},
@@ -156,6 +157,23 @@ class TestAccountSubcontractingFlows(TestMrpSubcontractingCommon):
             # Delivery com2 to subcontractor
             {'account_id': stock_valu_acc_id,   'product_id': self.comp1.id,       'debit': 0.0,   'credit': 10.0},
             {'account_id': stock_cop_acc_id,    'product_id': self.comp1.id,       'debit': 10.0,  'credit': 0.0},
+        ])
+
+        # Scrap first subcontract MO and ensure that the additional cost is not added.
+        scrap = self.env['stock.scrap'].create({
+            'product_id': self.finished.id,
+            'product_uom_id': self.uom_unit.id,
+            'scrap_qty': 1,
+            'production_id': mo1.id,
+            'location_id': self.stock_location.id,
+        })
+        scrap.do_scrap()
+
+        amls = self.env['account.move.line'].search([('id', 'not in', all_amls_ids)])
+        all_amls_ids += amls.ids
+        self.assertRecordValues(amls, [
+            {'account_id': stock_valu_acc_id, 'product_id': self.finished.id, 'debit': 0.0, 'credit': 60.0},
+            {'account_id': stock_out_acc_id, 'product_id': self.finished.id, 'debit': 60.0, 'credit': 0.0},
         ])
 
     def test_subcontracting_account_flow_2(self):


### PR DESCRIPTION
'_generate_valuation_lines_data' in mrp_subcontracting_account was not made to handle OUT stock move, this would cause problems when the user unarchive the subcontracting picking type, access the subcontracting MO and scrap parts of the produced quantity.

# How to Reproduce
- Create Subcontract BoM, with 1 cmp at $10
- Create & Produce a subcontracting MO with a purchase and additional cost of $10 => Finished product cost is $20 ($10 + $10)
- Scrap 1 unit of finished product => Journal entry for scrapped layer contains 3 AML instead of 2 => The additional cost is incorrectly added to the Stock Valuation account, making the line balance at -$30, while the layer is still at -$20

OPW-4640650

---

Test result without fix:
```
2025-04-24 09:26:06,083 18424 ERROR oes_test_17 odoo.addons.mrp_subcontracting_account.tests.test_subcontracting_account: FAIL: TestAccountSubcontractingFlows.test_subcontracting_account_flow_1
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/17.0/odoo/addons/mrp_subcontracting_account/tests/test_subcontracting_account.py", line 174, in test_subcontracting_account_flow_1
    self.assertRecordValues(amls, [
  File "/home/odoo/projects/odoo-src/multiverse/src/17.0/odoo/odoo/tests/common.py", line 667, in assertRecordValues
    self.fail('\n'.join(errors))
AssertionError: The records and expected_values do not match.
Wrong number of records to compare: 3 records versus 2 expected values.

==== Differences at index 0 ====
--- 

+++ 

@@ -1,3 +1,3 @@

-account_id:300
-debit:60.0
-credit:0.0
+account_id:301
+debit:0.0
+credit:60.0

==== Differences at index 1 ====
--- 

+++ 

@@ -1,2 +1,2 @@

-account_id:299
-debit:30.0
+account_id:300
+debit:60.0

==== Additional record ====
{'account_id': 301, 'credit': 90.0, 'debit': 0.0, 'product_id': 107}
 ```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
