### PR TITLE
[FIX] hw_drivers: double IoT Box when Ethernet and Wi-Fi

### DIFF
--- a/addons/hw_drivers/event_manager.py
+++ b/addons/hw_drivers/event_manager.py
@@ -56,7 +56,7 @@ class EventManager(object):
             # Notify via websocket
             send_to_controller({
                 'session_id': data.get('action_args', {}).get('session_id', ''),
-                'iot_box_identifier': helpers.get_mac_address(),
+                'iot_box_identifier': helpers.get_identifier(),
                 'device_identifier': device.device_identifier,
                 **data,
             })

--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -88,7 +88,7 @@ class DisplayDriver(Driver):
         :return: URL to display or None.
         """
         try:
-            response = requests.get(f"{server_url}/iot/box/{helpers.get_mac_address()}/display_url", timeout=5)
+            response = requests.get(f"{server_url}/iot/box/{helpers.get_identifier()}/display_url", timeout=5)
             response.raise_for_status()
             data = json.loads(response.content.decode())
             return data.get(self.device_identifier)

--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_L.py
@@ -127,7 +127,7 @@ class PrinterDriver(PrinterDriverBase):
 
     @classmethod
     def _get_iot_status(cls):
-        mac = helpers.get_mac_address()
+        identifier = helpers.get_identifier()
         pairing_code = connection_manager.pairing_code
         ssid = wifi.get_access_point_ssid() if wifi.is_access_point() else wifi.get_current()
 
@@ -139,7 +139,7 @@ class PrinterDriver(PrinterDriverBase):
                 if 'addr' in conf and conf['addr'] not in ['127.0.0.1', '10.11.12.1']:
                     ips.append(conf['addr'])
 
-        return { "mac": mac, "pairing_code": pairing_code, "ssid": ssid, "ips": ips }
+        return {"identifier": identifier, "pairing_code": pairing_code, "ssid": ssid, "ips": ips}
 
     def print_status(self, data=None):
         """Prints the status ticket of the IoT Box on the current printer.
@@ -179,8 +179,8 @@ class PrinterDriver(PrinterDriverBase):
         if iot_status["ssid"]:
             command += f"^FT35,{p} ^A0N,25 ^FDWi-Fi: {iot_status['ssid']}^FS"
             p += 35
-        if iot_status["mac"]:
-            command += f"^FT35,{p} ^A0N,25 ^FDMAC: {iot_status['mac']}^FS"
+        if iot_status["identifier"]:
+            command += f"^FT35,{p} ^A0N,25 ^FDIdentifier: {iot_status['identifier']}^FS"
             p += 35
         if iot_status["ips"]:
             command += f"^FT35,{p} ^A0N,25 ^FDIP: {', '.join(iot_status['ips'])}^FS"
@@ -196,7 +196,7 @@ class PrinterDriver(PrinterDriverBase):
         :rtype: tuple of bytes
         """
 
-        wlan = mac = homepage = pairing_code = ""
+        wlan = identifier = homepage = pairing_code = ""
         iot_status = self._get_iot_status()
 
         if iot_status["pairing_code"]:
@@ -221,11 +221,11 @@ class PrinterDriver(PrinterDriverBase):
             ip = '\nIoT Box IP Addresses:\n%s\n' % '\n'.join(ips)
 
         if len(ips) >= 1:
-            mac = '\nMAC Address:\n%s\n' % iot_status["mac"]
+            identifier = '\nIdentifier:\n%s\n' % iot_status["identifier"]
             homepage = '\nIoT Box Homepage:\nhttp://%s:8069\n\n' % ips[0]
 
         title = b'IoT Box Connected' if helpers.get_odoo_server_url() else b'IoT Box Status'
-        body = pairing_code + wlan + mac + ip + homepage
+        body = pairing_code + wlan + identifier + ip + homepage
 
         return title, body.encode()
 

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -39,7 +39,7 @@ class Manager(Thread):
             domain = helpers.get_ip()
         iot_box = {
             'name': helpers.get_hostname(),
-            'identifier': helpers.get_mac_address(),
+            'identifier': helpers.get_identifier(),
             'ip': domain,
             'token': helpers.get_token(),
             'version': helpers.get_version(detailed_version=True),

--- a/addons/hw_drivers/server_logger.py
+++ b/addons/hw_drivers/server_logger.py
@@ -69,7 +69,7 @@ class AsyncHTTPHandler(logging.Handler):
             return convert_to_byte(f"{log_level},{line_formatted}")
 
         def empty_queue():
-            yield convert_to_byte(f"mac {helpers.get_mac_address()}")
+            yield convert_to_byte(f"identifier {helpers.get_identifier()}")
             for _ in range(self._MAX_BATCH_SIZE):
                 # Use a limit to avoid having too heavy requests & infinite loop of the queue receiving new entries
                 try:

--- a/addons/hw_drivers/tools/certificate.py
+++ b/addons/hw_drivers/tools/certificate.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from odoo.addons.hw_drivers.tools.helpers import (
     get_conf,
-    get_mac_address,
+    get_identifier,
     get_path_nginx,
     odoo_restart,
     require_db,
@@ -123,7 +123,7 @@ def inform_database(ssl_certificate_end_date, server_url=None):
     try:
         response = requests.post(
             server_url + "/iot/box/update_certificate_status",
-            json={'params': {'iot_mac': get_mac_address(), 'ssl_certificate_end_date': ssl_certificate_end_date}},
+            json={'params': {'identifier': get_identifier(), 'ssl_certificate_end_date': ssl_certificate_end_date}},
             timeout=5,
         )
         response.raise_for_status()

--- a/addons/hw_drivers/tools/wifi.py
+++ b/addons/hw_drivers/tools/wifi.py
@@ -12,7 +12,7 @@ import time
 from pathlib import Path
 from functools import cache
 
-from .helpers import get_ip, get_mac_address, writable, get_conf
+from .helpers import get_ip, get_identifier, writable, get_conf
 
 _logger = logging.getLogger(__name__)
 
@@ -211,14 +211,13 @@ def _validate_configuration(ssid):
 @cache
 def get_access_point_ssid():
     """Generate a unique SSID for the access point.
-    Uses the MAC address of the device without the colons, or
-    a random token if mac was not found.
+    Uses the identifier of the device or a random token if the
+    identifier was not found.
 
     :return: Generated SSID
     :rtype: str
     """
-    mac = get_mac_address()
-    return "IoTBox-" + (''.join(mac.split(':')) if mac else secrets.token_hex(6))
+    return "IoTBox-" + get_identifier() or secrets.token_hex(8)
 
 
 def _configure_access_point(on=True):

--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -165,7 +165,7 @@ class IotBoxOwlHomePage(http.Controller):
             'enterprise_code': helpers.get_conf('enterprise_code'),
             'hostname': helpers.get_hostname(),
             'ip': helpers.get_ip(),
-            'mac': helpers.get_mac_address(),
+            'identifier': helpers.get_identifier(),
             'devices': grouped_devices,
             'server_status': odoo_server_url,
             'pairing_code': connection_manager.pairing_code,

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -148,7 +148,7 @@ export class Homepage extends Component {
                 </t>
             </SingleData>
             <SingleData t-if="store.advanced" name="'IP address'" value="state.data.ip" icon="'fa-globe'" />
-            <SingleData t-if="store.advanced" name="'MAC address'" value="state.data.mac.toUpperCase()" icon="'fa-address-card'" />
+            <SingleData t-if="store.advanced" name="'Identifier'" value="state.data.identifier" icon="'fa-address-card'" />
             <SingleData t-if="store.isLinux" name="'Internet Status'" value="networkStatus" icon="'fa-wifi'">
                 <t t-set-slot="button">
                     <WifiDialog />


### PR DESCRIPTION
IoT Boxes have both Ethernet and Wi-Fi interfaces, each with a unique MAC address. When connected via Ethernet, the database registers the Ethernet MAC.

If the Ethernet cable is later unplugged and the device switches to Wi-Fi, the database treats it as a new device due to the different MAC address, resulting in duplicate records for the same physical device.

This commit changes the identifier from the MAC address, to:
- the motherboard uuid on windows,
- the serial number on rpi.

Enterprise PR: [https://github.com/odoo/enterprise/pull/84259](https://github.com/odoo/enterprise/pull/84259)
Task: 4592611
