### PR TITLE
[FIX] pos_sale: ignore payment term discount

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -4,7 +4,6 @@
 from odoo import api, fields, models, _
 from odoo.tools import float_compare, float_is_zero
 
-
 class PosOrder(models.Model):
     _inherit = 'pos.order'
 
@@ -38,7 +37,9 @@ class PosOrder(models.Model):
             else:
                 addr = self.partner_id.address_get(['delivery'])
                 invoice_vals['partner_shipping_id'] = addr['delivery']
-            if sale_orders[0].payment_term_id:
+            if sale_orders[0].payment_term_id and not sale_orders[0].payment_term_id.early_discount:
+                invoice_vals['invoice_payment_term_id'] = sale_orders[0].payment_term_id.id
+            else:
                 invoice_vals['invoice_payment_term_id'] = False
             if sale_orders[0].partner_invoice_id != sale_orders[0].partner_id:
                 invoice_vals['partner_id'] = sale_orders[0].partner_invoice_id.id

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1150,3 +1150,79 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         self.assertEqual(sale_order.amount_to_invoice, 100.0, "Amount to invoice should be 100.0")
         self.env['pos.order'].create_from_ui([{"data": order_data}])
         self.assertEqual(sale_order.amount_to_invoice, 0.0, "Amount to invoice should be 0.0")
+
+    def test_payment_terms_with_early_discount(self):
+        """Make sure that orders invoiced in the pos do not use payment terms with early discount"""
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 10.0,
+            'taxes_id': [],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        payment_terms = self.env['account.payment.term'].create({
+            'name': "Test Payment Term",
+            'early_discount': True,
+            'line_ids': [(0, 0, {
+                'value': 'percent',
+                'value_amount': 100,
+                'nb_days': 45,
+            })]
+        })
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'payment_term_id': payment_terms.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.open_ui()
+        current_session = self.main_pos_config.current_session_id
+
+        pos_order = {'data':
+          {'amount_paid': 10,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 10,
+           'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': partner_test.id,
+           'pricelist_id': self.main_pos_config.available_pricelist_ids[0].id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 10,
+              'product_id': product_a.id,
+              'price_subtotal': 10,
+              'price_subtotal_incl': 10,
+              'sale_order_line_id': sale_order.order_line[0],
+              'sale_order_origin_id': sale_order,
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0014',
+           'pos_session_id': current_session.id,
+           'sequence_number': self.main_pos_config.journal_id.id,
+           'statement_ids': [[0,
+             0,
+             {'amount': 10,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
+           'uid': '00044-003-0014',
+           'user_id': self.env.uid},
+            }
+
+        pos_order_id = self.env['pos.order'].create_from_ui([pos_order])[0]['id']
+        pos_order = self.env['pos.order'].browse(pos_order_id)
+        self.assertFalse(pos_order.account_move.invoice_payment_term_id)


### PR DESCRIPTION
When you settle a sale order that has a payment term, it was always
ignored in the PoS. But it should only be ignored when the payment term
has an early discount.

Steps to reproduce:
-------------------
* Create a sale order with a payment term that has no early discount
* Go to the PoS and settle the sale order
* Invoice and validate the order
> Observation: In the backend, the sale order has the payment term
  applied on the invoice

Why the fix:
------------
Some modules needs the invoice to have payment terms set
(l10n_mx for example). But the PoS invoice was always ignoring it. We
should only ignore it if the payment terms has an early discount.

opw-4670234