### PR TITLE
[FIX] hr_contract: fix  holiday days calculation based on contract

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -203,10 +203,19 @@ class Employee(models.Model):
         ])
         if not employee_contracts:
             return super()._get_unusual_days(date_from, date_to)
+
+        # Filter contracts that are "running" during this period
+        running_contracts = employee_contracts.filtered(lambda c: c.state == 'open')
+
+        if running_contracts:
+            selected_contract = running_contracts[0]
+        else:
+            # No "open" contract, pick the latest created contract from the valid ones
+            selected_contract = sorted(employee_contracts, key=lambda c: (c.create_date, c.id), reverse=True)[0]
         unusual_days = {}
         date_from_date = datetime.strptime(date_from, '%Y-%m-%d %H:%M:%S').date()
         date_to_date = datetime.strptime(date_to, '%Y-%m-%d %H:%M:%S').date() if date_to else None
-        for contract in employee_contracts:
+        for contract in selected_contract:
             tmp_date_from = max(date_from_date, contract.date_start)
             tmp_date_to = min(date_to_date, contract.date_end) if contract.date_end else date_to_date
             unusual_days.update(contract.resource_calendar_id.sudo(False)._get_unusual_days(
@@ -307,13 +316,15 @@ class Employee(models.Model):
             return action
 
         target_contract = self.contract_id
-        if target_contract:
+        if target_contract.state == 'open' or \
+            (target_contract.state == 'draft' and target_contract.kanban_state == 'done'):
             action['res_id'] = target_contract.id
             return action
 
         target_contract = self.contract_ids.filtered(lambda c: c.state == 'draft')
-        if target_contract:
-            action['res_id'] = target_contract[0].id
+        latest_contract = max(target_contract, key=lambda c: (c.create_date, c.id), default=False)
+        if latest_contract:
+            action['res_id'] = latest_contract.id
             return action
 
         action['res_id'] = self.contract_ids[0].id


### PR DESCRIPTION
Steps:
- Install the hr_holidays_contract module
- Create two contracts for the same employee: 
    - Contract A (Part-time) starting from 01/01/2025 and set to Running 
    - Contract B (Full-time) also starting from 01/01/2025 and set to New 
- open holiday dashboard for that employee

Description of the issue/feature this PR addresses: 
The Time Off dashboard incorrectly considers the full-time contract instead of the part-time one, even though the part-time contract is in the running state.

Cause:
The contract selection logic did not correctly prioritize the running contract when multiple contracts existed for the same period.

Fix:
This PR updates the logic to ensure that:
   - If a contract is in the running state at a given time, it is used to determine the working schedule and time off calculations.
   - If no contract is running during that time and multiple contracts exist, the contract with the latest creation_id will be considered.

task-4724155
