### PR TITLE
[IMP] sale_loyalty: CoA template in test class

### DIFF
--- a/addons/sale_loyalty/tests/common.py
+++ b/addons/sale_loyalty/tests/common.py
@@ -12,8 +12,8 @@ from odoo.addons.sale.tests.test_sale_product_attribute_value_config import Test
 class TestSaleCouponCommon(TestSaleProductAttributeValueCommon):
 
     @classmethod
-    def setUpClass(cls):
-        super(TestSaleCouponCommon, cls).setUpClass()
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
         # set currency to not rely on demo data and avoid possible race condition
         cls.currency_ratio = 1.0
         pricelist = cls.env.ref('product.list0')


### PR DESCRIPTION
The base test class `TestSaleCouponCommon` does not allow to pass a specific CoA in the setup, which its parent class allows. In order to simplify extending that test class for custom addons, add the argument to `setupClass` and propagate it to the parent test case.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
