### PR TITLE
[FIX] website_sale: enable pricelists in tests

### DIFF
--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -174,6 +174,7 @@ class TestCheckoutAddress(WebsiteSaleCommon):
 
     def test_04_apply_empty_pl(self):
         ''' Ensure empty pl code reset the applied pl '''
+        self._enable_pricelists()
         so = self._create_so(partner_id=self.env.user.partner_id.id)
         eur_pl = self.env['product.pricelist'].create({
             'name': 'EUR_test',
@@ -189,6 +190,7 @@ class TestCheckoutAddress(WebsiteSaleCommon):
             self.assertNotEqual(so.pricelist_id, eur_pl, "Pricelist should be removed when sending an empty pl code")
 
     def test_04_pl_reset_on_login(self):
+        self._enable_pricelists()
         """Check that after login, the SO pricelist is correctly recomputed."""
         test_user = self.env['res.users'].create({
             'name': 'Toto',

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -64,6 +64,9 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         cls.env['product.pricelist'].action_archive()
 
     def test_01_admin_shop_custom_attribute_value_tour(self):
+        self.env.user.write(
+            {'group_ids': [Command.link(self.env.ref('product.group_product_pricelist').id)]}
+        )
         self.start_tour("/", 'a_shop_custom_attribute_value', login="admin")
 
     def test_02_admin_shop_custom_attribute_value_tour(self):
@@ -208,6 +211,9 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         )
 
     def test_07_editor_shop(self):
+        self.env.user.write(
+            {'group_ids': [Command.link(self.env.ref('product.group_product_pricelist').id)]}
+        )
         self.env['product.pricelist'].create([
             {'name': 'Base Pricelist', 'selectable': True},
             {'name': 'Other Pricelist', 'selectable': True}

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -236,6 +236,7 @@ class TestWebsiteSaleCart(ProductAttributesCommon, WebsiteSaleCommon):
     def test_cart_update_with_fpos(self):
         # We will test that the mapping of an 10% included tax by a 6% by a fiscal position is taken
         # into account when updating the cart
+        self._enable_pricelists()
         pricelist = self.pricelist
         # Create fiscal position mapping taxes 10% -> 6%
         fpos = self.env['account.fiscal.position'].create({

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -462,6 +462,7 @@ class TestWebsitePriceListAvailable(WebsiteSaleCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls._enable_pricelists()
         Pricelist = cls.env['product.pricelist']
         Website = cls.env['website']
 
@@ -821,6 +822,9 @@ class TestWebsiteSaleSession(HttpCaseWithUserPortal):
             The objective is to verify that the pricelist
             changes correctly according to the user.
         """
+        self.env.user.write(
+            {'group_ids': [Command.link(self.env.ref('product.group_product_pricelist').id)]}
+        )
         website = self.env.ref('website.default_website')
         test_user = self.env['res.users'].create({
             'name': 'Toto',

--- a/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
@@ -12,7 +12,7 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-
+        cls._enable_pricelists()
         ProductTemplate = cls.env['product.template']
         Pricelist = cls.env['product.pricelist']
 


### PR DESCRIPTION
After e1145d56162a5b88fe56b78abf70f7bd104ead00 we do not compute pricelists unless they are enabled which caused some tests to fail as they expected pricelists to be activated.

