### PR TITLE
[PERF] product_product: avoid injecting ids in product name_search

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -509,11 +509,12 @@ class ProductProduct(models.Model):
                 # on a database with thousands of matching products, due to the huge merge+unique needed for the
                 # OR operator (and given the fact that the 'name' lookup results come from the ir.translation table
                 # Performing a quick memory merge of ids in Python will give much better performance
-                product_ids = list(self._search(args + [('default_code', operator, name)], limit=limit))
+                products_query = self._search(args + [('default_code', operator, name)], limit=limit)
+                product_ids = list(products_query)
                 if not limit or len(product_ids) < limit:
                     # we may underrun the limit because of dupes in the results, that's fine
                     limit2 = (limit - len(product_ids)) if limit else False
-                    product2_ids = self._search(args + [('name', operator, name), ('id', 'not in', product_ids)], limit=limit2, access_rights_uid=name_get_uid)
+                    product2_ids = self._search(args + [('name', operator, name), ('id', 'not in', products_query)], limit=limit2, access_rights_uid=name_get_uid)
                     product_ids.extend(product2_ids)
             elif not product_ids and operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = expression.OR([


### PR DESCRIPTION
Before this PR, the name_search function would perform a search on products by injecting a list of ids in the domain instead of using a subquery. In cases where this list of ids is way too big, the search query becomes extremely slow.

This PR uses a subquery instead in the domain to avoid this problem.

Benchmarks:

|Num. product_ids| Before PR | After PR |
|---------------------|---------------|--------------| 
|28801| 65 s| <1 s|

opw-4743566

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
