### PR TITLE
[IMP] im_livechat: show agent name instead of display_name in reporting pivot

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -115,6 +115,7 @@
                 {
                     "search_default_filter_date_last_month": 1,
                     "pivot_measures": ["__count", "time_to_answer", "duration", "rating", "number_of_calls"],
+                    "im_livechat.hide_partner_company": True,
                 }
             </field>
             <field name="search_view_id" ref="im_livechat_report_channel_view_search"/>
@@ -132,6 +133,7 @@
                 {
                     "search_default_filter_date_last_month": 1,
                     "pivot_measures": ["__count", "time_to_answer", "duration", "rating", "number_of_calls"],
+                    "im_livechat.hide_partner_company": True,
                 }
             </field>
             <field name="help" type="html">


### PR DESCRIPTION
**Current behavior before PR:**

The agents reporting pivot view displayed the `display_name` of agents instead of their `name`.

**Desired behavior after PR is merged:**

The pivot view now shows the `name` of agents.

**Task**-4753030


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
