### PR TITLE
Add a graceful reload option

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -1014,33 +1014,105 @@ class PreforkServer(CommonServer):
             family = socket.AF_INET
             if ':' in self.interface:
                 family = socket.AF_INET6
-            self.socket = socket.socket(family, socket.SOCK_STREAM)
-            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            self.socket.setblocking(0)
-            self.socket.bind((self.interface, self.port))
-            self.socket.listen(8 * self.population)
 
-    def stop(self, graceful=True):
+            # reload
+            if os.environ.get('ODOO_HTTP_SOCKET_FD'):
+                self.socket = socket.socket(fileno=int(os.environ.pop('ODOO_HTTP_SOCKET_FD')))
+
+            # default
+            else:
+                self.socket = socket.socket(family, socket.SOCK_STREAM)
+                self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                self.socket.setblocking(0)
+                self.socket.bind((self.interface, self.port))
+                self.socket.listen(8 * self.population)
+
+    def fork_and_reload(self):
+        _logger.info("Reloading server")
+        pid = os.fork()
+        if pid != 0:
+            # keep the http listening socket open during _reexec() to ensure uptime
+            http_socket_fileno = self.socket.fileno()
+            flags = fcntl.fcntl(http_socket_fileno, fcntl.F_GETFD)
+            fcntl.fcntl(http_socket_fileno, fcntl.F_SETFD, flags & ~fcntl.FD_CLOEXEC)
+            os.environ['ODOO_HTTP_SOCKET_FD'] = str(http_socket_fileno)
+            os.environ['ODOO_READY_SIGHUP_PID'] = str(pid)
+            _reexec()  # stops execution
+
+        # child process handles old server shutdown
+        _logger.info("Waiting for new server to start ...")
+        phoenix_hatched = False
+
+        def sighup_handler(sig, frame):
+            nonlocal phoenix_hatched
+            phoenix_hatched = True
+
+        signal.signal(signal.SIGHUP, sighup_handler)
+
+        reload_timeout = time.monotonic() + 60
+        while not phoenix_hatched and time.monotonic() < reload_timeout:
+            time.sleep(0.1)
+
+        if not phoenix_hatched:
+            _logger.error("Server reload timed out (check the updated code)")
+        else:
+            _logger.info("New server has started")
+
+    def stop_workers_gracefully(self):
+        _logger.info("Stopping workers gracefully")
+
         if self.long_polling_pid is not None:
             # FIXME make longpolling process handle SIGTERM correctly
             self.worker_kill(self.long_polling_pid, signal.SIGKILL)
             self.long_polling_pid = None
+
+        # Signal workers to finish their current workload then stop
+        for pid in self.workers:
+            self.worker_kill(pid, signal.SIGINT)
+
+        is_main_server = self.pid == os.getpid()  # False if server reload, cannot reap children -> use psutil
+        if not is_main_server:
+            processes = {}
+            for pid in self.workers:
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    processes[pid] = psutil.Process(pid)
+
+        self.beat = 0.1
+        while self.workers:
+            try:
+                self.process_signals()
+            except KeyboardInterrupt:
+                _logger.info("Forced shutdown.")
+                break
+
+            if is_main_server:
+                self.process_zombie()
+            else:
+                for pid, proc in list(processes.items()):
+                    if not proc.is_running():
+                        self.worker_pop(pid)
+                        processes.pop(pid)
+
+            self.sleep()
+            self.process_timeout()
+
+    def stop(self, graceful=True):
+        global server_phoenix  # noqa: PLW0603
+        if server_phoenix:
+            # PreforkServer reloads gracefully, disable outdated mechanism
+            server_phoenix = False
+
+            self.fork_and_reload()
+            self.stop_workers_gracefully()
+
+            _logger.info("Old server stopped")
+            return
+
         if self.socket:
             self.socket.close()
         if graceful:
-            _logger.info("Stopping gracefully")
             super().stop()
-            limit = time.time() + self.timeout
-            for pid in self.workers:
-                self.worker_kill(pid, signal.SIGINT)
-            while self.workers and time.time() < limit:
-                try:
-                    self.process_signals()
-                except KeyboardInterrupt:
-                    _logger.info("Forced shutdown.")
-                    break
-                self.process_zombie()
-                time.sleep(0.1)
+            self.stop_workers_gracefully()
         else:
             _logger.info("Stopping forcefully")
         for pid in list(self.workers):
@@ -1057,6 +1129,9 @@ class PreforkServer(CommonServer):
 
         # Empty the cursor pool, we dont want them to be shared among forked workers.
         sql_db.close_all()
+
+        if os.environ.get('ODOO_READY_SIGHUP_PID'):
+            os.kill(int(os.environ.pop('ODOO_READY_SIGHUP_PID')), signal.SIGHUP)
 
         _logger.debug("Multiprocess starting")
         while 1:

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -956,7 +956,7 @@ class PreforkServer(CommonServer):
 
     def process_timeout(self):
         now = time.time()
-        for (pid, worker) in self.workers.items():
+        for (pid, worker) in list(self.workers.items()):
             if worker.watchdog_timeout is not None and \
                     (now - worker.watchdog_time) >= worker.watchdog_timeout:
                 _logger.error("%s (%s) timeout after %ss",
@@ -1041,7 +1041,7 @@ class PreforkServer(CommonServer):
                 time.sleep(0.1)
         else:
             _logger.info("Stopping forcefully")
-        for pid in self.workers:
+        for pid in list(self.workers):
             self.worker_kill(pid, signal.SIGTERM)
 
     def run(self, preload, stop):

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -910,6 +910,8 @@ class PreforkServer(CommonServer):
     def worker_kill(self, pid, sig):
         try:
             os.kill(pid, sig)
+            if sig == signal.SIGKILL:
+                self.worker_pop(pid)
         except OSError as e:
             if e.errno == errno.ESRCH:
                 self.worker_pop(pid)


### PR DESCRIPTION
Component of Odoo task: https://www.odoo.com/odoo/project/1105/tasks/2946044

Currently, the server reload option (through the `server_phoenix`
mechanism) activated by sending a SIGHUP signal to the main process.
This came with a consequential downtime while the server was restarting.

This commit changes it to reload the server with no downtime (POSIX +
Prefork mode)

When a SIGHUP signal is sent to the main server, it will now initiate
the shutdown procedure in a separate process that will first wait until
the main process has finished restarting and is ready to handle new
incoming HTTP requests.

The reexecuted server will reuse the same socket and notify its stopping
fork with a SIGHUP signal, which will then proceed with the graceful
shutdown procedure. It will not be able to reap the children processes,
so it will monitor them closely in a slightly different way using
psutil. The newly restarted server will reap them without consequence.

Note: the gevent longpolling server is not handled gracefully.

(+ a couple of small fixes)