### PR TITLE
[FIX] mail: Allow users to send messages on landscape mobile

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -11,7 +11,7 @@ import { prettifyMessageContent } from "@mail/utils/common/format";
 import { useSelection } from "@mail/utils/common/hooks";
 import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
-import { isMobileOS } from "@web/core/browser/feature_detection";
+import { isMobileOS, hasTouch } from "@web/core/browser/feature_detection";
 
 import {
     Component,
@@ -122,6 +122,7 @@ export class Composer extends Component {
         this.suggestion = this.store.user ? useSuggestion() : undefined;
         this.markEventHandled = markEventHandled;
         this.isMobileOS = isMobileOS;
+        this.hasTouch = hasTouch;
         this.onDropFile = this.onDropFile.bind(this);
         if (this.props.dropzoneRef) {
             useDropzone(

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -106,14 +106,14 @@
 </t>
 
 <t t-name="mail.Composer.sendButton">
-    <button t-if="!compact or ui.isSmall" class="o-mail-Composer-send btn o-last"
-        t-att-class="{'btn-primary': extended or (ui.isSmall and !isSendButtonDisabled), 'rounded-0 rounded-end-3': !extended and !compact, 'btn-link': !extended and !(ui.isSmall and !isSendButtonDisabled), 'align-self-stretch': !extended, 'border-start-0 ms-2 me-3': env.inDiscussApp}"
+    <button t-if="!compact or hasTouch()" class="o-mail-Composer-send btn o-last"
+        t-att-class="{'btn-primary': extended or (hasTouch() and !isSendButtonDisabled), 'rounded-0 rounded-end-3': !extended and !compact, 'btn-link': !extended and !(hasTouch() and !isSendButtonDisabled), 'align-self-stretch': !extended, 'border-start-0 ms-2 me-3': env.inDiscussApp}"
         t-on-click="sendMessage"
         t-att-disabled="isSendButtonDisabled"
         t-att-aria-label="SEND_TEXT"
     >
         <t t-if="thread and thread.type === 'chatter'" t-out="SEND_TEXT"/>
-        <t t-elif="ui.isSmall"><i class="fa fa-paper-plane-o"/></t>
+        <t t-elif="hasTouch()"><i class="fa fa-paper-plane-o"/></t>
         <t t-else="">Send</t>
     </button>
 </t>

--- a/addons/mail/static/tests/composer/composer_tests.js
+++ b/addons/mail/static/tests/composer/composer_tests.js
@@ -4,7 +4,6 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { Composer } from "@mail/core/common/composer";
 import { Command } from "@mail/../tests/helpers/command";
-import { patchUiSize, SIZES } from "@mail/../tests/helpers/patch_ui_size";
 import { start } from "@mail/../tests/helpers/test_utils";
 
 import {
@@ -280,18 +279,6 @@ QUnit.test('send button on discuss.channel should have "Send" as label', async (
     const { openDiscuss } = await start();
     openDiscuss(channelId);
     await contains(".o-mail-Composer-send:disabled", { text: "Send" });
-});
-
-QUnit.test("Show send button in mobile", async () => {
-    const pyEnv = await startServer();
-    patchUiSize({ size: SIZES.SM });
-    pyEnv["discuss.channel"].create({ name: "minecraft-wii-u" });
-    const { openDiscuss } = await start();
-    openDiscuss();
-    await click("button", { text: "Channel" });
-    await click(".o-mail-NotificationItem", { text: "minecraft-wii-u" });
-    await contains(".o-mail-Composer button[aria-label='Send']");
-    await contains(".o-mail-Composer button[aria-label='Send'] i.fa-paper-plane-o");
 });
 
 QUnit.test(

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -70,38 +70,6 @@ QUnit.test("Editing message keeps the mentioned channels", async () => {
     await contains(".o-mail-Discuss-threadName", { value: "other" });
 });
 
-QUnit.test("Edit message (mobile)", async () => {
-    patchUiSize({ size: SIZES.SM });
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({
-        name: "general",
-        channel_type: "channel",
-    });
-    pyEnv["mail.message"].create({
-        author_id: pyEnv.currentPartnerId,
-        body: "Hello world",
-        model: "discuss.channel",
-        res_id: channelId,
-        message_type: "comment",
-    });
-    const { openDiscuss } = await start();
-    await openDiscuss();
-    await click("button", { text: "Channel" });
-    await click("button", { text: "general" });
-    await contains(".o-mail-Message");
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message [title='Edit']");
-    await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
-    await click("button", { text: "Discard editing" });
-    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
-    await contains(".o-mail-Message-content", { text: "Hello world" });
-    await click(".o-mail-Message [title='Expand']");
-    await click(".o-mail-Message [title='Edit']");
-    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
-    await click(".o-mail-Message .fa-paper-plane-o");
-    await contains(".o-mail-Message-content", { text: "edited message" });
-});
-
 QUnit.test("Can edit message comment in chatter", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "TestPartner" });

--- a/addons/mail/static/tests/mobile/mobile_tests.js
+++ b/addons/mail/static/tests/mobile/mobile_tests.js
@@ -2,10 +2,11 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { patchUiSize } from "@mail/../tests/helpers/patch_ui_size";
+import { patchUiSize, SIZES } from "@mail/../tests/helpers/patch_ui_size";
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { click, contains } from "@web/../tests/utils";
+import { click, contains, insertText } from "@web/../tests/utils";
+import { nextTick } from "@web/../tests/helpers/utils";
 
 QUnit.module("mobile");
 
@@ -21,4 +22,50 @@ QUnit.test("auto-select 'Inbox' when discuss had channel as active thread", asyn
     await click("button", { text: "Mailboxes" });
     await contains(".o-mail-MessagingMenu-tab.text-primary.fw-bolder", { text: "Mailboxes" });
     await contains("button.active", { text: "Inbox" });
+});
+
+QUnit.test("Show send button in mobile", async () => {
+    const pyEnv = await startServer();
+    patchUiSize({ size: SIZES.SM });
+    pyEnv["discuss.channel"].create({ name: "minecraft-wii-u" });
+    const { openDiscuss } = await start();
+    openDiscuss();
+    await click("button", { text: "Channel" });
+    await click(".o-mail-NotificationItem", { text: "minecraft-wii-u" });
+    await nextTick();
+    await contains(".o-mail-Composer button[aria-label='Send']");
+    await contains(".o-mail-Composer button[aria-label='Send'] i.fa-paper-plane-o");
+});
+
+QUnit.test("Edit message (mobile)", async () => {
+    patchUiSize({ size: SIZES.SM });
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        name: "general",
+        channel_type: "channel",
+    });
+    pyEnv["mail.message"].create({
+        author_id: pyEnv.currentPartnerId,
+        body: "Hello world",
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "comment",
+    });
+    const { openDiscuss } = await start();
+    await openDiscuss();
+    await click("button", { text: "Channel" });
+    await click("button", { text: "general" });
+    await contains(".o-mail-Message");
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message [title='Edit']");
+    await contains(".o-mail-Message-editable .o-mail-Composer-input", { value: "Hello world" });
+    await click("button", { text: "Discard editing" });
+    await contains(".o-mail-Message-editable .o-mail-Composer", { count: 0 });
+    await contains(".o-mail-Message-content", { text: "Hello world" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message [title='Edit']");
+    await insertText(".o-mail-Message .o-mail-Composer-input", "edited message", { replace: true });
+    await nextTick();
+    await click(".o-mail-Message .fa-paper-plane-o");
+    await contains(".o-mail-Message-content", { text: "edited message" });
 });


### PR DESCRIPTION
Steps:
- Open chat messages on mobile landscape
- Write a message
- You can't send it because there are no Send button and enter button
is assigned for newlines

To fix this, this commit uses `hasTouch` instead of `isSmall` to add a
send button or not.

If a device has touch, it doesn't have a keyboard, so it needs a button.

opw-4710421