### PR TITLE
[FIX] pos_loyalty: require pos_discount for global discount test

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1080,6 +1080,9 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.start_pos_tour("PosLoyalty2DiscountsSpecificGlobal")
 
     def test_specific_product_discount_with_global_discount(self):
+        if self.env['ir.module.module']._get('pos_discount').state != 'installed':
+            self.skipTest("pos_discount module is required for this test")
+
         self.env['loyalty.program'].search([]).write({'active': False})
 
         self.discount_product = self.env["product.product"].create({


### PR DESCRIPTION
PR #202334 introduced a test in `pos_loyalty` that depends on the field `discount_product_id` that is created in the module `pos_discount`. However, `pos_loyalty` and `pos_discount` does not have dependence, so the fails if `pos_discount` is not installed.

This PR only runs it when `pos_discount` is installed.

opw-4622428