### PR TITLE
[FIX] l10n_my_edi: template

### DIFF
--- a/addons/l10n_my_edi/data/my_ubl_templates.xml
+++ b/addons/l10n_my_edi/data/my_ubl_templates.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <template id="ubl_21_InvoiceType_my" inherit_id="account_edi_ubl_cii.ubl_21_InvoiceType" primary="True">
-        <xpath expr="//*[local-name()='DocumentCurrencyCode']" position="after">
+        <xpath expr="//*[local-name()='BillingReference']" position="after">
             <t xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
                xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
-                <cac:AdditionalDocumentReference t-if="vals.get('invoice_incoterm_code')">
-                    <cbc:ID t-out="vals['invoice_incoterm_code']"/>
-                </cac:AdditionalDocumentReference>
                 <cac:AdditionalDocumentReference t-if="vals.get('custom_form_reference')">
                     <cbc:ID t-out="vals['custom_form_reference']"/>
                     <cbc:DocumentType>CustomsImportForm</cbc:DocumentType>
+                </cac:AdditionalDocumentReference>
+                <cac:AdditionalDocumentReference t-if="vals.get('invoice_incoterm_code')">
+                    <cbc:ID t-out="vals['invoice_incoterm_code']"/>
                 </cac:AdditionalDocumentReference>
             </t>
         </xpath>


### PR DESCRIPTION
Fix an issue in the xml template where
the custom import form reference is set
at the wrong place, causing errors when
it is in use at the same time as a customer reference.

task-4761954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
