### PR TITLE
[FIX] website: handle missing homepage view during website generation

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -901,10 +901,10 @@ class Website(models.Model):
         # Configure the pages
         for page_code in requested_pages:
             snippet_list = configurator_snippets.get(page_code, [])
-            if page_code == 'homepage':
-                page_view_id = self.with_context(website_id=website.id).viewref('website.homepage')
-            else:
-                page_view_id = self.env['ir.ui.view'].browse(pages_views[page_code])
+            home_page = self.with_context(website_id=website.id).viewref('website.homepage', raise_if_not_found=False) if page_code == 'homepage' else None
+            page_view_id = home_page or self.env['ir.ui.view'].browse(pages_views.get(page_code))
+            if not page_view_id:
+                continue  # Skip rendering this page
             rendered_snippets = []
             nb_snippets = len(snippet_list)
             for i, snippet in enumerate(snippet_list, start=1):


### PR DESCRIPTION
The error occurred because the website.homepage view was deleted. When the website configurator attempted to access it, a ValueError was raised.

Steps to replicate:
- Initialize a DB without any apps installed.
- Manually install website and wait till u reach `Website Configurator` page.
- Duplicate the current window and search for `views`, search `homepage` and delete the first record that you find.
- Go to `website > site > pages` and delete the record with page title as `Home`.
- Go back to the page with website configurator and build the website.

Error:
`ValueError: No record found for unique ID website.homepage. It may have been deleted.`

Solution:
- Used `raise_if_not_found=False` with `viewref()` to avoid crashing if the homepage view is missing.
- Safely skipped rendering the homepage instead of raising an error.

sentry-6311940742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
