### PR TITLE
[REF] tools: remove image_process, barcode, js from namespace

### DIFF
--- a/addons/html_editor/controllers/main.py
+++ b/addons/html_editor/controllers/main.py
@@ -12,6 +12,7 @@ from odoo import _, http, tools, SUPERUSER_ID
 from odoo.addons.html_editor.tools import get_video_url_data
 from odoo.exceptions import UserError, MissingError, AccessError
 from odoo.http import request
+from odoo.tools.image import image_process
 from odoo.tools.mimetypes import guess_mimetype
 from odoo.tools.misc import file_open
 from odoo.addons.iap.tools import iap_tools
@@ -338,7 +339,7 @@ class HTML_Editor(http.Controller):
                         str(uuid.uuid4())[:6],
                         SUPPORTED_IMAGE_MIMETYPES[mimetype],
                     )
-                data = tools.image_process(data, size=(width, height), quality=quality, verify_resolution=True)
+                data = image_process(data, size=(width, height), quality=quality, verify_resolution=True)
             except (ValueError, UserError) as e:
                 # When UserError thrown, browser considers file input an
                 # image but not recognized as such by PIL, eg .webp

--- a/addons/l10n_es_edi_facturae/models/res_partner.py
+++ b/addons/l10n_es_edi_facturae/models/res_partner.py
@@ -1,6 +1,6 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
-from odoo.tools import check_barcode_encoding
+from odoo.tools.barcode import check_barcode_encoding
 
 
 class L10n_Es_Edi_FacturaeAc_Role_Type(models.Model):

--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
@@ -8,7 +7,7 @@ from datetime import datetime
 from odoo import http
 from odoo.exceptions import AccessError, MissingError
 from odoo.http import request, Response
-from odoo.tools import image_process
+from odoo.tools.image import image_process
 from odoo.tools.translate import _
 from odoo.addons.portal.controllers import portal
 from odoo.addons.portal.controllers.portal import pager as portal_pager

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import operator as py_operator
@@ -10,10 +9,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools import float_is_zero, check_barcode_encoding
-from odoo.tools.float_utils import float_round
+from odoo.tools.barcode import check_barcode_encoding
 from odoo.tools.mail import html2plaintext, is_html_empty
-from odoo.tools.misc import groupby
 
 PY_OPERATORS = {
     '<': py_operator.lt,

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -12,7 +12,8 @@ from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.fields import Domain
 from odoo.osv import expression
-from odoo.tools import SQL, check_barcode_encoding, groupby
+from odoo.tools import SQL, groupby
+from odoo.tools.barcode import check_barcode_encoding
 from odoo.tools.float_utils import float_compare, float_is_zero
 
 _logger = logging.getLogger(__name__)

--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 import mimetypes
@@ -8,7 +7,8 @@ from urllib.parse import unquote, urlencode
 from odoo import http, modules
 from odoo.exceptions import AccessError
 from odoo.http import request
-from odoo.tools import file_open, file_path, image_process
+from odoo.tools import file_open, file_path
+from odoo.tools.image import image_process
 
 
 class WebManifest(http.Controller):

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -1,7 +1,5 @@
-# -*- encoding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import base64
 import contextlib
 import logging
 import re
@@ -14,7 +12,7 @@ from werkzeug.urls import url_encode
 from odoo import _
 from odoo.exceptions import ValidationError
 from odoo.http import request
-from odoo.tools import image_process
+from odoo.tools.image import image_process
 
 logger = logging.getLogger(__name__)
 

--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -7,8 +6,9 @@ import requests
 import werkzeug.utils
 from werkzeug.urls import url_encode
 
-from odoo import http, modules, tools, _
+from odoo import http, modules, _
 from odoo.http import request
+from odoo.tools.image import image_process
 from odoo.tools.mimetypes import guess_mimetype
 
 from odoo.addons.html_editor.controllers.main import HTML_Editor
@@ -98,7 +98,7 @@ class Web_Unsplash(http.Controller):
                 logger.exception("Timeout: " + str(e))
                 continue
 
-            image = tools.image_process(image, verify_resolution=True)
+            image = image_process(image, verify_resolution=True)
             mimetype = guess_mimetype(image)
             # append image extension in name
             query += mimetypes.guess_extension(mimetype) or ''

--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -26,6 +26,7 @@ from odoo.http import request
 from odoo.modules.module import get_manifest
 from odoo.osv.expression import AND, OR, FALSE_DOMAIN
 from odoo.tools import SQL, Query, sql as sqltools
+from odoo.tools.image import image_process
 from odoo.tools.translate import _, xml_translate
 
 logger = logging.getLogger(__name__)
@@ -366,7 +367,7 @@ class Website(models.Model):
     @api.model
     def _handle_favicon(self, vals):
         if vals.get('favicon'):
-            vals['favicon'] = base64.b64encode(tools.image_process(base64.b64decode(vals['favicon']), size=(256, 256), crop='center', output_format='ICO'))
+            vals['favicon'] = base64.b64encode(image_process(base64.b64decode(vals['favicon']), size=(256, 256), crop='center', output_format='ICO'))
 
     @api.model
     def _handle_domain(self, vals):

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -23,11 +23,12 @@ except ImportError:
 from odoo import release
 from odoo.api import SUPERUSER_ID
 from odoo.http import request
-from odoo.tools import (misc, transpile_javascript,
-    is_odoo_module, SourceMapGenerator, profiler, OrderedSet)
-from odoo.tools.json import scriptsafe as json
+from odoo.tools import OrderedSet, misc, profiler
 from odoo.tools.constants import SCRIPT_EXTENSIONS, STYLE_EXTENSIONS
+from odoo.tools.json import scriptsafe as json
+from odoo.tools.js_transpiler import is_odoo_module, transpile_javascript
 from odoo.tools.misc import file_open, file_path
+from odoo.tools.sourcemap_generator import SourceMapGenerator
 
 _logger = logging.getLogger(__name__)
 

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -27,7 +27,8 @@ from odoo.exceptions import UserError, AccessError, RedirectWarning
 from odoo.fields import Domain
 from odoo.service import security
 from odoo.http import request, root
-from odoo.tools import check_barcode_encoding, config, is_html_empty, parse_version, split_every
+from odoo.tools import config, is_html_empty, parse_version, split_every
+from odoo.tools.barcode import check_barcode_encoding
 from odoo.tools.misc import find_in_path
 from odoo.tools.pdf import PdfFileReader, PdfFileWriter, PdfReadError
 from odoo.tools.safe_eval import safe_eval, time

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -8,6 +8,7 @@ from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command, Domain
 from odoo.tools import html2plaintext, file_open, ormcache
+from odoo.tools.image import image_process
 
 _logger = logging.getLogger(__name__)
 
@@ -153,7 +154,7 @@ class ResCompany(models.Model):
     def _compute_logo_web(self):
         for company in self:
             img = company.partner_id.image_1920
-            company.logo_web = img and base64.b64encode(tools.image_process(base64.b64decode(img), size=(180, 0)))
+            company.logo_web = img and base64.b64encode(image_process(base64.b64decode(img), size=(180, 0)))
 
     @api.depends('partner_id.image_1920')
     def _compute_uses_default_logo(self):

--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
-from odoo.tools import transpile_javascript
+from odoo.tools.js_transpiler import transpile_javascript
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/addons/test_assetsbundle/tests/test_js_transpiler_regex.py
+++ b/odoo/addons/test_assetsbundle/tests/test_js_transpiler_regex.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
-from odoo.tools import URL_RE, ODOO_MODULE_RE
+from odoo.tools.js_transpiler import URL_RE, ODOO_MODULE_RE
 
 @tagged('post_install', '-at_install')
 class TestJsTranspiler(TransactionCase):

--- a/odoo/addons/test_http/tests/test_static.py
+++ b/odoo/addons/test_http/tests/test_static.py
@@ -11,7 +11,8 @@ from freezegun import freeze_time
 
 from odoo import api, http
 from odoo.tests import new_test_user, tagged, RecordCapturer
-from odoo.tools import config, file_open, image_process
+from odoo.tools import config, file_open
+from odoo.tools.image import image_process
 from odoo.tools.misc import submap
 
 from .test_common import TestHttpBase, HTTP_DATETIME_FORMAT

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 import psycopg2
 
 from odoo.exceptions import UserError
-from odoo.tools import SQL, human_size, image_process
+from odoo.tools import SQL, human_size
 from odoo.tools.mimetypes import guess_mimetype
 
 from .fields import Field
@@ -339,6 +339,8 @@ class Image(Binary):
                     return resized.datas or value
             return value
 
+        # delay import of image_process until this point
+        from odoo.tools.image import image_process  # noqa: PLC0415
         return base64.b64encode(image_process(img,
             size=(self.max_width, self.max_height),
             verify_resolution=self.verify_resolution,

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -3,7 +3,6 @@
 
 from . import constants
 from .parse_version import parse_version
-from .barcode import check_barcode_encoding
 from .cache import ormcache, ormcache_context
 from .config import config
 from .date_utils import *

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -19,6 +19,4 @@ from .sql import *
 from .translate import _, html_translate, xml_translate, LazyTranslate
 from .xml_utils import cleanup_xml_node, load_xsd_files_from_url, validate_xml_from_attachment
 from .convert import convert_csv_import, convert_file, convert_sql_import, convert_xml_import
-from .js_transpiler import transpile_javascript, is_odoo_module, URL_RE, ODOO_MODULE_RE
-from .sourcemap_generator import SourceMapGenerator
 from .set_expression import SetDefinitions

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -9,7 +9,6 @@ from .date_utils import *
 from .float_utils import float_compare, float_is_zero, float_repr, float_round, float_split, float_split_str
 from .func import classproperty, conditional, lazy, lazy_classproperty, reset_cached_properties
 from .i18n import format_list, py_to_js_locale
-from .image import image_process
 from .json import json_default
 from .mail import *
 from .misc import *


### PR DESCRIPTION
Remove some tools from the `odoo.tools` namespace to avoid loading them when importing tools as they are not always needed and quite big to load (for example `PIL` in images).

See also: odoo/enterprise#84134