### PR TITLE
[FIX] chart: data source not realoaded on domain update

### DIFF
--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -45,21 +45,16 @@ export class OdooChartUIPlugin extends OdooUIPlugin {
                 this._addDomains();
                 break;
             case "UPDATE_CHART": {
-                switch (cmd.definition.type) {
-                    case "odoo_pie":
-                    case "odoo_bar":
-                    case "odoo_line": {
-                        const dataSource = this.getChartDataSource(cmd.id);
-                        const chart = this.getters.getChart(cmd.id);
-                        if (
-                            cmd.definition.type !== chart.type ||
-                            chart.cumulative !== cmd.definition.cumulative ||
-                            dataSource.getInitialDomainString() !==
-                                new Domain(cmd.definition.searchParams.domain).toString()
-                        ) {
-                            this.shouldChartUpdateReloadDataSource = true;
-                        }
-                        break;
+                if (cmd.definition.type.startsWith("odoo_")) {
+                    const dataSource = this.getChartDataSource(cmd.id);
+                    const chart = this.getters.getChart(cmd.id);
+                    if (
+                        cmd.definition.type !== chart.type ||
+                        chart.cumulative !== cmd.definition.cumulative ||
+                        dataSource.getInitialDomainString() !==
+                            new Domain(cmd.definition.searchParams.domain).toString()
+                    ) {
+                        this.shouldChartUpdateReloadDataSource = true;
                     }
                 }
                 break;

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -11,7 +11,7 @@ import {
 } from "@spreadsheet/../tests/helpers/chart";
 import { insertListInSpreadsheet } from "@spreadsheet/../tests/helpers/list";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
-import { addGlobalFilter } from "@spreadsheet/../tests/helpers/commands";
+import { addGlobalFilter, updateChart } from "@spreadsheet/../tests/helpers/commands";
 import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/helpers/global_filter";
 import { mockService, makeServerError } from "@web/../tests/web_test_helpers";
 import * as spreadsheet from "@odoo/o-spreadsheet";
@@ -252,6 +252,33 @@ test("Data reloaded strictly upon domain update", async () => {
     await animationFrame();
     // it should have not have loaded the data since the domain was unchanged
     expect.verifySteps([]);
+});
+
+test("Data reloaded upon domain update for charts other than pie/bar/line", async () => {
+    const { model } = await createSpreadsheetWithChart({
+        type: "odoo_line",
+        mockRPC: async function (route, args) {
+            if (args.method === "web_read_group") {
+                expect.step("web_read_group");
+            }
+        },
+    });
+    const sheetId = model.getters.getActiveSheetId();
+    const chartId = model.getters.getChartIds(sheetId)[0];
+
+    await waitForDataLoaded(model);
+    expect.verifySteps(["web_read_group"]); // Data loaded
+
+    updateChart(model, chartId, { type: "odoo_pie" });
+    await waitForDataLoaded(model);
+    expect.verifySteps(["web_read_group"]); // Chart type changed
+
+    const newDefinition = model.getters.getChartDefinition(chartId);
+    updateChart(model, chartId, {
+        searchParams: { ...newDefinition.searchParams, domain: [["1", "=", "1"]] },
+    });
+    await waitForDataLoaded(model);
+    expect.verifySteps(["web_read_group"]); // Data re-loaded on domain update
 });
 
 test("Can import/export an Odoo chart", async () => {

--- a/addons/spreadsheet/static/tests/helpers/commands.js
+++ b/addons/spreadsheet/static/tests/helpers/commands.js
@@ -221,6 +221,15 @@ export function createGaugeChart(model, chartId, sheetId = model.getters.getActi
     });
 }
 
+export function updateChart(model, chartId, partialDefinition) {
+    const definition = model.getters.getChartDefinition(chartId);
+    return model.dispatch("UPDATE_CHART", {
+        definition: { ...definition, ...partialDefinition },
+        id: chartId,
+        sheetId: model.getters.getActiveSheetId(),
+    });
+}
+
 export function undo(model) {
     model.dispatch("REQUEST_UNDO");
 }


### PR DESCRIPTION
The data source of charts weren't reloaded on model update if the chart wasn't strictly an odoo_pie/line/bar.

Task: [4759433](https://www.odoo.com/web#id=4759433&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
