### PR TITLE
[FIX] im_livechat,web: fix time to answer format in reporting

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -32,7 +32,7 @@ class Im_LivechatReportChannel(models.Model):
         string="Day of the Week",
         readonly=True,
     )
-    time_to_answer = fields.Float("Response Time (sec)", digits=(16, 2), readonly=True, aggregator="avg", help="Average time in seconds to give the first answer to the visitor")
+    time_to_answer = fields.Float("Response Time", digits=(16, 6), readonly=True, aggregator="avg", help="Average time in hours to give the first answer to the visitor")
     start_date_hour = fields.Char('Hour of start Date of session', readonly=True)
     duration = fields.Float("Duration (min)", digits=(16, 2), readonly=True, aggregator="avg", help="Duration of the conversation (in minutes)")
     nbr_message = fields.Integer("Messages per Session", readonly=True, aggregator="avg", help="Number of message in the conversation")
@@ -177,7 +177,7 @@ class Im_LivechatReportChannel(models.Model):
                         EXTRACT('epoch' FROM MIN(message_vals.first_agent_message_dt) - c.create_date)
                     ELSE
                         EXTRACT('epoch' FROM MIN(message_vals.first_agent_message_dt_legacy) - c.create_date)
-                END AS time_to_answer,
+                END/3600 AS time_to_answer,
                 SUM(message_vals.message_count) as nbr_message,
                 CASE
                     WHEN C.livechat_is_escalated THEN 'escalated'

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -11,7 +11,7 @@
                     <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="partner_id" type="row"/>
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
-                    <field name="time_to_answer" type="measure"/>
+                    <field name="time_to_answer" string="Response Time (hh:mm:ss)" type="measure" widget="float_time" options="{'displaySeconds': True}" />
                     <field name="duration" type="measure"/>
                     <field name="rating" string="Rating (%)" type="measure" widget="im_livechat.rating_percentage"/>
                     <field name="number_of_calls" string="# of calls" type="measure" widget="integer"/>

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -55,13 +55,13 @@ class TestImLivechatReport(TestImLivechatCommon):
         # 09:15:54: wrong model
         # So the duration of the session is: (08:45:54 - 06:05:54) = 2h40 = 160 minutes
         # The time to answer of this session is: (08:15:54 - 06:05:54) = 2h10 = 7800 seconds
-        self.assertEqual(int(report.time_to_answer), 7800)
+        self.assertEqual(report.time_to_answer, 7800 / 3600)
         self.assertEqual(int(report.duration), 160)
 
     def test_im_livechat_report_operator(self):
         result = self.env["im_livechat.report.channel"].formatted_read_group([], aggregates=["time_to_answer:avg", "duration:avg"])
         self.assertEqual(len(result), 1)
-        self.assertEqual(int(result[0]['time_to_answer:avg']), 7800)
+        self.assertEqual(result[0]["time_to_answer:avg"], 7800 / 3600)
         self.assertEqual(int(result[0]['duration:avg']), 160)
 
     @classmethod

--- a/addons/web/static/src/views/pivot/pivot_arch_parser.js
+++ b/addons/web/static/src/views/pivot/pivot_arch_parser.js
@@ -1,5 +1,6 @@
 import { exprToBoolean } from "@web/core/utils/strings";
 import { visitXML } from "@web/core/utils/xml";
+import { evaluateExpr } from "@web/core/py_js/py";
 
 export class PivotArchParser {
     parse(arch) {
@@ -46,6 +47,16 @@ export class PivotArchParser {
                     ) {
                         archInfo.fieldAttrs[fieldName].isInvisible = true;
                         break;
+                    }
+                    for (const { name, value } of node.attributes) {
+                        if (["name", "type", "operator", "interval", "string", "widget"].includes(name)) {
+                            continue;
+                        }
+                        if (name === "options") {
+                            archInfo.fieldAttrs[fieldName].options = evaluateExpr(value);
+                        } else {
+                            archInfo.fieldAttrs[fieldName][name] = value;
+                        }
                     }
 
                     if (node.hasAttribute("interval")) {

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -84,13 +84,22 @@ export class PivotRenderer extends Component {
      */
     getFormattedValue(cell) {
         const field = this.model.metaData.measures[cell.measure];
+        const fieldAttrs = this.model.metaData.fieldAttrs[cell.measure] ?? {};
+        const fieldInfo = {
+            options: fieldAttrs.options ?? {},
+            attrs: fieldAttrs,
+        };
         let formatType = this.model.metaData.widgets[cell.measure];
         if (!formatType) {
             const fieldType = field.type;
             formatType = ["many2one", "reference"].includes(fieldType) ? "integer" : fieldType;
         }
         const formatter = formatters.get(formatType);
-        return formatter(cell.value, field);
+        const formatOptions = { field };
+        if (formatter.extractOptions) {
+            Object.assign(formatOptions, formatter.extractOptions(fieldInfo));
+        }
+        return formatter(cell.value, formatOptions);
     }
     /**
      * Get the formatted variation of a cell.

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -261,6 +261,49 @@ test("pivot rendering with widget", async () => {
     expect("td.o_pivot_cell_value:contains(32:00)").toHaveCount(1);
 });
 
+test("pivot rendering with widget and options", async () => {
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+			<pivot string="Partners">
+                <field name="foo" type="measure" widget="float_time" options="{'displaySeconds': True}"/>
+			</pivot>
+		`,
+    });
+    expect("td.o_pivot_cell_value:contains(32:00:00)").toHaveCount(1);
+});
+
+test("pivot rendering with widget and options from model field", async () => {
+    Partner._fields.biz = fields.Float({ digits: [16, 2] });
+    Partner._records[0].biz = 0.3333333;
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+			<pivot string="Partners">
+                <field name="biz" type="measure" widget="percentage"/>
+			</pivot>
+		`,
+    });
+    expect("td.o_pivot_cell_value:contains(33.33%)").toHaveCount(1);
+});
+
+test("pivot rendering with widget and options from field attrs", async () => {
+    Partner._fields.biz = fields.Float({ digits: [16, 2] });
+    Partner._records[0].biz = 0.3333333;
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        arch: `
+			<pivot string="Partners">
+                <field name="biz" type="measure" widget="float" digits="[16,4]"/>
+			</pivot>
+		`,
+    });
+    expect("td.o_pivot_cell_value:contains(0.3333)").toHaveCount(1);
+});
+
 test("pivot rendering with string attribute on field", async () => {
     Partner._fields.foo = fields.Integer();
 


### PR DESCRIPTION
Before this commit the time to answer in the livechat reporting was
shown as a float, now it shows the hh:mm:ss

In order to achieve this, we need to be able to give options to the
widget in a pivot view. Therefore this PR adds the support for the
options attribute in the fields of the pivot.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
