### PR TITLE
[FIX] stock: avoid error when scrap location is missing

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -82,7 +82,7 @@ class StockScrap(models.Model):
             for company, stock_warehouse_id in groups
         }
         for scrap in self:
-            scrap.scrap_location_id = locations_per_company[scrap.company_id.id]
+            scrap.scrap_location_id = locations_per_company.get(scrap.company_id.id)
 
     @api.depends('move_ids', 'move_ids.move_line_ids.quantity', 'product_id')
     def _compute_scrap_qty(self):

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -6888,3 +6888,15 @@ class StockMove(TransactionCase):
             {'quantity': 149.97, 'quantity_product_uom': 5.29},
             {'quantity': 0.03, 'quantity_product_uom': 0},
         ])
+
+    def test_scrap_creation_without_scrap_location(self):
+        """Test that a scrap can be created when no scrap location is available."""
+        scrap_location = self.env['stock.location'].search([('company_id', '=', self.env.company.id), ('scrap_location', '=', True)], limit=1)
+        scrap_location.write({'scrap_location': False})
+
+        scrap_form = Form(self.env['stock.scrap'])
+        scrap_form.product_id = self.product
+        scrap_form.scrap_qty = 1
+
+        self.assertTrue(scrap_form, "Scrap record should be created successfully.")
+        self.assertFalse(scrap_form.scrap_location_id)


### PR DESCRIPTION
This error occurs when the `Scrap Location` is disabled on a location, and we tried to create a New scrap record.

Steps to reproduce:
---
- Install `stock` module
- Inventory > Configurations > Settings > Enable `Storage Locations`
- Configurations > Locations > Remove Filter > Select `Virtual Locations/Scrap`
- Disable `Is a Scrap Location`
- Inventory > Operations > Scrap > New Scrap

Traceback:
---
`KeyError: 1`

At [1], the `groups` result is empty because no location with `Scrap Location` enabled is found. As a result, `locations_per_company` is empty, and accessing `locations_per_company[scrap.company_id.id]` causes a KeyError.

[1]- https://github.com/odoo/odoo/blob/3ddb91bf0e90177f12cec2c475ae57653c7032df/addons/stock/models/stock_scrap.py#L77-L85

sentry-6572853788

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
