### PR TITLE
[FIX] website_form_project: make project_id required in website form

### DIFF
--- a/addons/website_form_project/static/src/js/website_form_project_editor.js
+++ b/addons/website_form_project/static/src/js/website_form_project_editor.js
@@ -26,6 +26,7 @@ FormEditorRegistry.add('create_task', {
     fields: [{
         name: 'project_id',
         type: 'many2one',
+        required: true,
         relation: 'project.project',
         string: _lt('Project'),
         createAction: 'project.open_view_project_all',


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- The contact-us form allows task creation without a project (project_id = None).
These tasks are assigned to odoobot, have no followers, and no project, making
them inaccessible due to ACL restrictions. 

**steps to reproduce**
1. Install website_form_project.
2. Edit the contact-us form submit button.
3. Set action to 'Create a task' and select 'None' for the project.
4. Save and submit the form.

**Observation**
- Tasks created under such configuration are hidden in the UI and trigger access
errors when trying to open them.

![access error](https://github.com/user-attachments/assets/e5688152-d78b-4628-a0bd-d9f58e2ca442)

Desired behavior after PR is merged:
- Making the project field required, the created tasks will now be accessible/visible

[opw-4664601](https://www.odoo.com/odoo/project/49/tasks/4664601)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
