### PR TITLE
[IMP] point_of_sale: allow discount on parent combo product

### DIFF
--- a/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/components/orderline/orderline.xml
@@ -33,7 +33,7 @@
                             </t>
                         </span>
                     </div>
-                    <div t-if="!props.basic_receipt" t-out="line.getPriceString()" class="product-price price" t-attf-class="{{ props.mode == 'receipt' ? 'font-monospace' : 'fw-bolder' }}"/>
+                    <div t-if="!props.basic_receipt and !line.combo_parent_id" t-out="line.getPriceString()" class="product-price price" t-attf-class="{{ props.mode == 'receipt' ? 'font-monospace' : 'fw-bolder' }}"/>
                     <div t-if="props.showTaxGroup" t-esc="this.taxGroup" class="text-end" style="width: 2rem"/>
                 </div>
                 <ul class="info-list d-flex flex-column mb-0 ms-2" t-att-style="props.mode == 'receipt' and 'font-size: 75%;'" t-attf-class="{{ props.mode === 'receipt' ? '' : (line.customer_note || line.note || line.discount || line.packLotLines?.length) ? 'gap-2 mt-1' : '' }}">
@@ -46,8 +46,8 @@
                     </li>
                     <li t-if="line.discount" class="price-per-unit">
                         <t t-set="discount" t-value="line.getDiscountStr()" />
-                        <t t-if="!props.basic_receipt and line.price_unit !== 0 and discount and discount !== '0'">
-                            <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="env.utils.formatCurrency(line.allPrices.priceWithTaxBeforeDiscount)"/>
+                        <t t-if="!props.basic_receipt and discount and discount !== '0' and !line.combo_parent_id">
+                            <i class="fa fa-tag pe-1"/><em><t t-esc="discount" />% </em> discount off on <t t-esc="line.computePriceWithTaxBeforeDiscount()"/>
                         </t>
                     </li>
                     <li t-if="line.customer_note" class="customer-note w-100 rounded text-break bg-opacity-25" t-att-class="{'bg-warning text-warning p-2': this.props.mode === 'display'}">

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -538,6 +538,19 @@ export class PosOrderline extends Base {
         };
     }
 
+    computePriceWithTaxBeforeDiscount() {
+        return this.combo_line_ids.length > 0
+            ? // total of all combo lines if it is combo parent
+              formatCurrency(
+                  this.combo_line_ids.reduce(
+                      (total, cl) => total + cl.allPrices.priceWithTaxBeforeDiscount,
+                      0
+                  ),
+                  this.currency
+              )
+            : formatCurrency(this.allPrices.priceWithTaxBeforeDiscount, this.currency);
+    }
+
     get allPrices() {
         return this.getAllPrices();
     }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -162,6 +162,9 @@ export class OrderSummary extends Component {
                     }
                 }
             } else if (numpadMode === "discount" && val !== "remove") {
+                if (selectedLine.combo_parent_id) {
+                    selectedLine = selectedLine.combo_parent_id;
+                }
                 this.pos.setDiscountFromUI(selectedLine, val);
             } else if (numpadMode === "price" && val !== "remove") {
                 this.setLinePrice(selectedLine, val);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -707,6 +707,9 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     async setDiscountFromUI(line, val) {
+        for (const comboLine of line.combo_line_ids) {
+            comboLine.setDiscount(val);
+        }
         line.setDiscount(val);
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_combo_tour.js
@@ -218,3 +218,20 @@ registry.category("web_tour.tours").add("ProductComboChangePricelist", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("ProductComboDiscountTour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Office Combo"),
+            ProductScreen.checkProductExtraPrice("Combo Product 3", "2"),
+            combo.select("Combo Product 2"),
+            combo.select("Combo Product 4"),
+            combo.select("Combo Product 6"),
+            Dialog.confirm(),
+            inLeftSide([Numpad.click("%"), Numpad.click("2"), Numpad.click("0")]),
+            ProductScreen.totalAmountIs("80.00"),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1512,6 +1512,20 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'ProductComboChangePricelist', login="pos_user")
 
+    def test_product_combo_discount(self):
+        """
+        Verify that the combo product applies the correct discount and updates prices accordingly
+        """
+        setup_product_combo_items(self)
+        self.office_combo.write({'list_price': 100})
+        self.office_combo.combo_ids.combo_item_ids.product_id.taxes_id = False
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            f"/pos/ui?config_id={self.main_pos_config.id}",
+            'ProductComboDiscountTour',
+            login="pos_user",
+        )
+
     def test_cash_rounding_payment(self):
         """Verify than an error popup is shown if the payment value is more precise than the rounding method"""
         rounding_method = self.env['account.cash.rounding'].create({


### PR DESCRIPTION
Before this commit:
- No line discount was applicable on the parent combo product.

After this commit:
- Discount is now applicable on the combo product order line and if the discount is applied on combo line items, it will also get applied to the main combo product.

task-4677391
