### PR TITLE
[I18N] google_recaptcha: don't use `attribute` `add=""` to append string

### DIFF
--- a/addons/google_recaptcha/views/res_config_settings_view.xml
+++ b/addons/google_recaptcha/views/res_config_settings_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='recaptcha']" position="attributes">
-                <attribute name="help" add="If no keys are provided, no checks will be done." separator=" " />
+                <attribute name="help">Protect your forms from spam and abuse. If no keys are provided, no checks will be done.</attribute>
             </xpath>
             <div id="recaptcha_warning" position="replace">
                 <div class="content-group" id="reacaptcha_configuration_settings" invisible="not module_google_recaptcha">


### PR DESCRIPTION
When `<attribute name="string" add="something more"` is used to add onto a string in another view, the `"something more"` string isn't translatable. Therefore since there isn't anything else adding onto this string, let's completely replace it with the original string + the "something more" string.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
