### PR TITLE
[FIX] pos_self_order: fix preset_time tz conversion

### DIFF
--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -48,7 +48,9 @@ export class PresetInfoPopup extends Component {
         }
 
         if (this.preset.needsSlot && this.state.selectedSlot) {
-            this.selfOrder.currentOrder.preset_time = this.state.selectedSlot;
+            this.selfOrder.currentOrder.preset_time = DateTime.fromSQL(this.state.selectedSlot)
+                .toUTC()
+                .toFormat("yyyy-MM-dd HH:mm:ss");
         }
 
         this.props.callback(true);


### PR DESCRIPTION
Steps to reproduce
------------------
1. Enable self order, and enable presets
2. In self order interface, choose the preset "takeout" that will by default be configured to use time slots.
3. When paying the order, select a time, say 12:00

Observation
-----------
In the PoS session interface, go to orders, and observe that this order shows the time as 14:00 (or whatever your tz diff is + 12:00).

Reason
------
When assigning a datetime to `preset_time`, we assign it as a local datetime, when it waits to be assigned a UTC datetime. So for instance, if we assign "2025-04-25 12:00:00" to it, it will be interpreted as UTC date an hence in the PoS orders UI, we see it converted to local date and hence a mismatch.

Fix
---
Convert the formatted date string into UTC before assigning it to `preset_time`.

opw-4728248