### PR TITLE
[FIX] delivery: propagate product weight changes to existing moves

### DIFF
--- a/addons/delivery/models/stock_move.py
+++ b/addons/delivery/models/stock_move.py
@@ -25,7 +25,7 @@ class StockMove(models.Model):
 
     weight = fields.Float(compute='_cal_move_weight', digits='Stock Weight', store=True, compute_sudo=True)
 
-    @api.depends('product_id', 'product_uom_qty', 'product_uom')
+    @api.depends('product_id.weight', 'product_uom_qty', 'product_uom')
     def _cal_move_weight(self):
         moves_with_weight = self.filtered(lambda moves: moves.product_id.weight > 0.00)
         for move in moves_with_weight:


### PR DESCRIPTION
Before this commit, when shipping e.g. with SendCloud, the shipping couldn't continue due to missing weights. When changing the product weights, the new weights were not adjusted on the move lines. After this commit, the new weights are properly propagated.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
