### PR TITLE
[FIX] l10n_in_edi_ewaybill: avoid validation error on reversed credit note

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_move.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_move.py
@@ -49,7 +49,7 @@ class AccountMove(models.Model):
     @api.depends('state', 'edi_document_ids', 'edi_document_ids.state')
     def _compute_l10n_in_edi_ewaybill_show_send_button(self):
         edi_format = self.env.ref('l10n_in_edi_ewaybill.edi_in_ewaybill_json_1_03')
-        posted_moves = self.filtered(lambda x: x.is_invoice() and x.state == 'posted' and x.country_code == "IN")
+        posted_moves = self.filtered(lambda x: x.move_type in ('out_invoice', 'in_invoice', 'in_refund') and x.state == 'posted' and x.country_code == "IN")
         for move in posted_moves:
             already_sent = move.edi_document_ids.filtered(lambda x: x.edi_format_id == edi_format and x.state in ('sent', 'to_cancel', 'to_send'))
             if already_sent:

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -11,7 +11,7 @@
             </xpath>
             <xpath expr="//notebook/page[@name='other_info']" position="before">
                 <page string="eWayBill" name="l10n_in_edi_ewaybill_page"
-                    attrs="{'invisible':['|', ('move_type', '=', 'entry'), ('country_code', '!=', 'IN')]}">
+                    attrs="{'invisible':['|', ('move_type', 'in', ('entry', 'out_refund')), ('country_code', '!=', 'IN')]}">
                     <field name="l10n_in_edi_ewaybill_direct_api" invisible="1"/>
                     <group name="ewaybill_group">
                         <group string="Transaction Details" name="Transaction_group" 


### PR DESCRIPTION
When **reversing an invoice into a credit note** and confirming it, the system raises a user error requesting missing e-Waybill fields (e.g., Transportation Mode), because the journal has the 'e-Waybill' option enabled under Advanced Settings(which is trying to generate and send e waybill for credit note). However, generating an e-Waybill is not required for credit notes.

**Steps to reproduce:**
1) Go to Accounting → Configuration → Journals.
2) Open a Sales journal and enable the 'e-Waybill' option in Advanced Settings. 
3) Create and confirm a customer invoice using this journal. 
4) Reverse the invoice, creating a credit note.
5) Confirm the credit note → user error is raised: Impossible to send the
   E waybill. The following information are missing: - Document Type -
   Transportation Mode.

This change prevents the system from trying to validate or send an e-Waybill when confirming a reversed credit note, avoiding unnecessary validation errors and aligning with the expected behavior.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
