### PR TITLE
[FIX] fleet: fix mail to driver action

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -417,6 +417,5 @@ class FleetVehicle(models.Model):
             'res_model': 'fleet.vehicle.send.mail',
             'context': {
                 'default_vehicle_ids': self.ids,
-                'default_render_model': 'fleet.vehicle',
             }
         }

--- a/addons/fleet/wizard/fleet_vehicle_send_mail.py
+++ b/addons/fleet/wizard/fleet_vehicle_send_mail.py
@@ -15,6 +15,10 @@ class FleetVehicleSendMail(models.TransientModel):
         'ir.attachment', 'fleet_vehicle_mail_compose_message_ir_attachments_rel',
         'wizard_id', 'attachment_id', string='Attachments')
 
+    @api.depends('subject')
+    def _compute_render_model(self):
+        self.render_model = 'fleet.vehicle'
+
     @api.onchange('template_id')
     def _onchange_template_id(self):
         self.attachment_ids = self.template_id.attachment_ids


### PR DESCRIPTION
This commit changed the way to give the render_model to the model fleet_vehicle_send_mail (introduced by this commit : #61221b2e6552b21508a6a36ab69352e6793d70c5)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
