### PR TITLE
[FIX] l10n_ch: Use same address in text as in QR code

### DIFF
--- a/addons/l10n_ch/report/swissqr_report.xml
+++ b/addons/l10n_ch/report/swissqr_report.xml
@@ -43,7 +43,7 @@
         <template id="l10n_ch_swissqr_template">
             <div class="article" t-att-data-oe-model="o._name" t-att-data-oe-id="o.id">
                 <t t-set="o" t-value="o.with_context(lang=lang)"/>
-                <t t-set="company" t-value="o.company_id"/>
+                <t t-set="company" t-value="o.partner_bank_id.partner_id or o.company_id"/>
                 <t t-set="formated_amount" t-value="'{:,.2f}'.format(o.amount_residual).replace(',','\xa0')"/>
 
                 <t t-set="is_qrr" t-value="o.partner_bank_id.l10n_ch_qr_iban"/>
@@ -67,11 +67,11 @@
                                 <span t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
-                                <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
-                                <span t-field="o.company_id.street"/><br/>
-                                <span t-field="o.company_id.country_id.code"/>
-                                <span t-field="o.company_id.zip"/>
-                                <span t-field="o.company_id.city"/><br/>
+                                <span t-out="company.name"/><br/>
+                                <span t-field="company.street"/><br/>
+                                <span t-field="company.country_id.code"/>
+                                <span t-field="company.zip"/>
+                                <span t-field="company.city"/><br/>
                                 <br/>
                             </div>
 
@@ -179,11 +179,11 @@
                                 <span t-field="o.partner_bank_id.acc_number" t-if="not o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <span t-field="o.partner_bank_id.l10n_ch_qr_iban" t-if="o.partner_bank_id.l10n_ch_qr_iban"/>
                                 <br/>
-                                <span t-out="o.partner_bank_id.partner_id.name or o.company_id.name"/><br/>
-                                <span t-field="o.company_id.street"/><br/>
-                                <span t-field="o.company_id.country_id.code"/>
-                                <span t-field="o.company_id.zip"/>
-                                <span t-field="o.company_id.city"/><br/>
+                                <span t-out="company.name"/><br/>
+                                <span t-field="company.street"/><br/>
+                                <span t-field="company.country_id.code"/>
+                                <span t-field="company.zip"/>
+                                <span t-field="company.city"/><br/>
                                 <br/>
                             </div>
 

--- a/doc/cla/corporate/exelen.md
+++ b/doc/cla/corporate/exelen.md
@@ -1,0 +1,15 @@
+Switzerland, 24th-Apr-2025
+
+Exelen GmbH agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Olivier Hochreutiner olivier.hochreutiner@exelen.ch https://github.com/ohoc
+
+List of contributors:
+
+Olivier Hochreutiner olivier.hochreutiner@exelen.ch https://github.com/ohoc


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Wrong address/zip/city in Swiss QR bill template.

Current behavior before PR:
The template for Swiss QR bills uses the company address, zip code and city.

Desired behavior after PR is merged:
The template for Swiss QR bills uses the address/zip/city of the creditor's bank account, if available.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
