### PR TITLE
[IMP] l10n_in: added functionality to display payment method on customer invoice

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -24,6 +24,11 @@
         <xpath expr="//div[@name='no_shipping']//t[@t-set='address']" position="inside">
             <t t-call="l10n_in.place_of_supply"/>
         </xpath>
+        <xpath expr="//i[hasclass('oe_payment_label')]" position="inside">
+            <t t-if="payment_vals['payment_method_name'] != 'Manual Payment'">
+                using <t t-esc="payment_vals['payment_method_name']"/>
+            </t>
+        </xpath>
 
         <xpath expr="//table[@name='invoice_line_table']/thead/tr/th[1]" position="after">
             <t t-if="o.company_id.account_fiscal_country_id.code == 'IN' and o.company_id.l10n_in_is_gst_registered">


### PR DESCRIPTION
PURPOSE:
- Print the Payment Method used by the customer on the Customer Invoice.

SPECIFICATION:
- Added functionality in the l10n_in module to display the payment method 
  (e.g., Card, Cash, etc.) on the Customer Invoice PDF.
- If a payment is made using a specific method, it will be printed inside the 
  invoice.
- For Manual Payment, the standard view will be retained 
  (i.e., no changes to the invoice layout).

TASK ID:
- 4410103