### PR TITLE
[FIX] web: calendar: multi_create: popover not showing

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -295,8 +295,10 @@ export class CalendarModel extends Model {
                 }
             }
         }
-        await this.orm.create(this.meta.resModel, records, { context: this.meta.context });
-        return this.load();
+        if (records.length) {
+            await this.orm.create(this.meta.resModel, records, { context: this.meta.context });
+            return this.load();
+        }
     }
 
     async unlinkFilter(fieldName, recordId) {

--- a/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
@@ -86,11 +86,9 @@ export function useSquareSelection() {
     }
 
     function pointerDown(ev) {
-        if (ev.target.closest(".fc-event")) {
-            return;
-        }
+        const eventElement = ev.target.closest(".fc-event");
         const targetElement = ev.target.closest(".fc-day:not(.fc-col-header-cell)");
-        if (!targetElement) {
+        if (eventElement || !targetElement) {
             return;
         }
         document.activeElement?.blur(); // Force blur on activeElement to force update value

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -655,3 +655,38 @@ test("multi_create: test onChange on TimePicker with no blur (input text)", asyn
         "3_2019-03-04 00:30:00_2019-03-04 07:00:00",
     ]);
 });
+
+test.tags("desktop");
+test("multi_create: test popover in all mode", async () => {
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+    });
+
+    await click(".o_calendar_sidebar .btn-group .btn .fa-trash");
+    await animationFrame();
+    expect(".o_popover").toHaveCount(0);
+
+    await click(".fc-event[data-event-id='2']");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_popover").toHaveCount(1);
+
+    await click(".o_calendar_sidebar .btn-group .btn[data-tooltip='Filter']");
+    await animationFrame();
+    expect(".o_popover").toHaveCount(0);
+
+    await click(".fc-event[data-event-id='2']");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_popover").toHaveCount(1);
+
+    await click(".o_calendar_sidebar .btn-group .btn[data-tooltip='New']");
+    await animationFrame();
+    expect(".o_popover").toHaveCount(0);
+
+    await click(".fc-event[data-event-id='2']");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_popover").toHaveCount(1);
+});


### PR DESCRIPTION
In this commit, we avoid the calendar view to redraw if we click on an event in the "multi create add mode".

task-4751083

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
