### PR TITLE
[FIX] account: ensure correct model is used for invoice report generation

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -47,7 +47,8 @@ class IrActionsReport(models.Model):
         return collected_streams
 
     def _is_invoice_report(self, report_ref):
-        return self._get_report(report_ref).is_invoice_report
+        report = self._get_report(report_ref)
+        return report.is_invoice_report and report.model == 'account.move'
 
     def _get_splitted_report(self, report_ref, content, report_type):
         if report_type == 'html':

--- a/addons/account/views/ir_actions_views.xml
+++ b/addons/account/views/ir_actions_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.act_report_xml_view"/>
         <field name="arch" type="xml">
             <field name="paperformat_id" position="after">
-                <field name="is_invoice_report"/>
+                <field name="is_invoice_report" invisible="'model' != 'account.move'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Currently an error occurs during post-processing of a payment transaction.

Steps to Reproduce:

 - Install the `website_sale` module.
 - Open `Reports > Quotation / Order` and enable the Invoice report option.
 - Go to the Website, place an order using the Wire Transfer payment provider.
 - Open `Scheduled Actions`.
 - Find and manually run the `Payment: Post-process transactions action`.

`MissingError: Record does not exist or has been deleted. 
(Record: account.move(22,), User: 1)`

This issue was generated because the user clicked on the invoice report option on the report 
Quotation / Order as a result, when we try to print qutation /order it tries to browse the sale.order
 with id 22 as an account.move.

This commit ensures that the is_invoice_report field is only visible when the model is account.move. 
Additionally, the_is_invoice_report method has been modified to return True only when the model is 
account.move, thereby preventing a MissingError during scheduled actions.

Sentry-6563415103


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
