### PR TITLE
[FIX] stock: apply putaway rules on packaging

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -277,7 +277,7 @@ class StockMoveLine(models.Model):
             else:
                 for sml in smls:
                     putaway_loc_id = sml.move_id.location_dest_id.with_context(exclude_sml_ids=excluded_smls)._get_putaway_strategy(
-                        sml.product_id, quantity=sml.quantity,
+                        sml.product_id, quantity=sml.quantity, packaging=sml.move_id.packaging_uom_id,
                     )
                     if putaway_loc_id != sml.location_dest_id:
                         sml.location_dest_id = putaway_loc_id


### PR DESCRIPTION
To reproduce the issue:
1. In Settings, enable:
   - Storage Locations
   - Units of Measure & Packagings
   - Packages
2. In uom list, edit Pack of 6:
   - Package type: Pallet
3. Create a putaway rules:
   - From: WH/Stock
   - Package type: Pallet
   - To: WH/Stock/Shelf 1
4. Create and confirm a receipt with one Pack of 6 of any product

Error: in the detailed operations of the SM, the destination
location is still WH/Stock. It should be the shelf.

A small mistake happened during the big refactoring of UoM and
packaging: commit [1] simply removed the use of the SM's packaging
instead of using the new field

[1] https://github.com/odoo/odoo/commit/dc24a1d1c93cf6eeb6456b1591a0ab8ccc4086ba

OPW-4750639