### PR TITLE
[FIX] point_of_sale: prevent error when lines are added and removed

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -5,7 +5,7 @@
           taxTotals="currentOrder.taxTotals"
           generalNote="currentOrder.general_note or ''">
           <t t-set="line" t-value="scope.line" />
-          <Orderline line="line.getDisplayData()"
+          <Orderline line="line.getDisplayData()" t-if="line.order_id"
               t-on-click="(event) => this.clickLine(event, line)"
               class="{ ...line.getDisplayClasses(), 'selected' : line.isSelected() }">
               <t t-set-slot="product-name">


### PR DESCRIPTION
Before this commit, if an order line was added and then removed (for example, by the loyalty module), it could cause errors during rendering due to missing required props for the orderline. This scenario is common with the loyalty module.

opw-4724428

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
