### PR TITLE
[IMP] account: backport enable copy of account report expressions

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -712,6 +712,10 @@ class AccountReportExpression(models.Model):
 
         return result
 
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        return [dict(vals, label=self.env._("%s (copy)", expression.label)) for expression, vals in zip(self, vals_list)]
+
     @api.ondelete(at_uninstall=False)
     def _unlink_archive_used_tags(self):
         """


### PR DESCRIPTION
This commit is a backport of [this commit](https://github.com/odoo/odoo/commit/9c0baadc4bb58a75d17ef6963a5acd5cf6c34036) initially targetting saas-18.1 which enables the copy of account report expressions.

---

task-4728887

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
