### PR TITLE
[FIX] mail: fixed external id not found error

### DIFF
--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -53,10 +53,11 @@ class Users(models.Model):
         self.filtered_domain([('share', '=', True), ('notification_type', '=', 'inbox')]).notification_type = 'email'
 
     def _inverse_notification_type(self):
-        inbox_group = self.env.ref('mail.group_mail_notification_type_inbox')
-        inbox_users = self.filtered(lambda user: user.notification_type == 'inbox')
-        inbox_users.write({"groups_id": [Command.link(inbox_group.id)]})
-        (self - inbox_users).write({"groups_id": [Command.unlink(inbox_group.id)]})
+        inbox_group = self.env.ref('mail.group_mail_notification_type_inbox', raise_if_not_found=False)
+        if inbox_group:
+            inbox_users = self.filtered(lambda user: user.notification_type == 'inbox')
+            inbox_users.write({"groups_id": [Command.link(inbox_group.id)]})
+            (self - inbox_users).write({"groups_id": [Command.unlink(inbox_group.id)]})
 
     # ------------------------------------------------------------
     # CRUD


### PR DESCRIPTION
When the reference to external ID `mail.group_mail_notification_type_inbox` is not found while creating a user a value error is thrown.

**Steps to reproduce:**
* Install the module mail.
* Delete/rename id `mail.group_mail_notification_type_inbox` from External Identifiers.
* Create a new User and save.

`Value Error:External ID not found in the system:
 mail.group_mail_notification_type_inbox`

**Solution:**
* Make `raise_if_not_found=False` and add an if statement to check for `inbox_group` and only proceed if it exists.

**Sentry-6564294068**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
