### PR TITLE
[FIX] iot_box_image: add odoo user to dialout grp

### DIFF
--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -286,6 +286,7 @@ usermod -a -G video odoo
 usermod -a -G render odoo
 usermod -a -G lp odoo
 usermod -a -G input odoo
+usermod -a -G dialout odoo
 usermod -a -G pi odoo
 mkdir -v /var/log/odoo
 chown odoo:odoo /var/log/odoo


### PR DESCRIPTION
When connecting the new image to v16 serial drivers get an error when trying to open a new serial connection with "access denied" This PR fixes this issue by adding odoo user to "dialout" group which grants it the required access (= control over serial interfaces)
