### PR TITLE
[IMP] web: sort fields in model field selector

### DIFF
--- a/addons/web/static/src/core/model_field_selector/model_field_selector.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.js
@@ -19,6 +19,7 @@ export class ModelFieldSelector extends Component {
         isDebugMode: { type: Boolean, optional: true },
         update: { type: Function, optional: true },
         filter: { type: Function, optional: true },
+        sort: { type: Function, optional: true },
         followRelations: { type: Boolean, optional: true },
         showDebugInput: { type: Boolean, optional: true },
     };
@@ -67,6 +68,7 @@ export class ModelFieldSelector extends Component {
             showSearchInput: this.props.showSearchInput,
             isDebugMode: this.props.isDebugMode,
             filter: this.props.filter,
+            sort: this.props.sort,
             followRelations: this.props.followRelations,
             showDebugInput: this.props.showDebugInput,
         });

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -15,12 +15,13 @@ class Page {
             selectedName = null,
             isDebugMode,
             readProperty = false,
+            sortFn = (fieldDefs) => sortBy(Object.keys(fieldDefs), (key) => fieldDefs[key].string),
         } = options;
         this.previousPage = previousPage;
         this.selectedName = selectedName;
         this.isDebugMode = isDebugMode;
         this.readProperty = readProperty;
-        this.sortedFieldNames = sortBy(Object.keys(fieldDefs), (key) => fieldDefs[key].string);
+        this.sortedFieldNames = sortFn(fieldDefs);
         this.fieldNames = this.sortedFieldNames;
         this.query = "";
         this.focusedFieldName = null;
@@ -108,6 +109,7 @@ export class ModelFieldSelectorPopover extends Component {
     static props = {
         close: Function,
         filter: { type: Function, optional: true },
+        sort: { type: Function, optional: true },
         followRelations: { type: Boolean, optional: true },
         showDebugInput: { type: Boolean, optional: true },
         isDebugMode: { type: Boolean, optional: true },
@@ -185,6 +187,7 @@ export class ModelFieldSelectorPopover extends Component {
                 previousPage: this.state.page,
                 isDebugMode: this.props.isDebugMode,
                 readProperty: this.props.readProperty,
+                sortFn: this.props.sort,
             })
         );
     }
@@ -205,6 +208,7 @@ export class ModelFieldSelectorPopover extends Component {
             return new Page(resModel, this.filter(fieldDefs, path), {
                 isDebugMode: this.props.isDebugMode,
                 readProperty: this.props.readProperty,
+                sortFn: this.props.sort,
             });
         }
         const { isInvalid, modelsInfo, names } = await this.fieldService.loadPath(resModel, path);
@@ -217,6 +221,7 @@ export class ModelFieldSelectorPopover extends Component {
                     selectedName: path,
                     isDebugMode: this.props.isDebugMode,
                     readProperty: this.props.readProperty,
+                    sortFn: this.props.sort,
                 });
             }
             default: {
@@ -229,6 +234,7 @@ export class ModelFieldSelectorPopover extends Component {
                         selectedName: name,
                         isDebugMode: this.props.isDebugMode,
                         readProperty: this.props.readProperty,
+                        sortFn: this.props.sort,
                     });
                 }
                 return page;

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -184,6 +184,30 @@ test("use the filter option", async () => {
     expect(getDisplayedFieldNames()).toEqual(["Product"]);
 });
 
+test("use the sort option", async () => {
+    await mountWithCleanup(ModelFieldSelector, {
+        props: {
+            readonly: false,
+            path: "",
+            resModel: "partner",
+            sort: (fields) =>
+                Object.keys(fields).sort((a, b) =>
+                    fields[b].string.localeCompare(fields[a].string)
+                ),
+        },
+    });
+    await openModelFieldSelectorPopover();
+    expect(getDisplayedFieldNames()).toEqual([
+        "Product",
+        "Last Modified on",
+        "Id",
+        "Foo",
+        "Display name",
+        "Created on",
+        "Bar",
+    ]);
+});
+
 test("default `showSearchInput` option", async () => {
     await mountWithCleanup(ModelFieldSelector, {
         props: {


### PR DESCRIPTION
With this commit, the fields in the `ModelFieldSelector` component can now be sorted. This is achieved by adding a new optional `sort` prop, which takes the fields object and returns a sorted array of field names. By default, fields are sorted alphabetically.

This change will be used in the spreadsheet to order fields based on their type in the context of global filters.

Task: 4707731

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
