### PR TITLE
[FIX] orm: prevent error when user loses access to fields during active session

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3053,7 +3053,7 @@ class BaseModel(metaclass=MetaModel):
         )
 
         if self.env.user._has_group('base.group_no_one'):
-            if field.groups == NO_ACCESS:
+            if not field.groups or field.groups == NO_ACCESS:
                 allowed_groups_msg = _("always forbidden")
             else:
                 groups_list = [self.env.ref(g) for g in field.groups.split(',')]


### PR DESCRIPTION
An error occurs when a user's access rights are changed while they are actively using the system.

steps to Reproduce:

 - Install the `hr` module.
 - Assign the user (e.g., Demo) the following access rights: `Administrator` access under Employees. `Settings` access under Administration.
 - Open a new Incognito window and log in as the Demo user.
 - Navigate to the Employees view and apply a custom filter based on the `Website Messages` field.
 - In Admin session, remove the Employees access rights from the Demo user.
 - Go back to the Demo session and refresh the page.

`AttributeError: 'NoneType' object has no attribute 'split'`

The error occurs because the Demo user initially accessed a field (e.g., Website Messages) that required elevated access rights. After the Admin removed the access rights, the system attempted to process the previously accessible field without verifying current user permissions, resulting in a NoneType error when trying to access or split the field.

This commit ensures that if a user no longer has access to a field, the system will not raise an error.

sentry-6353349244,6843847915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
