### PR TITLE
[REF] hw_drivers,event: adapt to new IoT http service

### DIFF
--- a/addons/hw_drivers/controllers/driver.py
+++ b/addons/hw_drivers/controllers/driver.py
@@ -44,7 +44,6 @@ class DriverController(http.Controller):
             return False
 
         iot_device.data['owner'] = session_id
-        data = json.loads(data)
 
         _logger.debug("Calling action %s for device %s", data.get('action', ''), device_identifier)
         iot_device.action(data)

--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -84,7 +84,7 @@ export class IoTLongpolling {
         const body = {
             session_id: this._session_id,
             device_identifier: device_identifier,
-            data: JSON.stringify(data),
+            data,
         };
         return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback);
     }


### PR DESCRIPTION
This commit introduces a new `iot_http` service that allows performing an IoT action using longpolling then falling back sending a websocket message if the longpolling request fails.

Enterprise PR: odoo/enterprise#84436
Task: 4283647
