### PR TITLE
[REF] project: rename SELF_x_FIELDS to TASK_PORTAL_x_FIELDS

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -52,8 +52,8 @@ class ProjectTask(models.Model):
         Make sure to use the right format and order e.g. Improve the configuration screen 5h #feature #v16 @Mitchell !""",
     )
     @property
-    def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS | PROJECT_TASK_READABLE_FIELDS
+    def TASK_PORTAL_READABLE_FIELDS(self):
+        return super().TASK_PORTAL_READABLE_FIELDS | PROJECT_TASK_READABLE_FIELDS
 
     @api.constrains('project_id')
     def _check_project_root(self):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -333,13 +333,11 @@ class ProjectTask(models.Model):
                 raise ValidationError(_('This task has sub-tasks, so it can\'t be private.'))
 
     @property
-    def SELF_READABLE_FIELDS(self):
-        # TODO rename
-        return PROJECT_TASK_READABLE_FIELDS | self.SELF_WRITABLE_FIELDS
+    def TASK_PORTAL_READABLE_FIELDS(self):
+        return PROJECT_TASK_READABLE_FIELDS
 
     @property
-    def SELF_WRITABLE_FIELDS(self):
-        # TODO rename
+    def TASK_PORTAL_WRITABLE_FIELDS(self):
         return PROJECT_TASK_WRITABLE_FIELDS
 
     @api.depends('parent_id.project_id')
@@ -1005,8 +1003,8 @@ class ProjectTask(models.Model):
     @tools.ormcache()
     def _portal_accessible_fields(self) -> tuple[frozenset[str], frozenset[str]]:
         """Readable and writable fields by portal users."""
-        readable = frozenset(self.SELF_READABLE_FIELDS)
-        writeable = frozenset(self.SELF_WRITABLE_FIELDS)
+        readable = frozenset(self.TASK_PORTAL_READABLE_FIELDS)
+        writeable = frozenset(self.TASK_PORTAL_WRITABLE_FIELDS)
         return readable | writeable, writeable
 
     def _has_field_access(self, field, operation):

--- a/addons/project/tests/test_project_sharing_portal_access.py
+++ b/addons/project/tests/test_project_sharing_portal_access.py
@@ -29,25 +29,26 @@ class TestProjectSharingPortalAccess(TestProjectSharingCommon):
         })
 
         Task = cls.env['project.task']
+        readable_fields, writeable_fields = Task._portal_accessible_fields()
         cls.read_protected_fields_task = OrderedDict([
             (k, v)
             for k, v in Task._fields.items()
-            if k in Task.SELF_READABLE_FIELDS
+            if k in readable_fields
         ])
         cls.write_protected_fields_task = OrderedDict([
             (k, v)
             for k, v in Task._fields.items()
-            if k in Task.SELF_WRITABLE_FIELDS
+            if k in writeable_fields
         ])
         cls.readonly_protected_fields_task = OrderedDict([
             (k, v)
             for k, v in Task._fields.items()
-            if k in Task.SELF_READABLE_FIELDS and k not in Task.SELF_WRITABLE_FIELDS
+            if k in readable_fields and k not in writeable_fields
         ])
         cls.other_fields_task = OrderedDict([
             (k, v)
             for k, v in Task._fields.items()
-            if k not in Task.SELF_READABLE_FIELDS
+            if k not in readable_fields
         ])
 
     def test_mention_suggestions(self):

--- a/addons/sale_project/models/project_task.py
+++ b/addons/sale_project/models/project_task.py
@@ -41,8 +41,8 @@ class ProjectTask(models.Model):
     display_sale_order_button = fields.Boolean(string='Display Sales Order', compute='_compute_display_sale_order_button')
 
     @property
-    def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS | {'allow_billable', 'sale_order_id', 'sale_line_id', 'display_sale_order_button'}
+    def TASK_PORTAL_READABLE_FIELDS(self):
+        return super().TASK_PORTAL_READABLE_FIELDS | {'allow_billable', 'sale_order_id', 'sale_line_id', 'display_sale_order_button'}
 
     @api.model
     def _group_expand_sales_order(self, sales_orders, domain):

--- a/addons/sale_timesheet/models/project_task.py
+++ b/addons/sale_timesheet/models/project_task.py
@@ -28,8 +28,8 @@ class ProjectTask(models.Model):
     last_sol_of_customer = fields.Many2one('sale.order.line', compute='_compute_last_sol_of_customer')
 
     @property
-    def SELF_READABLE_FIELDS(self):
-        return super().SELF_READABLE_FIELDS | {
+    def TASK_PORTAL_READABLE_FIELDS(self):
+        return super().TASK_PORTAL_READABLE_FIELDS | {
             'remaining_hours_available',
             'remaining_hours_so',
         }


### PR DESCRIPTION
The name for the property is poorly chosen. These properties are used for `_portal_accessible_fields`. They are used to define custom access to fields only for portal users.

odoo/enterprise#84132

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
