### PR TITLE
[FIX] mail: add back implied groups to recipients data

### DIFF
--- a/addons/mail/models/mail_followers.py
+++ b/addons/mail/models/mail_followers.py
@@ -205,17 +205,28 @@ class MailFollowers(models.Model):
       JOIN sub_followers ON sub_followers.pid = partner.id
                         AND (sub_followers.internal IS NOT TRUE OR partner.partner_share IS NOT TRUE)
  LEFT JOIN LATERAL (
-        SELECT users.id AS uid,
-               users.share AS share,
-               users.notification_type AS notification_type,
-               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
-          FROM res_users users
-     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-         WHERE users.partner_id = partner.id AND users.active
-      GROUP BY users.id,
-               users.share,
-               users.notification_type
-      ORDER BY users.share ASC NULLS FIRST, users.id ASC
+        WITH RECURSIVE all_groups AS (
+            SELECT users.id AS uid,
+                   users.share AS share,
+                   users.notification_type AS notification_type,
+                   groups_rel.gid
+              FROM res_users users
+         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+             WHERE users.partner_id = partner.id AND users.active
+          UNION
+            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
+              FROM all_groups ag
+              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
+        )
+        SELECT uid,
+               share,
+               notification_type,
+               ARRAY_AGG(DISTINCT gid) AS groups
+          FROM all_groups
+      GROUP BY uid,
+               share,
+               notification_type
+      ORDER BY share ASC NULLS FIRST, uid ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 
@@ -244,17 +255,28 @@ class MailFollowers(models.Model):
                               AND fol.res_model = %s
                               AND fol.res_id IN %s
  LEFT JOIN LATERAL (
-        SELECT users.id AS uid,
-               users.share AS share,
-               users.notification_type AS notification_type,
-               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
-          FROM res_users users
-     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-         WHERE users.partner_id = partner.id AND users.active
-      GROUP BY users.id,
-               users.share,
-               users.notification_type
-      ORDER BY users.share ASC NULLS FIRST, users.id ASC
+        WITH RECURSIVE all_groups AS (
+            SELECT users.id AS uid,
+                   users.share AS share,
+                   users.notification_type AS notification_type,
+                   groups_rel.gid
+              FROM res_users users
+         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+             WHERE users.partner_id = partner.id AND users.active
+          UNION
+            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
+              FROM all_groups ag
+              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
+        )
+        SELECT uid,
+               share,
+               notification_type,
+               ARRAY_AGG(DISTINCT gid) AS groups
+          FROM all_groups
+      GROUP BY uid,
+               share,
+               notification_type
+      ORDER BY share ASC NULLS FIRST, uid ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 
@@ -296,17 +318,28 @@ class MailFollowers(models.Model):
            FALSE as is_follower
       FROM res_partner partner
  LEFT JOIN LATERAL (
-        SELECT users.id AS uid,
-               users.share AS share,
-               users.notification_type AS notification_type,
-               ARRAY_AGG(groups_rel.gid) FILTER (WHERE groups_rel.gid IS NOT NULL) AS groups
-          FROM res_users users
-     LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
-         WHERE users.partner_id = partner.id AND users.active
-      GROUP BY users.id,
-               users.share,
-               users.notification_type
-      ORDER BY users.share ASC NULLS FIRST, users.id ASC
+        WITH RECURSIVE all_groups AS (
+            SELECT users.id AS uid,
+                   users.share AS share,
+                   users.notification_type AS notification_type,
+                   groups_rel.gid
+              FROM res_users users
+         LEFT JOIN res_groups_users_rel groups_rel ON groups_rel.uid = users.id
+             WHERE users.partner_id = partner.id AND users.active
+          UNION
+            SELECT ag.uid, ag.share, ag.notification_type, implied.hid
+              FROM all_groups ag
+              JOIN res_groups_implied_rel implied ON ag.gid = implied.gid
+        )
+        SELECT uid,
+               share,
+               notification_type,
+               ARRAY_AGG(DISTINCT gid) AS groups
+          FROM all_groups
+      GROUP BY uid,
+               share,
+               notification_type
+      ORDER BY share ASC NULLS FIRST, uid ASC
          FETCH FIRST ROW ONLY
          ) sub_user ON TRUE
 

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -624,7 +624,7 @@ class RecipientsNotificationTest(MailCommon):
                 self.assertEqual(partner_data['lang'], partner.lang)
                 self.assertEqual(partner_data['name'], partner.name)
                 if user:
-                    self.assertEqual(partner_data['groups'], set(user.group_ids.ids))
+                    self.assertEqual(partner_data['groups'], set(user.all_group_ids.ids))
                     self.assertEqual(partner_data['notif'], user.notification_type)
                     self.assertEqual(partner_data['uid'], user.id)
                 else:


### PR DESCRIPTION
**Original issue**
The "View tasks" button was missing in the notification mail sent to users with "Administrator" rights in the Project app.

**Root cause**
Issue since commit 34a50e83e654017520c0add727215bd7b528ae19 after which implied groups are no longer added to the user.

The query in `_get_recipient_data` using the `res_groups_users_rel` table now doesn't fetch the implied groups.

In `_notify_get_recipients_groups` of `project.task`, button access was given to project users, this group is missing from the data returned by `_get_recipient_data`.

**Solution**
Restore previous behavior by adding the `all_implied_ids` of `res.groups` to the groups returned.

opw-4711892
