### PR TITLE
[FIX] pos_loyalty: remove duplicate when two variants with same discount

### DIFF
--- a/addons/pos_loyalty/static/src/app/services/pos_store.js
+++ b/addons/pos_loyalty/static/src/app/services/pos_store.js
@@ -369,10 +369,13 @@ patch(PosStore.prototype, {
         const productTmpl = vals.product_tmpl_id;
         const productIds = productTmpl.product_variant_ids.map((v) => v.id);
         const order = this.getOrder();
-        const linkedPrograms = productIds.flatMap(
-            (id) => this.models["loyalty.program"].getBy("trigger_product_ids", id) || []
-        );
-
+        const linkedPrograms = [
+            ...new Set(
+                productIds.flatMap(
+                    (id) => this.models["loyalty.program"].getBy("trigger_product_ids", id) || []
+                )
+            ),
+        ];
         let selectedProgram = null;
         if (linkedPrograms.length > 1) {
             selectedProgram = await makeAwaitable(this.dialog, SelectionPopup, {

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -581,3 +581,13 @@ registry.category("web_tour.tours").add("RefundRulesProduct", {
             ProductScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_two_variant_same_discount", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Sofa"),
+            Chrome.clickBtn("Add"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2688,3 +2688,52 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.assertEqual(len(gift_card_program.coupon_ids), 1, "Gift card not generated")
         self.assertEqual(gift_card_program.coupon_ids[0].code, "test-card-1234", "Gift card code not correct")
         self.assertEqual(gift_card_program.coupon_ids[0].partner_id, partner, "Gift card partner id not correct")
+
+    def test_two_variant_same_discount(self):
+        # test that if a product has two variants with the same discount, the selector widget does not appear (nor an error window in debug mode)
+        colors = ['red', 'blue']
+        prod_attr = self.env['product.attribute'].create({'name': 'Color', 'create_variant': 'dynamic'})
+        prod_attr_values = self.env['product.attribute.value'].create([{'name': color, 'attribute_id': prod_attr.id, 'sequence': 1} for color in colors])
+
+        product_template = self.env['product.template'].create({
+            'name': 'Sofa',
+            'available_in_pos': True,
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': prod_attr.id,
+                'value_ids': [(6, 0, prod_attr_values.ids)]
+            })]
+        })
+        prod_tmpl_attrs = self.env['product.template.attribute.value'].search([
+            ('attribute_line_id', '=', product_template.attribute_line_ids.id),
+            ('product_attribute_value_id', 'in', prod_attr_values.ids)
+        ])
+
+        product_1 = product_template._create_product_variant(prod_tmpl_attrs[0])
+        product_2 = product_template._create_product_variant(prod_tmpl_attrs[1])
+
+        self.env['loyalty.program'].create({
+            'name': 'Test Loyalty Program',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [
+                (0, 0, {
+                    'reward_point_mode': 'money',
+                    'minimum_amount': 1,
+                    'reward_point_amount': 1,
+                    'product_ids': [product_1.id, product_2.id]
+                }),
+            ],
+            'reward_ids': [
+                (0, 0, {
+                    'reward_type': 'discount',
+                    'discount': 1,
+                    'required_points': 1000,
+                    'discount_mode': 'percent',
+                    'discount_applicability': 'order',
+                }),
+            ],
+
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_two_variant_same_discount', login="pos_user")


### PR DESCRIPTION
[**Problem:**
In POS, if a product which has two variants with the same discount is selected, 
in debug mode an error window appears. If not in debug mode, the selector 
widget appears even though it should not because it's the same discount

**Steps to reproduce:**
- Enable the "variants" and the "Discounts" settings
- Create a new product, make it available in POS
- In the "Attributes & Variants" page, add a color attribute line and give it two values
- In the Point of Sale page, give it a category
- Open Point of Sale/Products/Discount & loyalty, and click on New
- Click on the text below "Conditional rules" on the bottom left of the screen
- In the Products field select the two variants of your new product
- Save
- Open a shop in Point of Sale
- Select your product

**Current behavior:**
If in debug mode an error message appears.
If not in debug mode, a selector widget appears, allowing the user to choose 
between two times the same discount

**Expected behavior:**
Because it's the same discount, no window of selection (and no error window) should appear

**Cause of the issue:**
when computing the list of the different discounts available for a product there's 
no mechanism to avoid duplicates. 
So linkedPrograms will be a list of two identical values
https://github.com/odoo/odoo/blob/2e4c704d80812aabe28ae491e28c5faa4c27d693/addons/pos_loyalty/static/src/app/services/pos_store.js#L372-L373 
makeAwataible is then called with "list" containing the two objects with the same id.
https://github.com/odoo/odoo/blob/2e4c704d80812aabe28ae491e28c5faa4c27d693/addons/pos_loyalty/static/src/app/services/pos_store.js#L377-L383

If not in debug mode: this will result in the creation of a SelectionPopup allowing 
to choose between two times the same discount

If in debug mode:
when __render will eventally be called,
https://github.com/odoo/odoo/blob/2e4c704d80812aabe28ae491e28c5faa4c27d693/addons/web/static/lib/owl/owl.js#L3050 
slotScope.this.props.list will be a list of two element with the same id, this will trigger 
an error thanks to this line which is added in debug mode https://github.com/odoo/odoo/blob/2e4c704d80812aabe28ae491e28c5faa4c27d693/addons/web/static/lib/owl/owl.js#L4486

opw-4703868