### PR TITLE
[FIX] mail: fix non-deterministic bus subscription test

### DIFF
--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -34,6 +34,7 @@ import {
 
 import { OutOfFocusService } from "@mail/core/common/out_of_focus_service";
 import { rpc } from "@web/core/network/rpc";
+import { runAllTimers } from "@odoo/hoot-dom";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -2020,6 +2021,7 @@ test("Message shows up even if channel data is incomplete", async () => {
         channel_type: "chat",
     });
     getService("bus_service").forceUpdateChannels();
+    await runAllTimers();
     await waitUntilSubscribe();
     await withUser(correspondentUserId, () =>
         rpc("/discuss/channel/notify_typing", {


### PR DESCRIPTION
Before this commit, the test "Message shows up even if channel data is incomplete" would sometimes fail. This happened because it waited for a bus subscription triggered by a call to the `_forceUpdateChannel` method of the bus service. However, this method is debounced, and as a result, the subscription sometimes occurred too late, causing the test to fail.

This commit resolves the issue by using `runAllTimers`, which immediately executes the debounced method.

fixes runbot-76011

