### PR TITLE
[17.0][FIX] stock: prioritize serial number over lot number in GS1 code

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -317,7 +317,8 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
     }
     async _parseElementsFromGS1(parsed_results) {
         const productBarcode = parsed_results.find((element) => element.type === "product");
-        const lotBarcode = parsed_results.find((element) => element.type === "lot");
+        const lotElements = parsed_results.filter((element) => element.type === "lot").sort((elem)=> elem.rule.sequence)
+        const lotBarcode = lotElements[0];
         const product = await this._getProductByBarcode(productBarcode);
         return { product, lotBarcode, customProductOptions: {} };
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When both a serial number (21) and a lot number (10) are present in a scanned GS1 barcode, only the serial number should be considered, as they are mutually exclusive in practice. This aligns with expected behavior for serialized products and prevents incorrect lot assignment.

Current behavior before PR: #190874

Desired behavior after PR is merged: When both serial and lot numbers are found in the GS1 barcode, only the serial number is used, and the lot number is ignored.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
