### PR TITLE
[FIX] hw_drivers: unsupported printer usb device

### DIFF
--- a/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/USBInterface_L.py
@@ -12,9 +12,16 @@ class USBInterface(Interface):
 
     @staticmethod
     def usb_matcher(dev):
-        # Ignore USB hubs
-        if dev.bDeviceClass == 9:
+        # USB Class codes documentation: https://www.usb.org/defined-class-codes
+        # Ignore USB hubs (9) and printers (7)
+        if dev.bDeviceClass in [7, 9]:
             return False
+        # If the device has generic base class (0) check its interface descriptor
+        elif dev.bDeviceClass == 0:
+            for conf in dev:
+                for interface in conf:
+                    if interface.bInterfaceClass == 7:  # 7 = printer
+                        return False
 
         # Ignore serial adapters
         return dev.product != "USB2.0-Ser!"


### PR DESCRIPTION
The printers connected through usb are currently detected as both a regular valid USB printer but also as an "unsupported device" This PR makes sure that if a usb connected printer is detected it doesn't get listed as "unsupported device"