### PR TITLE
[FIX] {,stock_}account: always permit account user access exchange journal & account

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -66,6 +66,17 @@ class AccountTestInvoicingCommon(TransactionCase):
             'company_id': cls.company_data['company'].id,
         })
 
+        cls.simple_accountman = cls.env['res.users'].create({
+            'name': 'simple accountman',
+            'login': 'simple_accountman',
+            'password': 'simple_accountman',
+            'groups_id': [
+                # from instantiate_accountman() without "default" superuser groups
+                Command.link(cls.env.ref('account.group_account_manager').id),
+                Command.link(cls.env.ref('account.group_account_user').id),
+            ],
+        })
+
         cls.currency_data = cls.setup_multi_currency_data()
 
         # ==== Taxes ====

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -4,8 +4,7 @@ from contextlib import closing
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.exceptions import UserError
-from odoo.tests import tagged
-from odoo.tests.common import Form
+from odoo.tests import Form, tagged, users
 from odoo import fields, Command
 
 
@@ -219,6 +218,7 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
     def _get_caba_moves(self, moves):
         return moves.search([('tax_cash_basis_origin_move_id', 'in', moves.ids)])
 
+    @users('simple_accountman')
     def test_full_reconcile_bunch_lines(self):
         """ Test the reconciliation with multiple lines at the same time and ensure the result is always a full
         reconcile whatever the number of involved currencies.

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -318,7 +318,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_journal(self, company):
         if (
-            self and self.move_id.stock_valuation_layer_ids and
+            self and self.move_id.sudo().stock_valuation_layer_ids and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_journal
@@ -326,7 +326,7 @@ class AccountMoveLine(models.Model):
 
     def _get_exchange_account(self, company, amount):
         if (
-            self and self.move_id.stock_valuation_layer_ids and
+            self and self.move_id.sudo().stock_valuation_layer_ids and
             self.product_id.categ_id.property_valuation == 'real_time'
         ):
             return self.product_id.categ_id.property_stock_valuation_account_id


### PR DESCRIPTION
In 80ff2d2 hooks were added so that we can guarantee currency exchange diff journal entries & items in the proper journal & account- but an accountant doesn't necessarily have a group that permits access to the `Stock.valuation.layer` model (which is checked raw, without sudo, when `stock_account` is installed)

-> AccessError

So we will always allow access to an SVL record in this context via `sudo()`.