### PR TITLE
[FIX] pos_loyalty: not use expired loyalty programs

### DIFF
--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -19,7 +19,13 @@ class PosConfig(models.Model):
     # NOTE: this funtions acts as a m2m field with loyalty.program model. We do this to handle an excpetional use case:
     # When no PoS is specified at a loyalty program form, this program is applied to every PoS (instead of none)
     def _get_program_ids(self):
-        return self.env['loyalty.program'].search(['&', ('pos_ok', '=', True), '|', ('pos_config_ids', '=', self.id), ('pos_config_ids', '=', False)])
+        today = fields.Date.context_today(self)
+        return self.env['loyalty.program'].search([
+            ('pos_ok', '=', True),
+            '|', ('pos_config_ids', '=', self.id), ('pos_config_ids', '=', False),
+            '|', ('date_from', '=', False), ('date_from', '<=', today),
+            '|', ('date_to', '=', False), ('date_to', '>=', today)
+        ])
 
     def _check_before_creating_new_session(self):
         self.ensure_one()

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -302,3 +302,17 @@ registry.category("web_tour.tours").add("PosCheapestProductTaxInclude", {
             PosLoyalty.orderTotalIs("6.00"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_not_create_loyalty_card_expired_program", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.addOrderline("Desk Organizer", "3"),
+            PosLoyalty.finalizeOrder("Cash", "15.3"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2476,3 +2476,23 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_loyalty_on_order_with_fixed_tax', login="pos_user")
+
+    def test_not_create_loyalty_card_expired_program(self):
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['res.partner'].create({'name': 'Test Partner'})
+
+        LoyaltyProgram = self.env['loyalty.program']
+        loyalty_program = LoyaltyProgram.create(LoyaltyProgram._get_template_values()['loyalty'])
+        loyalty_program.write({
+            'date_from': date.today() - timedelta(days=10),
+            'date_to': date.today() - timedelta(days=5),
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "test_not_create_loyalty_card_expired_program",
+            login="pos_user",
+        )
+
+        self.assertEqual(loyalty_program.coupon_count, 0)


### PR DESCRIPTION
Currently, when a loyalty program has expired, loyalty card are still getting created even though points are not granted.

Steps to reproduce:
-------------------
* Create a loyatly program and make it sot that is has already expired
* Open pos and make an order selecting any customer
* Go to the backend and check the loyalty program
> Observation: 1 card has been created with 0 points

Why the fix:
------------
Not loading the expired programs prevent the creation of loyalty cards.

Using the same logic as module `sale_loyalty`
https://github.com/odoo-dev/odoo/blob/5acb89b8ba9be0e18bca65e26c03f47199fcfb4b/addons/sale_loyalty/models/sale_order.py#L461-L465

opw-4671522