### PR TITLE
[IMP] fleet: add license plate and tags field to quick create view

### DIFF
--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -274,6 +274,8 @@
             <form>
                 <group>
                     <field name="model_id" placeholder="e.g. Model S"/>
+                    <field name="license_plate" placeholder="e.g. PAE 326"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                 </group>
             </form>
         </field>


### PR DESCRIPTION
This commit adds license plate and tags fields to the quick create view.

task-4748528

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
