### PR TITLE
[FIX] http,portal,sale: fix pdf preview filename

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -487,9 +487,9 @@ class CustomerPortal(Controller):
             ('Content-Type', 'application/pdf' if report_type == 'pdf' else 'text/html'),
             ('Content-Length', len(report)),
         ]
-        if report_type == 'pdf' and download:
+        if report_type == 'pdf':
             filename = "%s.pdf" % (re.sub(r'\W+', '-', model._get_report_base_filename()))
-            reporthttpheaders.append(('Content-Disposition', content_disposition(filename)))
+            reporthttpheaders.append(('Content-Disposition', content_disposition(filename, disposition_type='attachment' if download else 'inline')))
         return request.make_response(report, headers=reporthttpheaders)
 
 def get_error(e, path=''):

--- a/addons/sale/tests/test_controllers.py
+++ b/addons/sale/tests/test_controllers.py
@@ -66,6 +66,23 @@ class TestAccessRightsControllers(BaseUsersCommon, HttpCase, SaleCommon):
 
 
 @tagged('post_install', '-at_install')
+class TestSalesControllers(BaseUsersCommon, HttpCase, SaleCommon):
+    def test_sales_portal_report(self):
+        portal_so = self.sale_order.copy()
+        portal_so.message_subscribe(self.user_portal.partner_id.ids)
+
+        self.authenticate(None, None)
+
+        req = self.url_open(portal_so.get_portal_url(report_type='pdf'), allow_redirects=False)
+        self.assertEqual(req.status_code, 200)
+        self.assertEqual(req.headers['content-disposition'], f"inline; filename*=UTF-8''Quotation-S{portal_so.id:05}.pdf")
+
+        req = self.url_open(portal_so.get_portal_url(report_type='pdf', download=True), allow_redirects=False)
+        self.assertEqual(req.status_code, 200)
+        self.assertEqual(req.headers['content-disposition'], f"attachment; filename*=UTF-8''Quotation-S{portal_so.id:05}.pdf")
+
+
+@tagged('post_install', '-at_install')
 class TestSaleSignature(HttpCaseWithUserPortal):
 
     def test_01_portal_sale_signature_tour(self):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -284,10 +284,25 @@ STATIC_CACHE_LONG = 60 * 60 * 24 * 365
 class SessionExpiredException(Exception):
     pass
 
-def content_disposition(filename):
-    return "attachment; filename*=UTF-8''{}".format(
+
+def content_disposition(filename, disposition_type='attachment'):
+    """
+    Craft a ``Content-Disposition`` header, see :rfc:`6266`.
+
+    :param filename: The name of the file, should that file be saved on
+        disk by the browser.
+    :param disposition_type: Tell the browser what to do with the file,
+        either ``"attachment"`` to save the file on disk,
+        either ``"inline"`` to display the file.
+    """
+    if disposition_type not in ('attachment', 'inline'):
+        e = f"Invalid disposition_type: {disposition_type!r}"
+        raise ValueError(e)
+    return "{}; filename*=UTF-8''{}".format(
+        disposition_type,
         url_quote(filename, safe='', unsafe='()<>@,;:"/[]?={}\\*\'%') # RFC6266
     )
+
 
 def db_list(force=False, host=None):
     """


### PR DESCRIPTION
Before this commit, the filename for pdf reports when previewed from the portal is "\<database ID\>.pdf" instead of a readable name like "Sales-Order-S00001".pdf. This can be especially confusing if the database ID is a different number from the record's sequence number.

Steps to reproduce
-----
1. Open a sales order in the customer portal
2. Select the Print button
3. From the pdf preview, Print -> Save to PDF
4. The downloaded filename is "\<database ID\>.pdf", also the browser title bar is just the database ID

Cause
-----
No filename is being set in the Content-Disposition header, so the browser takes the filename from the last segment of the URL which is the database ID.

Solution
-----
Set an inline Content-Disposition with the filename argument when previewing, similar to what is done when downloading.

opw-4710501