### PR TITLE
[FIX] base: make update_path required for 'Update Record' server actions

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -341,7 +341,7 @@
                         <separator string="Action Details" groups="base.group_no_one" />
                         <div class="d-flex flex-row flex-wrap gap-2" invisible="state != 'object_write'">
                             <field name="evaluation_type" class="oe_inline"/>
-                            <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}"/>
+                            <field name="update_path" widget="DynamicModelFieldSelectorChar" class="oe_inline" options="{'model': 'model_name'}" required="state == 'object_write'"/>
                             <field name="update_field_id" invisible="True"/>  <!-- The field is store=True and readonly=False, in this view we want to save the value from compute/onchange -->
                             <field name="update_related_model_id" invisible="True"/> <!-- This field is required for 'resource_ref' to compute possible m2m and m2o values -->
                             <span invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']">by</span>


### PR DESCRIPTION
[FIX] base: make update_path required for 'Update Record' server actions

If a server action was previously created without an `update path`, the resulting 
error already fixes with this commit [1].

This commit ensures that the `update_path` field is marked as required when the 
action type is set to `Update Record`.

[1]:
https://github.com/odoo/odoo/pull/217723/commits/9d0144f97795d71474bf84bdfd7ed7025fd8a9a2
