### PR TITLE
[FIX] l10n_it_edi: export non-EU VAT number

### DIFF
--- a/addons/l10n_it_edi/models/res_partner.py
+++ b/addons/l10n_it_edi/models/res_partner.py
@@ -41,9 +41,12 @@ class ResPartner(models.Model):
         """ Generates all partner values needed by l10n_it_edi XML export.
 
             VAT number:
-            If there is a VAT number and the partner is not in EU, then the exported value is 'OO99999999999'
+            If there is a VAT number and the partner is not in EU, then we use the VAT number as is,
+                as an alphanumeric value identifying the counterparty, up to a maximum of
+                28 alphanumeric characters, on which the SdI does not perform validity checks.
             If there is a VAT number and the partner is in EU, then remove the country prefix
-            If there is no VAT and the partner is not in Italy, then the exported value is '0000000'
+            If there is no VAT and the partner is not in EU, then the exported value is 'OO99999999999'
+            If there is no VAT and the partner is in EU, then the exported value is '0000000'
             If there is no VAT and the partner is in Italy, the VAT is not set and Codice Fiscale will be relevant in the XML.
             If there is no VAT and no Codice Fiscale, the invoice is not even exported, so this case is not handled.
 
@@ -73,8 +76,7 @@ class ResPartner(models.Model):
         # VAT number and country code
         normalized_vat = self.vat
         normalized_country = self.country_code
-        has_vat = self.vat and not self.vat in ['/', 'NA']
-        if has_vat:
+        if has_vat := self.vat not in [False, '/', 'NA']:
             normalized_vat = self.vat.replace(' ', '')
             if in_eu:
                 # If there is no country-code prefix, it's domestic to Italy
@@ -89,17 +91,15 @@ class ResPartner(models.Model):
             # If customer is from San Marino
             elif is_sm:
                 normalized_vat = normalized_vat if normalized_vat[:2].isdecimal() else normalized_vat[2:]
-            # The Tax Agency arbitrarily decided that non-EU VAT are not interesting,
-            # so this default code is used instead
-            # Detect the country code from the partner country instead
-            else:
-                normalized_vat = 'OO99999999999'
 
         # If it has a codice fiscale (and no country), it's an Italian partner
         if not normalized_country and self.l10n_it_codice_fiscale:
             normalized_country = 'IT'
         elif not has_vat and self.country_id and self.country_id.code != 'IT':
-            normalized_vat = '0000000'
+            if in_eu:
+                normalized_vat = '0000000'
+            else:
+                normalized_vat = 'OO99999999999'
 
         if normalized_country == 'IT':
             pa_index = (self.l10n_it_pa_index or '0000000').upper()

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_discount.xml
@@ -37,7 +37,7 @@
       <DatiAnagrafici>
         <IdFiscaleIVA>
           <IdPaese>US</IdPaese>
-          <IdCodice>0000000</IdCodice>
+          <IdCodice>OO99999999999</IdCodice>
         </IdFiscaleIVA>
         <Anagrafica>
           <Denominazione>US Partner</Denominazione>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_global_simple_discount.xml
@@ -38,7 +38,7 @@
       <DatiAnagrafici>
         <IdFiscaleIVA>
           <IdPaese>US</IdPaese>
-          <IdCodice>0000000</IdCodice>
+          <IdCodice>OO99999999999</IdCodice>
         </IdFiscaleIVA>
         <Anagrafica>
           <Denominazione>US Partner</Denominazione>

--- a/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/export_foreign_currency_simple_discount.xml
@@ -37,7 +37,7 @@
       <DatiAnagrafici>
         <IdFiscaleIVA>
           <IdPaese>US</IdPaese>
-          <IdCodice>0000000</IdCodice>
+          <IdCodice>OO99999999999</IdCodice>
         </IdFiscaleIVA>
         <Anagrafica>
           <Denominazione>US Partner</Denominazione>


### PR DESCRIPTION
Default code 'OO99999999999' should only be used if no VAT number is present.

Task [link](https://www.odoo.com/odoo/project/967/tasks/4724520)
task-4724520