### PR TITLE
[FIX] hr_holidays: Add Validation in _compute_number_of_days()

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -259,7 +259,11 @@ class HolidaysAllocation(models.Model):
             if allocation_unit != 'hour':
                 allocation.number_of_days = allocation.number_of_days_display
             elif allocation_unit == 'hour' and allocation.employee_id:
-                allocation.number_of_days = allocation.number_of_hours_display / allocation.employee_id._get_hours_per_day(allocation.date_from)
+                employee_hours_per_day = allocation.employee_id._get_hours_per_day(allocation.date_from)
+                if not employee_hours_per_day:
+                    employee_hours_per_day = allocation.employee_id.resource_calendar_id.hours_per_day or\
+                        allocation.employee_id.company_id.resource_calendar_id.hours_per_day or 8.0
+                allocation.number_of_days = allocation.number_of_hours_display / employee_hours_per_day
 
     @api.depends('holiday_status_id', 'allocation_type')
     def _compute_accrual_plan_id(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Hour-based Time Off allocations use employee working hours for calculation. 
Contractors may have 0 hours/week as their working schedule. 
This caused ZeroDivisionError during time off allocation. 
Clients faced server errors, assuming Odoo was at fault. 

Current behavior before PR:
![image](https://github.com/user-attachments/assets/f6385a12-3ef6-4bc1-a16a-f8b5ebf69898)

Desired behavior after PR is merged:
![image](https://github.com/user-attachments/assets/531d1cbb-0201-4289-993b-08e9cb4db7a7)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
