### PR TITLE
[FIX] account_peppol: only show peppol mail footnote in some countries

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -35,6 +35,11 @@ PEPPOL_DEFAULT_COUNTRIES = [
     'NO', 'PL', 'PT', 'RO', 'SE', 'SI',
 ]
 
+# List of countries where Peppol footnote will be added when sending by mail.
+PEPPOL_MAILING_COUNTRIES = [
+    'BE', 'LU', 'NL', 'SE', 'NO',
+]
+
 # List of countries where Peppol is accessible.
 PEPPOL_LIST = PEPPOL_DEFAULT_COUNTRIES + [
     'AD', 'AL',  'BA', 'BG', 'GB', 'HR', 'HU', 'LI', 'MC', 'ME',

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -3,7 +3,7 @@
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.addons.account.models.company import PEPPOL_DEFAULT_COUNTRIES
+from odoo.addons.account.models.company import PEPPOL_MAILING_COUNTRIES
 
 
 class AccountMove(models.Model):
@@ -76,7 +76,8 @@ class AccountMove(models.Model):
         render_context = super()._notify_by_email_prepare_rendering_context(message, **kwargs)
         invoice = render_context['record']
         invoice_country = invoice.commercial_partner_id.country_code
-        if invoice_country in PEPPOL_DEFAULT_COUNTRIES:
+        company_country = invoice.company_id.country_code
+        if company_country in PEPPOL_MAILING_COUNTRIES and invoice_country in PEPPOL_MAILING_COUNTRIES:
             render_context['peppol_info'] = {
                 'peppol_country': invoice_country,
                 'is_peppol_sent': invoice.peppol_move_state in ('processing', 'done'),


### PR DESCRIPTION
This commit modifies the condition for the Peppol information footnote to be added to the mail to be only when the country of both the company and the partner is one of the following: BE/LU/NL/SE/NO.

task-id: 4750146