### PR TITLE
[IMP] web: use fetch cache options instead of a unique argument

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -72,10 +72,9 @@ class Home(http.Controller):
             return request.redirect('/web/login?error=access')
 
     @http.route('/web/webclient/load_menus', type='http', auth='user', methods=['GET'], readonly=True)
-    def web_load_menus(self, unique=None, lang=None):
+    def web_load_menus(self, lang=None):
         """
         Loads the menus for the webclient
-        :param unique: this parameters is not used: it is used by the HTTP stack to make a unique request
         :param lang: language in which the menus should be loaded (only works if language is installed)
         :return: the menus (including the images in Base64)
         """

--- a/addons/web/static/src/webclient/menus/menu_service.js
+++ b/addons/web/static/src/webclient/menus/menu_service.js
@@ -14,8 +14,7 @@ export const menuService = {
             if (!reload && odoo.loadMenusPromise) {
                 return odoo.loadMenusPromise;
             }
-            const loadMenusHash = new Date().getTime().toString();
-            const res = await browser.fetch(`${loadMenusUrl}?unique=${loadMenusHash}`);
+            const res = await browser.fetch(loadMenusUrl, { cache: "no-store" });
             if (!res.ok) {
                 throw new Error("Error while fetching menus");
             }

--- a/addons/web/tests/test_load_menus.py
+++ b/addons/web/tests/test_load_menus.py
@@ -36,7 +36,7 @@ class LoadMenusTests(HttpCase):
         self.authenticate("admin", "admin")
 
     def test_load_menus(self):
-        menu_loaded = self.url_open("/web/webclient/load_menus?unique=1234")
+        menu_loaded = self.url_open("/web/webclient/load_menus")
         expected = {
             str(self.menu.id): {
                 'actionID': self.action.id,  # Take the first action in children (see load_web_menus)

--- a/addons/web/views/webclient_templates.xml
+++ b/addons/web/views/webclient_templates.xml
@@ -280,12 +280,12 @@
                         odoo.__session_info__ = <t t-out="json.dumps(session_info)"/>;
                         const { user_context,  cache_hashes } = odoo.__session_info__;
                         const lang = new URLSearchParams(document.location.search).get("lang");
-                        let menuURL = `/web/webclient/load_menus?unique=${new Date().getTime().toString()}`;
+                        let menuURL = "/web/webclient/load_menus";
                         if (lang) {
                             user_context.lang = lang;
                             menuURL += `&amp;lang=${lang}`;
                         }
-                        odoo.reloadMenus = () => fetch(menuURL).then(res => res.json());
+                        odoo.reloadMenus = () => fetch(menuURL, { cache: "no-store" }).then(res => res.json());
                         odoo.loadMenusPromise = odoo.reloadMenus();
                         // Prefetch translations to speedup webclient. This is done in JS because link rel="prefetch"
                         // is not yet supported on safari.


### PR DESCRIPTION
Before this commit, a unique (timestamp) argument was sent to prevent the browser from caching the calls to `/web/webclient/load_menus`.

This is not the correct way to prevent the browser from caching, in this commit we will use the cache options of the fetch function, see [1][2].

[1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch
[2]: https://developer.mozilla.org/en-US/docs/Web/API/RequestInit