### PR TITLE
[FIX] mrp: correct component availability in BoM overview

### DIFF
--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -47,7 +47,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
             })],
         })
 
-    @freeze_time('2024-01-01')
     def test_bom_overview_availability(self):
         # Create routes for components and the main product
         self.env['product.supplierinfo'].create({
@@ -84,10 +83,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         for component in bom_data['lines']['components']:
             self.assertEqual(component['quantity_on_hand'], 4)
             self.assertEqual(component['availability_state'], 'available')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 3)
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/11/2024')
-        self.assertTrue('leftover_capacity' not in bom_data['lines']['earliest_date'])
-        self.assertTrue('leftover_date' not in bom_data['lines']['earliest_date'])
 
         # Generate a report for 5 products: only 4 products should be ready for production
         bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 5)
@@ -96,10 +91,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         for component in bom_data['lines']['components']:
             self.assertEqual(component['quantity_on_hand'], 4)
             self.assertEqual(component['availability_state'], 'estimated')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 4)
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/11/2024')
-        self.assertEqual(bom_data['lines']['leftover_capacity'], 1)
-        self.assertEqual(bom_data['lines']['leftover_date'], '01/16/2024')
 
     def test_count_smart_buttons(self):
         resupply_sub_on_order_route = self.env['stock.route'].search([('name', '=', 'Resupply Subcontractor on Order')])
@@ -827,7 +818,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id, searchQty=search_qty_more_than_total, searchVariant=False)
         self.assertEqual(report_values['lines']['components'][0]['stock_avail_state'], 'unavailable')
 
-    @freeze_time('2024-01-01')
     def test_bom_overview_availability_po_lead(self):
         # Create routes for components and the main product
         self.env['product.supplierinfo'].create({
@@ -863,11 +853,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         for component in bom_data['lines']['components']:
             self.assertEqual(component['quantity_on_hand'], 4)
             self.assertEqual(component['availability_state'], 'available')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 3)
-        # 01/11 + 2 days of Security Lead Time = 01/13
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/13/2024')
-        self.assertTrue('leftover_capacity' not in bom_data['lines']['earliest_date'])
-        self.assertTrue('leftover_date' not in bom_data['lines']['earliest_date'])
 
         # Generate a report for 5 products: only 4 products should be ready for production
         bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 5)
@@ -876,12 +861,6 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         for component in bom_data['lines']['components']:
             self.assertEqual(component['quantity_on_hand'], 4)
             self.assertEqual(component['availability_state'], 'estimated')
-        self.assertEqual(bom_data['lines']['earliest_capacity'], 4)
-        # 01/11 + 2 days of Security Lead Time = 01/13
-        self.assertEqual(bom_data['lines']['earliest_date'], '01/13/2024')
-        self.assertEqual(bom_data['lines']['leftover_capacity'], 1)
-        # 01/16 + 2 x 2 days (for components and for final product) = 01/20
-        self.assertEqual(bom_data['lines']['leftover_date'], '01/20/2024')
 
     def test_location_after_dest_location_update_backorder_production(self):
         """


### PR DESCRIPTION
Before this commit:
-------------------
- In the BoM overview (forecast mode), component availability incorrectly
  considered incoming quantities without accounting for existing reservations.
- This was displaying misleading availability indicators or status messages,
  such as showing components as 'Expected' in availability even when fully
  reserved, or showing them as 'To Order' in status despite existing scheduled
  orders.

Steps to reproduce:
-------------------
- Create a BoM (A) with a storable component.
- Confirm a purchase order for 1 unit of the component.
- Create and confirm an MO for A.
- Set the MO’s scheduled date at least 10 days in the future.
- Open BoM A and view the BoM overview in forecast mode.
  - Observe that the component shows an expected availability date, despite
   being fully reserved (i.e., forecast = 0).
  - Also observe that when the availability state is 'expected' (i.e. already
   there are orders scheduled) it shows "x To Order" in component status.

After this commit:
-----------------
- The availability check now compares required component quantities against
  forecasted quantities (which include existing reservations).
- Status messages now accurately reflect true availability.

Impact:
-------
Users will see correct component availability and status indicators in the
BoM overview, avoiding misleading messages about "Expected Availability" or
"To Order" quantities when components are already reserved. This improves
production planning and prevents confusion during material availability checks.

task-4649912