### PR TITLE
[IMP] stock: use 'Product Unit' decimal accuracy in forecast report

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -14,9 +14,7 @@ export class ForecastedDetails extends Component {
         this._prepareData();
         this._mergeLines();
 
-        this._formatFloat = (num) => {
-            return formatFloat(num, { digits: this.props.docs.precision });
-        };
+        this._formatFloat = (num) => formatFloat(num, { digits: [0, this.props.docs.precision] });
     }
 
     async _reserve(move_id){

--- a/addons/stock/static/src/stock_forecasted/forecasted_header.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_header.js
@@ -11,7 +11,7 @@ export class ForecastedHeader extends Component {
         this.action = useService("action");
         this.tooltip = useService("tooltip");
 
-        this._formatFloat = (num) => formatFloat(num, { digits: this.props.docs.precision });
+        this._formatFloat = (num) => formatFloat(num, { digits: [0, this.props.docs.precision] });
     }
 
     async _onClickInventory(){

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -54,7 +54,7 @@ export class StockForecasted extends Component {
         });
         this.docs = {
             ...reportValues.docs,
-            ...reportValues.precision,
+            precision: reportValues.precision,
             lead_horizon_date: this.context.lead_horizon_date,
             qty_to_order: this.context.qty_to_order,
         };


### PR DESCRIPTION

With this commit:
----------------
- The forecast report now uses the existing Product Unit decimal accuracy
  (configurable under Decimal Accuracy → Product Unit) instead of a fixed
  2-decimal display.
- This ensures quantities are displayed with the precision defined by the user,
  consistent with how they are handled elsewhere in stock operations.

Impact:
-------
Users who adjust decimal precision (e.g., for liquids, weights, or precious
materials) will now see that precision reflected in the forecast report as well,
leading to more accurate reporting, efficient planning, and improved stock
tracking.

task-4639502