### PR TITLE
[FIX] test_lint: python 3.8 & 3.9 compatibility

### DIFF
--- a/odoo/addons/test_lint/tests/_pylint_path_setup.py
+++ b/odoo/addons/test_lint/tests/_pylint_path_setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import os
 import sys
@@ -56,6 +58,8 @@ class AddonsPackageFinder(spec.Finder):
                 type=spec.ModuleType.PY_NAMESPACE,
                 submodule_search_locations=sys.modules[modname].__path__,
             )
+        else:
+            return None
 
     def contribute_to_path(self, spec: spec.ModuleSpec, processed: list[str]) -> Sequence[str] | None:
         return spec.submodule_search_locations


### PR DESCRIPTION
odoo/odoo#203874 broke compatibility with Python 3.8 and Python 3.9 due to the typing annotations, leading `test_pylint` to fail on Focal and Bullseye:

- `list[int]` requires Python 3.9 (PEP 585)
- type-wise `a | b` requires Python 3.10 (PEP 604)

Making annotations lazy works around the issue (and changes less stuff than removing the annotations).
