### PR TITLE
[IMP] bus: download bus logs for easier diagnostics

### DIFF
--- a/addons/bus/__manifest__.py
+++ b/addons/bus/__manifest__.py
@@ -12,6 +12,7 @@
     'assets': {
         'web.assets_backend': [
             'bus/static/src/*.js',
+            'bus/static/src/debug/**/*',
             'bus/static/src/services/**/*.js',
             'bus/static/src/workers/websocket_worker.js',
             'bus/static/src/workers/websocket_worker_utils.js',

--- a/addons/bus/static/src/@types/services.d.ts
+++ b/addons/bus/static/src/@types/services.d.ts
@@ -2,10 +2,12 @@ declare module "services" {
     import { multiTabService } from "@bus/multi_tab_service";
     import { busMonitoringservice } from "@bus/services/bus_monitoring_service";
     import { busService } from "@bus/services/bus_service";
+    import { busLogsService } from "@bus/services/debug/bus_logs_service";
     import { presenceService } from "@bus/services/presence_service";
 
     export interface Services {
         bus_service: typeof busService,
+        "bus.logs_service": typeof busLogsService,
         multi_tab: typeof multiTabService,
         presence_service: typeof presenceService,
         "bus.monitoring_service": typeof busMonitoringservice,

--- a/addons/bus/static/src/debug/bus_logs_menu_item.js
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.js
@@ -1,0 +1,33 @@
+import { Component, useRef } from "@odoo/owl";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+
+export class BusLogsMenuItem extends Component {
+    static components = { DropdownItem };
+    static template = "bus.BusLogsMenuItem";
+    static props = {};
+
+    setup() {
+        this.busLogsService = useService("bus.logs_service");
+        this.downloadButton = useRef("downloadButton");
+    }
+
+    onClickToggle() {
+        this.busLogsService.toggleLogging();
+    }
+
+    onClickDownload() {
+        this.env.services.bus_service.downloadLogs();
+    }
+}
+
+registry
+    .category("debug")
+    .category("default")
+    .add("bus.download_logs", () => ({
+        Component: BusLogsMenuItem,
+        sequence: 550,
+        section: "tools",
+        type: "component",
+    }));

--- a/addons/bus/static/src/debug/bus_logs_menu_item.xml
+++ b/addons/bus/static/src/debug/bus_logs_menu_item.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="bus.BusLogsMenuItem">
+        <DropdownItem>
+            <div class="d-flex align-items-center justify-content-between" style="padding-left: 12px;">
+                <div class="form-check form-switch">
+                    <label class="form-check-label" t-on-click.prevent.stop="onClickToggle">
+                        Enable Bus Logging <input class="form-check-input" t-att-checked="busLogsService.enabled" type="checkbox"/>
+                    </label>
+                </div>
+                <button class="btn btn-light text-muted ms-2" title="Download logs" t-ref="downloadButton" t-on-click="onClickDownload"><i class="fa fa-download"/></button>
+            </div>
+        </DropdownItem>
+    </t>
+</templates>

--- a/addons/bus/static/src/debug/bus_logs_service.js
+++ b/addons/bus/static/src/debug/bus_logs_service.js
@@ -1,0 +1,40 @@
+import { reactive } from "@odoo/owl";
+
+import { registry } from "@web/core/registry";
+
+export const busLogsService = {
+    dependencies: ["bus_service", "multi_tab"],
+    /**
+     * @param {import("@web/env").OdooEnv}
+     * @param {Partial<import("services").Services>} services
+     */
+    start(env, { bus_service, multi_tab }) {
+        const state = reactive({
+            enabled: multi_tab.getSharedValue("bus_log_menu.enabled", false),
+            toggleLogging() {
+                state.enabled = !state.enabled;
+                bus_service.setLoggingEnabled(state.enabled);
+                multi_tab.setSharedValue("bus_log_menu.enabled", state.enabled);
+            },
+        });
+        multi_tab.bus.addEventListener("shared_value_updated", ({ detail }) => {
+            if (detail.key === "bus_log_menu.enabled") {
+                state.enabled = detail.newValue;
+            }
+        });
+        bus_service.setLoggingEnabled(state.enabled);
+        odoo.busLogging = {
+            stop: () => state.enabled && state.toggleLogging(),
+            start: () => !state.enabled && state.toggleLogging(),
+            download: () => bus_service.downloadLogs(),
+        };
+        if (state.enabled) {
+            console.log(
+                "Bus logging is enabled. To disable it, use `odoo.busLogging.stop()`. To download the logs, use `odoo.busLogging.download()`."
+            );
+        }
+        return state;
+    },
+};
+
+registry.category("services").add("bus.logs_service", busLogsService);

--- a/addons/bus/static/src/workers/websocket_worker_script.js
+++ b/addons/bus/static/src/workers/websocket_worker_script.js
@@ -4,7 +4,7 @@
 import { WebsocketWorker } from "./websocket_worker";
 
 (function () {
-    const websocketWorker = new WebsocketWorker();
+    const websocketWorker = new WebsocketWorker(self.name);
 
     if (self.name.includes("shared")) {
         // The script is running in a shared worker: let's register every

--- a/addons/bus/static/src/workers/websocket_worker_utils.js
+++ b/addons/bus/static/src/workers/websocket_worker_utils.js
@@ -40,3 +40,91 @@ export class Deferred extends Promise {
         return Object.assign(prom, { resolve, reject });
     }
 }
+
+export class Logger {
+    static LOG_TTL = 45 * 60 * 1000; // 45 minutes
+    static gcInterval = null;
+    static instances = [];
+    _db;
+
+    static async gcOutdatedLogs() {
+        const threshold = Date.now() - Logger.LOG_TTL;
+        for (const logger of this.instances) {
+            try {
+                await logger._ensureDatabaseAvailable();
+                await new Promise((res, rej) => {
+                    const transaction = logger._db.transaction("logs", "readwrite");
+                    const store = transaction.objectStore("logs");
+                    const req = store
+                        .index("timestamp")
+                        .openCursor(IDBKeyRange.upperBound(threshold));
+                    req.onsuccess = (event) => {
+                        const cursor = event.target.result;
+                        if (cursor) {
+                            cursor.delete();
+                            cursor.continue();
+                        }
+                    };
+                    req.onerror = (e) => rej(e.target.error);
+                    transaction.oncomplete = res;
+                    transaction.onerror = (e) => rej(e.target.error);
+                });
+            } catch (error) {
+                console.error(`Failed to clear logs for logger "${logger._name}":`, error);
+            }
+        }
+    }
+
+    constructor(name) {
+        this._name = name;
+        Logger.instances.push(this);
+        Logger.gcOutdatedLogs();
+        clearInterval(Logger.gcInterval);
+        Logger.gcInterval = setInterval(() => Logger.gcOutdatedLogs(), Logger.LOG_TTL);
+    }
+
+    async _ensureDatabaseAvailable() {
+        if (this._db) {
+            return;
+        }
+        return new Promise((res, rej) => {
+            const request = indexedDB.open(this._name, 1);
+            request.onsuccess = (event) => {
+                this._db = event.target.result;
+                res();
+            };
+            request.onupgradeneeded = (event) => {
+                if (!event.target.result.objectStoreNames.contains("logs")) {
+                    const store = event.target.result.createObjectStore("logs", {
+                        autoIncrement: true,
+                    });
+                    store.createIndex("timestamp", "timestamp", { unique: false });
+                }
+            };
+            request.onerror = rej;
+        });
+    }
+
+    async log(message) {
+        await this._ensureDatabaseAvailable();
+        const transaction = this._db.transaction("logs", "readwrite");
+        const store = transaction.objectStore("logs");
+        const addRequest = store.add({ timestamp: Date.now(), message });
+        return new Promise((res, rej) => {
+            addRequest.onsuccess = res;
+            addRequest.onerror = rej;
+        });
+    }
+
+    async getLogs() {
+        await Logger.gcOutdatedLogs();
+        await this._ensureDatabaseAvailable();
+        const transaction = this._db.transaction("logs", "readonly");
+        const store = transaction.objectStore("logs");
+        const request = store.getAll();
+        return new Promise((res, rej) => {
+            request.onsuccess = (ev) => res(ev.target.result.map(({ message }) => message));
+            request.onerror = rej;
+        });
+    }
+}

--- a/addons/bus/static/tests/bus_logger.test.js
+++ b/addons/bus/static/tests/bus_logger.test.js
@@ -1,0 +1,20 @@
+import { Logger } from "@bus/workers/websocket_worker_utils";
+
+import { after, before, describe, expect, test } from "@odoo/hoot";
+import { advanceTime } from "@odoo/hoot-dom";
+
+describe.current.tags("desktop");
+
+before(() => indexedDB.deleteDatabase("test_db"));
+after(() => indexedDB.deleteDatabase("test_db"));
+
+test("logs are saved and garbage-collected after TTL", async () => {
+    indexedDB.deleteDatabase("test_db");
+    const logger = new Logger("test_db");
+    await logger.log("foo");
+    await logger.log("bar");
+    expect(await logger.getLogs()).toEqual(["foo", "bar"]);
+    await advanceTime(Logger.LOG_TTL + 1000);
+    expect(await logger.getLogs()).toEqual([]);
+    indexedDB.deleteDatabase("test_db");
+});

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -958,7 +958,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "saas-18.1-1"
+    _VERSION = "saas-18.2-1"
 
     @classmethod
     def websocket_allowed(cls, request):


### PR DESCRIPTION

Diagnosing bus issues can be challenging, as problems are often
detected too late (e.g., discovering missed messages only after a
reload). These issues can stem from various sources, making them
difficult for users to pinpoint.

This commit introduces a logger that stores the last 45 minutes of
bus worker events in IndexedDB, allowing them to be downloaded when
an issue occurs. The logs will persist even after a reload, making
it easier to diagnose and resolve bus-related issues.

A new debug menu item is added to toggle logging on/off and to
download the logs. This replaces the `condole.debug` calls that
bloated the console and were not easy to retrieve.