### PR TITLE
[FIX] project_timesheet_holidays: Time Off Admin cannot create public holidays

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -185,7 +185,8 @@ class ResourceCalendarLeaves(models.Model):
             'name': _("Time Off (%s/%s)", index + 1, len(work_hours_data)),
             'project_id': employee_id.company_id.internal_project_id.id,
             'task_id': employee_id.company_id.leave_timesheet_task_id.id,
-            'account_id': employee_id.company_id.internal_project_id.analytic_account_id.id,
+            # Holidays Administrator may not have read access on internal project
+            'account_id': employee_id.company_id.internal_project_id.sudo().analytic_account_id.id,
             'unit_amount': work_hours_count,
             'user_id': employee_id.user_id.id,
             'date': day_date,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Fix the error that Time Off Administrator (without Project Administrator group) cannot create public holidays

Current behavior before PR:
- Error popup:
![image](https://github.com/user-attachments/assets/89ddb8ea-d5e1-438e-be69-1174802572d9)

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
