### PR TITLE
[FIX] pos_self_order: error on adyen payment

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -49,13 +49,11 @@ export class PaymentPage extends Component {
     async startPayment() {
         this.selfOrder.paymentError = false;
         try {
-            const result = await rpc(`/kiosk/payment/${this.selfOrder.config.id}/kiosk`, {
+            await rpc(`/kiosk/payment/${this.selfOrder.config.id}/kiosk`, {
                 order: this.selfOrder.currentOrder.serialize({ orm: true }),
                 access_token: this.selfOrder.access_token,
                 payment_method_id: this.state.paymentMethodId,
             });
-            const order = result.order;
-            this.selfOrder.updateOrderFromServer(order);
         } catch (error) {
             this.selfOrder.handleErrorNotification(error);
             this.selfOrder.paymentError = true;

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -754,10 +754,6 @@ export class SelfOrder extends Reactive {
         this.router.navigate("default");
     }
 
-    updateOrderFromServer(order) {
-        this.currentOrder.updateDataFromServer(order);
-    }
-
     isOrder() {
         if (!this.currentOrder || !this.currentOrder.lines.length) {
             this.router.navigate("default");


### PR DESCRIPTION
Introduced in odoo/odoo#164793.

Steps to reproduce:
- Configure a POS to use self order
- Add an Adyen payment method to this POS
- Attempt to pay for a self order using the Adyen payment method
- The payment fails immediately with an error message, however the payment does go through to the payment terminal.

This bug was introduced by the refactor to use related models. The `start_payment` method in the payment page wasn't updated accordingly, leading to an error due to calling a non-existent function. All other payment terminals are unaffected as they override this method, but Adyen does not, so the bug was only affecting Adyen payments.

task-4749171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
