### PR TITLE
[FIX] account: fix invoice sync when changing currency rate and price

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2883,9 +2883,19 @@ class AccountMove(models.Model):
                 # A base line has been modified.
                 round_from_tax_lines = (
                     # The changed lines don't affect the taxes.
-                    all(not line.tax_ids and not move_base_lines_values_before.get(line, {}).get('tax_ids') for line in changed_lines)
+                    all(
+                        not line.tax_ids and not move_base_lines_values_before.get(line, {}).get('tax_ids')
+                        for line in changed_lines
+                    )
                     # Keep the tax lines amounts if an amount has been manually computed.
-                    or any_field_has_changed(move_tax_lines_values_before, tax_lines)
+                    or (
+                        list(move_tax_lines_values_before) != list(tax_lines)
+                        or any(
+                            self.env.is_protected(line._fields[fname], line)
+                            for line in tax_lines
+                            for fname in move_tax_lines_values_before[line]
+                        )
+                    )
                 )
 
                 # If the move has been created with all lines including the tax ones and the balance/amount_currency are provided on

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4697,3 +4697,42 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             {'tax_line_id': tax_a.id, 'tax_tag_ids': (tags_a[2] + tags_b[0]).ids},
             {'tax_line_id': tax_b.id, 'tax_tag_ids': tags_b[1].ids},
         ])
+
+    def test_lines_recomputation_after_currency_rate_change(self):
+        currency = self.setup_other_currency('EUR', rates=[
+            ('2025-01-01', 0.5),
+            ('2025-02-01', 0.4),
+        ])
+
+        with Form(self.env['account.move'].with_context(default_move_type='out_invoice')) as move_form:
+            # init the invoice
+            move_form.partner_id = self.partner_a
+            move_form.invoice_date = '2025-01-01'
+            move_form.currency_id = currency
+            with move_form.invoice_line_ids.new() as line_form:
+                line_form.product_id = self.product_a
+                line_form.price_unit = 1000.0
+            self.assertRecordValues(move_form.save().line_ids, [
+                {'amount_currency':   -1000.0, 'balance':   -2000.0},  # Product line
+                {'amount_currency':    -150.0, 'balance':    -300.0},  # Tax line
+                {'amount_currency':    1150.0, 'balance':    2300.0},  # Receivable line
+            ])
+
+            # change the invoice date to change the currency rate
+            move_form.invoice_date = '2025-02-01'
+            self.assertRecordValues(move_form.save().line_ids, [
+                {'amount_currency':   -1000.0, 'balance':   -2500.0},  # Product line
+                {'amount_currency':    -150.0, 'balance':    -375.0},  # Tax line
+                {'amount_currency':    1150.0, 'balance':    2875.0},  # Receivable line
+            ])
+
+            # change the invoice date to change the currency rate
+            move_form.invoice_date = '2025-01-01'
+            with move_form.invoice_line_ids.edit(0) as line_form:
+                # also change the price unit to check that the new computation is based on it
+                line_form.price_unit = 100.0
+            self.assertRecordValues(move_form.save().line_ids, [
+                {'amount_currency':   -100.0, 'balance':   -200.0},  # Product line
+                {'amount_currency':    -15.0, 'balance':    -30.0},  # Tax line
+                {'amount_currency':    115.0, 'balance':    230.0},  # Receivable line
+            ])


### PR DESCRIPTION
**Steps to reproduce:**
- Install account
- Activate a foreign currency (e.g. EUR)
- Set at least 2 different currency rates for date1 and date2
- Create an invoice:
  * Customer: [any]
  * Invoice Date: date1
  * Currency: EUR
  * Invoice line: [any]
- Save the invoice
- Check debit and credit amounts in "Journal Items" tab
- Change the price of the product and set "Invoice Date" to date2
- Save the invoice
- Check debit and credit amounts in "Journal Items" tab

**Issue:**
The debit and credit amounts have been recomputed with the new currency rate, but the conversion has been applied on the old price.

**Cause:**
In "_sync_invoice" method, when the currency rate has changed, balance (and subsequently debit/credit) is recomputed from amount_currency.
However, in this case, balance should be recomputed completely because the line subtotal has changed and amount_currency is not up-to-date with it.

**Solution:**
Do not recompute balance based on amount_currency when price_subtotal of a line has changed.
In that case, it will be recomputed anyway.

opw-4658156



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
