### PR TITLE
[FIX] partner_autocomplete: make sure jsvat is lazy loaded on time

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -8,6 +8,7 @@ import { KeepLast } from "@web/core/utils/concurrency";
 import { useService } from "@web/core/utils/hooks";
 import { renderToMarkup } from "@web/core/utils/render";
 import { getDataURLFromFile } from "@web/core/utils/urls";
+import { onWillStart } from "@odoo/owl";
 
 /**
  * Get list of companies via Autocomplete API
@@ -22,14 +23,15 @@ export function usePartnerAutocomplete() {
     const notification = useService("notification");
     const orm = useService("orm");
 
+    onWillStart(async () => {
+        await loadJS("/partner_autocomplete/static/lib/jsvat.js");
+    });
+
     function sanitizeVAT(value) {
         return value ? value.replace(/[^A-Za-z0-9]/g, '') : '';
     }
 
     async function isVATNumber(value) {
-        // Lazyload jsvat only if the component is being used.
-        await loadJS("/partner_autocomplete/static/lib/jsvat.js");
-
         // checkVATNumber is defined in library jsvat.
         // It validates that the input has a valid VAT number format
         return checkVATNumber(sanitizeVAT(value));


### PR DESCRIPTION
Before this fix, there was a non-deterministic error in the main flow tour : ´Uncaught (in promise)undefined´.

This issue occured when the loading of "jsvat" took too much time. The user could have time to click on one of the results, which then caused the destruction of the component before the loading was finish.

Then after the loading, there is a call to the "ORM service" in ´getSuggestions´ but no luck the component is already destroyed.

This error therefore typically occurs in a tour depending on :
- the quick selection of a result as soon as it appears (thx to the tour)
- the slow network that delays the loading of the lib (nightly builds)

It is likely that this error has been there for longer but was highlighted by changes that affected these timings. Even if the migration from Clearbit to Dun & Bradstreet [1] would be a good culprit.

In this case the main flow tour was impacted with steps flagged "mobile" only at the stage of creating an opportunity in the CRM. But we doesn't exclude to have the same issue for largest screens.

[1] https://github.com/odoo/odoo/pull/202546

runbot-error: 161434

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
