### PR TITLE
[FIX] html_editor: canonical form for sublists

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -832,7 +832,10 @@ export class DeletePlugin extends Plugin {
         if (
             block === commonAncestorContainer ||
             !this.isCursorAtEndOfElement(block, endContainer, endOffset) ||
-            (startList && endList && !compareListTypes(startList, endList))
+            (startList &&
+                endList &&
+                !compareListTypes(startList, endList) &&
+                !startList.contains(endList))
         ) {
             return range;
         }

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -4,7 +4,7 @@ import { callbacksForCursorUpdate } from "@html_editor/utils/selection";
 import { _t } from "@web/core/l10n/translation";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
-import { cleanTextNode, fillEmpty, splitTextNode, unwrapContents } from "../utils/dom";
+import { cleanTextNode, fillEmpty, removeClass, splitTextNode, unwrapContents } from "../utils/dom";
 import {
     areSimilarElements,
     isContentEditable,
@@ -175,7 +175,7 @@ export class FormatPlugin extends Plugin {
             ) {
                 continue;
             }
-            this._formatSelection(format, { applyStyle: false });
+            this.formatSelection(format, { applyStyle: false, removeFormat: true });
         }
         this.dependencies.history.addStep();
     }
@@ -228,9 +228,9 @@ export class FormatPlugin extends Plugin {
         );
     }
 
-    formatSelection(...args) {
-        this.delegateTo("format_selection_overrides", ...args);
-        if (this._formatSelection(...args)) {
+    formatSelection(formatName, options) {
+        this.delegateTo("format_selection_overrides", formatName, options);
+        if (this._formatSelection(formatName, options) && !options?.removeFormat) {
             this.dependencies.history.addStep();
         }
     }
@@ -323,6 +323,9 @@ export class FormatPlugin extends Plugin {
                         parentNode
                     );
                     removeFormat(newLastAncestorInlineFormat, formatSpec);
+                    if (["setFontSizeClassName", "fontSize"].includes(formatName) && applyStyle) {
+                        removeClass(newLastAncestorInlineFormat, "o_default_font_size");
+                    }
                     if (newLastAncestorInlineFormat.isConnected) {
                         inlineAncestors.push(newLastAncestorInlineFormat);
                         currentNode = newLastAncestorInlineFormat;

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -698,7 +698,9 @@ export class SelectionPlugin extends Plugin {
         const lastLeafNode = lastLeaf(node);
         return (
             // Custom rules
-            this.getResource("fully_selected_node_predicates").some((cb) => cb(node, selection)) ||
+            this.getResource("fully_selected_node_predicates").some((cb) =>
+                cb(node, selection, range)
+            ) ||
             // Default rule
             (range.isPointInRange(firstLeafNode, 0) &&
                 range.isPointInRange(lastLeafNode, nodeSize(lastLeafNode)))

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -293,6 +293,9 @@ export class ColorPlugin extends Plugin {
             if (mode === "backgroundColor" && color) {
                 return !closestElement(node, "table.o_selected_table");
             }
+            if (closestElement(node).classList.contains("o_default_color")) {
+                return false;
+            }
             const li = closestElement(node, "li");
             if (li && color && this.dependencies.selection.areNodeContentsFullySelected(li)) {
                 return rgbaToHex(li.style.color).toLowerCase() !== hexColor;
@@ -423,10 +426,6 @@ export class ColorPlugin extends Plugin {
         // Color the selected <font>s and remove uncolored fonts.
         const fontsSet = new Set(fonts);
         for (const font of fontsSet) {
-            const closestLI = closestElement(font, "li");
-            if (font && color === "" && closestLI?.style.color) {
-                color = "initial";
-            }
             this.colorElement(font, color, mode);
             if (
                 !hasColor(font, "color") &&

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -290,7 +290,8 @@ export class FontPlugin extends Plugin {
         /** Processors */
         clipboard_content_processors: this.processContentForClipboard.bind(this),
 
-        format_splittable_class: (className) => FONT_SIZE_CLASSES.includes(className),
+        format_splittable_class: (className) =>
+            [...FONT_SIZE_CLASSES, "o_default_font_size"].includes(className),
     };
 
     setup() {

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -20,13 +20,28 @@ ul.o_checklist {
             border: 1px solid;
             cursor: pointer;
         }
-        &.o_checked:after {
-            content: "✓";
-            transition: opacity .5s;
-            position: absolute;
-            left: -18px;
-            top: -1px;
-            opacity: 1;
+        &.o_checked {
+            &::before {
+                content: "✓";
+                transition: opacity .5s;
+                position: absolute;
+                left: -18px;
+                top: -1px;
+                opacity: 1;
+            }
+
+            &:has(ul, ol)::before {
+                opacity: 0.5;
+            }
+
+            &:not(:has(ul, ol)) {
+                text-decoration: line-through;
+                opacity: 0.5;
+            }
+            &:has(ul, ol) > :not(ul, ol) {
+                text-decoration: line-through;
+                opacity: 0.5;
+            }
         }
     }
 }

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,6 +2,14 @@ li p {
     margin-bottom: 0px;
 }
 
+.o_default_color {
+    color: $body-color;
+}
+
+.o_default_font_size {
+    font-size: $font-size-base;
+}
+
 // Checklist
 ul.o_checklist {
     > li {

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -132,7 +132,7 @@ export class ListPlugin extends Plugin {
             { commandId: "toggleListCL" },
         ].map((item) => withSequence(15, item)),
 
-        hints: [{ selector: "LI", text: _t("List") }],
+        hints: [{ selector: `LI, LI > ${baseContainerGlobalSelector}`, text: _t("List") }],
 
         /** Handlers */
         input_handlers: this.onInput.bind(this),

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -127,7 +127,7 @@ export class PowerButtonsPlugin extends Plugin {
             editableRect.bottom > blockRect.top &&
             isEmptyBlock(block) &&
             !this.services.ui.isSmall &&
-            !closestElement(editableSelection.anchorNode, "td") &&
+            !closestElement(editableSelection.anchorNode, "td, li") &&
             !block.style.textAlign &&
             this.getResource("power_buttons_visibility_predicates").every((predicate) =>
                 predicate(editableSelection)

--- a/addons/html_editor/static/src/utils/color.js
+++ b/addons/html_editor/static/src/utils/color.js
@@ -98,7 +98,6 @@ export function hasColor(element, mode) {
     return (
         (style[mode] &&
             style[mode] !== "inherit" &&
-            style[mode] !== "initial" &&
             (!parent || style[mode] !== parent.style[mode])) ||
         (classRegex.test(element.className) &&
             (!parent || getComputedStyle(element)[mode] !== getComputedStyle(parent)[mode]))

--- a/addons/html_editor/static/src/utils/formatting.js
+++ b/addons/html_editor/static/src/utils/formatting.js
@@ -93,7 +93,9 @@ export const formatsSpecs = {
         removeStyle: (node) => removeStyle(node, "font-family"),
     },
     fontSize: {
-        isFormatted: (node) => closestElement(node)?.style["font-size"],
+        isFormatted: (node) =>
+            closestElement(node)?.style["font-size"] ||
+            closestElement(node, "li")?.style["font-size"],
         hasStyle: (node) => node.style && node.style["font-size"],
         addStyle: (node, props) => {
             node.style["font-size"] = props.size;
@@ -103,7 +105,11 @@ export const formatsSpecs = {
     },
     setFontSizeClassName: {
         isFormatted: (node) =>
-            FONT_SIZE_CLASSES.find((cls) => closestElement(node)?.classList?.contains(cls)),
+            FONT_SIZE_CLASSES.find(
+                (cls) =>
+                    closestElement(node)?.classList?.contains(cls) ||
+                    closestElement(node, "LI")?.classList?.contains(cls)
+            ),
         hasStyle: (node, props) => FONT_SIZE_CLASSES.find((cls) => node.classList.contains(cls)),
         addStyle: (node, props) => {
             node.style.removeProperty("font-size");

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -915,8 +915,7 @@ describe("Selection collapsed", () => {
 
         test("should delete a h1 inside a nested list immediately after insertion", async () => {
             await testEditor({
-                contentBefore:
-                    '<ul><li>abc</li><li class="oe-nested"><ul><li>[]<br></li></ul></li></ul>',
+                contentBefore: "<ul><li><p>abc</p><ul><li>[]<br></li></ul></li></ul>",
                 stepFunction: async (editor) => {
                     await insertText(editor, "/");
                     await insertText(editor, "Heading");
@@ -926,7 +925,7 @@ describe("Selection collapsed", () => {
                     deleteBackward(editor);
                     deleteBackward(editor);
                 },
-                contentAfter: "<ul><li>abc[]</li></ul>",
+                contentAfter: "<ul><li><p>abc[]</p></li></ul>",
             });
         });
     });

--- a/addons/html_editor/static/tests/format/text_direction.test.js
+++ b/addons/html_editor/static/tests/format/text_direction.test.js
@@ -50,24 +50,24 @@ test("should properly switch the direction of the single level list (ltr).", asy
 
 test("should properly switch the direction of nested list (ltr).", async () => {
     await testEditor({
-        contentBefore: `<ul><li>a[]</li><li class="oe-nested"><ul><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul><li><p>a[]</p><ul><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul dir="rtl"><li>a[]</li><li class="oe-nested"><ul dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul dir="rtl"><li><p>a[]</p><ul dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
     });
     await testEditor({
-        contentBefore: `<ol><li>a[]</li><li class="oe-nested"><ol><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
+        contentBefore: `<ol><li><p>a[]</p><ol><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
         stepFunction: switchDirection,
-        contentAfter: `<ol dir="rtl"><li>a[]</li><li class="oe-nested"><ol dir="rtl"><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
+        contentAfter: `<ol dir="rtl"><li><p>a[]</p><ol dir="rtl"><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
     });
     await testEditor({
-        contentBefore: `<ul class="o_checklist"><li>a[]</li><li class="oe-nested"><ul class="o_checklist"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul class="o_checklist"><li><p>a[]</p><ul class="o_checklist"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul class="o_checklist" dir="rtl"><li>a[]</li><li class="oe-nested"><ul class="o_checklist" dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul class="o_checklist" dir="rtl"><li><p>a[]</p><ul class="o_checklist" dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
     });
     await testEditor({
-        contentBefore: `<ul><li>a[]</li><li class="oe-nested"><ul class="o_checklist"><li>b</li><li class="oe-nested"><ol><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul><li><p>a[]</p><ul class="o_checklist"><li><p>b</p><ol><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul dir="rtl"><li>a[]</li><li class="oe-nested"><ul class="o_checklist" dir="rtl"><li>b</li><li class="oe-nested"><ol dir="rtl"><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul dir="rtl"><li><p>a[]</p><ul class="o_checklist" dir="rtl"><li><p>b</p><ol dir="rtl"><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
     });
 });
 
@@ -91,24 +91,24 @@ test("should properly switch the direction of the single level list (rtl).", asy
 
 test("should properly switch the direction of nested list (rtl).", async () => {
     await testEditor({
-        contentBefore: `<ul dir="rtl"><li>a[]</li><li class="oe-nested"><ul dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul dir="rtl"><li><p>a[]</p><ul dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul><li>a[]</li><li class="oe-nested"><ul><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul><li><p>a[]</p><ul><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
     });
     await testEditor({
-        contentBefore: `<ol dir="rtl"><li>a[]</li><li class="oe-nested"><ol dir="rtl"><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
+        contentBefore: `<ol dir="rtl"><li><p>a[]</p><ol dir="rtl"><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
         stepFunction: switchDirection,
-        contentAfter: `<ol><li>a[]</li><li class="oe-nested"><ol><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
+        contentAfter: `<ol><li><p>a[]</p><ol><li>b</li><li>c</li></ol></li><li>d</li></ol>`,
     });
     await testEditor({
-        contentBefore: `<ul class="o_checklist" dir="rtl"><li>a[]</li><li class="oe-nested"><ul class="o_checklist" dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul class="o_checklist" dir="rtl"><li><p>a[]</p><ul class="o_checklist" dir="rtl"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul class="o_checklist"><li>a[]</li><li class="oe-nested"><ul class="o_checklist"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul class="o_checklist"><li><p>a[]</p><ul class="o_checklist"><li>b</li><li>c</li></ul></li><li>d</li></ul>`,
     });
     await testEditor({
-        contentBefore: `<ul dir="rtl"><li>a[]</li><li class="oe-nested"><ul class="o_checklist" dir="rtl"><li>b</li><li class="oe-nested"><ol dir="rtl"><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
+        contentBefore: `<ul dir="rtl"><li><p>a[]</p><ul class="o_checklist" dir="rtl"><li><p>b</p><ol dir="rtl"><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
         stepFunction: switchDirection,
-        contentAfter: `<ul><li>a[]</li><li class="oe-nested"><ul class="o_checklist"><li>b</li><li class="oe-nested"><ol><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
+        contentAfter: `<ul><li><p>a[]</p><ul class="o_checklist"><li><p>b</p><ol><li>g</li><li>e</li></ol></li><li>c</li></ul></li><li>d</li></ul>`,
     });
 });
 

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -170,3 +170,10 @@ test("hint for blockquote should have the same padding as its text content", asy
     const paddingText = getComputedStyle(blockquote).padding;
     expect(paddingHint).toBe(paddingText);
 });
+
+test("hint for list containing a nested list", async () => {
+    const { el } = await setupEditor("<ul><li><p>[]<br></p><ul><li>abc</li></ul></li></ul>");
+    expect(getContent(el)).toBe(
+        `<ul><li><p o-we-hint-text="List" class="o-we-hint">[]<br></p><ul><li>abc</li></ul></li></ul>`
+    );
+});

--- a/addons/html_editor/static/tests/list/checklist.test.js
+++ b/addons/html_editor/static/tests/list/checklist.test.js
@@ -94,8 +94,7 @@ test("should check a nested item and the previous checklist item used as title",
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li>2</li>
-                <li class="oe-nested">
+                <li><p>2</p>
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
                         <li>2.2</li>
@@ -103,16 +102,13 @@ test("should check a nested item and the previous checklist item used as title",
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[2];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li>2</li>
-                <li class="oe-nested">
+                <li><p>2</p>
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
                         <li class="o_checked">2.2</li>
@@ -126,8 +122,7 @@ test("should uncheck a nested item and the previous checklist item used as title
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">2</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>2</p>
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
                         <li class="o_checked">2.2</li>
@@ -135,16 +130,13 @@ test("should uncheck a nested item and the previous checklist item used as title
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[2];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">2</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>2</p>
                     <ul class="o_checklist">
                         <li class="o_checked">2.1</li>
                         <li>2.2</li>
@@ -158,11 +150,9 @@ test("should check a nested item and the wrapper wrapper title", async () => {
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li>3.2.2</li>
@@ -172,19 +162,15 @@ test("should check a nested item and the wrapper wrapper title", async () => {
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[3];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li class="o_checked">3.2.2</li>
@@ -200,11 +186,9 @@ test("should uncheck a nested item and the wrapper wrapper title", async () => {
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li class="o_checked">3.1.2</li>
@@ -214,19 +198,15 @@ test("should uncheck a nested item and the wrapper wrapper title", async () => {
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[3];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li>3.1.2</li>
@@ -243,17 +223,13 @@ test("should check all nested checklist item", async () => {
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li>3.1.2</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li>3.2.2</li>
@@ -264,19 +240,15 @@ test("should check all nested checklist item", async () => {
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[0];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li>3.1.2</li>
@@ -296,17 +268,13 @@ test("should uncheck all nested checklist item", async () => {
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li class="o_checked">3.1.2</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li class="o_checked">3.2.2</li>
@@ -317,19 +285,15 @@ test("should uncheck all nested checklist item", async () => {
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[0];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.1.1</li>
                                 <li class="o_checked">3.1.2</li>
@@ -348,11 +312,9 @@ test("should check all nested checklist item and update wrapper title", async ()
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li>3.2.2</li>
@@ -362,19 +324,15 @@ test("should check all nested checklist item and update wrapper title", async ()
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[1];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li>3</li>
-                <li class="oe-nested">
+                <li><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li>3.2.2</li>
@@ -390,11 +348,9 @@ test("should uncheck all nested checklist items and update wrapper title", async
     await testEditor({
         contentBefore: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li class="o_checked">3.1</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li class="o_checked">3.2.2</li>
@@ -404,19 +360,15 @@ test("should uncheck all nested checklist items and update wrapper title", async
                 </li>
             </ul>`),
         stepFunction: async (editor) => {
-            const lis = editor.editable.querySelectorAll(
-                '.o_checklist > li:not([class^="oe-nested"])'
-            );
+            const lis = editor.editable.querySelectorAll(".o_checklist > li");
             const li = lis[1];
             await clickCheckbox(li);
         },
         contentAfter: unformat(`
             <ul class="o_checklist">
-                <li class="o_checked">3</li>
-                <li class="oe-nested">
+                <li class="o_checked"><p>3</p>
                     <ul class="o_checklist">
-                        <li>3.1</li>
-                        <li class="oe-nested">
+                        <li><p>3.1</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">3.2.1</li>
                                 <li class="o_checked">3.2.2</li>

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -163,7 +163,7 @@ test("should remove color from partially selected list item", async () => {
         contentBefore: '<ol><li style="color: rgb(255, 0, 0);">ab[cd]ef</li></ol>',
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter:
-            '<ol><li style="color: rgb(255, 0, 0);">ab<font style="color: initial;">[cd]</font>ef</li></ol>',
+            '<ol><li style="color: rgb(255, 0, 0);">ab<font class="o_default_color">[cd]</font>ef</li></ol>',
     });
 });
 

--- a/addons/html_editor/static/tests/list/color_list.test.js
+++ b/addons/html_editor/static/tests/list/color_list.test.js
@@ -206,3 +206,12 @@ test("should change color of subpart of a list item (2)", async () => {
             '<ol><li style="color: rgb(255, 0, 0);">a<font style="color: rgb(0, 0, 255);">[bc</font></li><li style="color: rgb(255, 0, 0);"><font style="color: rgb(0, 0, 255);">gh]</font>i</li></ol>',
     });
 });
+
+test("should apply color to a list containing sublist if list contents are fully selected", async () => {
+    await testEditor({
+        contentBefore: "<ol><li><p>[abc]</p><ol><li>def</li></ol></li></ol>",
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfter:
+            '<ol><li style="color: rgb(255, 0, 0);"><p>[abc]</p><ol class="o_default_color"><li>def</li></ol></li></ol>',
+    });
+});

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -2572,11 +2572,21 @@ describe("Selection not collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
+                await testEditor({
+                    contentBefore: "<ol><li><p>[abcd</p><ul><li>efgh]</li></ul></li></ol>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<ol><li><p>[]<br></p></li></ol>",
+                });
                 // Backward selection
                 await testEditor({
                     contentBefore: "<ol><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ol>",
                     stepFunction: deleteBackward,
                     contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
+                });
+                await testEditor({
+                    contentBefore: "<ol><li><p>]abcd</p><ul><li>efgh[</li></ul></li></ol>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<ol><li><p>[]<br></p></li></ol>",
                 });
             });
 

--- a/addons/html_editor/static/tests/list/delete_backward.test.js
+++ b/addons/html_editor/static/tests/list/delete_backward.test.js
@@ -106,8 +106,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
@@ -125,8 +124,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                         <li>d</li>
@@ -141,8 +139,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b</li>
                                     </ol>
@@ -161,14 +158,12 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b</li>
                                     </ol>
                                 </li>
-                                <li>c[]d</li>
-                                <li class="oe-nested">
+                                <li><p>c[]d</p>
                                     <ol>
                                         <li>e</li>
                                     </ol>
@@ -190,8 +185,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
@@ -209,8 +203,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                     </ul>
@@ -231,14 +224,13 @@ describe("Selection collapsed", () => {
             test("should merge an indented list item into a non-indented list item", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>[]def</li><li>ghi</li></ol></li></ol>',
+                        "<ol><li><p>abc</p><ol><li>[]def</li><li>ghi</li></ol></li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter:
-                        '<ol><li>abc[]def</li><li class="oe-nested"><ol><li>ghi</li></ol></li></ol>',
+                    contentAfter: "<ol><li><p>abc[]def</p><ol><li>ghi</li></ol></li></ol>",
                 });
             });
 
@@ -257,14 +249,13 @@ describe("Selection collapsed", () => {
 
             test("should merge the only item in an indented list into a non-indented list item and remove the now empty indented list", async () => {
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>[]def</li></ol></li></ol>',
+                    contentBefore: "<ol><li><p>abc</p><ol><li>[]def</li></ol></li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>abc[]def</li></ol>",
+                    contentAfter: "<ol><li><p>abc[]def</p></li></ol>",
                 });
             });
 
@@ -314,25 +305,25 @@ describe("Selection collapsed", () => {
             test("should outdent an empty list item within a list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>[]<br></li><li><br></li></ol></li><li>def</li></ol>',
+                        "<ol><li><p>abc</p><ol><li>[]<br></li><li><br></li></ol></li><li>def</li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ol><li>abc</li></ol><p>[]<br></p><ol><li class="oe-nested"><ol><li><br></li></ol></li><li>def</li></ol>',
+                        '<ol><li><p>abc</p></li></ol><p>[]<br></p><ol><li class="oe-nested"><ol><li><br></li></ol></li><li>def</li></ol>',
                 });
             });
 
             test("should outdent an empty list within a list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>[]<br></li></ol></li><li>def</li></ol>',
+                        "<ol><li><p>abc</p><ol><li>[]<br></li></ol></li><li>def</li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>abc</li></ol><p>[]<br></p><ol><li>def</li></ol>",
+                    contentAfter: "<ol><li><p>abc</p></li></ol><p>[]<br></p><ol><li>def</li></ol>",
                 });
             });
 
@@ -371,8 +362,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <ul>
-                            <li>abc</li>
-                            <li class="oe-nested">
+                            <li><p>abc</p>
                                 <ul dir="rtl" style="text-align: right;">
                                     <li>abc</li>
                                     <li>[]<br></li>
@@ -385,8 +375,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                         <ul>
-                            <li>abc</li>
-                            <li class="oe-nested">
+                            <li><p>abc</p>
                                 <ul dir="rtl" style="text-align: right;">
                                     <li>abc</li>
                                 </ul>
@@ -536,8 +525,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
@@ -555,8 +543,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                         <li>d</li>
@@ -571,8 +558,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
@@ -591,14 +577,12 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
                                 </li>
-                                <li>c[]d</li>
-                                <li class="oe-nested">
+                                <li><p>c[]d</p>
                                     <ul>
                                         <li>e</li>
                                     </ul>
@@ -620,8 +604,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b</li>
                                     </ol>
@@ -639,8 +622,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b[]c</li>
                                     </ol>
@@ -662,8 +644,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>abc</li>
-                                <li class="oe-nested">
+                                <li><p>abc</p>
                                     <ul>
                                         <li>[]def</li>
                                         <li>ghi</li>
@@ -677,8 +658,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                             <ul>
-                                <li>abc[]def</li>
-                                <li class="oe-nested">
+                                <li><p>abc[]def</p>
                                     <ul>
                                         <li>ghi</li>
                                     </ul>
@@ -702,14 +682,13 @@ describe("Selection collapsed", () => {
 
             test("should merge the only item in an indented list into a non-indented list item and remove the now empty indented list", async () => {
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul><li>[]def</li></ul></li></ul>',
+                    contentBefore: "<ul><li><p>abc</p><ul><li>[]def</li></ul></li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc[]def</li></ul>",
+                    contentAfter: "<ul><li><p>abc[]def</p></li></ul>",
                 });
             });
 
@@ -737,25 +716,25 @@ describe("Selection collapsed", () => {
             test("should outdent an empty list item within a list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>',
+                        "<ul><li><p>abc</p><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc</li></ul><p>[]<br></p><ul><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ul>',
+                        '<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ul>',
                 });
             });
 
             test("should outdent an empty list within a list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul><li>[]<br></li></ul></li><li>def</li></ul>',
+                        "<ul><li><p>abc</p><ul><li>[]<br></li></ul></li><li>def</li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc</li></ul><p>[]<br></p><ul><li>def</li></ul>",
+                    contentAfter: "<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li>def</li></ul>",
                 });
             });
 
@@ -1034,8 +1013,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
@@ -1053,8 +1031,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b[]c</li>
                                         <li class="o_checked">d</li>
@@ -1066,8 +1043,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
@@ -1085,8 +1061,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b[]c</li>
                                         <li>d</li>
@@ -1101,8 +1076,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
@@ -1121,14 +1095,12 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
                                 </li>
-                                <li class="o_checked">c[]d</li>
-                                <li class="oe-nested">
+                                <li class="o_checked"><p>c[]d</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">e</li>
                                     </ul>
@@ -1139,8 +1111,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
@@ -1159,14 +1130,12 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
                                 </li>
-                                <li>c[]d</li>
-                                <li class="oe-nested">
+                                <li><p>c[]d</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">e</li>
                                     </ul>
@@ -1190,8 +1159,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b</li>
                                     </ul>
@@ -1209,8 +1177,7 @@ describe("Selection collapsed", () => {
                     stepFunction: deleteBackward,
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                     </ul>
@@ -1231,14 +1198,14 @@ describe("Selection collapsed", () => {
             test("should merge an indented list item into a non-indented list item", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul></li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc[]def</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>abc[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
                 });
             });
 
@@ -1258,14 +1225,13 @@ describe("Selection collapsed", () => {
             test("should merge the only item in an indented list into a non-indented list item and remove the now empty indented list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">[]def</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li class="o_checked">[]def</li></ul></li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc[]def</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>abc[]def</p></li></ul>',
                 });
             });
 
@@ -1295,8 +1261,8 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore:
                         "<ul>" +
-                        "<li>abc</li>" +
-                        '<li class="oe-nested"><ul>' +
+                        "<li>abc" +
+                        "<ul>" +
                         "<li><h1>[]def</h1></li>" +
                         "</ul></li>" +
                         "</ul>",
@@ -1304,7 +1270,7 @@ describe("Selection collapsed", () => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul>" + "<li>abc</li>" + "</ul>" + "<h1>[]def</h1>",
+                    contentAfter: "<ul>" + "<li><p>abc</p></li>" + "</ul>" + "<h1>[]def</h1>",
                 });
             });
 
@@ -1335,8 +1301,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li>abc</li>
-                                <li class="oe-nested">
+                                <li><p>abc</p>
                                     <ul class="o_checklist">
                                         <li>[]<br></li>
                                         <li><br></li>
@@ -1350,7 +1315,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li>abc</li>
+                                <li><p>abc</p></li>
                             </ul>
                             <p>[]<br></p>
                             <ul class="o_checklist">
@@ -1367,13 +1332,13 @@ describe("Selection collapsed", () => {
             test("should outdent an empty list within a list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li>[]<br></li></ul></li><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li>[]<br></li></ul></li><li class="o_checked">def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li>abc</li></ul><p>[]<br></p><ul class="o_checklist"><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p></li></ul><p>[]<br></p><ul class="o_checklist"><li class="o_checked">def</li></ul>',
                 });
             });
 
@@ -1553,13 +1518,13 @@ describe("Selection collapsed", () => {
             test("should merge an ordered list item that is in an unordered list item into a non-indented list item", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ol><li>[]def</li><li>ghi</li></ol></li></ul>',
+                        "<ul><li><p>abc</p><ol><li>[]def</li><li>ghi</li></ol></li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc</li></ul><p>[]def</p><ul><li class="oe-nested"><ol><li>ghi</li></ol></li></ul>',
+                        '<ul><li><p>abc</p></li></ul><p>[]def</p><ul><li class="oe-nested"><ol><li>ghi</li></ol></li></ul>',
                 });
             });
 
@@ -1578,14 +1543,13 @@ describe("Selection collapsed", () => {
 
             test("should merge the only item in an ordered list that is in an unordered list into a list item that is in the same unordered list, and remove the now empty ordered list", async () => {
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ol><li>[]def</li></ol></li></ul>',
+                    contentBefore: "<ul><li><p>abc</p><ol><li>[]def</li></ol></li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc[]def</li></ul>",
+                    contentAfter: "<ul><li><p>abc[]def</p></li></ul>",
                 });
             });
 
@@ -1613,25 +1577,25 @@ describe("Selection collapsed", () => {
             test("should outdent an empty ordered list item within an unordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ol><li>[]<br></li><li><br></li></ol></li><li>def</li></ul>',
+                        "<ul><li><p>abc</p><ol><li>[]<br></li><li><br></li></ol></li><li>def</li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc</li></ul><p>[]<br></p><ul><li class="oe-nested"><ol><li><br></li></ol></li><li>def</li></ul>',
+                        '<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li class="oe-nested"><ol><li><br></li></ol></li><li>def</li></ul>',
                 });
             });
 
             test("should outdent an empty ordered list within an unordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ol><li>[]<br></li></ol></li><li>def</li></ul>',
+                        "<ul><li><p>abc</p><ol><li>[]<br></li></ol></li><li>def</li></ul>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc</li></ul><p>[]<br></p><ul><li>def</li></ul>",
+                    contentAfter: "<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li>def</li></ul>",
                 });
             });
 
@@ -1690,8 +1654,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ol>
-                                <li>abc</li>
-                                <li class="oe-nested">
+                                <li><p>abc</p>
                                     <ul>
                                         <li>[]def</li>
                                         <li>ghi</li>
@@ -1704,7 +1667,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                             <ol>
-                                <li>abc</li>
+                                <li><p>abc</p></li>
                             </ol>
                             <p>[]def</p>
                             <ol>
@@ -1732,14 +1695,13 @@ describe("Selection collapsed", () => {
 
             test("should merge the only item in an unordered list that is in an ordered list into a list item that is in the same ordered list, and remove the now empty unordered list", async () => {
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ul><li>[]def</li></ul></li></ol>',
+                    contentBefore: "<ol><li><p>abc</p><ul><li>[]def</li></ul></li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>abc[]def</li></ol>",
+                    contentAfter: "<ol><li><p>abc[]def</p></li></ol>",
                 });
             });
 
@@ -1767,25 +1729,25 @@ describe("Selection collapsed", () => {
             test("should outdent an empty unordered list item within an ordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ol>',
+                        "<ol><li><p>abc</p><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ol><li>abc</li></ol><p>[]<br></p><ol><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ol>',
+                        '<ol><li><p>abc</p></li></ol><p>[]<br></p><ol><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ol>',
                 });
             });
 
             test("should outdent an empty unordered list within an ordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ul><li>[]<br></li></ul></li><li>def</li></ol>',
+                        "<ol><li><p>abc</p><ul><li>[]<br></li></ul></li><li>def</li></ol>",
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ol><li>abc</li></ol><p>[]<br></p><ol><li>def</li></ol>",
+                    contentAfter: "<ol><li><p>abc</p></li></ol><p>[]<br></p><ol><li>def</li></ol>",
                 });
             });
 
@@ -1846,14 +1808,14 @@ describe("Selection collapsed", () => {
             test("should merge an checklist list item that is in an unordered list item into a non-indented list item", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul></li></ul>',
+                        '<ul><li><p>abc</p><ul class="o_checklist"><li class="o_checked">[]def</li><li class="o_checked">ghi</li></ul></li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc[]def</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
+                        '<ul><li><p>abc[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
                 });
             });
 
@@ -1873,13 +1835,13 @@ describe("Selection collapsed", () => {
             test("should merge the only item in an checklist list that is in an unordered list into a checklist item that is in the same unordered list, and remove the now empty checklist list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">[]def</li></ul></li></ul>',
+                        '<ul><li><p>abc</p><ul class="o_checklist"><li class="o_checked">[]def</li></ul></li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc[]def</li></ul>",
+                    contentAfter: "<ul><li><p>abc[]def</p></li></ul>",
                 });
             });
 
@@ -1908,25 +1870,25 @@ describe("Selection collapsed", () => {
             test("should outdent an empty checklist list item within an unordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>',
+                        '<ul><li><p>abc</p><ul class="o_checklist"><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc</li></ul><p>[]<br></p><ul><li class="oe-nested"><ul class="o_checklist"><li><br></li></ul></li><li>def</li></ul>',
+                        '<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li class="oe-nested"><ul class="o_checklist"><li><br></li></ul></li><li>def</li></ul>',
                 });
             });
 
             test("should outdent an empty checklist list within an unordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li>[]<br></li></ul></li><li>def</li></ul>',
+                        '<ul><li><p>abc</p><ul class="o_checklist"><li>[]<br></li></ul></li><li>def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter: "<ul><li>abc</li></ul><p>[]<br></p><ul><li>def</li></ul>",
+                    contentAfter: "<ul><li><p>abc</p></li></ul><p>[]<br></p><ul><li>def</li></ul>",
                 });
             });
 
@@ -1995,8 +1957,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">abc</li>
-                                <li class="oe-nested">
+                                <li><p>abc</p>
                                     <ul>
                                         <li>[]def</li>
                                         <li>ghi</li>
@@ -2010,8 +1971,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">abc[]def</li>
-                                <li class="oe-nested">
+                                <li><p>abc[]def</p>
                                     <ul>
                                         <li>ghi</li>
                                     </ul>
@@ -2036,14 +1996,13 @@ describe("Selection collapsed", () => {
             test("should merge the only item in an unordered list that is in an checklist list into a checklist item that is in the same checklist list, and remove the now empty unordered list", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul><li>[]def</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul><li>[]def</li></ul></li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
-                    contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc[]def</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>abc[]def</p></li></ul>',
                 });
             });
 
@@ -2072,52 +2031,52 @@ describe("Selection collapsed", () => {
             test("should outdent an empty unordered list item within an checklist list (o_checked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul><li>[]<br></li><li><br></li></ul></li><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul><li>[]<br></li><li><br></li></ul></li><li class="o_checked">def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul><li><br></li></ul></li><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p></li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul><li><br></li></ul></li><li class="o_checked">def</li></ul>',
                 });
             });
 
             test("should outdent an empty unordered list item within an checklist list (unchecked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li>abc</li><li class="oe-nested"><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul><li>[]<br></li><li><br></li></ul></li><li>def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li>abc</li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p></li></ul><p>[]<br></p><ul class="o_checklist"><li class="oe-nested"><ul><li><br></li></ul></li><li>def</li></ul>',
                 });
             });
 
             test("should outdent an empty unordered list within an checklist list (checked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul><li>[]<br></li></ul></li><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul><li>[]<br></li></ul></li><li class="o_checked">def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li></ul><p>[]<br></p><ul class="o_checklist"><li class="o_checked">def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p></li></ul><p>[]<br></p><ul class="o_checklist"><li class="o_checked">def</li></ul>',
                 });
             });
 
             test("should outdent an empty unordered list within an checklist list (unchecked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li>abc</li><li class="oe-nested"><ul><li>[]<br></li></ul></li><li>def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul><li>[]<br></li></ul></li><li>def</li></ul>',
                     stepFunction: async (editor) => {
                         deleteBackward(editor);
                         deleteBackward(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li>abc</li></ul><p>[]<br></p><ul class="o_checklist"><li>def</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p></li></ul><p>[]<br></p><ul class="o_checklist"><li>def</li></ul>',
                 });
             });
 
@@ -2224,17 +2183,15 @@ describe("Selection not collapsed", () => {
         test("should delete across an unindented list item and an indented list item", async () => {
             // Forward selection
             await testEditor({
-                contentBefore:
-                    '<ol><li>ab[cd</li><li class="oe-nested"><ol><li>ef]gh</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ol>",
                 stepFunction: deleteBackward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
+                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
             // Backward selection
             await testEditor({
-                contentBefore:
-                    '<ol><li>ab]cd</li><li class="oe-nested"><ol><li>ef[gh</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ol>",
                 stepFunction: deleteBackward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
+                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
         });
 
@@ -2329,17 +2286,15 @@ describe("Selection not collapsed", () => {
         test("should delete across an unindented list item and an indented list item", async () => {
             // Forward selection
             await testEditor({
-                contentBefore:
-                    '<ul><li>ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ul>',
+                contentBefore: "<ul><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>",
                 stepFunction: deleteBackward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
+                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
             // Backward selection
             await testEditor({
-                contentBefore:
-                    '<ul><li>ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ul>',
+                contentBefore: "<ul><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>",
                 stepFunction: deleteBackward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
+                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
         });
 
@@ -2457,44 +2412,44 @@ describe("Selection not collapsed", () => {
             test("should delete across an unindented list item and an indented list item (1)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
             test("should delete across an unindented list item and an indented list item (2)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li>ef]gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab[cd</p><ul class="o_checklist"><li>ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
                     // The indented list cannot be unchecked while its
                     // parent is checked: it gets checked automatically
                     // as a result. So "efgh" gets rendered as checked.
                     // Given that the parent list item was explicitely
                     // set as "checked", that status is preserved.
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
             // Backward selection
             test("should delete across an unindented list item and an indented list item (3)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
             test("should delete across an unindented list item and an indented list item (4)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
                     // The indented list cannot be unchecked while its
                     // parent is checked: it gets checked automatically
                     // as a result. So "efgh" gets rendered as checked.
                     // Given that the parent list item was explicitely
                     // set as "checked", that status is preserved.
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
         });
@@ -2613,17 +2568,15 @@ describe("Selection not collapsed", () => {
             test("should delete across an ordered list item and an unordered list item within an ordered list", async () => {
                 // Forward selection
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ol>',
+                    contentBefore: "<ol><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ol>",
                     stepFunction: deleteBackward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
+                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
                 // Backward selection
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ol>',
+                    contentBefore: "<ol><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ol>",
                     stepFunction: deleteBackward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
+                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
             });
 
@@ -2689,17 +2642,15 @@ describe("Selection not collapsed", () => {
             test("should delete across an unordered list item and an ordered list item within an unordered list", async () => {
                 // Forward selection
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>ab[cd</li><li class="oe-nested"><ol><li>ef]gh</li></ol></li></ul>',
+                    contentBefore: "<ul><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ul>",
                     stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
                 // Backward selection
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>ab]cd</li><li class="oe-nested"><ol><li>ef[gh</li></ol></li></ul>',
+                    contentBefore: "<ul><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ul>",
                     stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 
@@ -2786,16 +2737,16 @@ describe("Selection not collapsed", () => {
                 // Forward selection
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
                 // Backward selection
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ul>',
+                        '<ul class="o_checklist"><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                    contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                 });
             });
 
@@ -2870,16 +2821,16 @@ describe("Selection not collapsed", () => {
                 // Forward selection
                 await testEditor({
                     contentBefore:
-                        '<ul><li>ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
+                        '<ul><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
                 // Backward selection
                 await testEditor({
                     contentBefore:
-                        '<ul><li>ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
+                        '<ul><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
                     stepFunction: deleteBackward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 

--- a/addons/html_editor/static/tests/list/delete_forward.test.js
+++ b/addons/html_editor/static/tests/list/delete_forward.test.js
@@ -100,8 +100,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]</li>
                                     </ul>
@@ -119,8 +118,7 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ul>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                         <li>d</li>
@@ -135,8 +133,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b</li>
                                     </ol>
@@ -155,14 +152,12 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ol>
                                         <li>b</li>
                                     </ol>
                                 </li>
-                                <li>c[]d</li>
-                                <li class="oe-nested">
+                                <li><p>c[]d</p>
                                     <ol>
                                         <li>e</li>
                                     </ol>
@@ -184,8 +179,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]</li>
                                     </ul>
@@ -203,8 +197,7 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ol>
-                                <li>a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li>b[]c</li>
                                     </ul>
@@ -304,8 +297,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b[]</li>
                                     </ul>
@@ -323,8 +315,7 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b[]c</li>
                                         <li>d</li>
@@ -339,8 +330,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
@@ -359,14 +349,12 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">b</li>
                                     </ul>
                                 </li>
-                                <li class="o_checked">c[]d</li>
-                                <li class="oe-nested">
+                                <li class="o_checked"><p>c[]d</p>
                                     <ul class="o_checklist">
                                         <li>e</li>
                                     </ul>
@@ -390,8 +378,7 @@ describe("Selection collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li class="o_checked">b[]</li>
                                     </ul>
@@ -409,8 +396,7 @@ describe("Selection collapsed", () => {
                 stepFunction: deleteForward,
                 contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">a</li>
-                                <li class="oe-nested">
+                                <li><p>a</p>
                                     <ul>
                                         <li class="o_checked">b[]c</li>
                                     </ul>
@@ -430,23 +416,19 @@ describe("Selection collapsed", () => {
     describe("Indented", () => {
         test("should merge an indented list item into a non-indented list item 1", async () => {
             await testEditor({
-                contentBefore:
-                    '<ol><li>abc[]</li><li class="oe-nested"><ol><li>def</li><li>ghi</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>abc[]</p><ol><li>def</li><li>ghi</li></ol></li></ol>",
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                 },
-                contentAfter:
-                    '<ol><li>abc[]def</li><li class="oe-nested"><ol><li>ghi</li></ol></li></ol>',
+                contentAfter: "<ol><li><p>abc[]def</p><ol><li>ghi</li></ol></li></ol>",
             });
             await testEditor({
-                contentBefore:
-                    '<ol><li>2bc[]</li><li class="oe-nested"><ol><li>def</li><li>ghi</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>2bc[]</p><ol><li>def</li><li>ghi</li></ol></li></ol>",
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                     deleteForward(editor);
                 },
-                contentAfter:
-                    '<ol><li>2bc[]ef</li><li class="oe-nested"><ol><li>ghi</li></ol></li></ol>',
+                contentAfter: "<ol><li><p>2bc[]ef</p><ol><li>ghi</li></ol></li></ol>",
             });
         });
 
@@ -461,36 +443,35 @@ describe("Selection collapsed", () => {
 
         test("should merge the only item in an indented list into a non-indented list item and remove the now empty indented list", async () => {
             await testEditor({
-                contentBefore:
-                    '<ul><li>abc[]</li><li class="oe-nested"><ul><li>def</li></ul></li></ul>',
+                contentBefore: "<ul><li><p>abc[]</p><ul><li>def</li></ul></li></ul>",
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                     deleteForward(editor);
                 },
-                contentAfter: "<ul><li>abc[]ef</li></ul>",
+                contentAfter: "<ul><li><p>abc[]ef</p></li></ul>",
             });
         });
 
         test("should merge an indented list item into a non-indented list item", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>abc[]</li><li class="oe-nested"><ul class="o_checklist"><li>def</li><li class="o_checked">ghi</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>abc[]</p><ul class="o_checklist"><li>def</li><li class="o_checked">ghi</li></ul></li></ul>',
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                 },
                 contentAfter:
-                    '<ul class="o_checklist"><li>abc[]def</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>abc[]def</p><ul class="o_checklist"><li class="o_checked">ghi</li></ul></li></ul>',
             });
         });
 
         test("should merge the only item in an indented list into a non-indented list item and remove the now empty indented list (2)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>abc[]</li><li class="oe-nested"><ul class="o_checklist"><li>def</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>abc[]</p><ul class="o_checklist"><li>def</li></ul></li></ul>',
                 stepFunction: async (editor) => {
                     deleteForward(editor);
                 },
-                contentAfter: '<ul class="o_checklist"><li>abc[]def</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>abc[]def</p></li></ul>',
             });
         });
     });
@@ -736,17 +717,15 @@ describe("Selection not collapsed", () => {
         test("should delete across an unindented list item and an indented list item", async () => {
             // Forward selection
             await testEditor({
-                contentBefore:
-                    '<ol><li>ab[cd</li><li class="oe-nested"><ol><li>ef]gh</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ol>",
                 stepFunction: deleteForward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
+                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
             // Backward selection
             await testEditor({
-                contentBefore:
-                    '<ol><li>ab]cd</li><li class="oe-nested"><ol><li>ef[gh</li></ol></li></ol>',
+                contentBefore: "<ol><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ol>",
                 stepFunction: deleteForward,
-                contentAfter: "<ol><li>ab[]gh</li></ol>",
+                contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
             });
         });
 
@@ -834,17 +813,15 @@ describe("Selection not collapsed", () => {
         test("should delete across an unindented list item and an indented list item", async () => {
             // Forward selection
             await testEditor({
-                contentBefore:
-                    '<ul><li>ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ul>',
+                contentBefore: "<ul><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>",
                 stepFunction: deleteForward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
+                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
             // Backward selection
             await testEditor({
-                contentBefore:
-                    '<ul><li>ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ul>',
+                contentBefore: "<ul><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>",
                 stepFunction: deleteForward,
-                contentAfter: "<ul><li>ab[]gh</li></ul>",
+                contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
             });
         });
 
@@ -1005,62 +982,62 @@ describe("Selection not collapsed", () => {
         test("should delete across an unindented list item and an indented list item (1)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li class="o_checked">ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
         test("should delete across an unindented list item and an indented list item (2)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li>ef]gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab[cd</p><ul class="o_checklist"><li>ef]gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
                 // The indented list's parent gets rendered as
                 // checked because its only child is checked.
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
         test("should delete across an unindented list item and an indented list item (3)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
                 // The indented list's parent gets rendered as
                 // checked because its only child is checked. When
                 // we remove that child, the checklist gets
                 // unchecked because it becomes independant again.
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
         // Backward selection
         test("should delete across an unindented list item and an indented list item (4)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
-                contentAfter: '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
         test("should delete across an unindented list item and an indented list item (5)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li>ef[gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
                 // The indented list's parent gets rendered as
                 // checked because its only child is checked.
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
         test("should delete across an unindented list item and an indented list item (6)", async () => {
             await testEditor({
                 contentBefore:
-                    '<ul class="o_checklist"><li>ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
+                    '<ul class="o_checklist"><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
                 stepFunction: deleteForward,
                 // The indented list's parent gets rendered as
                 // checked because its only child is checked. When
                 // we remove that child, the checklist gets
                 // unchecked because it becomes independant again.
-                contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
             });
         });
     });
@@ -1176,17 +1153,15 @@ describe("Selection not collapsed", () => {
             test("should delete across an ordered list item and an unordered list item within an ordered list", async () => {
                 // Forward selection
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ol>',
+                    contentBefore: "<ol><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ol>",
                     stepFunction: deleteForward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
+                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
                 // Backward selection
                 await testEditor({
-                    contentBefore:
-                        '<ol><li>ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ol>',
+                    contentBefore: "<ol><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ol>",
                     stepFunction: deleteForward,
-                    contentAfter: "<ol><li>ab[]gh</li></ol>",
+                    contentAfter: "<ol><li><p>ab[]gh</p></li></ol>",
                 });
             });
 
@@ -1224,17 +1199,15 @@ describe("Selection not collapsed", () => {
             test("should delete across an unordered list item and an ordered list item within an unordered list", async () => {
                 // Forward selection
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>ab[cd</li><li class="oe-nested"><ol><li>ef]gh</li></ol></li></ul>',
+                    contentBefore: "<ul><li><p>ab[cd</p><ol><li>ef]gh</li></ol></li></ul>",
                     stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
                 // Backward selection
                 await testEditor({
-                    contentBefore:
-                        '<ul><li>ab]cd</li><li class="oe-nested"><ol><li>ef[gh</li></ol></li></ul>',
+                    contentBefore: "<ul><li><p>ab]cd</p><ol><li>ef[gh</li></ol></li></ul>",
                     stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 
@@ -1332,36 +1305,34 @@ describe("Selection not collapsed", () => {
                 test("should delete across an checklist list item and an unordered list item within an checklist list (1)", async () => {
                     await testEditor({
                         contentBefore:
-                            '<ul class="o_checklist"><li class="o_checked">ab[cd</li><li class="oe-nested"><ul><li class="o_checked">ef]gh</li></ul></li></ul>',
+                            '<ul class="o_checklist"><li><p>ab[cd</p><ul><li class="o_checked">ef]gh</li></ul></li></ul>',
                         stepFunction: deleteForward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                     });
                 });
                 test("should delete across an checklist list item and an unordered list item within an checklist list (2)", async () => {
                     await testEditor({
                         contentBefore:
-                            '<ul class="o_checklist"><li>ab[cd</li><li class="oe-nested"><ul><li>ef]gh</li></ul></li></ul>',
+                            '<ul class="o_checklist"><li><p>ab[cd</p><ul><li>ef]gh</li></ul></li></ul>',
                         stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                     });
                 });
                 // Backward selection
                 test("should delete across an checklist list item and an unordered list item within an checklist list (3)", async () => {
                     await testEditor({
                         contentBefore:
-                            '<ul class="o_checklist"><li class="o_checked">ab]cd</li><li class="oe-nested"><ul><li class="o_checked">ef[gh</li></ul></li></ul>',
+                            '<ul class="o_checklist"><li><p>ab]cd</p><ul><li class="o_checked">ef[gh</li></ul></li></ul>',
                         stepFunction: deleteForward,
-                        contentAfter:
-                            '<ul class="o_checklist"><li class="o_checked">ab[]gh</li></ul>',
+                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                     });
                 });
                 test("should delete across an checklist list item and an unordered list item within an checklist list (4)", async () => {
                     await testEditor({
                         contentBefore:
-                            '<ul class="o_checklist"><li>ab]cd</li><li class="oe-nested"><ul><li>ef[gh</li></ul></li></ul>',
+                            '<ul class="o_checklist"><li><p>ab]cd</p><ul><li>ef[gh</li></ul></li></ul>',
                         stepFunction: deleteForward,
-                        contentAfter: '<ul class="o_checklist"><li>ab[]gh</li></ul>',
+                        contentAfter: '<ul class="o_checklist"><li><p>ab[]gh</p></li></ul>',
                     });
                 });
             });
@@ -1405,16 +1376,16 @@ describe("Selection not collapsed", () => {
                 // Forward selection
                 await testEditor({
                     contentBefore:
-                        '<ul><li>ab[cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
+                        '<ul><li><p>ab[cd</p><ul class="o_checklist"><li class="o_checked">ef]gh</li></ul></li></ul>',
                     stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
                 // Backward selection
                 await testEditor({
                     contentBefore:
-                        '<ul><li>ab]cd</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
+                        '<ul><li><p>ab]cd</p><ul class="o_checklist"><li class="o_checked">ef[gh</li></ul></li></ul>',
                     stepFunction: deleteForward,
-                    contentAfter: "<ul><li>ab[]gh</li></ul>",
+                    contentAfter: "<ul><li><p>ab[]gh</p></li></ul>",
                 });
             });
 

--- a/addons/html_editor/static/tests/list/indent.test.js
+++ b/addons/html_editor/static/tests/list/indent.test.js
@@ -48,10 +48,10 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li class="o_checked">
+                            <p>abc</p>
                             <ul class="o_checklist">
-                            <li class="o_checked">d[e]f</li>
+                                <li class="o_checked">d[e]f</li>
                             </ul>
                         </li>
                     </ul>`),
@@ -65,8 +65,8 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li class="o_checked">
+                            <p>abc</p>
                             <ul class="o_checklist">
                                 <li>d[e]f</li>
                             </ul>
@@ -82,10 +82,10 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li>
+                            <p>abc</p>
                             <ul class="o_checklist">
-                            <li>d[e]f</li>
+                                <li>d[e]f</li>
                             </ul>
                         </li>
                     </ul>`),
@@ -99,10 +99,10 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li>
+                            <p>abc</p>
                             <ul class="o_checklist">
-                            <li class="o_checked">d[e]f</li>
+                                <li class="o_checked">d[e]f</li>
                             </ul>
                         </li>
                     </ul>`),
@@ -135,8 +135,7 @@ describe("Checklist", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li>def</li>
                             </ul>
@@ -146,8 +145,7 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li>def</li>
                                 <li class="o_checked">g[h]i</li>
@@ -158,8 +156,7 @@ describe("Checklist", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                             </ul>
@@ -169,8 +166,7 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                                 <li>g[h]i</li>
@@ -185,8 +181,7 @@ describe("Checklist", () => {
             contentBefore: unformat(`
                     <ul class="o_checklist">
                         <li class="o_checked">abc</li>
-                        <li class="o_checked">d[e]f</li>
-                        <li class="oe-nested">
+                        <li class="o_checked">d[e]f
                             <ul class="o_checklist">
                                 <li class="o_checked">ghi</li>
                             </ul>
@@ -195,10 +190,9 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>abc</p>
                             <ul class="o_checklist">
-                                <li class="o_checked">d[e]f</li>
+                                <li class="o_checked"><p>d[e]f</p></li>
                                 <li class="o_checked">ghi</li>
                             </ul>
                         </li>
@@ -208,8 +202,7 @@ describe("Checklist", () => {
             contentBefore: unformat(`
                     <ul class="o_checklist">
                         <li>abc</li>
-                        <li class="o_checked">d[e]f</li>
-                        <li class="oe-nested">
+                        <li><p>d[e]f</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">ghi</li>
                             </ul>
@@ -218,10 +211,9 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
-                                <li class="o_checked">d[e]f</li>
+                                <li><p>d[e]f</p></li>
                                 <li class="o_checked">ghi</li>
                             </ul>
                         </li>
@@ -231,8 +223,7 @@ describe("Checklist", () => {
             contentBefore: unformat(`
                     <ul class="o_checklist">
                         <li class="o_checked">abc</li>
-                        <li>d[e]f</li>
-                        <li class="oe-nested">
+                        <li><p>d[e]f</p>
                             <ul class="o_checklist">
                                 <li>ghi</li>
                             </ul>
@@ -241,10 +232,9 @@ describe("Checklist", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li class="o_checked"><p>abc</p>
                             <ul class="o_checklist">
-                                <li>d[e]f</li>
+                                <li><p>d[e]f</p></li>
                                 <li>ghi</li>
                             </ul>
                         </li>
@@ -265,8 +255,7 @@ describe("Regular list", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul>
                                 <li>[]</li>
                             </ul>
@@ -289,8 +278,7 @@ describe("Regular list", () => {
             },
             contentAfter: unformat(`
                     <ul>
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul>
                                 <li>[]<br></li>
                             </ul>
@@ -321,8 +309,7 @@ describe("Regular list", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li><br></li>
-                    <li class="oe-nested">
+                    <li><p><br></p>
                         <ul>
                             <li>
                                 []<br>
@@ -375,10 +362,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>[]b</li>
                         </ul>
@@ -434,10 +420,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ol>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ol>
                             <li>[]b</li>
                         </ol>
@@ -457,10 +442,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>[]b</li>
                         </ul>
@@ -497,10 +481,7 @@ describe("with selection collapsed", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
-                        []b
-                    </li>
-                    <li class="oe-nested">
+                    <li><p>[]b</p>
                         <ul>
                             <li>c</li>
                         </ul>
@@ -509,12 +490,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
-                        a
-                    </li>
-                    <li class="oe-nested">
+                    <li><p>a</p>
                         <ul>
-                            <li>[]b</li>
+                            <li><p>[]b</p></li>
                             <li>c</li>
                         </ul>
                     </li>
@@ -527,10 +505,9 @@ describe("with selection collapsed", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         []b
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ol>
                             <li>c</li>
                         </ol>
@@ -539,12 +516,11 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ol>
-                            <li>[]b</li>
+                            <li><p>[]b</p></li>
                             <li>c</li>
                         </ol>
                     </li>
@@ -561,10 +537,9 @@ describe("with selection collapsed", () => {
                             <li>a</li>
                         </ol>
                     </li>
-                    <li>
+                    <li><p>
                         []b
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ol>
                             <li>c</li>
                         </ol>
@@ -576,7 +551,7 @@ describe("with selection collapsed", () => {
                     <li class="oe-nested">
                         <ol>
                             <li>a</li>
-                            <li>[]b</li>
+                            <li><p>[]b</p></li>
                             <li>c</li>
                         </ol>
                     </li>
@@ -613,8 +588,7 @@ describe("with selection collapsed", () => {
                                 <tr>
                                     <td>
                                         <ul>
-                                            <li>abc</li>
-                                            <li class="oe-nested">
+                                            <li><p>abc</p>
                                                 <ul>
                                                     <li>def[]</li>
                                                 </ul>
@@ -663,8 +637,7 @@ describe("with selection collapsed", () => {
                                 <tr>
                                     <td>
                                         <ul class="o_checklist">
-                                            <li>abc</li>
-                                            <li class="oe-nested">
+                                            <li><p>abc</p>
                                                 <ul class="o_checklist">
                                                     <li>def[]</li>
                                                 </ul>
@@ -703,8 +676,7 @@ describe("with selection collapsed", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ol style="padding-inline-start: 58px;">
-                    <li style="font-size: 56px;">abc</li>
-                    <li class="oe-nested">
+                    <li style="font-size: 56px;"><p>abc</p>
                         <ol style="padding-inline-start: 59px;">
                             <li style="font-size: 56px;">def[]</li>
                         </ol>
@@ -747,10 +719,9 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>[b]</li>
                         </ul>
@@ -836,10 +807,9 @@ describe("with selection", () => {
         await testEditor({
             contentBefore: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>[b]</li>
                         </ul>
@@ -848,10 +818,9 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
@@ -865,10 +834,9 @@ describe("with selection", () => {
         await testEditor({
             contentBefore: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
@@ -881,10 +849,9 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
@@ -899,19 +866,62 @@ describe("with selection", () => {
                     </li>
                 </ul>`),
         });
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li><p>[a</p>
+                        <ul>
+                            <li><p>b</p>
+                                <ul>
+                                    <li><p>c</p>
+                                        <ul>
+                                            <li>d</li>
+                                        </ul>
+                                    </li>
+                                    <li>e</li>
+                                </ul>
+                            </li>
+                            <li>f</li>
+                        </ul>
+                    </li>
+                    <li>g]</li>
+                </ul>`),
+            stepFunction: keydownTab,
+            contentAfter: unformat(`
+                <ul>
+                    <li class="oe-nested">
+                        <ul>
+                            <li><p>[a</p>
+                                <ul>
+                                    <li><p>b</p>
+                                        <ul>
+                                            <li><p>c</p>
+                                                <ul>
+                                                    <li>d</li>
+                                                </ul>
+                                            </li>
+                                            <li>e</li>
+                                        </ul>
+                                    </li>
+                                    <li>f</li>
+                                </ul>
+                            </li>
+                            <li>g]</li>
+                        </ul>
+                    </li>
+                </ul>`),
+        });
     });
 
     test("should indent two multi-levels", async () => {
         await testEditor({
             contentBefore: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
-                            <li>[b</li>
-                            <li class="oe-nested">
+                            <li><p>[b</p>
                                 <ul>
                                     <li>c]</li>
                                 </ul>
@@ -922,15 +932,13 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
-                                    <li>[b</li>
-                                    <li class="oe-nested">
+                                    <li><p>[b</p>
                                         <ul>
                                             <li>c]</li>
                                         </ul>
@@ -944,15 +952,14 @@ describe("with selection", () => {
         await testEditor({
             contentBefore: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
-                                    <li>[b
-                                    </li><li class="oe-nested">
+                                    <li><p>[b
+                                    </p>
                                         <ul>
                                             <li>c]</li>
                                         </ul>
@@ -965,17 +972,15 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li class="oe-nested">
                                 <ul>
                                     <li class="oe-nested">
                                         <ul>
-                                            <li>[b</li>
-                                            <li class="oe-nested">
+                                            <li><p>[b</p>
                                                 <ul>
                                                     <li>c]</li>
                                                 </ul>
@@ -1002,10 +1007,9 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>[b</li>
                             <li>c]</li>
@@ -1030,10 +1034,9 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>]b</li>
                             <li>c[</li>
@@ -1051,9 +1054,9 @@ describe("with selection", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         [b
-                    </li><li class="oe-nested">
+                    </p>
                         <ul>
                             <li>c</li>
                         </ul>
@@ -1064,15 +1067,13 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
-                            <li>
+                            <li><p>
                                 [b
-                            </li>
-                            <li class="oe-nested">
+                            </p>
                                 <ul>
                                     <li>c</li>
                                 </ul>
@@ -1090,9 +1091,9 @@ describe("with selection", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         [b
-                    </li><li class="oe-nested">
+                    </p>
                         <ol>
                             <li>c]</li>
                         </ol>
@@ -1101,15 +1102,13 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>
+                    <li><p>
                         a
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ol>
-                            <li>
+                            <li><p>
                                 [b
-                            </li>
-                            <li class="oe-nested">
+                            </p>
                                 <ol>
                                     <li>c]</li>
                                 </ol>
@@ -1125,9 +1124,9 @@ describe("with selection", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         [b
-                    </li><li class="oe-nested">
+                    </p>
                         <ol>
                             <li>]c</li>
                         </ol>
@@ -1136,11 +1135,11 @@ describe("with selection", () => {
             stepFunction: keydownTab,
             contentAfter: unformat(`
                 <ul>
-                    <li>a</li>
-                    <li class="oe-nested">
+                    <li><p>a</p>
                         <ol>
-                            <li>[b</li>
-                            <li class="oe-nested">
+                            <li><p>
+                                [b
+                            </p>
                                 <ol>
                                     <li>]c</li>
                                 </ol>
@@ -1158,8 +1157,7 @@ describe("with selection", () => {
                 <ul>
                     <li>a</li>
                     <li>
-                        b
-                    </li><li class="oe-nested">
+                        <p>b</p>
                         <ol>
                             <li>c</li>
                         </ol>
@@ -1171,10 +1169,9 @@ describe("with selection", () => {
             },
             contentAfter: unformat(`
                 <ul>
-                    <li>a</li>
-                    <li class="oe-nested">
+                    <li><p>a</p>
                         <ol>
-                            <li>[b]</li>
+                            <li><p>[b]</p></li>
                             <li>c</li>
                         </ol>
                     </li>
@@ -1187,19 +1184,17 @@ describe("with selection", () => {
             contentBefore: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         b
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>c</li>
                             <li>[d</li>
                         </ul>
                     </li>
-                    <li>
+                    <li><p>
                         e
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
                             <li>f</li>
                             <li>g</li>
@@ -1212,23 +1207,20 @@ describe("with selection", () => {
             contentAfter: unformat(`
                 <ul>
                     <li>a</li>
-                    <li>
+                    <li><p>
                         b
-                    </li>
-                    <li class="oe-nested">
+                    </p>
                         <ul>
-                            <li>
+                            <li><p>
                                 c
-                            </li>
-                            <li class="oe-nested">
+                            </p>
                                 <ul>
                                     <li>[d</li>
                                 </ul>
                             </li>
-                            <li>
+                            <li><p>
                             e
-                            </li>
-                            <li class="oe-nested">
+                            </p>
                             <ul>
                                 <li>f</li>
                                 <li>g</li>
@@ -1301,8 +1293,7 @@ describe("with selection", () => {
                                 <tr>
                                     <td>
                                         <ol>
-                                            <li>abc</li>
-                                            <li class="oe-nested">
+                                            <li><p>abc</p>
                                                 <ol>
                                                     <li>[def]</li>
                                                 </ol>

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -9,17 +9,17 @@ import {
 import { execCommand } from "../_helpers/userCommands";
 import { unformat } from "../_helpers/format";
 
-before(() => {
-    return document.fonts.add(new FontFace(
-        "Roboto",
-        "url(/web/static/fonts/google/Roboto/Roboto-Regular.ttf)",
-    )).ready;
-});
+before(
+    () =>
+        document.fonts.add(
+            new FontFace("Roboto", "url(/web/static/fonts/google/Roboto/Roboto-Regular.ttf)")
+        ).ready
+);
 
 test.tags("font-dependent");
 test("should apply font-size to completely selected list item", async () => {
     await testEditor({
-        styleContent: ':root { font: 14px Roboto }',
+        styleContent: ":root { font: 14px Roboto }",
         contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
         stepFunction: setFontSize("56px"),
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[abc]</li><li>def</li></ol>`,
@@ -28,8 +28,7 @@ test("should apply font-size to completely selected list item", async () => {
         styleContent: ":root { font: 14px Roboto }",
         contentBefore: unformat(`
             <ol>
-                <li>[abc</li>
-                <li class="oe-nested">
+                <li><p>[abc</p>
                     <ol>
                         <li>def</li>
                     </ol>
@@ -40,8 +39,7 @@ test("should apply font-size to completely selected list item", async () => {
         stepFunction: setFontSize("64px"),
         contentAfter: unformat(`
             <ol style="padding-inline-start: 69px;">
-                <li style="font-size: 64px;">[abc</li>
-                <li class="oe-nested">
+                <li style="font-size: 64px;"><p>[abc</p>
                     <ol style="padding-inline-start: 68px;">
                         <li style="font-size: 64px;">def</li>
                     </ol>
@@ -162,7 +160,7 @@ test("should carry font-size of list item to paragraph (4)", async () => {
 test.tags("font-dependent");
 test("should keep list item font-size on toggling list twice", async () => {
     await testEditor({
-        styleContent: 'ol { font: 14px Roboto }',
+        styleContent: "ol { font: 14px Roboto }",
         contentBefore:
             '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 32px;">def]</li></ol>',
         stepFunction: (editor) => {
@@ -185,7 +183,7 @@ test("should change font-size of a list item", async () => {
 test.tags("font-dependent");
 test("should change font-size of a list item (2)", async () => {
     await testEditor({
-        styleContent: 'ol { font: 14px Roboto }',
+        styleContent: "ol { font: 14px Roboto }",
         contentBefore:
             '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 18px;">ghi]</li></ol>',
         stepFunction: setFontSize("32px"),
@@ -225,7 +223,7 @@ test("should pad list based on font-size", async () => {
 test.tags("font-dependent");
 test("should pad list based on font-size (2)", async () => {
     await testEditor({
-        styleContent: 'ol { font: 14px Roboto }',
+        styleContent: "ol { font: 14px Roboto }",
         contentBefore: `<span style="font-size: 56px">[a]</span>`,
         stepFunction: toggleOrderedList,
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[]a</li></ol>`,

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -40,7 +40,7 @@ test("should apply font-size to completely selected list item", async () => {
         contentAfter: unformat(`
             <ol style="padding-inline-start: 69px;">
                 <li style="font-size: 64px;"><p>[abc</p>
-                    <ol style="padding-inline-start: 68px;">
+                    <ol class="o_default_font_size" style="padding-inline-start: 68px;">
                         <li style="font-size: 64px;">def</li>
                     </ol>
                 </li>
@@ -227,5 +227,15 @@ test("should pad list based on font-size (2)", async () => {
         contentBefore: `<span style="font-size: 56px">[a]</span>`,
         stepFunction: toggleOrderedList,
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[]a</li></ol>`,
+    });
+});
+
+test.tags("font-dependent");
+test("should apply color to a list containing sublist if list contents are fully selected", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: "<ol><li><p>[abc]</p><ol><li>def</li></ol></li></ol>",
+        stepFunction: setFontSize("56px"),
+        contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;"><p>[abc]</p><ol class="o_default_font_size"><li>def</li></ol></li></ol>`,
     });
 });

--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -239,3 +239,69 @@ test("should apply color to a list containing sublist if list contents are fully
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;"><p>[abc]</p><ol class="o_default_font_size"><li>def</li></ol></li></ol>`,
     });
 });
+
+test("should remove font-size from list item", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li style="font-size: 56px;">[a]</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li>[a]</li></ol>`,
+    });
+});
+
+test("should remove font-size class from list item", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li class="h2-fs">[a]</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li>[a]</li></ol>`,
+    });
+});
+
+test("should remove font-size from list item containing sublist", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li>a</li><li style="font-size: 56px;"><p>[b]</p><ol class="o_default_font_size"><li>c</li></ol></li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li>a</li><li><p>[b]</p><ol><li>c</li></ol></li></ol>`,
+    });
+});
+
+test("should remove font-size class from list item containing sublist", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li>a</li><li class="h2-fs"><p>[b]</p><ol class="o_default_font_size"><li>c</li></ol></li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li>a</li><li><p>[b]</p><ol><li>c</li></ol></li></ol>`,
+    });
+});
+
+test("should remove font-size and its classes from partially selected list item", async () => {
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li>a</li><li style="font-size: 56px;">b[c]d</li><li>e</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol style="padding-inline-start: 60px;"><li>a</li><li style="font-size: 56px;">b<span class="o_default_font_size">[c]</span>d</li><li>e</li></ol>`,
+    });
+
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li>a</li><li class="h2-fs">b[c]d</li><li>e</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li>a</li><li class="h2-fs">b<span class="o_default_font_size">[c]</span>d</li><li>e</li></ol>`,
+    });
+
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li style="font-size: 56px;">a[bc</li><li style="font-size: 56px;">def</li><li style="font-size: 56px;">gh]i</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">a<span class="o_default_font_size">[bc</span></li><li>def</li><li style="font-size: 56px;"><span class="o_default_font_size">gh]</span>i</li></ol>`,
+    });
+
+    await testEditor({
+        styleContent: "ol { font: 14px Roboto }",
+        contentBefore: `<ol><li class="h2-fs">a[bc</li><li class="h2-fs">def</li><li class="h2-fs">gh]i</li></ol>`,
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: `<ol><li class="h2-fs">a<span class="o_default_font_size">[bc</span></li><li>def</li><li class="h2-fs"><span class="o_default_font_size">gh]</span>i</li></ol>`,
+    });
+});

--- a/addons/html_editor/static/tests/list/normalization.test.js
+++ b/addons/html_editor/static/tests/list/normalization.test.js
@@ -146,14 +146,11 @@ describe("Nested lists without class oe-nested", () => {
             contentAfter: unformat(`
                 <ul>
                     <li>abc</li>
-                    <li>def</li>
-                    <li class="oe-nested">
+                    <li>def
                         <ul>
                             <li>ghi</li>
                             <li>jkl</li>
                         </ul>
-                    </li>
-                    <li class="oe-nested">
                         <ol>
                             <li>mno</li>
                             <li>pqr</li>

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -18,7 +18,7 @@ describe("Regular list", () => {
             styleContent: "ul { font: 14px Roboto }",
             contentBefore: unformat(`
                     <ul>
-                        <li style="list-style: upper-latin;">
+                        <li class="oe-nested" style="list-style: upper-latin;">
                             <ul>
                                 <li>a[b]c</li>
                             </ul>
@@ -27,7 +27,6 @@ describe("Regular list", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li style="list-style: upper-latin;"></li>
                         <li>a[b]c</li>
                     </ul>`),
         });
@@ -72,8 +71,7 @@ describe("Checklist", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">d[e]f</li>
                             </ul>
@@ -82,15 +80,14 @@ describe("Checklist", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
+                        <li><p>abc</p></li>
                         <li class="o_checked">d[e]f</li>
                     </ul>`),
         });
         await testEditor({
             contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li>d[e]f</li>
                             </ul>
@@ -99,7 +96,7 @@ describe("Checklist", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li>abc</li>
+                        <li><p>abc</p></li>
                         <li>d[e]f</li>
                     </ul>`),
         });
@@ -111,9 +108,9 @@ describe("with selection collapsed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li><li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>[]b</li>
                             </ul>
@@ -122,7 +119,7 @@ describe("with selection collapsed", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>a</li>
+                        <li><p>a</p></li>
                         <li>[]b</li>
                     </ul>`),
         });
@@ -132,10 +129,9 @@ describe("with selection collapsed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ol>
-                        <li>
+                        <li><p>
                             a
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ol>
                                 <li>[]b</li>
                             </ol>
@@ -144,7 +140,7 @@ describe("with selection collapsed", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ol>
-                        <li>a</li>
+                        <li><p>a</p></li>
                         <li>[]b</li>
                     </ol>`),
         });
@@ -154,10 +150,9 @@ describe("with selection collapsed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>[]b</li>
                             </ul>
@@ -169,7 +164,7 @@ describe("with selection collapsed", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>a</li>
+                        <li><p>a</p></li>
                         <li>[]b</li>
                         <li>c</li>
                     </ul>`),
@@ -196,10 +191,9 @@ describe("with selection collapsed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ul>
                                 <li class="oe-nested">
                                     <ul>
@@ -212,10 +206,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>[]c</li>
                             </ul>
@@ -225,10 +218,9 @@ describe("with selection collapsed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>[]c</li>
                             </ul>
@@ -237,9 +229,9 @@ describe("with selection collapsed", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li>
+                        </p></li>
                         <li>[]c</li>
                     </ul>`),
         });
@@ -256,8 +248,7 @@ describe("with selection collapsed", () => {
                                 </td>
                                 <td>
                                     <ul>
-                                        <li>abc</li>
-                                        <li class="oe-nested">
+                                        <li><p>abc</p>
                                             <ul>
                                                 <li>def[]</li>
                                             </ul>
@@ -281,7 +272,7 @@ describe("with selection collapsed", () => {
                                 </td>
                                 <td>
                                     <ul>
-                                        <li>abc</li>
+                                        <li><p>abc</p></li>
                                         <li>def[]</li>
                                     </ul>
                                 </td>
@@ -306,8 +297,7 @@ describe("with selection collapsed", () => {
                                 </td>
                                 <td>
                                     <ul class="o_checklist">
-                                        <li>abc</li>
-                                        <li class="oe-nested">
+                                        <li><p>abc</p>
                                             <ul class="o_checklist">
                                                 <li>def[]</li>
                                             </ul>
@@ -331,7 +321,7 @@ describe("with selection collapsed", () => {
                                 </td>
                                 <td>
                                     <ul class="o_checklist">
-                                        <li>abc</li>
+                                        <li><p>abc</p></li>
                                         <li>def[]</li>
                                     </ul>
                                 </td>
@@ -551,9 +541,9 @@ describe("with selection", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>
+                        <li><p>
                             a
-                        </li><li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>[b]</li>
                             </ul>
@@ -565,7 +555,7 @@ describe("with selection", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li>a</li>
+                        <li><p>a</p></li>
                         <li>[b]</li>
                         <li>c</li>
                     </ul>`),
@@ -611,6 +601,54 @@ describe("with selection", () => {
         });
     });
 
+    test("should outdent multi-levl list", async () => {
+        await testEditor({
+            contentBefore: unformat(`
+                <ul>
+                    <li class="oe-nested">
+                        <ul>
+                            <li><p>[a</p>
+                                <ul>
+                                    <li><p>b</p>
+                                        <ul>
+                                            <li><p>c</p>
+                                                <ul>
+                                                    <li>d</li>
+                                                </ul>
+                                            </li>
+                                            <li>e</li>
+                                        </ul>
+                                    </li>
+                                    <li>f</li>
+                                </ul>
+                            </li>
+                            <li>g]</li>
+                        </ul>
+                    </li>
+                </ul>`),
+            stepFunction: keydownShiftTab,
+            contentAfter: unformat(`
+                <ul>
+                    <li><p>[a</p>
+                        <ul>
+                            <li><p>b</p>
+                                <ul>
+                                    <li><p>c</p>
+                                        <ul>
+                                            <li>d</li>
+                                        </ul>
+                                    </li>
+                                    <li>e</li>
+                                </ul>
+                            </li>
+                            <li>f</li>
+                        </ul>
+                    </li>
+                    <li>g]</li>
+                </ul>`),
+        });
+    });
+
     // @wrongCommand
     // This test fails because the original test tested the "indentList" command
     // (with mode="outdent"), which has a different behavior than keydown
@@ -642,10 +680,9 @@ describe("with selection", () => {
             contentAfter: unformat(`
                     <ul>
                         <li>a</li>
-                        <li>
+                        <li><p>
                             [b
-                        </li>
-                        <li class="oe-nested">
+                        </p>
                             <ul>
                                 <li>c</li>
                             </ul>
@@ -724,8 +761,7 @@ describe("with selection", () => {
                                 <li>[d</li>
                             </ul>
                         </li>
-                        <li>e</li>
-                        <li class="oe-nested">
+                        <li><p>e</p>
                             <ul>
                                 <li>f</li>
                                 <li>g</li>
@@ -776,8 +812,7 @@ describe("with selection", () => {
                                 </td>
                                 <td>
                                     <ol>
-                                        <li>abc</li>
-                                        <li class="oe-nested">
+                                        <li><p>abc</p>
                                             <ol>
                                                 <li>[def]</li>
                                             </ol>
@@ -801,7 +836,7 @@ describe("with selection", () => {
                                 </td>
                                 <td>
                                     <ol>
-                                        <li>abc</li>
+                                        <li><p>abc</p></li>
                                         <li>[def]</li>
                                     </ol>
                                 </td>

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -61,8 +61,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                         <ol>
-                            <li>a</li>
-                            <li class="oe-nested">
+                            <li><p>a</p>
                                 <ol>
                                     <li>b</li>
                                 </ol>
@@ -79,8 +78,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                         <ol>
-                            <li>a</li>
-                            <li class="oe-nested">
+                            <li><p>a</p>
                                 <ol>
                                     <li>b</li>
                                 </ol>
@@ -134,13 +132,13 @@ describe("Selection collapsed", () => {
             test("should add an empty list item at the end of an indented list, then remove it", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>def[]</li></ol></li><li>ghi</li></ol>',
+                        "<ol><li><p>abc</p><ol><li>def[]</li></ol></li><li>ghi</li></ol>",
                     stepFunction: async (editor) => {
                         splitBlock(editor);
                         splitBlock(editor);
                     },
                     contentAfter:
-                        '<ol><li>abc</li><li class="oe-nested"><ol><li>def</li></ol></li><li>[]<br></li><li>ghi</li></ol>',
+                        "<ol><li><p>abc</p><ol><li>def</li></ol></li><li>[]<br></li><li>ghi</li></ol>",
                 });
             });
 
@@ -219,8 +217,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     contentBefore: unformat(`
                             <ul>
-                                <li>ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul>
                                         <li>
                                             <font style="color: red;">cd[]</font>
@@ -236,8 +233,7 @@ describe("Selection collapsed", () => {
                     },
                     contentAfter: unformat(`
                             <ul>
-                                <li>ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul>
                                         <li><font style="color: red;">cd</font></li>
                                         <li><font style="color: red;">b</font></li>
@@ -308,13 +304,13 @@ describe("Selection collapsed", () => {
             test("should add an empty list item at the end of an indented list, then remove it", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul><li>abc</li><li class="oe-nested"><ul><li>def[]</li></ul></li><li>ghi</li></ul>',
+                        "<ul><li><p>abc</p><ul><li>def[]</li></ul></li><li>ghi</li></ul>",
                     stepFunction: async (editor) => {
                         splitBlock(editor);
                         splitBlock(editor);
                     },
                     contentAfter:
-                        '<ul><li>abc</li><li class="oe-nested"><ul><li>def</li></ul></li><li>[]<br></li><li>ghi</li></ul>',
+                        "<ul><li><p>abc</p><ul><li>def</li></ul></li><li>[]<br></li><li>ghi</li></ul>",
                 });
             });
 
@@ -514,26 +510,26 @@ describe("Selection collapsed", () => {
             test("should add an empty list item at the end of an indented list, then outdent it (checked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">def[]</li></ul></li><li class="o_checked">ghi</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li class="o_checked">def[]</li></ul></li><li class="o_checked">ghi</li></ul>',
                     stepFunction: async (editor) => {
                         splitBlock(editor);
                         splitBlock(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li class="o_checked">abc</li><li class="oe-nested"><ul class="o_checklist"><li class="o_checked">def</li></ul></li><li>[]<br></li><li class="o_checked">ghi</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li class="o_checked">def</li></ul></li><li>[]<br></li><li class="o_checked">ghi</li></ul>',
                 });
             });
 
             test("should add an empty list item at the end of an indented list, then outdent it (unchecked)", async () => {
                 await testEditor({
                     contentBefore:
-                        '<ul class="o_checklist"><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li>def[]</li></ul></li><li class="o_checked">ghi</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li>def[]</li></ul></li><li class="o_checked">ghi</li></ul>',
                     stepFunction: async (editor) => {
                         splitBlock(editor);
                         splitBlock(editor);
                     },
                     contentAfter:
-                        '<ul class="o_checklist"><li>abc</li><li class="oe-nested"><ul class="o_checklist"><li>def</li></ul></li><li>[]<br></li><li class="o_checked">ghi</li></ul>',
+                        '<ul class="o_checklist"><li><p>abc</p><ul class="o_checklist"><li>def</li></ul></li><li>[]<br></li><li class="o_checked">ghi</li></ul>',
                 });
             });
 
@@ -616,8 +612,7 @@ describe("Selection collapsed", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li>ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul class="o_checklist">
                                         <li>
                                             <font style="color: red;">cd[]</font>
@@ -633,8 +628,7 @@ describe("Selection collapsed", () => {
                         },
                         contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li>ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul class="o_checklist">
                                         <li><font style="color: red;">cd</font></li>
                                         <li><font style="color: red;">0</font></li>
@@ -709,8 +703,7 @@ describe("Selection collapsed", () => {
                     await testEditor({
                         contentBefore: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked">
                                             <font style="color: red;">cd[]</font>
@@ -726,8 +719,7 @@ describe("Selection collapsed", () => {
                         },
                         contentAfter: unformat(`
                             <ul class="o_checklist">
-                                <li class="o_checked">ab</li>
-                                <li class="oe-nested">
+                                <li><p>ab</p>
                                     <ul class="o_checklist">
                                         <li class="o_checked"><font style="color: red;">cd</font></li>
                                         <li><font style="color: red;">0</font></li>

--- a/addons/html_editor/static/tests/list/toggle_cl.test.js
+++ b/addons/html_editor/static/tests/list/toggle_cl.test.js
@@ -101,18 +101,13 @@ describe("Range collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul>
                                 <li>g[]hi</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">jkl</li>
                             </ul>
@@ -122,8 +117,7 @@ describe("Range collapsed", () => {
                 /* @todo @phoenix: move this test case to a new file, with tests for checkitem IDs.
                 contentAfterEdit: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked" id="checkId-1">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked" id="checkId-2">def</li>
                                 <li id="checkId-4">g[]hi</li>
@@ -133,8 +127,7 @@ describe("Range collapsed", () => {
                     </ul>`), */
                 contentAfterEdit: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                                 <li>g[]hi</li>
@@ -146,28 +139,24 @@ describe("Range collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul>
                                 <li class="a">g[]hi</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul class="o_checklist">
                                 <li class="o_checked">jkl</li>
                             </ul>
                         </li>
                     </ul>`),
-                stepFunction: toggleCheckList,
+                stepFunction: (editable) => {
+                    toggleCheckList(editable);
+                },
                 contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">abc</li>
-                        <li class="oe-nested">
+                        <li><p>abc</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">def</li>
                                 <li class="a">g[]hi</li>
@@ -327,15 +316,9 @@ describe("Range collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                         <ul class="o_checklist">
-                            <li class="o_checked">a</li>
-                            <li class="oe-nested">
+                            <li><p>a</p>
                                 <ul class="o_checklist">
-                                    <li class="o_checked">[]b</li>
-                                </ul>
-                            </li>
-                            <li class="oe-nested">
-                                <ul class="o_checklist">
-                                    <li class="oe-nested">
+                                    <li class="o_checked"><p>[]b</p>
                                         <ul class="o_checklist">
                                             <li class="o_checked">c</li>
                                         </ul>
@@ -346,7 +329,7 @@ describe("Range collapsed", () => {
                 stepFunction: toggleCheckList,
                 contentAfter: unformat(`
                         <ul class="o_checklist">
-                            <li class="o_checked">a</li>
+                            <li><p>a</p></li>
                         </ul>
                         <p>[]b</p>
                         <ul class="o_checklist">

--- a/addons/html_editor/static/tests/list/toggle_misc.test.js
+++ b/addons/html_editor/static/tests/list/toggle_misc.test.js
@@ -33,8 +33,7 @@ describe("Mixed", () => {
             contentBefore: unformat(`
                     <p>a[b</p>
                     <ul>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ul>
                                 <li>ef</li>
                             </ul>
@@ -46,8 +45,7 @@ describe("Mixed", () => {
             contentAfter: unformat(`
                     <ol>
                         <li>a[b</li>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ol>
                                 <li>ef</li>
                             </ol>
@@ -62,11 +60,9 @@ describe("Mixed", () => {
         await testEditor({
             contentBefore: unformat(`
                                 <ul>
-                                    <li><h1>abc</h1></li>
-                                    <li class="oe-nested">
+                                    <li><h1>abc</h1>
                                         <ul>
-                                            <li><h2>a[bc</h2></li>
-                                            <li class="oe-nested">
+                                            <li><h2>a[bc</h2>
                                                 <ul>
                                                     <li><h2>abc</h2></li>
                                                     <li><h3>abc</h3></li>
@@ -76,11 +72,9 @@ describe("Mixed", () => {
                                             <li><h2>abc</h2></li>
                                         </ul>
                                     </li>
-                                    <li><h1>abc</h1></li>
-                                    <li class="oe-nested">
+                                    <li><h1>abc</h1>
                                         <ul>
-                                            <li><h2>abc</h2></li>
-                                            <li class="oe-nested">
+                                            <li><h2>abc</h2>
                                                 <ul>
                                                     <li><h2>abc</h2></li>
                                                     <li><h3>abc</h3></li>
@@ -96,11 +90,9 @@ describe("Mixed", () => {
             stepFunction: toggleOrderedList,
             contentAfter: unformat(`
                                 <ol>
-                                    <li><h1>abc</h1></li>
-                                    <li class="oe-nested">
+                                    <li><h1>abc</h1>
                                         <ol>
-                                            <li><h2>a[bc</h2></li>
-                                            <li class="oe-nested">
+                                            <li><h2>a[bc</h2>
                                                 <ol>
                                                     <li><h2>abc</h2></li>
                                                     <li><h3>abc</h3></li>
@@ -110,11 +102,9 @@ describe("Mixed", () => {
                                             <li><h2>abc</h2></li>
                                         </ol>
                                     </li>
-                                    <li><h1>abc</h1></li>
-                                    <li class="oe-nested">
+                                    <li><h1>abc</h1>
                                         <ol>
-                                            <li><h2>abc</h2></li>
-                                            <li class="oe-nested">
+                                            <li><h2>abc</h2>
                                                 <ol>
                                                     <li><h2>abc</h2></li>
                                                     <li><h3>abc</h3></li>
@@ -133,11 +123,9 @@ describe("Mixed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li><h1><strong>abc</strong></h1></li>
-                        <li class="oe-nested">
+                        <li><h1><strong>abc</strong></h1>
                             <ul>
-                                <li><h3><strong>a[bc</strong></h3></li>
-                                <li class="oe-nested">
+                                <li><h3><strong>a[bc</strong></h3>
                                     <ul>
                                         <li><h2><em>abc</em></h2></li>
                                         <li><h2><s>abc</s></h2></li>
@@ -147,11 +135,9 @@ describe("Mixed", () => {
                                 <li><h1><strong>abc</strong></h1></li>
                             </ul>
                         </li>
-                        <li><h1><strong>abc</strong></h1></li>
-                        <li class="oe-nested">
+                        <li><h1><strong>abc</strong></h1>
                             <ul>
-                                <li><h3><strong>abc</strong></h3></li>
-                                <li class="oe-nested">
+                                <li><h3><strong>abc</strong></h3>
                                     <ul>
                                         <li><h2><em>abc</em></h2></li>
                                         <li><h2><s>abc</s></h2></li>
@@ -167,11 +153,9 @@ describe("Mixed", () => {
             stepFunction: toggleOrderedList,
             contentAfter: unformat(`
                     <ol>
-                        <li><h1><strong>abc</strong></h1></li>
-                        <li class="oe-nested">
+                        <li><h1><strong>abc</strong></h1>
                             <ol>
-                                <li><h3><strong>a[bc</strong></h3></li>
-                                <li class="oe-nested">
+                                <li><h3><strong>a[bc</strong></h3>
                                     <ol>
                                         <li><h2><em>abc</em></h2></li>
                                         <li><h2><s>abc</s></h2></li>
@@ -181,11 +165,9 @@ describe("Mixed", () => {
                                 <li><h1><strong>abc</strong></h1></li>
                             </ol>
                         </li>
-                        <li><h1><strong>abc</strong></h1></li>
-                        <li class="oe-nested">
+                        <li><h1><strong>abc</strong></h1>
                             <ol>
-                                <li><h3><strong>abc</strong></h3></li>
-                                <li class="oe-nested">
+                                <li><h3><strong>abc</strong></h3>
                                     <ol>
                                         <li><h2><em>abc</em></h2></li>
                                         <li><h2><s>abc</s></h2></li>
@@ -236,8 +218,7 @@ describe("Mixed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul>
-                        <li>ab</li>
-                        <li class="oe-nested">
+                        <li><p>ab</p>
                             <ul>
                                 <li>c[d</li>
                                 <li>e]f</li>
@@ -248,8 +229,7 @@ describe("Mixed", () => {
             stepFunction: toggleOrderedList,
             contentAfter: unformat(`
                     <ul>
-                        <li>ab</li>
-                        <li class="oe-nested">
+                        <li><p>ab</p>
                             <ol>
                                 <li>c[d</li>
                                 <li>e]f</li>
@@ -265,16 +245,13 @@ describe("Mixed", () => {
             contentBefore: unformat(`
                     <ul>
                         <li>a[b</li>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ul>
                                 <li>ef</li>
-                                <li>gh</li>
-                                <li class="oe-nested">
+                                <li><p>gh</p>
                                     <ol>
                                         <li>ij</li>
-                                        <li>kl</li>
-                                        <li class="oe-nested">
+                                        <li><p>kl</p>
                                             <ul>
                                                 <li>mn</li>
                                             </ul>
@@ -291,16 +268,13 @@ describe("Mixed", () => {
             contentAfter: unformat(`
                     <ol>
                         <li>a[b</li>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ol>
                                 <li>ef</li>
-                                <li>gh</li>
-                                <li class="oe-nested">
+                                <li><p>gh</p>
                                     <ol>
                                         <li>ij</li>
-                                        <li>kl</li>
-                                        <li class="oe-nested">
+                                        <li><p>kl</p>
                                             <ol>
                                                 <li>mn</li>
                                             </ol>
@@ -321,16 +295,13 @@ describe("Mixed", () => {
             contentBefore: unformat(`
                     <ul>
                         <li>a</li>
-                        <li>b</li>
-                        <li class="oe-nested">
+                        <li><p>b</p>
                             <ol>
                                 <li>c</li>
-                                <li>d</li>
-                                <li class="oe-nested">
+                                <li><p>d</p>
                                     <ul>
                                         <li>[]e</li>
-                                        <li>f</li>
-                                        <li class="oe-nested">
+                                        <li><p>f</p>
                                             <ul>
                                                 <li>g</li>
                                             </ul>
@@ -347,16 +318,13 @@ describe("Mixed", () => {
             contentAfter: unformat(`
                     <ul>
                         <li>a</li>
-                        <li>b</li>
-                        <li class="oe-nested">
+                        <li><p>b</p>
                             <ol>
                                 <li>c</li>
-                                <li>d</li>
-                                <li class="oe-nested">
+                                <li><p>d</p>
                                     <ol>
                                         <li>[]e</li>
-                                        <li>f</li>
-                                        <li class="oe-nested">
+                                        <li><p>f</p>
                                             <ul>
                                                 <li>g</li>
                                             </ul>
@@ -394,13 +362,10 @@ describe("Mixed", () => {
         await testEditor({
             contentBefore: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">title</li>
-                        <li class="oe-nested">
+                        <li><p>title</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">abc</li>
                             </ul>
-                        </li>
-                        <li class="oe-nested">
                             <ul>
                                 <li>d[e]f</li>
                             </ul>
@@ -409,8 +374,7 @@ describe("Mixed", () => {
             stepFunction: toggleCheckList,
             contentAfter: unformat(`
                     <ul class="o_checklist">
-                        <li class="o_checked">title</li>
-                        <li class="oe-nested">
+                        <li><p>title</p>
                             <ul class="o_checklist">
                                 <li class="o_checked">abc</li>
                                 <li>d[e]f</li>

--- a/addons/html_editor/static/tests/list/toggle_ul.test.js
+++ b/addons/html_editor/static/tests/list/toggle_ul.test.js
@@ -215,15 +215,9 @@ describe("Range collapsed", () => {
             await testEditor({
                 contentBefore: unformat(`
                         <ul>
-                            <li>a</li>
-                            <li class="oe-nested">
+                            <li><p>a</p>
                                 <ul>
-                                    <li>[]b</li>
-                                </ul>
-                            </li>
-                            <li class="oe-nested">
-                                <ul>
-                                    <li class="oe-nested">
+                                    <li><p>[]b</p>
                                         <ul>
                                             <li>c</li>
                                         </ul>
@@ -234,7 +228,7 @@ describe("Range collapsed", () => {
                 stepFunction: toggleUnorderedList,
                 contentAfter: unformat(`
                         <ul>
-                            <li>a</li>
+                            <li><p>a</p></li>
                         </ul>
                         <p>[]b</p>
                         <ul>

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2057,8 +2057,7 @@ describe("Special cases", () => {
                         unformat(`
                             <ul>
                                 <li>abc</li>
-                                <li>def</li>
-                                <li class="oe-nested">
+                                <li>def
                                     <ul>
                                         <li>123</li>
                                         <li>456</li>
@@ -2072,8 +2071,7 @@ describe("Special cases", () => {
                     <ol>
                         <li>Alpha</li>
                         <li>abc</li>
-                        <li>def</li>
-                        <li class="oe-nested">
+                        <li><p>def</p>
                             <ol>
                                 <li>123</li>
                                 <li>456[]</li>
@@ -2114,8 +2112,7 @@ describe("Special cases", () => {
                 },
                 contentAfter: unformat(`
                     <ul>
-                        <li>Alpha</li>
-                        <li class="oe-nested">
+                        <li><p>Alpha</p>
                             <ul>
                                 <li class="oe-nested">
                                     <ul>
@@ -2145,12 +2142,10 @@ describe("Special cases", () => {
                         unformat(`
                             <ul>
                                 <li>ab</li>
-                                <li>cd</li>
-                                <li class="oe-nested">
+                                <li>cd
                                     <ol>
                                         <li>ef</li>
-                                        <li>gh</li>
-                                        <li class="oe-nested">
+                                        <li>gh
                                             <ul class="o_checklist">
                                                 <li>ij</li>
                                                 <li>kl</li>
@@ -2165,12 +2160,10 @@ describe("Special cases", () => {
                 contentAfter: unformat(`
                     <ol>
                         <li>ab</li>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ol>
                                 <li>ef</li>
-                                <li>gh</li>
-                                <li class="oe-nested">
+                                <li><p>gh</p>
                                     <ol>
                                         <li>ij</li>
                                         <li>kl[]</li>
@@ -2192,12 +2185,10 @@ describe("Special cases", () => {
                         unformat(`
                             <ul>
                                 <li>ab</li>
-                                <li>cd</li>
-                                <li class="oe-nested">
+                                <li>cd
                                     <ol>
                                         <li>ef</li>
-                                        <li>gh</li>
-                                        <li class="oe-nested">
+                                        <li>gh
                                             <ul class="o_checklist">
                                                 <li>ij</li>
                                                 <li>kl</li>
@@ -2212,12 +2203,10 @@ describe("Special cases", () => {
                 contentAfter: unformat(`
                     <ul>
                         <li>ab</li>
-                        <li>cd</li>
-                        <li class="oe-nested">
+                        <li><p>cd</p>
                             <ul>
                                 <li>ef</li>
-                                <li>gh</li>
-                                <li class="oe-nested">
+                                <li><p>gh</p>
                                     <ul>
                                         <li>ij</li>
                                         <li>kl[]</li>
@@ -2324,12 +2313,10 @@ describe("Special cases", () => {
                 },
                 contentAfter: unformat(`
                     <ul>
-                        <li>ab</li>
-                        <li class="oe-nested">
+                        <li><p>ab</p>
                             <ul>
                                 <li>cd</li>
-                                <li>ef</li>
-                                <li class="oe-nested">
+                                <li><p>ef</p>
                                     <ul>
                                         <li>gh</li>
                                         <li>ij</li>
@@ -2338,8 +2325,7 @@ describe("Special cases", () => {
                                     </ul>
                                 </li>
                                 <li>op</li>
-                                <li>qr</li>
-                                <li class="oe-nested">
+                                <li><p>qr</p>
                                     <ul>
                                         <li>st</li>
                                         <li>uv[]</li>

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -61,6 +61,11 @@ describe("visibility", () => {
         expect(".o_we_power_buttons").not.toBeVisible();
     });
 
+    test("should not show power buttons withing a nested list", async () => {
+        await setupEditor("<ul><li><p>[]<br></p><ul><li>abc</li></ul></li></ul>");
+        expect(".o_we_power_buttons").not.toBeVisible();
+    });
+
     test("should not overlap with long placeholders", async () => {
         const placeholder = "This is a very very very very long placeholder";
         class TestPowerboxPlugin extends PowerboxPlugin {

--- a/addons/html_editor/static/tests/tabs.test.js
+++ b/addons/html_editor/static/tests/tabs.test.js
@@ -362,8 +362,7 @@ describe("insert tabulation", () => {
             contentBefore:
                 `<p>${oeTab()}a[${oeTab()}b${oeTab()}</p>` +
                 `<ul>` +
-                    `<li>c${oeTab()}d${oeTab()}</li>` +
-                    `<li class="oe-nested">` +
+                    `<li><p>c${oeTab()}d${oeTab()}</p>` +
                         `<ul>` +
                             `<li>${oeTab()}e${oeTab()}</li>` +
                         `</ul>` +
@@ -376,8 +375,7 @@ describe("insert tabulation", () => {
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +
-                            `<li>c${oeTab(tabAfterCinNestedLI, false)}d${oeTab(tabAfterD, false)}</li>` +
-                            `<li class="oe-nested">` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI, false)}d${oeTab(tabAfterD, false)}</p>` +
                                 `<ul>` +
                                     `<li>${oeTab(tabInDoubleNestedList, false)}e${oeTab(tabAfterE, false)}</li>` +
                                 `</ul>` +
@@ -391,8 +389,7 @@ describe("insert tabulation", () => {
                 `<ul>` +
                     `<li class="oe-nested">` +
                         `<ul>` +
-                            `<li>c${oeTab(tabAfterCinNestedLI)}d${oeTab(tabAfterD)}</li>` +
-                            `<li class="oe-nested">` +
+                            `<li><p>c${oeTab(tabAfterCinNestedLI)}d${oeTab(tabAfterD)}</p>` +
                                 `<ul>` +
                                     `<li>${oeTab(tabInDoubleNestedList)}e${oeTab(tabAfterE)}</li>` +
                                 `</ul>` +
@@ -746,8 +743,8 @@ describe("remove tabulation with shift+tab", () => {
             contentBefore:
                 `<p>${oeTab()}${oeTab()}a[${oeTab()}b${oeTab()}</p>` +
                 `<ul>` +
-                `<li class="oe-nested"><ul><li>c${oeTab()}d${oeTab()}</li>` +
-                `<li class="oe-nested"><ul><li>${oeTab()}e${oeTab()}</li></ul></li></ul></li>` +
+                `<li class="oe-nested"><ul><li><p>c${oeTab()}d${oeTab()}</p>` +
+                `<ul><li>${oeTab()}e${oeTab()}</li></ul></li></ul></li>` +
                 `</ul>` +
                 `<blockquote>${oeTab()}f${oeTab()}]g</blockquote>`,
             stepFunction: keydownShiftTab,
@@ -757,8 +754,8 @@ describe("remove tabulation with shift+tab", () => {
                     false
                 )}</p>` +
                 `<ul>` +
-                `<li>c${oeTab(tabAfterCinLI, false)}d${oeTab(tabAfterD, false)}</li>` +
-                `<li class="oe-nested"><ul><li>${oeTab(tabInNestedList, false)}e${oeTab(
+                `<li><p>c${oeTab(tabAfterCinLI, false)}d${oeTab(tabAfterD, false)}</p>` +
+                `<ul><li>${oeTab(tabInNestedList, false)}e${oeTab(
                     tabAfterE,
                     false
                 )}</li></ul></li>` +
@@ -767,10 +764,8 @@ describe("remove tabulation with shift+tab", () => {
             contentAfter:
                 `<p>${oeTab(TAB_WIDTH)}a[${oeTab(tabAfterA)}b${oeTab(tabAfterB)}</p>` +
                 `<ul>` +
-                `<li>c${oeTab(tabAfterCinLI)}d${oeTab(tabAfterD)}</li>` +
-                `<li class="oe-nested"><ul><li>${oeTab(tabInNestedList)}e${oeTab(
-                    tabAfterE
-                )}</li></ul></li>` +
+                `<li><p>c${oeTab(tabAfterCinLI)}d${oeTab(tabAfterD)}</p>` +
+                `<ul><li>${oeTab(tabInNestedList)}e${oeTab(tabAfterE)}</li></ul></li>` +
                 `</ul>` +
                 `<blockquote>f${oeTab(tabAfterFinBlockquote)}]g</blockquote>`,
         });

--- a/addons/html_editor/static/tests/utils/dom_traversal.test.js
+++ b/addons/html_editor/static/tests/utils/dom_traversal.test.js
@@ -261,7 +261,7 @@ describe("getAdjacents", () => {
     });
 });
 describe("getCommonAncestor", () => {
-    let root, p1, p2, span1, span2, ul, li1, li2, li3, li4, ol;
+    let root, p1, p2, p3, span1, span2, li1, li2, li3, ol;
     const prepareHtml = () => {
         [root] = insertTestHtml(
             unformat(`
@@ -273,21 +273,19 @@ describe("getCommonAncestor", () => {
                     <span> span2 </span>
                 <p/>
                 <ul>
-                    <li> list item 1 </li>
-                    <li id="li2" class="oe-nested">
+                    <li><p> list item 1 </p>
                         <ol>
+                            <li> list item 2 </li>
                             <li> list item 3 </li>
-                            <li> list item 4 </li>
                         </ol>
                     </li>
                 </ul>
             </div>
         `)
         );
-        [p1, p2] = root.querySelectorAll("p");
+        [p1, p2, p3] = root.querySelectorAll("p");
         [span1, span2] = root.querySelectorAll("span");
-        [ul] = root.querySelectorAll("ul");
-        [li1, li2, li3, li4] = root.querySelectorAll("li");
+        [li1, li2, li3] = root.querySelectorAll("li");
         [ol] = root.querySelectorAll("ol");
     };
 
@@ -314,7 +312,7 @@ describe("getCommonAncestor", () => {
         let result = getCommonAncestor([span1, span2], p1);
         expect(result).toBe(null);
 
-        result = getCommonAncestor([ol], li1);
+        result = getCommonAncestor([ol], p3);
         expect(result).toBe(null);
     });
 
@@ -323,14 +321,14 @@ describe("getCommonAncestor", () => {
         let result = getCommonAncestor([span1, span2]);
         expect(result).toBe(p2);
 
-        result = getCommonAncestor([li1, li3]);
-        expect(result).toBe(ul);
+        result = getCommonAncestor([li2, li3]);
+        expect(result).toBe(ol);
     });
 
     test("should return the common ancestor element of multiple nodes", () => {
         prepareHtml();
-        let result = getCommonAncestor([li1, li2, li3, li4], root);
-        expect(result).toBe(ul);
+        let result = getCommonAncestor([li1, li2, li3], root);
+        expect(result).toBe(li1);
 
         result = getCommonAncestor([p2, span1, span2], root);
         expect(result).toBe(p2);

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -164,8 +164,6 @@ ul.o_checklist {
             cursor: pointer;
         }
         &.o_checked {
-            text-decoration: line-through;
-            opacity: 0.5;
             &::before {
                 content: "✓";
                 display: flex;
@@ -174,6 +172,19 @@ ul.o_checklist {
                 justify-content: center;
                 padding-left: 1px #{"/*rtl:ignore*/"};
                 padding-top: 1px;
+            }
+
+            &:has(ul, ol)::before {
+                opacity: 0.5;
+            }
+
+            &:not(:has(ul, ol)) {
+                text-decoration: line-through;
+                opacity: 0.5;
+            }
+            &:has(ul, ol) > :not(ul, ol) {
+                text-decoration: line-through;
+                opacity: 0.5;
             }
         }
     }


### PR DESCRIPTION
Description of the feature this PR addresses:

This PR updates the way nested lists are represented in the editor. Previously, nesting a list would create a new list with the class `oe-nested`, and the current list item would be wrapped inside it, like so:
```html
<ul>
    <li>abc</li>
    <li class="oe-nested">
        <ul>
            <li>ghi</li>
        </ul>
    </li>
</ul>
```
Now, nested lists are appended directly inside the parent list item, in a canonical structure:
```html
<ul>
    <li><p>abc</p>
        <ul>
            <li>ghi</li>
        </ul>
    </li>
</ul>
```

task-4717435

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
