### PR TITLE
[FIX] base, mail: prevent inverse methods from re-adding user types

### DIFF
--- a/addons/mail/tests/test_res_users.py
+++ b/addons/mail/tests/test_res_users.py
@@ -82,6 +82,27 @@ class TestUser(MailCommon):
         self.assertEqual(user.notification_type, 'email')
         self.assertNotIn(self.env.ref('mail.group_mail_notification_type_inbox'), user.groups_id)
 
+        admin = mail_new_test_user(
+            self.env,
+            login="user_test_constraint_4",
+            name="Test User 4",
+            email="user_test_constraint_3@test.example.com",
+            notification_type='inbox',
+            groups='base.group_erp_manager',
+        )
+        # Re-check that no error occurs when we have overlapping writes on admin user
+        admin.write({
+            'notification_type': 'email',
+            'groups_id': [
+                (3, self.env.ref('base.group_user').id),
+                (4, self.env.ref('base.group_portal').id),
+            ],
+        })
+        self.assertFalse(admin._is_admin())
+        self.assertTrue(admin._is_portal())
+        self.assertEqual(admin.notification_type, 'email')
+        self.assertNotIn(self.env.ref('mail.group_mail_notification_type_inbox'), admin.groups_id)
+
     def test_web_create_users(self):
         src = [
             'POILUCHETTE@test.example.com',


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a new internal user with some administrator rights;
2. set notification preference to "Handle in Odoo";
3. save changes;
4. switch user type to portal.

Issue
-----
Validation Error: The user cannot have more than one user types.

Cause
-----
In the write method of `UsersImplied`, a check happens on whether a user was demoted, by saving the internal users before `super().write`, and comparing it to the internal users after `super().write`[^1].
[^1]: https://github.com/odoo/odoo/blob/6ba1106aecf71886b7df3b7943089fa72a6c506c/odoo/addons/base/models/res_users.py#L1455-L1457

This was working fine until commit 141852dc6613c introduced the `_inverse_notification_type` method[^4]. It adds or removes the `mail.group_mail_notification_type_inbox` group from users when the `notification_type` gets changed.
[^4]: https://github.com/odoo/odoo/blob/6ba1106aecf71886b7df3b7943089fa72a6c506c/addons/mail/models/res_users.py#L54-L58

In our first call to `UsersImplied.write`, we store the user as an internal user and call `super().write`. This unlinks `base.group_user`, links `base.group_portal` and sets `notification_type` to `email`.

Before returning from `super().write`, the `_inverse_notification_type` method gets triggered to unlink the inbox group, which will lead to a recursive call to `UsersImplied.write`.

The recursive call no longer registers the user as internal or being demoted, hence it will re-add `base.group_user` as an implied group[^2] of its still present administrator group, leading to the `api.constrains` violation in `_check_one_user_type`[^3], as we already have the `base.group_portal` group.
[^2]: https://github.com/odoo/odoo/blob/6ba1106aecf71886b7df3b7943089fa72a6c506c/odoo/addons/base/models/res_users.py#L1466-L1469
[^3]: https://github.com/odoo/odoo/blob/6ba1106aecf71886b7df3b7943089fa72a6c506c/odoo/addons/base/models/res_users.py#L589-L599

Solution
--------
Add a context value when calling `super().write`. If this value is present in the current call, this indicates we are in a recursive write, and can return without adding/removing implied groups, as these will get handled later by the base call.

opw-4676929