### PR TITLE
[FIX] product,sale: enable pricelists in tests

### DIFF
--- a/addons/product/tests/test_common.py
+++ b/addons/product/tests/test_common.py
@@ -10,6 +10,7 @@ from odoo.addons.product.tests.common import ProductCommon
 class TestProduct(ProductCommon):
 
     def test_common(self):
+        self._enable_pricelists()
         self.assertEqual(self.product.type, 'consu')
         self.assertEqual(self.service_product.type, 'service')
 

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -24,7 +24,7 @@ class SaleCommon(
         (cls.product + cls.service_product).write({
             'taxes_id': [Command.clear()],
         })
-
+        cls._enable_pricelists()
         cls.empty_order, cls.sale_order = cls.env['sale.order'].create([
             {
                 'partner_id': cls.partner.id,


### PR DESCRIPTION
After e1145d56162a5b88fe56b78abf70f7bd104ead00 we do not compute pricelists unless they are enabled which caused some tests to fail as they expected pricelists to be activated.

