### PR TITLE
[FIX] crm: restore forecast tour test

### DIFF
--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -69,6 +69,7 @@ registry.category("web_tour.tours").add('crm_forecast', {
     }, {
         trigger: "button[name=action_set_won_rainbowman]",
         content: "win the lead",
+        run: "click"
     }, {
         trigger: '.o_back_button',
         content: 'navigate back to the kanban view',

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -52,9 +52,8 @@ class TestUi(HttpCase, TestCrmCommon):
         })
         self.start_tour("/odoo", 'crm_rainbowman', login="temp_crm_user")
 
-    # def test_03_crm_tour_forecast(self):
-    #     # TDE TODO: fixme
-    #     self.start_tour("/odoo", 'crm_forecast', login="admin")
+    def test_03_crm_tour_forecast(self):
+        self.start_tour("/odoo", 'crm_forecast', login="admin")
 
     def test_email_and_phone_propagation_edit_save(self):
         """Test the propagation of the email / phone on the partner.


### PR DESCRIPTION
The test test_03_crm_tour_forecast has been deactivated in the recent commit 55cccddeb12a2096730e4fadc84c52fa838b1aec

It can be restored with a simple fix, being an explicit call to run "click", which is the expected behavior now, since starting from a recent commit, click is not performed by default, but a check of the element existence is performed instead. Said commit is 84feb3035ff3e829d6602a5d3544d64c673358fb

Task-4756945
