### PR TITLE
[FIX] project: prevent error when no suggested partners are returned

### DIFF
--- a/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
@@ -13,12 +13,7 @@ patch(SuggestionService.prototype, {
                 { abortSignal }
             );
             this.store.insert(suggestedPartners);
-            const suggestedPartnersIds = suggestedPartners["res.partner"].map(
-                (partner) => partner.id
-            );
-            thread.limitedMentions = Object.values(this.store.Persona.records).filter((persona) =>
-                suggestedPartnersIds.includes(persona.id)
-            );
+            thread.limitedMentions = suggestedPartners["res.partner"];
         }
         return super.fetchPartners(...arguments);
     },


### PR DESCRIPTION
Before this commit,
mapping over `suggestedPartners['res.partner']` without checking caused runtime errors when the RPC returned no data.

removed the mapping step and adding data to store as returned by server

task-[4737958](https://www.odoo.com/odoo/project/1519/tasks/4737958)