### PR TITLE
[IMP] mail: add switch camera action for call

### DIFF
--- a/addons/mail/static/src/core/common/settings_model.js
+++ b/addons/mail/static/src/core/common/settings_model.js
@@ -87,6 +87,7 @@ export class Settings extends Record {
             return this.useBlur && rtc.state?.cameraTrack && !hasHardwareAcceleration();
         },
     });
+    cameraFacingMode = undefined;
 
     logRtc = false;
     /**
@@ -107,7 +108,9 @@ export class Settings extends Record {
         const constraints = {
             width: 1280,
         };
-        if (this.cameraInputDeviceId) {
+        if (this.cameraFacingMode) {
+            constraints.facingMode = this.cameraFacingMode;
+        } else if (this.cameraInputDeviceId) {
             constraints.deviceId = this.cameraInputDeviceId;
         }
         return constraints;
@@ -218,6 +221,7 @@ export class Settings extends Record {
      * @param {String} cameraInputDeviceId
      */
     async setCameraInputDevice(cameraInputDeviceId) {
+        this.cameraFacingMode = undefined;
         this.cameraInputDeviceId = cameraInputDeviceId;
         browser.localStorage.setItem(
             "mail_user_setting_camera_input_device_id",

--- a/addons/mail/static/src/discuss/call/common/call_action_list.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_list.xml
@@ -5,7 +5,7 @@
         <div class="o-discuss-CallActionList d-flex flex-column justify-content-center" t-attf-class="{{ className }}" t-ref="root">
             <div class="o-discuss-CallActionList-bar d-flex align-items-center flex-wrap justify-content-between" t-att-class="{ 'w-100 ps-2 pe-2': isSmall }">
                 <t t-if="isOfActiveCall and rtc.selfSession">
-                    <t t-foreach="callActions.actions.slice(0, isMobileOS ? 3 : 4)" t-as="action" t-key="action_index">
+                    <t t-foreach="callActions.actions.slice(0, 4)" t-as="action" t-key="action_index">
                         <CallActionButton action="action" isSmall="isSmall" isActive="action.isActive"/>
                     </t>
                     <CallPopover position="'top-end'" clickToClose="true" contentClass="'o-discuss-CallActionList-dropdown p-1'">
@@ -17,7 +17,7 @@
                         </button>
                         <t t-set-slot="content">
                             <div class="d-flex flex-column py-0">
-                                <span t-foreach="callActions.actions.slice(isMobileOS ? 3 : 4)" t-as="action" t-key="action_index" class="o-discuss-CallActionList-dropdownItem cursor-pointer rounded-1 d-flex align-items-center px-2 py-2 m-0" t-att-title="action.name" t-on-click="action.select">
+                                <span t-foreach="callActions.actions.slice(4)" t-as="action" t-key="action_index" class="o-discuss-CallActionList-dropdownItem cursor-pointer rounded-1 d-flex align-items-center px-2 py-2 m-0" t-att-title="action.name" t-on-click="action.select">
                                     <i t-att-class="{
                                         'fa fa-fw': (action.isActive or !action.inactiveIcon ? action.icon : action.inactiveIcon).includes('fa-'), 
                                         'oi oi-fw': (action.isActive or !action.inactiveIcon ? action.icon : action.inactiveIcon).includes('oi-'),

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -48,6 +48,14 @@ callActionsRegistry
         select: (component) => component.rtc.toggleVideo("camera", { env: component.env }),
         sequence: 30,
     })
+    .add("switch-camera", {
+        condition: (component) => isMobileOS() && component.rtc.selfSession?.is_camera_on,
+        name: _t("Switch Camera"),
+        isActive: () => false,
+        icon: "fa-refresh",
+        select: (component) => component.rtc.toggleCameraFacingMode(),
+        sequence: 40,
+    })
     .add("raise-hand", {
         condition: (component) => component.rtc,
         name: (component) =>

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.js
@@ -13,6 +13,7 @@ export class CallParticipantVideo extends Component {
     setup() {
         super.setup();
         this.rtc = useService("discuss.rtc");
+        this.store = useService("mail.store");
         this.root = useRef("root");
         onMounted(() => this._update());
         onPatched(() => this._update());

--- a/addons/mail/static/src/discuss/call/common/call_participant_video.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_video.xml
@@ -4,6 +4,7 @@
         <video class="w-100 h-100 cursor-pointer"
             t-att-class="{ 'o-inset rounded-1': props.inset }"
             t-att-type="props.type"
+            t-att-data-facing-mode="store.settings.cameraFacingMode"
             playsinline="true"
             autoplay="true"
             muted="true"

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -228,6 +228,22 @@ test("can share user camera", async () => {
     await contains("video", { count: 0 });
 });
 
+test("switch front/back camera in mobile", async () => {
+    mockGetMedia();
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    // Switch camera action is only available for mobiles
+    mockUserAgent("Chrome/0.0.0 Android (OdooMobile; Linux; Android 13; Odoo TestSuite)");
+    expect(isMobileOS()).toBe(true);
+    await start();
+    await openDiscuss(channelId);
+    await click("[title='Start Call']");
+    await click("[title='Turn camera on']");
+    await contains("video[data-facing-mode='user']");
+    await click("[title='Switch Camera']");
+    await contains("video[data-facing-mode='environment']");
+});
+
 test("Camera video stream stays in focus when on/off", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
Purpose of this PR:

- Adds a new "switch camera" action next to the camera toggle on mobile devices.
- Mobile devices now display 4 call actions outside the "More" dropdown instead of 3.
- It enables users to switch between front and rear cameras during an active call.
- RTC service now tracks the current camera facing mode.
- Video stream is reinitialized appropriately when the camera is switched.

task-[4687205](https://www.odoo.com/odoo/project/1519/tasks/4687205)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
