### PR TITLE
[IMP] point_of_sale: add numpad to cash move popup in mobile view

### DIFF
--- a/addons/point_of_sale/static/src/app/components/inputs/input/input.js
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/input.js
@@ -28,6 +28,7 @@ export class Input extends TModelInput {
         class: { type: String, optional: true },
         callback: { type: Function, optional: true },
         isOpenCallback: { type: Function, optional: true },
+        readonly: { type: Boolean, optional: true },
     };
     static defaultProps = {
         class: "",
@@ -39,6 +40,7 @@ export class Input extends TModelInput {
         autofocusMobile: false,
         iconOnLeftSide: true,
         isValid: () => true,
+        readonly: false,
     };
     setup() {
         this.state = useState({ isOpen: false });

--- a/addons/point_of_sale/static/src/app/components/inputs/input/input.xml
+++ b/addons/point_of_sale/static/src/app/components/inputs/input/input.xml
@@ -21,7 +21,8 @@
                         t-att-placeholder="props.placeholder"
                         t-ref="input"
                         t-att-value="getValue()"
-                        t-on-input="(event) => this.setValue(event.target.value)" />
+                        t-on-input="(event) => this.setValue(event.target.value)"
+                        t-att-readonly="props.readonly" />
                     <t t-if="!props.iconOnLeftSide" t-call="point_of_sale.inputIcon" />
                     <i t-att-class="{ 'invisible': !getValue() }" class="fa fa-times mx-2" t-on-click="() => this.setValue('')"/>
                 </div>

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.js
@@ -9,6 +9,8 @@ import { CashMoveListPopup } from "@point_of_sale/app/components/popups/cash_mov
 import { Dialog } from "@web/core/dialog/dialog";
 import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 import { Input } from "@point_of_sale/app/components/inputs/input/input";
+import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
+import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 
 const { DateTime } = luxon;
 
@@ -111,5 +113,19 @@ export class CashMovePopup extends Component {
             cashMoves: cashMoves.map((m) => ({ ...m, date: DateTime.fromSQL(m.date) })),
             partnerId: this.partnerId,
         });
+    }
+    async openNumpadDialog() {
+        if (!this.ui.isSmall) {
+            return;
+        }
+
+        const result = await makeAwaitable(this.dialog, NumberPopup, {
+            title: _t("Amount"),
+            startingValue: this.state.amount,
+        });
+
+        if (result) {
+            this.state.amount = result;
+        }
     }
 }

--- a/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/cash_move_popup/cash_move_popup.xml
@@ -18,9 +18,11 @@
                         iconOnLeftSide="pos.currency.position === 'before'"
                         isValid.bind="env.utils.isValidFloat"
                         autofocus="true"
-                        getRef="(ref) => this.inputRef = ref" />
+                        getRef="(ref) => this.inputRef = ref"
+                        t-on-click="openNumpadDialog"
+                        readonly="ui.isSmall ? true : false" />
                 </div>
-            </div> 
+            </div>
             <div class="form-floating">
                 <textarea class="form-control cash-reason" placeholder="Leave a reason here" name="reason" id="reason" t-model="state.reason" style="height:100px;" />
                 <label for="reason">Reason</label>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/chrome_util.js
@@ -1,6 +1,7 @@
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import { negate } from "@point_of_sale/../tests/generic_helpers/utils";
 import { waitFor } from "@odoo/hoot-dom";
+import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 const { DateTime } = luxon;
 
 export function confirmPopup() {
@@ -32,12 +33,30 @@ export function isCashMoveButtonHidden() {
     ];
 }
 export function doCashMove(amount, reason) {
+    const numpadWrite = (val) => val.split("").flatMap((key) => Numpad.click(key));
     return [
         ...clickMenuOption("Cash In/Out"),
         fillTextArea(".cash-reason", reason),
         {
-            trigger: ".modal .input-amount input",
+            isActive: ["desktop"],
+            content: "Enter the amount to cash in/out",
+            trigger: ".modal input.o_input",
             run: "edit " + amount,
+        },
+        {
+            isActive: ["mobile"],
+            content: "Enter the amount to cash in/out",
+            trigger: ".modal input.o_input",
+            run: "click",
+        },
+        ...numpadWrite(amount).map((step) => ({
+            isActive: ["mobile"],
+            ...step,
+        })),
+        {
+            isActive: ["mobile"],
+            trigger: ".o-overlay-item:nth-child(2) .modal-footer button:contains('Ok')",
+            run: "click",
         },
         Dialog.confirm(),
     ];


### PR DESCRIPTION
In this commit:
==========
- We improve the user experience for cash in/out operations on mobile devices by introducing a numpad interface.
- Replaced manual text input process with a number popup for entering amounts in the cash in/out popup on mobile.
- Introduced a `readonly` prop to the `Input` component to allow disabling manual input when needed.
- This enhancement streamlines input on touch devices and ensures better usability.

task-4564392