### PR TITLE
[FIX] hr_recruitment: prevent RecursionError when updating applicant in pool

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -677,7 +677,7 @@ class HrApplicant(models.Model):
         res = super().write(vals)
 
         for applicant in self:
-            if applicant.pool_applicant_id and (not applicant.is_pool_applicant):
+            if applicant.pool_applicant_id and applicant != applicant.pool_applicant_id and (not applicant.is_pool_applicant):
                 if 'email_from' in vals:
                     applicant.pool_applicant_id.email_from = vals['email_from']
                 if 'partner_phone' in vals:

--- a/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
+++ b/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
@@ -271,3 +271,19 @@ class TestRecruitmentTalentPool(TransactionCase):
             expected,
             "new_job_applicants, created through the wizard, should be linked to Job 2 and Job 3",
         )
+
+    def test_update_applicant_after_adding_to_pool(self):
+        """
+        Test that an applicant's fields (e.g., email) can still be updated after adding them to a talent pool.
+        """
+        self.env["talent.pool.add.applicants"].create({
+            "applicant_ids": self.t_applicant_1.ids,
+        }).action_add_applicants_to_pool()
+
+        new_email = "updated@gmail.com"
+        self.t_applicant_1.write({"email_from": new_email})
+        self.assertEqual(
+            self.t_applicant_1.email_from,
+            new_email,
+            "The email_from field should be updated successfully",
+        )


### PR DESCRIPTION
Currently, an error occurs when a user adds an applicant to the pool and then
modifies specific fields such as Email, Phone, LinkedIn Profile, or Degree.

**Steps to produce:**

- Install the `hr_recruitment` module.
- Open any applicant record.
- If not already added to a pool, click `Add to Pool`.
- Update any of the following fields: `Email`,`Phone`, `LinkedIn Profile`, or
 `Detail > Degree` and click Save.

**Error:**
`RecursionError: maximum recursion depth exceeded`

**Root Cause:**
At [1], the condition checks if `applicant.pool_applicant_id`exists and the
current record is not a pool applicant. However, if the record is its own pool
reference, it leads to recursive calls, causing a recursion overflow.

[1]
https://github.com/odoo/odoo/blob/7129ea7686dcc0327b4f56d1d29e752aba3448ee/addons/hr_recruitment/models/hr_applicant.py#L680

This commit ensures that the recursion check does not trigger when the applicant
is equal to its own `pool_applicant_id`, thus preventing an infinite loop.

sentry - 6557786828