### PR TITLE
[FIX] portal_rating: remove edit composer when clicking the comment button

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.js
@@ -34,6 +34,8 @@ patch(Message.prototype, {
                     direction: "none",
                 },
             };
+        } else {
+            this.message.composer = null;
         }
     },
 

--- a/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews_comment.js
@@ -1,0 +1,48 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("course_reviews_comment", {
+    url: "/slides",
+    steps: () => [
+        {
+            trigger: "a:contains(Basics of Gardening - Test)",
+            run: "click",
+        },
+        {
+            trigger: "a[id=review-tab]",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains('comment')",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input",
+            run: "edit Putting a comment...",
+        },
+        // When the comment box is closed, the content of the composer is preserved
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains('comment')",
+            run: "click",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message:not(:has(.o-mail-Composer-input))",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message button:contains('comment')",
+            run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message .o-mail-Composer-input:value('Putting a comment...')",
+        },
+        // Send the comment
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message a:contains('save')",
+            run: "click",
+        },
+        {
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message:contains('Putting a comment...') :not(:has(button:contains('comment')))",
+        },
+    ],
+});

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -199,6 +199,17 @@ class TestUi(TestUICommon):
 
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
+    def test_course_review_comment(self):
+        self.channel._action_add_members(self.user_demo.partner_id)
+        self.channel.with_user(self.user_demo).message_post(
+            body="New Review",
+            message_type="comment",
+            rating_value="3",
+            subtype_xmlid="mail.mt_comment",
+        )
+
+        self.start_tour("/slides", "course_reviews_comment", login=self.user_admin.login)
+
     def test_course_reviews_reaction_public(self):
         password = "Pl1bhD@2!kXZ"
         manager = self.user_admin


### PR DESCRIPTION
Since odoo/odoo#202366 the editing state of the message is no longer used and the edit mode relies on checking the availability of the message composer. Clicking on a comment button opens a composer on the message. When clicking again on this button if we don't remove that composer from the message, the message is assumed to be in edit mode.

Steps to reproduce:
- Install a module that uses the comment feature such as elearning
- Go to the portal view of a course as admin
- In the chatter click on a comment button below a message
- Without saving or canceling the comment, click on the comment button again
- The comment composer is closed but an edit composer in the message is opened