### PR TITLE
[FIX] hw_drivers: screen orientation mismatch for kiosk mode

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/DisplayDriver_L.py
@@ -162,7 +162,7 @@ class DisplayController(http.Controller):
         if action == 'get':
             return {'status': 'retrieved', 'data': display.customer_display_data}
         if action == 'rotate_screen':
-            display.set_orientation(Orientation(data))
+            display.set_orientation(Orientation[data.upper()])
             return {'status': 'rotated'}
 
     def ensure_display(self):


### PR DESCRIPTION
Before this commit:
====================
Screen rotation was failing due to a mismatch in the orientation key format. The orientation key was saved in lowercase from the form view, but the set_orientation method expects the key in uppercase to match the format used by xrandr/wlr-randr.

After this commit:
===================
The orientation key is now properly passed in uppercase using Orientation[data.upper()], ensuring that screen rotation works as expected in kiosk mode.

Task-4755613

