### PR TITLE
[IMP] point_of_sale: allow to use pos config in receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.js
@@ -5,6 +5,7 @@ import { Orderline } from "@point_of_sale/app/generic_components/orderline/order
 import { OrderWidget } from "@point_of_sale/app/generic_components/order_widget/order_widget";
 import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
 import { omit } from "@web/core/utils/objects";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
 
 export class OrderReceipt extends Component {
     static template = "point_of_sale.OrderReceipt";
@@ -19,5 +20,14 @@ export class OrderReceipt extends Component {
     };
     omit(...args) {
         return omit(...args);
+    };
+    setup() {
+        super.setup();
+        /* usePos will error in self order because the asset bundle not loading all necessary stuff */
+        try {
+           this.pos = usePos();
+        } catch {
+           this.pos = null;
+        }
     }
 }

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -72,6 +72,7 @@
             "point_of_sale/static/src/app/generic_components/**/*",
             "point_of_sale/static/src/css/pos_receipts.css",
             "point_of_sale/static/src/app/screens/receipt_screen/receipt/**/*",
+            "point_of_sale/static/src/app/store/pos_hook.js",
             "pos_self_order/static/src/overrides/components/receipt_header/*",
             "point_of_sale/static/src/app/printer/base_printer.js",
             "point_of_sale/static/src/app/printer/printer_service.js",


### PR DESCRIPTION
* This commit support to use pos config by simply using usePos from pos_hook
* This facilitates accessing POS configuration and state directly within the receipt rendering process, enabling more flexible customizations and conditional logic based on the POS settings

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
