### PR TITLE
[FIX] account_3way_match: correct unpaid amount on dashboard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -719,6 +719,9 @@ class AccountJournal(models.Model):
             ('move_type', 'in', self.env['account.move'].get_invoice_types(include_receipts=True)),
         ])
 
+    def _get_to_pay_select(self):
+        return SQL("TRUE AS to_pay")
+
     def _get_open_sale_purchase_query(self, journal_type):
         assert journal_type in ('sale', 'purchase')
         query = self.env['account.move']._where_calc([
@@ -736,7 +739,7 @@ class AccountJournal(models.Model):
             SQL("SUM(amount_residual_signed) AS amount_total_company"),
             SQL("SUM((CASE WHEN move_type = 'in_invoice' THEN -1 ELSE 1 END) * amount_residual) AS amount_total"),
             SQL("COUNT(*)"),
-            SQL("TRUE AS to_pay")
+            self._get_to_pay_select(),
         ]
 
         return query, selects


### PR DESCRIPTION
Currently, the “Unpaid” and “Late” buttons in the sale journal dashboard used the total invoice amount instead of the remaining due amount when account_3way_match was installed.

Steps to reproduce:
- Install account_3way_match
- Create and partially pay an invoice
- Go to the dashboard
- The displayed amount should reflect the residual, but it shows the full amount

This fix restores the expected behavior by using the same logic as the original `_get_open_sale_purchase_query` to compute `amount_total` and `amount_total_company`.

opw-4731478