### PR TITLE
[FIX] portal_rating: composer behaviour upon clicking comment button

### DIFF
--- a/addons/portal_rating/static/src/chatter/frontend/message_patch.js
+++ b/addons/portal_rating/static/src/chatter/frontend/message_patch.js
@@ -34,6 +34,8 @@ patch(Message.prototype, {
                     direction: "none",
                 },
             };
+        } else {
+            this.message.composer = null;
         }
     },
 


### PR DESCRIPTION
**Steps to Reproduce:**
- Open website > course
- Click on `Review` tab
- Click on `Comment` button below any review
- Again click on `Comment` button

**Before PR:**
- Upon clicking the `Comment` button a second time, the composer should close instead of replacing `Review`.

**After PR:**
- Composer is closed when the `Comment` button is clicked a second time.

task-4715179

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
