### PR TITLE
[FIX] mail, account: fix traceback when send invoices in batch

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -9,7 +9,7 @@ from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.exceptions import UserError
-from odoo.tests import users, warmup, tagged
+from odoo.tests import users, warmup, tagged, Form
 from odoo.tools import formataddr, mute_logger
 
 
@@ -683,6 +683,19 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             ('res_field', '=', 'invoice_pdf_report_file'),
         ])
         self.assertEqual(len(invoice_attachments), 1)
+
+    def test_compute_value_of_send_invoice_batch_wizard(self):
+        invoices = (
+            self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True) +
+            self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)
+        )
+
+        move_send_batch_wizard = Form(self.env['account.move.send.batch.wizard'].with_context(
+            active_model='account.move', active_ids=invoices.ids))
+
+        self.assertEqual(move_send_batch_wizard.move_ids.ids, invoices.ids)
+        self.assertEqual(move_send_batch_wizard.summary_data, {'email': {'count': len(invoices), 'label': 'by Email'}})
+        self.assertFalse(move_send_batch_wizard.alerts)
 
     def test_invoice_multi_email_missing(self):
         invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1952,7 +1952,7 @@ class MailThread(models.AbstractModel):
             self.ensure_one()
         return self._partner_find_from_emails(
             {self: emails}, avoid_alias=avoid_alias, filter_found=filter_found, additional_values=additional_values, no_create=no_create
-        )[self.id]
+        )[self._origin.id]
 
     def _partner_find_from_emails(self, records_emails, avoid_alias=True, ban_emails=None,
                                   filter_found=None, additional_values=None, no_create=False):


### PR DESCRIPTION
This error occurs when a user attempts to send multiple invoices at once.

Steps to Reproduce:

 - Install the `account` module.
 - Open `Invoices`.
 - Select multiple invoices and click `Send`.

`KeyError: <NewId origin=3>`

This error occurs when the wizard tries to compute the summary data of invoices. Since this is a computed field, so we got newId here.

This commit will fix the above issue by using _origin.id, ensuring that it always returns the ID of a valid record.

Sentry-6562659542


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
