### PR TITLE
[FIX] html_editor: apply font size outside <font> and remove font-size classes with gradient styles

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -572,7 +572,7 @@ export const editorCommands = {
             element.style.removeProperty('color');
             element.style.removeProperty('background');
             element.style.removeProperty('-webkit-text-fill-color');
-            if (hasAnyFontSizeClass(element)) {
+            if (!hasFontSizeClass && closestElement(node, hasAnyFontSizeClass)) {
                 hasFontSizeClass = true;
             }
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1298,12 +1298,13 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         let parentNode = node.parentElement;
 
         // Remove the format on all inline ancestors until a block or an element
-        // with a class that is not related to font size (in case the formatting
-        // comes from the class).
+        // with a class that is not related to font size or color (in case the
+        // formatting comes from the class).
         while (
             parentNode && !isBlock(parentNode) &&
             !isUnbreakable(parentNode) && !isUnbreakable(currentNode) &&
-            (parentNode.classList.length === 0 ||
+            (parentNode.nodeName === "FONT" ||
+                parentNode.classList.length === 0 ||
                 [...parentNode.classList].every(cls => FONT_SIZE_CLASSES.includes(cls)))
         ) {
             const isUselessZws = parentNode.tagName === 'SPAN' &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -1108,6 +1108,18 @@ describe('Format', () => {
                 contentAfter: `<p>a<span style="font-size: 18px;"><s><u>[b]</u></s></span>c</p>`,
             });
         });
+        it("should apply font size on top of `font` tag", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></p>`,
+                stepFunction: setFontSize("80px"),
+                contentAfter: `<p><span style="font-size: 80px;"><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></span></p>`,
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p><font class="bg-o-color-1 text-black">[abcdefg]</font></p>`,
+                stepFunction: setFontSize("72px"),
+                contentAfter: `<p><span style="font-size: 72px;"><font class="bg-o-color-1 text-black">[abcdefg]</font></span></p>`,
+            });
+        });
     });
 
     describe('setFontSizeClassName', () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -1233,6 +1233,18 @@ describe('Format', () => {
 
             });
         });
+        it("should remove font size classes and gradient color styles", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: `<p><span class="display-1-fs"><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></span></p>`,
+                stepFunction: (editor) => editor.execCommand("removeFormat"),
+                contentAfter: `<p>[abcdefg]</p>`,
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: `<p><span class="display-2-fs"><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></span></p>`,
+                stepFunction: (editor) => editor.execCommand("removeFormat"),
+                contentAfter: `<p>[abcdefg]</p>`,
+            });
+        });
         it('should remove font-size classes when clearing the format' , async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p>123<span class="h1-fs">[abc]</span>456</p>`,


### PR DESCRIPTION
### Steps to reproduce:

**Issue 1:**
- Go to To-do.
- Type any text and apply a gradient color.
- Select the text and increase the font size.
- The top part of the text became invisible.

**Issue 2:**
- Write and select some text .
- Apply a gradient text/background color.
- Click the 'Remove Format' button in the toolbar.
- Gradient styles are removed, but the font size class remains.
- Only on a second click, the font size class is removed.

### Description of the issue/feature this PR addresses:

- When text or background color is applied using classes, applying a font size would nest the font-size <span> inside the <font> tag.
- Font size class was not removed when gradient styles were present, as the closest element after `removeFormat` contained the gradient styles, not the font size class.

### Desired behavior after PR is merged:

- Font size is now applied outside the <font> tag even when it has color-related classes.
- `removeFormat` correctly removes both gradient styles and font size classes.

task-4736914

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
