### PR TITLE
[FIX] point_of_sale: compute cost of delayed shipped refund avco/fifo

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1533,6 +1533,8 @@ class PosOrderLine(models.Model):
             product = line.product_id
             if line._is_product_storable_fifo_avco() and stock_moves:
                 product_cost = product._compute_average_price(0, line.qty, line._get_stock_moves_to_consider(stock_moves, product))
+                if (product.cost_currency_id.is_zero(product_cost) and self.order_id.shipping_date and self.refunded_orderline_id):
+                    product_cost = self.refunded_orderline_id.total_cost / self.refunded_orderline_id.qty
             else:
                 product_cost = product.standard_price
             line.total_cost = line.qty * product.cost_currency_id._convert(

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2313,3 +2313,80 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         ])
         account_moves = self.env['account.move'].search([('pos_payment_ids', 'in', pos_order.payment_ids.ids)])
         self.assertEqual(sum(account_moves.mapped('amount_total')), pos_order.amount_total)
+
+    def test_pos_order_refund_ship_delay_totalcost(self):
+        # test that the total cost is computed for refund with a shipping delay and an avco/fifo product
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        self.pos_config.write({'ship_later': True})
+        categ = self.env['product.category'].create({
+            'name': 'test',
+            'property_cost_method': 'average',
+            'property_valuation': 'real_time',
+        })
+        product = self.env['product.product'].create({
+            'name': 'Product A',
+            'type': 'product',
+            'categ_id': categ.id,
+            'lst_price': 10,
+            'standard_price': 10
+        })
+        order = self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner1.id,
+            'lines': [[0, 0, {
+                'name': "OL/0001",
+                'product_id': product.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 2,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': 20,
+                'price_subtotal_incl': 20,
+                'total_cost': 20,
+            }]],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+            'last_order_preparation_change': '{}'
+            })
+        refund_values = [{
+            'data': {
+                'name': 'a new test refund order',
+                'company_id': self.env.company.id,
+                'user_id': self.env.user.id,
+                'pos_session_id': current_session.id,
+                'partner_id': self.partner1.id,
+                'amount_paid': -10,
+                'amount_tax': 0,
+                'amount_return': 0,
+                'amount_total': -10,
+                'fiscal_position_id': False,
+                'lines': [[0, 0, {
+                    'product_id': product.id,
+                    'price_unit': 10,
+                    'discount': 0,
+                    'qty': -2,
+                    'tax_ids': [[6, False, []]],
+                    'price_subtotal': -20,
+                    'price_subtotal_incl': -20,
+                    'refunded_orderline_id': order.lines[0].id,
+                    'price_type': 'automatic'
+                }]],
+                'shipping_date': fields.Date.today(),
+                'sequence_number': 2,
+                'to_invoice': True,
+                'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+                'statement_ids': [[0, 0, {
+                    'amount': -10,
+                    'name': fields.Datetime.now(),
+                    'payment_method_id': self.cash_payment_method.id
+                }]],
+            }
+        }]
+        self.PosOrder.create_from_ui(refund_values)
+        refunded_order_line = self.env['pos.order.line'].search([('product_id', '=', product.id), ('qty', '=', -2)])
+        self.assertEqual(refunded_order_line.total_cost, -20)


### PR DESCRIPTION
**Problem:**
when doing a refund from pos of an avco (or fifo) product, with the option 
"ship later" the cost of the product does not appear on the pos order line

**Steps to reproduce:**
- Enable Settings "Allow Ship Later", "Automatic Accounting"
- Navigate to Sales/Configuration/Product Categories
- Create a new category with Inventory Valuation field as "Automated" 
and the Costing Method field as "Average Cost (AVCO)"
- Open Point of Sale/Product
- Create a new storable product
- In the general information tab set a cost and select your new 
category for the product category field
- In the Sales tab, make sure that "Available in POS" is checked 
and select a category
- Set an on Hand quantity
- Open a point of sale from the Point of Sale Dashboard
- Select your product and click on Payment
- On the top right of the screen select a customer with an adress,
click on Invoice and on Ship later
- Select a payment method and validate
- Navigate to Point of Sale/Orders
- click on the last order created, and click on the "Pickings" smart button
- validate the picking
- come back to the store in point of sale
- select the three horizontal lines on the top right and click on Orders
- filter by paid orders
- select the last order created and click on refund and then on payment
- check Invoice and Ship Later on the top right, select a payment method and validate
- Navigate back to Point of Sale/orders and select the last order created

**Current behavior:**
 The total cost is zero on the pos order line
 Even if the delivery is validated via the Picking smart button
 the total cost is still zero

**Expected behavior:**
 It should reflect the cost of the product (depending on the costing method)

**Cause of the issue:**

When the pos order is created from Point of Sale, the process_saved_order method is called
this method calls (1)create_order_picking and then (2)compute_total_cost.
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/point_of_sale/models/pos_order.py#L183-L184 

**Scenario A** Inside (1) create_order_picking, if the PosOrder doesn't have 
a shipping_date the if statement is False
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/point_of_sale/models/pos_order.py#L1017 
and the method _create_picking_from_pos_order_lines is called.
This method then calls _action_done.
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/point_of_sale/models/stock_picking.py#L70 
Inside the stock_account override of _action_done, _create_in_svl is called.
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/stock_account/models/stock_move.py#L289
This method sets the value of the stock_valuation_layer_ids attribute
of the stock move to a new stock valuation layer.

**Scenario B** Inside (1) create_order_picking, if the PosOrder has a 
shipping_date (in the case where we selected "Ship Later") the 
method _launch_stock_rule_from_pos_order_lines is called.
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/point_of_sale/models/pos_order.py#L1017-L1018 
and nowhere inside this method is _action_done called.
This makes sense because the stock move hasn't been validated.

When (2) compute_total_cost is then called by process_saved_oder, if the product category is avco, _compute_average_price will be called. 
If we are in Scenario B there is no stock valuation layer for this stock move.
Consequently there will be no candidates and the price will not be computed.
https://github.com/odoo/odoo/blob/504ef7cdeb1600b86feefbe8668144da9cd5a70b/addons/stock_account/models/product.py#L795-L798

opw-4614503

