### PR TITLE
[IMP] sale_project: display project stat button on SO when project linked

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -122,6 +122,7 @@ class SaleOrder(models.Model):
             projects_per_so[project.sale_order_id.id] |= project
         for order in self:
             projects = order.order_line.mapped('product_id.project_id')
+            projects |= order.project_id
             projects |= order.order_line.mapped('project_id')
             projects |= projects_per_so[order.id or order._origin.id]
             if not is_project_manager:

--- a/addons/sale_timesheet/tests/test_reinvoice.py
+++ b/addons/sale_timesheet/tests/test_reinvoice.py
@@ -120,7 +120,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
 
         self.assertFalse(sale_order_line3.task_id, "Adding a new expense SO line should not create a task (sol3)")
         self.assertFalse(sale_order_line4.task_id, "Adding a new expense SO line should not create a task (sol4)")
-        self.assertEqual(len(self.sale_order.project_ids), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
+        self.assertEqual(len(self.sale_order.order_line.mapped('project_id')), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
 
         self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_order_cost'].standard_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
         self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_delivery_cost'].standard_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
@@ -214,7 +214,7 @@ class TestReInvoice(TestCommonSaleTimesheet):
 
         self.assertFalse(sale_order_line3.task_id, "Adding a new expense SO line should not create a task (sol3)")
         self.assertFalse(sale_order_line4.task_id, "Adding a new expense SO line should not create a task (sol4)")
-        self.assertEqual(len(self.sale_order.project_ids), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
+        self.assertEqual(len(self.sale_order.order_line.mapped('project_id')), 1, "SO create only one project with its service line. Adding new expense SO line should not impact that")
 
         self.assertEqual((sale_order_line3.price_unit, sale_order_line3.qty_delivered, sale_order_line3.product_uom_qty, sale_order_line3.qty_invoiced), (self.company_data['product_delivery_sales_price'].list_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')
         self.assertEqual((sale_order_line4.price_unit, sale_order_line4.qty_delivered, sale_order_line4.product_uom_qty, sale_order_line4.qty_invoiced), (self.company_data['product_order_sales_price'].list_price, 3.0, 3.0, 0), 'Sale line is wrong after confirming vendor invoice')


### PR DESCRIPTION
Before:
In Odoo 18, the smart button to navigate from a sales order to its linked
project only appears when the link is explicitly confirmed from both ends (sales
order and project), or when tasks are created from the SO. This differs from
previous versions, where the button appeared more intuitively upon linking.

After:
Ensured that the smart button linking to the project appears on the sales order
even when:
  - A project is manually assigned to the sales order.
  - No tasks have been created from the sales order.

Impact:
  - Restores intuitive navigation between sales orders and projects, as in older
    Odoo versions.
  - Improves user experience by reducing manual steps to confirm links.
  - Supports managing projects directly from sales orders, enhancing workflow
    efficiency.

task: 4644443