### PR TITLE
[FIX] portal, project: remove focus from portal chatter composer in all cases

### DIFF
--- a/addons/portal/static/src/chatter/core/portal_chatter.xml
+++ b/addons/portal/static/src/chatter/core/portal_chatter.xml
@@ -4,7 +4,7 @@
 <t t-name="portal.Chatter">
     <div t-if="state.thread" class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex pt-2" t-att-class="{ 'row':props.twoColumns, 'flex-column':!props.twoColumns }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div t-if="props.composer" class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'col-lg-6':props.twoColumns, 'bg-view':env.inFrontendPortalChatter }" t-att-style="(!props.twoColumns and env.inFrontendPortalChatter and !env.projectSharingId) and 'top: -1px !important; margin-top:-15px; padding-top: 20px'" t-ref="top">
-            <Composer composer="state.thread.composer" autofocus="env.inFrontendPortalChatter ? false : true" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId"/>
+            <Composer composer="state.thread.composer" mode="'extended'" onPostCallback.bind="onPostCallback" dropzoneRef="rootRef" t-key="props.threadId" type="'message'"/>
         </div>
         <div class="o-mail-Chatter-content" t-att-class="{ 'col-lg-6':props.twoColumns }">
             <Thread thread="state.thread" t-key="state.thread.localId" order="'desc'" scrollRef="rootRef" jumpPresent="state.jumpThreadPresent"/>

--- a/addons/project/static/src/project_sharing/chatter/chatter_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/chatter_patch.js
@@ -13,7 +13,6 @@ patch(Chatter.prototype, {
         this.orm = useService("orm");
         useSubEnv({
             projectSharingId: this.props.projectSharingId,
-            inFrontendPortalChatter: true,
         });
     },
 


### PR DESCRIPTION
PR #189568 removes the focus from the project sharing composer by setting the `inFrontendPortalChatter` to true, which goes against the whole idea of having this parameter. The correct fix is to remove the `autofocus` (prop) from the composer, because it was only there to keep the focus on the project sharing composer.
This commit undoes the change in the mentioned PR and removes the `autofocus` from the portal chatter composer.
Consequently, the composer placeholder in project sharing becomes the one related to `note`, so this commit adds `type="'message'"` to the composer to ensure consistency with the backend when sending a message.