### PR TITLE
[FIX] test_website: wait for pending im_livechat init in systray test

### DIFF
--- a/addons/test_website/static/tests/tours/systray.js
+++ b/addons/test_website/static/tests/tours/systray.js
@@ -204,4 +204,12 @@ register("test_systray_not_reditor_not_tester", () => [
     {
         trigger: ":iframe main:contains(test model)",
     },
+    {
+        content: "Wait for livechat to be ready - if it tried to start",
+        trigger: "body",
+        run: async () => {
+            const iframeDocument = document.querySelector("iframe").contentDocument.defaultView;
+            await iframeDocument.odoo.__WOWL_DEBUG__.root.env.services["im_livechat.initialized"]?.ready;
+        },
+    },
 ]);


### PR DESCRIPTION
If im_livechat is installed and `test_systray_not_reditor_not_tester`
is run, it might have started requests to `im_livechat/init` that are
still running at the end of the test. Such pending requests are
detected as issues by runbot.

This commit adds a final step to the test that awaits a promise
from livechat that guarantees that these requests are completed.

runbot-184582
