### PR TITLE
[FIX] sale_mrp: find `bom_line_id` for kit comp. move run_pull

### DIFF
--- a/addons/sale_mrp/models/stock_rule.py
+++ b/addons/sale_mrp/models/stock_rule.py
@@ -9,3 +9,15 @@ class StockRule(models.Model):
         if values.get('sale_line_id'):
             res['sale_line_id'] = values['sale_line_id']
         return res
+
+    def _get_stock_move_values(self, product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values):
+        move_values = super()._get_stock_move_values(product_id, product_qty, product_uom, location_dest_id, name, origin, company_id, values)
+        if (sol_id := values.get('sale_line_id')) is not None and 'product_id' in move_values:
+            # if the SOL is for a kit
+            if move_values['product_id'] != self.env['sale.order.line'].browse(sol_id).product_id.id:
+                bom_line_id = self.env['sale.order.line'].browse(sol_id).move_ids.bom_line_id.filtered(
+                    lambda bl: bl.product_id.id == move_values.get('product_id')
+                ).id
+                if bom_line_id:
+                    move_values['bom_line_id'] = bom_line_id
+        return move_values

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2560,3 +2560,33 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         internal_picking.button_validate()
         self.assertEqual(internal_picking.state, 'done')
         self.assertEqual(order.order_line.qty_delivered, 0)
+
+    def test_return_for_exchange_kit_product_component(self):
+        """ Returning for exchange a kit's component should leave the original sale order line's
+        qty_delivered with the correct value.
+        """
+        for comp in self.bom_kit_1.bom_line_ids.product_id:
+            self.env['stock.quant']._update_available_quantity(comp, self.company_data['default_warehouse'].lot_stock_id, quantity=10)
+
+        comp_to_return = self.bom_kit_1.bom_line_ids.filtered(lambda bl: bl.product_qty == 1).product_id
+        kit_product = self.kit_1
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [Command.create({
+                'product_id': kit_product.id,
+                'product_uom_qty': 1.0,
+            })],
+        })
+        sale_order.action_confirm()
+        delivery = sale_order.picking_ids
+        delivery.action_assign()
+        delivery.button_validate()
+        return_picking_form = Form(self.env['stock.return.picking'].with_context(active_id=delivery.id, active_model='stock.picking'))
+        return_wizard = return_picking_form.save()
+        return_wizard.product_return_moves.filtered(lambda prm: prm.product_id == comp_to_return).quantity = 1
+        res = return_wizard.action_create_exchanges()
+        return_picking = self.env['stock.picking'].browse(res['res_id'])
+        return_picking.button_validate()
+        exchange_picking = sale_order.picking_ids.filtered(lambda so: so.state != 'done')
+        exchange_picking.button_validate()
+        self.assertEqual(sale_order.order_line.qty_delivered, 1)


### PR DESCRIPTION
**Current behavior:**
Using the return & exchange functionality when the product to exchange is a kit's component will not correctly update the SOL `qty_delivered` field upon validation of the exchange (out) picking.

**Expected behavior:**
accurate `qty_delivered`

**Steps to reproduce:**
1. Create a product w/ kit bom like:
* 2 units componentA
* 1 units componentB

2. Sell 1 unit of the kit product, validate delivery

3. Create a return for the 1 unit of componentB and select the exchange option on the wizard

4. Validate the return, then validate the exchange

5. Look at the sale order line `qty_delivered` -> it's 0

**Cause of the issue:**
The exchange picking move doesn't get a `bom_line_id` and thus is not properly aggregated in the computation of qty_delivered when incoming and outgoing quantities are being calculated (wherein these quantities must offset, but can't in this situation).

**Fix:**
When the procurement occurs to create the exchanging move, find the `bom_line_id` by looking at the original sale line's moves' bom's bom lines.

opw-4676609