### PR TITLE
[FIX] point_of_sale: not load point_of_sale on iot

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/odoo.conf
+++ b/addons/point_of_sale/tools/posbox/configuration/odoo.conf
@@ -7,4 +7,4 @@ pidfile = /var/run/odoo/odoo.pid
 limit_time_cpu = 600
 limit_time_real = 1200
 max_cron_threads = 0
-server_wide_modules=hw_drivers,hw_escpos,hw_posbox_homepage,point_of_sale,web
+server_wide_modules=hw_drivers,hw_escpos,hw_posbox_homepage,web


### PR DESCRIPTION
THis PR removes the module "point_of_sale" from the modules which are loaded by Odoo on the IoT Box in v16.
Since on the IoT Box "point_of_sale" module is downloaded via a sparse checkout it only has some configuration files and doesn't need to be loaded.
This fixes the following error in the logs:
```
2025-04-28 14:27:34,185 9805 CRITICAL ? odoo.modules.module: Couldn't load module point_of_sale 2025-04-28 14:27:34,185 9805 CRITICAL ? odoo.modules.module: 'post_load' 2025-04-28 14:27:34,185 9805 ERROR ? odoo.service.server: Failed to load server-wide module `point_of_sale`. Traceback (most recent call last):
  File "/home/pi/odoo/odoo/service/server.py", line 1275, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "/home/pi/odoo/odoo/modules/module.py", line 477, in load_openerp_module
    if info['post_load']:
```