### PR TITLE
[FIX] website_sale: float quantities on order lines

### DIFF
--- a/addons/website_sale/controllers/cart.py
+++ b/addons/website_sale/controllers/cart.py
@@ -132,6 +132,7 @@ class Cart(PaymentPortal):
         :rtype: dict
         """
         order_sudo = request.cart or request.website._create_cart()
+        quantity = int(quantity)  # Do not allow float values in ecommerce by default
 
         product = request.env['product.product'].browse(product_id).exists()
         if quantity and (not product or not product._is_add_to_cart_allowed()):
@@ -246,6 +247,7 @@ class Cart(PaymentPortal):
         :params dict kwargs: additional parameters given to _cart_update_line_quantity calls.
         """
         order_sudo = request.cart
+        quantity = int(quantity)  # Do not allow float values in ecommerce by default
 
         # This method must be only called from the cart page BUT in some advanced logic
         # eg. website_sale_loyalty, a cart line could be a temporary record without id.


### PR DESCRIPTION
Commit 34ba0d3251486a3f7fd16709debb5c2b2d14ffa9 dropped the cast to integer for cart quantities, potentially allowing customers to buy 0.01 quantities of a product, which isn't the expected behavior.

This commit casts the values given through the controllers, still keeping the ability for custom code to generate lines with floats as quantities if needed.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
