### PR TITLE
[FIX] l10n_ar: 5614/2024: Tax Breakdown on B2C (0.0 taxes)

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -377,27 +377,26 @@ class AccountMove(models.Model):
 
             # Prepare the subtotals to show in the report
             currency_symbol = self.currency_id.symbol
-            detail_info = {}
+            detail_info = {
+                'vat_taxes': {'name': _("VAT Content %s", currency_symbol), 'tax_amount': 0.0, 'group': 'vat'},
+                'other_taxes': {'name': _("Other National Ind. Taxes %s", currency_symbol), 'tax_amount': 0.0,
+                                'group': 'other'},
+            }
 
             for subtotals in temp['groups_by_subtotal'].values():
                 for subtotal in subtotals:
                     tax_group_id = subtotal['tax_group_id']
-                    tax_amount = subtotal['tax_group_amount']
-
                     if tax_group_id in nat_int_tax_groups.ids:
                         key = 'other_taxes'
-                        name = _("Other National Ind. Taxes %s", currency_symbol)
                     elif tax_group_id in vat_tax_groups.ids:
                         key = 'vat_taxes'
-                        name = _("VAT Content %s", currency_symbol)
                     else:
                         continue  # If not belongs to the needed groups we ignore them
 
-                    if key not in detail_info:
-                        if tax_amount != 0.0:
-                            detail_info[key] = {"name": name, "tax_amount": tax_amount}
-                    else:
-                        detail_info[key]["tax_amount"] += tax_amount
+                    detail_info[key]["tax_amount"] += subtotal['tax_group_amount']
+
+            if detail_info['other_taxes']["tax_amount"] == 0.0:
+                detail_info.pop('other_taxes')
 
             # Format the amounts to show in the report
             for _item, values in detail_info.items():

--- a/addons/l10n_ar/tests/test_manual.py
+++ b/addons/l10n_ar/tests/test_manual.py
@@ -113,6 +113,14 @@ class TestManual(common.TestAr):
             if len_l10n_ar_price_unit_digits == len_line_price_unit_digits == decimal_price_digits_setting:
                 self.assertEqual(l10n_ar_price_unit_decimal_part, line_price_unit_decimal_part)
 
+    def _get_simple_detail_ar_tax(self, invoice):
+        """ Get the simple detail_ar_tax list of tuples with the vat group name and the amount
+        [("vat_taxes", float), ("other_taxes", float)] """
+        return [
+            (item.get('group'), item.get('tax_amount'))
+            for item in invoice._l10n_ar_get_invoice_totals_for_report().get('detail_ar_tax')
+        ]
+
     def test_16_invoice_b_tax_breakdown_1(self):
         """ Display Both VAT and Other Taxes """
         invoice1 = self._create_invoice_from_dict({
@@ -132,10 +140,7 @@ class TestManual(common.TestAr):
                     'tax_ids': [(6, 0, [self.tax_0.id, self.tax_other.id])]},
             ],
         })
-        res1 = invoice1._l10n_ar_get_invoice_totals_for_report()
-        self.assertEqual(res1.get('detail_ar_tax'), [
-            {'formatted_amount_tax': '868.51', 'name': 'VAT Content $', 'tax_amount': 868.51},
-            {'formatted_amount_tax': '142.20', 'name': 'Other National Ind. Taxes $', 'tax_amount': 142.20}])
+        self.assertEqual(self._get_simple_detail_ar_tax(invoice1), [("vat", 868.51), ("other", 142.20)])
 
     def test_17_invoice_b_tax_breakdown_2(self):
         """ Display only Other Taxes (VAT taxes are 0) """
@@ -150,6 +155,19 @@ class TestManual(common.TestAr):
                     'tax_ids': [(6, 0, [self.tax_no_gravado.id, self.tax_internal.id])]},
             ],
         })
-        res2 = invoice2._l10n_ar_get_invoice_totals_for_report()
-        self.assertEqual(res2.get('detail_ar_tax'), [
-            {'formatted_amount_tax': '300.00', 'name': 'Other National Ind. Taxes $', 'tax_amount': 300.00}])
+        self.assertEqual(self._get_simple_detail_ar_tax(invoice2), [("vat", 0.0), ("other", 300.0)])
+
+    def test_18_invoice_b_tax_breakdown_3(self):
+        """ Display only Other Taxes (VAT taxes are 0 and non other taxes) """
+        invoice3 = self._create_invoice_from_dict({
+            'ref': 'test_invoice_22:  Final Consumer Invoice B with 0 only',
+            "move_type": 'out_invoice',
+            "partner_id": self.partner_cf,
+            "company_id": self.company_ri,
+            "invoice_date": "2021-03-20",
+            "invoice_line_ids": [
+                {'product_id': self.product_iva_105_perc, 'price_unit': 10000.0, 'quantity': 1,
+                    'tax_ids': [(6, 0, [self.tax_no_gravado.id])]},
+            ],
+        })
+        self.assertEqual(self._get_simple_detail_ar_tax(invoice3), [("vat", 0.0)])


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

When doing an Invoice B to exempts customer we have a problem the RG Legend new table is not showing: this because if the VAT Content or other taxes sum is 0.0 (we are not showing any information if sums 0.0)

After checking with ARCA Online PDF sxampels, and some feedback of Argentinen users, we found out that the Legend should be always present. event if the totals of theTax Breakdown are shown with 0.0

### Steps to reproduce

1. Go to an Argentina Company
2. Create a new invoice for "Final Consumer" with document type "Invoice B"
3. Create a product line with tax 0 (could use either VAT Exempt, VAT 0, VAT Not Taxed)
4. Print the PDF

### Current behavior before PR:

The PDF is NOT showing the Tax Breakdown table

![image](https://github.com/user-attachments/assets/94bbddc1-1dcf-4eb4-887b-2106914290df)

### Desired behavior after PR is merged:

The PDF is showing the Tax Breakdown with the line VAT Content 0.0

![image](https://github.com/user-attachments/assets/c6b8a1b6-322b-4eb7-b11e-3df8bcb3ec42)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
