### PR TITLE
[FIX] stock{,_account}: always permit account user access exchange journal & account

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -318,7 +318,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_journal(self, company):
         if (
-            self and self.move_id.stock_valuation_layer_ids and
+            self and self.move_id.sudo().stock_valuation_layer_ids and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_journal
@@ -326,7 +326,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_account(self, company, amount):
         if (
-            self and self.move_id.stock_valuation_layer_ids and
+            self and self.move_id.sudo().stock_valuation_layer_ids and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_valuation_account_id


### PR DESCRIPTION
In 80ff2d2 hooks were added so that we can guarantee currency exchange diff journal entries & items in the proper journal & account- but an accountant doesn't necessarily have a group that permits access to the `Stock.valuation.layer` model (which is checked raw, without sudo, when `stock_account` is installed)

-> AccessError

So we will always allow access to an SVL record in this context via `sudo()`.