### PR TITLE
[FIX] web_hierarchy: disable the cap if employee's manager is themselves

### DIFF
--- a/addons/web_hierarchy/static/src/hierarchy_card.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_card.xml
@@ -4,7 +4,7 @@
     <t t-name="web_hierarchy.HierarchyCard">
         <div class="o_hierarchy_node_container d-flex flex-column" t-att-class="classNames" t-att-data-node-id="props.node.id">
             <div class="o_hierarchy_node_button_container w-100 d-flex justify-content-center">
-                <button t-if="props.node.parentResId !== false and !props.node.parentNode"
+                <button t-if="props.node.parentResId !== false and !props.node.parentNode and props.node.parentResId !== props.node.resId"
                         name="hierarchy_search_parent_node"
                         class="btn p-0"
                         t-on-click.synthetic="onClickArrowUp"

--- a/addons/web_hierarchy/static/tests/hierarchy_view_tests.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view_tests.js
@@ -270,6 +270,19 @@ QUnit.module("Views", (hooks) => {
         );
     });
 
+    QUnit.test("prohibit `hierarchy_search_parent_node` button from appearing on a node where you're your own manager", async function (assert) {
+        serverData.models["hr.employee"].records.push(
+            {id: 5, name: "Lisa", parent_id: 5, child_ids: []}
+        );
+        await makeView({
+            type: "hierarchy",
+            resModel: "hr.employee",
+            serverData,
+            domain: [["id", "=", 5]],
+        })
+        assert.containsNone(target, ".o_hierarchy_node_container button[name=hierarchy_search_parent_node]");
+    });
+    
     QUnit.test("search record in hierarchy view with child field name defined in the arch", async function (assert) {
         await makeView({
             type: "hierarchy",


### PR DESCRIPTION
When we are in the org chart, and click on the cap of an employee to see the manager information, if the manager of the employee is themselves, there's an traceback error. We can fix it by disabling the cap if the you are your own manager.

To Reproduce on Runbot:
1. Go to an employee in Employee module.
2. Make sure the manager field has themselves as the manager
3. Click on the org chart
4. Click on the cap icon, and you'll see the error.

opw-4716216