### PR TITLE
[FIX] analytic: update plan parents with hierarchies

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -299,7 +299,7 @@ class AccountAnalyticPlan(models.Model):
                 self.env['account.analytic.account']._update_accounts_in_analytic_lines(
                     new_fname=new_parent._column_name(),
                     current_fname=plan._column_name(),
-                    accounts=plan.account_ids,
+                    accounts=self.env['account.analytic.account'].search([('plan_id', 'child_of', plan.id)]),
                 )
 
         res = super().write(vals)
@@ -310,7 +310,7 @@ class AccountAnalyticPlan(models.Model):
                 self.env['account.analytic.account']._update_accounts_in_analytic_lines(
                     new_fname=plan._column_name(),
                     current_fname=previous_parent._column_name(),
-                    accounts=plan.account_ids,
+                    accounts=self.env['account.analytic.account'].search([('plan_id', 'child_of', plan.id)]),
                 )
         return res
 

--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -310,7 +310,34 @@ class TestAnalyticAccount(TransactionCase):
         self.env['account.analytic.line'].create({
             'name': 'test',
             plan_1_col: self.analytic_account_1.id,
-            plan_2_col: self.analytic_account_2.id,
+            plan_2_col: self.analytic_account_3.id,
         })
         with self.assertRaisesRegex(RedirectWarning, "Making this change would wipe out"):
             self.analytic_plan_1.parent_id = self.analytic_plan_2
+
+    def test_change_parent_plan_with_intermediate(self):
+        """All the accounts are updated even if not direct members of the plan changed."""
+        plan_1_col = self.analytic_plan_1._column_name()
+        plan_2_col = self.analytic_plan_2._column_name()
+        intermediate_plan = self.env['account.analytic.plan'].create({
+            'name': 'Mid level',
+            'parent_id': self.analytic_plan_1.id,
+        })
+        self.analytic_account_1.plan_id = intermediate_plan
+        line = self.env['account.analytic.line'].create({
+            'name': 'test',
+            plan_1_col: self.analytic_account_1.id,
+        })
+
+        # Setting a parent plan should lead to the line having analytic_account_1 under Plan 2
+        self.analytic_plan_1.parent_id = self.analytic_plan_2
+        self.assertRecordValues(line, [{
+            plan_2_col: self.analytic_account_1.id,
+        }])
+
+        # Removing the parent plan should fully reverse the analytic line
+        self.analytic_plan_1.parent_id = False
+        self.assertRecordValues(line, [{
+            plan_1_col: self.analytic_account_1.id,
+            plan_2_col: False,
+        }])


### PR DESCRIPTION
If a plan B has sub plans (C1, C2) already with analytics entries, and then plan B is updated to also have a parent plan A, hence the structure would be A/B/C1 and A/B/C2, the Analytic entries data on the sub plans is cleared off from C1 and C2.

opw-4338406
