### PR TITLE
[FIX] mass_mailing: handled image encoding exception

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+import binascii
 from collections import defaultdict
 import hashlib
 import hmac
@@ -1408,7 +1409,10 @@ class MassMailing(models.Model):
         checksums_set, checksum_original_id, new_attachment_by_checksum = set(), {}, {}
         next_img_id = len(existing_attachments)
         for (b64image, original_id) in b64images:
-            checksum = IrAttachment._compute_checksum(base64.b64decode(b64image))
+            try:
+                checksum = IrAttachment._compute_checksum(base64.b64decode(b64image))
+            except binascii.Error:
+                raise ValidationError(_("One or more of the images seem to be broken or incomplete. Please make sure all images are valid."))
             checksums.append(checksum)
             existing_attach = existing_attachments.get(checksum)
             # Existing_attach can be None, in which case it acts as placeholder


### PR DESCRIPTION
When user edits mail template html and pastes an image tag with invalid encoding it throws an error.

**Steps to reproduce:**
* Install Email marketing and activate developer mode.
* Email marketing>New>Mail Body> Start From Scratch>click `</>` icon
* Paste any improper image element which doesn't have proper base64 encoding, for example: 
`<img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU 5ErkJgg'/>`
* Enter any Subject name and save.

`binascii.Error: Invalid base64-encoded string: number of data characters (113) cannot be 1 more than a multiple of 4`

**Solution:**
* It would be better to let the user know about the error than to let them mass mail corrupted image element.
* This can be done and handled by a try and except statement when the image element  added is not proper.

Sentry-6495526846

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
