### PR TITLE
[FIX] project: missing extended controller in kanban view

### DIFF
--- a/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
+++ b/addons/project/static/src/views/project_project_kanban/project_task_kanban_view.js
@@ -1,9 +1,11 @@
 import { registry } from "@web/core/registry";
 import { kanbanView } from "@web/views/kanban/kanban_view";
+import { ProjectKanbanController } from "./project_project_kanban_controller";
 import { ProjectProjectKanbanRenderer } from "./project_project_kanban_renderer";
 
 export const projectProjectKanbanView = {
     ...kanbanView,
+    Controller: ProjectKanbanController,
     Renderer: ProjectProjectKanbanRenderer,
 };
 


### PR DESCRIPTION
The controller extended in the PR https://github.com/odoo/odoo/pull/194090 is not added in to the view.
Adding into project kanban view.
