### PR TITLE
[FIX] point_of_sale: prevent error on enabling preparation display

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -358,7 +358,7 @@
                                 </div>
                             </setting>
                             <setting string="Preparation Display" help="Display orders on the preparation display" id="preparation_display">
-                                <field name="module_pos_preparation_display" widget="upgrade_boolean"/>
+                                <field name="module_pos_preparation_display" readonly="pos_has_active_session or not pos_module_pos_restaurant" widget="upgrade_boolean"/>
                             </setting>
                         </block>
 


### PR DESCRIPTION
This error occurs when the user disables Preparation Display and again tries to `Enable` it during an open pos restaurant session.

Steps to reproduce:
1. Install the module pos_restaurant.
2. Open `Restaurant Session`.
3. Disable `Preparation Display` from `configurations > settings`.
4. Enable `Preparation Display`

ParseError  :
while parsing /home/odoo/src/enterprise/saas18.2/pos_restaurant_preparation_display /data/main_restaurant_preparation_display_data.xml:24

This error occurs when the system tries to load `Preparation Display` data while there are active POS sessions, which prevent modifying the stages.

This commit resolves the error by restricting the user from disabling the `Preparation Display` during open pos restaurant sessions.

Sentry - 6343151926