### PR TITLE
[FIX] hr_attendance: fix access right issue for attendance officers

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -14,7 +14,7 @@ class HrEmployee(models.Model):
     attendance_manager_id = fields.Many2one(
         'res.users', store=True, readonly=False,
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
-        groups="hr_attendance.group_hr_attendance_manager",
+        groups="hr_attendance.group_hr_attendance_officer",
         help="The user set in Attendance will access the attendance of the employee through the dedicated app and will be able to edit them.")
     attendance_ids = fields.One2many(
         'hr.attendance', 'employee_id', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")


### PR DESCRIPTION
Attendance module was inaccessible for users that had access to employee records, but were not attendance admins. This was due to [this](https://github.com/odoo/odoo/pull/205031/commits/ef423640c4e2402509eafc6aa8696e33dacf51ea) backported change that did not also backport the access right change for the attendance_manager_id field.

opw-4750765
