### PR TITLE
[FIX] website,web_editor: handled error when form is submitted without fields

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -40,6 +40,7 @@ import { ColumnLayoutMixin } from "@web_editor/js/common/column_layout_mixin";
 import { Tooltip as OdooTooltip } from "@web/core/tooltip/tooltip";
 import { AddSnippetDialog } from "@web_editor/js/editor/add_snippet_dialog";
 import { scrollTo } from "@web_editor/js/common/scrolling";
+import { toggleSubmitButton } from '@website/js/utils';
 
 let cacheSnippetTemplate = {};
 
@@ -1645,7 +1646,25 @@ var SnippetEditor = publicWidget.Widget.extend({
     _onRemoveClick: function (ev) {
         ev.preventDefault();
         ev.stopPropagation();
-        this.trigger_up('snippet_edition_request', {exec: this.removeSnippet.bind(this)});
+
+        const $form = this.$target.closest('form');
+        const hasFormField = this.$target.hasClass('s_website_form_field');
+
+        this.trigger_up('snippet_edition_request', {
+            exec: async () => {
+                await this.removeSnippet();
+
+                if (hasFormField && $form.length) {
+                    const remainingFields = $form.find('.s_website_form_field').filter(function () {
+                        return $(this).find('input, select, textarea').length > 0;
+                    }).length;
+
+                    if (remainingFields === 0) {
+                        toggleSubmitButton($form, true); // disable button
+                    }
+                }
+            }
+        });
     },
     /**
      * @private

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -513,6 +513,44 @@ export function checkAndNotifySEO(seo_data, OptimizeSEODialog, services) {
     }
 }
 
+/**
+ * Toggles the submit button state in a website form based on given parameters.
+ *
+ * Disables or enables the submit button, and optionally shows a tooltip for
+ * designers if no form field is present.
+ *
+ * @param {jQuery} $form - jQuery object of the form containing the submit button.
+ * @param {boolean} [disable=true] - Whether to disable the submit button.
+ * @param {boolean} [showTooltip=false] - Whether to show a tooltip when disabling.
+ * @param {boolean} [isDesignerUser=false] - Whether the user is a website designer.
+ */
+export function toggleSubmitButton($form, disable = true, showTooltip = false, isDesignerUser = false) {
+    const $submitButton = $form.find('.s_website_form_send, .o_website_form_send');
+
+    if (disable) {
+        $submitButton.addClass('disabled').attr('disabled', 'disabled');
+
+        if (showTooltip && isDesignerUser) {
+            if (!$submitButton.parent().hasClass('tooltip-wrapper')) {
+                $submitButton.wrap('<div class="tooltip-wrapper" style="display:inline-block; cursor: not-allowed;"></div>');
+            }
+            $submitButton.tooltip({
+                title: "Add at least one field to enable the submit button!",
+                trigger: "manual",
+                placement: "bottom"
+            });
+
+            const $wrapper = $submitButton.parent('.tooltip-wrapper');
+            $wrapper.hover(
+                () => $submitButton.tooltip('show'),
+                () => $submitButton.tooltip('hide')
+            );
+        }
+    } else {
+        $submitButton.removeClass('disabled').removeAttr('disabled');
+    }
+ }
+
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -22,7 +22,7 @@ import { addLoadingEffect } from "@web/core/utils/ui";
 import { scrollTo } from "@web_editor/js/common/scrolling";
 const DEBOUNCE = 400;
 const { DateTime } = luxon;
-import wUtils from '@website/js/utils';
+import wUtils, { toggleSubmitButton } from '@website/js/utils';
 
     publicWidget.registry.EditModeWebsiteForm = publicWidget.Widget.extend({
         selector: '.s_website_form form, form.s_website_form', // !compatibility
@@ -97,12 +97,18 @@ import wUtils from '@website/js/utils';
                     this._getUserPreFillFields()
                 ))[0] || {};
             }
+            this.isDesignerUser = await user.hasGroup('website.group_website_designer')
             return res;
         },
         start: function () {
             // Reset the form first, as it is still filled when coming back
             // after a redirect.
             this.resetForm();
+
+            const formFields = this.$target.find('.s_website_form_field');
+            if (formFields.length === 0) {
+                toggleSubmitButton(this.$target, true, true, this.isDesignerUser);
+            }
 
             // Prepare visibility data and update field visibilities
             const visibilityFunctionsByFieldName = new Map();

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -12,7 +12,7 @@ import { memoize } from "@web/core/utils/functions";
 import { renderToElement } from "@web/core/utils/render";
 import { escape } from "@web/core/utils/strings";
 import { formatDate, formatDateTime } from "@web/core/l10n/dates";
-import wUtils from '@website/js/utils';
+import wUtils, { toggleSubmitButton } from '@website/js/utils';
 
 let currentActionName;
 
@@ -920,6 +920,9 @@ options.registry.WebsiteFormEditor = FormEditor.extend({
                     targetEl.parentNode.insertBefore(this._renderField(_field), targetEl);
                 }
             });
+            toggleSubmitButton(this.$target, false);
+        } else {
+            toggleSubmitButton(this.$target, true);
         }
     },
     /**
@@ -1764,6 +1767,7 @@ options.registry.AddFieldForm = FormEditor.extend({
         this.trigger_up('activate_snippet', {
             $snippet: $(fieldEl),
         });
+        toggleSubmitButton(this.$target, false);
     },
 });
 


### PR DESCRIPTION
The system will crash when the user adds the form from the studio to a website and submits the form without any required field data.

**Steps to produce:**
1. Install `Website` and `Studio`.
2. Open the Website, click Editor, then edit.
3. Add a Form to the homepage using the Studio tool.
4. In the Customize tab:-
     - Go to the Form section. 
     - Under Action, click on `More Models`. 
     - Select the model `res.partner`. 
     - Click Save to apply the changes.
5. Submit the form on the website.

**Error:**
`InFailedSqlTransaction: current transaction is aborted, commands
 ignored until end of transaction block`
 
**Root Cause:**
- when we try to submit the form then ` /website/form/<string:model_name>`
  route is executed.
- At [1], we can see `_handle_website_form` method is called. and At [2],
  we can see `insert_record` method is called during execution.
- And in `insert_record`, At [3], the record is created. but when our values
  are empty then in creation of new record the `A bad SQL query` is generated.
- Once this exception is raised, the control returns to the `website_form`
  method. However, since the transaction is already in a failed state due
  to the `SQL error`,it `cannot cleanly roll back` to the savepoint. This results
  in the `InFailedSqlTransaction` error.

[1]
https://github.com/odoo/odoo/blob/fed7a99fabadf6101995b825954d52a17e707fa3/addons/website/controllers/form.py#L51
[2]
https://github.com/odoo/odoo/blob/fed7a99fabadf6101995b825954d52a17e707fa3/addons/website/controllers/form.py#L80
[3]
https://github.com/odoo/odoo/blob/fed7a99fabadf6101995b825954d52a17e707fa3/addons/website/controllers/form.py#L273-L275


**Solution:-** 
- If there is not present any field in form, then disable the submit button.

**Sentry-5770070274**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
