### PR TITLE
[FIX] account: prevent unwanted journal override during payment

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -389,7 +389,7 @@ class AccountPayment(models.Model):
             if partner or payment_type:
                 field_name = f'property_{payment_type}_payment_method_line_id'
                 default_payment_method_line = payment.partner_id.with_company(payment.company_id)[field_name]
-                journal = default_payment_method_line.journal_id
+                journal = default_payment_method_line.journal_id or payment.journal_id
                 if journal:
                     payment.journal_id = journal
                     continue


### PR DESCRIPTION
Steps to reproduce:
- Create a vendor or customer payment from accounting dashboard.
- Manually select a specific bank journal for the payment.
- Save the record.

Current behavior:
- Odoo may override the selected journal with the one linked to the default payment method line, even if a specific journal was already chosen.

Expected behavior:
- Odoo should retain the manually selected journal and only use the default if no journal is explicitly set.

This fix ensures that the payment's `journal_id` is only updated from the default method line if it is not already set, preserving user intent.

opw: 4654830
