### PR TITLE
[FIX] setup: Virtual IoT builder nginx path

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -122,7 +122,7 @@ def start_nginx_server():
         path_nginx = get_path_nginx()
         if path_nginx:
             _logger.info('Start Nginx server: %s\\nginx.exe', path_nginx)
-            os.popen(str(path_nginx / 'nginx.exe'))
+            subprocess.Popen([str(path_nginx / 'nginx.exe')], cwd=str(path_nginx))
     elif platform.system() == 'Linux':
         subprocess.check_call(["sudo", "service", "nginx", "restart"])
 

--- a/setup/win32/setup-iot.nsi
+++ b/setup/win32/setup-iot.nsi
@@ -231,7 +231,7 @@ Section -$(TITLE_Nginx) Nginx
 
     FindFirst $0 $1 "$INSTDIR\nginx*"
     DetailPrint "Setting up nginx"
-    Rename "$TEMP\$1" "$INSTDIR\nginx"
+    Rename "$INSTDIR\$1" "$INSTDIR\nginx"
     FindClose $0
 
     SetOutPath "$INSTDIR\nginx\conf"


### PR DESCRIPTION
A wrong variable name made the installer unable to rename `nginx-1.22.0` to `nginx`, making odoo unable to resolve the certificate's path.

Additionally, this commit fixes the method that starts the Nginx server, as it was missing the working directory information, and was unable to correctly start the executable.
