### PR TITLE
[FIX] account: fix traceback when send and print invoices in batch

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -684,6 +684,23 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         ])
         self.assertEqual(len(invoice_attachments), 1)
 
+    def test_send_invoice_batch_with_origin_id(self):
+        invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)
+        invoice2 = self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)
+
+        wizard = self.env['account.move.send.batch.wizard'].with_context(
+            active_model='account.move',
+            active_ids=(invoice1 + invoice2).ids
+        ).new()
+
+        self.assertEqual(wizard.summary_data, {'email': {'count': 2, 'label': 'by Email'}})
+        self.assertEqual(len(wizard.move_ids), 2)
+        self.assertFalse(wizard.alerts)
+
+        results = wizard.action_send_and_print()
+        self.assertEqual(results['type'], 'ir.actions.client')
+        self.assertEqual(results['params']['next']['type'], 'ir.actions.act_window_close')
+
     def test_invoice_multi_email_missing(self):
         invoice1 = self.init_invoice("out_invoice", partner=self.partner_a, amounts=[1000], post=True)
         invoice2 = self.init_invoice("out_invoice", partner=self.partner_b, amounts=[1000], post=True)

--- a/addons/account/wizard/account_move_send_batch_wizard.py
+++ b/addons/account/wizard/account_move_send_batch_wizard.py
@@ -42,7 +42,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
 
             for move in wizard.move_ids:
                 edi_counter += Counter([edi for edi in self._get_default_extra_edis(move)])
-                sending_settings = self._get_default_sending_settings(move)
+                sending_settings = self._get_default_sending_settings(move._origin)
                 sending_method_counter += Counter([
                     sending_method
                     for sending_method in self._get_default_sending_methods(move)
@@ -60,7 +60,7 @@ class AccountMoveSendBatchWizard(models.TransientModel):
     @api.depends('summary_data')
     def _compute_alerts(self):
         for wizard in self:
-            moves_data = {move: self._get_default_sending_settings(move) for move in wizard.move_ids}
+            moves_data = {move: self._get_default_sending_settings(move._origin) for move in wizard.move_ids}
             wizard.alerts = self._get_alerts(wizard.move_ids, moves_data)
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Currently, a traceback is occurring when the user tries to send and print invoices in batch.

<b>To reproduce this issue:</b>

1) Open the customer invoices list view in Accounting 
2) Select multiple posted invoices and click send

<b>Error:- </b>
```
KeyError: <NewId origin=2125>
```

<b>Cause:</b>

The issue arises because the wizard record has not been saved, 
resulting in an issue in returning the origin id for move while computing the `_compute_alerts` method.

This leads to the traceback from the below line because self.id origin id in this case.

https://github.com/odoo/odoo/blob/255a612a63be883bf9b73fff1bca4f66db430091/addons/mail/models/mail_thread.py#L1953-L1955

<b>Solution:-</b>

Instead of passing the record with origin id, we can pass the actual move record.

opw-4750394

