### PR TITLE
[FIX] point_of_sale: correct ui behavior for online paid orders on TicketScreen

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -64,7 +64,6 @@ export class PosOrder extends Base {
                 screen_data: {},
                 selected_orderline_uuid: undefined,
                 selected_paymentline_uuid: undefined,
-                locked: this.state !== "draft",
                 // Pos restaurant specific to most proper way is to override this
                 TipScreen: {
                     inputTipAmount: "",

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -376,7 +376,6 @@ export class PaymentScreen extends Component {
 
                 if (this.pos.config.iface_print_skip_screen) {
                     this.currentOrder.set_screen_data({ name: "" });
-                    this.currentOrder.uiState.locked = true;
                     switchScreen = this.currentOrder.uuid === this.pos.selectedOrderUuid;
                     nextScreen = "ProductScreen";
                     if (switchScreen) {

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -30,7 +30,6 @@ export class ReceiptScreen extends Component {
         this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
         onMounted(() => {
             const order = this.pos.get_order();
-            this.currentOrder.uiState.locked = true;
 
             if (!this.pos.config.module_pos_restaurant) {
                 this.pos.sendOrderInPreparation(order);
@@ -83,7 +82,6 @@ export class ReceiptScreen extends Component {
     }
     orderDone() {
         this.currentOrder.uiState.screen_data.value = "";
-        this.currentOrder.uiState.locked = true;
         this._addNewOrder();
         this.pos.searchProductWord = "";
         const { name, props } = this.nextScreen;

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -131,7 +131,7 @@ export class TicketScreen extends Component {
     onClickOrder(clickedOrder) {
         this.setSelectedOrder(clickedOrder);
         this.numberBuffer.reset();
-        if ((!clickedOrder || clickedOrder.uiState.locked) && !this.getSelectedOrderlineId()) {
+        if ((!clickedOrder || clickedOrder.finalized) && !this.getSelectedOrderlineId()) {
             // Automatically select the first orderline of the selected order.
             const firstLine = this.getSelectedOrder().get_orderlines()[0];
             if (firstLine) {
@@ -156,7 +156,7 @@ export class TicketScreen extends Component {
         this.setSelectedOrder(order);
     }
     onClickOrderline(orderline) {
-        if (this.getSelectedOrder()?.uiState.locked) {
+        if (this.getSelectedOrder()?.finalized) {
             const order = this.getSelectedOrder();
             this.state.selectedOrderlineIds[order.id] = orderline.id;
             this.numberBuffer.reset();
@@ -332,7 +332,7 @@ export class TicketScreen extends Component {
     }
     get isOrderSynced() {
         return (
-            this.getSelectedOrder()?.uiState.locked &&
+            this.getSelectedOrder()?.finalized &&
             (this.getSelectedOrder().get_screen_data().name === "" ||
                 this.state.filter === "SYNCED")
         );
@@ -401,7 +401,7 @@ export class TicketScreen extends Component {
     }
     getStatus(order) {
         if (
-            order.uiState?.locked &&
+            order.finalized &&
             (order.get_screen_data().name === "" || this.state.filter === "SYNCED")
         ) {
             return _t("Paid");

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -45,7 +45,7 @@
                             </div>
                             <t t-if="!ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                 <div class="order-row" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
-                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.finalized ? ()=>{} : this._setOrder(order)" >
                                     <div class="col wide p-2 ">
                                         <div><t t-esc="getDate(order)"></t></div>
                                     </div>
@@ -79,7 +79,7 @@
                             </t>
                             <t t-if="ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                 <div class="mobileOrderList order-row rounded-3" t-att-class="{ 'highlight bg-primary text-white': isHighlighted(order) }"
-                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.finalized ? ()=>{} : this._setOrder(order)" >
                                     <div class="col p-2 d-flex justify-content-between align-items-center">
                                         <div><t t-esc="order.pos_reference"></t> / <t t-esc="order.tracking_number"></t></div>
                                         <div><t t-esc="getTotal(order)"></t></div>

--- a/addons/pos_online_payment_self_order/controllers/payment_portal.py
+++ b/addons/pos_online_payment_self_order/controllers/payment_portal.py
@@ -25,6 +25,7 @@ class PaymentPortalSelfOrder(PaymentPortal):
 
     def _send_notification_payment_status(self, pos_order_id, status):
         pos_order = request.env['pos.order'].sudo().browse(pos_order_id)
+        pos_order.config_id.notify_synchronisation(pos_order.config_id.current_session_id.id, 0)
         pos_order.config_id._notify("ONLINE_PAYMENT_STATUS", {
             'status': status, # progress, success, fail
             'data': {

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/receipt_screen.js
@@ -11,7 +11,6 @@ patch(ReceiptScreen.prototype, {
     continueSplitting() {
         const originalOrderUuid = this.currentOrder.uiState.splittedOrderUuid;
         this.currentOrder.uiState.screen_data.value = "";
-        this.currentOrder.uiState.locked = true;
         this.pos.selectedOrderUuid = originalOrderUuid;
         this.pos.showScreen("ProductScreen");
     },

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -6,6 +6,7 @@ import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
+import { notify } from "@pos_restaurant/../tests/tours/utils/devices_synchronization";
 
 registry.category("web_tour.tours").add("PosResTicketScreenTour", {
     steps: () =>
@@ -48,5 +49,24 @@ registry.category("web_tour.tours").add("OrderNumberConflictTour", {
             TicketScreen.nthColumnContains(2, 2, "Self-Order"),
             TicketScreen.nthColumnContains(2, 3, "S"),
             TicketScreen.nthColumnContains(2, 3, "1"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("OrderSynchronisationTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            notify(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("All active orders"),
+            TicketScreen.checkStatus("002", "Ongoing"),
+            Chrome.clickPlanButton(),
+            notify(),
+            Chrome.clickMenuOption("Orders"),
+            TicketScreen.selectFilter("Paid"),
+            TicketScreen.checkStatus("002", "Paid"),
+            TicketScreen.selectOrder("002"),
+            TicketScreen.confirmRefund(),
         ].flat(),
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/devices_synchronization.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/devices_synchronization.js
@@ -1,0 +1,19 @@
+/* global posmodel */
+
+export function notify() {
+    return {
+        trigger: "body",
+        run: async () => {
+            try {
+                const orm = posmodel.env.services.orm;
+                await orm.call("pos.config", "notify_synchronisation", [
+                    odoo.pos_config_id,
+                    odoo.pos_session_id,
+                    0,
+                ]);
+            } catch (error) {
+                console.log(error);
+            }
+        },
+    };
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -6,6 +6,7 @@ from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_c
 from odoo.addons.point_of_sale.tests.common import archive_products
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo import Command
+from unittest.mock import patch
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestFrontendCommon(TestPointOfSaleHttpCommon):
@@ -519,6 +520,51 @@ class TestFrontend(TestFrontendCommon):
         })
         self.pos_config.with_user(self.pos_admin).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.pos_config.id}", 'test_combo_preparation_receipt_layout', login="pos_admin")
+
+    def test_synchronisation_of_orders(self):
+        """ Test order synchronization with order data using the notify_synchronisation method.
+            First, an ongoing order is created on the server, and verify its presence in the POS UI.
+            Then, the order is paid from the server, and confirm if the order state is updated correctly.
+        """
+        notify_synchronisation_og = self.env.registry['pos.config'].notify_synchronisation
+        bank_payment_method = self.bank_payment_method
+        assertEqual = self.assertEqual
+
+        def notify_synchronisation_patch(self, session_id, login_number, records={}):
+            orders = self.env['pos.order'].search([('session_id', '=', session_id)])
+            if not orders:
+                product_desk_organizer = self.env["product.product"].search([('available_in_pos', '=', True), ('name', '=', 'Desk Organizer')], limit=1)
+                order = self.env["pos.order"].create({
+                    'company_id': self.env.company.id,
+                    'session_id': session_id,
+                    'partner_id': False,
+                    'lines': [(0, 0, {
+                        'name': 'OL/0001',
+                        'product_id': product_desk_organizer.id,
+                        'price_unit': 10.00,
+                        'tax_ids': False,
+                        'price_subtotal': 10.00,
+                        'price_subtotal_incl': 10.00,
+                    })],
+                    'amount_paid': 0,
+                    'amount_total': 10.00,
+                    'amount_tax': 0.0,
+                    'amount_return': 0.0,
+                    "pos_reference": "Order 00000-001-0002"
+                })
+            else:
+                order = orders[0]
+                payment_context = {"active_ids": order.ids, "active_id": order.id}
+                order_payment = self.env['pos.make.payment'].with_context(**payment_context).sudo().create({
+                    'amount': order.amount_total,
+                    'payment_method_id': bank_payment_method.id
+                })
+                order_payment.with_context(**payment_context).check()
+                assertEqual(order.state, "paid")
+            return notify_synchronisation_og(self, session_id, login_number)
+
+        with patch.object(self.env.registry.models['pos.config'], "notify_synchronisation", notify_synchronisation_patch):
+            self.start_pos_tour("OrderSynchronisationTour")
 
     def test_book_and_release_table(self):
         self.pos_config.with_user(self.pos_user).open_ui()


### PR DESCRIPTION
**Steps:**
- Configure POS with self-ordering via QR code and online payment.
- Open a session and place a paid order through self-ordering.
- In the POS UI, open the TicketScreen and apply the "Paid Orders" filter.

**Issues:**
- The paid order does not show the "Paid" tag.
- The "Load Order" button appears instead of the "Refund" button.

**Cause:**
- The paid order retains an outdated uiState, with `uiState.locked` incorrectly set to false.

**Fix:**
- Use `finalized` instead of `uiState.locked` to determine order state on TicketScreen.
- Remove the unused `locked` property from `uiState` in posOrder.

Task: 4745869

Related: odoo/enterprise#86684
