### PR TITLE
[FIX] pos_self_order: remove combo product child lines in order summary

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.js
@@ -27,7 +27,7 @@ export class KioskCartPage extends Component {
     }
 
     get lines() {
-        return this.selfOrder.currentOrder.lines;
+        return this.selfOrder.currentOrder.lines.filter((line) => !line.combo_parent_id);
     }
 
     get optionalProducts() {

--- a/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_card_page/kiosk_cart_page.xml
@@ -13,20 +13,24 @@
                             </div>
                             <div class="w-100" >
                                 <h3 t-esc="product.name" class="text-break"/>
-                                <h4 t-if="line.attribute_value_ids?.length > 0 || line.combo_line_ids.length > 0" class="border-start">
-                                    <t t-if="line.attribute_value_ids?.length > 0" >
-                                        <div t-foreach="line.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 text-muted fw-medium">
-                                            <t t-esc="attrVal.attribute_id.name" />: 
-                                            <t t-esc="attrVal.name" />
-                                        </div>
-                                    </t>
-                                    <div t-foreach="line.combo_line_ids" t-as="cline" t-key="cline.uuid" class="ps-3 mb-2">
-                                        <t t-esc="cline.product_id.name"/> <t t-set="c_qty" t-value="cline.qty / line.qty"/>
-                                        <t t-if="c_qty &gt; 1" > x <t t-esc="c_qty"/></t> 
+                                <h4 t-if="line.attribute_value_ids?.length > 0 || line.combo_line_ids.length > 0">
+                                    <div class="border-start">
+                                        <t t-if="line.attribute_value_ids?.length > 0" >
+                                            <div t-foreach="line.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 text-muted fw-medium">
+                                                <t t-esc="attrVal.attribute_id.name" />: 
+                                                <t t-esc="attrVal.name" />
+                                            </div>
+                                        </t>
+                                    </div>
+                                    <div class="border-start ms-4">
+                                        <div t-foreach="line.combo_line_ids" t-as="cline" t-key="cline.uuid" class="ps-3 mb-2">
+                                            <t t-esc="cline.product_id.name"/> <t t-set="c_qty" t-value="cline.qty / line.qty"/>
+                                            <t t-if="c_qty &gt; 1" > x <t t-esc="c_qty"/></t> 
 
-                                        <div t-foreach="cline.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 fw-medium text-muted">
-                                            <t t-esc="attrVal.attribute_id.name" />: 
-                                            <t t-esc="attrVal.name" />
+                                            <div t-foreach="cline.attribute_value_ids" t-as="attrVal" t-key="attrVal.id" class="ps-3 mt-1 fw-medium text-muted">
+                                                <t t-esc="attrVal.attribute_id.name" />: 
+                                                <t t-esc="attrVal.name" />
+                                            </div>
                                         </div>
                                     </div>
                                 </h4>

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -176,6 +176,17 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
             { name: "Fabric", value: "Leather" },
         ]),
         Utils.clickBtn("Add to cart"),
+        // Check if the combo choice does not have an individual order line
+        Utils.clickBtn("Checkout"),
+        {
+            trigger: ".product-item",
+            run: () => {
+                const productItems = document.querySelectorAll(".product-item");
+                if (productItems.length !== 1) {
+                    throw new Error(`Expected 1 product item, but found ${productItems.length}`);
+                }
+            },
+        },
     ],
 });
 


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------------
- Install the point_of_sale module.
- Select Kiosk mode
- 1. Open Kiosk.
- 2. Order Now & add combo product
- 3. Checkout

Issue:
---------------------------------
- When a combo product is added to the cart in kiosk self-order mode, the order summary displays both the combo parent line and all its child lines.

Cause:
-----------------------
- After Checkout all cart product orderline shown.

Fix:
------------------------------
- Now we are sending  the orderline properly after filtering , if combo product
 then their child product not show as diffrent order line.
- The condition is updated correctly.
-----------------------------------
Task:4758958