### PR TITLE
[FIX] account_peppol: don't suggest sending on PEPPOL if company not registered

### DIFF
--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -107,7 +107,8 @@ class AccountMoveSend(models.AbstractModel):
     def _is_applicable_to_company(self, method, company):
         # EXTENDS 'account'
         if method == 'peppol':
-            return company.country_code in PEPPOL_LIST and company.account_peppol_proxy_state != 'rejected'
+            can_send = self.env['account_edi_proxy_client.user']._get_can_send_domain()
+            return company.country_code in PEPPOL_LIST and company.account_peppol_proxy_state in can_send
         else:
             return super()._is_applicable_to_company(method, company)
 
@@ -119,7 +120,6 @@ class AccountMoveSend(models.AbstractModel):
             return all([
                 self._is_applicable_to_company(method, move.company_id),
                 self.env['res.partner']._get_peppol_verification_state(partner.peppol_endpoint, partner.peppol_eas, invoice_edi_format) == 'valid',
-                move.company_id.account_peppol_proxy_state != 'rejected',
                 move._need_ubl_cii_xml(invoice_edi_format)
                 or move.ubl_cii_xml_id and move.peppol_move_state not in ('processing', 'done'),
             ])


### PR DESCRIPTION
Use case:

- Create an database with eCommerce (`website_sale`) (and for a country where PEPPOL is supported)

- Enable `Automatic Invoice` in General Settings.

- Configure everything for PEPPOL but do not register the company (Partner have their PEPPOL EAS and Endpoint correctly configured)

- Enable a card payment provider

- As a customer, buy something from the shop and paid using a card

=> When post-processing the customer payment (payment.transaction) we will automatically generate and send the invoice; and while trying to send the invoice we will crash with:

`ValueError: Expected singleton: account_edi_proxy_client.user()`

  The reason is that we try to send the invoice to both email and
PEPPOL while the company's registration on PEPPOL was not yet be done.

  This commit ensure we don't suggest sending by default on PEPPOL
if the company is not allowed to send on PEPPOL.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
