### PR TITLE
[FIX] account: resolve rounding issue with price-included tax cache

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -600,6 +600,7 @@ class AccountTax(models.Model):
             'division_taxes': [],
             'fixed_amount': 0.0,
         }
+        custom_fixed_amount_after = 0.0
         # Store the tax amounts we compute while searching for the total_excluded
         cached_base_amounts = {}
         cached_tax_amounts = {}
@@ -630,14 +631,18 @@ class AccountTax(models.Model):
                         incl_tax_amounts['fixed_amount'] += tax_amount
                         # Avoid unecessary re-computation
                         cached_tax_amounts[i] = tax_amount
+                        custom_fixed_amount_after += tax_amount
                     # In case of a zero tax, do not store the base amount since the tax amount will
                     # be zero anyway. Group and Python taxes have an amount of zero, so do not take
                     # them into account.
-                    if store_included_tax_total and (
-                        tax.amount or tax.amount_type not in ("percent", "division", "fixed")
+                    if (
+                        store_included_tax_total
+                        and (tax.amount or tax.amount_type not in ("percent", "division", "fixed"))
+                        and i not in cached_tax_amounts
                     ):
-                        total_included_checkpoints[i] = base
+                        total_included_checkpoints[i] = base - custom_fixed_amount_after
                         store_included_tax_total = False
+                        custom_fixed_amount_after = 0.0
                 i -= 1
                 is_base_affected = tax.is_base_affected
 


### PR DESCRIPTION
Steps to Reproduce:
---

1. Create a tax with the following settings:

> - Rate: 12%
> - Price Included: True
> - Affect Base of Subsequent Taxes: False.

2. Create another tax with the following settings:

> - Type: Python Code
> - Code: result = 22.503
> - Price Included: True
> - Affect Base of Subsequent Taxes: False.
> - Ensure the sequence of this tax is greater than the 12% tax (this tax is after the 12% tax in order).

3. Create a product with a sales price of 516.00 and assign both taxes to it.
4. Create a new invoice and add the product to the invoice. The total will show an extra 0.01 due to rounding.

Cause:
---
When applying price-included taxes with multiple taxes, the rounding difference is carried to the last tax to ensure the total matches the product's tax-included price. However, cached values for Python code taxes were used even for the last tax, preventing the rounding correction from being applied.

Fix:
---
An additional condition was added to ensure cached values are only used when there is no price total checkpoint, allowing the rounding correction to be applied to the last tax.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
