### PR TITLE
[IMP] web: improve list header sort icon clarity

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -169,7 +169,7 @@
     }
 
     &, & .o_form_editable {
-        // FIXME: those specific rules shouldn't be necessary but require a more 
+        // FIXME: those specific rules shouldn't be necessary but require a more
         // global cleanup of the fields + .o_row styling to be removed in master.
         .o_field_reference .o_row > * {
             flex: 1 1 auto;
@@ -911,7 +911,6 @@
     // One2Many List views
     .o_field_widget .o_list_renderer {
         --ListRenderer-thead-bg-color: #{$o-view-background-color};
-        --ListRenderer-thead-bg-active-color: #{$o-form-lightsecondary};
         --ListRenderer-tfoot-bg-color: #{$o-view-background-color};
 
         margin-bottom: 10px;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -754,11 +754,11 @@ export class ListRenderer extends Component {
 
     getSortableIconClass(column) {
         const { orderBy } = this.props.list;
-        const classNames = this.isSortable(column) ? ["fa", "fa-lg"] : ["d-none"];
+        const classNames = this.isSortable(column) ? ["fa"] : ["d-none"];
         if (orderBy.length && orderBy[0].name === column.name) {
-            classNames.push(orderBy[0].asc ? "fa-angle-up" : "fa-angle-down");
+            classNames.push(orderBy[0].asc ? "fa-sort-asc" : "fa-sort-desc");
         } else {
-            classNames.push("fa-angle-down", "opacity-0", "opacity-100-hover");
+            classNames.push("fa-sort", "opacity-0", "opacity-100-hover");
         }
 
         return classNames.join(" ");

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -3,7 +3,6 @@
     --ListRenderer-table-padding-x: #{$table-cell-padding-x-sm};
     --ListRenderer-thead-padding-y: #{map-get($spacers, 4)};
     --ListRenderer-thead-bg-color: #{$o-webclient-background-color};
-    --ListRenderer-thead-bg-active-color: #{$o-gray-200};
     --ListRenderer-thead-border-end-color: #{$border-color};
     --ListRenderer-tfoot-bg-color: #{$o-list-footer-bg-color};
     --sticky-header-zindex: 1;
@@ -92,7 +91,6 @@
                 }
 
                 &.table-active {
-                    background: var(--ListRenderer-thead-bg-active-color);
                     box-shadow: none;
                 }
             }
@@ -104,15 +102,11 @@
 
             .o_column_sortable {
 
-                .o_list_sortable_caret {
+                .o_list_sortable_icon {
                     background: var(--ListRenderer-thead-bg-color);
                     position: absolute;
-                    right: .2rem;
+                    right: .5rem;
                     padding: 0 .2rem;
-                }
-
-                &.table-active .o_list_sortable_caret {
-                    background: var(--ListRenderer-thead-bg-active-color);
                 }
 
                 .o_list_header_label_spacer {
@@ -317,7 +311,7 @@
             // 'initial' as it will force them to 'inline', not 'table-cell'.
             display: table-cell !important;
         }
-        
+
         tbody .o_column_resizing {
             position: relative;
             &:after {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -28,13 +28,13 @@
                                 tabindex="-1">
                                 <t t-if="column.hasLabel and column.widget !== 'handle'">
                                 <t t-set="isNumeric" t-value="isNumericColumn(column)"/>
-                                    <div class="d-flex"
+                                    <div class="d-flex align-items-center"
                                         t-att-data-tooltip-template="isDebugMode ? 'web.FieldTooltip' : 'web.ListHeaderTooltip'"
                                         t-att-data-tooltip-info="makeTooltip(column)">
                                         <span class="d-block min-w-0 text-truncate flex-grow-1 flex-shrink-1" t-att-class="isNumeric ? 'o_list_number_th' : ''"
                                               t-esc="column.label"/>
                                         <div class="o_list_header_label_spacer"/>
-                                        <i class="o_list_sortable_caret" t-att-class="getSortableIconClass(column)"/>
+                                        <i class="o_list_sortable_icon" t-att-class="getSortableIconClass(column)"/>
                                     </div>
                                     <span
                                           class="o_resize position-absolute top-0 end-0 bottom-0 ps-1 bg-black-25 opacity-0 opacity-50-hover z-1"

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -15966,7 +15966,7 @@ test(`sort on a non sortable field with allow_order option`, async () => {
     expect(queryAllProperties(`[name=bar] input`, "checked")).toEqual([false, true, true]);
     expect(`th[data-name=bar]`).toHaveClass("o_column_sortable");
     expect(`th[data-name=bar]`).toHaveClass("table-active");
-    expect(`th[data-name=bar] i`).toHaveClass("fa-angle-up");
+    expect(`th[data-name=bar] i`).toHaveClass("fa-sort-asc");
 });
 
 test(`sort rows in a grouped list view`, async () => {
@@ -15983,7 +15983,7 @@ test(`sort rows in a grouped list view`, async () => {
     await contains(`th[data-name=int_field]`).click();
     expect(queryAllTexts(`.o_data_cell`)).toEqual(["9", "10", "17"]);
     expect(`th[data-name=int_field]`).toHaveClass("o_column_sortable");
-    expect(`th[data-name=int_field] i`).toHaveClass("fa-angle-up");
+    expect(`th[data-name=int_field] i`).toHaveClass("fa-sort-asc");
 });
 
 test.tags("desktop");


### PR DESCRIPTION
This commit refines the UI of list headers by replacing caret icons with clearer fa-sort, fa-sort-asc and fa-sort-desc icons. It also removes the background color change on sorted headers, as the new icons provide sufficient visual indication on their own.

task-4730251
