### PR TITLE
[FIX] portal_rating,website_slides: undeterministic error

### DIFF
--- a/addons/portal_rating/static/src/interactions/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/interactions/portal_rating_composer.js
@@ -54,12 +54,13 @@ export class RatingPopupComposer extends Interaction {
 
         // Append the modal
         const modalEl = this.el.querySelector(".o_rating_popup_composer_modal");
+        modalEl.replaceChildren();
         this.renderAt(
             "portal_rating.PopupComposer", {
             inline_mode: true,
             widget: this,
             val: this.rating_avg,
-        }, modalEl) || "";
+        }, modalEl);
 
         if (this.composerEl) {
             this.services["public.interactions"].stopInteractions(this.composerEl);
@@ -69,7 +70,7 @@ export class RatingPopupComposer extends Interaction {
         // TODO Exchange options through another mean ?
         const options = PortalComposer.prepareOptions(this.options);
         this.env.portalComposerOptions = options;
-        const locationEl = this.composerEl || this.el.querySelector(".o_rating_popup_composer_modal .o_portal_chatter_composer");
+        const locationEl = this.el.querySelector(".o_rating_popup_composer_modal .o_portal_chatter_composer");
         // TODO maybe always put in this.options - and prepare in setup ???
         if (!locationEl) {
             return;

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -69,7 +69,7 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-QuickReactionMenu-emoji span:contains('👍'):not(:visible)",
+            trigger: "#chatterRoot:shadow .o-mail-QuickReactionMenu-emoji span:contains('👍')",
             run: "click",
         },
         {

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -34,8 +34,7 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger: "a[id=review-tab]",
-            run: "click",
+            trigger: "body:not(:has(.modal.show))",
         },
         {
             // If it fails here, it means the system is allowing you to add another review.
@@ -52,7 +51,7 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             content: "Reload page (fetch message)",
-            trigger: ".modal",
+            trigger: "body:not(:has(.modal.show))",
             run() {
                 location.reload();
             },


### PR DESCRIPTION
**[FIX] portal_rating: replace the old modal with the new one**

This commit fixes the modal of the "portal rating composer".
Before this commit when a message was post a new modal was added after
the old one. So when we want to modify the review the old modal was
displayed.
In this commit we delete the old modal before adding the new one.

Steps to reproduce:
* Install website_sildes
* Login as an internal user or portal user
* Go to the website (if not already there)
* Click to "Courses" menu
* Click on the "Basics of Gardening course"
* Click on "Add Review"
* Entre a review
* Click on "Post review"
* Click on "Edit Review"
=> Bug there is two modal in the DOM and the showed one is the oldest
modal.

---

**[FIX] website_slides: tour doesn't wait the modal to disappear**

This commit fixes the undeterministic error, the tour needs to wait that
the modal is closed to ensure that the change has been sent.
After that we can reload the page to see the message.

Note:
The following step
```
{
  trigger: "a[id=review-tab]",
  run: "click",
},
```
was overkill as we are already in "Reviews tab".
The goal of this step is to wait the modal to be closed.
This is now explicit.

runbot-error-161614

Original commit that add this undeterministic error:
https://github.com/odoo/odoo/commit/0e621e73219c3a081cce6874938474f2892b4762

---

**[FIX] website_slides: wait for end animation**

This commit fixes the undeterministic error, wait for the emoji to be
visible.

runbot-error-181751

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
