### PR TITLE
[FIX] web_editor: handled the case where arch of view is getting null

### DIFF
--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -360,7 +360,11 @@ class IrUiView(models.Model):
 
         views_to_return = view
 
-        node = etree.fromstring(view.arch)
+        try:
+            node = etree.fromstring(view.arch)
+        except etree.XMLSyntaxError:
+            return views_to_return
+
         xpath = "//t[@t-call]"
         if bundles:
             xpath += "| //t[@t-call-assets]"


### PR DESCRIPTION
The system will crash when they get the view where the arch is null.

Steps to Produce:
1. Install `Sales` and `Studio`.
2. Sales > Toggle studio > Reports.
3. Click on New > External.
4. `Add a separator` to the page after `Expression` and save the report.
5. On the right side, click on `Edit Source`.
6. Remove all content and save the report.

Error:
`lxml.etree.XMLSyntaxError: Document is empty, line 1, column 1`

Solution:
   - I used the try-except block to prevent the application from crashing when `view.arch` is empty.

Sentry - 6288795955

Related Enterprise PR-https://github.com/odoo/enterprise/pull/84503
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
