### PR TITLE
[IMP] im_livechat: improve empty session history help text

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -139,9 +139,9 @@
             <field name="context">{'search_default_filter_session_date': 'custom_rated_on_last_30_days'}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
-                    Your chatter history is empty
+                    No data yet!
                 </p><p>
-                    Create a channel and start chatting to fill up your history.
+                    Start a conversation to populate your chat history.
                 </p>
             </field>
         </record>


### PR DESCRIPTION
This PR improves the help text shown when there is no session history available.

Task-4753053


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
