### PR TITLE
[FIX] survey: avoid timer early submissions due to time difference

### DIFF
--- a/addons/survey/static/src/js/survey_timer.js
+++ b/addons/survey/static/src/js/survey_timer.js
@@ -24,10 +24,10 @@ publicWidget.registry.SurveyTimerWidget = publicWidget.Widget.extend({
 
 
     /**
-    * Two responsabilities : Validate that time limit is not exceeded and Run timer otherwise.
-    * If end-user's clock OR the system clock  is de-synchronized before the survey is started, we apply the
-    * difference in timer (if time difference is more than 5 seconds) so that we can
-    * display the 'absolute' counter
+    * Two responsibilities: Validate that the time limit is not exceeded and Run timer otherwise.
+    * If the end-user's clock OR the system clock is desynchronized,
+    * we apply the difference in the clocks (if the time difference is more than 500 ms).
+    * This makes the timer fair across users and helps avoid early submissions to the server.
     *
     * @override
     */
@@ -35,7 +35,7 @@ publicWidget.registry.SurveyTimerWidget = publicWidget.Widget.extend({
         var self = this;
         return this._super.apply(this, arguments).then(function () {
             self.countDownDate = moment.utc(self.timer).add(self.timeLimitMinutes, 'minutes');
-            if (Math.abs(self.timeDifference) >= 5000) {
+            if (Math.abs(self.timeDifference) >= 500) {
                 self.countDownDate = self.countDownDate.add(self.timeDifference, 'milliseconds');
             }
             if (self.timeLimitMinutes <= 0 || self.countDownDate.diff(moment.utc(), 'seconds') < 0) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

This commit addresses early submissions of surveys due to timer expiry.
Differences in server/client clocks can leave the survey in an incorrect state.

Current behavior before PR:

The server, seeing a submission come before the time limit that was triggered by the client timer, lets the survey continue.
Clients are receiving error messages when trying to do more submissions, which bump against the cheating prevention.
This is true if the client is "ahead" of the server.
Currently, a difference would only be addressed if above 5 s.
This is not enough as the client being "ahead" by 1 s can cause this issue. This was detected in real use. Looking at server logs has led me to this cause.
Here's a diagram that could help understand the issue with the current behaviour:
<img width="455" alt="Survey Timer bug" src="https://github.com/user-attachments/assets/1804f848-ad4b-4b8a-97fe-7562b76ea66c" />
The above diagram shows how, for a survey with a 30 min timer, a 1 sec difference between the clocks can lead to an early submission.

Desired behavior after PR is merged:

The fix here is to tighten when to apply the time difference to when it is above 500 ms.
This should help avoid the early submission bug but conversely also not allow late submissions, even below 5 s, making the timer fair across users.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
