### PR TITLE
[IMP] im_livechat: add session outcome in kanban view

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -71,6 +71,16 @@
                                     <span class="fw-bold">Date: <field name="create_date" class="fw-normal"/></span>
                                     <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time" options="{'displaySeconds': True}"/></span>
                                     <span class="fw-bold">Messages: <field name="message_count" class="fw-normal"/></span>
+                                    <field name="livechat_failure" invisible="1"/>
+                                    <field name="livechat_is_escalated" invisible="1"/>
+                                    <span t-if="record.livechat_is_escalated.raw_value or record.livechat_failure.raw_value" class="fw-bold">
+                                        Status:
+                                        <span class="fw-normal">
+                                            <t t-if="record.livechat_is_escalated.raw_value">Escalated</t>
+                                            <t t-elif="record.livechat_failure.raw_value === 'no_failure'">Success</t>
+                                            <t t-else="" t-esc="record.livechat_failure.value"/>
+                                        </span>
+                                    </span>
                                 </div>
                                 <field name="rating_last_image" string="Rating" widget="image" options='{"size": [40, 40]}' class="ms-auto" invisible="not rating_last_image"/>
                             </div>


### PR DESCRIPTION
Purpose of this commit:
To show the status of the livechat session in the kanban view.

task-4753047
