### PR TITLE
[FIX] base: handled random types in ir.ui.view.type

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -478,6 +478,7 @@ actual arch.
 
     @api.model_create_multi
     def create(self, vals_list):
+        valid_types = self._fields['type']._selection
         for values in vals_list:
             if 'arch_db' in values and not values['arch_db']:
                 # delete empty arch_db to avoid triggering _check_xml before _inverse_arch_base is called
@@ -492,6 +493,13 @@ actual arch.
                         if not values.get('arch') and not values.get('arch_base'):
                             raise ValidationError(_('Missing view architecture.'))
                         values['type'] = etree.fromstring(values.get('arch') or values.get('arch_base')).tag
+                        if values['type'] not in valid_types:
+                            raise ValidationError(_(
+                                "Invalid view type: '%(view_type)s'.\n"
+                                "You might have used an invalid starting tag in the architecture.\n"
+                                "Allowed types are: %(valid_types)s",
+                                view_type=values['type'], valid_types=', '.join(valid_types)
+                            ))
                     except LxmlError:
                         # don't raise here, the constraint that runs `self._check_xml` will
                         # do the job properly.

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -1909,6 +1909,15 @@ class TestViews(ViewCase):
             '''Field "not_a_field" does not exist in model "ir.ui.view"''',
         )
 
+    def test_invalid_type(self):
+        """Ensure invalid root tag infers an invalid type and raises ValidationError"""
+        with self.assertRaises(ValidationError):
+            self.View.create({
+                'name': 'invalid_view',
+                'arch': '<template></template>',
+                'inherit_id': False,
+            })
+
     def test_context_in_view(self):
         arch = """
             <form string="View">


### PR DESCRIPTION
When a user tries to save a view with an invalid tag, an error occurs.

**Steps to produce:-**
1. Go to Settings > Technical > User Interface > Views.
2. Click on New.
3. Add the view name. In architecture -> add `<template></template>`.
4. Try to save the changes.

**Error:-**
`ValueError:Wrong value for ir.ui.view.type: 'template'`.

**Root cause:-**
- The view type in `ir.ui.view` is automatically inferred from the 
  `root tag` of the XML defined in the `arch` field.
- In this case, `<template>` becomes the inferred view type, 
  which is not part of the valid selections for the type field in the 
  model `ir.ui.view`.

**Solution:-**

 - Before calling `super().create(vals_list)`, add a validation check to ensure
  `values['type']` is in the allowed types. If not, raise a ValidationError.

sentry-6561028171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
