### PR TITLE
[FIX] gamification: prevent invalid SUM on non-numeric fields

### DIFF
--- a/addons/gamification/models/gamification_goal.py
+++ b/addons/gamification/models/gamification_goal.py
@@ -199,6 +199,9 @@ class Goal(models.Model):
                                     goals_to_write.update(goal._get_write_values(aggregate))
 
                 else:
+                    field_name = definition.field_id.name
+                    field = Obj._fields.get(field_name)
+                    sum_supported = bool(field) and field.type in {'integer', 'float', 'monetary'}
                     for goal in goals:
                         # eval the domain with user replaced by goal user object
                         domain = safe_eval(definition.domain, {'user': goal.user_id})
@@ -209,8 +212,7 @@ class Goal(models.Model):
                         if goal.end_date and field_date_name:
                             domain.append((field_date_name, '<=', goal.end_date))
 
-                        if definition.computation_mode == 'sum':
-                            field_name = definition.field_id.name
+                        if definition.computation_mode == 'sum' and sum_supported:
                             res = Obj._read_group(domain, [], [f'{field_name}:{definition.computation_mode}'])
                             new_value = res[0][0] or 0.0
 


### PR DESCRIPTION
The system raised a `psycopg2.errors.UndefinedFunction` error when attempting to compute a `SUM` on a `timestamp field (create_date)` in gamification goals. This is because PostgreSQL does not support `SUM(timestamp)` — `SUM` can only be used with numeric types such as integer, float, or monetary.

Steps to reproduce:
---
- Install `Gamification` and `hr_appraisal` modules
- Create a Gamification Challenge, and also create a Goal Definition and set `Computation Mode` -> `Sum`, `Model` -> `Appraisal Goal`, `Field to Sum` -> `Created on (Appraisal Goal)`, `Filter Domain` -> `[]`
- `Start Challenge` in Gamification Challenge

Traceback:
---
```
UndefinedFunction
function sum(timestamp without time zone) does not exist LINE 1: SELECT SUM("hr_appraisal_goal"."create_date") FROM "hr_appra...
               ^
HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
```

To fix this, we now check the field type before applying aggregation. If the computation mode is set to `sum` but the field is not numeric, we gracefully fallback to using `count` instead. This prevents SQL errors and ensures that goal computations remain reliable even with misconfigured definitions.

sentry-6575130734

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
