### PR TITLE
[FIX] web, project: Adapt project task to `x2many_field`

### DIFF
--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -1,8 +1,8 @@
 import { registry } from "@web/core/registry";
 import { pick } from "@web/core/utils/objects";
-import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
+import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 
-import { SubtaskListRenderer } from './subtask_list_renderer';
+import { SubtaskListRenderer } from "./subtask_list_renderer";
 
 export class SubtaskOne2ManyField extends X2ManyField {
     static components = {
@@ -10,25 +10,12 @@ export class SubtaskOne2ManyField extends X2ManyField {
         ListRenderer: SubtaskListRenderer,
     };
 
-    async switchToForm(record, options) {
-        await this.props.record.save();
-        this.action.doAction(
-            {
-                type: "ir.actions.act_window",
-                views: [[false, "form"]],
-                res_id: record.resId,
-                res_model: this.list.resModel,
-                context: pick(
-                    this.props.context,
-                    "active_test",
-                    "default_project_id",
-                    "propagate_not_active"
-                ),
-            },
-            {
-                props: { resIds: this.list.resIds },
-                newWindow: options.newWindow,
-            }
+    getFormActionContext() {
+        return pick(
+            this.props.context,
+            "active_test",
+            "default_project_id",
+            "propagate_not_active"
         );
     }
 }
@@ -37,6 +24,6 @@ export const subtaskOne2ManyField = {
     ...x2ManyField,
     component: SubtaskOne2ManyField,
     additionalClasses: ["o_field_one2many"],
-}
+};
 
 registry.category("fields").add("subtasks_one2many", subtaskOne2ManyField);

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -271,12 +271,17 @@ export class X2ManyField extends Component {
                 views: [[false, "form"]],
                 res_id: resId,
                 res_model: this.list.resModel,
+                context: this.getFormActionContext(),
             },
             {
                 props: { resIds: this.list.resIds },
                 newWindow: options.newWindow,
             }
         );
+    }
+
+    getFormActionContext() {
+        return this.props.context;
     }
 
     async onAdd({ context, editable } = {}) {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9233,6 +9233,12 @@ test(`Can switch to form view on inline tree`, async () => {
         doAction(action, options) {
             expect.step("doAction");
             expect(action).toEqual({
+                context: {
+                    allowed_company_ids: [1],
+                    lang: "en",
+                    tz: "taht",
+                    uid: 7,
+                },
                 res_id: id,
                 res_model: "partner",
                 type: "ir.actions.act_window",


### PR DESCRIPTION
Since https://github.com/odoo/odoo/pull/197629 there's no need to save to access newly created child records: pressing “View” to switch to the form view is done directly by triggering a save.

But this has been broken on project since https://github.com/odoo/odoo/pull/200153/files#diff-e9f20117c15ae605880f16d452197f66d140754be214b7e32b3dcdbd75fd7e37R12-R32

The `switchToForm` override completely bypasses the original flow.

This pr corrects this problem by splitting the `x2many_field` logic into two functions to allow easier override of the action (as in the case of project), and thus fixes the problem on the project side.

task-4752252