### PR TITLE
[FIX] mrp: change path of workcenters kanban/list

### DIFF
--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -375,6 +375,7 @@
 
         <record id="mrp_workcenter_action" model="ir.actions.act_window">
             <field name="name">Work Centers</field>
+            <field name="path">workcenters</field>
             <field name="res_model">mrp.workcenter</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="view_id" ref="mrp_workcenter_tree_view"/>


### PR DESCRIPTION
Add a path to the workcenter action to facilitate a redirect in the linked enterprise PR.

task-4731403

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
