### PR TITLE
[FIX] core: can't copy if field has group while user is not

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5468,6 +5468,12 @@ class BaseModel(metaclass=MetaModel):
         :param default: field values to override in the original values of the copied record
         :return: list with a dictionary containing all the field values
         """
+        def valid(field):
+            """ determine whether user has access to field ``fname`` """
+            if field and field.groups:
+                return self.user_has_groups(field.groups)
+            else:
+                return True
         # In the old API, this method took a single id and return a dict. When
         # invoked with the new API, it returned a list of dicts.
         self.ensure_one()
@@ -5501,7 +5507,7 @@ class BaseModel(metaclass=MetaModel):
 
         fields_to_copy = {name: field
                           for name, field in self._fields.items()
-                          if field.copy and name not in default and name not in blacklist}
+                          if field.copy and name not in default and name not in blacklist and valid(field)}
 
         for name, field in fields_to_copy.items():
             if field.type == 'one2many':


### PR DESCRIPTION
* Currently if user try to duplicate a record which have a field that also have groups on it but user doesn't have that group, an access error will be raise
* This commit aim to remove that field out of copy data to avoid that

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
