### PR TITLE
[IMP] l10n_in: enhance GSTIN validation to avoid API calls

### DIFF
--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -120,12 +120,13 @@ class ResConfigSettings(models.TransientModel):
         }
 
     def _l10n_in_check_gst_number(self):
-        if not self.company_id.vat:
+        company = self.company_id
+        if not company.partner_id.check_vat_in(company.vat):
             action = {
                 'view_mode': 'form',
                 'res_model': 'res.company',
                 'type': 'ir.actions.act_window',
-                'res_id': self.company_id.id,
+                'res_id': company.id,
                 'views': [[self.env.ref('base.view_company_form').id, 'form']],
             }
-            raise RedirectWarning(_("Please enter a GST number in company."), action, _("Go to Company"))
+            raise RedirectWarning(_("Please set a valid GST number on company."), action, _("Go to Company"))

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -322,8 +322,9 @@ class L10nInEwaybill(models.Model):
 
     def _check_transporter(self):
         error_message = []
-        if self.transporter_id and not self.transporter_id.vat:
-            error_message.append(_("- Transporter %s does not have a GST Number", self.transporter_id.name))
+        transporter = self.transporter_id
+        if transporter and not transporter.check_vat_in(transporter.vat):
+            error_message.append(_("- Transporter %s does not have a valid GST Number", transporter.name))
         if self.mode == "4" and self.vehicle_no and self.vehicle_type == "R":
             error_message.append(_("- Vehicle type can not be regular when the transportation mode is ship"))
         return error_message


### PR DESCRIPTION
Currently, we only check if a GST number is present before making API calls for GST, e-Invoice, and E-Waybill services. This allows invalid GST numbers (such as single-character inputs), leading to unnecessary API calls and ambiguous error responses.

This **PR** aims to ensure that only valid GST numbers, formatted according to GST specifications, are sent for API requests.

**task**-4668014

**Enterprise PR** - https://github.com/odoo/enterprise/pull/84384