### PR TITLE
[FIX] *: add spacing between addresses on reports

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -10,7 +10,7 @@
                         <div class="col-6">
                             <t t-set="information_block">
                                 <div groups="account.group_delivery_invoice_address" name="shipping_address_block">
-                                    <strong>Shipping Address</strong>
+                                    <strong class="d-block mt-3">Shipping Address</strong>
                                     <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                                 </div>
                             </t>

--- a/addons/l10n_hu_edi/views/report_invoice.xml
+++ b/addons/l10n_hu_edi/views/report_invoice.xml
@@ -48,7 +48,7 @@
             <div t-if="o.partner_id.l10n_hu_group_vat">Group Member Tax ID: <span t-field="o.partner_id.l10n_hu_group_vat"/></div>
             <div groups="account.group_delivery_invoice_address" name="shipping_address_block">
                 <div/>
-                <strong>Shipping Address:</strong>
+                <strong class="d-block mt-3">Shipping Address:</strong>
                 <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
             </div>
         </xpath>

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -27,7 +27,7 @@
                             t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
                     </p>
                     <div class="col-6" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)" groups="account.group_delivery_invoice_address" name="shipping_address_block">
-                        <strong>Shipping Address:</strong>
+                        <strong class="d-block mt-3">Shipping Address:</strong>
                         <div t-field="o.partner_shipping_id" t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
                     </div>
                 </div>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -9,7 +9,7 @@
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">
-                <strong>Shipping address</strong>
+                <strong class="d-block mt-3">Shipping address</strong>
                 <div t-if="o.dest_address_id">
                     <div t-field="o.dest_address_id"
                         t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -10,7 +10,7 @@
         </t>
         <t t-if="o.dest_address_id">
             <t t-set="information_block">
-                <strong>Shipping address:</strong>
+                <strong class="d-block mt-3">Shipping address:</strong>
                 <div t-field="o.dest_address_id"
                     t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}' name="purchase_shipping_address"/>
             </t>

--- a/addons/purchase_stock/report/purchase_report_templates.xml
+++ b/addons/purchase_stock/report/purchase_report_templates.xml
@@ -5,7 +5,7 @@
         <xpath expr="//t[@t-if='o.dest_address_id']" position="after">
             <t t-else="">
                 <t t-set="information_block">
-                    <strong>Shipping address:</strong>
+                    <strong class="d-block mt-3">Shipping address:</strong>
                     <div t-if="o.picking_type_id and o.picking_type_id.warehouse_id">
                         <span t-field="o.picking_type_id.warehouse_id.name"/>
                         <div t-field="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "phone"], "no_marker": True, "phone_icons": True}'/>
@@ -29,7 +29,7 @@
         <xpath expr="//t[@t-if='o.dest_address_id']" position="after">
             <t t-else="">
                 <t t-set="information_block">
-                    <strong>Shipping address:</strong>
+                    <strong class="d-block mt-3">Shipping address</strong>
                     <div t-if="o.picking_type_id and o.picking_type_id.warehouse_id">
                         <span t-field="o.picking_type_id.warehouse_id.name"/>
                         <div t-field="o.picking_type_id.warehouse_id.partner_id" t-options='{"widget": "contact", "fields": ["address", "phone"], "no_marker": True, "phone_icons": True}'/>

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -27,7 +27,7 @@
                 <div t-field="doc.partner_invoice_id"
                     t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                 <t t-if="doc.partner_shipping_id != doc.partner_invoice_id">
-                    <strong>Shipping Address</strong>
+                    <strong class="d-block mt-3">Shipping Address</strong>
                     <div t-field="doc.partner_shipping_id"
                         t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'/>
                 </t>


### PR DESCRIPTION
*: account,l10n_hu_edi,l10n_sa,purchase,purchase_stock,sale

When a Shipping Address is displayed inside the `information_block` there is no spacing to differentiate it from the Invoicing Address, making it harder to read.

The `:` character is inconsistent with other reports, but will be removed in the master forward port to avoid overriding stable translation.

task-4730464

Enterprise PR: https://github.com/odoo/enterprise/pull/84281

| Issue solved in this PR |
|--------|
| ![image](https://github.com/user-attachments/assets/002cfb48-53cf-4a16-a60e-3810ac05a466)| 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
