### PR TITLE
[FIX] point_of_sale: refund qty when order cancel

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1355,10 +1355,11 @@ class PosOrderLine(models.Model):
     def _is_field_accepted(self, field):
         return field in self._fields and not field in ['combo_parent_id', 'combo_line_ids']
 
-    @api.depends('refund_orderline_ids')
+    @api.depends('refund_orderline_ids', 'refund_orderline_ids.order_id.state')
     def _compute_refund_qty(self):
         for orderline in self:
-            orderline.refunded_qty = -sum(orderline.mapped('refund_orderline_ids.qty'))
+            refund_order_line = orderline.refund_orderline_ids.filtered(lambda l: l.order_id.state != 'cancel')
+            orderline.refunded_qty = -sum(refund_order_line.mapped('qty'))
 
     def _prepare_refund_data(self, refund_order, PosOrderLineLot):
         """

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2191,3 +2191,57 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         ])
         account_moves = self.env['account.move'].search([('pos_payment_ids', 'in', pos_order.payment_ids.ids)])
         self.assertEqual(sum(account_moves.mapped('amount_total')), pos_order.amount_total)
+
+    def test_refund_qty_refund_cancel(self):
+        """
+        Test the refunded qty of an order, when the refund order has been cancelled
+        """
+
+        product1 = self.env['product.product'].create({
+            'name': 'Test Product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'lst_price': 100,
+            'type': 'consu',
+        })
+
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+
+        pos_order_data = {
+            'amount_paid': 100,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': 100,
+            'date_order': fields.Datetime.to_string(fields.Datetime.now()),
+            'fiscal_position_id': False,
+            'lines': [(0, 0, {
+                'discount': 0,
+                'pack_lot_ids': [],
+                'price_unit': 100.0,
+                'product_id': product1.id,
+                'price_subtotal': 100.0,
+                'price_subtotal_incl': 100.0,
+                'qty': 1,
+                'tax_ids': []
+            })],
+            'name': 'Order 12345-123-1234',
+            'partner_id': False,
+            'session_id': current_session.id,
+            'sequence_number': 2,
+            'payment_ids': [(0, 0, {
+                'amount': 100,
+                'name': fields.Datetime.now(),
+                'payment_method_id': self.cash_payment_method.id
+            })],
+            'uuid': '12345-123-1234',
+            'last_order_preparation_change': '{}',
+            'user_id': self.env.uid
+        }
+
+        self.env['pos.order'].sync_from_ui([pos_order_data])
+        order = current_session.order_ids[0]
+        refund_action = order.refund()
+        refund = self.PosOrder.browse(refund_action['res_id'])
+        self.assertEqual(order.lines[0].refunded_qty, 1)
+        refund.action_pos_order_cancel()
+        self.assertEqual(order.lines[0].refunded_qty, 0)


### PR DESCRIPTION
When a refund order is canceled the refunded quantity was not updated accordingly.

Steps to reproduce:
-------------------
* Make an order in PoS and pay it
* Go in the backend
* Go to the order and click on "Refund"
* Cancel the order
* Go back to the PoS and try to refund the order
> Observation: There will already be 1 qty refunded

opw-4750645