### PR TITLE
[FIX] website: prevent error when user clicks publish button of profile

### DIFF
--- a/addons/website/models/res_users.py
+++ b/addons/website/models/res_users.py
@@ -105,3 +105,8 @@ class ResUsers(models.Model):
         internal_users = self.env.ref('base.group_user').users & self
         if any(user.website_id for user in internal_users):
             raise ValidationError(_("Remove website on related partner before they become internal user."))
+
+    # The model inherits the publishing fields from res.partner, this implements
+    # the required method.
+    def website_publish_button(self):
+        return self.partner_id.website_publish_button()


### PR DESCRIPTION
Currently, an error is encountered when clicking on the publish button in the 
profile page in the website view.

**Steps to Reproduce:**
- Install `website_profile` module.
- Navigate to the user's profile page.`(/profile/user/2)`
- Click on the publish button in the editor view.

**Note:**
- The error is generic and could be generated via different website modules as 
  well (e.g, website_forum).

**Error:**
AttributeError: The method `res.users.website_publish_button` does not exist.

**Root Cause:**
- since [1] we are using `website_publish_button` method to publish/unpublish
  records, however, `res.users` model **inherits** the publishing fields from its 
  `res.partner`, but not its related publishing methods

[1]- https://github.com/odoo/odoo/commit/97d00377de0c32e919587a98210679376e27ecc4

**Solution:**
- This commit ensures that the `res.users` model can handle publish/unpublish
  calls by adding the `website_publish_button` method to `res.users`.

sentry-6356507720
