### PR TITLE
[DRAFT][FIX] hr_recruitment: error when no template_id is found

### DIFF
--- a/addons/hr_recruitment/wizard/applicant_refuse_reason.py
+++ b/addons/hr_recruitment/wizard/applicant_refuse_reason.py
@@ -97,11 +97,11 @@ class ApplicantGetRefuseReason(models.TransientModel):
             'subject': 'subject',
         }
         for wizard in self:
-            if wizard.template_id:
-                for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
+            for wizard_field_name, template_field_name in fields_to_copy_name_mapping.items():
+                if wizard.template_id:
                     wizard[wizard_field_name] = wizard.template_id[template_field_name]
-            else:
-                wizard[wizard_field_name] = False
+                else:
+                    wizard[wizard_field_name] = False
 
     def action_refuse_reason_apply(self):
         if self.send_mail:


### PR DESCRIPTION
Steps to reproduce:
- create a new refusal reason from hr_recruitment > configuration > refusal reason without any template.
- try refusing an application selecting the newly created refusal reason.

Fix:
- We were assigning a value in wizard[wizard_field_name] = False where wizard_field_name was not declared

task: 4715325

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
