### PR TITLE
[FIX] hw_drivers: checkout on restart, not reboot

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -215,19 +215,18 @@ def check_git_branch(server_url=None):
             db_branch,
         )
 
-        if db_branch != local_branch:
-            try:
-                with writable():
-                    subprocess.run(git + ['branch', '-m', db_branch], check=True)
-                    subprocess.run(git + ['remote', 'set-branches', 'origin', db_branch], check=True)
-                    _logger.info("Updating odoo folder to the branch %s", db_branch)
-                    subprocess.run(
-                        ['/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh'], check=True
-                    )
-            except subprocess.CalledProcessError:
-                _logger.exception("Failed to update the code with git.")
-            finally:
-                odoo_restart()
+        try:
+            with writable():
+                subprocess.run(git + ['branch', '-m', db_branch], check=True)
+                subprocess.run(git + ['remote', 'set-branches', 'origin', db_branch], check=True)
+                _logger.info("Updating odoo folder to the branch %s", db_branch)
+                subprocess.run(
+                    ['/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh'], check=True
+                )
+        except subprocess.CalledProcessError:
+            _logger.exception("Failed to update the code with git.")
+        finally:
+            odoo_restart()
     except Exception:
         _logger.exception('An error occurred while trying to update the code with git')
 

--- a/addons/iot_box_image/overwrite_after_init/etc/rc.local
+++ b/addons/iot_box_image/overwrite_after_init/etc/rc.local
@@ -29,10 +29,4 @@ if [ -f $start_wifi ]; then
   $start_wifi &
 fi
 
-update_odoo=/home/pi/odoo/addons/iot_box_image/configuration/checkout.sh
-if [ -f $update_odoo ]; then
-  printf "Updating Odoo service...\n"
-  $update_odoo &
-fi
-
 exit 0


### PR DESCRIPTION
saas-18.4 does not have the `checkout.sh`, which is replaced by python code. There is no way for an IoT Box to call the python upgrade code on boot, so it was more convenient to call it on Odoo service restart.
