### PR TITLE
[REM] hr_holidays: removed unused js im_status override

### DIFF
--- a/addons/hr_holidays/static/src/persona_model_patch.js
+++ b/addons/hr_holidays/static/src/persona_model_patch.js
@@ -6,18 +6,6 @@ import { patch } from "@web/core/utils/patch";
 const { DateTime } = luxon;
 
 patch(Persona.prototype, {
-    updateImStatus(newStatus) {
-        if (newStatus == "online" && this.out_of_office_date_end) {
-            this.im_status = "leave_online";
-        } else if (newStatus == "offline" && this.out_of_office_date_end) {
-            this.im_status = "leave_offline";
-        } else if (newStatus == "away" && this.out_of_office_date_end) {
-            this.im_status = "leave_away";
-        } else {
-            return super.updateImStatus(...arguments);
-        }
-    },
-
     get outOfOfficeText() {
         if (!this.out_of_office_date_end) {
             return "";


### PR DESCRIPTION
Since #203903 the user `im_status` is sent directly from the identity model in order to take into account other module overrides without having to re-establish them client side.

This commit removes the method patching `updateImStatus` as the value arrives client side already patched from `hr_holidays`.
