### PR TITLE
[IMP] im_livechat: remove agent display name from channel kanban card

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel_member_history.py
+++ b/addons/im_livechat/models/im_livechat_channel_member_history.py
@@ -66,12 +66,13 @@ class ImLivechatChannelMemberHistory(models.Model):
                 history.agent_expertise_ids or history.member_id.agent_expertise_ids
             )
 
-    @api.depends("partner_id.name", "guest_id.name")
+    @api.depends("livechat_member_type", "partner_id.name", "partner_id.display_name", "guest_id.name")
     def _compute_display_name(self):
         for history in self:
-            history.display_name = (
-                history.partner_id.name or history.guest_id.name or self.env._("Unknown")
-            )
+            name = history.partner_id.name or history.guest_id.name
+            if history.partner_id and history.livechat_member_type == "visitor":
+                name = history.partner_id.display_name
+            history.display_name = name or self.env._("Unknown")
 
     @api.depends("partner_id.avatar_128", "guest_id.avatar_128")
     def _compute_avatar_128(self):

--- a/addons/im_livechat/static/src/views/discuss_channel_kanban/one2many_names_field.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_kanban/one2many_names_field.js
@@ -1,0 +1,18 @@
+import { formatList } from "@web/core/l10n/utils";
+import { registry } from "@web/core/registry";
+import { ListX2ManyField } from "@web/views/fields/x2many/list_x2many_field";
+
+export class One2manyNamesField extends ListX2ManyField {
+    get formattedValue() {
+        return formatList(
+            this.props.record.data[this.props.name].records.map((r) => r.data.display_name)
+        );
+    }
+}
+
+registry.category("fields").add("im_livechat.one2many_names", {
+    component: One2manyNamesField,
+    relatedFields() {
+        return [{ name: "display_name", type: "char" }];
+    },
+});

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -69,7 +69,7 @@
                         <t t-name="card">
                             <div class="d-flex">
                                 <div class="d-flex flex-column">
-                                    <field class="fw-bolder" name="name"/>
+                                    <field class="fw-bolder" name="livechat_customer_history_ids" widget="im_livechat.one2many_names"/>
                                     <span class="fw-bold">Date: <field name="create_date" class="fw-normal"/></span>
                                     <span class="fw-bold">Duration: <field class="d-inline fw-normal" name="duration" widget="float_time" options="{'displaySeconds': True}"/></span>
                                     <span class="fw-bold">Messages: <field name="message_count" class="fw-normal"/></span>


### PR DESCRIPTION
**Current behavior before PR:**

channel kanban card displayed both the visitor and agent name in display name.

**Desired behavior after PR is merged:**

now only visitor name displayed for better visibility.

task-[4753171](https://www.odoo.com/odoo/project/1519/tasks/4753171)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
