### PR TITLE
[IMP] event: enhance multi slots ux and mail templates

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -63,16 +63,33 @@
                             <strong t-out="object.event_id.name or ''">OpenWood Collection Online Reveal</strong>.
                         </t>
                     </div>
-                    <div>
-                        <br />
-                        <strong>Add this event to your calendar</strong>
-                        <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
-                            <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
-                        </a>
-                        <br /><br />
-                    </div>
+                    <br/>
+                    <table style="width: auto;">
+                        <tr>
+                            <td>
+                                <strong>Add this event to your calendar</strong>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/apple-calendar.svg" alt="iCal" title="iCal" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" title="Outlook" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" target="new"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/google-calendar.svg" alt="Google" title="Google" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                    <br/><br/>
                     <div>
                         See you soon,<br/>
                         <span style="color: #454748;">
@@ -333,16 +350,33 @@
                             <t t-out="object.sale_order_line_id.price_unit" t-options="{'widget': 'monetary', 'display_currency': object.sale_order_line_id.currency_id}"/>
                         </t>.
                     </div>
-                    <div>
-                        <br />
-                        <strong>Add this event to your calendar</strong>
-                        <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; ;color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
-                            <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
-                        </a>
-                        <br /><br />
-                    </div>
+                    <br/>
+                    <table style="width: auto;">
+                        <tr>
+                            <td>
+                                <strong>Add this event to your calendar</strong>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/apple-calendar.svg" alt="iCal" title="iCal" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" title="Outlook" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" target="new"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/google-calendar.svg" alt="Google" title="Google" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                    <br/><br/>
                     <div>
                         See you soon,<br/>
                         <span style="color: #454748;">
@@ -590,16 +624,33 @@
                         </t>
                         is starting <strong t-out="object.event_date_range or ''">today</strong>.
                     </div>
-                    <div>
-                        <br />
-                        <strong>Add this event to your calendar</strong>
-                        <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Google</a>
-                        <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}" t-attf-style="padding:3px 5px; color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;"><img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> iCal/Outlook</a>
-                        <a t-attf-href="https://calendar.yahoo.com/?v=60&amp;view=d&amp;type=20&amp;title={{ object.event_id.name }}&amp;in_loc={{ location }}&amp;st={{ format_datetime(object.event_begin_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}&amp;et={{ format_datetime(object.event_end_date, tz='UTC', dt_format='yyyyMMdd\'T\'HHmmss') }}" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
-                            <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
-                        </a>
-                        <br /><br />
-                    </div>
+                    <br/>
+                    <table style="width: auto;">
+                        <tr>
+                            <td>
+                                <strong>Add this event to your calendar</strong>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/apple-calendar.svg" alt="iCal" title="iCal" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="/event/{{ slug(object.event_id) }}/ics?slot_id={{ object.event_slot_id.id }}"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" title="Outlook" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                            <td>
+                                <a t-attf-href="https://www.google.com/calendar/render?action=TEMPLATE&amp;text={{ object.event_id.name }}&amp;dates={{ date_begin }}/{{ date_end }}&amp;location={{ location }}&amp;details={{ object.event_id._get_external_description() }}" target="new"
+                                    style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                    <img src="/event/static/src/img/google-calendar.svg" alt="Google" title="Google" style="height: 20px; vertical-align: baseline;"/>
+                                </a>
+                            </td>
+                        </tr>
+                    </table>
+                    <br/><br/>
                     <div>
                         We confirm your registration and hope to meet you there,<br/>
                         <span style="color: #454748;">

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_controller.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_controller.js
@@ -1,0 +1,16 @@
+import { CalendarController } from "@web/views/calendar/calendar_controller";
+import { _t } from "@web/core/l10n/translation";
+
+export class EventSlotCalendarController extends CalendarController {
+    /**
+     * Rename mobile quick create dialog.
+     * Load model after save to show created record.
+     */
+    getQuickCreateFormViewProps(record) {
+        return {
+            ...super.getQuickCreateFormViewProps(record),
+            onRecordSaved: () => this.model.load(),
+            title: _t("New Slot"),
+        };
+    }
+}

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_model.js
@@ -1,18 +1,39 @@
 import { CalendarModel } from "@web/views/calendar/calendar_model";
 import { serializeDate } from "@web/core/l10n/dates";
 
+/**
+ * Slots are created differently depending on the screen size.
+ * Desktop: Using the multi create feature.
+ * Mobile: Using the calendar quick create dialog.
+ */
 export class EventSlotCalendarModel extends CalendarModel {
 
     /**
      * @override
-     * Save slot date and hours from selected datetimes
+     * Set slot date and hours from selected datetimes.
      */
     buildRawRecord(partialRecord, options = {}) {
-        const rawRecord = super.buildRawRecord(partialRecord, options)
+        const rawRecord = super.buildRawRecord(partialRecord, options);
         rawRecord["date"] = serializeDate(partialRecord.start);
         rawRecord["start_hour"] = partialRecord.start.hour + partialRecord.start.minute / 60;
-        rawRecord["end_hour"] = partialRecord.end.hour + partialRecord.end.minute / 60;
+        // There could be no 'end' when opening the mobile quick create dialog.
+        if (partialRecord.end) {
+            rawRecord["end_hour"] = partialRecord.end.hour + partialRecord.end.minute / 60;
+        }
         return rawRecord;
+    }
+
+    /**
+     * @override
+     * Save selected date in context defaults for mobile quick create form dialog.
+     *
+     * Only needed for mobile quick create as the desktop multi create feature
+     * is directly saving the raw records with the 'date' returned from 'buildRawRecord'.
+     */
+    makeContextDefaults(rawRecord) {
+        const context = super.makeContextDefaults(rawRecord);
+        context["default_date"] = rawRecord["date"];
+        return context;
     }
 
     /**
@@ -28,6 +49,8 @@ export class EventSlotCalendarModel extends CalendarModel {
         const tz = rawRecord.date_tz || 'utc';
         normalizedRecord.start = normalizedRecord.start.setZone(tz).setZone('local', {keepLocalTime: true});
         normalizedRecord.end = normalizedRecord.end.setZone(tz).setZone('local', {keepLocalTime: true});
+        // Always display the slot time
+        normalizedRecord.isTimeHidden = false;
         return normalizedRecord;
     }
 

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_renderer.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_renderer.js
@@ -5,6 +5,49 @@ import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar
 export class EventSlotCalendarCommonRenderer extends CalendarCommonRenderer {
     // Display end time and hide title on the full calendar library event.
     static eventTemplate = "event.EventSlotCalendarCommonRenderer.event";
+    // Prevent square selection over disabled cells on desktop.
+    static cellIsSelectable = (cell) => !cell.classList.contains("o_calendar_disabled");
+
+    setup() {
+        super.setup(...arguments);
+        this.rangeStartDate = this.props.model.meta.context.event_calendar_range_start_date;
+        this.rangeEndDate = this.props.model.meta.context.event_calendar_range_end_date;
+    }
+
+    /**
+     * Add overlay to disable days outside of event time range.
+     */
+    getDayCellClassNames(info) {
+        const date = luxon.DateTime.fromJSDate(info.date).toISODate();
+        if (
+            this.rangeStartDate &&
+            this.rangeEndDate &&
+            (date < this.rangeStartDate || date > this.rangeEndDate)
+        ) {
+            return ["o_calendar_disabled"];
+        }
+        return [];
+    }
+
+    /**
+     * @override
+     * Slots cannot be created over multiple days on mobile.
+     * On desktop, using the multi create feature which doesn't consider this value.
+     */
+    isSelectionAllowed(event) {
+        return false;
+    }
+
+    /**
+     * @override
+     * Prevent click on disabled dates in mobile.
+    */
+    onDateClick(info) {
+        if (info.dayEl.classList.contains("o_calendar_disabled")) {
+            return;
+        }
+        return super.onDateClick(info);
+    }
 }
 
 export class EventSlotCalendarRenderer extends CalendarRenderer {

--- a/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_view.js
+++ b/addons/event/static/src/views/event_slot_calendar/event_slot_calendar_view.js
@@ -1,4 +1,5 @@
 import { calendarView } from "@web/views/calendar/calendar_view";
+import { EventSlotCalendarController } from "@event/views/event_slot_calendar/event_slot_calendar_controller";
 import { EventSlotCalendarModel } from "@event/views/event_slot_calendar/event_slot_calendar_model";
 import { EventSlotCalendarRenderer } from "@event/views/event_slot_calendar/event_slot_calendar_renderer";
 import { registry } from "@web/core/registry";
@@ -6,6 +7,7 @@ import { registry } from "@web/core/registry";
 
 export const EventSlotCalendarView = {
     ...calendarView,
+    Controller: EventSlotCalendarController,
     Model: EventSlotCalendarModel,
     Renderer: EventSlotCalendarRenderer,
 };

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -40,13 +40,6 @@
                                 help="Total Registrations for this Event">
                             <field name="seats_taken" widget="statinfo" string="Attendees"/>
                         </button>
-                        <button name="%(event.act_event_slot_from_event)d"
-                                type="action"
-                                class="oe_stat_button"
-                                icon="fa-calendar"
-                                invisible="not is_multi_slots">
-                            <field name="event_slot_count" widget="statinfo" string="Slots"/>
-                        </button>
                     </div>
                     <field name="active" invisible="1"/>
                     <field name="company_id" invisible="1"/>
@@ -62,7 +55,16 @@
                             <field name="date_begin" string="Date" widget="daterange" options="{'end_date_field': 'date_end'}" />
                             <field name="date_end" invisible="1" />
                             <field name="date_tz"/>
-                            <field name="is_multi_slots" string="Multiple Slots"/>
+                            <label for="is_multi_slots"/>
+                            <div class="o_row">
+                                <field name="is_multi_slots" string="Multiple Slots"/>
+                                <div invisible="not is_multi_slots">
+                                     <button name="action_open_slot_calendar"
+                                        type="object" class="btn-link p-0 pb-sm-1">
+                                        <field name="event_slot_count" class="oe_inline"/> Slot(s)
+                                    </button>
+                                </div>
+                            </div>
                             <field name="lang"/>
                             <field name="event_type_id" string="Template"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_quick_create': True}"/>

--- a/addons/event/views/event_registration_views.xml
+++ b/addons/event/views/event_registration_views.xml
@@ -236,6 +236,7 @@
                 <group>
                     <filter string="Partner" name="partner" domain="[]" context="{'group_by':'partner_id'}"/>
                     <filter string="Event" name="group_event" domain="[]" context="{'group_by':'event_id'}"/>
+                    <filter string="Slot" name="group_by_event_slot_id" context="{'group_by': 'event_slot_id'}"/>
                     <filter string="Ticket Type" name ="group_event_ticket_id" domain="[]" context="{'group_by': 'event_ticket_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by':'state'}"/>
                     <filter string="Registration Date" name="group_by_create_date_week" domain="[]" context="{'group_by': 'create_date:week'}"

--- a/addons/event/views/event_slot_views.xml
+++ b/addons/event/views/event_slot_views.xml
@@ -6,13 +6,19 @@
         <field name="model">event.slot</field>
         <field name="arch" type="xml">
             <form>
+                <field name="event_id" invisible="1"/>
                 <group>
                     <group>
-                        <field name="start_hour" string="From" widget="float_time"/>
-                        <field name="color" widget="color_picker"/>
+                        <label for="start_hour" string="Hour range"/>
+                        <div>
+                            <field name="start_hour" class="oe_inline o_input_5ch" widget="float_time"/>
+                            <i class="fa fa-arrow-right mx-2" title="to"/>
+                            <field name="end_hour" class="oe_inline o_input_5ch" widget="float_time"/>
+                        </div>
+                        <field name="date_tz" string="Timezone"/>
                     </group>
                     <group>
-                        <field name="end_hour" string="To" widget="float_time"/>
+                        <field name="color" widget="color_picker"/>
                     </group>
                 </group>
             </form>
@@ -25,10 +31,11 @@
         <field name="priority">20</field>
         <field name="arch" type="xml">
             <form>
-                <div class="row">
-                    <label class="col-4" for="color" string="Color"/>
-                    <field class="col-8" name="color" widget="color_picker"/>
-                </div>
+                <field name="event_id" invisible="1"/>
+                <group>
+                    <field name="date_tz" string="Timezone"/>
+                    <field name="color" widget="color_picker"/>
+                </group>
             </form>
         </field>
     </record>
@@ -53,7 +60,8 @@
         <field name="model">event.slot</field>
         <field name="arch" type="xml">
             <calendar js_class="event_slot_calendar" date_start="start_datetime" date_stop="end_datetime"
-                string="Slots" scales="month" color="color" multi_create_view="event.view_event_slot_multi_create_form">
+                string="Slots" scales="month" color="color" quick_create_view_id="%(event.view_event_slot_form)d"
+                multi_create_view="event.view_event_slot_multi_create_form">
                 <field name="start_datetime" invisible="1"/>
                 <field name="end_datetime" invisible="1"/>
                 <field name="date_tz" invisible="1"/>
@@ -61,10 +69,11 @@
         </field>
     </record>
 
-    <record id="act_event_slot_from_event" model="ir.actions.act_window">
+    <record id="event_slot_action_from_event" model="ir.actions.act_window">
         <field name="name">Slots</field>
         <field name="res_model">event.slot</field>
         <field name="view_mode">calendar,list,form</field>
+        <field name="mobile_view_mode">list</field>
         <field name="domain">[('event_id', '=', active_id)]</field>
         <field name="context">{'default_event_id': active_id}</field>
     </record>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -85,7 +85,9 @@ export class CalendarCommonRenderer extends Component {
             },
             () => [this.fc.el]
         );
-        useSquareSelection();
+        useSquareSelection({
+            cellIsSelectable: this.constructor.cellIsSelectable,
+        });
     }
 
     get options() {

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -242,11 +242,17 @@ export class CalendarController extends Component {
         this.callbackRecorder = new CallbackRecorder();
         this._baseRendererProps.callbackRecorder = this.callbackRecorder;
         this._baseRendererProps.onSquareSelection = (selectedCells) => {
-            this.selectedCells = selectedCells;
-            this.multiSelectionButtonsReactive.visible = true;
-            this.multiSelectionButtonsReactive.nbSelected = this.getSelectedRecordIds(
-                this.selectedCells
-            ).length;
+            if (selectedCells.length) {
+                this.selectedCells = selectedCells;
+                this.multiSelectionButtonsReactive.visible = true;
+                this.multiSelectionButtonsReactive.nbSelected = this.getSelectedRecordIds(
+                    this.selectedCells
+                ).length;
+            } else {
+                this.selectedCells = null;
+                this.multiSelectionButtonsReactive.visible = false;
+                this.multiSelectionButtonsReactive.nbSelected = 0;
+            }
         };
         this._baseRendererProps.cleanSquareSelection = this.cleanSquareSelection.bind(this);
 

--- a/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
@@ -42,15 +42,18 @@ function getResult(ctx) {
         }
     }
     const selector = selectorParts.join(",");
-    return { selectedCells: [...ref.el.querySelectorAll(selector)] };
+    return { selectedCells: [...ref.el.querySelectorAll(selector)].filter(ctx.cellIsSelectable) };
 }
 
 // @ts-ignore
 const useBlockSelection = makeDraggableHook({
     name: "useBlockSelection",
-    acceptedParams: {},
-    onComputeParams({ ctx }) {
+    acceptedParams: {
+        cellIsSelectable: [Function],
+    },
+    onComputeParams({ ctx, params }) {
         ctx.followCursor = false;
+        ctx.cellIsSelectable = params.cellIsSelectable;
     },
     onWillStartDrag({ addClass, ctx }) {
         const { current, ref } = ctx;
@@ -80,7 +83,8 @@ const useBlockSelection = makeDraggableHook({
     },
 });
 
-export function useSquareSelection() {
+export function useSquareSelection(params = {}) {
+    const cellIsSelectable = params.cellIsSelectable || (() => true);
     const component = useComponent();
     const ref = useRef("fullCalendar");
     const highlightClass = "o-highlight";
@@ -104,6 +108,7 @@ export function useSquareSelection() {
         elements: CELL_SELECTOR,
         ref,
         edgeScrolling: { speed: 40, threshold: 150 },
+        cellIsSelectable,
         onWillStartDrag: removeHighlight,
         onDragStart: highlight,
         onDrag: highlight,
@@ -131,7 +136,7 @@ export function useSquareSelection() {
         }
         const coord = getCoordinates(cell);
         const current = { initCoord: coord, coord };
-        const { selectedCells } = getResult({ current, ref });
+        const { selectedCells } = getResult({ current, ref, cellIsSelectable });
         highlight({ selectedCells });
         component.props.onSquareSelection(selectedCells);
     };

--- a/addons/web/static/src/views/view_components/multi_create_popover.xml
+++ b/addons/web/static/src/views/view_components/multi_create_popover.xml
@@ -20,7 +20,7 @@
                     />
                 </div>
                 <Record t-props="multiCreateRecordProps" t-slot-scope="data">
-                    <FormRenderer record="data.record" archInfo="multiCreateArchInfo" class="'p-0'"/>
+                    <FormRenderer record="data.record" archInfo="multiCreateArchInfo" class="'p-0 pt-2'"/>
                 </Record>
             </div>
             <div class="popover-footer p-3 pt-0 d-flex gap-1">

--- a/addons/website_event/static/src/interactions/website_event_slot_details.js
+++ b/addons/website_event/static/src/interactions/website_event_slot_details.js
@@ -88,8 +88,10 @@ export class SlotDetails extends Interaction {
      * @param {MouseEvent} ev
      */
     _onSlotSelected(ev) {
-        this.selectedSlotDatetime = deserializeDateTime(
-            ev.currentTarget.dataset.slotStart).toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY);
+        const dataset = ev.currentTarget.dataset;
+        this.selectedSlotDatetime =
+            deserializeDateTime(dataset.slotStart, {tz: dataset.eventTz}).toLocaleString(DateTime.DATETIME_MED_WITH_WEEKDAY) +
+            " - " + deserializeDateTime(dataset.slotEnd, {tz: dataset.eventTz}).toLocaleString(DateTime.TIME_SIMPLE);
         this.form.setAttribute("data-selected-slot-id", parseInt(ev.currentTarget.dataset.slotId));
     }
 

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -230,7 +230,10 @@
     <div t-attf-class="o_wevent_dates_block {{is_one_day_without_slots and 'd-flex flex-wrap justify-content-between align-items-center gap-2'}}">
         <div t-if="opt_event_dates_block" class="pb-3 flex-wrap gap-3 w-lg-100">
             <div t-if="event.is_multi_slots">
-                <small class="fw-bold">Next Dates</small>
+                <small class="d-flex align-items-end justify-content-between gap-2 fw-bold text-nowrap">
+                    Next Dates
+                    <span t-if="website_visitor_timezone != event.date_tz" class="text-truncate small fw-normal" t-out="event.date_tz"/>
+                </small>
                 <div class="card bg-transparent py-3 px-2 px-md-3">
                     <!-- Up to the next 3 closest dates -->
                     <t t-set="slots_to_preview" t-value="dict(list(slots.items())[:3])"/>
@@ -669,7 +672,8 @@
                             <time t-out="date" class="text-nowrap pe-5 me-5" t-options="{'widget': 'date', 'format': 'full'}"/>
                             <div class="d-flex flex-wrap gap-2">
                                 <button type="button" t-foreach="slots[date]" t-as="slot" class="o_wevent_slot_btn btn btn-sm btn-light"
-                                    t-att-data-slot-id="slot.id" t-att-data-slot-start="slot.start_datetime">
+                                    t-att-data-slot-id="slot.id" t-att-data-event-tz="event.date_tz"
+                                    t-att-data-slot-start="slot.start_datetime" t-att-data-slot-end="slot.end_datetime">
                                     <time t-out="slot.start_datetime" class="lh-1"
                                         t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'time_only': 'true', 'format': 'short'}"/>
                                 </button>

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -44,7 +44,6 @@
             <t t-set="agenda_urls" t-value="object._get_track_calendar_urls()"/>
             <t t-set="google_url" t-value="agenda_urls.get('google_url')"/>
             <t t-set="iCal_url" t-value="agenda_urls.get('iCal_url')"/>
-            <t t-set="yahoo_url" t-value="agenda_urls.get('yahoo_url')"/>
             <table border="0" cellpadding="0" cellspacing="0"  width="590" style="padding: 16px; background-color: white; color: #454748; border-collapse:separate;">
             <tbody>
                 <!-- HEADER -->
@@ -78,20 +77,30 @@
                                     <span t-else="" style="font-weight:bold;" t-out="object.name or ''">OpenWood Collection Online Reveal</span>.
                                 </div>
                                 <div t-if="agenda_urls">
-                                    <br />
-                                    <strong>Add this talk to your calendar</strong>
-                                    <a t-if="google_url" t-att-href="google_url" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
-                                        <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/>
-                                        Google
-                                    </a>
-                                    <a t-if="iCal_url" t-att-href="iCal_url" t-attf-style="padding:3px 5px; color:{{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;">
-                                        <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/>
-                                        iCal/Outlook
-                                    </a>
-                                    <a t-if="yahoo_url" t-att-href="yahoo_url" t-attf-style="padding:3px 5px; color: {{object.event_id.user_id.company_id.email_secondary_color or '#875A7B'}}; text-decoration:none;border-radius:3px;" target="new">
-                                        <img src="/web_editor/font_to_img/61525/rgb(135,90,123)/16" style="vertical-align:middle;" height="16" alt=""/> Yahoo
-                                    </a>
-                                    <br /><br />
+                                    <br/>
+                                    <table style="width: auto;">
+                                        <tr>
+                                            <td>
+                                                <strong>Add this talk to your calendar</strong>
+                                            </td>
+                                            <td>
+                                                <a t-if="iCal_url" t-att-href="iCal_url" style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                                    <img src="/event/static/src/img/apple-calendar.svg" alt="iCal" title="iCal" style="height: 20px; vertical-align: baseline;"/>
+                                                </a>
+                                            </td>
+                                            <td>
+                                                <a t-if="iCal_url" t-att-href="iCal_url" style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                                    <img src="/event/static/src/img/outlook-calendar.svg" alt="Outlook" title="Outlook" style="height: 20px; vertical-align: baseline;"/>
+                                                </a>
+                                            </td>
+                                            <td>
+                                                <a t-if="google_url" t-att-href="google_url" target="new" style="padding-top: 10px; padding-right:8px; padding-bottom:2px; padding-left:8px; margin-left: 8px; border-radius: 3px; background-color: #E7E9ED;">
+                                                    <img src="/event/static/src/img/google-calendar.svg" alt="Google" title="Google" style="height: 20px; vertical-align: baseline;"/>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <br/><br/>
                                 </div>
                                 <div>
                                     See you soon,<br/>

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -25,7 +25,6 @@ except ImportError:
     vobject = None
 
 GOOGLE_CALENDAR_URL = 'https://www.google.com/calendar/render?'
-YAHOO_CALENDAR_URL = 'https://calendar.yahoo.com/?v=60&view=d&type=20&'
 
 
 class EventTrack(models.Model):
@@ -754,16 +753,7 @@ class EventTrack(models.Model):
             'location': location,
         }
 
-        yahoo_params = {
-            'title':  f'{self.event_id.name}: {self.name}',
-            'in_loc': location,
-            'st': url_date_begin,
-            'et': url_date_end,
-            'desc': shorten(html_to_inner_content(self.description), 1900) + f'\n\n{html_to_inner_content(self._get_track_calendar_reminder_times_warning())}'
-        }
-
         return {
             'google_url': GOOGLE_CALENDAR_URL + werkzeug.urls.url_encode(google_params),
             'iCal_url': f'{self.get_base_url()}/event/{self.event_id.id}/track/{self.id}/ics',
-            'yahoo_url': YAHOO_CALENDAR_URL + werkzeug.urls.url_encode(yahoo_params)
         }


### PR DESCRIPTION
Purpose
=======
Enhance multi slots ux and event mail templates.

Specification
===========
Event form view:
- Ease the slot views access by replacing the 'Slots' stat button by
a button next to the multi slots option.

Slot calendar view:
- Ease the slots creation in batch by adding a grayed-out overlay
to prevent creation outside of the event time range.
- Indicate that the slots are expressed in the event timezone.
- On mobile, prevent selection over multiple days as slots cannot go
over multiple days. Open the list view by default for ease of use.

Slots on front-end:
- Display the slot end datetime when selecting the slot.
- Display the timezone at slot selection when the user current timezone
is different from the one of the event.

Also improving the calendar links:
- Removing the yahoo calendar urls.
- Improving the event mail templates to use nice image buttons like on the
registration page instead of text buttons.

Task-4743999

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
