### PR TITLE
[FIX] stock: forecast widget fixes

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -491,26 +491,41 @@ Please change the quantity done or the rounding precision in your settings.""",
         prefetch_virtual_available = defaultdict(set)
         virtual_available_dict = {}
         for move in product_moves:
-            if move._is_consuming() and move.state == 'draft':
+            if move._is_consuming() and move.state == 'draft' or move.picking_code == 'internal':
                 prefetch_virtual_available[key_virtual_available(move)].add(move.product_id.id)
             elif move.picking_type_id.code == 'incoming':
                 prefetch_virtual_available[key_virtual_available(move, incoming=True)].add(move.product_id.id)
         for key_context, product_ids in prefetch_virtual_available.items():
-            read_res = self.env['product.product'].browse(product_ids).with_context(warehouse_id=key_context[0], to_date=key_context[1]).read(['virtual_available'])
-            virtual_available_dict[key_context] = {res['id']: res['virtual_available'] for res in read_res}
+            read_res = self.env['product.product'].browse(product_ids).with_context(warehouse_id=key_context[0], to_date=key_context[1]).read([
+                'virtual_available',
+                'free_qty',
+            ])
+            virtual_available_dict[key_context] = {res['id']: (res['virtual_available'], res['free_qty']) for res in read_res}
 
         for move in product_moves:
+            if key_virtual_available(move) in virtual_available_dict and move.product_id.id in virtual_available_dict[key_virtual_available(move)]:
+                free_qty = virtual_available_dict[key_virtual_available(move)][move.product_id.id][1]
+            else:
+                free_qty = 0.0
+            if move.state == 'assigned':
+                move.forecast_availability = move.product_uom._compute_quantity(
+                    move.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
+                continue
+            elif move.state == 'draft' and float_compare(free_qty, move.product_qty, precision_rounding=move.product_id.uom_id.rounding) >= 0:
+                move.forecast_availability = free_qty
+                continue
             if move._is_consuming():
-                if move.state == 'assigned':
-                    move.forecast_availability = move.product_uom._compute_quantity(
-                        move.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
-                elif move.state == 'draft':
+                if move.state == 'draft':
                     # for move _is_consuming and in draft -> the forecast_availability > 0 if in stock
-                    move.forecast_availability = virtual_available_dict[key_virtual_available(move)][move.product_id.id] - move.product_qty
+                    move.forecast_availability = virtual_available_dict[key_virtual_available(move)][move.product_id.id][0] - move.product_qty
                 elif move.state in ('waiting', 'confirmed', 'partially_available'):
                     outgoing_unreserved_moves_per_warehouse[move.location_id.warehouse_id].add(move.id)
+            elif move.picking_type_id.code == 'internal':
+                if float_compare(free_qty, move.product_qty, precision_rounding=move.product_id.uom_id.rounding) >= 0:
+                    move.forecast_availability = free_qty
+                    continue
             elif move.picking_type_id.code == 'incoming':
-                forecast_availability = virtual_available_dict[key_virtual_available(move, incoming=True)][move.product_id.id]
+                forecast_availability = virtual_available_dict[key_virtual_available(move, incoming=True)][move.product_id.id][0]
                 if move.state == 'draft':
                     forecast_availability += move.product_qty
                 move.forecast_availability = forecast_availability

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -764,7 +764,10 @@ class StockPicking(models.Model):
 
     @api.depends('state', 'picking_type_code', 'scheduled_date', 'move_ids', 'move_ids.forecast_availability', 'move_ids.forecast_expected_date')
     def _compute_products_availability(self):
-        pickings = self.filtered(lambda picking: picking.state in ('waiting', 'confirmed', 'assigned') and picking.picking_type_code == 'outgoing')
+        pickings = self.filtered(lambda picking:
+            picking.state in ('waiting', 'confirmed', 'assigned') and
+            picking.picking_type_code in ('outgoing', 'internal')
+        )
         pickings.products_availability_state = 'available'
         pickings.products_availability = _('Available')
         other_pickings = self - pickings

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -85,7 +85,7 @@
                     <field name="products_availability_state" column_invisible="True" options='{"lazy": true}'/>
                     <field name="products_availability" options='{"lazy": true}'
                         optional="hide"
-                        invisible="picking_type_code != 'outgoing' or state not in ['confirmed', 'waiting', 'assigned']"
+                        invisible="picking_type_code not in ('outgoing', 'internal') or state not in ['confirmed', 'waiting', 'assigned']"
                         decoration-success="state == 'assigned' or products_availability_state == 'available'"
                         decoration-warning="state != 'assigned' and products_availability_state in ('expected', 'available')"
                         decoration-danger="state != 'assigned' and products_availability_state == 'late'"/>
@@ -237,7 +237,7 @@
                                 decoration-bf="date_deadline and date_deadline &lt; current_date"/>
                             <field name="products_availability_state" invisible="1"/>
                             <field name="products_availability"
-                                invisible="picking_type_code != 'outgoing' or state not in ['confirmed', 'waiting', 'assigned']"
+                                invisible="picking_type_code not in ('outgoing', 'internal') or state not in ['confirmed', 'waiting', 'assigned']"
                                 decoration-success="state == 'assigned' or products_availability_state == 'available'"
                                 decoration-warning="state != 'assigned' and products_availability_state in ('expected', 'available')"
                                 decoration-danger="state != 'assigned' and products_availability_state == 'late'"/>
@@ -304,7 +304,7 @@
                                     <button name="action_show_details" type="object" string="Details" title="Details"
                                             invisible="not show_details_visible"/>
                                     <field name="forecast_availability" string=""
-                                        column_invisible="parent.state in ('draft', 'done')" widget="forecast_widget"/>
+                                        column_invisible="parent.state in ('cancel', 'done') or parent.picking_type_code not in ['internal', 'outgoing']" widget="forecast_widget"/>
                                 </list>
                             </field>
                             <field name="id" invisible="1"/>


### PR DESCRIPTION
Commit https://github.com/odoo/odoo/commit/4fbd88ad3ac2d92b47b024b96f1c40ed4b3f97e3 changed the forecast widget decoration on
`stock.move` but made it visible on receipt. As it doens't make sense to
see a potential forecast issue on a incoming move, this commit hides the
widget in those cases.
Moreover, we introduce a computation difference between internal and
delivery transfers. Internal transfers will be marked as `Available` if
the entire demand quantity is available. Deliveries need only a positive
forecast quantity to be marked as `Available`.

Task: 4747117


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
