### PR TITLE
[IMP] mail: auto-mention author on chatter note and inbox reply

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -3,7 +3,7 @@ import { Activity } from "@mail/core/web/activity";
 import { AttachmentList } from "@mail/core/common/attachment_list";
 import { Chatter } from "@mail/chatter/web_portal/chatter";
 import { FollowerList } from "@mail/core/web/follower_list";
-import { isDragSourceExternalFile } from "@mail/utils/common/misc";
+import { assignGetter, isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { useCustomDropzone } from "@web/core/dropzone/dropzone_hook";
 import { useHover, useMessageScrolling } from "@mail/utils/common/hooks";
@@ -244,7 +244,8 @@ patch(Chatter.prototype, {
 
     get childSubEnv() {
         const res = Object.assign(super.childSubEnv, { messageHighlight: this.messageHighlight });
-        res.inChatter.aside = this.props.isChatterAside;
+        assignGetter(res.inChatter, { aside: () => this.props.isChatterAside });
+        Object.assign(res.inChatter, { toggleComposer: this.toggleComposer.bind(this) });
         return res;
     },
 
@@ -439,10 +440,10 @@ patch(Chatter.prototype, {
         this.state.showActivities = !this.state.showActivities;
     },
 
-    toggleComposer(mode = false) {
+    toggleComposer(mode = false, { force = false } = {}) {
         this.closeSearch();
         const toggle = async () => {
-            if (this.state.composerType === mode) {
+            if (!force && this.state.composerType === mode) {
                 this.state.composerType = false;
             } else {
                 if (mode === "message") {

--- a/addons/mail/static/src/core/common/composer_model.js
+++ b/addons/mail/static/src/core/common/composer_model.js
@@ -17,6 +17,24 @@ export class Composer extends Record {
         });
     }
 
+    /**
+     * @param {string} text - text to insert
+     * @param {number} position - insertion position
+     * @param {Object} [options]
+     * @param {boolean} [options.moveCursorToEnd=false] - If true, place cursor at end of composerText
+     */
+    insertText(text, position, { moveCursorToEnd = false } = {}) {
+        const before = this.composerText.substring(0, position);
+        const after = this.composerText.substring(position);
+        this.composerText = before + text + after;
+        this.selection.start = before.length + text.length;
+        if (moveCursorToEnd) {
+            this.selection.start = this.composerText.length;
+        }
+        this.selection.end = this.selection.start;
+        this.forceCursorMove = true;
+    }
+
     attachments = fields.Many("ir.attachment");
     /** @type {boolean} */
     emailAddSignature = true;

--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -151,36 +151,25 @@ export class UseSuggestion {
         return this.composer.thread || this.composer.message.thread;
     }
     insert(option) {
-        const position = this.composer.selection.start;
-        const text = this.composer.composerText;
-        let before = text.substring(0, this.search.position + 1);
-        let after = text.substring(position, text.length);
+        let position = this.search.position + 1;
         if ([":", "::"].includes(this.search.delimiter)) {
-            before = text.substring(0, this.search.position);
-            after = text.substring(position, text.length);
+            position = this.search.position;
         }
         if (option.partner) {
-            this.composer.mentionedPartners.add({
-                id: option.partner.id,
-            });
-        }
-        if (option.role) {
+            this.composer.mentionedPartners.add({ id: option.partner.id });
+        } else if (option.role) {
             this.composer.mentionedRoles.add(option.role);
-        }
-        if (option.thread) {
-            this.composer.mentionedChannels.add({
-                model: "discuss.channel",
-                id: option.thread.id,
-            });
-        }
-        if (option.cannedResponse) {
+        } else if (option.thread) {
+            this.composer.mentionedChannels.add({ model: "discuss.channel", id: option.thread.id });
+        } else if (option.cannedResponse) {
             this.composer.cannedResponses.push(option.cannedResponse);
         }
+        // remove the user-typed search delimiter
+        this.composer.composerText =
+            this.composer.composerText.substring(0, position) +
+            this.composer.composerText.substring(this.composer.selection.end);
         this.clearSearch();
-        this.composer.composerText = before + option.label + " " + after;
-        this.composer.selection.start = before.length + option.label.length + 1;
-        this.composer.selection.end = before.length + option.label.length + 1;
-        this.composer.forceCursorMove = true;
+        this.composer.insertText(`${option.label} `, position);
     }
     update() {
         if (!this.search.delimiter) {

--- a/addons/mail/static/src/utils/common/misc.js
+++ b/addons/mail/static/src/utils/common/misc.js
@@ -11,6 +11,19 @@ export function assignDefined(obj, data, keys = Object.keys(data)) {
     return obj;
 }
 
+export function assignGetter(obj, data) {
+    const properties = Object.fromEntries(
+        Object.entries(data).map(([getterName, getterFn]) => [
+            getterName,
+            {
+                get: getterFn,
+                set: () => {}, // avoids Proxy "trap returned falsish" error
+            },
+        ])
+    );
+    Object.defineProperties(obj, properties);
+}
+
 export function assignIn(obj, data, keys = Object.keys(data)) {
     for (const key of keys) {
         if (key in data) {

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -391,12 +391,13 @@ test("reply to message from inbox (message linked to document)", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Refactoring" });
     const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
         body: "<p>Test</p>",
         date: "2019-04-20 11:00:00",
         message_type: "comment",
-        needaction: true,
         model: "res.partner",
-        res_id: partnerId,
+        needaction: true,
+        res_id: serverState.partnerId,
     });
     pyEnv["mail.notification"].create({
         mail_message_id: messageId,
@@ -406,22 +407,23 @@ test("reply to message from inbox (message linked to document)", async () => {
     await start();
     await openDiscuss("mail.box_inbox");
     await contains(".o-mail-Message");
-    await contains(".o-mail-Message-header small", { text: "on Refactoring" });
+    await contains(".o-mail-Message-header small", { text: "on Mitchell Admin" });
     await click("[title='Expand']");
     await click(".o-dropdown-item:contains('Reply')");
     await contains(".o-mail-Message.o-selected");
     await contains(".o-mail-Composer");
-    await contains(".o-mail-Composer-coreHeader", { text: "on: Refactoring" });
+    await contains(".o-mail-Composer-coreHeader", { text: "on: Mitchell Admin" });
     await insertText(".o-mail-Composer-input:focus", "Hello");
     await press("Enter");
     await contains(".o-mail-Composer", { count: 0 });
     await contains(".o-mail-Message:not(.o-selected)");
     await contains(".o_notification:has(.o_notification_bar.bg-info)", {
-        text: 'Message posted on "Refactoring"',
+        text: 'Message posted on "Mitchell Admin"',
     });
-    await openFormView("res.partner", partnerId);
+    await openFormView("res.partner", serverState.partnerId);
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-Message-content", { text: "Hello" });
+    await contains(".o-mail-Message-content", { text: "@Refactoring Hello" });
+    await contains(".o-mail-Message.o-selfAuthored a.o_mail_redirect", { text: "@Refactoring" });
 });
 
 test("Can reply to starred message", async () => {
@@ -446,8 +448,10 @@ test("Can reply to starred message", async () => {
 
 test("Can reply to history message", async () => {
     const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Refactoring" });
     const channelId = pyEnv["discuss.channel"].create({ name: "RandomName" });
     const messageId = pyEnv["mail.message"].create({
+        author_id: partnerId,
         body: "not empty",
         model: "discuss.channel",
         res_id: channelId,


### PR DESCRIPTION
**Description of the feature this PR addresses:**
It should be quicker and easier to reply and notify to someone's note in the Chatter.

**Current behavior before PR:**

- The "Reply" button is not available for notes in the Chatter.
- Users must manually type @mentions to notify someone, even when replying directly to their message.

**Desired behavior after PR is merged:**

- A "Reply" button is shown on notes in the Chatter (excluding self-authored messages).  
- When clicked, the composer is pre-filled with an @mention of the original message author.
- introduces a new `insertText` method on the composer model.

task-[4707331](https://www.odoo.com/odoo/project/1519/tasks/4707331)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
