### PR TITLE
[IMP] account,l10n_my_edi: extensible send button visibility

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -712,13 +712,13 @@
                         <button name="action_invoice_sent"
                                 type="object"
                                 string="Send"
-                                invisible="state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund')"
+                                invisible="not display_send_button or not highlight_send_button"
                                 class="oe_highlight"
                                 data-hotkey="y"/>
                         <button name="action_invoice_sent"
                                 type="object"
                                 string="Send"
-                                invisible="state != 'posted' or not is_being_sent and not invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund')"
+                                invisible="not display_send_button or highlight_send_button"
                                 data-hotkey="y"/>
                         <button name="action_print_pdf"
                                 type="object"

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -140,6 +140,14 @@ class AccountMove(models.Model):
         super()._compute_show_reset_to_draft_button()
         self.filtered(lambda m: m.l10n_my_edi_state and m.l10n_my_edi_state not in CANCELLED_STATES).show_reset_to_draft_button = False
 
+    @api.depends('l10n_my_invoice_need_edi', 'l10n_my_edi_state')
+    def _compute_highlight_send_button(self):
+        # EXTENDS 'account' to not highlight the "Send" button when the "Send To MyInvois" button is available to have just one call to action.
+        super()._compute_highlight_send_button()
+        for move in self:
+            if move.l10n_my_invoice_need_edi:
+                move.highlight_send_button &= move.l10n_my_edi_state == 'valid'
+
     @api.depends('company_id', 'invoice_line_ids.tax_ids')
     def _compute_l10n_my_edi_display_tax_exemption_reason(self):
         """ Some users will never use tax-exempt taxes, so it's better to only show the field when necessary. """

--- a/addons/l10n_my_edi/views/account_move_view.xml
+++ b/addons/l10n_my_edi/views/account_move_view.xml
@@ -9,24 +9,6 @@
                 <widget name="web_ribbon" title="Processing" bg_color="text-bg-info" invisible="l10n_my_edi_state != 'in_progress'"/>
                 <widget name="web_ribbon" title="Rejected" bg_color="text-bg-warning" invisible="l10n_my_edi_state != 'rejected'"/>
             </xpath>
-            <!-- Hide the original send & print button, as it is difficult to update its invisible condition -->
-            <button name="action_invoice_sent" class="oe_highlight" position="attributes">
-                <attribute name="invisible" add="l10n_my_invoice_need_edi" separator=" or "/>
-            </button>
-            <!-- Instead, we display our own buttons so that we can write the invisible properly for our use case. -->
-            <xpath expr="//button[@name='action_invoice_sent' and not(@class)]" position="after">
-                <button name="action_invoice_sent"
-                        type="object"
-                        string="Send"
-                        invisible="(not l10n_my_invoice_need_edi or l10n_my_edi_state != 'valid') or (state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund'))"
-                        class="oe_highlight"
-                        data-hotkey="y"/>
-                <button name="action_invoice_sent"
-                        type="object"
-                        string="Send"
-                        invisible="(not l10n_my_invoice_need_edi or l10n_my_edi_state == 'valid') or (state != 'posted' or is_being_sent or invoice_pdf_report_id or move_type not in ('out_invoice', 'out_refund'))"
-                        data-hotkey="y"/>
-            </xpath>
             <!-- We want the CTA to be primary only on invoices, and secondary on vendor bills. -->
             <button name="action_invoice_sent" position="before">
                 <button name="action_l10n_my_edi_send_invoice" string="Send To MyInvois" type="object"


### PR DESCRIPTION
Some modules require changes to the visibility conditions of the "Send" buttons. This moves the conditions from the view to non-stored computed fields so the behavior can be easily modified.

To simplify the logic, purchase documents are excluded entirely. The non-highlighted invisible domain included them, but the _check_move_constrains() method on account.move.send prevents the wizard from being called on purchase documents.

The l10n_my_edi visibility conditions were complex: it hides the standard primary button, keeps the secondary button and then it adds two new buttons: a primary and a (second) secondary. We take this opportunity to simplify. This instead hides the "Send" button when EDI is needed and the MyInvois status is invalid. In this state, the next action for the user should always be MyInvois, not the standard Send button.

task-4608570