### PR TITLE
[IMP] account: added tax type beside tax name in reconciliation model form view.

### DIFF
--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -200,7 +200,8 @@
                                             <field name="tax_ids"
                                                    widget="many2many_tags"
                                                    optional="hide"
-                                                   domain="[('type_tax_use', '=?', parent.counterpart_type if parent.counterpart_type in ('sale', 'purchase') and rule_type == 'writeoff_button' else None)]"/>
+                                                   domain="[('type_tax_use', '=?', parent.counterpart_type if parent.counterpart_type in ('sale', 'purchase') and rule_type == 'writeoff_button' else None)]"
+                                                   context="{'append_type_to_tax_name': True}"/>
                                             <field name="analytic_distribution" widget="analytic_distribution"
                                                    groups="analytic.group_analytic_accounting"
                                                    options="{'account_field': 'account_id', 'business_domain': 'general'}"/>


### PR DESCRIPTION
Before this commit:
- In the bank reconciliation model form view, under the "Counterpart Items" section, the "Taxes" column displayed only the tax name.
- Taxes were not distinguished between Sales and Purchase types, making it difficult to identify their type.

After this commit:
- The "Taxes" column now displays the tax type beside the tax name, making it easier to distinguish between them.

task-4752604