### PR TITLE
[FIX] web: prevent crash on going back

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -7,8 +7,7 @@ import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_se
 import { fuzzyTest } from "@web/core/utils/search";
 import { _t } from "@web/core/l10n/translation";
 import { SearchBarMenu } from "../search_bar_menu/search_bar_menu";
-
-import { Component, useRef, useState } from "@odoo/owl";
+import { Component, status, useRef, useState } from "@odoo/owl";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -682,7 +681,7 @@ export class SearchBar extends Component {
     }
 
     onInputDropdownChanged(isOpen) {
-        if (!isOpen) {
+        if (!isOpen && status(this) === "mounted") {
             this.resetState({ focus: false });
         }
     }

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -24,10 +24,13 @@ import {
     contains,
     defineActions,
     defineModels,
+    defineWebModels,
     editSearch,
     fields,
     getFacetTexts,
+    getService,
     models,
+    mountWebClient,
     mountWithCleanup,
     mountWithSearch,
     onRpc,
@@ -118,6 +121,12 @@ class Partner extends models.Model {
                 <filter string="Birthday" name="date_group_by" context="{'group_by': 'birthday:day'}"/>
             </search>
         `,
+        form: `
+            <form>
+                <field name="foo" />
+                <field name="bool" />
+            </form>
+        `,
     };
 }
 
@@ -129,7 +138,10 @@ defineActions([
         name: "Partners Action",
         res_model: "partner",
         search_view_id: [false, "search"],
-        views: [[false, "list"]],
+        views: [
+            [false, "list"],
+            [false, "form"],
+        ],
     },
 ]);
 
@@ -1916,4 +1928,21 @@ test("single name_search call and no flicker when holding ArrowRight", async fun
     }
     await press("arrowright");
     expect.verifySteps(["name_search"]);
+});
+
+test.tags("desktop");
+test("no crash when search component is destroyed with input", async () => {
+    const def = new Deferred();
+    onRpc("web_read", () => def);
+    defineWebModels();
+    await mountWebClient();
+    await getService("action").doAction(1);
+    expect(".o_list_view").toHaveCount(1);
+    await contains(".o_data_cell:eq(0)").click();
+    expect(".o_list_view").toHaveCount(1);
+    await editSearch("Jethalal");
+    def.resolve();
+    await animationFrame();
+    await runAllTimers();
+    expect(".o_form_view").toHaveCount(1);
 });


### PR DESCRIPTION
Before this commit a traceback was occurring on
going back from a view with search bar.

After this commit the traceback will not occur
anymore on going back from a view with search bar.

task-4735022

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
