### PR TITLE
[IMP] base: add thread_time to profiler

### DIFF
--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -29,7 +29,10 @@ class IrProfile(models.Model):
 
     session = fields.Char('Session', index=True)
     name = fields.Char('Description')
-    duration = fields.Float('Duration')
+    duration = fields.Float('Duration', digits=(9, 3),
+        help="Real elapsed time")
+    cpu_duration = fields.Float('CPU Duration', digits=(9, 3),
+        help="CPU clock (not including other processes or SQL)")
 
     init_stack_trace = fields.Text('Initial stack trace', prefetch=False)
 

--- a/odoo/addons/base/views/ir_profile_views.xml
+++ b/odoo/addons/base/views/ir_profile_views.xml
@@ -28,6 +28,7 @@
                 <field name="sql_count" optional="hide"/>
                 <field name="speedscope_url" widget="url"/>
                 <field name="duration"/>
+                <field name="cpu_duration" optional="hide"/>
             </list>
         </field>
     </record>
@@ -40,6 +41,7 @@
                 <group>
                     <field name="name"/>
                     <field name="session"/>
+                    <field name="cpu_duration"/>
                     <field name="entry_count"/>
                     <!-- Do not rely on sql field for the invisible attrs to avoid fetching whole trace from server. -->
                     <field name="sql_count" invisible="sql_count == 0"/>


### PR DESCRIPTION
Adding cpu_duration to ir.profile that contains the duration based on `time.thread_time`. This number indicates how much CPU time was spent by the request excluding other processes and sleep time. It can be used to distinguish at a single glance between time spent in the python process and time spent elsewhere (process context switching, database, etc.).

Duration fields are now stored with a precision down to the millisecond. They used to be stored as float and displayed only 2 digits.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
