### PR TITLE
[FIX] bus: detect lost notifications after reconnecting

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -15,33 +15,50 @@ export class OutdatedPageWatcherService {
      */
     setup(env, { bus_service, multi_tab, notification }) {
         this.notification = notification;
+        this.multi_tab = multi_tab;
         this.lastNotificationId = null;
         /** @deprecated */
         this.lastDisconnectDt = null;
         this.closeNotificationFn;
+        let wasBusAlreadyConnected;
+        bus_service.addEventListener(
+            "worker_state_updated",
+            ({ detail: state }) => {
+                wasBusAlreadyConnected = state !== "IDLE";
+            },
+            { once: true }
+        );
         bus_service.addEventListener("disconnect", () => {
             this.lastNotificationId = bus_service.lastNotificationId;
             this.lastDisconnectDt = DateTime.now();
         });
-        bus_service.addEventListener("reconnect", async () => {
-            if (!multi_tab.isOnMainTab()) {
-                return;
+        bus_service.addEventListener("connect", async () => {
+            if (wasBusAlreadyConnected) {
+                this.checkHasMissedNotifications();
             }
-            const hasMissedNotifications = await rpc(
-                "/bus/has_missed_notifications",
-                { last_notification_id: this.lastNotificationId },
-                { silent: true }
-            );
-            if (hasMissedNotifications) {
-                this.showOutdatedPageNotification();
-                multi_tab.setSharedValue("bus.has_missed_notifications", Date.now());
-            }
+            wasBusAlreadyConnected = true;
         });
+        bus_service.addEventListener("reconnect", () => this.checkHasMissedNotifications());
         multi_tab.bus.addEventListener("shared_value_updated", ({ detail: { key } }) => {
             if (key === "bus.has_missed_notifications") {
                 this.showOutdatedPageNotification();
             }
         });
+    }
+
+    async checkHasMissedNotifications() {
+        if (!this.multi_tab.isOnMainTab()) {
+            return;
+        }
+        const hasMissedNotifications = await rpc(
+            "/bus/has_missed_notifications",
+            { last_notification_id: this.lastNotificationId },
+            { silent: true }
+        );
+        if (hasMissedNotifications) {
+            this.showOutdatedPageNotification();
+            this.multi_tab.setSharedValue("bus.has_missed_notifications", Date.now());
+        }
     }
 
     showOutdatedPageNotification() {

--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -243,7 +243,7 @@ export class WebsocketWorker {
         if (this.newestStartTs && this.newestStartTs > startTs) {
             this.debugModeByClient.set(client, debug);
             this.isDebug = [...this.debugModeByClient.values()].some(Boolean);
-            this.sendToClient(client, "update_state", this.state);
+            this.sendToClient(client, "worker_state_updated", this.state);
             this.sendToClient(client, "initialized");
             return;
         }
@@ -265,7 +265,7 @@ export class WebsocketWorker {
             }
             this.channelsByClient.forEach((_, key) => this.channelsByClient.set(key, []));
         }
-        this.sendToClient(client, "update_state", this.state);
+        this.sendToClient(client, "worker_state_updated", this.state);
         this.sendToClient(client, "initialized");
         if (!this.active) {
             this.sendToClient(client, "outdated");

--- a/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
+++ b/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
@@ -4,8 +4,9 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 import { waitForBusEvent } from "@bus/../tests/helpers/websocket_event_deferred";
 import { outdatedPageWatcherService } from "@bus/outdated_page_watcher_service";
+import { BACK_ONLINE_RECONNECT_DELAY } from "@bus/services/bus_service";
 import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
-import { patchWithCleanup } from "@web/../tests/legacy/helpers/utils";
+import { mockTimeout, patchWithCleanup } from "@web/../tests/legacy/helpers/utils";
 import { assertSteps, click, contains, step } from "@web/../tests/legacy/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { browser } from "@web/core/browser/browser";
@@ -33,4 +34,26 @@ QUnit.test("disconnect during bus gc should ask for reload", async () => {
     patchWithCleanup(browser.location, { reload: () => step("reload") });
     await click(".o_notification button", { text: "Refresh" });
     await assertSteps(["reload"]);
+});
+
+QUnit.test("reconnect after going offline after bus gc should ask for reload", async () => {
+    addBusServicesToRegistry();
+    registry.category("services").add("bus.outdated_page_watcher", outdatedPageWatcherService);
+    const { advanceTime } = mockTimeout();
+    const { env } = await createWebClient({
+        mockRPC(route) {
+            if (route === "/bus/has_missed_notifications") {
+                return true;
+            }
+        },
+    });
+    env.services.bus_service.start();
+    await waitForBusEvent(env, "connect");
+    browser.dispatchEvent(new Event("offline"));
+    await waitForBusEvent(env, "disconnect");
+    browser.dispatchEvent(new Event("online"));
+    await advanceTime(BACK_ONLINE_RECONNECT_DELAY);
+    await contains(".o_notification", {
+        text: "Save your work and refresh to get the latest updates and avoid potential issues.",
+    });
 });

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -890,7 +890,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "18.0-3"
+    _VERSION = "18.0-4"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION
In [1], a mechanism was introduced to detect lost notifications when the bus table is cleared during socket disconnection. However, this relies on the "reconnect" event. The "reconnect" event is not triggered when the connection is closed cleanly. In such cases, the next connection is treated as a new one and triggers the "connect" event, which does not check for missed notifications.

As a result, any notifications sent while the socket was disconnected can be missed.

This commit ensures that the missed notification check is performed on all connections after the initial one, not only during a "reconnect".

[1]: https://github.com/odoo/odoo/pull/206106

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
