### PR TITLE
[FIX] html_editor: reintroduce o_editable_media

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -143,7 +143,23 @@ export class DeletePlugin extends Plugin {
         // see collapseIfZWS
 
         let range = this.getNormalizedRange(selection);
-        if (range.collapsed || !closestElement(range.commonAncestorContainer).isContentEditable) {
+        if (range.collapsed) {
+            return;
+        }
+        // Delete only if the selection is all editable or if every non-editable
+        // node's editable ancestor is fully selected.
+        const selectedNodes = this.dependencies.selection.getSelectedNodes();
+        if (
+            !selectedNodes.every(
+                (node) =>
+                    this.dependencies.selection.isNodeEditable(node) ||
+                    selectedNodes.includes(
+                        closestElement(node, (node) =>
+                            this.dependencies.selection.isNodeEditable(node)
+                        )
+                    )
+            )
+        ) {
             return;
         }
         range = this.adjustRange(range, [

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -683,18 +683,19 @@ export class SelectionPlugin extends Plugin {
 
     /**
      * Returns the nodes intersected by the current selection, up to the common
-     * ancestor container (inclusive).
+     * ancestor container (inclusive if `includeCommonAncestor` is true).
      *
      * @returns {Node[]}
      */
-    getTraversedNodes() {
+    getTraversedNodes(includeCommonAncestor = true) {
         const selection = this.getSelectionData().deepEditableSelection;
         const { commonAncestorContainer: root } = selection;
 
-        let traversedNodes = [
-            root,
-            ...descendants(root).filter((node) => selection.intersectsNode(node)),
-        ];
+        let traversedNodes = [];
+        if (includeCommonAncestor) {
+            traversedNodes.push(root);
+        }
+        traversedNodes.push(...descendants(root).filter((node) => selection.intersectsNode(node)));
 
         const modifiers = [
             // Remove the editable from the list

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -204,11 +204,13 @@ export class SelectionPlugin extends Plugin {
         "focusEditable",
         // "collapseIfZWS",
         "isSelectionInEditable",
+        "isNodeEditable",
         "selectAroundNonEditable",
     ];
     resources = {
         user_commands: { id: "selectAll", run: this.selectAll.bind(this) },
         shortcuts: [{ hotkey: "control+a", commandId: "selectAll" }],
+        is_node_editable_predicates: (node) => node.parentElement?.isContentEditable,
     };
 
     setup() {
@@ -923,6 +925,10 @@ export class SelectionPlugin extends Plugin {
             this.editable.contains(anchorNode) &&
             (focusNode === anchorNode || this.editable.contains(focusNode))
         );
+    }
+
+    isNodeEditable(node) {
+        return this.getResource("is_node_editable_predicates").some((p) => p(node));
     }
 
     focusEditable() {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -205,6 +205,7 @@ export class SelectionPlugin extends Plugin {
         // "collapseIfZWS",
         "isSelectionInEditable",
         "isNodeEditable",
+        "isSelectionEditable",
         "selectAroundNonEditable",
     ];
     resources = {
@@ -666,7 +667,14 @@ export class SelectionPlugin extends Plugin {
             this.getResource("fully_selected_node_predicates").some((cb) => cb(node, selection)) ||
             // Default rule
             (range.isPointInRange(node, 0) && range.isPointInRange(node, nodeSize(node)));
-        return this.getTraversedNodes().filter(isNodeFullySelected);
+        const selectedNodes = this.getTraversedNodes(false).filter(isNodeFullySelected);
+        // If no selectedNodes were find, it could still be that the whole
+        // selection is contained within a text node and that all the contents
+        // of its parent are selected.
+        // TODO: check this first instead of calling getTraversedNodes twice?
+        return selectedNodes.length
+            ? selectedNodes
+            : this.getTraversedNodes().filter(isNodeFullySelected);
     }
 
     isNodeContentsFullySelected(node) {
@@ -929,6 +937,10 @@ export class SelectionPlugin extends Plugin {
 
     isNodeEditable(node) {
         return this.getResource("is_node_editable_predicates").some((p) => p(node));
+    }
+
+    isSelectionEditable() {
+        return this.getSelectedNodes().every((node) => this.isNodeEditable(node));
     }
 
     focusEditable() {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import {
     ICON_SELECTOR,
     isIconElement,
+    isMediaElement,
     isProtected,
     isProtecting,
 } from "@html_editor/utils/dom_info";
@@ -14,6 +15,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 
 const MEDIA_SELECTOR = `${ICON_SELECTOR} , .o_image, .media_iframe_video`;
+export const EDITABLE_MEDIA_CLASS = "o_editable_media";
 
 /**
  * @typedef { Object } MediaShared
@@ -65,6 +67,7 @@ export class MediaPlugin extends Plugin {
         selectionchange_handlers: this.selectAroundIcon.bind(this),
 
         unsplittable_node_predicates: isIconElement, // avoid merge
+        is_node_editable_predicates: this.isEditableMediaElement.bind(this),
         clipboard_content_processors: this.clean.bind(this),
         clipboard_text_processors: (text) => text.replace(/\u200B/g, ""),
 
@@ -73,6 +76,13 @@ export class MediaPlugin extends Plugin {
 
     get recordInfo() {
         return this.config.getRecordInfo ? this.config.getRecordInfo() : {};
+    }
+
+    isEditableMediaElement(node) {
+        return (
+            (isMediaElement(node) || node.nodeName === "IMG") &&
+            node.classList.contains(EDITABLE_MEDIA_CLASS)
+        );
     }
 
     replaceImage() {

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -309,9 +309,9 @@ export class ToolbarPlugin extends Plugin {
         }
     }
 
-    getFilterTraverseNodes() {
+    getFilterTraverseNodes(includeRoot = true) {
         return this.dependencies.selection
-            .getTraversedNodes()
+            .getTraversedNodes(includeRoot)
             .filter((node) => !isTextNode(node) || (node.textContent !== "\n" && !isZWS(node)));
     }
 
@@ -349,7 +349,17 @@ export class ToolbarPlugin extends Plugin {
         if (isCollapsed) {
             return !!closestElement(selectionData.editableSelection.anchorNode, "td.o_selected_td");
         }
-        return this.getFilterTraverseNodes().length;
+        let traversedNodes = this.getFilterTraverseNodes(false);
+        if (!traversedNodes.length) {
+            // If no traversed nodes were found, the selection might be
+            // contained in a single text node so we need to include that text
+            // node.
+            traversedNodes = this.getFilterTraverseNodes();
+        }
+        return (
+            traversedNodes.every((node) => node.parentElement.isContentEditable) &&
+            !!traversedNodes.length
+        );
     }
 
     shouldPreventClosing(selectionData) {

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -357,8 +357,8 @@ export class ToolbarPlugin extends Plugin {
             traversedNodes = this.getFilterTraverseNodes();
         }
         return (
-            traversedNodes.every((node) => node.parentElement.isContentEditable) &&
-            !!traversedNodes.length
+            !!traversedNodes.length &&
+            traversedNodes.every(this.dependencies.selection.isNodeEditable)
         );
     }
 

--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -13,6 +13,10 @@ export const Direction = {
     FORWARD: "FORWARD",
 };
 
+// A generic base64 image for testing
+export const base64Img =
+    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
 class TestEditor extends Component {
     static template = xml`
         <t t-if="props.styleContent">
@@ -102,11 +106,7 @@ export async function setupEditor(content, options = {}) {
     // awaiting for mountWithCleanup is not enough when mounted in an iframe,
     // @see Wysiwyg.onMounted
     const editor = await attachedEditor;
-    const plugins = new Map(
-        editor.plugins.map((plugin) => {
-            return [plugin.constructor.id, plugin];
-        })
-    );
+    const plugins = new Map(editor.plugins.map((plugin) => [plugin.constructor.id, plugin]));
     if (plugins.get("embeddedComponents")) {
         // await an extra animation frame for embedded components mounting
         // TODO @phoenix: would be more accurate to register mounting

--- a/addons/html_editor/static/tests/chatgpt.test.js
+++ b/addons/html_editor/static/tests/chatgpt.test.js
@@ -138,7 +138,17 @@ test("Translate/ChatGPT should be disabled if selection spans across non editabl
     expect(".o-we-toolbar [name='translate']").not.toHaveAttribute("disabled");
 });
 
-test("Translate/ChatGPT should be disabled if selection spans across non editable content or unsplittable (3)", async () => {
+test.tags("desktop");
+test("Translate/ChatGPT should be disabled if selection spans across non editable content or unsplittable (3-desktop)", async () => {
+    await setupEditor('<div contenteditable="false">a[b</div><div>c]d</div>');
+    await animationFrame();
+    await tick();
+    // The toolbar itself is disabled.
+    expect(".o-we-toolbar").toHaveCount(0);
+});
+
+test.tags("mobile");
+test("Translate/ChatGPT should be disabled if selection spans across non editable content or unsplittable (3-mobile)", async () => {
     await setupEditor('<div contenteditable="false">a[b</div><div>c]d</div>');
     await animationFrame();
     await tick();

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -324,7 +324,7 @@ describe("Selection collapsed", () => {
                 contentAfter: `<p>[]&nbsp;def</p>`,
             });
         });
-        test("should merge p elements inside conteneditbale=true inside contenteditable=false", async () => {
+        test("should merge p elements inside contenteditable=true inside contenteditable=false", async () => {
             await testEditor({
                 contentBefore: `<div contenteditable="false"><div contenteditable="true"><p>abc[]</p><p>def</p></div></div>`,
                 stepFunction: deleteForward,

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -2,12 +2,9 @@ import { expect, test } from "@odoo/hoot";
 import { click, dblclick, press, queryOne, waitFor, waitForNone } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { contains } from "@web/../tests/web_test_helpers";
-import { setupEditor } from "./_helpers/editor";
+import { base64Img, setupEditor } from "./_helpers/editor";
 import { getContent, setContent } from "./_helpers/selection";
 import { undo } from "./_helpers/user_actions";
-
-const base64Img =
-    "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
 
 test("image can be selected", async () => {
     const { plugins } = await setupEditor(`

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -6,6 +6,7 @@ import { base64Img, setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
 import { cleanHints } from "./_helpers/dispatch";
+import { EDITABLE_MEDIA_CLASS } from "@html_editor/main/media/media_plugin";
 
 test("Can replace an image", async () => {
     onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
@@ -152,6 +153,17 @@ describe("(non-)editable media", () => {
             expect(getContent(editor.editable)).toBe(
                 `<div contenteditable="false">[<img src="${base64Img}">]</div>`
             );
+        });
+        test("toolbar should open when clicking on an editable image in a non-editable context", async () => {
+            const { editor } = await setupEditor(
+                `<div contenteditable="false"><img src="${base64Img}" class="${EDITABLE_MEDIA_CLASS}"></div>`
+            );
+            await click("img");
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(1);
+            // Now pressing the delete button should remove the image.
+            await click(".o-we-toolbar button[name='image_delete']");
+            expect(getContent(editor.editable)).toBe(`<div contenteditable="false">[]<br></div>`);
         });
     });
 });

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -1183,6 +1183,12 @@ describe("toolbar open and close on user interaction", () => {
             await animationFrame();
             expect(".o-we-toolbar").toHaveCount(0);
         });
+
+        test("toolbar should not open with a non-collapsed selection inside a contenteditable=false", async () => {
+            await setupEditor(`<div contenteditable="false"><p>[test]</p></div>`);
+            await animationFrame();
+            expect(".o-we-toolbar").toHaveCount(0);
+        });
     });
 });
 


### PR DESCRIPTION
This PR reintroduces the concept of editable media, which existed in `web_editor` but was not moved over to `html_editor`. This is necessary in order for media to be editable when their parent has the `contenteditable` attribute set to `false`. There can be cases where we want to be able to edit an image but not to write in its container. This is the case for instance for the following common structure:

```html
<figure contenteditable="false">
    <img/>
    <figcaption contenteditable="true">Image caption</figcaption>
</figure>
```

We typically only want to write in the caption and not in the figure, but we want to be able to replace the image or transform it.

For such a case, we mark the image with the `o_editable_media` class.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
