### PR TITLE
[FIX] mail: prevent to star pending message

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -335,7 +335,12 @@ export class Message extends Component {
     }
 
     get isPersistentMessageFromAnotherThread() {
-        return !this.isOriginThread && !this.message.is_transient && this.message.thread;
+        return (
+            !this.isOriginThread &&
+            !this.message.is_transient &&
+            !this.message.isPending &&
+            this.message.thread
+        );
     }
 
     get isOriginThread() {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -375,6 +375,7 @@ export class Message extends Record {
     get canToggleStar() {
         return Boolean(
             !this.is_transient &&
+                !this.isPending &&
                 this.thread &&
                 this.store.self.type === "partner" &&
                 this.store.self.isInternalUser
@@ -383,7 +384,7 @@ export class Message extends Record {
 
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canAddReaction(thread) {
-        return Boolean(!this.is_transient && this.thread?.can_react);
+        return Boolean(!this.is_transient && !this.isPending && this.thread?.can_react);
     }
 
     /** @param {import("models").Thread} thread the thread where the message is shown */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -430,7 +430,7 @@ export class Thread extends Record {
     }
 
     get persistentMessages() {
-        return this.messages.filter((message) => !message.is_transient);
+        return this.messages.filter((message) => !message.is_transient && !message.isPending);
     }
 
     get prefix() {


### PR DESCRIPTION
If the user is fast (which happens in tours), it is possible to star a pending message, which leads to a crash on the server. This should simply not be possible.

runbot-164180