### PR TITLE
[IMP] website: add city name in MockRequest

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -17,7 +17,7 @@ HOST = '127.0.0.1'
 @contextlib.contextmanager
 def MockRequest(
     env, *, path='/mockrequest', routing=True, multilang=True,
-    context=frozendict(), cookies=frozendict(), country_code=None,
+    context=frozendict(), cookies=frozendict(), country_code=None, city_name=None,
     website=None, remote_addr=HOST, environ_base=None, url_root=None,
 ):
     # TODO move MockRequest to a package in addons/web/tests
@@ -73,11 +73,11 @@ def MockRequest(
         request.httprequest.url = werkzeug.urls.url_join(url_root, path)
     if website:
         request.website_routing = website.id
-    if country_code:
+    if country_code or city_name:
         try:
-            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
+            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country=(country_code and {'iso_code': country_code}) or {}, city=(city_name and {'names': {'en': city_name}}) or {})
         except TypeError:
-            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
+            request.geoip._city_record = odoo.http.geoip2.models.City({'country': (country_code and {'iso_code': country_code}) or {}, 'city': (city_name and {'names': {'en': city_name}}) or {}})
 
     # The following code mocks match() to return a fake rule with a fake
     # 'routing' attribute (routing=True) or to raise a NotFound


### PR DESCRIPTION
[IMP] website: add city name in MockRequest
Before this commit:
- mocking request city is possible only with the country, city record
contains country attribute but not the city informations like name.

After this commit:
- it's possible to mock the city by prividing its name according to 'en' local.

Related PR: https://github.com/odoo/enterprise/pull/84322
task-4745995