### PR TITLE
[FIX] web_editor, *: fix background repeat issues with multi-layer setup

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -7906,6 +7906,11 @@ registry.BackgroundToggler = SnippetOptionWidget.extend({
      */
     toggleBgImage(previewMode, widgetValue, params) {
         if (!widgetValue) {
+            // When background image with position "Repeat pattern" is removed,
+            // remove background size to avoid repeating gradient
+            const targetEl = this.$target[0];
+            targetEl.style.removeProperty("background-size");
+            targetEl.classList.remove("o_bg_img_opt_repeat");
             this.$target.find('> .o_we_bg_filter').remove();
             // TODO: use setWidgetValue instead of calling background directly when possible
             const [bgImageWidget] = this._requestUserValueWidgets('bg_image_opt');
@@ -8686,7 +8691,9 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
     backgroundType: function (previewMode, widgetValue, params) {
         this.$target.toggleClass('o_bg_img_opt_repeat', widgetValue === 'repeat-pattern');
         this.$target.css('background-position', '');
-        this.$target.css('background-size', widgetValue !== 'repeat-pattern' ? '' : '100px');
+        // Set image size to "100px" for repeating, and "cover" for gradient.
+        // Ensures gradient doesn’t repeat while image does.
+        this.$target[0].style.backgroundSize = widgetValue !== "repeat-pattern" ? "" : "100px, cover";
     },
     /**
      * Saves current background position and enables overlay.
@@ -8731,10 +8738,21 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
      * @override
      */
     selectStyle: function (previewMode, widgetValue, params) {
-        if (params.cssProperty === 'background-size'
-                && !this.$target.hasClass('o_bg_img_opt_repeat')) {
-            // Disable the option when the image is in cover mode, otherwise
-            // the background-size: auto style may be forced.
+        if (params.cssProperty === "background-size") {
+            const targetEl = this.$target[0];
+            if (!targetEl.classList.contains("o_bg_img_opt_repeat")) {
+                // Disable the option when the image is in cover mode, otherwise
+                // the background-size: auto style may be forced.
+                return;
+            }
+            const sizeLayers = getComputedStyle(targetEl)
+                .getPropertyValue("background-size")
+                .split(",")
+                .map((bgSize) => bgSize.trim());
+            // Update only the image layer's background-size (first layer)
+            // while keeping other layers (e.g., gradient) unchanged.
+            sizeLayers[0] = widgetValue;
+            targetEl.style.setProperty("background-size", sizeLayers.join(", "));
             return;
         }
         this._super(...arguments);
@@ -8754,8 +8772,17 @@ registry.BackgroundPosition = SnippetOptionWidget.extend({
      * @override
      */
     _computeWidgetState: function (methodName, params) {
-        if (methodName === 'backgroundType') {
-            return this.$target.css('background-repeat') === 'repeat' ? 'repeat-pattern' : 'cover';
+        const computedStyle = getComputedStyle(this.$target[0]);
+        if (methodName === "backgroundType") {
+            return computedStyle.backgroundRepeat.includes("no-repeat")
+                ? "cover"
+                : "repeat-pattern";
+        }
+        if (methodName === "selectStyle" && params.cssProperty === "background-size") {
+            const bgSize = computedStyle.getPropertyValue("background-size").trim();
+            // Handle multi-layer background (image + gradient)
+            // return first layer's size
+            return bgSize.split(",")[0].trim();
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2168,6 +2168,12 @@ options.registry.Parallax = options.Class.extend({
                 this.parallaxEl = document.createElement('span');
                 this.parallaxEl.classList.add('s_parallax_bg');
                 this.$target.prepend(this.parallaxEl);
+                // Remove the repeat class and background-size from the original
+                // target to prevent gradient repetition in multi-background
+                // setup (image + gradient).
+                const targetEl = this.$target[0];
+                targetEl.style.removeProperty("background-size");
+                targetEl.classList.remove("o_bg_img_opt_repeat");
             }
         } else {
             if (this.parallaxEl) {


### PR DESCRIPTION
*=website

Target: 17.0 to saas-18.3

Issue: 
This issue applies to any block where multiple backgrounds are present (gradient + image).

Steps to Reproduce:
1. Drop a masonry snippet onto the page.
2. Select a block and change the background color to the gradient.
3. Add background image.
3. Change the image position from "Cover" to "Repeat Pattern."
4. Observe the traceback in the console.

Reason:
The issue occurred due to incorrect parsing of CSS background values when multiple background layers were applied (e.g., a gradient + image). When both are set, the element ends up with multiple background-related properties. Previously, In setValue method, Inside MultiUserValueWidget when value = "100px, 100px", the resulting values array was ['100px,', '100px'], which included an extra comma. This has now been corrected to properly handle such cases.

Other edge cases fixed:
1. Gradient was repeating along with the image.
2. Switching to parallax after repeat-pattern causes gradient to repeat.
3. Removing image kept repeat class, causing gradient to repeat.

Fix Summary:
1. We updated `selectStyle` and _computeWidgetState to correctly handle multi-layer background-size and repeat styles.
In selectStyle, we set the height and width values from options and apply them only to the image layer (not gradient), keeping the gradient layer unchanged.
In `_computeWidgetState`, we fetch the background-size from the target and, if multiple layers are present, return only the first one (image layer), since height and width options apply only to that. Now, setValue receives only single-layer values like
`100px 50px`, ensuring correct behavior.
Set background-size 'cover' to gradient which ensures only the image
repeats while the gradient remains fixed.
2. Remove `o_bg_img_opt_repeat` and reset background-size when
   - Image is removed.
   - Switching to parallax.
   
task-4577864