### PR TITLE
[BACKPORT][FIX] hw_drivers: ensure requests headers creation

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -23,7 +23,7 @@ _post = requests.post
 def set_user_agent(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        headers = kwargs.pop('headers', {})
+        headers = kwargs.pop('headers', None) or {}
         headers['User-Agent'] = 'OdooIoTBox/1.0'
         return func(*args, headers=headers, **kwargs)
 


### PR DESCRIPTION
Previously, if `headers` was explicitly passed to `None`, we couldn't assign it the custom User Agent. Now, we ensure to set it to an empty dictionary before assigning it.
