### PR TITLE
[FIX] base_automation: fixed multiple sql transaction error by automation

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -1072,18 +1072,17 @@ class BaseAutomation(models.Model):
             now = self.env.cr.now()
             records = automation._search_time_based_automation_records(until=now)
             # run the automation on the records
-            try:
-                for record in records:
+            for record in records:
+                try:
                     automation._process(record)
-                self.env.flush_all()
-            except Exception as e:
-                if not auto_commit:
-                    raise
-                self.env.cr.rollback()
-                _logger.exception("Error in time-based automation rule `%s`.", automation.name)
-                final_exception = e
-                continue
-
+                except Exception as e:
+                    if not auto_commit:
+                        raise
+                    self.env.cr.rollback()
+                    _logger.exception("Error in time-based automation rule `%s`.", automation.name)
+                    final_exception = e
+                    continue
+            self.env.flush_all()
             automation.write({'last_run': now})
             if auto_commit:
                 # auto-commit for batch processing


### PR DESCRIPTION
SQL traceback occurs when user creates their own automation rule involving python code.

**Steps to reproduce:**
Install base_automation,discuss if not already installed
* `Setting> Technical>Automation rules`
* name it as `Whatsapp add admin`
* model as `discuss channel` and trigger `after creation` any amount of time
* `Add an action>Execute code`
* Add the following code:  

```python
try: 
 env['discuss.channel.member'].create({ 'partner_id': 1,  # Likely invalid 'channel_id': 1, }) 
except Exception: 
 pass

env['res.partner'].search([], limit=1)
```

* Go to `techinical>automation>scheduled actions>Automation rules:check and execute` run it manually.

`ValueError:InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\n') while evaluating
'model._cron_process_time_based_actions()'`

**Solution:**
* Place try and except inside the loop to handle errors per record and allow the loop to continue and handle the transaction error better.
* This will only one occurence of the error instead of repeating occurrence each time the cron runs.

**Sentry-6562754804**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
