### PR TITLE
[FIX] calendar: prevent access error on contact opening

### DIFF
--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -48,7 +48,7 @@ class Partner(models.Model):
             # Add the events linked to the children of the partner
             for p in self.browse(meetings.keys()):
                 partner = p
-                while partner.parent_id:
+                while partner.parent_id and partner.parent_id.id in all_partners.ids:
                     partner = partner.parent_id
                     if partner in self:
                         meetings[partner.id] = meetings.get(partner.id, set()) | meetings[p.id]

--- a/addons/calendar/tests/test_res_partner.py
+++ b/addons/calendar/tests/test_res_partner.py
@@ -76,3 +76,48 @@ class TestResPartner(TransactionCase):
         self.assertEqual(test_partner_5.meeting_count, 2)
         self.assertEqual(test_partner_6.meeting_count, 1)
         self.assertEqual(test_partner_7.meeting_count, 1)
+
+    def test_meeting_count_access_error(self):
+        main_co = self.env['res.company'].create({'name': 'main company'})
+        be_co = self.env['res.company'].create({'name': 'belgian Company'})
+        admin_user = self.env.ref('base.user_admin')
+        admin_user.write({
+            'company_id': main_co.id,
+            'company_ids': [(4, main_co.id), (4, be_co.id)]
+        })
+        no_access_user = new_test_user(
+            self.env,
+            login='test_user',
+            name="no access user",
+            groups='base.group_user',
+            company_id=main_co.id,
+            company_ids=[main_co.id]
+        )
+        partner_be = be_co.partner_id
+        partner_be.write({
+            'company_id': be_co.id
+        })
+        access_user = new_test_user(
+            self.env,
+            login='test_user_2',
+            name="laurie",
+            groups='base.group_user',
+            company_id=be_co.id,
+            company_ids=[main_co.id, be_co.id],
+        )
+        laurie = access_user.commercial_partner_id
+        laurie.write({
+            'parent_id':  partner_be.id,
+            'company_id': be_co.id,
+        })
+        self.env['calendar.event'].with_user(admin_user).create({
+            'name':        'laurie Meeting',
+            'partner_ids': [laurie.id],
+        })
+        self.env['calendar.event'].with_user(admin_user).create({
+            'name': 'second meetin',
+            'partner_ids': [laurie.id],
+        })
+        partner = self.env['res.partner'].with_user(no_access_user)
+        meet_count = partner.search([('id', 'in', [laurie.id])]).mapped('meeting_count')
+        self.assertEqual(meet_count, [2], 'the meeting count should me [2]')


### PR DESCRIPTION
**Issue:**
An AccessError is triggered during `meeting_count` computation when a user lacks read access to a parent partner.

**Steps to reproduce:**
1. In Users & Companies, ensure the “demo” user does **not** have access to “My Belgian Company”, but “Laurie Poiret” does.
2. In Contacts:
   - Open “Laurie Poiret” and set its Company to “My Belgian Company”.
   - Open “My Belgian Company” and, under the Sales & Purchase tab, set the company as "My Belgian Company"
   - still in the form, click the meeting icon and create a meeting for My Belgian Company, Laurie Poiret”.
3. Log in as “demo” and attempt to open either contact — an AccessError is raised.

the  reason is partner.parent_id can refers to a company/contact that the user (e.g. “demo”) does not have read access to

opw-4731972
