### PR TITLE
[FIX] hr_holidays_attendance: unlink overtime_id if not deductable

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -52,6 +52,7 @@ class HRLeave(models.Model):
         # If the type of leave is overtime deductible, we have to check that the employee has enough extra hours
         for leave in leaves:
             if not leave.overtime_deductible:
+                leave.overtime_id.sudo().unlink()
                 continue
             employee = leave.employee_id.sudo()
             duration = leave.number_of_hours_display


### PR DESCRIPTION
This commit fixes a bug that occurs when switching a leave request of type "Extra Hours" to another time-off type. The issue happens when editing a leave request that allows deduction from overtime, as it remains linked to attendance overtime that needs to be unlinked.

task-4756706

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
