### PR TITLE
[FIX] repair: fix runbot error for test_anglo_saxon_valuation

### DIFF
--- a/addons/repair/tests/test_anglo_saxon_valuation.py
+++ b/addons/repair/tests/test_anglo_saxon_valuation.py
@@ -67,7 +67,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         ro.sudo().action_create_sale_order()
         so = ro.sale_order_id
-        so.action_confirm()
+        so.sudo().action_confirm()
         self.assertEqual(so.order_line.qty_to_invoice, 1)
 
         invoice = so._create_invoices()


### PR DESCRIPTION
Before this PR (https://github.com/odoo/odoo/pull/205318), the `test_inv_ro_with_auto_fifo_part` test passed thanks to the `pos_manager` group rights. After the PR, the test fails when trying to confirm the `sale.order`. Now we use sudo to confirm the `sale.order` in the test and avoid this issue.

runbot error: 182087




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
