### PR TITLE
[FIX] mail: activity creation for x2m user field

### DIFF
--- a/addons/mail/models/ir_actions_server.py
+++ b/addons/mail/models/ir_actions_server.py
@@ -405,7 +405,9 @@ class IrActionsServer(models.Model):
             elif self.activity_user_type == 'generic' and self.activity_user_field_name in record:
                 user = record[self.activity_user_field_name]
             if user:
-                vals['user_id'] = user.id
+                # if x2m field, assign to the first user found
+                # (same behavior as Field.traverse_related)
+                vals['user_id'] = user.ids[0]
             record.activity_schedule(**vals)
         return False
 


### PR DESCRIPTION
Have a server action that creates an activity based on a record's x2m user field.
Run that action on a record that has more than one user in this field.

Before this commit: display traceback "ValueError: Expected singleton"

After this commit: the activity is created for the first user found in the x2m field value.

Task id: opw-4745032