### PR TITLE
[FIX] mail: keep sidebar open on popover actions in Discuss

### DIFF
--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -41,7 +41,6 @@ test("Can invite a partner to a livechat channel", async () => {
         text: "Mitch (FR) invited James to the channel",
     });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "James" });
 });
 

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -41,7 +41,6 @@ test("Thread name unchanged when inviting new users", async () => {
     });
     await click("button:enabled", { text: "Invite" });
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("button[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "James" });
     await contains(".o-mail-Discuss-threadName[title='Visitor #20']");
 });

--- a/addons/mail/static/tests/discuss/core/channel_member_list.test.js
+++ b/addons/mail/static/tests/discuss/core/channel_member_list.test.js
@@ -162,7 +162,6 @@ test("Channel member count update after user joined", async () => {
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMemberList h6", { text: "Offline - 2" });
 });
 

--- a/addons/mail/static/tests/discuss/core/crosstab.test.js
+++ b/addons/mail/static/tests/discuss/core/crosstab.test.js
@@ -24,7 +24,6 @@ test("Add member to channel", async () => {
     await click(".o-discuss-ChannelInvitation-selectable", { text: "Harry" });
     await click("[title='Invite to Channel']:enabled");
     await contains(".o-discuss-ChannelInvitation", { count: 0 });
-    await click("[title='Members']");
     await contains(".o-discuss-ChannelMember", { text: "Harry" });
 });
 


### PR DESCRIPTION
Current behavior before PR:
- When performing actions from the Discuss header popover, the right sidebar will closed.

Desired behavior after PR is merged:
- The right sidebar remains open when using actions from the Discuss header popover.

task - 4521333


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
