### PR TITLE
[FIX] mail: find_create partner with company from context

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -95,7 +95,11 @@ class Partner(models.Model):
         if not parsed_email_normalized and assert_valid_email:
             raise ValueError(_('%(email)s is not recognized as a valid email. This is required to create a new customer.'))
         if parsed_email_normalized:
-            partners = self.search([('email_normalized', '=', parsed_email_normalized)], limit=1)
+            domain = [('email_normalized', '=', parsed_email_normalized)]
+            company_id = self.env.context.get('default_company_id', False)
+            if company_id:
+                domain.append(('company_id', '=', company_id))
+            partners = self.search(domain, limit=1)
             if partners:
                 return partners
 


### PR DESCRIPTION
To reproduce:
=============
1. have a partner with email test@odoo.com in company1
2. allow to Demo only the company2
3. setup helpdesk team for company2 and enable it on website
4. create a ticket from website with email : test@odoo.com
5. check the ticket will be created with the partner from company1
6. try to open the ticket as Demo user, you will get an access error

Problem:
=========
`find_or_create` method of `res.partner` model is not taking into account the company_id from the context when searching for the partner.

Solution:
=========
The `find_or_create` method of `res.partner` model is modified to consider the company_id from the context when searching for the partner.

opw-4699518
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
