### PR TITLE
[IMP] portal_rating: do not update rating comment metadata

### DIFF
--- a/addons/portal_rating/models/rating_rating.py
+++ b/addons/portal_rating/models/rating_rating.py
@@ -49,8 +49,12 @@ class RatingRating(models.Model):
         to be modified manually, behaving like a tracking. """
         if values.get('publisher_comment'):
             self._check_synchronize_publisher_values()
-            if not values.get('publisher_datetime'):
+            if not values.get('publisher_datetime') and (
+                not self or all(not rating.publisher_datetime for rating in self)
+            ):
                 values['publisher_datetime'] = fields.Datetime.now()
-            if not values.get('publisher_id'):
+            if not values.get('publisher_id') and (
+                not self or all(not rating.publisher_id for rating in self)
+            ):
                 values['publisher_id'] = self.env.user.partner_id.id
         return values

--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_embed_detection
 from . import test_gamification_karma
 from . import test_load_chatter_bundle
 from . import test_mail
+from . import test_portal_rating
 from . import test_security
 from . import test_slide_channel
 from . import test_slide_question

--- a/addons/website_slides/tests/test_portal_rating.py
+++ b/addons/website_slides/tests/test_portal_rating.py
@@ -1,0 +1,42 @@
+
+from odoo import fields
+from odoo.addons.website_slides.tests import common as slides_common
+from odoo.tests.common import users
+
+from freezegun import freeze_time
+
+
+class TestPortalRating(slides_common.SlidesCase):
+
+    @users('user_officer')
+    def test_portal_rating(self):
+        self.channel._action_add_members(self.user_portal.partner_id)
+        rating = self.channel.with_user(self.user_portal).message_post(
+            body='Love the course, would benefit from more videos though.',
+            rating_value=5,
+        ).rating_id
+
+        rating = rating.with_env(self.env)
+
+        with freeze_time('2025-05-01'):
+            rating.write({'publisher_comment': 'Thank you, we will loo into it!'})
+
+        # rating metadata is set to publisher / date
+        self.assertEqual(rating.publisher_id, self.user_officer.partner_id)
+        self.assertEqual(
+            rating.publisher_datetime,
+            fields.Datetime.from_string('2025-05-01 00:00:00')
+        )
+
+        # manager fixes typo
+        with freeze_time('2025-05-02'):
+            rating.with_user(self.user_manager).write({
+                'publisher_comment': 'Thank you, we will look into it!'
+            })
+
+        # rating metadata is not modified, only content is
+        self.assertEqual(rating.publisher_id, self.user_officer.partner_id)
+        self.assertEqual(
+            rating.publisher_datetime,
+            fields.Datetime.from_string('2025-05-01 00:00:00')
+        )


### PR DESCRIPTION
The portal rating "comment" feature is meant as a simple tool to let content publishers interact with reviews by leaving a comment.

It was designed with minimal user rights management and allows people with write access to the underlying record to add/edit/delete comments.

However, when editing the comment from someone else, it looks a bit odd as you visually become the "author" of this comment.

This commit changes the behavior to not alter the metadata (publisher partner and date) when the comment content is modified (fixed a typo, ...).

Task-3834294
