### PR TITLE
[FIX] payment_stripe: ensure minimal date for backdated subscriptions

### DIFF
--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -212,9 +212,10 @@ class PaymentTransaction(models.Model):
             f'{OPTION_PATH_PREFIX}[amount]': payment_utils.to_minor_currency_units(
                 mandate_values.get('amount', 15000), self.currency_id
             ),  # Use the specified amount, if any, or define the maximum amount of 15.000 INR.
-            f'{OPTION_PATH_PREFIX}[start_date]': int(round(
-                (mandate_values.get('start_datetime') or fields.Datetime.now()).timestamp()
-            )),
+            f'{OPTION_PATH_PREFIX}[start_date]': round(max(
+                mandate_values.get('start_datetime') or fields.Datetime.now(),
+                fields.Datetime.now(),
+            ).timestamp()),
             f'{OPTION_PATH_PREFIX}[interval]': 'sporadic',
             f'{OPTION_PATH_PREFIX}[supported_types][]': 'india',
         }


### PR DESCRIPTION
## Version:
17.0+

## Issue:
Stripe payments with an unregistered card on backdated subscriptions lead to Stripe API refusal.

## Steps to reproduce:
Requires OE's `sale_subscription` app.
- Ensure Stripe is well configured in `Test Mode` with `Credentials`;
- Create a new Sale Order with `Monthly Cleaning` as `Quotation Template` for any customer:
  - Under `Other Info` tab, change the `Subscription` `Start Date` for a date at least 2 days before current date;
  - Confirm and create regular invoice:
    - Set `Invoice Date` to the same date as the subscription;
    - Confirm and go to the invoice's preview and start payment process:
      - Use a new card for payment;
      - Check `Save my payment details` checkbox and pay.

## Cause:
The Stripe mandate needs to be filled with a start date at least equal to current timestamp. OS's Subscription app sets the start date to the SO's `start_date` via https://github.com/odoo/enterprise/blob/5642ad28919081a44bb47c0d936aa51980178d09/sale_subscription/models/payment_transaction.py#L51-L52. The values are retrieved by `_stripe_prepare_mandate_options()` via https://github.com/odoo/odoo/blob/d231565ec9054556d025b093195a934f28d067c3/addons/payment_stripe/models/payment_transaction.py#L206 and sent to Stipe under a new structure given by
https://github.com/odoo/odoo/blob/d231565ec9054556d025b093195a934f28d067c3/addons/payment_stripe/models/payment_transaction.py#L209-L220

opw-4654142