### PR TITLE
[FIX] calendar: fix privacy field lable in user form

### DIFF
--- a/addons/calendar/i18n/calendar.pot
+++ b/addons/calendar/i18n/calendar.pot
@@ -785,6 +785,7 @@ msgstr ""
 #: model:ir.ui.menu,name:calendar.mail_menu_calendar
 #: model:ir.ui.menu,name:calendar.menu_calendar_configuration
 #: model_terms:ir.ui.view,arch_db:calendar.res_config_settings_view_form
+#: model_terms:ir.ui.view,arch_db:calendar.res_users_form_view
 #: model_terms:ir.ui.view,arch_db:calendar.res_users_view_form
 msgid "Calendar"
 msgstr ""

--- a/addons/calendar/views/res_users_views.xml
+++ b/addons/calendar/views/res_users_views.xml
@@ -19,7 +19,9 @@
             <field name="inherit_id" ref="base.view_users_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='signature']" position="after">
-                    <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
+                    <group string="Calendar" name="calendar">
+                        <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
+                    </group>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
**Version**:
- saas-18.3

**issue**:
- The calendar privacy field has no label.

**cause**:
- after merge this PR https://github.com/odoo/odoo/pull/195101 a new group was
  added in the mail module, which caused the label to no longer display.

**solution**:
- Add the new group in the calendar module to restore the label visibility.

task-4748282
