### PR TITLE
[FIX] sale_project: display COGS in project updates if COGS lines exist

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -682,13 +682,13 @@ class ProjectProject(models.Model):
         if invoices_move_lines:
             revenues_lines = []
             cogs_lines = []
-            amount_invoiced = amount_to_invoice = 0.0
             for move_line in invoices_move_lines:
                 if move_line['display_type'] == 'cogs':
                     cogs_lines.append(move_line)
                 else:
                     revenues_lines.append(move_line)
             for move_lines, ml_type in ((revenues_lines, 'revenues'), (cogs_lines, 'costs')):
+                amount_invoiced = amount_to_invoice = 0.0
                 for move_line in move_lines:
                     currency = move_line.currency_id
                     price_subtotal = currency._convert(move_line.price_subtotal, self.currency_id, self.company_id)


### PR DESCRIPTION
Problem: When viewing the project update of a project that timesheets on a service product with standard valuation, the 'cost_of_goods_sold' section is displayed when it should not be.

Purpose: The COGS section should only be displayed in the project updates if COGS lines exists in relation to the project. The behavior should stay consistent with v17.0 as with this commit: #203936

Steps to reproduce the issue:
1. Install Purchase, Sales, Project,sale_project, Inventory, Timesheets
2. Create a service product with standard valuation and creates project & task on order
3. Create a sales order with the service product
4. Invoice the sales order and confirm
5. Create another invoice not linked to the sales order but contains project's analytic account
6. Load the project update or dashboard of the project and notice there's a COGS section displayed despite no related COGS invoice line

opw-4684445

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
