### PR TITLE
[Fix] sale_project: False Analytic distribution corner case fix.

### DIFF
--- a/addons/sale_project/models/account_move_line.py
+++ b/addons/sale_project/models/account_move_line.py
@@ -25,7 +25,7 @@ class AccountMoveLine(models.Model):
                     [(self.env['account.analytic.account'].browse(int(account_id)).root_plan_id._column_name(), "=", int(account_id))]
                     for account_id in key.split(",")
                 ])
-                for key in line.analytic_distribution
+                for key in line.analytic_distribution or []
             ])
             for line in self
         ])

--- a/addons/sale_project/tests/test_analytic_distribution.py
+++ b/addons/sale_project/tests/test_analytic_distribution.py
@@ -106,3 +106,34 @@ class TestAnalyticDistribution(HttpCase, TestSaleProjectCommon):
             1,
             "Analytic distribution is not set on the payable/receivable lines"
         )
+
+    def test_get_so_mapping_domain_with_no_analytic_distribution(self):
+        """
+        Ensure _get_so_mapping_domain doesnt fail when analytic_distribution is not set
+        """
+
+        account = self.env['account.account'].create({
+            'name': 'Receivable test account',
+            'code': '00001',
+            'account_type': 'asset_receivable',
+        })
+
+        move = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+        })
+
+        line = self.env['account.move.line'].create({
+            'move_id': move.id,
+            'name': 'Line without analytic',
+            'quantity': 1,
+            'price_unit': 100,
+            'account_id': account.id,
+        })
+        domain = line._get_so_mapping_domain()
+
+        self.assertEqual(
+            domain,
+            [(0, '=', 1)],
+            "Domain should be (0, '=', 1) when analytic_distribution is missing."
+        )


### PR DESCRIPTION
This fix solves a specific corner case where the analytic distribution could False by defaulting to an empty list.

To reproduce the issue:

- Enable analytic accounting.
- Create an expense paid by the company with a linked SO.
- Disable Analytic Accounting (also ensure the analytic distribution in the journal entry is False at this point)
- Try to reset the Expense or its journal entry back to draft.

This issue happens because the code assumes that the analytic distribution is always a list, which might not since analytic accounting is disabled.

opw-4710518