### PR TITLE
[FIX] hr_holidays: fix off-by-one error in date context for custom hours

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -269,7 +269,7 @@
                             <field name="display_name" attrs="{'invisible': [('holiday_status_id', '=', False)]}"/>
                         </div>
                         <group name="col_left">
-                            <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':date_from, 'default_date_to':date_to}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" />
+                            <field name="holiday_status_id" force_save="1" domain="['|', ('requires_allocation', '=', 'no'), '&amp;', ('has_valid_allocation', '=', True), '&amp;', ('virtual_remaining_leaves', '&gt;', 0), ('max_leaves', '>', '0')]" context="{'employee_id':employee_id, 'default_date_from':request_date_from, 'default_date_to':request_date_to}" options="{'no_create': True, 'no_open': True, 'request_type':'leave'}" />
                             <field name="date_from" invisible="1" />
                             <field name="date_to" invisible="1" />
                             <!-- half day or custom hours: only show one date -->


### PR DESCRIPTION
When creating a time off request with 'Custom Hours' enabled, the context sent for `default_date_from` and `default_date_to` was using incorrect variables, causing the dates to shift by one day earlier (e.g., clicking on the 14th would send the 13th). This prevented valid time off types from appearing in the dropdown if their allocation started on the selected date.

This commit updates the context to use `request_date_from` and `request_date_to` instead of `date_from` and `date_to`, ensuring the correct dates are passed and the appropriate time off types are displayed.

Steps to reproduce:
- Create a time off allocation valid from April 14 to 18
- Open a new time off request on April 14
- Enable 'Custom Hours' and check the dropdown
- 'TEST TIME OFF TYPE' no longer appears due to incorrect date context

With this fix, the dropdown correctly displays available time off types based on the selected date.

opw: 4657742

