### PR TITLE
[FIX] account: move report name should match report

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6381,12 +6381,13 @@ class AccountMove(models.Model):
         elif allow_fallback:
             return [self._get_invoice_pdf_proforma()]
 
-    def _get_invoice_report_filename(self, extension='pdf'):
+    def _get_invoice_report_filename(self, extension='pdf', report=None):
         """ Get the filename of the generated invoice report with extension file. """
         self.ensure_one()
-        report_id = self.partner_id.invoice_template_pdf_report_id or self.env.ref('account.account_invoices')
-        if report_id.print_report_name and isinstance(report_id.print_report_name, str):
-            file_name = safe_eval(report_id.print_report_name, {'object': self})
+        if not report:
+            report = self.partner_id.invoice_template_pdf_report_id or self.env.ref('account.account_invoices')
+        if report.print_report_name and isinstance(report.print_report_name, str):
+            file_name = safe_eval(report.print_report_name, {'object': self})
         else:
             file_name = self.name
         return f"{file_name.replace('/', '_')}.{extension}"

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -221,7 +221,7 @@ class AccountMoveSendWizard(models.TransientModel):
             if wizard.template_id:
                 wizard.body = self._get_default_mail_body(wizard.move_id, wizard.template_id, wizard.lang)
 
-    @api.depends('template_id', 'invoice_edi_format', 'extra_edis')
+    @api.depends('template_id', 'invoice_edi_format', 'extra_edis', 'pdf_report_id')
     def _compute_mail_attachments_widget(self):
         for wizard in self:
             manual_attachments_data = [x for x in wizard.mail_attachments_widget or [] if x.get('manual')]

--- a/addons/account_edi_ubl_cii/models/account_move_send.py
+++ b/addons/account_edi_ubl_cii/models/account_move_send.py
@@ -55,9 +55,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.ubl_cii_xml_id
 
-    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None, pdf_report=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis, pdf_report=pdf_report)
         if move._need_ubl_cii_xml(invoice_edi_format):
             builder = move.partner_id.commercial_partner_id._get_edi_builder(invoice_edi_format)
             filename = builder._export_invoice_filename(move)

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -49,9 +49,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_es_edi_facturae_xml_id
 
-    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None, pdf_report=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis, pdf_report=pdf_report)
 
         if (
             ('es_facturae' in extra_edis or invoice_edi_format == 'es_facturae')

--- a/addons/l10n_es_edi_tbai/models/account_move_send.py
+++ b/addons/l10n_es_edi_tbai/models/account_move_send.py
@@ -22,9 +22,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id.xml_attachment_id
 
-    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None, pdf_report=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis, pdf_report=pdf_report)
 
         if (
             not move.l10n_es_tbai_post_document_id.xml_attachment_id

--- a/addons/l10n_jo_edi/models/account_move_send.py
+++ b/addons/l10n_jo_edi/models/account_move_send.py
@@ -45,9 +45,9 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(move) + move.l10n_jo_edi_xml_attachment_id
 
-    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None, pdf_report=None):
         # EXTENDS 'account'
-        res = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        res = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis, pdf_report=pdf_report)
 
         if not move.l10n_jo_edi_xml_attachment_id and 'jo_edi' in extra_edis:
             attachment_name = move._l10n_jo_edi_get_xml_attachment_name()

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -284,10 +284,10 @@ class AccountMove(models.Model):
             return self.with_context(l10n_sa_file_format=False).env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(self)
         return super()._get_report_base_filename()
 
-    def _get_invoice_report_filename(self, extension='pdf'):
+    def _get_invoice_report_filename(self, extension='pdf', report=None):
         if self._is_l10n_sa_eligibile_invoice():
             return self.with_context(l10n_sa_file_format=extension).env['account.edi.xml.ubl_21.zatca']._export_invoice_filename(self)
-        return super()._get_invoice_report_filename(extension)
+        return super()._get_invoice_report_filename(extension, report)
 
     def _l10n_sa_is_in_chain(self):
         """

--- a/addons/l10n_vn_edi_viettel/models/account_move_send.py
+++ b/addons/l10n_vn_edi_viettel/models/account_move_send.py
@@ -34,9 +34,9 @@ class AccountMoveSend(models.AbstractModel):
             + move.l10n_vn_edi_sinvoice_pdf_file_id
         )
 
-    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
+    def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None, pdf_report=None):
         # EXTENDS 'account'
-        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
+        results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis, pdf_report=pdf_report)
         if invoice_edi_format == 'vn_sinvoice' and move._l10n_vn_edi_get_credentials_company():
             results.extend([{
                 'id': 'placeholder_sinvoice.pdf',


### PR DESCRIPTION
Default pdf report name should match the "print report name" set on the action report

Task 4646733