### PR TITLE
[FIX] hr(_holidays): Move float widget to HR

### DIFF
--- a/addons/hr/static/src/components/float_without_trailing_zeros/float_without_trailing_zeros.js
+++ b/addons/hr/static/src/components/float_without_trailing_zeros/float_without_trailing_zeros.js
@@ -7,7 +7,7 @@ const fieldRegistry = registry.category("fields");
 
 class FloatWithoutTrailingZeros extends FloatField {
     get formattedValue() {
-        return super.formattedValue.replace(/\.0+$/, '');
+        return super.formattedValue.replace(/\.0+$/, "");
     }
 }
 


### PR DESCRIPTION
Since the widget for non trailing zeros float is used in payroll and payroll does not depend on hr_holidays now, we move the widget to core hr
