### PR TITLE
[IMP] crm: fix kanban label and tour

### DIFF
--- a/addons/crm/static/src/views/forecast_kanban/forecast_kanban_column_quick_create.js
+++ b/addons/crm/static/src/views/forecast_kanban/forecast_kanban_column_quick_create.js
@@ -9,7 +9,7 @@ export class ForecastKanbanColumnQuickCreate extends KanbanColumnQuickCreate {
     get relatedFieldName() {
         const { granularity = "month" } = this.props.groupByField;
         const { description } = INTERVAL_OPTIONS[granularity];
-        return _t("Add next %s", description.toLocaleLowerCase());
+        return _t("next %s", description.toLocaleLowerCase());
     }
     /**
      * @override

--- a/addons/crm/static/tests/tours/crm_forecast_tour.js
+++ b/addons/crm/static/tests/tours/crm_forecast_tour.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('crm_forecast', {
         content: 'Open Forecast menu',
         run: 'click',
     }, {
-        trigger: '.o_column_quick_create:contains(Add next month)',
+        trigger: '.o_column_quick_create',
         content: 'Wait page loading',
     }, {
         trigger: ".o-kanban-button-new",
@@ -69,6 +69,7 @@ registry.category("web_tour.tours").add('crm_forecast', {
     }, {
         trigger: "button[name=action_set_won_rainbowman]",
         content: "win the lead",
+        run:"click"
     }, {
         trigger: '.o_back_button',
         content: 'navigate back to the kanban view',

--- a/addons/crm/tests/test_crm_ui.py
+++ b/addons/crm/tests/test_crm_ui.py
@@ -46,9 +46,8 @@ class TestUi(HttpCase, TestCrmCommon):
         })
         self.start_tour("/odoo", 'crm_rainbowman', login="temp_crm_user")
 
-    # def test_03_crm_tour_forecast(self):
-    #     # TDE TODO: fixme
-    #     self.start_tour("/odoo", 'crm_forecast', login="admin")
+    def test_03_crm_tour_forecast(self):
+        self.start_tour("/odoo", 'crm_forecast', login="admin")
 
     def test_email_and_phone_propagation_edit_save(self):
         """Test the propagation of the email / phone on the partner.


### PR DESCRIPTION
The test test_03_crm_tour_forecast has been deactivated in the recent commit 55cccddeb12a2096730e4fadc84c52fa838b1aec

It can be restored with a simple fix, being an explicit call to run "click", which is the expected behavior now, since starting from a recent commit, click is not performed by default, but a check of the element existence is performed instead. Said commit is 84feb3035ff3e829d6602a5d3544d64c673358fb

Also, the kanban quick create design has changed in recent commit 566824d0fe5764a434bb2b4f899ef864ed6cc56d

Small label / selector changes are applied to make the test succeed now, and to prevent the current column label 'Add add next month'.

Task-4756945
