### PR TITLE
[FIX] html_editor: scroll to `closestElement` on invisible range

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -23,7 +23,6 @@ import {
     normalizeDeepCursorPosition,
     normalizeFakeBR,
 } from "../utils/selection";
-import { isElement } from "../utils/dom_info";
 import { closestScrollableY } from "@web/core/utils/scrolling";
 
 /**
@@ -124,22 +123,10 @@ function scrollToSelection(selection) {
         return;
     }
     let rect = range.getBoundingClientRect();
-    // If the range is invisible (0 width & height) and selection is collapsed,
-    // it's likely inside an empty paragraph.
-    // In that case, we try to get the bounding rect from a nearby child element
-    // within the anchorNode to better get position the selection.
-    if (
-        rect.width === 0 &&
-        rect.height === 0 &&
-        selection.isCollapsed &&
-        selection.anchorNode.hasChildNodes()
-    ) {
-        const target =
-            selection.anchorNode.childNodes[selection.anchorOffset] ||
-            selection.anchorNode.childNodes[selection.anchorOffset - 1];
-        if (isElement(target)) {
-            rect = target.getBoundingClientRect();
-        }
+    // If the range is invisible (0 width & height),
+    // We call `getBoundingClientRect` on closest element.
+    if (rect.width === 0 && rect.height === 0 && selection.isCollapsed) {
+        rect = closestElement(selection.anchorNode).getBoundingClientRect();
     }
 
     const containerRect = container.getBoundingClientRect();


### PR DESCRIPTION
Problem:
In case of programmatic selection change (e.g., on paste), the selection may be set on an invisible range, like:
`setSelection({anchorNode: <div>, anchorOffset: 1});` This case was not properly handled by the `scrollToSelection` function.

Solution:
When encountering an invisible collapsed range, use the `anchorNode`'s closest element to calculate offset and perform scrolling. This prevents unnecessary scrolling when the selection is already inside the viewport and within an element.

Steps to reproduce:
1. Add enough text to make the editable area scrollable.
2. Insert a list (any type).
3. Copy some text and paste it into the last list element. → Even if the selection is in the viewport, it still scrolls
   incorrectly.

opw-4745939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
