### PR TITLE
[WIP][FIX] l10n_ar: show report totals in negative for Liquido Producto CN

### DIFF
--- a/addons/l10n_ar/models/account_move_line.py
+++ b/addons/l10n_ar/models/account_move_line.py
@@ -24,6 +24,11 @@ class AccountMoveLine(models.Model):
                 price, invoice.currency_id, self.quantity, self.product_id, invoice.partner_id)['total_included']
         price_net = price_unit * (1 - (self.discount or 0.0) / 100.0)
 
+        if invoice._is_refund_invoice():
+            price_unit = -price_unit
+            price_subtotal = -price_subtotal
+            price_net = -price_net
+
         return {
             'price_unit': price_unit,
             'price_subtotal': price_subtotal,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
There are some documents that share the same ARCA code `(l10n_latam_document_type_id.code)` for creating invoices and credit notes. They are the ones contained in `_get_l10n_ar_codes_used_for_inv_and_ref` method. For this cases, both documents reports looks similar, which makes it difficult for the user to distinguish one from each other.
The goal of this PR is to improve the readability of these documents by making the credit notes amounts appear in negative in the report. This change is only for the appearance of CN report, it should not affect the calculation of the amounts.

Current behavior before PR:
Before this PR, both invoices and credit notes had the same report and same ARCA code.

Desired behavior after PR is merged:
After this PR, the credit note report related to an invoice that has the same ARCA code will appear with negative amounts.

![image](https://github.com/user-attachments/assets/0b9662e0-ea8f-4312-affa-2aaf50ee99dd)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
