### PR TITLE
[FIX] hr_recruitment: update the restriction on chatter button

### DIFF
--- a/addons/hr_recruitment/static/src/views/form_view.js
+++ b/addons/hr_recruitment/static/src/views/form_view.js
@@ -4,9 +4,18 @@ import { registry } from '@web/core/registry';
 
 import { formView } from '@web/views/form/form_view';
 import { FormController } from '@web/views/form/form_controller';
+import { onWillStart } from "@odoo/owl";
+import { useService } from '@web/core/utils/hooks';
 
 export class InterviewerFormController extends FormController {
 
+    setup() {
+        super.setup();
+        this.user = useService("user");
+        onWillStart(async () => {
+            this.isInterviewer = await this.user.hasGroup("hr_recruitment.group_hr_recruitment_interviewer");
+        });
+    }
     /**
      * Add `o_applicant_interviewer_form` class if necessary
      */
@@ -16,8 +25,7 @@ export class InterviewerFormController extends FormController {
         if (!root.data.interviewer_ids || !root.data.user_id) {
             return result;
         }
-        result["o_applicant_interviewer_form"] = root.data.interviewer_ids.records.findIndex(
-            interviewer => interviewer.resId === root.data.user_id[0]) > -1;
+        result["o_applicant_interviewer_form"] = this.isInterviewer
         return result;
     }
 }


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install `Recruitment` module.
2. Make a Portal user with recruitment `Interviewer` rights.
3. Create a job application, set the Portal user as the interviewer.
4. Login with Portal user.
5. open that assign job application.

**Observation:**
- The chatter buttons 'Send Message' and 'Log Note' are shown. but If user has 
  only interviewer rights the chatter button will disappear to show. 
  Reference - (https://github.com/odoo/odoo/pull/114548/commits/9fea777691c9c80c86ecde769fe35d4d0e552655)

**Solution:**
- Hide 'Send Message' and 'Log Note' buttons for interviewer user only.

opw-4660071

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
