### PR TITLE
[FIX] hw_drivers: Adam driver priority

### DIFF
--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -14,6 +14,7 @@ class Driver(Thread):
     Hook to register the driver into the drivers list
     """
     connection_type = ''
+    priority = 0
 
     def __init__(self, identifier, device):
         super(Driver, self).__init__()
@@ -32,11 +33,8 @@ class Driver(Thread):
 
     def __init_subclass__(cls):
         super().__init_subclass__()
-        if hasattr(cls, 'priority'):
-            cls.priority += 1
-        else:
-            cls.priority = 0
-        drivers.append(cls)
+        if cls not in drivers:
+            drivers.append(cls)
 
     @classmethod
     def supported(cls, device):

--- a/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialScaleDriver.py
@@ -213,7 +213,7 @@ class AdamEquipmentDriver(ScaleDriver):
     """Driver for the Adam Equipment serial scale."""
 
     _protocol = ADAMEquipmentProtocol
-    priority = 0  # Test the supported method of this driver last, after all other serial drivers
+    priority = -1  # Test the supported method of this driver last, after all other serial drivers
 
     def __init__(self, identifier, device):
         super(AdamEquipmentDriver, self).__init__(identifier, device)


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/84122

Since commit ae16d9d, the Adam driver priority has been incorrectly set higher than it should be. The issue was a side-effect of removing the meta-class, since it no longer registered the `Driver` base class as a driver.

The fix was just to simplify the priority system to not be affected by inheritance. Then we manually set the Adam priority to -1, and the Blackbox priority to 1. Everything else will have priority 0.


For a detailed breakdown of the old behaviour and the cause of the bug, keep reading:

The priority system was influenced by inheritance - the more levels of inheritance, the higher the priority. For example, in saas-18.1, you get these priorities:
- `SerialBaseDriver`: 1
- `BlackBoxDriver`: 2
- `ScaleDriver`: 2
- `Toledo8217Driver`: 3

The Adam driver sets its priority to zero, but it still gets +1 from the meta class. So the final priorities are as follows in saas-18.1:
- `SerialBaseDriver`: 1
- `AdamEquipmentDriver`: 1
- `BlackBoxDriver`: 2
- `ScaleDriver`: 2
- `Toledo8217Driver`: 3

This results in the Adam driver runs last.

In saas-18.2, the priorities are shifted by 1 due to the `Driver` base class not being registered, but the Adam driver still ends up with the same value. So the priorities now look like this:
- `SerialBaseDriver`: 0
- `AdamEquipmentDriver`: 1
- `BlackBoxDriver`: 1
- `ScaleDriver`: 1
- `Toledo8217Driver`: 2

The Adam driver and blackbox driver have the same priority, so the Adam driver could end up running first and breaking the blackbox.

task-4750364

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
