### PR TITLE
[FIX] web: control panel missing gap

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -19,7 +19,7 @@
                     <t t-call="web.embeddedActionsDropdown" />
                 </div>
             </Transition>
-            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-lg-3 flex-grow-1">
+            <div class="o_control_panel_main d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-lg-start gap-2 gap-lg-3 flex-grow-1">
                 <div class="o_control_panel_breadcrumbs d-flex align-items-center gap-1 order-0 h-lg-100">
                     <div class="o_control_panel_main_buttons d-flex gap-1 d-empty-none d-print-none" t-ref="mainButtons" t-on-keydown="onMainButtonsKeydown">
                         <div t-if="env.isSmall" class="btn-group o_control_panel_collapsed_create">

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -102,7 +102,7 @@
     </t>
 
     <t t-name="web.SearchBar">
-        <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group mt-1 mt-md-0" role="search" t-ref="root">
+        <div t-if="visibilityState.showSearchBar" class="o_cp_searchview d-flex input-group" role="search" t-ref="root">
             <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                  role="search" aria-autocomplete="list">
                 <button class="d-print-none btn border-0 p-0"


### PR DESCRIPTION
requires: https://github.com/odoo/enterprise/pull/84124

---

In the control panel, any middle element (whether it's the search bar or control_panel_actions) tends to drop below the rest of the content under the `lg` breakpoint due to missing spacing. Under `md`, these elements collapse into dropdowns or toggle buttons as expected.

Prior to this commit, there was an issue with the spacing applied between `md` and `lg`. This was either caused by the `mt-md-0` class on the search bar or the specific breakpoint use of `gap-lg-3`

To resolve the spacing issue between `md` and `lg`, we now apply the correct gap (by adding a `gap-2` alongside the `gap-lg-3`) on the control panel’s main div, and remove unwanted margin/padding classes.



| | Before (between md and lg) | After (between md and lg) |
|--------|--------|--------|
| w/ searchbar | ![search-before](https://github.com/user-attachments/assets/894a0adf-2707-4a35-8dd4-7ea8fa45f434) | ![search-after](https://github.com/user-attachments/assets/cc023d0b-8e43-4de7-83de-09a637f62221) |
| w/ actions | ![action-before](https://github.com/user-attachments/assets/c0e17a72-406a-437e-92b8-c1ac869110e9) | ![action-after](https://github.com/user-attachments/assets/8962946f-2122-46f2-9f25-563503f2debd) | 

task-4568501

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
