### PR TITLE
[FIX] sale_management: allow sections to be added to quote templates

### DIFF
--- a/addons/sale_management/views/sale_order_template_views.xml
+++ b/addons/sale_management/views/sale_order_template_views.xml
@@ -90,6 +90,7 @@
                                     <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                                     <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                                 </control>
+                                <field name="display_type" column_invisible="True"/>
                                 <field name="sequence" widget="handle"/>
                                 <field name="product_id"/>
                                 <field name="name"/>


### PR DESCRIPTION
### Issue:
Numerous SO views were recently cleaned up in PR #167023. However, removing `display_type` from the Quotation Template Form no longer adds the key into the `web_save`, so we'll eventually fail the  SQL constraint `_accountable_product_id_required` if we try to add a Section or Note to the Template.

### Solution:
Add the hidden `display_type` field back to the view.

opw-4757060