### PR TITLE
[FIX] sale_stock_margin: recompute cost standard product added in del…

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -14,17 +14,17 @@ class SaleOrderLine(models.Model):
             product = line.product_id.with_company(line.company_id)
             if not line.has_valued_move_ids():
                 line_ids_to_pass.add(line.id)
-            elif (
+            elif line.product_id and line.product_id.categ_id.property_cost_method != 'standard':
                 # don't overwrite any existing value unless non-standard cost method
-                (line.product_id and line.product_id.categ_id.property_cost_method != 'standard') or
-                # if line added from delivery, allow recomputation
-                (not line.product_uom_qty and line.qty_delivered)
-            ):
-                purch_price = product._compute_average_price(0, line.product_uom_qty or line.qty_to_invoice, line.move_ids)
+                qty_from_delivery = line.qty_delivered if line.product_id.invoice_policy == 'order' else line.qty_to_invoice
+                purch_price = product._compute_average_price(0, line.product_uom_qty or qty_from_delivery, line.move_ids)
                 if line.product_uom != product.uom_id:
                     purch_price = product.uom_id._compute_price(purch_price, line.product_uom)
                 line.purchase_price = line._convert_to_sol_currency(
                     purch_price,
                     product.cost_currency_id,
                 )
+            elif not line.product_uom_qty and line.qty_delivered:
+                # if line added from delivery and standard price, pass to super
+                line_ids_to_pass.add(line.id)
         return super(SaleOrderLine, self.browse(line_ids_to_pass))._compute_purchase_price()

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -352,3 +352,61 @@ class TestSaleStockMargin(TestStockValuationCommon):
                 'margin_percent': 0.5,
             }]
         )
+
+    def test_add_standard_product_on_delivery_cost_on_sale_order(self):
+        """ test that if product with standard cost method is added in delivery, the cost is computed."""
+        self.product1.write({
+                'standard_price': 20,
+                'list_price': 25,
+                'invoice_policy': 'order',
+            })
+        product2 = self.env['product.product'].create({
+            'name': 'product2',
+            'type': 'product',
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'standard_price': 10,
+            'list_price': 20,
+            'invoice_policy': 'order',
+        })
+        sale_order = self._create_sale_order()
+        self._create_sale_order_line(sale_order, self.product1, 10, self.product1.list_price)
+        sale_order.action_confirm()
+        delivery = sale_order.picking_ids[0]
+        with Form(delivery) as delivery_form:
+            with delivery_form.move_ids_without_package.new() as move:
+                move.product_id = product2
+                move.product_uom_qty = 10
+        delivery.move_ids.quantity = 10
+        delivery.button_validate()
+        self.assertEqual(sale_order.order_line.filtered(lambda sol: sol.product_id == product2).purchase_price, 10)
+
+    def test_add_avco_product_on_delivery_cost_on_sale_order(self):
+        """ test that if product with avco cost method and an order "invoice_policy" is added in delivery, the cost is computed."""
+        categ_average = self.env['product.category'].create({
+            'name': 'AVERAGE',
+            'property_cost_method': 'average'
+        })
+        self.product1.write({
+                'standard_price': 20,
+                'list_price': 25,
+                'invoice_policy': 'order',
+            })
+        product2 = self.env['product.product'].create({
+            'name': 'product2',
+            'type': 'product',
+            'categ_id': categ_average.id,
+            'standard_price': 10,
+            'list_price': 20,
+            'invoice_policy': 'order',
+        })
+        sale_order = self._create_sale_order()
+        self._create_sale_order_line(sale_order, self.product1, 10, self.product1.list_price)
+        sale_order.action_confirm()
+        delivery = sale_order.picking_ids[0]
+        with Form(delivery) as delivery_form:
+            with delivery_form.move_ids_without_package.new() as move:
+                move.product_id = product2
+                move.product_uom_qty = 10
+        delivery.move_ids.quantity = 10
+        delivery.button_validate()
+        self.assertEqual(sale_order.order_line.filtered(lambda sol: sol.product_id == product2).purchase_price, 10)


### PR DESCRIPTION
…ivery

**Problem:**
When a product is added to a sale order from the delivery 
the cost is not computed

**Steps to reproduce:**
- Activate the "Margins" Settings
- Open Sales/Products and create a product
- In the product Type field, choose consumable 
and set a postive cost
- Do the same for a second product
- Navigate to Sales/Order and create a new quotation
- Add your first product and Confirm
- Click on the Delivery smart button and then on the 
Detailed Operations smart button
- Click on New, add your second product and set 
a quantity of 1
- Go back to the delivery and validate it
- Go back to the sale order

**Current behavior:**
A line has been added with the product but the Cost is zero 

**Expected behavior:**
The cost should be computed

**Cause of the issue:**

Because of the elif logic here 
https://github.com/odoo/odoo/blob/799761246820eee73492277ab18f327ba04b6b96/addons/sale_stock_margin/models/sale_order_line.py#L17-L22
the cost of products added on delivery with a standard price 
will be computed using _compute_average_price
https://github.com/odoo/odoo/blob/799761246820eee73492277ab18f327ba04b6b96/addons/sale_stock_margin/models/sale_order_line.py#L23
We should instead add the line to "line_ids_to_pass" so 
they're computed with the super method

**Fix:**

Changing the elif logic to make sure that if a product is added in 
delivery and has a non standard cost method it's cost is computed 
here 
https://github.com/odoo/odoo/blob/799761246820eee73492277ab18f327ba04b6b96/addons/sale_stock_margin/models/sale_order_line.py#L23
but if it's added in delivery and has a standard cost method,
we call the super method for this line

opw-4581531
