### PR TITLE
[FIX] website_sale{_collect}: pass default locations on address change

### DIFF
--- a/addons/website_sale_collect/controllers/delivery.py
+++ b/addons/website_sale_collect/controllers/delivery.py
@@ -41,3 +41,12 @@ class InStoreDelivery(Delivery):
             in_store_dm = request.website.sudo().in_store_dm_id
             order_sudo.set_delivery_line(in_store_dm, in_store_dm.product_id.list_price)
         order_sudo._set_pickup_location(pickup_location_data)
+
+    def _get_additional_delivery_context(self):
+        """ Override of `website_sale` to include the default pickup location data for in-store
+        delivery methods with a single warehouse. """
+        res = super()._get_additional_delivery_context()
+        order_sudo = request.cart
+        if request.website.sudo().in_store_dm_id:
+            res.update(order_sudo._prepare_in_store_default_location_data())
+        return res

--- a/addons/website_sale_collect/controllers/main.py
+++ b/addons/website_sale_collect/controllers/main.py
@@ -41,21 +41,7 @@ class WebsiteSaleCollect(WebsiteSale):
         location and set the pickup location when there is only one warehouse available. """
         res = super()._prepare_checkout_page_values(order_sudo, **query_params)
 
-        res['default_pickup_locations'] = {
-            in_store_dm.id: {
-                'pickup_location_data': (
-                    pickup_location_data := in_store_dm._in_store_get_close_locations(
-                        partner_address=order_sudo.partner_shipping_id,
-                    )[0]
-                ),
-                'unavailable_order_lines': order_sudo._get_unavailable_order_lines(
-                    pickup_location_data['id']
-                ),
-            }
-            for in_store_dm in order_sudo._get_delivery_methods().filtered(
-                lambda dm: dm.delivery_type == 'in_store' and len(dm.warehouse_ids) == 1
-            ) - order_sudo.carrier_id  # If Pickup is selected, assume location data is included.
-        }
+        res.update(order_sudo._prepare_in_store_default_location_data())
         if order_sudo.carrier_id.delivery_type == 'in_store' and order_sudo.pickup_location_data:
             res['unavailable_order_lines'] = order_sudo._get_unavailable_order_lines(
                 order_sudo.pickup_location_data.get('id')

--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -81,6 +81,27 @@ class SaleOrder(models.Model):
 
     # === TOOLING ===#
 
+    def _prepare_in_store_default_location_data(self):
+        """ Prepare the default pickup location values for each in-store delivery method available
+        for the order. """
+        default_pickup_locations = {}
+        for dm in self._get_delivery_methods():
+            if (
+                dm.delivery_type == 'in_store'
+                and dm.id != self.carrier_id.id
+                and len(dm.warehouse_ids) == 1
+            ):
+                pickup_location_data = dm.warehouse_ids[0]._prepare_pickup_location_data()
+                if pickup_location_data:
+                    default_pickup_locations[dm.id] = {
+                        'pickup_location_data': pickup_location_data,
+                        'unavailable_order_lines': self._get_unavailable_order_lines(
+                            pickup_location_data['id']
+                        ),
+                    }
+
+        return {'default_pickup_locations': default_pickup_locations}
+
     def _is_in_stock(self, wh_id):
         """ Check whether all storable products of the cart are in stock in the given warehouse.
 


### PR DESCRIPTION
a37614a9c56c493494e5ed00db1434b97dd2957d default pick-up locations were added for the in-store dms with only 1 wh.

Steps to reproduce:
1) Configure in-store dm and publish
2) Go to checkout
3) Change addresses
4) Observe a traceback

Reason:
When a delivery address is changed, the delivery template is rerendered and shop_delivery_methods is called but default locations are not passed
