### PR TITLE
[FIX] pos_self_order: fixed slideshow not working in QR menu ordering mode

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -250,10 +250,6 @@ class PosConfig(models.Model):
                 'id': image.id,
                 'data': image.sudo().datas.decode('utf-8'),
             })
-
-            # Only one image is needed for the mobile mode
-            if self.self_ordering_mode == 'mobile':
-                break
         return encoded_images
 
     def _load_self_data_models(self):

--- a/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_common_tour.js
@@ -21,6 +21,10 @@ registry.category("web_tour.tours").add("self_order_is_open_consultation", {
     ],
 });
 
+registry.category("web_tour.tours").add("self_order_landing_page_carousel", {
+    steps: () => [Utils.checkIsNoBtn("My Order"), LandingPage.checkCarouselAutoPlaying()],
+});
+
 registry.category("web_tour.tours").add("self_order_pos_closed", {
     steps: () => [
         LandingPage.isClosed(),

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -1,3 +1,5 @@
+import { delay } from "@odoo/hoot-dom";
+
 export function selectLocation(locationName) {
     return {
         content: `Click on location '${locationName}'`,
@@ -31,5 +33,23 @@ export function checkCountryFlagShown(country_code) {
     return {
         content: `Check what the current flag is`,
         trigger: `.self_order_language_selector > img[src*=${country_code}]`,
+    };
+}
+
+export function checkCarouselAutoPlaying() {
+    return {
+        content: `Check that the slideshow is working`,
+        trigger: `.carousel-item.active`,
+        timeout: 5600,
+        async run() {
+            const firstSlideHtml = document.querySelector(".carousel-item.active")?.outerHTML;
+            await delay(5000);
+            const currentSlideHtml = document.querySelector(".carousel-item.active")?.outerHTML;
+            if (firstSlideHtml === currentSlideHtml) {
+                throw new Error(
+                    "Slideshow is not working. Slide should change in all self ordering mode."
+                );
+            }
+        },
     };
 }

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -36,6 +36,11 @@ class TestSelfOrderCommon(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self.start_tour(self_route, "self_order_is_open_consultation")
 
+    def test_self_order_pos_landing_page_carousel(self):
+        for mode in ("mobile", "consultation", "kiosk"):
+            self.pos_config.write({"self_ordering_mode": mode})
+            self.start_tour(self.pos_config._get_self_order_route(), "self_order_landing_page_carousel")
+
     def test_self_order_pos_closed(self):
         """
         Verify than when the pos is closed and self ordering is set to mobile, consultation or kiosk,


### PR DESCRIPTION
Steps to reproduce:
----
- Install pos_self_order
- Configuration > Settings > Under Mobile self-order & Kiosk
- Select Self Ordering Mode as QR menu + Ordering and save changes
- Click Preview Web Interface

Issue:
----
- Slideshow is not working in QR menu + Ordering mode.

Cause:
----
- It was intentionally bypassed for the QR menu + Ordering mode.

Fix:
----
- Removed unnecessary code which caused the issue.

---
task-4745666