### PR TITLE
[IMP] l10n_ae: Added report line totals in company currency

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -31,6 +31,27 @@
                 <span t-field="line.l10n_ae_vat_amount" id="line_tax_amount"/>
             </td>
         </xpath>
+
+        <xpath expr="//td[@name='td_subtotal']/span" position="attributes">
+            <attribute name="t-if">o.company_id.country_id.code != 'AE' or o.company_price_include == 'tax_excluded'</attribute>
+        </xpath>
+        
+        <xpath expr="//td[@name='td_subtotal']/span" position="after">
+            <span t-if="o.company_id.country_id.code == 'AE' and o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
+        </xpath>
+
+        <xpath expr="//th[@name='th_subtotal']" position="after">
+            <th class="text-end" t-if="o.company_id.country_id.code == 'AE' and o.currency_id != o.company_currency_id">
+                <span>Amount (<span t-field="o.company_currency_id"/>)</span>
+            </th>
+        </xpath>
+
+        <xpath expr="//td[@name='td_subtotal']" position="after">
+            <td class="text-end o_price_total" t-if="o.company_id.country_id.code == 'AE' and o.currency_id != o.company_currency_id">
+                <span class="text-nowrap" t-if="o.company_price_include == 'tax_excluded'" t-out="line.currency_id._convert(line.price_subtotal, o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())" t-options="{'widget': 'monetary', 'display_currency': o.company_currency_id}"/>
+                <span class="text-nowrap" t-if="o.company_price_include == 'tax_included'" t-out="line.currency_id._convert(line.price_total, o.company_currency_id, o.company_id, o.invoice_date or datetime.date.today())" t-options="{'widget': 'monetary', 'display_currency': o.company_currency_id}"/>
+            </td>
+        </xpath>
     </template>
 
     <template id="document_tax_totals_company_currency_template" inherit_id="account.document_tax_totals_company_currency_template">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Task ID: 4636082


Current Behavior before PR:
- When printing an invoice with a currency that is different than the company's currency. The amount value of each line is only printed in the invoice's currency and not the company's currency.
- As per the FTA article 59, the line amount should also be expressed in AED.
- The tax excluded amount was also always printed regardless of the company's setting. (something that was fixed in https://www.odoo.com/odoo/project.task/4625855?debug=1 but there seems to be no intention to backport this to 18.0).


Desired behavior after PR is merged:
- Add a new column to print the line amount in the company's currency if the invoice has a different currency than the company.
- Print tax excluded/include amount based on company's setting.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
