### PR TITLE
[FIX] point_of_sale: react to qr code with customer_display_type != local

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1731,7 +1731,7 @@ export class PosStore extends Reactive {
             {},
             QRPopup
         ).then((result) => {
-            payment.qrPaymentData = undefined;
+            payment.qrPaymentData = null;
             return result;
         });
     }

--- a/addons/point_of_sale/static/tests/tours/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/tours/customer_display_tour.js
@@ -55,7 +55,7 @@ const PAY_WITH_CARD = {
     paymentLines: [{ name: "CARD", amount: "2,972.75" }],
     change: 0,
     onlinePaymentData: {},
-    qrPaymentData: undefined,
+    qrPaymentData: null,
 };
 
 const SEND_QR = {


### PR DESCRIPTION
If the customer display type is remote or proxy, the data goes through JSON serialization before being sent. This causes undefined property to not be send.

When we change `this.order.qrPaymentData` from an object to undefined, the useEffect will not be triggered. This is not the case with null.

https://github.com/odoo/odoo/blob/2439af09c7586a22822549164b677fa6fb805359/addons/point_of_sale/static/src/customer_display/customer_display.js#L42-L51