### PR TITLE
[FIX] web_editor: list created with wrong element structure

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/sanitize.js
@@ -245,10 +245,21 @@ function sanitizeNode(node, root) {
         node = parent; // The node has been removed, update the reference.
     } else if (node.nodeName === 'LI' && !node.closest('ul, ol')) {
         // Transform <li> into <p> if they are not in a <ul> / <ol>.
-        const paragraph = document.createElement('p');
-        paragraph.replaceChildren(...node.childNodes);
-        node.replaceWith(paragraph);
-        node = paragraph; // The node has been removed, update the reference.
+        if (node.children.length && [...node.children].every(isBlock)) {
+            // Unwrap <li> if each of its children is a block element.
+            const restoreCursor =
+                shouldPreserveCursor(node, root) && preserveCursor(root.ownerDocument);
+            const nodeToReplace = node.firstElementChild;
+            unwrapContents(node);
+            restoreCursor && restoreCursor(new Map([[node, nodeToReplace]]));
+            node = nodeToReplace;
+        } else {
+            // Otherwise, wrap its content in a new <p> element.
+            const paragraph = document.createElement("p");
+            paragraph.replaceChildren(...node.childNodes);
+            node.replaceWith(paragraph);
+            node = paragraph; // The node has been removed, update the reference.
+        }
     } else if (
         ['UL', 'OL'].includes(node.nodeName) &&
         ['UL', 'OL'].includes(node.parentNode.nodeName)

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1282,7 +1282,8 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
 
     const selectedNodes = getSelectedNodes(editor.editable).filter(
         (n) =>
-            ((n.nodeType === Node.TEXT_NODE && (isVisibleTextNode(n) || isZWS(n))) ||
+            ((n.nodeType === Node.TEXT_NODE &&
+                (isVisibleTextNode(n) || isZWS(n) || (/^\n+$/.test(n.nodeValue) && !applyStyle))) ||
                 n.nodeName === "BR") &&
             closestElement(n).isContentEditable
     );
@@ -1665,8 +1666,12 @@ export function hasAnyFontSizeClass(node) {
  * @returns {boolean}
  */
 export function isSelectionFormat(editable, format) {
-    const selectedNodes = getTraversedNodes(editable)
-        .filter((n) => n.nodeType === Node.TEXT_NODE && n.nodeValue.replaceAll(ZWNBSP_CHAR, '').length);
+    const selectedNodes = getTraversedNodes(editable).filter(
+        (n) =>
+            n.nodeType === Node.TEXT_NODE &&
+            n.nodeValue.replaceAll(ZWNBSP_CHAR, "").length &&
+            (!/^\n+$/.test(n.nodeValue) || !isBlock(closestElement(n)))
+    );
     const isFormatted =
         format === "setFontSizeClassName" ? hasAnyFontSizeClass : formatsSpecs[format].isFormatted;
     return selectedNodes.length && selectedNodes.every(n => isFormatted(n, editable));

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -1196,6 +1196,89 @@ describe('Paste', () => {
                     contentAfter: '<p>a</p><p><br></p><p><br></p><p><br>[]</p>',
                 });
             });
+            it('should unwrap li elements having no ul/ol', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><p>abc</p></li><li><p>def</p></li>');
+                    },
+                    contentAfter: '<p>abc</p><p>def[]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><h1>abc</h1></li><li><h1>def</h1></li');
+                    },
+                    contentAfter: '<h1>abc</h1><h1>def[]</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><blockquote>abc</blockquote></li><li><blockquote>def</blockquote></li>');
+                    },
+                    contentAfter: '<blockquote>abc</blockquote><blockquote>def[]</blockquote>',
+                });
+            });
+            it('should unwrap li elements with multiple blocks having no ul/ol', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><p>abc</p><p>def</p></li><li><p>abc</p><p>def</p></li>');
+                    },
+                    contentAfter: '<p>abc</p><p>def</p><p>abc</p><p>def[]</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><h1>abc</h1><h1>def</h1></li><li><h1>abc</h1><h1>def</h1></li');
+                    },
+                    contentAfter: '<h1>abc</h1><h1>def</h1><h1>abc</h1><h1>def[]</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<li><blockquote>abc</blockquote><blockquote>def</blockquote></li><li><blockquote>abc</blockquote><blockquote>def</blockquote></li>');
+                    },
+                    contentAfter: '<blockquote>abc</blockquote><blockquote>def</blockquote><blockquote>abc</blockquote><blockquote>def[]</blockquote>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, unformat(`
+                            <li>
+                                <p>abc</p>
+                                <ul>
+                                    <li>abc</li>
+                                    <li>def</li>
+                                    <li>ghi</li>
+                                </ul>
+                            </li>
+                            <li>
+                                <p>abc</p>
+                                <ul>
+                                    <li>abc</li>
+                                    <li>def</li>
+                                    <li>ghi</li>
+                                </ul>
+                            </li>
+                        `));
+                    },
+                    contentAfter: unformat(`
+                        <p>abc</p>
+                        <ul>
+                            <li>abc</li>
+                            <li>def</li>
+                            <li>ghi</li>
+                        </ul>
+                        <p>abc</p>
+                        <ul>
+                            <li>abc</li>
+                            <li>def</li>
+                            <li>ghi[]</li>
+                        </ul>
+                    `),
+                });
+            });
         });
     });
     describe('Pasting within Blockquote', () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -237,6 +237,14 @@ describe('Format', () => {
                 contentAfter: `<p>${strong('[a')}</p><p contenteditable="false">b</p><p>${strong('c]')}</p>`,
             });
         });
+        it("should remove bold format when having newline character nodes in selection", async () => {
+            await testEditor(BasicEditor, {
+                contentBefore:
+                    "<p><strong>[abc</strong></p>\n<p><strong>def</strong></p>\n<p><strong>ghi]</strong></p>",
+                stepFunction: bold,
+                contentAfter: "<p>[abc</p>\n<p>def</p>\n<p>ghi]</p>",
+            });
+        });
 
         describe('inside container or inline with class already bold', () => {
             it('should force the font-weight to normal with an inline with class', async () => {


### PR DESCRIPTION
**Current behavior before PR:**

**Issue 1:**

- Paste a content with multiple `<li>` elements without `ol/ul` tag, each `<li>` having a paragraph element inside.
- Try to create a list from these elements.
- List is created with wrong element structure.

The problem occurs because when pasting multiple `<li>` elements without an `<ol>/<ul>` tag, `sanitizeNode` replaces existing `<li>` elements with new `<p>` elements. Since each `<li>` already contains a `<p>`, this results in paragraphs being nested inside other paragraphs. As a result, creating the list from these paragraphs leads to an incorrect structure.

**Issue 2:**

If there are multiple paragraph selected along with newline character nodes `(\n)`, it is not possible to remove bold or italic
format from selected content using toolbar. The issue happens because `isSelectionFormat` method fails to give correct value if traversed nodes contains one or more newline `(\n)` characters.


**Desired behavior after PR is merged:**

**Issue 1:**

Now, if an `<li>` contains a `<p>`, the `<li>` is unwrapped instead of creating a new paragraph, resulting in a correct element structure when creating a list.

**Issue 2:**

Now, `\n` nodes are filtered from traversed nodes so that format can be removed from selected content.

task-4752385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
