### PR TITLE
[FIX] stock: prevent error while creating new warehouse

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -121,8 +121,9 @@ class Warehouse(models.Model):
                 if 'partner_id' not in vals:
                     vals['partner_id'] = company.partner_id.id
             # create view location for warehouse then create all locations
+            default_location = self.env.ref('stock.stock_location_locations', raise_if_not_found=False)
             loc_vals = {'name': vals.get('code'), 'usage': 'view',
-                        'location_id': self.env.ref('stock.stock_location_locations').id}
+                        'location_id': default_location and default_location.id}
             if vals.get('company_id'):
                 loc_vals['company_id'] = vals.get('company_id')
             vals['view_location_id'] = self.env['stock.location'].create(loc_vals).id


### PR DESCRIPTION
Currently, an error occurs when a user tries to create a new warehouse, but the referenced stock location (record: **Physical Locations**) has been deleted.

**Steps to reproduce:**
- Install the `stock` module without the demo data.
- Enable **Multi-Step Routes** in Inventory settings.
- Delete all Stock Rules and then the existing warehouses.
- Navigate to `Inventory > Reporting > Locations` and delete the **Physical Locations**.
- Try to create a new warehouse.

**Error:**
`ValueError: External ID not found in the system: stock.stock_location_locations`

Here, an error occurs when the system tries to fetch `stock.stock_location_locations` during warehouse creation [1], but the record has been deleted, resulting in a parse error.

[1] - https://github.com/odoo/odoo/blob/834eff6e770280e911bb99e2abab4ea42d4ca8ff/addons/stock/models/stock_warehouse.py#L123-L125

This commit prevents the error by assigning `False` to `location_id`, if the reference is missing.

Sentry - 6577063404