### PR TITLE
[IMP] *: simplify tree editor buttons

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_favourite_filter_tests.js
@@ -377,7 +377,7 @@ QUnit.module('favorite filter widget', (hooks) => {
 
         // If domain is not set on mailing and no filter available, both drop-down and icon container are hidden
         
-        await testUtils.click(fixture.querySelector(".o_tree_editor_node_control_panel > button:nth-child(3)"));
+        await testUtils.click(fixture.querySelector(".o_tree_editor_node_control_panel > button:nth-child(2)"));
         assert.isNotVisible(fixture.querySelector('.o_field_mailing_filter .o_input_dropdown'),
             "should not display drop-down because there is still no filter available to select from");
         assert.isNotVisible(fixture.querySelector('.o_mass_mailing_filter_container'),

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -6,18 +6,11 @@
             <div t-attf-class="o_tree_editor_node d-flex flex-column #{props.readonly ? (props.isSubTree ? 'gap-0' : 'gap-2') : 'gap-1'}">
                 <t t-set="ancestors" t-value="[]"/>
                 <t t-set="node" t-value="tree" />
-                <div class="o_tree_editor_row d-flex align-items-center flex-wrap" t-att-class="{'ps-4': props.isSubTree}">
-                    <div class="o_tree_editor_connector d-flex flex-grow-1 align-items-center">
+                <div class="o_tree_editor_row o_tree_editor_connector d-flex align-items-center flex-wrap" t-att-class="{'ps-4': props.isSubTree}">
+                    <div class="d-flex flex-grow-1 align-items-center">
                         <t t-if="node.children.length">
                             <span t-if="!props.isSubTree">Match</span>
-                            <t t-if="node.children.length > 1">
-                                <t t-call="web.TreeEditor.connector.dropdown" />
-                            </t>
-                            <t t-else="">
-                                <span class="px-1">
-                                    <t t-call="web.TreeEditor.connector.title" />
-                                </span>
-                            </t>
+                            <t t-call="web.TreeEditor.connector.value" />
                             <span t-if="props.isSubTree">of:</span>
                             <span t-else="">of the following rules:</span>
                         </t>
@@ -30,7 +23,7 @@
                 <t t-if="node.children.length" t-call="web.TreeEditor.connector.children" />
                 <t t-if="!props.readonly">
                     <div class="o_tree_editor_row d-flex align-items-center" t-att-class="{ 'ps-4': addPadding || props.isSubTree }">
-                        <a href="#" role="button" t-on-click="() => this.insertRootLeaf(node)">New Rule</a>
+                        <a href="#" role="button" t-on-click="() => this.addNewCondition(node)">New Rule</a>
                     </div>
                 </t>
             </div>
@@ -39,33 +32,37 @@
 
     <t t-name="web.TreeEditor.controls">
         <div class="o_tree_editor_node_control_panel d-flex" role="toolbar" aria-label="Domain node">
-            <button
-                class="btn px-2 fs-4"
-                role="button"
-                data-tooltip="Add New Rule"
-                aria-label="Add New Rule"
-                t-on-click="() => this.insertLeaf(parent, node)"
-                t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
-                t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
-            >
-                <i class="fa fa-plus" />
-            </button>
-            <button
-                class="btn px-2 fs-4"
-                role="button"
-                data-tooltip="Add branch"
-                aria-label="Add branch"
-                t-on-click="() => this.insertBranch(parent, node)"
-                t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
-                t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
-            >
-                <i class="fa fa-sitemap" />
-            </button>
+            <t t-if="node.type !== 'connector'">
+                <button
+                    t-if="ancestors.length === 1"
+                    class="btn px-2 fs-4"
+                    role="button"
+                    data-tooltip="Add nested rule"
+                    aria-label="Add nested rule"
+                    t-on-click="() => this.addNewConnector(parent, node)"
+                    t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
+                    t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
+                >
+                    <i class="fa fa-sitemap" />
+                </button>
+                <button
+                    t-else=""
+                    class="btn px-2 fs-4"
+                    role="button"
+                    data-tooltip="Add rule"
+                    aria-label="Add rule"
+                    t-on-click="() => this.addNewCondition(parent, node)"
+                    t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
+                    t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
+                >
+                    <i class="fa fa-plus" />
+                </button>
+            </t>
             <button
                 class="btn btn-link px-2 text-danger fs-4"
                 role="button"
-                data-tooltip="Delete node"
-                aria-label="Delete node"
+                data-tooltip="Delete rule"
+                aria-label="Delete rule"
                 t-on-click="() => this.delete(ancestors, node)"
                 t-on-mouseenter="(ev) => this.highlightNode(ev.target, true)"
                 t-on-mouseleave="(ev) => this.highlightNode(ev.target, false)"
@@ -75,7 +72,7 @@
         </div>
     </t>
 
-    <t t-name="web.TreeEditor.connector.title">
+    <t t-name="web.TreeEditor.connector.value">
         <t t-set="title">
             <t t-if="node.value === '|'">
                 <t t-if="node.negate">none</t>
@@ -86,26 +83,16 @@
                 <t t-else="">all</t>
             </t>
         </t>
-        <t t-esc="title" />
-    </t>
-
-    <t t-name="web.TreeEditor.connector.dropdown">
         <t t-if="props.readonly">
-            <strong class="px-1">
-                <t t-call="web.TreeEditor.connector.title" />
-            </strong>
+            <div class="o_tree_editor_connector_value px-1">
+                <strong class="text-primary" t-esc="title"/>
+            </div>
         </t>
         <t t-else="">
-            <div aria-atomic="true">
-                <Dropdown>
-                    <button class="btn btn-link btn-primary py-0 px-1 o-dropdown-caret">
-                        <t t-call="web.TreeEditor.connector.title" />
-                    </button>
-                    <t t-set-slot="content">
-                        <DropdownItem onSelected="() => this.updateConnector(node, '&amp;')">all</DropdownItem>
-                        <DropdownItem onSelected="() => this.updateConnector(node, '|')">any</DropdownItem>
-                    </t>
-                </Dropdown>
+            <div class="o_tree_editor_connector_value px-1" aria-atomic="true">
+                <button class="btn o-dropdown o-dropdown-caret p-0 opacity-75" t-on-click="() => this.updateConnector(node)">
+                    <strong class="text-primary" t-esc="title"/>
+                </button>
             </div>
         </t>
     </t>
@@ -123,9 +110,9 @@
     </t>
 
     <t t-name="web.TreeEditor.connector">
-        <div class="o_tree_editor_row d-flex align-items-center">
-            <div class="o_tree_editor_connector d-flex flex-grow-1">
-                <t t-call="web.TreeEditor.connector.dropdown" />
+        <div class="o_tree_editor_row o_tree_editor_connector d-flex align-items-center">
+            <div class="d-flex flex-grow-1">
+                <t t-call="web.TreeEditor.connector.value" />
                 <span>of:</span>
             </div>
             <t t-if="!props.readonly">

--- a/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.xml
+++ b/addons/web/static/src/search/custom_group_by_item/custom_group_by_item.xml
@@ -2,7 +2,7 @@
 
     <t t-name="web.CustomGroupByItem">
         <select class="o_add_custom_group_menu o_menu_item dropdown-item" t-on-change="(ev) => this.onSelected(ev)">
-            <option value="" disabled="true" selected="true" hidden="true">Add Custom Group</option>
+            <option value="" disabled="true" selected="true" hidden="true">Custom Group</option>
             <option t-foreach="props.fields" t-as="field" t-key="field.name"
                 t-if="field.type !== 'properties' and !field.isProperty"
                 t-att-value="field.name"

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -524,7 +524,9 @@ export class SearchBar extends Component {
                 }
             },
             disableConfirmButton: (domain) => domain === `[]`,
-            title: _t("Modify Condition"),
+            title: _t("Custom Filter"),
+            confirmButtonText: _t("Search"),
+            discardButtonText: _t("Discard"),
             isDebugMode: this.env.searchModel.isDebugMode,
         });
     }

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -75,7 +75,7 @@
                     </a>
                 </t>
                 <a href="#" t-on-click.prevent="" t-att-class="{'ps-3 pe-2 text-truncate': item.isFieldProperty }" t-att-title="item.title">
-                    <t t-if="item.isAddCustomFilterButton"><span class="text-action">Add Custom Filter</span></t>
+                    <t t-if="item.isAddCustomFilterButton"><span class="text-action">Custom Filter...</span></t>
                     <t t-elif="item.loadMore"><span class="text-action"><t t-esc="item.label"/></span></t>
                     <t t-elif="item.isChild">
                         <t t-esc="item.label"/>

--- a/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
+++ b/addons/web/static/src/search/search_bar_menu/search_bar_menu.xml
@@ -56,7 +56,7 @@
                         <t t-if="filterItems.length">
                             <div role="separator" class="dropdown-divider"/>
                         </t>
-                        <DropdownItem class="'o_menu_item o_add_custom_filter'" onSelected.bind="onAddCustomFilterClick">Add Custom Filter</DropdownItem>
+                        <DropdownItem class="'o_menu_item o_add_custom_filter'" onSelected.bind="onAddCustomFilterClick">Custom Filter...</DropdownItem>
                     </div>
                 </t>
                 <!-- GroupBy -->

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -926,9 +926,9 @@ export class SearchModel extends EventBus {
             context: this.globalContext,
             onConfirm: (domain) => this.splitAndAddDomain(domain),
             disableConfirmButton: (domain) => domain === `[]`,
-            title: _t("Add Custom Filter"),
-            confirmButtonText: _t("Add"),
-            discardButtonText: _t("Cancel"),
+            title: _t("Custom Filter"),
+            confirmButtonText: _t("Search"),
+            discardButtonText: _t("Discard"),
             isDebugMode: this.isDebugMode,
         });
     }

--- a/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
@@ -102,11 +102,13 @@ export const SELECTORS = {
     row: ".o_tree_editor_row",
     tree: ".o_tree_editor > .o_tree_editor_node",
     connector: ".o_tree_editor_connector",
+    connectorValue: ".o_tree_editor_connector .o_tree_editor_connector_value",
+    connectorToggler: ".o_tree_editor_connector .o_tree_editor_connector_value button.o-dropdown",
     condition: ".o_tree_editor_condition",
     addNewRule: ".o_tree_editor_row > a",
-    buttonAddNewRule: ".o_tree_editor_node_control_panel > button:nth-child(1)",
-    buttonAddBranch: ".o_tree_editor_node_control_panel > button:nth-child(2)",
-    buttonDeleteNode: ".o_tree_editor_node_control_panel > button:nth-child(3)",
+    buttonAddNewRule: ".o_tree_editor_node_control_panel > button[data-tooltip='Add rule']",
+    buttonAddBranch: ".o_tree_editor_node_control_panel > button[data-tooltip='Add nested rule']",
+    buttonDeleteNode: ".o_tree_editor_node_control_panel > button[data-tooltip='Delete rule']",
     pathEditor: ".o_tree_editor_condition > .o_tree_editor_editor:nth-child(1)",
     operatorEditor: ".o_tree_editor_condition > .o_tree_editor_editor:nth-child(2)",
     valueEditor: ".o_tree_editor_condition > .o_tree_editor_editor:nth-child(3)",
@@ -249,7 +251,7 @@ function getCurrentCondition(index, target) {
  */
 function getCurrentConnector(index, target) {
     const connectorText = queryAllTexts(
-        `${SELECTORS.connector} .dropdown-toggle, ${SELECTORS.connector} > span:nth-child(2), ${SELECTORS.connector} > span > strong`,
+        `${SELECTORS.connector} > div > span > strong, ${SELECTORS.connectorValue}`,
         { root: target }
     ).at(index);
     return connectorText.includes("all") ? "all" : connectorText;
@@ -285,6 +287,14 @@ export function isNotSupportedValue(index, target) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * @param {number} [index=0]
+ * @param {Target} [target]
+ */
+export async function toggleConnector(index, target) {
+    await contains(queryAt(SELECTORS.connectorToggler, index, target)).click();
+}
 
 /**
  * @param {any} operator
@@ -325,7 +335,7 @@ export async function editValue(value, options, index, target) {
  * @param {number} [index=0]
  * @param {Target} [target]
  */
-export async function clickOnButtonAddNewRule(index, target) {
+export async function clickOnButtonAddRule(index, target) {
     await contains(queryAt(SELECTORS.buttonAddNewRule, index, target)).click();
 }
 
@@ -353,8 +363,8 @@ export async function clearNotSupported(index, target) {
     await contains(queryAt(SELECTORS.clearNotSupported, index, target)).click();
 }
 
-export async function addNewRule() {
-    await contains(SELECTORS.addNewRule).click();
+export async function addNewRule(index, target) {
+    await contains(queryAt(SELECTORS.addNewRule, index, target)).click();
 }
 
 export async function toggleArchive() {

--- a/addons/web/static/tests/search/custom_group_by_item.test.js
+++ b/addons/web/static/tests/search/custom_group_by_item.test.js
@@ -39,7 +39,7 @@ test(`simple rendering`, async () => {
     });
 
     await toggleSearchBarMenu();
-    expect(`.o_group_by_menu option[disabled]`).toHaveText(`Add Custom Group`);
+    expect(`.o_group_by_menu option[disabled]`).toHaveText(`Custom Group`);
     expect(queryAllTexts`.o_add_custom_group_menu option:not([disabled])`).toEqual([
         "Birthday",
         "Created on",
@@ -50,7 +50,7 @@ test(`simple rendering`, async () => {
     ]);
 });
 
-test(`the ID field should not be proposed in "Add Custom Group" menu`, async () => {
+test(`the ID field should not be proposed in "Custom Group" menu`, async () => {
     await mountWithSearch(SearchBar, {
         resModel: "foo",
         searchMenuTypes: ["groupBy"],
@@ -65,7 +65,7 @@ test(`the ID field should not be proposed in "Add Custom Group" menu`, async () 
     expect(queryAllTexts`.o_add_custom_group_menu option:not([disabled])`).toEqual(["Foo"]);
 });
 
-test(`stored many2many should be proposed in "Add Custom Group" menu`, async () => {
+test(`stored many2many should be proposed in "Custom Group" menu`, async () => {
     await mountWithSearch(SearchBar, {
         resModel: "foo",
         searchMenuTypes: ["groupBy"],
@@ -95,7 +95,7 @@ test(`stored many2many should be proposed in "Add Custom Group" menu`, async () 
     ]);
 });
 
-test(`add a date field in "Add Custom Group" activate a groupby with global default option "month"`, async () => {
+test(`add a date field in "Custom Group" activate a groupby with global default option "month"`, async () => {
     const component = await mountWithSearch(SearchBar, {
         resModel: "foo",
         searchMenuTypes: ["groupBy"],
@@ -114,7 +114,7 @@ test(`add a date field in "Add Custom Group" activate a groupby with global defa
 
     await toggleSearchBarMenu();
     expect(component.env.searchModel.groupBy).toEqual([]);
-    expect(`.o_add_custom_group_menu`).toHaveCount(1); // Add Custom Group
+    expect(`.o_add_custom_group_menu`).toHaveCount(1); // Custom Group
 
     await selectGroup("date");
     expect(component.env.searchModel.groupBy).toEqual(["date:month"]);
@@ -142,14 +142,14 @@ test(`click on add custom group toggle group selector`, async () => {
     });
 
     await toggleSearchBarMenu();
-    expect(`.o_add_custom_group_menu option[disabled]`).toHaveText("Add Custom Group");
+    expect(`.o_add_custom_group_menu option[disabled]`).toHaveText("Custom Group");
 
     // Single select node with a single option
     expect(`.o_add_custom_group_menu option:not([disabled])`).toHaveCount(1);
     expect(`.o_add_custom_group_menu option:not([disabled])`).toHaveText("Super Date");
 });
 
-test(`select a field name in Add Custom Group menu properly trigger the corresponding field`, async () => {
+test(`select a field name in Custom Group menu properly trigger the corresponding field`, async () => {
     await mountWithSearch(SearchBar, {
         resModel: "foo",
         searchMenuTypes: ["groupBy"],

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -770,7 +770,7 @@ test("many2one_reference fields are supported in search view", async () => {
     expect(queryAllTexts`.o_searchview_autocomplete .o-dropdown-item`).toEqual([
         "Search Foo for: 12",
         "Search Resource ID for: 12",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     await keyDown("ArrowDown");
@@ -783,7 +783,7 @@ test("many2one_reference fields are supported in search view", async () => {
     await editSearch("1a");
     expect(queryAllTexts`.o_searchview_autocomplete .o-dropdown-item`).toEqual([
         "Search Foo for: 1a",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     await validateSearch();
@@ -969,7 +969,7 @@ test("search a property", async () => {
         "My Tags (Bar 1) for: A",
         "My Tags (Bar 1) for: AA",
         "My Text (Bar 2) for: a",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // click again on the expand icon to hide the properties
@@ -977,7 +977,7 @@ test("search a property", async () => {
     expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(2);
     expect(queryAllTexts`.o_searchview_autocomplete .o-dropdown-item`).toEqual([
         "Search Properties",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // search for a partner, and expand the many2many property
@@ -993,7 +993,7 @@ test("search a property", async () => {
         "Bob",
         "Bobby",
         "My Text (Bar 2) for: Bo",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // fold all the properties (included the search result)
@@ -1001,7 +1001,7 @@ test("search a property", async () => {
     expect(`.o_searchview_autocomplete .o-dropdown-item`).toHaveCount(2);
     expect(queryAllTexts`.o_searchview_autocomplete .o-dropdown-item`).toEqual([
         "Search Properties",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // unfold all the properties but fold the search result
@@ -1013,7 +1013,7 @@ test("search a property", async () => {
         "My Partner (Bar 1)",
         "My Partners (Bar 1)",
         "My Text (Bar 2) for: Bo",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // select Bobby
@@ -1039,7 +1039,7 @@ test("search a property", async () => {
         "My Tags (Bar 1) for: A",
         "My Tags (Bar 1) for: AA",
         "My Text (Bar 2) for: a",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // select the selection option "AA"
@@ -1090,7 +1090,7 @@ test("search a property", async () => {
         "Alicia",
         "My Partners (Bar 1)",
         "My Text (Bar 2) for: Ali",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
     await contains(".o_searchview_autocomplete .o-dropdown-item:nth-child(4)").click();
     expect(searchBar.env.searchModel.domain).toEqual([
@@ -1113,7 +1113,7 @@ test("search a property", async () => {
         "My Tags (Bar 1) for: A",
         "My Tags (Bar 1) for: AA",
         "My Text (Bar 2) for: A",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     await contains(".o_searchview_autocomplete .o-dropdown-item:nth-child(7)").click();
@@ -1138,7 +1138,7 @@ test("search a property", async () => {
         "My Selection (Bar 1) for: B",
         "My Tags (Bar 1) for: B",
         "My Text (Bar 2) for: B",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
     await contains(".o_searchview_autocomplete .o-dropdown-item:nth-child(5)").click();
     expect(searchBar.env.searchModel.domain).toEqual([
@@ -1180,7 +1180,7 @@ test("search a property", async () => {
         "(no result)",
         "My Partners (Bar 1)",
         "My Text (Bar 2) for: Bobby",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 
     // test the navigation with keyboard
@@ -1316,10 +1316,10 @@ test("edit a filter", async () => {
 
     await contains(".o_facet_with_domain .o_searchview_facet_label").click();
     expect(`.modal`).toHaveCount(1);
-    expect(`.modal header`).toHaveText("Modify Condition");
+    expect(`.modal header`).toHaveText("Custom Filter");
     expect(`.modal .o_domain_selector`).toHaveCount(1);
     expect(SELECTORS.condition).toHaveCount(1);
-    expect(queryAllTexts`.modal footer button`).toEqual(["Confirm", "Discard"]);
+    expect(queryAllTexts`.modal footer button`).toEqual(["Search", "Discard"]);
     expect(getCurrentPath()).toBe("Birthday");
     expect(getCurrentOperator()).toBe("is greater or equal");
     expect(getCurrentValue()).toBe("context_today()");
@@ -1561,7 +1561,7 @@ test("select autocompleted many2one with allowed_company_ids domain (cids: 1-5)"
         "Search Bar for: rec",
         "Second record",
         "Third record",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 });
 
@@ -1598,7 +1598,7 @@ test("select autocompleted many2one with allowed_company_ids domain (cids: 1)", 
     expect(queryAllTexts(`.o_searchview_autocomplete .o-dropdown-item`)).toEqual([
         "Search Bar for: rec",
         "Second record",
-        "Add Custom Filter",
+        "Custom Filter...",
     ]);
 });
 
@@ -1620,7 +1620,7 @@ test("throw error when domain can not be parsed", async () => {
     expect.verifyErrors(["Error: Name 'wrong' is not defined"]);
 });
 
-test("dropdown menu last element is 'Add Custom Filter'", async () => {
+test("dropdown menu last element is 'Custom Filter...'", async () => {
     await mountWithSearch(SearchBar, {
         resModel: "partner",
         searchMenuTypes: [],
@@ -1633,9 +1633,7 @@ test("dropdown menu last element is 'Add Custom Filter'", async () => {
     });
     await editSearch("a");
     await animationFrame();
-    expect(".o_searchview_autocomplete .o-dropdown-item:last-child").toHaveText(
-        "Add Custom Filter"
-    );
+    expect(".o_searchview_autocomplete .o-dropdown-item:last-child").toHaveText("Custom Filter...");
 });
 
 test("order by count resets when there is no group left", async () => {

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1361,7 +1361,7 @@ test("edit a filter with context: context is kept after edition", async () => {
     await contains(".o_facet_with_domain .o_searchview_facet_label").click();
     await contains(`.modal ${SELECTORS.addNewRule}`).click();
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual([`Custom filter`]);
+    expect(getFacetTexts()).toEqual([`Foo`]);
     expect(searchBar.env.searchModel.context.specialKey).toBe("abc");
 });
 

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -41,7 +41,7 @@ test("simple rendering with no filter", async () => {
     expect(".o_menu_item").toHaveCount(1);
     expect(".dropdown-divider").toHaveCount(0);
     expect(".dropdown-item").toHaveCount(1);
-    expect(`.dropdown-item`).toHaveText("Add Custom Filter");
+    expect(`.dropdown-item`).toHaveText("Custom Filter...");
 });
 
 test("simple rendering with a single filter", async () => {
@@ -60,7 +60,7 @@ test("simple rendering with a single filter", async () => {
     expect(`.o_menu_item[role=menuitemcheckbox]`).toHaveCount(1);
     expect(queryFirst`.o_menu_item`).toHaveProperty("ariaChecked", "false");
     expect(`.dropdown-divider`).toHaveCount(1);
-    expect(`.o_menu_item:nth-of-type(2)`).toHaveText("Add Custom Filter");
+    expect(`.o_menu_item:nth-of-type(2)`).toHaveText("Custom Filter...");
 });
 
 test(`toggle a "simple" filter in filter menu works`, async () => {
@@ -601,7 +601,7 @@ test("arch order of groups of filters preserved", async () => {
     );
 });
 
-test("Open 'Add Custom Filter' dialog", async () => {
+test("Open 'Custom Filter' dialog", async () => {
     await mountWithSearch(SearchBarMenu, {
         resModel: "foo",
         searchMenuTypes: ["filter"],
@@ -609,18 +609,18 @@ test("Open 'Add Custom Filter' dialog", async () => {
         searchViewArch: `<search></search>`,
     });
     await toggleSearchBarMenu();
-    expect(queryAllTexts`.o_filter_menu .dropdown-item`).toEqual(["Add Custom Filter"]);
+    expect(queryAllTexts`.o_filter_menu .dropdown-item`).toEqual(["Custom Filter..."]);
     expect(".modal").toHaveCount(0);
 
     await openAddCustomFilterDialog();
     expect(".modal").toHaveCount(1);
-    expect(".modal header").toHaveText("Add Custom Filter");
+    expect(".modal header").toHaveText("Custom Filter");
     expect(".modal .o_domain_selector").toHaveCount(1);
     expect(".modal .o_domain_selector .o_tree_editor_condition").toHaveCount(1);
-    expect(queryAllTexts`.modal footer button`).toEqual(["Add", "Cancel"]);
+    expect(queryAllTexts`.modal footer button`).toEqual(["Search", "Discard"]);
 });
 
-test("Default leaf in 'Add Custom Filter' dialog is based on ID (if no special fields on model)", async () => {
+test("Default leaf in 'Custom Filter' dialog is based on ID (if no special fields on model)", async () => {
     await mountWithSearch(SearchBarMenu, {
         resModel: "foo",
         searchMenuTypes: ["filter"],
@@ -634,7 +634,7 @@ test("Default leaf in 'Add Custom Filter' dialog is based on ID (if no special f
     expect(getCurrentPath()).toBe("Id");
 });
 
-test("Default leaf in 'Add Custom Filter' dialog is based on first special field (if any special fields on model)", async () => {
+test("Default leaf in 'Custom Filter' dialog is based on first special field (if any special fields on model)", async () => {
     defineModels([class Country extends models.Model {}]);
     Foo._fields.country_id = fields.Many2one({ string: "Country", relation: "country" });
     await mountWithSearch(SearchBarMenu, {

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -2,11 +2,14 @@ import { expect, test } from "@odoo/hoot";
 import { queryAll, queryAllTexts, queryFirst } from "@odoo/hoot-dom";
 import { animationFrame, mockDate } from "@odoo/hoot-mock";
 import {
+    addNewRule,
     clickOnButtonAddBranch,
-    clickOnButtonAddNewRule,
+    clickOnButtonAddRule,
     getCurrentPath,
     openModelFieldSelectorPopover,
     selectOperator,
+    SELECTORS,
+    toggleConnector,
 } from "@web/../tests/core/tree_editor/condition_tree_editor_test_helpers";
 import {
     contains,
@@ -662,11 +665,11 @@ test("Default connector is '|' (any)", async () => {
     expect(".modal .o_domain_selector .o_tree_editor_condition").toHaveCount(1);
     expect(".o_tree_editor_condition .o_model_field_selector_chain_part").toHaveCount(1);
     expect(getCurrentPath()).toBe("Id");
-    expect(".o_domain_selector .o_tree_editor_connector").toHaveCount(1);
+    expect(SELECTORS.connectorValue).toHaveCount(1);
 
-    await clickOnButtonAddNewRule();
-    expect(".o_domain_selector .dropdown-toggle").toHaveCount(1);
-    expect(".o_domain_selector .dropdown-toggle").toHaveText("any");
+    await addNewRule();
+    expect(SELECTORS.connectorValue).toHaveCount(1);
+    expect(SELECTORS.connectorValue).toHaveText("any");
     expect(".modal .o_domain_selector .o_tree_editor_condition").toHaveCount(2);
 });
 
@@ -692,14 +695,12 @@ test("Add a custom filter", async () => {
     expect(".o_filter_menu .o_menu_item:not(.o_add_custom_filter)").toHaveCount(1);
 
     await openAddCustomFilterDialog();
-    await clickOnButtonAddNewRule();
-    await contains(".o_domain_selector .dropdown-toggle").click();
-    await contains(queryFirst(".dropdown-menu .dropdown-item")).click();
-
+    await addNewRule();
+    await toggleConnector();
     await clickOnButtonAddBranch(-1);
-    await clickOnButtonAddBranch(-1);
+    await clickOnButtonAddRule(-1);
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Filter", "Custom filter"]);
+    expect(getFacetTexts()).toEqual(["Filter", "Id"]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
         ["foo", "=", "abc"],
@@ -708,10 +709,6 @@ test("Add a custom filter", async () => {
         ["id", "=", 1],
         ["id", "=", 1],
         "|",
-        "|",
-        ["id", "=", 1],
-        ["id", "=", 1],
-        "&",
         ["id", "=", 1],
         ["id", "=", 1],
     ]);
@@ -785,7 +782,7 @@ test("consistent display of ! in debug mode", async () => {
     await contains(`.o_domain_selector_debug_container textarea`).edit(
         `["!", "|", ("foo", "=", 1 ), ("id", "=", 2)]`
     );
-    expect(".o_tree_editor_row .dropdown-toggle").toHaveText("none");
+    expect(SELECTORS.connectorValue).toHaveText("none");
 
     await contains(".modal footer button").click();
     expect(getFacetTexts()).toEqual([`Custom filter`]);

--- a/addons/web/static/tests/search/with_search.test.js
+++ b/addons/web/static/tests/search/with_search.test.js
@@ -212,9 +212,9 @@ test("load view description with given id if it is not provided and loadSearchVi
     await toggleSearchBarMenu();
     expect(getMenuItemTexts()).toEqual([
         "True domain",
-        "Add Custom Filter",
+        "Custom Filter...",
         "Name",
-        "Add Custom Group\nCreated on\nDisplay name\nLast Modified on\nName",
+        "Custom Group\nCreated on\nDisplay name\nLast Modified on\nName",
         "Save current search",
     ]);
 });

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5220,7 +5220,7 @@ test("edit a favorite: group by = default_group_by", async () => {
 
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
-    await contains("button:contains('Confirm')").click();
+    await contains("button:contains('Search')").click();
     expect(getFacetTexts()).toEqual(["Id\n1"]);
 });
 
@@ -5263,7 +5263,7 @@ test("edit a favorite: group by != default_group_by", async () => {
 
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
-    await contains("button:contains('Confirm')").click();
+    await contains("button:contains('Search')").click();
     expect(getFacetTexts()).toEqual(["Id\n1", "Product"]);
 });
 

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -17,7 +17,7 @@ const checkKanbanGroupBy = [
         run: "click",
     },
     {
-        content: "Select 'Active' in the select of Add Custom Group",
+        content: "Select 'Active' in the select of Custom Group",
         trigger: "select.o_add_custom_group_menu",
         run: "select active",
     },


### PR DESCRIPTION
We modify the tree editor buttons:
- the button "Add branch" becomes a button "Add nested rule" and is only available for simplex/complex conditions that are at first level. A single copy of the related condition is put in a new connector.
- the button "Add New Rule" becomes a button "Add rule" and is only available for simplex/complex conditions that are at second level. A single copy of the related condition is put in its related connector.
- the dropdowns for connectors becomes simple buttons that allows to modify the connectors in one click

In the end, this means we can no longer create in the UI more that three or more level of connectors.

First part of task ID: 4610804