### PR TITLE
[FIX] pos_restaurant: prevent order deletion on table merge

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -442,7 +442,8 @@ export class PosStore extends Reactive {
             if (order && (await this._onBeforeDeleteOrder(order))) {
                 if (
                     typeof order.id === "number" &&
-                    Object.keys(order.last_order_preparation_change.lines).length > 0
+                    Object.keys(order.last_order_preparation_change.lines).length > 0 &&
+                    !order.skip_send_kitchen
                 ) {
                     await this.sendOrderInPreparation(order, true);
                 }
@@ -1184,6 +1185,7 @@ export class PosStore extends Reactive {
             }
 
             const serializedOrder = orders.map((order) => order.serialize({ orm: true }));
+            debugger;
             const data = await this.data.call("pos.order", "sync_from_ui", [serializedOrder], {
                 context,
             });

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -321,6 +321,7 @@ patch(PosStore.prototype, {
                         destinationOrder,
                         adoptingLine
                     );
+                    adoptingLine.skip_change = true;
                 } else {
                     const serialized = orphanLine.serialize();
                     serialized.order_id = destinationOrder.id;
@@ -331,6 +332,7 @@ patch(PosStore.prototype, {
                         false,
                         true
                     );
+                    newOrderLine.skip_change = true;
 
                     const preparationLine =
                         order.last_order_preparation_change.lines[orphanLine.preparationKey];
@@ -346,7 +348,9 @@ patch(PosStore.prototype, {
             }
 
             this.set_order(destinationOrder);
+            order.skip_send_kitchen = true
             await this.deleteOrders([order]);
+            delete order.skip_send_kitchen;
         }
 
         await this.syncAllOrders({ orders: [destinationOrder || order] });


### PR DESCRIPTION
**Problem:**
When merging two tables in the middle of their service, the moving table's order would be deleted and then made again. The problem is that this order would be sent to the kitchen, making the order cancelled and displaying another one with the same content. This would lead to food wastage as the order would be made twice.

**Steps to reproduce:**
- Open the restaurant, chose two tables and make an order for the two of them.
- Confirm the order.
- Drag and drop the tables next to each other to merge them.
- The dragged table's order will be deleted and made again in the kitchen.

**Why the fix**
https://github.com/odoo/odoo/blob/cf525d2a981515d39a126c6dfb5a612338cc8d14/addons/pos_restaurant/static/src/overrides/models/pos_store.js#L349 The order was deleted, causing the kitchen to receive the same order two times. It was done because when merging the tables, the order would be cancelled, and put in the new table's orders that need to be confirmed (order button). It was only when pressing this button that the order was sent again to the kitchen. This was done in two steps, because we needed to first cancel the order and then manually confirm it again. The order is no longer cancelled, the kitchen doesn't get the order twice, as the order is not replaced.

opw-4654226
