### PR TITLE
[FIX] sale_timesheet: remove filtering in so_line domain

### DIFF
--- a/addons/sale_timesheet/models/hr_timesheet.py
+++ b/addons/sale_timesheet/models/hr_timesheet.py
@@ -27,7 +27,6 @@ class AccountAnalyticLine(models.Model):
             self.env['sale.order.line']._sellable_lines_domain(),
             self.env['sale.order.line']._domain_sale_line_service(),
             [
-                ('qty_delivered_method', 'in', ['analytic', 'timesheet']),
                 ('order_partner_id.commercial_partner_id', '=', unquote('commercial_partner_id')),
             ],
         ])


### PR DESCRIPTION
**Steps to reproduce:**
- Create a service with "Create on Order" = `Project & Task` and "Invoicing Policy" = `Based on Delivered Quantity (Manual)`.
- Create a quotation using this service as a product.
- Create a new line in Timesheet with the Project of the service.
- The Sales Order Item field updates automatically.
- If manually modified, the item no longer appears in the lists of `name_search` or `web_search_read`.

**Issue:**
Inconsistent behavior on the domain used for the Sale Order Item showed in the Timesheet app.

**Fix:**
Removed `qty_delivered_method` domain filtering to allow sale order line with any `qty_delivered_method` to
be used in the Timesheet app.

opw-4710840

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
