### PR TITLE
[FIX] pos_restaurant: prevent order deletion on table merge

### DIFF
--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -346,7 +346,6 @@ patch(PosStore.prototype, {
             }
 
             this.set_order(destinationOrder);
-            await this.deleteOrders([order]);
         }
 
         await this.syncAllOrders({ orders: [destinationOrder || order] });


### PR DESCRIPTION
**Problem:**
When merging two tables in the middle of their service, the moving table's order would be deleted and then made again. The problem is that this order would be sent to the kitchen, making the order cancelled and displaying another one with the same content. This would lead to food wastage as the order would be made twice.

**Steps to reproduce:**
- Open the restaurant, chose two tables and make an order for the two of them.
- Confirm the order.
- Drag and drop the tables next to each other to merge them.
- The dragged table's order will be deleted and made again in the kitchen.

**Why the fix**
https://github.com/odoo/odoo/blob/cf525d2a981515d39a126c6dfb5a612338cc8d14/addons/pos_restaurant/static/src/overrides/models/pos_store.js#L349 The order was deleted, causing the kitchen to receive the same order two times. 
It was done because when merging the tables, the order would be cancelled, and put in the new table's orders that need to be confirmed (order button). 
It was only when pressing this button that the order was sent again to the kitchen. This was done in two steps, because we needed to first cancel the order and then manually confirm it again. 
The order is no longer cancelled, the kitchen doesn't get the order twice, as the order is not replaced. 
The deleteOrders function would make those two steps, first sending another ticket in the kitchen, then deleting the one that was duplicated and just sent to the kitchen.

opw-4654226
