### PR TITLE
[FIX] event_crm: fix broken layout in lead generation form view

### DIFF
--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -61,7 +61,7 @@
                         </group>
                     </group>
                     <group string="If the Attendees meet these Conditions">
-                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': 'event.registration'}" nolabel="1"/>
+                        <field name="event_registration_filter" widget="domain" options="{'foldable': True, 'model': 'event.registration'}" nolabel="1" colspan="2"/>
                     </group>
                     <group string="Lead Default Values">
                         <group class="col">


### PR DESCRIPTION
In the lead generation form view, the widget that allows the user to select a filter currently spans into the label column in the grid, causing it to appear squished. To ensure it occupies the entire row properly, we will add the colspan="2" attribute to the field definition.

Task-4750253

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
