### PR TITLE
[FIX] stock: fix setting the default lot sequence in case of null prefix

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -843,7 +843,7 @@ class ProductTemplate(models.Model):
                     template.lot_sequence_id = new_sequence
                     sequences_by_prefix[template.serial_prefix_format] = new_sequence
             else:
-                template.lot_sequence_id = False
+                template.lot_sequence_id = self.env.ref('stock.sequence_production_lots', raise_if_not_found=False)
 
     @api.depends('serial_prefix_format', 'lot_sequence_id')
     def _compute_next_serial(self):

--- a/addons/stock/tests/test_stock_lot.py
+++ b/addons/stock/tests/test_stock_lot.py
@@ -309,3 +309,14 @@ class TestLotSerial(TestStockCommon):
         lot_id = self.env['stock.lot'].search([('partner_ids.name', 'ilike', 'bo')])
         self.assertEqual(len(lot_id), 1)
         self.assertEqual(lot_id, self.lot_p_a)
+
+    def test_default_lot_sequence(self):
+        """Test that the default lot sequence is used when the product is created with a null prefix"""
+        product_a = self.env['product.product'].create({
+            'name': 'Test Product A',
+            'tracking': 'lot',
+            'serial_prefix_format': False,
+        })
+        default_lot_sequence = self.env.ref('stock.sequence_production_lots')
+        product_a.invalidate_recordset()
+        self.assertEqual(product_a.lot_sequence_id, default_lot_sequence)


### PR DESCRIPTION
This commit fixes setting the default sequence for serials/lots introduced in #200395. Previously, the sequence was set to False when the custom prefix is empty. Now it falls back to the default serials sequence defined in the module data.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
