### PR TITLE
[FIX] hr_skills: prevent error when loading sample data for Attendances

### DIFF
--- a/addons/hr_skills/models/hr_employee.py
+++ b/addons/hr_skills/models/hr_employee.py
@@ -46,4 +46,5 @@ class Employee(models.Model):
         demo_tag = self.env.ref('hr_skills.employee_resume_line_emp_eg_1', raise_if_not_found=False)
         if demo_tag:
             return
+        convert.convert_file(self.env, 'hr', 'data/scenarios/hr_scenario.xml', None, mode='init', kind='data')
         convert.convert_file(self.env, 'hr_skills', 'data/scenarios/hr_skills_scenario.xml', None, mode='init', kind='data')


### PR DESCRIPTION
Currently, an error occurs when loading sample data for **Attendances** if a referenced employee record has been deleted by the user.

**Steps to reproduce:**
- Install the `hr_appraisal` module without demo data.
- Load sample data for **Appraisals**.
- Navigate to **Employees** and delete record for **Emma Granger**.
- Install `hr_attendance` module and load sample data for **Attendances**.
- Observe the error.

**Error:**
`ValueError - ParseError('while parsing /home/odoo/src/odoo/saas-18.2/addons/hr_skills/data/scenarios/hr_skills_scenario.xml:209, ...`

The error occurs because the method at [1] tries to load the `hr_skills_scenario.xml` file, which references a deleted `employee_id` [2], resulting in a parsing failure.

[1] - https://github.com/odoo/odoo/blob/547327f30d2d4bf778b9d358dbea4b133d55188a/addons/hr_skills/models/hr_employee.py#L49
[2] - https://github.com/odoo/odoo/blob/5c1db495828a7fe8c6ec987de432b1916ad32922/addons/hr_skills/data/scenarios/hr_skills_scenario.xml#L210

This commit ensures that all the referenced data is loaded properly, preventing errors due to missing references.

Sentry - 6426462322