### PR TITLE
[IMP] pos_preparation_display: not display future order immediately

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.2\n"
+"Project-Id-Version: Odoo Server saas~18.2+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-19 20:36+0000\n"
-"PO-Revision-Date: 2025-03-19 20:36+0000\n"
+"POT-Creation-Date: 2025-04-29 07:14+0000\n"
+"PO-Revision-Date: 2025-04-29 07:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -194,6 +194,12 @@ msgstr ""
 #. module: point_of_sale
 #: model_terms:ir.ui.view,arch_db:point_of_sale.report_userlabel
 msgid "1234567890"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/pos_store.js:0
+msgid "18:45 John 4P"
 msgstr ""
 
 #. module: point_of_sale
@@ -584,6 +590,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_order__message_needaction
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_session__message_needaction
 msgid "Action Needed"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml:0
+msgid "Activate"
 msgstr ""
 
 #. module: point_of_sale
@@ -1913,7 +1925,15 @@ msgstr ""
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_category__color
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_preset__color
 #: model:product.attribute,name:point_of_sale.product_attribute_color
+#: model_terms:ir.ui.view,arch_db:point_of_sale.product_template_form_view
+#: model_terms:ir.ui.view,arch_db:point_of_sale.product_template_view_form_normalized_pos
 msgid "Color"
+msgstr ""
+
+#. module: point_of_sale
+#: model:ir.model.fields,field_description:point_of_sale.field_product_product__color
+#: model:ir.model.fields,field_description:point_of_sale.field_product_template__color
+msgid "Color Index"
 msgstr ""
 
 #. module: point_of_sale
@@ -2235,11 +2255,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/components/navbar/navbar.xml:0
 msgid "Create Product"
-msgstr ""
-
-#. module: point_of_sale
-#: model:ir.model,website_form_label:point_of_sale.model_res_partner
-msgid "Create a Customer"
 msgstr ""
 
 #. module: point_of_sale
@@ -2958,6 +2973,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/screens/partner_list/partner_line/partner_line.xml:0
 msgid "Edit Details"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/pos_store.js:0
+msgid "Edit Order Name"
 msgstr ""
 
 #. module: point_of_sale
@@ -3710,12 +3731,6 @@ msgstr ""
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_pos_close_session_wizard__message
 msgid "Information message"
-msgstr ""
-
-#. module: point_of_sale
-#. odoo-javascript
-#: code:addons/point_of_sale/static/src/backend/pos_payment_provider_cards/pos_payment_provider_cards.xml:0
-msgid "Install"
 msgstr ""
 
 #. module: point_of_sale
@@ -4549,11 +4564,6 @@ msgstr ""
 #. module: point_of_sale
 #: model:product.template,name:point_of_sale.newspaper_rack_product_template
 msgid "Newspaper Rack"
-msgstr ""
-
-#. module: point_of_sale
-#: model:ir.model.fields,field_description:point_of_sale.field_pos_session__activity_calendar_event_id
-msgid "Next Activity Calendar Event"
 msgstr ""
 
 #. module: point_of_sale
@@ -6013,6 +6023,7 @@ msgstr ""
 
 #. module: point_of_sale
 #: model:ir.model.fields,field_description:point_of_sale.field_res_config_settings__module_pos_preparation_display
+#: model:ir.ui.menu,name:point_of_sale.menu_pos_preparation_display
 #: model_terms:ir.ui.view,arch_db:point_of_sale.res_config_settings_view_form
 msgid "Preparation Display"
 msgstr ""
@@ -6516,12 +6527,6 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/components/navbar/sale_details_button/sales_detail_report.xml:0
 msgid "REFUNDED:"
-msgstr ""
-
-#. module: point_of_sale
-#: model:ir.model.fields,field_description:point_of_sale.field_pos_order__rating_ids
-#: model:ir.model.fields,field_description:point_of_sale.field_pos_session__rating_ids
-msgid "Ratings"
 msgstr ""
 
 #. module: point_of_sale
@@ -8353,6 +8358,14 @@ msgid ""
 msgstr ""
 
 #. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
+msgid ""
+"This barcode is not compatible with the GS1 standard. Consider configuring a"
+" fallback barcode parser from the PoS settings."
+msgstr ""
+
+#. module: point_of_sale
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_config.py:0
 msgid ""
@@ -8856,18 +8869,6 @@ msgstr ""
 
 #. module: point_of_sale
 #. odoo-javascript
-#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
-msgid "This barcode is not compatible with the GS1 standard. Consider configuring a fallback barcode parser from the PoS settings."
-msgstr ""
-
-#. module: point_of_sale
-#. odoo-javascript
-#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
-msgid "Unsupported Barcode Format"
-msgstr ""
-
-#. module: point_of_sale
-#. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/hooks/hooks.js:0
 #: code:addons/point_of_sale/static/src/app/utils/error_handlers.js:0
 msgid "Unknown Error"
@@ -8877,6 +8878,12 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/point_of_sale/static/src/app/screens/scale_screen/scale_service.js:0
 msgid "Unnamed Product"
+msgstr ""
+
+#. module: point_of_sale
+#. odoo-javascript
+#: code:addons/point_of_sale/static/src/app/services/barcode_reader_service.js:0
+msgid "Unsupported Barcode Format"
 msgstr ""
 
 #. module: point_of_sale
@@ -9291,15 +9298,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_order.py:0
 msgid "You cannot invoice orders belonging to different companies."
-msgstr ""
-
-#. module: point_of_sale
-#. odoo-python
-#: code:addons/point_of_sale/models/account_cash_rounding.py:0
-#, python-format
-msgid ""
-"You cannot delete a rounding method that is used in a Point of Sale "
-"configuration."
 msgstr ""
 
 #. module: point_of_sale

--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -17,12 +17,8 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
-import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
-import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
-
-const { DateTime } = luxon;
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -167,20 +163,7 @@ export class Navbar extends Component {
     }
 
     async openPresetTiming() {
-        const order = this.pos.getOrder();
-        const data = await makeAwaitable(this.dialog, PresetSlotsPopup);
-
-        if (data) {
-            if (order.preset_id.id != data.presetId) {
-                await this.pos.selectPreset(this.pos.models["pos.preset"].get(data.presetId));
-            }
-
-            order.preset_time = data.slot.datetime;
-            if (data.slot.datetime > DateTime.now()) {
-                this.pos.addPendingOrder([order.id]);
-                await this.pos.syncAllOrders();
-            }
-        }
+        await this.pos.openPresetTiming();
     }
 
     get mainButton() {

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -40,6 +40,8 @@ import { debounce } from "@web/core/utils/timing";
 import DevicesSynchronisation from "../utils/devices_synchronisation";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
+import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
+import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
 
 const { DateTime } = luxon;
 
@@ -1232,7 +1234,6 @@ export class PosStore extends WithLazyGetterTrap {
             for (const order of orders) {
                 order.recomputeOrderData();
             }
-
             const serializedOrder = orders.map((order) =>
                 order.serialize({ orm: true, clear: true })
             );
@@ -1895,6 +1896,20 @@ export class PosStore extends WithLazyGetterTrap {
     async selectPricelist(pricelist) {
         await this.getOrder().setPricelist(pricelist);
     }
+    async editFloatingOrderName(order) {
+        const newName = await makeAwaitable(this.dialog, EditOrderNamePopup, {
+            title: _t("Edit Order Name"),
+            placeholder: _t("18:45 John 4P"),
+            startingValue: order.floating_order_name || "",
+        });
+        if (typeof order.id == "number") {
+            this.data.write("pos.order", [order.id], {
+                floating_order_name: newName,
+            });
+        } else {
+            order.floating_order_name = newName;
+        }
+    }
     async selectPreset(preset = false, order = this.getOrder()) {
         if (!preset) {
             const selectionList = this.models["pos.preset"].map((preset) => ({
@@ -1912,8 +1927,6 @@ export class PosStore extends WithLazyGetterTrap {
         }
 
         if (preset) {
-            order.setPreset(preset);
-
             if (preset.needsPartner) {
                 const partner = order.partner_id || (await this.selectPartner(order));
                 if (!partner) {
@@ -1924,19 +1937,40 @@ export class PosStore extends WithLazyGetterTrap {
                     await this.editPartner(partner);
                 }
             }
-
             if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
                 order.floating_order_name = order.getPartner()?.name;
                 if (!order.floating_order_name) {
-                    this.editFloatingOrderName(order);
+                    await this.editFloatingOrderName(order);
+                    //re-set the order in case an order was selected from the current orders list in the EditOrderNamePopup
+                    order = this.getOrder();
+                    if (!order.floating_order_name) {
+                        return;
+                    }
                 }
             }
-
+            order.setPreset(preset);
             if (preset.use_timing && !order.preset_time) {
-                await this.syncPresetSlotAvaibility(preset);
-                order.preset_time = preset.nextSlot?.datetime || false;
+                await this.openPresetTiming(order);
+                if (!order.preset_time) {
+                    await this.syncPresetSlotAvaibility(preset);
+                    order.preset_time = preset.nextSlot?.datetime || false;
+                }
             } else if (!preset.use_timing) {
                 order.preset_time = false;
+            }
+        }
+    }
+    async openPresetTiming(order = this.getOrder()) {
+        const data = await makeAwaitable(this.dialog, PresetSlotsPopup);
+        if (data) {
+            if (order.preset_id.id != data.presetId) {
+                await this.selectPreset(this.models["pos.preset"].get(data.presetId));
+            }
+
+            order.preset_time = data.slot.datetime;
+            if (data.slot.datetime > DateTime.now()) {
+                this.addPendingOrder([order.id]);
+                await this.syncAllOrders({ orders: [order] });
             }
         }
     }

--- a/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -25,6 +25,5 @@
         <xpath expr="//button[hasclass('o-default-button', 'btn-primary')]" position="attributes">
             <attribute name="t-attf-class">{{state.inputValue ? '' : 'disabled'}}</attribute>
         </xpath>
-        <xpath expr="//button[hasclass('o-default-button', 'btn-secondary')]" position="replace"/>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -2,7 +2,6 @@ import { patch } from "@web/core/utils/patch";
 import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
-import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
@@ -542,22 +541,6 @@ patch(PosStore.prototype, {
                 this.addNewOrder({ table_id: table });
             }
         }
-    },
-    editFloatingOrderName(order) {
-        this.dialog.add(EditOrderNamePopup, {
-            title: _t("Edit Order Name"),
-            placeholder: _t("18:45 John 4P"),
-            startingValue: order.floating_order_name || "",
-            getPayload: async (newName) => {
-                if (typeof order.id == "number") {
-                    this.data.write("pos.order", [order.id], {
-                        floating_order_name: newName,
-                    });
-                } else {
-                    order.floating_order_name = newName;
-                }
-            },
-        });
     },
     setFloatingOrder(floatingOrder) {
         if (this.getOrder()?.isFilledDirectSale) {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -604,6 +604,7 @@ registry.category("web_tour.tours").add("RestaurantPresetTakeoutTour", {
             FloorScreen.clickTable("4"),
             ProductScreen.clickDisplayedProduct("Coca-Cola", true),
             ProductScreen.selectPreset("Takeout"),
+            Dialog.discard(),
             ProductScreen.clickPartnerButton(),
             ProductScreen.clickCustomer("Deco Addict"),
             ProductScreen.clickPayButton(),


### PR DESCRIPTION
After this commit, when a preset that is set to use_time is selected, the PresetSlotsPopup is shown to select the time.

Related: https://github.com/odoo/enterprise/pull/84099

task-4725279

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
