### PR TITLE
[IMP] im_livechat: sessions report to line chart with count measure by default

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -51,7 +51,7 @@
             <field name="name">im_livechat.report.channel.graph</field>
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
-                <graph string="Livechat Support Statistics" stacked="1" sample="1">
+                <graph string="Livechat Support Statistics" type="line" sample="1">
                     <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="has_call" invisible="1"/>
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>
@@ -118,7 +118,7 @@
             <field name="name">Sessions</field>
             <field name="res_model">im_livechat.report.channel</field>
             <field name="view_mode">graph,pivot</field>
-            <field name="context">{"search_default_filter_date_last_month": 1}</field>
+            <field name="context">{"graph_measure": "__count__", "search_default_filter_date_last_month": 1}</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">No data yet!</p>
                 <p>Track and improve livechat performance with insights on session activity, response time, customer ratings, and call interactions.</p>


### PR DESCRIPTION
**Current behavior before PR:**

Prior to this PR, the chart type was by default a bar chart, and the default measure was sessions with calls.

**Desired behavior after PR is merged:**

Now, the default chart type is changed to a line chart, and the default measure is set to count (number of records).

task-[4752951](https://www.odoo.com/odoo/project.task/4752951)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
