### PR TITLE
[IMP] sale_timesheet: add project's accounts to the timesheet's accounts

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -220,7 +220,8 @@ class AccountAnalyticLine(models.Model):
             int(account_id) for account_id in next(iter(distribution)).split(',')
         ]).exists()
 
-        if not accounts:
+        has_one_project_main_account = len(accounts) == 1 and accounts[0] == self.env['project.project'].sudo().browse(vals.get('project_id')).account_id
+        if not accounts or has_one_project_main_account:
             return super()._timesheet_preprocess_get_accounts(vals)
 
         plan_column_names = {account.root_plan_id._column_name() for account in accounts}


### PR DESCRIPTION
After this commit, when adding/editing the SOL of a timesheet, if the distribution of the SOL only contains the AA of the project (in other words, it wasn't modified by the user),
we take all the accounts of the project into account in the accounts given to the timesheet.

task-4564855