### PR TITLE
[IMP] im_livechat: change icon when reporting is empty for session action

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -120,7 +120,7 @@
             <field name="view_mode">graph,pivot</field>
             <field name="context">{"search_default_filter_date_last_month": 1}</field>
             <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">No data yet!</p>
+                <p class="o_view_nocontent_empty_folder">No data yet!</p>
                 <p>Track and improve livechat performance with insights on session activity, response time, customer ratings, and call interactions.</p>
             </field>
         </record>


### PR DESCRIPTION
Purpose of this PR:

Replaced `o_view_nocontent_smiling_face` with `o_view_nocontent_empty_folder` for better consistency in the session reporting view.

Before:
<img src="https://github.com/user-attachments/assets/f389ebae-3ae4-4c7d-b8ba-9ac657d0f64c" width="60%">

After:
<img src="https://github.com/user-attachments/assets/be07992f-e897-4d2e-96e3-378d37684e00" width="60%">


task-4753044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
