### PR TITLE
[IMP] mail: more precise mail logs

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -617,7 +617,7 @@ class MailMail(models.Model):
                 )
                 if not modules.module.current_test:
                     _logger.info(
-                        'Sent batch %s emails via mail server ID #%s',
+                        "Processed batch of %s mail.mail records via mail server ID #%s",
                         len(batch_ids), mail_server_id)
             finally:
                 if smtp_session:


### PR DESCRIPTION
In tandem with https://github.com/odoo/odoo/pull/206657 we propose changing the wording of the log message for the `send` method in mailing to clarify that it's reporting the number of `mail.mail` records processed.

As the ratio between `mail.mail` records and emails sent through SMTP in `_send` is not always 1:1,
the above PR added an extra log line to count the emails. Thus changing this log line to distinguish the slight nuance.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
