### PR TITLE
[IMP] web_editor: enhance background position orientation interface

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -9022,10 +9022,8 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
 
         this.$overlayContent.offset(targetOffset);
 
-        this.$bgDragger.css({
-            width: `${this.$target.innerWidth()}px`,
-            height: `${this.$target.innerHeight()}px`,
-        });
+        this.$bgDragger[0].style.setProperty("width", `${this.$target.innerWidth()}px`, "important");
+        this.$bgDragger[0].style.setProperty("height", `${this.$target.innerHeight()}px`, "important");
 
         const topPos = Math.max(0, $(window).scrollTop() - this.$target.offset().top);
         this.$overlayContent.find('.o_we_overlay_buttons').css('top', `${topPos}px`);

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8907,6 +8907,11 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
      * @see this.selectClass for params
      */
     backgroundPositionOverlay: async function (previewMode, widgetValue, params) {
+        if (!widgetValue) {
+            this._toggleBgOverlay(false);
+            return;
+        }
+        this.el.querySelector(".fa-arrows-alt").classList.add("o_toggle_background_position_overlay");
         // Updates the internal image
         await new Promise(resolve => {
             this.img = document.createElement('img');
@@ -8969,6 +8974,9 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
     _computeWidgetState: function (methodName, params) {
         if (methodName === 'backgroundType') {
             return this.$target.css('background-repeat') === 'repeat' ? 'repeat-pattern' : 'cover';
+        }
+        if (methodName === "backgroundPositionOverlay") {
+            return this.el.querySelector(".fa-arrows-alt").classList.contains("o_toggle_background_position_overlay");
         }
         return this._super(...arguments);
     },
@@ -9034,6 +9042,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         }
 
         if (!activate) {
+            this.el.querySelector(".fa-arrows-alt").classList.remove("o_toggle_background_position_overlay", "active");
             this.$backgroundOverlay.removeClass('oe_active');
             this.trigger_up('unblock_preview_overlays');
             this.trigger_up('activate_snippet', {$snippet: this.$target});
@@ -9073,6 +9082,12 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         this.$overlayBackground.empty().append(this.$bgDragger);
         this.$backgroundOverlay.addClass('oe_active');
         this._dimensionOverlay();
+        const shapeEl =  this.$bsTarget[0].querySelector(".o_we_shape");
+        if (shapeEl) {
+            const shapeOverlayEl = document.createElement("div");
+            shapeOverlayEl.classList.add(...shapeEl.classList);
+            this.$bgDragger[0].insertAdjacentElement("afterend", shapeOverlayEl);
+        }
         this.$bgDragger.tooltip('show');
 
         // Needs to be deferred or the click event that activated the overlay deactivates it as well.

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -8873,10 +8873,11 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
 
         this._initOverlay();
 
-        // Resize overlay content on window resize because background images
+        // Resize overlay content on body resize because background images
         // change size, and on carousel slide because they sometimes take up
         // more space and move elements around them.
-        $(window).on('resize.bgposition', () => this._dimensionOverlay());
+        this.resizeObserver = new ResizeObserver(this._dimensionOverlay.bind(this));
+        this.resizeObserver.observe(this.ownerDocument.body);
     },
     /**
      * @override
@@ -8885,6 +8886,7 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
         this._toggleBgOverlay(false);
         $(window).off('.bgposition');
         this._super.apply(this, arguments);
+        this.resizeObserver.disconnect();
     },
 
     //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -380,7 +380,7 @@
         <div class="o_we_background_position_overlay oe_overlay">
             <div class="o_we_overlay_content position-absolute">
                 <div class="o_overlay_background"/>
-                <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0">
+                <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0; right: 0;">
                     <button class="btn btn-primary me-1 o_btn_apply">Apply</button>
                     <button class="btn btn-danger o_btn_discard">Discard</button>
                 </div>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -159,7 +159,7 @@
                     <we-button data-background-type="cover">Cover</we-button>
                     <we-button data-background-type="repeat-pattern" data-name="background_repeat_opt">Repeat pattern</we-button>
                 </we-select>
-                <we-button class="fa fa-fw fa-crosshairs" title="Background Position" data-background-position-overlay="true" data-no-preview="true"/>
+                <we-button class="fa fa-fw fa-arrows-alt" title="Background Position" data-background-position-overlay="true" data-no-preview="true"/>
             </we-row>
             <we-multi data-css-property="background-size" data-dependencies="background_repeat_opt">
                 <we-input string="Width" class="o_we_sublevel_3" data-select-style="auto" placeholder="auto" data-unit="px"/>

--- a/addons/website/static/src/builder/plugins/background_option/background_position_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_option.xml
@@ -8,7 +8,7 @@
                 <BuilderSelectItem actionValue="'cover'">Cover</BuilderSelectItem>
                 <BuilderSelectItem actionValue="'repeat-pattern'" id="'background_repeat_opt'">Repeat pattern</BuilderSelectItem>
             </BuilderSelect>
-            <BuilderButton icon="'fa-crosshairs'" title.translate="Background Position" preview="false" action="'backgroundPositionOverlay'"/>
+            <BuilderButton icon="'fa-arrows-alt'" title.translate="Background Position" preview="false" action="'backgroundPositionOverlay'"/>
         </BuilderRow>
         <BuilderContext t-if="isActiveItem('background_repeat_opt')" action="'setBackgroundSize'">
             <BuilderRow label.translate="Width" level="3">

--- a/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_option_plugin.js
@@ -91,6 +91,10 @@ export class BackgroundPositionOverlayAction extends BuilderAction {
                 { onRemove: onRemove }
             );
             const applyPosition = (bgPosition) => {
+                this.apply({
+                    editingElement: editingElement,
+                    loadResult: bgPosition,
+                });
                 appliedBgPosition = bgPosition;
                 overlay.close();
             };
@@ -101,7 +105,13 @@ export class BackgroundPositionOverlayAction extends BuilderAction {
                     editingElement: editingElement,
                     mockEditingElOnImg: imgEl,
                     applyPosition: applyPosition,
-                    discardPosition: () => overlay.close(),
+                    discardPosition: () => {
+                        this.apply({
+                            editingElement: editingElement,
+                            loadResult: "",
+                        });
+                        overlay.close();
+                    },
                     editable: this.editable,
                 },
             });
@@ -114,9 +124,16 @@ export class BackgroundPositionOverlayAction extends BuilderAction {
         return copyEl.outerHTML;
     }
     apply({ editingElement, loadResult: bgPosition }) {
+        editingElement.classList.add("o_toggle_bg_position");
         if (bgPosition) {
             editingElement.style.backgroundPosition = bgPosition;
         }
+    }
+    clean({ editingElement }) {
+        editingElement.classList.remove("o_toggle_bg_position");
+    }
+    isApplied({ editingElement }) {
+        return editingElement.classList.contains("o_toggle_bg_position");
     }
 }
 

--- a/addons/website/static/src/builder/plugins/background_option/background_position_overlay.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_overlay.js
@@ -50,7 +50,14 @@ export class BackgroundPositionOverlay extends Component {
             this.bgDraggerEl.style.backgroundAttachment = getComputedStyle(
                 this.props.editingElement
             ).backgroundAttachment;
-            window.addEventListener("resize", this._dimensionOverlay);
+            this.resizeObserver = new ResizeObserver(this.dimensionOverlay.bind(this));
+            this.resizeObserver.observe(this.props.editingElement);
+            const shapeEl = this.props.editingElement.parentElement.querySelector(".o_we_shape");
+            if (shapeEl) {
+                const shapeOverlayEl = document.createElement("div");
+                shapeOverlayEl.classList.add(...shapeEl.classList);
+                this.parentBgDraggerRef.el.insertAdjacentElement("afterend", shapeOverlayEl);
+            }
         });
 
         useEffect(() => {
@@ -62,7 +69,7 @@ export class BackgroundPositionOverlay extends Component {
         });
 
         onWillUnmount(() => {
-            window.removeEventListener("resize", this._dimensionOverlay);
+            this.resizeObserver.disconnect();
             this.tooltip.dispose();
         });
     }

--- a/addons/website/static/src/builder/plugins/background_option/background_position_overlay.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_position_overlay.xml
@@ -10,7 +10,7 @@
                 >
                 <t t-out="props.outerHtmlEditingElement"/>
             </div>
-            <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0">
+            <div class="o_we_overlay_buttons position-absolute d-flex m-1" style="top: 0; right: 0;">
                 <button class="btn btn-primary me-1 o_btn_apply" t-on-click="apply">Apply</button>
                 <button class="btn btn-danger o_btn_discard" t-on-click="this.props.discardPosition">Discard</button>
             </div>

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -105,7 +105,7 @@ test("Change the background position and discard", async () => {
 test("Change the background position and click out of the iframe", async () => {
     await dragAndDropBgImage();
     await contains(".o_customize_tab").click();
-    expect("button.fa-undo").not.toBeEnabled();
+    expect("button.fa-undo").toBeEnabled();
 });
 
 async function dragAndDropBgImage() {


### PR DESCRIPTION
This pull request enhances the usability and reliability of the background position tool in the web editor, particularly for shaped snippets and column layouts.

> Improvements
* Enhanced the interface for background image positioning:
     - Users can now toggle the position tool by clicking the icon again.
     - Moved the background position button to the top-right corner for better accessibility.
     - Replaced the icon with fa-arrows-alt for clearer representation.
     - While editing shaped snippets, users can now view the background's working area for more precise adjustments.

> Fixes
* Fullscreen Overlay Sizing Issue
     - The background position overlay failed to resize in fullscreen mode when pressing the Escape key.
     - This was due to a resize event bound to the window instead of the body.
     - Resolved by using a `ResizeObserver` on the body to dynamically adapt the overlay size.

* Incorrect Overlay Height in Columns
     -  When using three-column snippets, the working area on a column card appeared too small.
     - This was caused by the `h-100` class enforcing a fixed height, which the overlay inherited.
     - Fixed by prioritizing the `dimensionOverlay` values, ensuring the overlay adapts to intended dimensions, regardless of the element’s height.

task-4600335