### PR TITLE
[FIX] account: hide electronic format in portal

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -269,19 +269,21 @@
                     </select>
                 </div>
             </div>
-            <div class="row m-0 mb-3 p-0">
-                <div class="col-xl-6">
-                    <label class="col-form-label" for="invoice_edi_format">Electronic format</label>
-                    <select name="invoice_edi_format" class="form-select">
-                        <option value=""/>
-                        <t t-foreach="invoice_edi_formats" t-as="format">
-                            <option t-att-value="format" t-att-selected="(invoice_edi_format or partner.invoice_edi_format) == format">
-                                <t t-esc="format_value"/>
-                            </option>
-                        </t>
-                    </select>
+            <t t-if="invoice_edi_formats">
+                <div class="row m-0 mb-3 p-0">
+                    <div class="col-xl-6">
+                        <label class="col-form-label" for="invoice_edi_format">Electronic format</label>
+                        <select name="invoice_edi_format" class="form-select">
+                            <option value=""/>
+                            <t t-foreach="invoice_edi_formats" t-as="format">
+                                <option t-att-value="format" t-att-selected="(invoice_edi_format or partner.invoice_edi_format) == format">
+                                    <t t-esc="format_value"/>
+                                </option>
+                            </t>
+                        </select>
+                    </div>
                 </div>
-            </div>
+            </t>
         </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
The electronic format field should not be displayed in the portal when no option is available for it.

Steps to reproduce:
-------------------
* (The reported flow was using PoS)
* Install the l10n_mx_edi_pos module
* Create a PoS and use the self invoicing feature
* Make an order and pay for it
* On the ticket scan the QR Code and access the invoice portal
> Observation: The electronic format field is displayed in the portal
but it is empty

Why the fix:
------------
We hide the field when no value is available for it.

opw-4628351