### PR TITLE
[FIX] website: fix test_01_beacon external call

### DIFF
--- a/addons/website/tests/test_unsplash_beacon.py
+++ b/addons/website/tests/test_unsplash_beacon.py
@@ -6,6 +6,11 @@ import odoo.tests
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestUnsplashBeacon(odoo.tests.HttpCase):
 
+    def fetch_proxy(self, url):
+        if 'unsplash.com' in url:
+            return self.make_fetch_proxy_response('{"success": true}')
+        return super().fetch_proxy(url)
+
     def test_01_beacon(self):
         self.env['ir.config_parameter'].sudo().set_param('unsplash.app_id', '123456')
         # Create page with unsplash image.


### PR DESCRIPTION
test_01_beacon was disabled to allow an easier forwardport of #207720
This commit fixes the issue by providing a correct substitution for the external call.

Runbot error: 182085
