### PR TITLE
[FIX] account,sale: Fix downpayment rounding issue

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1652,7 +1652,7 @@ class AccountTax(models.Model):
                     tax_amounts['base_lines'].append(base_line)
 
                 if index == 0:
-                    base_rounding_key = (currency, base_line['is_refund'])
+                    base_rounding_key = (currency, base_line['is_refund'], computation_key)
                     base_amounts = total_per_base[base_rounding_key]
                     base_amounts['base_amount_currency'] += tax_data['base_amount_currency']
                     base_amounts['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
@@ -1663,7 +1663,7 @@ class AccountTax(models.Model):
 
             # If not, just account the base amounts.
             if not taxes_data:
-                tax_rounding_key = (None, currency, base_line['is_refund'], False, None)
+                tax_rounding_key = (None, currency, base_line['is_refund'], False, computation_key)
                 tax_amounts = total_per_tax[tax_rounding_key]
                 tax_amounts['base_amount_currency'] += tax_details['total_excluded_currency']
                 tax_amounts['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
@@ -1672,7 +1672,7 @@ class AccountTax(models.Model):
                 if not base_line['special_type']:
                     tax_amounts['base_lines'].append(base_line)
 
-                base_rounding_key = (currency, base_line['is_refund'])
+                base_rounding_key = (currency, base_line['is_refund'], computation_key)
                 base_amounts = total_per_base[base_rounding_key]
                 base_amounts['base_amount_currency'] += tax_details['total_excluded_currency']
                 base_amounts['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
@@ -1689,7 +1689,7 @@ class AccountTax(models.Model):
             tax_amounts['raw_base_amount'] = company.currency_id.round(tax_amounts['raw_base_amount'])
 
         # Round 'total_per_base'.
-        for (currency, _is_refund), base_amounts in total_per_base.items():
+        for (currency, _is_refund, _computation_key), base_amounts in total_per_base.items():
             base_amounts['raw_base_amount_currency'] = currency.round(base_amounts['raw_base_amount_currency'])
             base_amounts['raw_base_amount'] = company.currency_id.round(base_amounts['raw_base_amount'])
 
@@ -1836,7 +1836,7 @@ class AccountTax(models.Model):
                     else:
                         tax_details[f'delta_total_excluded{delta_currency_indicator}'] += amount_to_distribute
 
-                        base_rounding_key = (currency, base_line['is_refund'])
+                        base_rounding_key = (currency, base_line['is_refund'], base_line['computation_key'])
                         base_amounts = total_per_base[base_rounding_key]
                         base_amounts[f'base_amount{delta_currency_indicator}'] += amount_to_distribute
 
@@ -1851,7 +1851,7 @@ class AccountTax(models.Model):
         # 13%: base = 146.89, tax = 19.1
         # However, for the whole document, there is a delta in term of base amount: 293.79 - 146.89 - 146.89 = 0.01
         # This delta won't be there in any base but still has to be accounted.
-        for (currency, _is_refund), base_amounts in total_per_base.items():
+        for (currency, _is_refund, _computation_key), base_amounts in total_per_base.items():
             if not base_amounts['base_lines']:
                 continue
 

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -749,7 +749,7 @@ export const accountTaxHelpers = {
                 }
 
                 if (index === 0) {
-                    const base_rounding_key = [currency.id, base_line.is_refund];
+                    const base_rounding_key = [currency.id, base_line.is_refund, computation_key];
                     if (!(base_rounding_key in total_per_base)) {
                         total_per_base[base_rounding_key] = {
                             currency: currency,
@@ -776,7 +776,7 @@ export const accountTaxHelpers = {
 
             // If not, just account the base amounts.
             if (!taxes_data.length) {
-                const tax_rounding_key = [null, currency.id, base_line.is_refund, false, null];
+                const tax_rounding_key = [null, currency.id, base_line.is_refund, false, computation_key];
                 if (!(tax_rounding_key in total_per_tax)) {
                     total_per_tax[tax_rounding_key] = {
                         tax: null,
@@ -801,7 +801,7 @@ export const accountTaxHelpers = {
                     tax_amounts.base_lines.push(base_line);
                 }
 
-                const base_rounding_key = [currency.id, base_line.is_refund];
+                const base_rounding_key = [currency.id, base_line.is_refund, computation_key];
                 if (!(base_rounding_key in total_per_base)) {
                     total_per_base[base_rounding_key] = {
                         currency: currency,
@@ -985,7 +985,7 @@ export const accountTaxHelpers = {
                         tax_details[`delta_total_excluded${delta_currency_indicator}`] +=
                             amount_to_distribute;
 
-                        const base_rounding_key = [currency.id, base_line.is_refund];
+                        const base_rounding_key = [currency.id, base_line.is_refund, base_line.computation_key];
                         const base_amounts = total_per_base[base_rounding_key];
                         base_amounts[`base_amount${delta_currency_indicator}`] +=
                             amount_to_distribute;

--- a/addons/account/tests/test_taxes_global_discount.py
+++ b/addons/account/tests/test_taxes_global_discount.py
@@ -777,16 +777,16 @@ class TestTaxesGlobalDiscount(TestTaxCommon):
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
                 'base_amount_currency': 31.14,
-                'base_amount': 6.23,
+                'base_amount': 6.22,
                 'tax_amount_currency': 4.79,
                 'tax_amount': 0.95,
                 'total_amount_currency': 35.93,
-                'total_amount': 7.18,
+                'total_amount': 7.17,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
                         'base_amount_currency': 31.14,
-                        'base_amount': 6.23,
+                        'base_amount': 6.22,
                         'tax_amount_currency': 4.79,
                         'tax_amount': 0.95,
                         'tax_groups': [
@@ -834,16 +834,16 @@ class TestTaxesGlobalDiscount(TestTaxCommon):
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
                 'base_amount_currency': 29.53,
-                'base_amount': 5.91,
+                'base_amount': 5.9,
                 'tax_amount_currency': 4.56,
                 'tax_amount': 0.9,
                 'total_amount_currency': 34.09,
-                'total_amount': 6.81,
+                'total_amount': 6.8,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
                         'base_amount_currency': 29.53,
-                        'base_amount': 5.91,
+                        'base_amount': 5.9,
                         'tax_amount_currency': 4.56,
                         'tax_amount': 0.9,
                         'tax_groups': [
@@ -891,16 +891,16 @@ class TestTaxesGlobalDiscount(TestTaxCommon):
                 'currency_id': self.foreign_currency.id,
                 'company_currency_id': self.currency.id,
                 'base_amount_currency': 26.04,
-                'base_amount': 5.21,
+                'base_amount': 5.2,
                 'tax_amount_currency': 4.02,
                 'tax_amount': 0.79,
                 'total_amount_currency': 30.06,
-                'total_amount': 6.0,
+                'total_amount': 5.99,
                 'subtotals': [
                     {
                         'name': "Untaxed Amount",
                         'base_amount_currency': 26.04,
-                        'base_amount': 5.21,
+                        'base_amount': 5.2,
                         'tax_amount_currency': 4.02,
                         'tax_amount': 0.79,
                         'tax_groups': [

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -210,11 +210,6 @@ class TestSaleCommon(AccountTestInvoicingCommon):
 class TestTaxCommonSale(TestSaleCommon, TestTaxCommon):
 
     @classmethod
-    def get_default_groups(cls):
-        groups = super().get_default_groups()
-        return groups | cls.quick_ref('sales_team.group_sale_manager')
-
-    @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls.foreign_currency_pricelist = cls.env['product.pricelist'].create({

--- a/addons/sale/tests/test_taxes_downpayment.py
+++ b/addons/sale/tests/test_taxes_downpayment.py
@@ -593,6 +593,73 @@ class TestTaxesDownPaymentSale(TestTaxCommonSale, TestTaxesDownPayment):
             'amount_total': so.amount_total - dp_invoice_2.amount_total,
         }])
 
+    def test_down_payment_100_first_then_0_final_invoice(self):
+        self.env.company.tax_calculation_rounding_method = 'round_globally'
+        product = self.company_data['product_order_cost']
+        tax_23 = self.percent_tax(23.0)
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'name': 'line_1',
+                    'product_id': product.id,
+                    'price_unit': price_unit,
+                    'product_uom_qty': quantity,
+                    'discount': discount,
+                    'tax_ids': [Command.set(tax_23.ids)],
+                })
+                for quantity, price_unit, discount in (
+                    (1.0, 519.03, 2.0),
+                    (2.0, 211.97, 2.0),
+                    (2.0, 75.16, 2.0),
+                    (1.0, 82.84, 2.0),
+                    (4.0, 1.19, 0.0),
+                    (2.0, 13.63, 2.0),
+                    (1.0, 2.86, 2.0),
+                    (1.0, 10.0, 0.0),
+                )
+            ],
+        })
+        so.action_confirm()
+        self.assertRecordValues(so, [{
+            'amount_untaxed': 1196.89,
+            'amount_tax': 275.28,
+            'amount_total': 1472.17,
+        }])
+
+        # Create a down payment invoice of 100%.
+        wizard = (
+            self.env['sale.advance.payment.inv']
+            .with_context(active_model=so._name, active_ids=so.ids)
+            .create({
+                'advance_payment_method': 'percentage',
+                'amount': 100,
+            })
+        )
+        action_values = wizard.create_invoices()
+        dp_invoice = self.env['account.move'].browse(action_values['res_id'])
+        dp_invoice.action_post()
+        self.assertRecordValues(dp_invoice, [{
+            'amount_untaxed': 1196.89,
+            'amount_tax': 275.28,
+            'amount_total': 1472.17,
+        }])
+
+        # Create the final invoice.
+        wizard = (
+            self.env['sale.advance.payment.inv']
+            .with_context(active_model=so._name, active_ids=so.ids)
+            .create({'advance_payment_method': 'delivered'})
+        )
+        action_values = wizard.create_invoices()
+        final_invoice = self.env['account.move'].browse(action_values['res_id'])
+        self.assertRecordValues(final_invoice, [{
+            'amount_untaxed': 0.0,
+            'amount_tax': 0.0,
+            'amount_total': 0.0,
+        }])
+
     def test_down_payment_analytic_distribution_aggregation(self):
         tax_account = self.company_data['default_account_tax_sale']
         product = self.company_data['product_order_cost']


### PR DESCRIPTION
During the creation of the final invoice, the tax computation is performing the rounding of all base_lines/tax_details. However, the base line were aggregated without considering the computation_key making the result wrong in case of a down payment.

opw-4685953

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
