### PR TITLE
[IMP] website_sale, _*: redirect zero-price orders to confirmation page

### DIFF
--- a/addons/website_event_sale/controllers/main.py
+++ b/addons/website_event_sale/controllers/main.py
@@ -89,5 +89,7 @@ class WebsiteEventSaleController(WebsiteEventController):
                 # Free order -> auto confirmation without checkout
                 order_sudo.action_confirm()  # tde notsure: email sending ?
                 request.website.sale_reset()
+                request.session['sale_last_order_id'] = order_sudo.id
+                return request.redirect("/shop/confirmation")
 
         return res

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1585,14 +1585,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         if order_sudo.amount_total and not tx_sudo:
             return request.redirect(self._get_shop_path())
 
-        if not order_sudo.amount_total and not tx_sudo:
-            if order_sudo.state != 'sale':
-                # Only confirm the order if it wasn't already confirmed.
-                order_sudo._validate_order()
-
-            # clean context and session, then redirect to the portal page
-            request.website.sale_reset()
-            return request.redirect(order_sudo.get_portal_url())
+        if not order_sudo.amount_total and not tx_sudo and order_sudo.state != 'sale':
+            # Only confirm the order if it wasn't already confirmed.
+            order_sudo._validate_order()
 
         # clean context and session, then redirect to the confirmation page
         request.website.sale_reset()

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -3704,7 +3704,10 @@
             </t>
 
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
-            <div t-if="tx_sudo.state in ['pending', 'done']" class="d-flex justify-content-between align-items-center">
+            <div
+                t-if="tx_sudo.state in ['pending', 'done'] or not order.amount_total"
+                class="d-flex justify-content-between align-items-center"
+            >
                 <h3>Thank you for your order.</h3>
                 <a
                     title="Print"
@@ -3842,6 +3845,7 @@
         <div class="oe_website_sale_tx_status mt-3" t-att-data-order-id="order.id" t-att-data-order-tracking-info="json.dumps(order_tracking_info)">
             <t t-set="tx_sudo" t-value="order.get_portal_last_transaction()"/>
             <div
+                t-if="tx_sudo"
                 t-attf-class="alert px-3 pb-0 pt-3 #{
                     (tx_sudo.state == 'pending' and 'alert-info') or
                     (tx_sudo.state == 'done' and order.amount_total == tx_sudo.amount and 'alert-success') or

--- a/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_ewallet_tour.js
@@ -32,7 +32,7 @@ registry.category("web_tour.tours").add("shop_sale_ewallet", {
             expectUnloadPage: true,
         },
         {
-            trigger: 'div[id="introduction"] h2:contains("Sales Order")',
+            trigger: 'div h3:contains("Thank you for your order.")'
         },
         {
             trigger: 'a[href="/shop/cart"]',


### PR DESCRIPTION
_* = website_event_sale

Before this commit:
- On confirming a zero-priced order, the user is redirected to the Sale Order page instead of a confirmation page.

After this commit:
- Zero-priced orders redirect to the standard order confirmation page. All relevant order details are shown, excluding payment-related information, as no payment is involved.

Affected version: master
Task: 4711803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
