### PR TITLE
[FIX] point_of_sale: runbot error 164215: waitForSync option

### DIFF
--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -30,10 +30,6 @@ patch(ActionpadWidget.prototype, {
                 : hasChange.count || hasChange.generalCustomerNote || hasChange.modeUpdate;
         return hasChange;
     },
-    async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.showDefault();
-    },
     hasQuantity(order) {
         if (!order) {
             return false;

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -15,7 +15,7 @@
             <div t-if="this.swapButton and currentOrder" class="d-flex gap-2 flex-fill">
                 <button
                     class="submit-order h-100 button btn btn-lg d-flex align-items-center w-50 flex-fill position-relative px-3 highlight btn-primary justify-content-between"
-                    t-on-click="() => this.submitOrder()"
+                    t-on-click="() => this.pos.submitOrder()"
                     t-if="!this.currentOrder.isDirectSale and this.displayCategoryCount.length"
                 >
                     <t t-if="!(ui.isSmall or displayCategoryCount.length > 2) or (!displayCategoryCount.length and ui.isSmall)">Order</t>

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
@@ -47,11 +47,6 @@ patch(ProductScreen.prototype, {
     get displayCategoryCount() {
         return this.pos.categoryCount.slice(0, 3);
     },
-    async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.addPendingOrder([this.currentOrder.id]);
-        this.pos.showScreen(this.pos.defaultScreen, {}, this.pos.defaultScreen == "ProductScreen");
-    },
     get primaryReviewButton() {
         return (
             this.pos.config.module_pos_restaurant &&

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
@@ -8,7 +8,7 @@
                     <button
                         t-if="!this.currentOrder.isDirectSale and nbrOfChanges"
                         class="btn-switchpane pay-button btn btn-lg flex-grow-1 position-relative lh-sm overflow-hidden"
-                        t-on-click="submitOrder"
+                        t-on-click="() => this.pos.submitOrder()"
                         t-attf-class="{{ primaryOrderButton ? 'btn-primary' : 'btn-light' }}">
                         <!-- Replace the payment button by the order button -->
                         <span class="d-block">Order</span>
@@ -23,7 +23,7 @@
                     </button>
                     <button
                             class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
-                            t-on-click="() => this.submitOrder()"
+                            t-on-click="() => this.pos.submitOrder()"
                             t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint">
                         <i class="fa fa-cutlery" aria-hidden="true"></i>
                     </button>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -541,4 +541,10 @@ patch(PosStore.prototype, {
             this.tableSelectorState = false;
         }
     },
+    async submitOrder() {
+        const order = this.getOrder();
+        await this.sendOrderInPreparationUpdateLastChange(order);
+        this.addPendingOrder([order.id]);
+        this.showDefault();
+    },
 });

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -17,7 +17,12 @@ export function clickOrderButton({ waitForSync = false } = {}) {
         },
     ];
     if (waitForSync) {
-        steps.push(...Chrome.waitRequest());
+        steps.push(
+            {
+                trigger: ".status-buttons .fa-spin",
+            },
+            Chrome.isSynced()
+        );
     }
     return steps;
 }

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -2,15 +2,24 @@ import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_uti
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 
-export function clickOrderButton() {
-    return [
+/**
+ * @param {Object} [param0={}]
+ * @param {boolean} [param0.waitForSync=false] - If `true`, wait for the sync to finish after the order button is clicked.
+ */
+export function clickOrderButton({ waitForSync = false } = {}) {
+    const steps = [
         {
             content: "click order button",
             trigger: ".actionpad .submit-order",
             run: "click",
         },
     ];
+    if (waitForSync) {
+        steps.push(...Chrome.waitRequest());
+    }
+    return steps;
 }
 export function orderlinesHaveNoChange() {
     return Order.doesNotHaveLine({ withClass: ".has-change" });


### PR DESCRIPTION
This is a complement to the fix of runbot error 164215. We're introducing a feature for the `clickOrderButton` to allow it to wait for the sync to finish.

Runbot error: 164215 (https://runbot.odoo.com/odoo/error/164215)
Enteprise PR: https://github.com/odoo/enterprise/pull/84389

