### PR TITLE
[FIX] website_sale_stock: avoid warehouse_id recomputation once set

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -27,6 +27,14 @@ class TestSaleOrder(ClickAndCollectCommon):
         so._set_pickup_location('{"id":' + str(self.warehouse.id) + '}')
         self.assertEqual(so.warehouse_id, self.warehouse)
 
+    def test_warehouse_is_not_reset_on_public_user_checkout(self):
+        warehouse_2 = self._create_warehouse()
+        so = self._create_in_store_delivery_order(partner_id=self.public_user.id)
+        so._set_pickup_location('{"id":' + str(warehouse_2.id) + '}')
+        # change the partner_id as would happen in a checkout
+        so.partner_id = self.partner.id
+        self.assertEqual(so.warehouse_id, warehouse_2)
+
     def test_setting_pickup_location_assigns_correct_fiscal_position(self):
         fp_us = self.env['account.fiscal.position'].create({
             'name': "Test US fiscal position",


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable: Click & Collect, Multi Steps Routes
- Set up a a demo payment provider
- Create a second warehouse for the company of your website
- Create a storable product, put units in stock for WH2 and publish it on the website
- As an anonymous portal user, add one unit to your chart using the "pickup in store" button > select warehouse 2
- Click on checkout fill the form and pay
#### > The sale order was attached to the warehouse 1 and the associated delivery is therefore erroneous.

### Cause of the issue:

Once a product is added to the chart, the sale order is created and since you added it using the pick up in store option, the sale order's warehouse_id and pickup location will be correcty updated by these calls: https://github.com/odoo/odoo/blob/785ea79c9ccd655079abeb4b13806e8174968dc3/addons/website_sale_collect/controllers/delivery.py#L22-L36 https://github.com/odoo/odoo/blob/785ea79c9ccd655079abeb4b13806e8174968dc3/addons/website_sale_collect/models/sale_order.py#L34-L36 However, during the checkout you will set a `partner_id` on the SO this will mark the `warhouse_id` field as a field to recompute because of the chain of dependencies of its compute methods: https://github.com/odoo/odoo/blob/785ea79c9ccd655079abeb4b13806e8174968dc3/addons/sale/models/sale_order.py#L463-L464 https://github.com/odoo/odoo/blob/785ea79c9ccd655079abeb4b13806e8174968dc3/addons/sale_stock/models/sale_order.py#L185-L186 And, the computed value of the `warehouse_id` will then override the current one..

opw-4737862
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
