### PR TITLE
[FIX] web, product, project: allow reopening deletion confirmation dialog

### DIFF
--- a/addons/project/static/tests/project_task_subtask.test.js
+++ b/addons/project/static/tests/project_task_subtask.test.js
@@ -286,3 +286,24 @@ test("project.task (form): check focus on new subtask's name", async () => {
         message: "Upon clicking on 'Add a line', the new subtask's name should be focused.",
     });
 });
+
+test("project.project (form): check subtask delete confirmation dialog can be reopened again", async () => {
+    await mountView({
+        resModel: "project.task",
+        resId: 5,
+        type: "form",
+    });
+    expect(`.o_list_record_remove`).toHaveCount(1);
+    await click(".o_list_record_remove");
+    await animationFrame();
+    expect(`.modal-footer .btn-primary:contains(Ok)`).toHaveCount(1, {
+        message: "Delete action should be visible",
+    });
+    await click(".modal-footer .btn-secondary");
+    await animationFrame();
+    await click(".o_list_record_remove");
+    await animationFrame();
+    expect(`.modal-footer .btn-primary:contains(Ok)`).toHaveCount(1, {
+        message: "Delete action should be visible on reopening the dialog",
+    });
+});

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -8,6 +8,7 @@ import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable_owl";
+import { debounce } from "@web/core/utils/timing";
 import { getTabableElements } from "@web/core/utils/ui";
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
@@ -96,6 +97,11 @@ export class ListRenderer extends Component {
         this.groupByButtons = this.props.archInfo.groupBy.buttons;
         useExternalListener(document, "click", this.onGlobalClick.bind(this));
         this.tableRef = useRef("table");
+        this.debouncedOnDeleteRecord = debounce(
+            this.onDeleteRecord.bind(this),
+            50,
+            { immediate: true }
+        );
 
         this.longTouchTimer = null;
         this.touchStartMs = 0;
@@ -1046,13 +1052,9 @@ export class ListRenderer extends Component {
     }
 
     onRemoveCellClicked(record, ev) {
-        const element = ev.target.closest(".o_list_record_remove");
-        if (element.dataset.clicked) {
-            return;
-        }
-        element.dataset.clicked = true;
-
-        this.onDeleteRecord(record, ev);
+        // This method should be removed in future versions. It is rendered
+        // obsolete by debouncing the onDeleteRecord method.
+        this.debouncedOnDeleteRecord(record);
     }
 
     async onDeleteRecord(record) {


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Behavior in <= v17.4:

The onclick method for the delete button in the one2many list calls the `onDeleteRecord` method. This is inherited by the model-specific list renderer components to insert the deletion confirmation dialog before calling super which sets the clicked data attribute to be true. In this case, we display the dialog before setting the button as clicked.

Behavior in v18:

The onclick method for the delete button in the one2many list calls the `onRemoveCellClicked`. This method sets the clicked as True and then calls the `onDeleteRecord` method that is inherited by the various model-specific list renderer components to insert the Confirmation Dialog. In these cases, the dialog is called after we set the 'clicked' data-attribute on the delete button to be True. Hence now we are unable to click on the same button again due to it being in the clicked state.

### Current behavior before PR:

[Deletion Dialog does not reopen](https://github.com/user-attachments/assets/29b6c2c7-553b-4745-a20b-26a470952a01)

1. Try to delete a record of Project Subtask or Product Attribute Value
2. This would open the Deletion Confirmation Dialog box
3. Click on cancel 
4. Try to delete the same record again 

Result: Nothing happens and the confirmation dialog does not show up again for the second time


### Desired behavior after PR is merged:

If user attempts to delete any record that opens the confirmation dialog and then cancels it, the user is able to delete it as the confirmation dialog box is no longer disabled after spawning once.


opw-4731375

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
