### PR TITLE
[FIX] sale_stock: properly initialize warehouse_id in Sale Orders

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -56,15 +56,19 @@ class SaleOrder(models.Model):
         """
         if column_name != "warehouse_id":
             return super(SaleOrder, self)._init_column(column_name)
-        field = self._fields[column_name]
-        default = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
-        value = field.convert_to_write(default, self)
-        value = field.convert_to_column(value, self)
-        if value is not None:
-            _logger.debug("Table '%s': setting default value of new column %s to %r",
-                self._table, column_name, value)
-            query = f'UPDATE "{self._table}" SET "{column_name}" = %s WHERE "{column_name}" IS NULL'
-            self._cr.execute(query, (value,))
+
+        default_warehouse = self.env["stock.warehouse"].search([], limit=1)
+
+        query = """
+        UPDATE sale_order so
+        SET warehouse_id = COALESCE(wh.id, %s)
+        FROM stock_warehouse wh
+        WHERE so.company_id = wh.company_id
+        """
+        params = [default_warehouse.id]
+
+        _logger.debug("Initializing column '%s' in table '%s'", column_name, self._table)
+        self._cr.execute(query, params)
 
     @api.depends('picking_ids.date_done')
     def _compute_effective_date(self):


### PR DESCRIPTION
Steps to reproduce:
   - Install sales
   - Create a new company (CMP2)
   - Switch to CMP2
   - Create a sales order
   - Install stock
   - Go to the SO created, update it and save

The problem is that in a multi-company environment, we cannot access
the warehouse of a different company. In the sale_order model, the
`_init_column` method populates the warehouse value for existing sales
orders before stock is installed. It uses self.env.company to set
the warehouse, but `_init_column` is called with superuser privileges,
which lack user context. This causes warehouses to always be linked to
the superuser's company (id=1). As a result, modifying sales orders
from different companies becomes impossible.

opw-4735086

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
