### PR TITLE
[FIX] pos_restaurant: fix splitting combo orders

### DIFF
--- a/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
+++ b/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js
@@ -107,20 +107,27 @@ export class SplitBillScreen extends Component {
     _splitQuantity(line) {
         const split = this.splitlines[line.id];
         // total quantity of the product in this line
-        // we add up the quantities of all the lines that have this product
+        // we add up the quantities of all the lines that have this product,
+        // except for lines belonging to different combos (allowing us to be
+        // more granular when selecting combos)
         let totalQuantity = 0;
 
         this.pos
             .get_order()
             .get_orderlines()
             .forEach(function (orderLine) {
-                if (orderLine.get_product().id === split.product) {
+                const isComboParent = !!orderLine.comboLines?.length;
+                if (
+                    orderLine.get_product().id === split.product &&
+                    (!isComboParent || orderLine.id === line.id) &&
+                    orderLine.comboParent?.id === line.comboParent?.id
+                ) {
                     totalQuantity += orderLine.get_quantity();
                 }
             });
 
         if (line.get_quantity() > 0) {
-            if (!line.is_pos_groupable()) {
+            if (!line.is_pos_groupable() && !line.isPartOfCombo()) {
                 if (split.quantity !== line.get_quantity()) {
                     split.quantity = line.get_quantity();
                 } else {

--- a/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/SplitBillScreen.tour.js
@@ -149,28 +149,35 @@ registry.category("web_tour.tours").add("SplitBillScreenTour4PosCombo", {
         combo.select("Combo Product 4"),
         combo.select("Combo Product 7"),
         combo.confirm(),
+        // now we set the qty of this combo combination to 2
+        ...ProductScreen.clickOrderline("Combo Product 2"),
+        ...ProductScreen.pressNumpad("2"),
+        ...ProductScreen.selectedOrderlineHas("Combo Product 2", "2"),
 
         ...ProductScreen.addOrderline("Water", "1"),
         ...ProductScreen.addOrderline("Minute Maid", "1"),
 
-        // The water and the first combo will go in the new splitted order
-        // we will then check if the rest of the items from this combo
-        // are automatically sent to the new order.
+        // The water, the first combo, and one out of the two items
+        // of the second combo will go in the new splitted order.
+        // we will then check if the rest of the items from the selected
+        // combos are automatically sent to the new order.
         ...ProductScreen.clickSplitBillButton(),
         ...SplitBillScreen.clickOrderline("Water"),
         ...SplitBillScreen.clickOrderline("Combo Product 3"),
+        ...SplitBillScreen.clickOrderline("Combo Product 2"),
+
         // we check that all the lines in the combo are splitted together
         ...SplitBillScreen.orderlineHas("Water", "1", "1"),
         ...SplitBillScreen.orderlineHas("Office Combo", "1", "1"),
         ...SplitBillScreen.orderlineHas("Combo Product 3", "1", "1"),
         ...SplitBillScreen.orderlineHas("Combo Product 5", "1", "1"),
         ...SplitBillScreen.orderlineHas("Combo Product 8", "1", "1"),
-        ...SplitBillScreen.orderlineHas("Office Combo", "1", "1"),
-        ...SplitBillScreen.orderlineHas("Combo Product 2", "1", "0"),
-        ...SplitBillScreen.orderlineHas("Combo Product 4", "1", "0"),
-        ...SplitBillScreen.orderlineHas("Combo Product 7", "1", "0"),
+        ...SplitBillScreen.orderlineHas("Office Combo", "2", "1"),
+        ...SplitBillScreen.orderlineHas("Combo Product 2", "2", "1"),
+        ...SplitBillScreen.orderlineHas("Combo Product 4", "2", "1"),
+        ...SplitBillScreen.orderlineHas("Combo Product 7", "2", "1"),
 
-        ...SplitBillScreen.subtotalIs("53.80"),
+        ...SplitBillScreen.subtotalIs("97.13"),
         ...SplitBillScreen.clickPay(),
         ...PaymentScreen.clickPaymentMethod("Bank"),
         ...PaymentScreen.clickValidate(),


### PR DESCRIPTION
Steps:
------
1. Create a combo product and make it available in restaurant
2. In PoS, add this product to an order
3. Click the product line, and set the quantity to 2 let's
4. Click split button, it takes you to the split screen

Observation: We can not select one of these 2 combos to split, it's either all of them, or none.

Reason:
-------
That's because combos are considered as non groupable in pos, see `is_pos_groupable` [1]. And then, when splitting a combo in `_splitQuantity` [2], we either take all the quantity or 0.

Fix:
----
We update the split logic to account for special combo cases.

[1]: https://github.com/odoo/odoo/blob/bee8b55d7783ea11f2362990cd9d7695b877b8e9/addons/point_of_sale/static/src/app/store/models.js#L829
[2]: https://github.com/odoo/odoo/blob/bee8b55d7783ea11f2362990cd9d7695b877b8e9/addons/pos_restaurant/static/src/app/split_bill_screen/split_bill_screen.js#L124-L127

opw-4737788