### PR TITLE
[IMP] project: drag&drop tasks to plan in calendar view

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -1948,6 +1948,10 @@ class ProjectTask(models.Model):
             },
         }
 
+    def plan_task_in_calendar(self, vals):
+        self.ensure_one()
+        return self.write(vals)
+
     @api.model
     def _get_template_default_context_whitelist(self):
         """

--- a/addons/project/static/src/views/project_task_calendar/hooks/project_task_calendar_task_to_plan_draggable.js
+++ b/addons/project/static/src/views/project_task_calendar/hooks/project_task_calendar_task_to_plan_draggable.js
@@ -1,0 +1,118 @@
+import { onWillUnmount, reactive, useEffect, useExternalListener } from "@odoo/owl";
+import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder";
+import { pick } from "@web/core/utils/objects";
+import { useThrottleForAnimation } from "@web/core/utils/timing";
+
+const hookParams = {
+    name: "useCalendarTaskToPlanDraggable",
+    onDragStart(params) {
+        const { ctx, addClass, addListener, addStyle, callHandler, getRect, removeClass, removeStyle } = params;
+
+        const onElementPointerEnter = (ev) => {
+            const element = ev.currentTarget;
+            current.calendarCell = element;
+            if (current.timeSlotElement) {
+                current.timeSlotElement = null;
+            }
+            callHandler("onElementEnter", { element });
+        };
+
+        const onElementPointerLeave = (ev) => {
+            const element = ev.currentTarget;
+            current.calendarCell = null;
+            callHandler("onElementLeave", { element });
+        };
+
+        const onTimeSlotElementPointerEnter = (ev) => {
+            const element = ev.currentTarget;
+            current.timeSlotElement = element;
+            callHandler("onElementEnter", { element });
+        }
+
+        const onTimeSlotElementPointerLeave = (ev) => {
+            const element = ev.currentTarget;
+            current.timeSlotElement = null;
+            callHandler("onElementLeave", { element })
+        }
+
+        const { ref, current } = ctx;
+        const containerSelector = ".o_calendar_renderer .o_calendar_widget";
+        let selector = `${containerSelector} .fc-timegrid-slot.fc-timegrid-slot-lane`;
+        const slotElements = ref.el.querySelectorAll(selector);
+        if (slotElements.length) {
+            const eventContainer = ref.el.querySelector(".o_calendar_renderer .o_task_event_to_plan_container");
+
+            const onTimeGridPointerMove = (ev) => {
+                current.calendarCell = null;
+                const nodes = document.elementsFromPoint(ev.clientX, ev.clientY);
+                for (const node of nodes) {
+                    if (node.classList.contains("fc-day")) {
+                        if (!(current.calendarCell && node.isEqualNode(current.calendarCell))) {
+                            current.calendarCell = node;
+                        }
+                        break;
+                    }
+                }
+                if (eventContainer && current.calendarCell && current.timeSlotElement) {
+                    const { bottom, height } = getRect(current.timeSlotElement, { adjust: true });
+                    const { left, width } = getRect(current.calendarCell, { adjust: true });
+                    addStyle(eventContainer, {
+                        bottom: `${document.documentElement.clientHeight - bottom - height}px`,
+                        width:`${width}px`,
+                        left: `${left}px`,
+                        height: `${height * 2}px`,
+                    });
+                    removeClass(eventContainer, "d-none");
+                } else if (eventContainer) {
+                    removeStyle(eventContainer, "bottom", "width", "left", "height");
+                    addClass(eventContainer, "d-none");
+                }
+            }
+
+            const onTimeGridPointerCancel = (ev) => {
+                current.calendarCell = null;
+                if (eventContainer) {
+                    removeStyle(eventContainer, "bottom", "width", "left", "height");
+                    addClass(eventContainer, "d-none");
+                }
+            }
+
+            for (const timeSlotCalendarCell of slotElements) {
+                addListener(timeSlotCalendarCell, "pointerenter", onTimeSlotElementPointerEnter);
+                addListener(timeSlotCalendarCell, "pointerleave", onTimeSlotElementPointerLeave);
+            }
+            const timeSlotContainerEl = ref.el.querySelector(`${containerSelector} .fc-timegrid-body`);
+            addListener(timeSlotContainerEl, "pointermove", onTimeGridPointerMove);
+            addListener(timeSlotContainerEl, "pointercancel", onTimeGridPointerCancel);
+        }
+        selector = `${containerSelector} .fc-day`;
+        for (const calendarCell of ref.el.querySelectorAll(selector)) {
+            addListener(calendarCell, "pointerenter", onElementPointerEnter);
+            addListener(calendarCell, "pointerleave", onElementPointerLeave);
+        }
+        return pick(current, "element");
+    },
+    onDragEnd({ ctx }) {
+        return pick(ctx.current, "element", "calendarCell");
+    },
+    onDrop({ ctx}) {
+        const { element, calendarCell, timeSlotElement } = ctx.current;
+        if (element && calendarCell) {
+            return {
+                element,
+                calendarCell,
+                timeSlotElement,
+            }
+        }
+    },
+};
+export function useCalendarTaskToPlanDraggable(params) {
+    const setupHooks = {
+        addListener: useExternalListener,
+        setup: useEffect,
+        teardown: onWillUnmount,
+        throttle: useThrottleForAnimation,
+        wrapState: reactive,
+    };
+    return makeDraggableHook({ ...hookParams, setupHooks })(params);
+}

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.js
@@ -19,5 +19,7 @@ export function patchCommonRenderer(CommonRenderer) {
     });
 }
 
-export class ProjectTaskCalendarCommonRenderer extends CalendarCommonRenderer { }
+export class ProjectTaskCalendarCommonRenderer extends CalendarCommonRenderer {
+    static template = "project.ProjectTaskCalendarCommonRenderer";
+}
 patchCommonRenderer(ProjectTaskCalendarCommonRenderer);

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.xml
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_common/project_task_calendar_common_renderer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="project.ProjectTaskCalendarCommonRenderer" t-inherit="web.CalendarCommonRenderer">
+        <xpath expr="//div[hasclass('o_calendar_widget')]" position="after">
+            <div class="o_task_event_to_plan_container d-none position-absolute"/>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_controller.js
@@ -1,7 +1,11 @@
+import { useRef } from "@odoo/owl";
+
 import { _t } from "@web/core/l10n/translation";
 import { CalendarController } from "@web/views/calendar/calendar_controller";
 import { subTaskDeleteConfirmationMessage } from "@project/views/project_task_form/project_task_form_controller";
-import { ProjectTaskCalendarSidePanel } from "./project_task_calendar_side_panel";
+
+import { ProjectTaskCalendarSidePanel } from "./side_panel/project_task_calendar_side_panel";
+import { useCalendarTaskToPlanDraggable } from "./hooks/project_task_calendar_task_to_plan_draggable";
 
 export class ProjectTaskCalendarController extends CalendarController {
     static components = {
@@ -9,8 +13,52 @@ export class ProjectTaskCalendarController extends CalendarController {
         CalendarSidePanel: ProjectTaskCalendarSidePanel,
     };
 
+    setup() {
+        super.setup();
+        this.rootRef = useRef("root");
+        if (this.canDragAndDropRecord) {
+            useCalendarTaskToPlanDraggable({
+                ref: this.rootRef,
+                enable: this.draggable,
+                elements: ".o_task_to_plan_draggable",
+                ignore: "button",
+                onElementEnter: ({ addClass, element }) => {
+                    addClass(element, "o-highlight");
+                },
+                onElementLeave: ({ removeClass, element }) => {
+                    removeClass(element, "o-highlight");
+                },
+                onDrop: (params) => {
+                    this.dropTaskToPlan(params);
+                }
+            });
+        }
+    }
+
+    get modelParams() {
+        return {
+            ...super.modelParams,
+            showTasksToPlan: this.canDragAndDropRecord,
+        }
+    }
+
     get editRecordDefaultDisplayText() {
         return _t("New Task");
+    }
+
+    get sidePanelProps() {
+        return {
+            ...super.sidePanelProps,
+            editRecord: this.editRecord.bind(this),
+        };
+    }
+
+    get canDragAndDropRecord() {
+        return this.draggable && !this.env.isSmall;
+    }
+
+    get draggable() {
+        return Boolean(this.props.context.default_project_id);
     }
 
     deleteConfirmationDialogProps(record) {
@@ -22,6 +70,21 @@ export class ProjectTaskCalendarController extends CalendarController {
         return {
             ...deleteConfirmationDialogProps,
             body: subTaskDeleteConfirmationMessage,
+        }
+    }
+
+    async dropTaskToPlan(params) {
+        const { element, calendarCell, timeSlotElement } = params;
+        const taskId = Number(element.dataset.resId);
+        let dateStr = calendarCell.dataset.date;
+        if (timeSlotElement) {
+            dateStr += `T${timeSlotElement.dataset.time}`;
+        }
+        const date = luxon.DateTime.fromISO(dateStr);
+        if (date.isValid) {
+            element.hidden = true;
+            await this.model.planTask(taskId, date, Boolean(timeSlotElement));
+            element.hidden = false;
         }
     }
 }

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_list_to_plan/project_task_calendar_list_to_plan.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_list_to_plan/project_task_calendar_list_to_plan.js
@@ -1,0 +1,21 @@
+import { Component } from "@odoo/owl";
+
+export class ProjectTaskCalendarListToPlan extends Component {
+    static template = "project.ProjectTaskCalendarListToPlan";
+    static props = {
+        model: Object,
+        editRecord: Function,
+    };
+
+    get displayLoadMoreButton() {
+        return this.props.model.tasksToPlan && this.props.model.tasksToPlan.records.length < this.props.model.tasksToPlan.length;
+    }
+
+    openRecord(task) {
+        this.props.editRecord({ ...task, title: task.name });
+    }
+
+    async loadMoreTasksToPlan() {
+        await this.props.model.loadMoreTasksToPlan();
+    }
+}

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_list_to_plan/project_task_calendar_list_to_plan.xml
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_list_to_plan/project_task_calendar_list_to_plan.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskCalendarListToPlan">
+        <h5>Drag Tasks to Schedule</h5>
+        <div class="d-flex flex-column">
+            <div class="d-flex align-items-center cursor-pointer o_task_to_plan_draggable py-1" t-foreach="props.model.tasksToPlan.records" t-as="task" t-key="task.id" t-att-data-res-id="task.id" t-on-click="() => this.openRecord(task)">
+                <i class="text-muted oi oi-draggable"/>
+                <span class="ps-1 text-truncate" t-out="task.name" t-att-title="task.name"/>
+            </div>
+        </div>
+        <button t-if="displayLoadMoreButton" class="btn btn-link" t-on-click="loadMoreTasksToPlan">Load More</button>
+    </t>
+</templates>

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_model.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_model.js
@@ -1,3 +1,5 @@
+import { Domain } from "@web/core/domain";
+import { serializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { CalendarModel } from '@web/views/calendar/calendar_model';
 
@@ -11,5 +13,95 @@ export class ProjectTaskCalendarModel extends CalendarModel {
             return _t("Private");
         }
         return super.defaultFilterLabel;
+    }
+
+    get tasksToPlanSpecification() {
+        return {
+            name: {},
+        };
+    }
+
+    async load(params = {}) {
+        return super.load({
+            planTask: false,
+            ...(params || {}),
+        });
+    }
+
+    async loadRecords(data) {
+        const [records] = await Promise.all([
+            super.loadRecords(data),
+            this.fetchTasksToPlan({ data }),
+        ]);
+        return records;
+    }
+
+    async fetchTasksToPlan(params) {
+        if (this.meta.showTasksToPlan && !this.meta.planTask) {
+            this.tasksToPlan = await this._fetchTasksToPlan(params);
+        }
+    }
+
+    async loadMoreTasksToPlan() {
+        const { records, length } = this.tasksToPlan;
+        const offset = records.length;
+        let limit = offset + 20;
+        if (limit > length) {
+            limit = length;
+        }
+        const { records: newRecords } = await this._fetchTasksToPlan({ limit, offset });
+        this.tasksToPlan.records.push(...newRecords);
+        this.notify();
+    }
+
+    async _fetchTasksToPlan({ data, limit, offset }) {
+        const projectId = this.meta.context.default_project_id;
+        if (!projectId) {
+            return [];
+        }
+        const { date_start, date_stop } = this.meta.fieldMapping;
+        const fieldsToRemove = [...new Set([date_start, date_stop, 'planned_date_begin', 'date_deadline'])]
+        let domain = Domain.removeDomainLeaves(
+            Domain.and([
+                this.meta.domain,
+                this.computeFiltersDomain(data || this.data),
+            ]),
+            fieldsToRemove
+        );
+        domain = Domain.and([
+            domain,
+            [['planned_date_begin', '=', false], ['date_deadline', '=', false], ['project_id', '=', projectId]],
+        ]);
+        return await this.orm.webSearchRead(this.resModel, domain.toList(this.meta.context), {
+            specification: this.tasksToPlanSpecification,
+            limit: limit || 20,
+            offset: offset || 0,
+        });
+    }
+
+    _getPlanTaskVals(taskToPlan, date, timeSlotSelected = false) {
+        const [, end] = this.getAllDayDates(date, date);
+        return { date_deadline: serializeDateTime(end) };
+    }
+
+    _getPlanTaskContext(taskToPlan, timeSlotSelected) {
+        return {
+            ...this.meta.context,
+            task_calendar_plan_full_day: ["day", "week"].includes(this.meta.scale) && !timeSlotSelected,
+        };
+    }
+
+    async planTask(taskId, date, timeSlotSelected = false) {
+        this.tasksToPlan.length -= 1;
+        const taskToPlanIndex = this.tasksToPlan.records.findIndex((task) => task.id === taskId);
+        if (taskToPlanIndex < 0) {
+            return;
+        }
+        const [taskToPlan] = this.tasksToPlan.records.splice(taskToPlanIndex, 1);
+        const context = this._getPlanTaskContext(taskToPlan, timeSlotSelected);
+        await this.orm.call(this.meta.resModel, "plan_task_in_calendar", [[taskId], this._getPlanTaskVals(taskToPlan, date, timeSlotSelected)], {
+            context,
+        });
+        await this.load({ planTask: true });
     }
 }

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_renderer.scss
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_renderer.scss
@@ -1,0 +1,6 @@
+.o_task_event_to_plan_container {
+    background-color: var(--fc-highlight-color) !important;
+    &.fc-day-disabled {
+        background-image: repeating-linear-gradient(-45deg, transparent, var(--fc-neutral-bg-color) 25px, transparent 50px);
+    }
+}

--- a/addons/project/static/src/views/project_task_calendar/project_task_calendar_side_panel.js
+++ b/addons/project/static/src/views/project_task_calendar/project_task_calendar_side_panel.js
@@ -1,9 +1,0 @@
-import { CalendarSidePanel } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
-import { ProjectTaskCalendarFilterSection } from "./project_task_calendar_filter_section/project_task_calendar_filter_section";
-
-export class ProjectTaskCalendarSidePanel extends CalendarSidePanel {
-    static components = {
-        ...CalendarSidePanel.components,
-        FilterSection: ProjectTaskCalendarFilterSection,
-    };
-}

--- a/addons/project/static/src/views/project_task_calendar/side_panel/project_task_calendar_side_panel.js
+++ b/addons/project/static/src/views/project_task_calendar/side_panel/project_task_calendar_side_panel.js
@@ -1,0 +1,17 @@
+import { CalendarSidePanel } from "@web/views/calendar/calendar_side_panel/calendar_side_panel";
+
+import { ProjectTaskCalendarListToPlan } from "../project_task_calendar_list_to_plan/project_task_calendar_list_to_plan";
+import { ProjectTaskCalendarFilterSection } from "../project_task_calendar_filter_section/project_task_calendar_filter_section";
+
+export class ProjectTaskCalendarSidePanel extends CalendarSidePanel {
+    static components = {
+        ...CalendarSidePanel.components,
+        FilterSection: ProjectTaskCalendarFilterSection,
+        ProjectTaskCalendarListToPlan,
+    };
+    static props = [
+        ...CalendarSidePanel.props,
+        "editRecord",
+    ];
+    static template = "project.ProjectTaskCalendarSidePanel";
+}

--- a/addons/project/static/src/views/project_task_calendar/side_panel/project_task_calendar_side_panel.xml
+++ b/addons/project/static/src/views/project_task_calendar/side_panel/project_task_calendar_side_panel.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.ProjectTaskCalendarSidePanel" t-inherit="web.CalendarSidePanel">
+        <div class="o_calendar_sidebar" position="inside">
+            <ProjectTaskCalendarListToPlan
+                t-if="props.model.meta.showTasksToPlan and props.model.tasksToPlan?.length"
+                model="props.model"
+                editRecord="props.editRecord"
+            />
+        </div>
+    </t>
+</templates>

--- a/addons/project/static/tests/mock_server/mock_models/project_task.js
+++ b/addons/project/static/tests/mock_server/mock_models/project_task.js
@@ -2,4 +2,8 @@ import { models } from "@web/../tests/web_test_helpers";
 
 export class ProjectTask extends models.ServerModel {
     _name = "project.task";
+
+    plan_task_in_calendar(idOrIds, values) {
+        return this.write(idOrIds, values);
+    }
 }

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -103,6 +103,10 @@ export class ProjectTask extends models.Model {
     is_closed = fields.Boolean();
     is_template = fields.Boolean({ string: "Is Template", default: false });
 
+    plan_task_in_calendar(idOrIds, values) {
+        return this.write(idOrIds, values);
+    }
+
     _records = [
         {
             id: 1,

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -70,13 +70,7 @@ export class CalendarController extends Component {
         this.orm = useService("orm");
         this.displayDialog = useUniqueDialog();
 
-        this.model = useModelWithSampleData(this.props.Model, {
-            ...this.props.archInfo,
-            resModel: this.props.resModel,
-            domain: this.props.domain,
-            fields: this.props.fields,
-            date: this.props.state?.date,
-        });
+        this.model = useModelWithSampleData(this.props.Model, this.modelParams);
 
         useSetupAction({
             getLocalState: () => this.model.exportedState,
@@ -109,6 +103,16 @@ export class CalendarController extends Component {
             async multiDeleteRecords(ids) {
                 await this.model.unlinkRecords(ids);
             },
+        };
+    }
+
+    get modelParams() {
+        return {
+            ...this.props.archInfo,
+            resModel: this.props.resModel,
+            domain: this.props.domain,
+            fields: this.props.fields,
+            date: this.props.state?.date,
         };
     }
 


### PR DESCRIPTION
## [IMP] web: add modelParams hook in calendar controller

Before this commit, it was possible to give extra params to calendar
model in override of calendar controller.

This commit creates a getter called `modelParams` to be able to override
that getter if the params given to the calendar model needs to be
altered.

## [IMP] project: display tasks to plan in calendar side panel

Before this commit, the tasks unplanned are not visible in the calendar
view and so the user has to change the view to be able to see the
unplanned tasks.

This commit adds the tasks to plan in the calendar sidebar if the action
loaded is the one called when the user clicks on a project to see the
tasks of that project. By default, 20 tasks are displayed and a load more
button is displayed if there are more than 20 tasks to plan in the project
to let the user to view more tasks in that side panel.
The unplanned tasks also takes into account filters added in the search
view except if the filters used the planned dates in that case the
domain containing the planned dates is just ignored.
Moreover, this commit allows the user to drag and drop those tasks in
the calendar cells to automatically plan the tasks.
If the scale is in month and year, the task will be planed for the whole
day, otherwise the task will be planned on the time slot selected or the
whole day if the cell is the "column header" (the cell above the time
slots) of the calendar view.

task-4645814