### PR TITLE
[FIX] html_editor: treat a div with text-empty buttons as non-empty block

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -598,7 +598,10 @@ export function isEmptyBlock(blockEl) {
         // this visible is a "visible empty" node like an image.
         if (
             node.nodeName != "BR" &&
-            (isSelfClosingElement(node) || isMediaElement(node) || isProtecting(node))
+            (isSelfClosingElement(node) ||
+                isMediaElement(node) ||
+                isProtecting(node) ||
+                isButton(node))
         ) {
             return false;
         }

--- a/addons/html_editor/static/tests/utils/dom_info.test.js
+++ b/addons/html_editor/static/tests/utils/dom_info.test.js
@@ -425,6 +425,12 @@ describe("isEmptyBlock", () => {
         const result = isEmptyBlock(p);
         expect(result).toBe(false);
     });
+
+    test("should identify a div contains button without text content as non-empty", () => {
+        const [div] = insertTestHtml("<div><button></button></div>");
+        const result = isEmptyBlock(div);
+        expect(result).toBe(false);
+    });
 });
 
 describe("isShrunkBlock", () => {


### PR DESCRIPTION
Before this commit: Since the base container PR, eligible `<div>` elements are now treated as `<p>` elements. At normalize, when a block is without visible height, a `<br>` is inserted inside the block. This behavior caused issues in the html_builder, where `<div>` elements containing buttons without text content were incorrectly normalized. These buttons are visible, and the addition of a `<br>` breaks certain website features.

After this commit: A new check is added to consider a block with button inside is not empty


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
