### PR TITLE
[IMP] orm: Add optimization to bypass redundant comodel lookup

### DIFF
--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -1756,7 +1756,7 @@ class TestQueries(TransactionCase):
             LEFT JOIN "res_partner" AS "res_users__partner_id" ON
                 ("res_users"."partner_id" = "res_users__partner_id"."id")
             WHERE "res_users"."active" IS TRUE
-            AND ("res_users"."id" IN %s AND "res_users__partner_id"."id" IN %s)
+            AND ("res_users"."id" IN %s AND "res_users"."partner_id" IN %s)
             ORDER BY "res_users__partner_id"."name", "res_users"."login"
         ''']):
             Model.search([])
@@ -2271,10 +2271,8 @@ class TestOne2many(TransactionCase):
                     EXISTS (SELECT FROM (
                         SELECT "res_partner_bank"."partner_id" AS __inverse
                         FROM "res_partner_bank"
-                        WHERE (
-                            "res_partner_bank"."id" IN %s
-                            AND "res_partner_bank"."sanitized_acc_number" LIKE %s
-                        )
+                        WHERE "res_partner_bank"."id" IN %s
+                        AND "res_partner_bank"."sanitized_acc_number" LIKE %s
                     ) AS __sub WHERE __inverse = "res_partner"."id")
                     AND ("res_partner"."name" NOT IN %s OR "res_partner"."name" IS NULL)
                     AND "res_partner"."parent_id" IS NOT NULL


### PR DESCRIPTION
Description
-----------
Add a domain optimization to transform expressions like: `[('partner_id.id', 'in', (42))]` into `[('partner_id', 'in', (42))]` The additional `.id` in the left-hand side creates an unnecessary subquery on the comodel table. This optimization is safe when record rules don't apply (i.e., only in `su=True` context).

This transforms SQL WHERE clauses from:
`rel_column IN (SELECT id FROM comodel_table WHERE id IN (42))` to the simpler:
`rel_column IN (42)`

Benefits of this query optimization:

- Eliminates unnecessary scanning of `comodel_table`
- Allows direct querying of `pg_stats` for `fkey_column` statistics (subquery results lack these statistics)
- Removes potential optimization barriers caused by subqueries that Postgres may plan separately, enabling better execution plans

References
----------
task-4750311

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
