### PR TITLE
[IMP] web: Improve list view handle behavior and sorting UX

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -180,7 +180,11 @@ export class DynamicList extends DataPoint {
         return this.model.mutex.exec(() => {
             let orderBy = [...this.orderBy];
             if (orderBy.length && orderBy[0].name === fieldName) {
-                orderBy[0] = { name: orderBy[0].name, asc: !orderBy[0].asc };
+                if (orderBy[0].asc) {
+                    orderBy[0] = { name: orderBy[0].name, asc: false };
+                } else {
+                    orderBy = [];
+                }
             } else {
                 orderBy = orderBy.filter((o) => o.name !== fieldName);
                 orderBy.unshift({

--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -1009,7 +1009,11 @@ export class StaticList extends DataPoint {
         if (fieldName) {
             if (orderBy.length && orderBy[0].name === fieldName) {
                 if (!this._needsReordering) {
-                    orderBy[0] = { name: orderBy[0].name, asc: !orderBy[0].asc };
+                    if (orderBy[0].asc) {
+                        orderBy[0] = { name: orderBy[0].name, asc: false };
+                    } else {
+                        orderBy = [];
+                    }
                 }
             } else {
                 orderBy = orderBy.filter((o) => o.name !== fieldName);

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -341,7 +341,8 @@ export class ListRenderer extends Component {
             readonly:
                 this.props.readonly ||
                 this.isCellReadonly(column, record) ||
-                this.isRecordReadonly(record),
+                this.isRecordReadonly(record) ||
+                (column.widget === "handle" && !this.canResequenceRows),
         };
     }
 

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10087,6 +10087,7 @@ test(`editable target, handle widget locks and unlocks on sort`, async () => {
             </list>
         `,
     });
+    expect(`.o_row_handle.o_disabled`).toHaveCount(0);
     expect(queryAllTexts(`tbody div[name=amount]`)).toEqual(
         ["1,200.00", "500.00", "300.00", "0.00"],
         {
@@ -10112,6 +10113,9 @@ test(`editable target, handle widget locks and unlocks on sort`, async () => {
             message: "should have been sorted by amount",
         }
     );
+    expect(`.o_row_handle.o_disabled`).toHaveCount(4, {
+        message: "handle fields should now be readonly and therefore disabled",
+    });
 
     // Drag and drop the fourth line in second position (not)
     await contains(`tbody tr:eq(3) .o_row_handle`).dragAndDrop(`tbody tr:eq(1)`);
@@ -10130,6 +10134,7 @@ test(`editable target, handle widget locks and unlocks on sort`, async () => {
             message: "records should be ordered as per the previous resequence",
         }
     );
+    expect(`.o_row_handle.o_disabled`).toHaveCount(0);
 
     // Drag and drop the fourth line in second position
     await contains(`tbody tr:eq(3) .o_row_handle`).dragAndDrop(`tbody tr:eq(1)`);

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -6371,15 +6371,24 @@ test(`can sort records when clicking on header`, async () => {
         arch: `<list><field name="foo"/><field name="bar"/></list>`,
     });
     expect.verifySteps(["web_search_read"]);
+    expect(`.o_column_sortable.table-active`).toHaveCount(0);
     expect(queryAllTexts(`.o_data_cell.o_list_char`)).toEqual(["yop", "blip", "gnap", "blip"]);
 
     await contains(`thead th:contains(Foo)`).click();
+    expect(`.o_column_sortable.table-active`).toHaveCount(1);
     expect.verifySteps(["web_search_read"]);
     expect(queryAllTexts(`.o_data_cell.o_list_char`)).toEqual(["blip", "blip", "gnap", "yop"]);
 
     await contains(`thead th:contains(Foo)`).click();
+    expect(`.o_column_sortable.table-active`).toHaveCount(1);
     expect.verifySteps(["web_search_read"]);
     expect(queryAllTexts(`.o_data_cell.o_list_char`)).toEqual(["yop", "gnap", "blip", "blip"]);
+
+    // Clicking on a header with a descending order resets the sort to the default from server
+    await contains(`thead th:contains(Foo)`).click();
+    expect(`.o_column_sortable.table-active`).toHaveCount(0);
+    expect.verifySteps(["web_search_read"]);
+    expect(queryAllTexts(`.o_data_cell.o_list_char`)).toEqual(["yop", "blip", "gnap", "blip"]);
 });
 
 test(`do not sort records when clicking on header with nolabel`, async () => {


### PR DESCRIPTION
This PR brings two usability improvements to the list view:

1. **Removable orderBy from column headers**: Clicking on a column header that is already sorted in descending order will now clear all applied sorting instead of reverting to ascending order. This gives users a quick way to reset sorting and return to the default record order.

2. **Readonly visual for locked handle fields**: When handle fields are present but resequencing is disabled (e.g., due to a different orderBy being active), the handles are now displayed in a readonly state. This provides clear visual feedback that reordering is not currently allowed.

Part of task-4613142
