### PR TITLE
[FIX] point_of_sale: add iot_base to IoT Box sparse-checkout

### DIFF
--- a/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
+++ b/addons/point_of_sale/tools/posbox/configuration/posbox_update.sh
@@ -9,6 +9,7 @@ localbranch=$(git symbolic-ref -q --short HEAD)
 localremote=$(git config branch.$localbranch.remote)
 
 echo "addons/point_of_sale/tools/posbox/overwrite_after_init/home/pi/odoo" >> .git/info/sparse-checkout
+echo "addons/iot_base" >> .git/info/sparse-checkout
 
 git fetch "${localremote}" "${localbranch}" --depth=1
 git reset "${localremote}"/"${localbranch}" --hard


### PR DESCRIPTION
When checking out `saas-18.3`, IoT Box images until `25.01` are missing `iot_base`, resulting in odoo not being able to start.
