### PR TITLE
[IMP] mrp,purchase,repair,stock: hardcode width for priority fields

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -48,7 +48,7 @@
                         <button name="action_cancel" type="object" string="Cancel" confirm="Are you sure you want to cancel these manufacturing orders?"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
-                    <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                    <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                     <field name="message_needaction" column_invisible="True"/>
                     <field name="name" decoration-bf="1"/>
                     <field name="date_start" optional="show" widget="remaining_days"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -554,7 +554,7 @@
             <field name="arch" type="xml">
                 <list string="Purchase Order"
                       decoration-muted="state=='cancel'" sample="1">
-                    <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                    <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                     <field name="partner_ref" optional="hide"/>
                     <field name="name" string="Reference" readonly="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'purchase']" optional="show"/>
@@ -591,7 +591,7 @@
                         <button name="button_cancel" type="object" string="Cancel"
                             confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
-                    <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                    <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                     <field name="partner_ref" optional="hide"/>
                     <field name="name" string="Reference" readonly="1" decoration-bf="1"/>
                     <field name="date_approve" column_invisible="context.get('quotation_only', False)" optional="show"/>
@@ -634,7 +634,7 @@
                         <button name="button_cancel" type="object" string="Cancel"
                             confirm="Are you sure you want to cancel the selected RFQs/Orders?"/>
                     </header>
-                    <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                    <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                     <field name="partner_ref" optional="hide"/>
                     <field name="name" string="Reference" readonly="1" decoration-bf="1" decoration-info="state in ('draft','sent')"/>
                     <field name="date_approve" column_invisible="context.get('quotation_only', False)" optional="show"/>

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -28,7 +28,7 @@
         <field name="arch" type="xml">
             <list string="Repairs order" multi_edit="1" sample="1" decoration-info="state == 'draft'">
                 <field name="company_id" column_invisible="True"/>
-                <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                 <field name="name"/>
                 <field name="schedule_date" optional="show" widget="remaining_days"/>
                 <field name="product_id" readonly="1" optional="show"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -73,7 +73,7 @@
                         <button name="action_assign" type="object" string="Check Availability"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
-                    <field name="priority" optional="show" widget="priority" nolabel="1"/>
+                    <field name="priority" optional="show" widget="priority" nolabel="1" width="20px"/>
                     <field name="name" decoration-bf="1"/>
                     <field name="location_id" options="{'no_create': True}" string="From" groups="stock.group_stock_multi_locations" optional="show" readonly="state == 'done'"/>
                     <field name="location_dest_id" options="{'no_create': True}" string="To" groups="stock.group_stock_multi_locations" optional="show" readonly="state == 'done'"/>


### PR DESCRIPTION
The priority column takes up too much unnecessary space in the list view because it is defined as a selection rather than a boolean (because modules like `project` add further values to the priority field) and the selection field has a high default minimum width in list views.

Thus, we hardcode the column width to 20 px to accommodate exactly one star, making sure the `nolabel="1"` attribute is set (existing behaviour), so we don't end up with an ugly truncated label.

`width="20px"` was set on the field in the following models' list views: `mrp.production`, `purchase.order`, `repair.order` and `stock.picking`.


Task ID: [4688315](https://www.odoo.com/odoo/project/966/tasks/4688315)