### PR TITLE
[FIX] mail: fix issue regarding send invoices in batch

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1983,7 +1983,7 @@ class MailThread(models.AbstractModel):
         if self and len(self) != len(records_emails):
             raise ValueError('Invoke with either self maching records_emails, either on a void recordset.')
         # when invoked through MailThread, ids may come from records_emails (not recommended tool usage)
-        res_ids = self.ids or [record.id for record in records_emails]
+        res_ids = self._ids or [record.id for record in records_emails]
         found_results = dict.fromkeys(res_ids, self.env['res.partner'])
         # email_key is email_normalized, unless email is wrong and cannot be normalized
         # in which case the raw input is used instead, to distinguish various wrong


### PR DESCRIPTION
[FIX] mail: fixed issue regarding send the invoice in batch

PURPOSE:
- To solve the below trackback. 
```py
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/fields.py", line 1603, in 
      compute_value  records._compute_field_value(self)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/models.py", line 4581, in 
_compute_field_value  determine(field.compute, self)
  File "/home/odoo/src/odoo/saas-18.2/odoo/orm/fields.py", line 69, in determine
    return needle(*args)
           ^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.2/addons/account/wizard/
  account_move_send_batch_wizard.py", line 63, in _compute_alerts
    moves_data = {move: self._get_default_sending_settings(move) for move in 
    wizard.move_ids}
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/home/odoo/src/odoo/saas-18.2/addons/account/models/account_move_send.py"
 line 90, in _get_default_sending_settings
    'mail_partner_ids': get_setting('mail_partner_ids', default_value=
  self._get_default_mail_partner_ids(move, mail_template, mail_lang).ids),
                                          ^^^^^^^^^^
File "/home/odoo/src/odoo/saas-18.2/addons/account/models/account_move_send.py",
   line 177, in _get_default_mail_partner_ids
    partners |= move._partner_find_from_emails_single(
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/odoo/src/odoo/saas-18.2/addons/mail/models/mail_thread.py", 
   line 1955, in _partner_find_from_emails_single
    return self._partner_find_from_emails(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: <NewId origin=10645736>
```
#STEPS TO REPRODUCE:- 
 1) Install Invoicing from Apps.
 1) Create more then one  invoices (fill necessary details to post them) and 
    post the invoice by clicking  on confirm button
 3) select more then one invoice from list view of invoice and click on the 
     "Send" button 
 4) The Error above shown will be there.

#SPECIFICATION
 - The core issue is inside method _partner_find_from_emails.
 - the move passed in argument is of type 'NewId origin=45'
 - _partner_find_from_emails_single method has empty record-set for res.partner
