### PR TITLE
[IMP] stock_landed_costs: access rights to bookkeepers & purchase managers

### DIFF
--- a/addons/mrp_landed_costs/__manifest__.py
+++ b/addons/mrp_landed_costs/__manifest__.py
@@ -11,6 +11,8 @@ take them into account in your stock valuation.
     'depends': ['stock_landed_costs', 'mrp'],
     'category': 'Supply Chain/Manufacturing',
     'data': [
+        'security/ir.model.access.csv',
+        'security/mrp_landed_costs_security.xml',
         'views/stock_landed_cost_views.xml',
     ],
     'auto_install': True,

--- a/addons/mrp_landed_costs/security/ir.model.access.csv
+++ b/addons/mrp_landed_costs/security/ir.model.access.csv
@@ -1,0 +1,13 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+"access_stock_landed_cost_mrp","stock.landed.cost mrp_manager","model_stock_landed_cost","mrp.group_mrp_manager",1,1,1,1
+"access_stock_landed_cost_lines_mrp","stock.landed.cost.lines mrp_manager","stock_landed_costs.model_stock_landed_cost_lines","mrp.group_mrp_manager",1,1,1,1
+"access_stock_valuation_adjustment_lines_mrp","stock.valuation.adjustment.lines mrp_manager","stock_landed_costs.model_stock_valuation_adjustment_lines","mrp.group_mrp_manager",1,1,1,1
+"access_product_value_mrp","product.value mrp_manager","stock_account.model_product_value","mrp.group_mrp_manager",1,0,0,0
+"access_account_move_mrp","account.move mrp_manager","account.model_account_move","mrp.group_mrp_manager",1,0,0,0
+"access_account_move_line_mrp","account.move.line mrp_manager","account.model_account_move_line","mrp.group_mrp_manager",1,0,0,0
+"access_account_journal_mrp","account.journal mrp_manager","account.model_account_journal","mrp.group_mrp_manager",1,0,0,0
+
+"access_mrp_workorder_stock","mrp.workorder stock_manager","mrp.model_mrp_workorder","stock.group_stock_manager",1,0,0,0
+
+"access_mrp_production_bookkeeper","mrp.production bookkeeper","mrp.model_mrp_production","account.group_account_user",1,0,0,0
+"access_mrp_workorder_bookkeeper","mrp.workorder bookkeeper","mrp.model_mrp_workorder","account.group_account_user",1,0,0,0

--- a/addons/mrp_landed_costs/security/mrp_landed_costs_security.xml
+++ b/addons/mrp_landed_costs/security/mrp_landed_costs_security.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <record model="ir.rule" id="mrp_manager_account_move_mrp_landed_costs">
+        <field name="name">MRP Manager Bills with Landed Costs</field>
+        <field name="model_id" ref="stock_landed_costs.model_account_move"/>
+        <field name="domain_force">['&amp;', ('move_type', '=', 'in_invoice'), ('landed_costs_ids', '!=', False)]</field>
+        <field name="groups" eval="[Command.link(ref('mrp.group_mrp_manager'))]"/>
+        <field name="perm_read"   eval="True"/>
+        <field name="perm_write"  eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record model="ir.rule" id="purchase_manager_stock_landed_cost_mrp_landed_costs">
+        <field name="name">Purchase Manager Landed Costs for Manufacturing Orders</field>
+        <field name="model_id" ref="mrp_landed_costs.model_stock_landed_cost"/>
+        <field name="domain_force">[('target_model', '!=', 'manufacturing')]</field>
+        <field name="groups" eval="[Command.link(ref('purchase.group_purchase_manager'))]"/>
+    </record>
+</odoo>

--- a/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_landed_costs/views/stock_landed_cost_views.xml
@@ -7,19 +7,20 @@
         <field name="arch" type="xml">
             <field name="target_model" position="attributes">
                 <attribute name="invisible">0</attribute>
-                <attribute name="groups">stock.group_stock_manager</attribute>
+                <attribute name="groups">mrp.group_mrp_manager,stock.group_stock_manager,account.group_account_user</attribute>
             </field>
             <field name="picking_ids" position="after">
                 <field name="target_model" invisible="1" readonly="state == 'done'"/>
                 <field name="mrp_production_ids" 
-                    widget="many2many_tags" options="{'no_create_edit': True}"
+                    widget="many2many_tags" options="{'no_create': True}"
                     invisible="target_model != 'manufacturing'"
                     readonly="state == 'done'"
+                    groups="mrp.group_mrp_manager,stock.group_stock_manager,account.group_account_user"
                     domain="[('company_id', '=', company_id), ('move_finished_ids.is_in', '!=', False)]"/>
             </field>
             <button name="action_view_pickings" position="after">
                 <button class="oe_stat_button" name="action_view_mrp_productions" icon="fa-wrench"
-                    type="object" invisible="mrp_productions_count == 0">
+                        groups="mrp.group_mrp_user" type="object" invisible="mrp_productions_count == 0">
                     <field name="mrp_productions_count" string="Manufacturing" widget="statinfo"/>
                 </button>
             </button>

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -51,6 +51,7 @@
                         name="action_view_source_sale_orders"
                         type="object"
                         icon="fa-pencil-square-o"
+                        groups="base.group_portal,account.group_account_invoice,account.group_account_readonly,sales_team.group_sale_salesman"
                         invisible="sale_order_count == 0 or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')">
                     <field string="Sale Orders" name="sale_order_count" widget="statinfo"/>
                 </button>

--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -129,7 +129,8 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='backorder_id']" position="after">
                     <field name="carrier_tracking_ref" optional="hide"/>
-                    <field name="carrier_id" optional="hide"/>
+                    <field name="carrier_id" optional="hide"
+                           groups="base.group_partner_manager,base.group_system,stock.group_stock_user,sales_team.group_sale_salesman"/>
                     <field name="destination_country_code" optional="hide" string="Destination"/>
                     <field name="weight" optional="hide"/>
                     <field name="shipping_weight" optional="hide"/>

--- a/addons/stock_landed_costs/security/ir.model.access.csv
+++ b/addons/stock_landed_costs/security/ir.model.access.csv
@@ -2,3 +2,19 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 "access_stock_landed_cost","stock.landed.cost","model_stock_landed_cost","stock.group_stock_manager",1,1,1,1
 "access_stock_landed_cost_lines","stock.landed.cost.lines","model_stock_landed_cost_lines","stock.group_stock_manager",1,1,1,1
 "access_stock_valuation_adjustment_lines","stock.valuation.adjustment.lines","model_stock_valuation_adjustment_lines","stock.group_stock_manager",1,1,1,1
+"access_product_value_stock","product.value stock_manager","stock_account.model_product_value","stock.group_stock_manager",1,0,0,0
+"access_account_move_stock","account.move stock_manager","account.model_account_move","stock.group_stock_manager",1,0,0,0
+"access_account_move_line_stock","account.move.line stock_manager","account.model_account_move_line","stock.group_stock_manager",1,0,0,0
+
+"access_stock_landed_cost_purchase","stock.landed.cost purchase_manager","model_stock_landed_cost","purchase.group_purchase_manager",1,1,1,1
+"access_stock_landed_cost_lines_purchase","stock.landed.cost.lines purchase_manager","model_stock_landed_cost_lines","purchase.group_purchase_manager",1,1,1,1
+"access_stock_valuation_adjustment_lines_purchase","stock.valuation.adjustment.lines purchase_manager","model_stock_valuation_adjustment_lines","purchase.group_purchase_manager",1,1,1,1
+"access_stock_lot_purchase","stock.lot purchase_manager","stock.model_stock_lot","purchase.group_purchase_manager",1,0,0,0
+"access_product_value_purchase","product.value purchase_manager","stock_account.model_product_value","purchase.group_purchase_manager",1,0,0,0
+"access_account_payment_purchase","account.payment purchase_manager","account.model_account_payment","purchase.group_purchase_manager",1,0,0,0
+
+"access_stock_landed_cost_bookkeeper","stock.landed.cost bookkeeper","model_stock_landed_cost","account.group_account_user",1,1,1,1
+"access_stock_landed_cost_lines_bookkeeper","stock.landed.cost.lines bookkeeper","model_stock_landed_cost_lines","account.group_account_user",1,1,1,1
+"access_stock_valuation_adjustment_lines_bookkeeper","stock.valuation.adjustment.lines bookkeeper","model_stock_valuation_adjustment_lines","account.group_account_user",1,1,1,1
+"access_stock_lot_bookkeeper","stock.lot bookkeeper","stock.model_stock_lot","account.group_account_user",1,0,0,0
+"access_product_value_bookkeeper","product.value bookkeeper","stock_account.model_product_value","account.group_account_user",1,0,0,0

--- a/addons/stock_landed_costs/views/account_move_views.xml
+++ b/addons/stock_landed_costs/views/account_move_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <t groups="stock.group_stock_manager">
+                <t name="landed_costs_button" groups="stock.group_stock_manager,purchase.group_purchase_manager,account.group_account_user">
                     <field name="landed_costs_ids" invisible="1"/>
                     <button string="Landed Costs" type="object"
                         name="action_view_landed_costs"
@@ -16,20 +16,23 @@
             </xpath>
 
             <field name="state" position="before">
-                <t groups="stock.group_stock_manager">
+                <t name="landed_costs_create_button" groups="stock.group_stock_manager,purchase.group_purchase_manager,account.group_account_user">
                     <field name="landed_costs_visible" invisible="1" />
-                    <button name="button_create_landed_costs" class="oe_highlight" string="Create Landed Costs" data-hotkey="l" type="object" groups="account.group_account_invoice" invisible="not landed_costs_visible"/>
+                    <button name="button_create_landed_costs" class="oe_highlight" string="Create Landed Costs" data-hotkey="l" type="object" invisible="not landed_costs_visible"/>
                 </t>
             </field>
 
             <xpath expr="//field[@name='invoice_line_ids']/list/field[@name='quantity']" position="before">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
-                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type not in ('in_invoice', 'in_receipt')" readonly="product_type != 'service'" optional="hide" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" string="Landed Costs" column_invisible="parent.move_type not in ('in_invoice', 'in_receipt')" readonly="product_type != 'service'"
+                       optional="hide" groups="stock.group_stock_manager,purchase.group_purchase_manager,account.group_account_user"/>
             </xpath>
+
 
             <xpath expr="//field[@name='line_ids']/list/field[@name='name']" position="after">
                 <field name="product_type" column_invisible="True" groups="stock.group_stock_manager"/>
-                <field name="is_landed_costs_line" column_invisible="True" groups="stock.group_stock_manager"/>
+                <field name="is_landed_costs_line" column_invisible="True"
+                       groups="stock.group_stock_manager,purchase.group_purchase_manager,account.group_account_user"/>
             </xpath>
         </field>
     </record>

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -16,7 +16,7 @@
                     <sheet>
                         <div class="oe_button_box" name="button_box">
                             <button class="oe_stat_button" name="action_view_pickings" icon="fa-truck"
-                                type="object" invisible="pickings_count == 0">
+                                    groups="stock.group_stock_user" type="object" invisible="pickings_count == 0">
                                 <field name="pickings_count" string="Transfers" widget="statinfo"/>
                             </button>
                         </div>
@@ -31,7 +31,7 @@
                                 <field name="date" readonly="state == 'done'"/>
                                 <field name="target_model" widget="radio" invisible="1" readonly="state == 'done'"/>
                                 <field name="picking_ids" widget="many2many_tags" 
-                                    options="{'no_create_edit': True}" invisible="target_model != 'picking'" readonly="state == 'done'"
+                                    options="{'no_create': True}" invisible="target_model != 'picking'" readonly="state == 'done'"
                                     domain="[('company_id', '=', company_id), '|', ('move_ids.is_in', '!=', False), ('move_ids.is_out', '!=', False)]"/>
                             </group>
                             <group>
@@ -39,7 +39,8 @@
                                 <field name="account_journal_id" nolabel="1" readonly="state == 'done'"/>
                                 <field name="company_id" groups="base.group_multi_company"/>
                                 <field name="account_move_id" invisible="not account_move_id"/>
-                                <field name="vendor_bill_id"/>
+                                <field name="vendor_bill_id" options="{'no_create': True}"
+                                       context="{'default_move_type': 'in_invoice', 'input_full_display_name': True}"/>
                             </group>
                         </group>
                         <notebook>


### PR DESCRIPTION
The `stock.landed.cost` model is only accessible to stock managers even though it's within accountants' field of work. Thus it makes sense to give access rights to bookkeepers and purchase managers for this model as well as adjacent models that are needed for manipulating landed costs (see Table 1.a). Same with manufacturing managers, in order to create manufacturing order landed costs, although we need to make sure they can't view other account moves, just bills with landed costs (see Table 1.b).

(Additionally, bookkeepers should be able to create and validate landed costs for manufacturing orders, so we grant them read permission for `mrp.production` and `mrp.workorder`.)

We do not grant this MRP access to purchase managers, who will not be able to validate landed costs for MOs or change a landed cost's type (from transfer to manufacturing or vice versa).

There are also a lot of access rights fixes along the way to insulate fields with `groups` parameters.

Task ID: [4689761](https://www.odoo.com/odoo/project/966/tasks/4689761)

--

### Outdated information kept for future reference

We need to determine every model and field these four groups need access to and exactly how much access they need to manage landed costs (which entails accessing the landed costs of a bill or a PO, manipulating it and validating it), which touches account, stock, purchase and mrp and their submodules. Because we need to provide a lot of access rights to these groups, some of it should be restricted through record rules, such as disallowing access to bills that don't have a landed cost associated with it.

All landed costs tests are disabled after the valuationpocalypse, so it's not possible to test this at the moment.

## Access rights

| Model                              | Stock Manager | MRP Manager | Purchase Manager | Bookkeeper  | Notes                                                                 |
|:-----------------------------------|:-------------:|:-----------:|:----------------:|:-----------:|:----------------------------------------------------------------------|
| `stock.landed.cost`                |     1111      | 0000 - 1111 |   0000 - 1111    | 0000 - 1111 | All permissions required for all four.                                |
| `stock.landed.cost.lines`          |     1111      | 0000 - 1111 |   0000 - 1111    | 0000 - 1111 | Ditto.                                                                |
| `stock.valuation.adjustment.lines` |     1111      | 0000 - 1111 |   0000 - 1111    | 0000 - 1111 | Ditto.                                                                |
| `product.value`                    |     1111      | 0000 - 1000 |   0000 - 1000    | 0000 - 1000 | Necessary for validating the landed cost.                             |
| `account.move`                     |  0000 - 1000  | 0000 - 1000 |       1111       |    1111     | Necessary for creating the landed cost. Field in form.                |
| `account.move.line`                |  0000 - 1000  | 0000 - 1000 |       1111       |    1111     | Necessary for validating the landed cost.                             |
| `account.payment`                  |     0000      |    0000     |   0000 - 1000    |    1111     | Necessary for viewing the bill from which the landed cost is created. |
| `account.journal`                  |     1100      | 0000 - 1000 |       1000       |    1111     | Field in form. Required to access bill search.                        |
| `mrp.production`                   |     1000      |    1111     |       0000       | 0000 - 1000 | Field in form. Maybe record rules?                                    |
| `mrp.workorder`                    |  0000 - 1000  |    1111     |       0000       | 0000 - 1000 | Required to access MO search. Too pervasively used to block in views. |
| `stock.lot`                        |     1111      |    1111     |   0000 - 1000    | 0000 - 1000 | Required to access picking search. Ditto.                             |
| `quality.check`                    |     1110      |    1110     |       0000       |    0000     | Required to access picking search. Added groups to view instead.      |
| `delivery.carrier`                 |     1111      |    1000     |       0000       |    0000     | Required to access picking search. Ditto.                             |
| `delivery.zip.prefix`              |     1111      |    0000     |       0000       |    0000     | Required to access picking search. Ditto.                             |
| `sale.move.line`                   |     1100      |    1100     |       0000       |    1100     | Required to view bill form view. Ditto.                               |
| `account.asset`                    |     0000      |    0000     |       0000       |    1111     | Required to view bill form view. Ditto.                               |

## Record rules

| Model               |                             Rule                             | Perms |        Groups         | Explanation                                                      |
|:--------------------|:------------------------------------------------------------:|:-----:|:---------------------:|:-----------------------------------------------------------------|
| `stock.landed.cost` |             `(target_model != 'manufacturing')`              | 1111  |     Purchase Mgr      | No access to landed costs for MOs                                |
| `account.move`      | `((move_type = 'in_invoice') & (landed_costs_ids != False))` | 1000  |  MRP Mgr, Stock Mgr   | Access to bills attached to landed costs                         |
| `account.move`      | `((move_type = 'in_invoice') & (landed_costs_ids = False))`  | 0100  |  MRP Mgr, Stock Mgr   | Allow attaching landed costs to a bill without it                |
| `mrp.production`    |                `(landed_costs_ids != False)`                 | 1000  | Bookkeeper, Stock Mgr | Access to MOs attached to landed costs? (requires inverse field) |

(The latter two are probably not needed.)
