### PR TITLE
[FIX] core: fix `_sql_error_to_message` when no uid

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3217,7 +3217,7 @@ class BaseModel(metaclass=MetaModel):
         Note that the cursor on self has to be in a valid state.
         """
         if (constraint_name := exc.diag.constraint_name) and (cons := self._table_objects.get(constraint_name)):
-            cons_rec = self.env['ir.model.constraint'].search_fetch([
+            cons_rec = self.env['ir.model.constraint'].sudo().search_fetch([
                 ('name', '=', constraint_name),
                 ('model.model', '=', self._name),
             ], ['message'], limit=1)


### PR DESCRIPTION
During `retrying` method we still don't have any uid on the
current env (the authentification is inside the `func` ->
`_serve_ir_http`). If there is an Integrity Error coming from the
method/controller called, the error is catch by `retrying` and call
`_sql_error_to_message` leading to a traceback:

```
...
File "/home/odoo/src/odoo/saas-18.2/odoo/http.py", line 2016, in _transactioning
  return service_model.retrying(func, env=self.env)
File "/home/odoo/src/odoo/saas-18.2/odoo/service/model.py", line 186, in retrying
  message = env._("The operation cannot be completed: %s", model._sql_error_to_message(exc))
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 2916, in _sql_error_to_message
  cons_rec = self.env['ir.model.constraint'].search_fetch([
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 1390, in search_fetch
  query = self._search(domain, offset=offset, limit=limit, order=order or self._order)
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 4993, in _search
  self.browse().check_access('read')
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 3719, in check_access
  if not self.env.su and (result := self._check_access(operation)):
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 3752, in _check_access
  if not Access.check(self._name, operation, raise_exception=False):
File "/home/odoo/src/odoo/saas-18.2/odoo/addons/base/models/ir_model.py", line 2051, in check
  has_access = model in self._get_allowed_models(mode)
File "decorator.py", line 232, in fun
  return caller(func, *(extras + args), **kw)
File "/home/odoo/src/odoo/saas-18.2/odoo/tools/cache.py", line 125, in lookup
  value = d[key] = self.method(*args, **kwargs)
File "/home/odoo/src/odoo/saas-18.2/odoo/addons/base/models/ir_model.py", line 2023, in _get_allowed_models
  group_ids = self.env.user._get_group_ids()
File "decorator.py", line 232, in fun
  return caller(func, *(extras + args), **kw)
File "/home/odoo/src/odoo/saas-18.2/odoo/tools/cache.py", line 125, in lookup
  value = d[key] = self.method(*args, **kwargs)
File "/home/odoo/src/odoo/saas-18.2/odoo/addons/base/models/res_users.py", line 1026, in _get_group_ids
  self.ensure_one()
File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 5497, in ensure_one
  raise ValueError("Expected singleton: %s" % self)
```
It actually hides the legit constraint message error.

Fix it by adding a sudo() to the constraint search, since whatever the
user (public or not), the error message should be accessible and
returned.

