### PR TITLE
[FIX] pos_self_order: Fix kiosk blank screen with online payment

### DIFF
--- a/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
+++ b/addons/pos_online_payment_self_order/static/tests/tours/pos_self_order_mobile_online_payment_tour.js
@@ -27,3 +27,15 @@ registry.category("web_tour.tours").add("self_mobile_online_payment_meal_table",
         Utils.clickBtn("Pay"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_online_payment_kiosk_qr_code", {
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickKioskProduct("Coca-Cola"),
+        Utils.clickBtn("Checkout"),
+        CartPage.checkKioskProduct("Coca-Cola", "2.53", "1"),
+        Utils.clickBtn("Pay"),
+        Utils.checkQRCodeGenerated(),
+    ],
+});

--- a/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_online_payment_self_order/tests/test_self_order_mobile.py
@@ -42,3 +42,18 @@ class TestSelfOrderMobile(SelfOrderCommonTest, OnlinePaymentCommon):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "self_mobile_online_payment_meal_table")
+
+    def test_online_payment_kiosk_qr_code(self):
+        """
+        Verify that when making an order from kiosk with online payment, a QR code is generated
+        """
+        self_route = self.pos_config._get_self_order_route()
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_service_mode': 'counter',
+            'self_order_online_payment_method_id': self.online_payment_method.id,
+            'use_presets': False,
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self.start_tour(self_route, "test_online_payment_kiosk_qr_code")

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.PaymentPage">
-        <div t-if="state.selection" class="d-flex flex-column flex-grow-1 overflow-y-auto o_kiosk_background o_kiosk_fade"
+        <div class="d-flex flex-column flex-grow-1 overflow-y-auto o_kiosk_background o_kiosk_fade"
         t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
             <div class="scroll_container d-flex flex-column flex-grow-1 overflow-y-auto justify-content-center my-auto">
-                <div class="o_kiosk_container d-grid gap-4 align-items-center justify-content-center w-100 p-3 overflow-y-auto">
+                <div t-if="state.selection" class="o_kiosk_container d-grid gap-4 align-items-center justify-content-center w-100 p-3 overflow-y-auto">
                     <button
                         t-foreach="selfOrder.models['pos.payment.method'].getAll()"
                         t-as="payment_method"

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -72,3 +72,10 @@ export function clickBackBtn() {
         run: "click",
     };
 }
+
+export function checkQRCodeGenerated() {
+    return {
+        content: `Check that the QR code is shown`,
+        trigger: "h1:contains('Scan the QR code to pay')",
+    };
+}


### PR DESCRIPTION
- Fix issue where a blank screen appear in Kiosk when trying to pay when an order.
- This recent issue was causeb by this UI revmap commit : https://github.com/odoo/odoo/pull/207148
- Add tour to make sure the QR code is generated when ordering in Kiosk with online payment.

Steps to reproduce:
- Configure a Kiosk with online payment
- Open Kiosk
- Create an order
- Click on Pay
- => Blank screen

task-id :4756588



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
