### PR TITLE
[FIX] purchase_stock: invalid location for interco dropship

### DIFF
--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -242,8 +242,10 @@ class PurchaseOrder(models.Model):
 
     def _get_final_location_record(self):
         self.ensure_one()
-        if self.dest_address_id and self.picking_type_id.code == 'dropship':
-            return self.dest_address_id.property_stock_customer
+        if self.picking_type_id.code == 'dropship':
+            if self.dest_address_id:
+                return self.dest_address_id.property_stock_customer
+            return self.picking_type_id.default_location_dest_id
         return self.picking_type_id.warehouse_id.lot_stock_id
 
     @api.model

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -242,6 +242,9 @@ class StockRule(models.Model):
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         company_id = self.company_id.id
         copied_quantity = move_to_copy.quantity
+        final_location_id = False
+        if move_to_copy.location_final_id and not move_to_copy.location_dest_id._child_of(move_to_copy.location_final_id):
+            final_location_id = move_to_copy.location_final_id.id
         if float_compare(move_to_copy.product_uom_qty, 0, precision_rounding=move_to_copy.product_uom.rounding) < 0:
             copied_quantity = move_to_copy.product_uom_qty
         if not company_id:
@@ -251,7 +254,7 @@ class StockRule(models.Model):
             'origin': move_to_copy.origin or move_to_copy.picking_id.name or "/",
             'location_id': move_to_copy.location_dest_id.id,
             'location_dest_id': self.location_dest_id.id,
-            'location_final_id': move_to_copy.location_final_id.id,
+            'location_final_id': final_location_id,
             'rule_id': self.id,
             'date': new_date,
             'date_deadline': move_to_copy.date_deadline,


### PR DESCRIPTION
In some case, the dest_address is not available when the picking type is dropship. In those cases, the final_location will be arbitrary fallback on default behavior and set to stock depsite we don't go through it. Instead we use the default location dest on the picking type as the final location since we can't guess where it goes.

Also remove a location_final propagation through push rule if we already reach it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
