### PR TITLE
[FIX] web: fix typing of omit and pick

### DIFF
--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -67,7 +67,7 @@ export function isObject(value) {
  * @template T
  * @template {keyof T} K
  * @param {T} object
- * @param {K[]} properties
+ * @param {...(K)} properties
  */
 export function omit(object, ...properties) {
     /** @type {Omit<T, K>} */
@@ -85,7 +85,7 @@ export function omit(object, ...properties) {
  * @template T
  * @template {keyof T} K
  * @param {T} object
- * @param {K[]} properties
+ * @param {...(K)} properties
  * @returns {Pick<T, K>}
  */
 export function pick(object, ...properties) {


### PR DESCRIPTION
`K[]` means that `properties` should be passed as an array, which is not the expected format. Typing must be rigorously correct to be useful. See example of error in related ENT PR. 

Task-4749289
