### PR TITLE
[FIX] tests: avoid TestCursor corruption

### DIFF
--- a/addons/bus/tests/common.py
+++ b/addons/bus/tests/common.py
@@ -74,8 +74,7 @@ class WebsocketCase(HttpCase):
             self.session = self.authenticate(None, None)
             kwargs['cookie'] = f'session_id={self.session.sid}'
         kwargs['cookie'] += f';{TEST_CURSOR_COOKIE_NAME}={self.http_request_key}'
-        if 'timeout' not in kwargs:
-            kwargs['timeout'] = 5
+        kwargs['timeout'] = 10  # keep a large timeout to avoid aving a websocket request escaping the test
         ws = websocket.create_connection(
             self._WEBSOCKET_URL, *args, **kwargs
         )

--- a/addons/mail/tests/discuss/test_bus_presence.py
+++ b/addons/mail/tests/discuss/test_bus_presence.py
@@ -25,7 +25,7 @@ class TestBusPresence(WebsocketCase, MailCommon):
         else:
             self.authenticate(None, None)
             auth_cookie = f"{recipient._cookie_name}={recipient._format_auth_cookie()};"
-        websocket = self.websocket_connect(cookie=auth_cookie, timeout=1)
+        websocket = self.websocket_connect(cookie=auth_cookie)
         sender_bus_target = sender.partner_id if sent_from_user else sender
         self.subscribe(
             websocket,

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -580,15 +580,16 @@ class TestCursor(BaseCursor):
 
     def close(self):
         if not self._closed:
-            self.rollback()
-            self._closed = True
-            if self._savepoint:
-                self._savepoint.close(rollback=False)
-
-            tos = self._cursors_stack.pop()
-            if tos is not self:
-                _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
-            self._lock.release()
+            try:
+                self.rollback()
+                if self._savepoint:
+                    self._savepoint.close(rollback=False)
+            finally:
+                self._closed = True
+                tos = self._cursors_stack.pop()
+                if tos is not self:
+                    _logger.warning("Found different un-closed cursor when trying to close %s: %s", self, tos)
+                self._lock.release()
 
     def commit(self):
         """ Perform an SQL `COMMIT` """

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -62,7 +62,7 @@ from odoo.http import BadRequest
 from odoo.modules import module
 from odoo.modules.registry import Registry
 from odoo.service import security
-from odoo.sql_db import BaseCursor, Cursor
+from odoo.sql_db import BaseCursor, Cursor, TestCursor
 from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import find_in_path, lower_logging
@@ -951,6 +951,14 @@ class TransactionCase(BaseCase):
 
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(cls.cr.close)
+
+        def check_cursor_stack():
+            for cursor in TestCursor._cursors_stack:
+                _logger.info('One curor was remaining in the TestCursor stack at the end of the test')
+                cursor._closed = True
+            TestCursor._cursors_stack = []
+
+        cls.addClassCleanup(check_cursor_stack)
 
         if cls.freeze_time:
             cls.startClassPatcher(freezegun.freeze_time(cls.freeze_time))


### PR DESCRIPTION
Build error 162704

Will be backported in 16.0 via 207975 (focusing on 18.0->master to start)

Follow-up on other WebSocket fixes, this time for the execution of the WebSocket request inside the same test, but not after a Chrome browser.

This case is quite specific and is related to a low timeout set on websocket_connect, leading to the request being randomly executed inside the test. This is a problem for the current test (fixed by increasing the timeout), but also for the next test: if the TestCursor rollback fails, the cursor_stack of the TestCursor is not emptied, leading to a case where an existing read-only test cursor in the stack makes the next TestCursor read-only, causing chain failures.

This pr adresses the problem by
- increasing the timeout
- making the TestCursor.close more robust
- Ensuring that the cursor_stack is empty at the end of a test. 
