### PR TITLE
[FIX] account: don't update fpos when force_create=False

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -336,18 +336,24 @@ class AccountChartTemplate(models.AbstractModel):
                     if xmlid not in xmlid2fiscal_position and not force_create:
                         skip_update.add((model_name, xmlid))
                         continue
-                    # Only add tax mappings containing new taxes
-                    if old_tax_ids := values.pop('tax_ids', []):
-                        new_tax_ids = []
-                        for element in old_tax_ids:
-                            match element:
-                                case Command.CREATE, _, {'tax_src_id': src_id, 'tax_dest_id': dest_id} if (
-                                    not self.ref(src_id, raise_if_not_found=False)
-                                    or (dest_id and not self.ref(dest_id, raise_if_not_found=False))
-                                ):
-                                    new_tax_ids.append(element)
-                        if new_tax_ids:
-                            values['tax_ids'] = new_tax_ids
+                    # Only add accounts and taxes mappings containing new records
+                    for model in ['account', 'tax']:
+                        if not force_create:  # there can't be new records if we don't create them
+                            values.pop(f'{model}_ids', [])
+                        if old_ids := values.pop(f'{model}_ids', []):
+                            new_ids = []
+                            for element in old_ids:
+                                match element:
+                                    case Command.CREATE, _, (
+                                        {'tax_src_id': src_id, 'tax_dest_id': dest_id}
+                                        | {'account_src_id': src_id, 'account_dest_id': dest_id}
+                                    ) if (
+                                        not self.ref(src_id, raise_if_not_found=False)
+                                        or (dest_id and not self.ref(dest_id, raise_if_not_found=False))
+                                    ):
+                                        new_ids.append(element)
+                            if new_ids:
+                                values[f'{model}_ids'] = new_ids
 
                 elif model_name == 'account.tax':
                     # Only update the tags of existing taxes

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -295,6 +295,25 @@ class TestChartTemplate(AccountTestInvoicingCommon):
             ])
             return data
 
+        # First try with `force_create=False` (during an upgrade)
+        with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=local_get_data, autospec=True):
+            self.env['account.chart.template'].try_loading('test', company=self.company, install_demo=False, force_create=False)
+
+        taxes = self.env['account.tax'].search([('company_id', '=', self.company.id)])
+        self.assertRecordValues(taxes, [
+            {'name': 'Tax 1'},
+            {'name': 'Tax 2'},
+        ])
+
+        fiscal_position = self.env['account.fiscal.position'].search([])
+        self.assertRecordValues(fiscal_position.tax_ids.tax_src_id, [
+            {'name': 'Tax 1'},
+        ])
+        self.assertRecordValues(fiscal_position.tax_ids.tax_dest_id, [
+            {'name': 'Tax 2'},
+        ])
+
+        # then try with `force_create=True` (when updating the CoA manually)
         with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=local_get_data, autospec=True):
             self.env['account.chart.template'].try_loading('test', company=self.company, install_demo=False)
 


### PR DESCRIPTION
Since we only update the fiscal positions for newly created taxes, there is nothing to update in the mapping when nothing will be created.

upg-2769042

