### PR TITLE
[IMP] l10n_it_edi_proxy: Users identification through aliases

### DIFF
--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -29,6 +29,11 @@ class AccountEdiProxyClientUser(models.Model):
             return company.partner_id._l10n_it_edi_normalized_codice_fiscale()
         return super()._get_proxy_identification(company, proxy_type)
 
+    def _get_iap_params(self, company, proxy_type, private_key_sudo):
+        iap_params = super()._get_iap_params(company, proxy_type, private_key_sudo)
+        iap_params['l10n_it_vat'] = company.vat
+        return iap_params
+
     def _register_proxy_user(self, company, proxy_type, edi_mode):
         if proxy_type == 'l10n_it_edi':
             company = company._l10n_it_get_edi_company()


### PR DESCRIPTION
This improvement addresses an issue in the Italian e-invoicing (l10n_it_edi) and IAP registration logic where incoming vendor bills with only a VAT number failed to match the correct registered EDI user.

Changes introduced:
- Added `edi_identification_secondary` (e.g. VAT number) to support fallback user matching.
- Updated the `/create_user` endpoint to accept and store the secondary identifier.
- Modified `create_user` logic to send both primary and secondary IDs from Odoo.
- Prepared the base for matching incoming invoices against both identifiers.

See also: odoo/iap-apps#1056

Task [link](https://www.odoo.com/odoo/project/967/tasks/4619718)
task-4619718