### PR TITLE
[FIX] portal, website_slides: resolve 'add review' button issues

### DIFF
--- a/addons/portal/static/src/chatter/frontend/portal_chatter.js
+++ b/addons/portal/static/src/chatter/frontend/portal_chatter.js
@@ -18,5 +18,17 @@ export class PortalChatter extends Component {
             inFrontendPortalChatter: true,
         });
         this.overlayService = useService("overlay");
+        this.store = useService("mail.store");
+        this.env.bus.addEventListener("reload_chatter_content", (ev) =>
+            this._reloadChatterContent(ev.detail)
+        );
+    }
+
+    async _reloadChatterContent(data) {
+        const thread = this.store.Thread.get({
+            id: this.props.resId,
+            model: this.props.resModel,
+        });
+        thread.messages = await thread.fetchMessages();
     }
 }

--- a/addons/website_slides/__manifest__.py
+++ b/addons/website_slides/__manifest__.py
@@ -200,6 +200,9 @@ Featuring
             ('remove', 'website_slides/static/tests/legacy/**/*'),
             ('remove', 'website_slides/static/tests/tours/**/*'),
         ],
+        'portal.assets_chatter': [
+            'website_slides/static/src/chatter/frontend/**/*',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_slides/static/src/chatter/frontend/portal_chatter_patch.js
+++ b/addons/website_slides/static/src/chatter/frontend/portal_chatter_patch.js
@@ -1,0 +1,22 @@
+import { PortalChatter } from "@portal/chatter/frontend/portal_chatter";
+
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+
+patch(PortalChatter.prototype, {
+    /**
+     * Update review count on review tab in courses
+     *
+     * @override
+     * @private
+     */
+    async _reloadChatterContent(data) {
+        super._reloadChatterContent(...arguments);
+        if (this.props.resModel === "slide.channel") {
+            document.querySelector("#review-tab").textContent = _t(
+                "Reviews (%s)",
+                data.rating_count || data["mail.thread"][0].rating_count
+            );
+        }
+    },
+});

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -36,8 +36,17 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger: "a[id=review-tab]",
-            run: "click",
+            trigger: ".o_wslides_course_header_nav_review",
+            run() {
+                const a = document.querySelector("a[id=review-tab]");
+                if (a.textContent !== "Reviews (1)") {
+                    throw Error("Text should be 'Reviews (1)'.")
+                }
+                a.click();
+            },
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message-textContent:contains(Great course!)",
         },
         {
             // If it fails here, it means the system is allowing you to add another review.


### PR DESCRIPTION
**Before this PR:**
When a user attempts to add a review, the label on the "Review tab" doesn't update, and the portal chatter fails to display the review message. 
https://youtu.be/H1XRamn9Koc

**Technical:**
The code related to these features was removed in commit 368eb78a9cedfce0802b64fd2782e1c018541e40, but it was never addressed afterward.

**After this PR:**
Adding a review updates the tab label and displays the message in portal chatter.

**Task**-4677251
