### PR TITLE
[FIX] website: edit theme with google 300 size only font


### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -158,7 +158,7 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
 
         const fontsToLoad = [];
         for (const font of this.googleFonts) {
-            const fontURL = `https://fonts.googleapis.com/css?family=${encodeURIComponent(font).replace(/%20/g, '+')}`;
+            const fontURL = `https://fonts.googleapis.com/css?family=${encodeURIComponent(font).replace(/%20/g, '+')}:300,300i,400,400i,700,700i`;
             fontsToLoad.push(fontURL);
         }
         for (const font of this.googleLocalFonts) {


### PR DESCRIPTION

Scenario:
- edit the website theme and change a font to external font Buda
- save and go back to edition and theme tab

Result:
Infinite spinning when loading the theme tab, and we see an
error of AssetsLoadingError as well as an error 400 in console when
loading https://fonts.googleapis.com/css?family=Buda URL.

Issue:
Buda font only has a 300 size, but when loading for the
FontFamilyPickerUserValueWidget, we don't specify sizes so google fonts
returns an error because there os no 400 size version of the font.

This is not an issue when adding the font because we use 300 up to 700:
d0ba6c26e64e711e21b191bdba0ede14abc6afb9

This is also not an issue for self-hosted google font because we load it
with the same parameters: 5145d84dc02d8068a5feaac769f5d83cefc65804

opw-4657897 opw-4497707 opw-4338034 opw-3236787 opw-3584322 opw-3306789
