### PR TITLE
Saas 17.4 disable turnstile and recaptcha on neutralize 

### DIFF
--- a/addons/google_recaptcha/data/neutralize.sql
+++ b/addons/google_recaptcha/data/neutralize.sql
@@ -1,0 +1,4 @@
+-- disable reCAPTCHA
+UPDATE ir_config_parameter
+SET value = ''
+WHERE key IN ('recaptcha_public_key', 'recaptcha_private_key');

--- a/addons/website_cf_turnstile/data/neutralize.sql
+++ b/addons/website_cf_turnstile/data/neutralize.sql
@@ -1,0 +1,4 @@
+-- disable cf turnstile 
+UPDATE ir_config_parameter
+SET value = ''
+WHERE key IN ('cf.turnstile_site_key','cf.turnstile_secret_key');


### PR DESCRIPTION
This commit disable both protection upon neutralizing a db by removing the tokens.

Manual forward port of #207020

opw-4734555
upg-2759374
