### PR TITLE
[IMP] account: added functionality to display payment method on customer invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -246,7 +246,11 @@
                                                     <t t-foreach="payments_vals" t-as="payment_vals">
                                                         <tr t-if="payment_vals['is_exchange'] == 0">
                                                             <td>
-                                                                <i class="oe_form_field text-end oe_payment_label">Paid on <t t-out="payment_vals['date']" t-options='{"widget": "date"}'>2021-09-19</t></i>
+                                                                <i class="oe_form_field text-end oe_payment_label">Paid on <t t-out="payment_vals['date']" t-options='{"widget": "date"}'>2021-09-19</t>
+                                                                    <t t-if="payment_vals['payment_method_name']">
+                                                                        using <t t-out="payment_vals['payment_method_name']">Cash</t>
+                                                                    </t>
+                                                                </i>
                                                             </td>
                                                             <td class="text-end">
                                                                 <span t-out="payment_vals['amount']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>20.00</span>


### PR DESCRIPTION
PURPOSE:
- Print the Payment Method used by the customer on the Customer Invoice.

SPECIFICATION:
- Added functionality in the l10n_in module to display the payment method 
  (e.g., Card, Cash, etc.) on the Customer Invoice PDF.
- If a payment is made using a specific method, it will be printed inside the 
  invoice.
- For Manual Payment, the standard view will be retained 
  (i.e., no changes to the invoice layout).

TASK ID:
-4410103
