### PR TITLE
[FIX] html_editor: close link popover on discard without input

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -482,7 +482,9 @@ export class LinkPlugin extends Plugin {
             onChange: applyCallback,
             onDiscard: () => {
                 restoreSavePoint();
-                this.openLinkTools(linkElement);
+                if (linkElement.isConnected) {
+                    this.openLinkTools(linkElement);
+                }
                 this.dependencies.selection.focusEditable();
             },
             onRemove: () => {

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -68,7 +68,7 @@ export class LinkPopover extends Component {
         });
 
         this.editingWrapper = useRef("editing-wrapper");
-        this.inputRef = useRef(this.state.isImage || "label");
+        this.inputRef = useRef(this.state.isImage ? "url" : "label");
         useEffect(
             (el) => {
                 if (el) {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -510,6 +510,18 @@ describe("Link creation", () => {
                 '<p><a href="https://test.com">Hello[]</a></p>'
             );
         });
+        test("when you open image link popover, url input should be focus by default", async () => {
+            const { el } = await setupEditor(`<p>[<img src="${base64Img}">]</p>`);
+            await waitFor(".o-we-toolbar");
+            await click(".o-we-toolbar .fa-link");
+            await waitFor(".o-we-linkpopover", { timeout: 1500 });
+            expect(".o-we-linkpopover input.o_we_href_input_link").toBeFocused();
+
+            await press("escape");
+            await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+            expect(".o-we-linkpopover").toHaveCount(0);
+            expect(getContent(el)).toBe(`<p><img src="${base64Img}"></p>`);
+        });
         test("should be correctly unlink/link", async () => {
             const { el } = await setupEditor('<p>aaaa[b<a href="http://test.com/">cd</a>e]f</p>');
             await waitFor(".o-we-toolbar");

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -685,6 +685,42 @@ describe("Link formatting in the popover", () => {
             '<p><a href="http://test.com/">link1[]</a></p>'
         );
     });
+    test("should close link popover on discard without input", async () => {
+        const { el, editor } = await setupEditor("<p>[]</p>");
+        await insertText(editor, "/link");
+        await animationFrame();
+        await click(".o-we-command-name:first");
+        await animationFrame();
+        await waitFor(".o-we-linkpopover");
+
+        await contains(".o_we_discard_link").click();
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+        expect(".o-we-linkpopover").toHaveCount(0);
+        expect(getContent(el)).toBe(
+            `<p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]</p>`
+        );
+    });
+    test("clicking the discard button should revert the link creation", async () => {
+        const { el } = await setupEditor("<p>[link1]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#", {
+            confirm: false,
+        });
+
+        await click('select[name="link_type"]');
+        await select("secondary");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="#" class="btn btn-fill-secondary">link1</a></p>'
+        );
+        await click(".o_we_discard_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[link1]</p>");
+        await animationFrame();
+        await waitForNone(".o-we-linkpopover"); // Popover should be closed.
+        await animationFrame();
+        await waitFor(".o-we-toolbar"); // Toolbar should re open.
+    });
     test("when no label input, the link should have the content of the url", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/link");


### PR DESCRIPTION
### Steps to reproduce:

**Issue 1:**
- Create a new link (e.g., type /link).
- The link editing popover appears.
- Click the Discard button.
- Link popover remains open at the bottom.

**Issue 2:**
- Insert an image (e.g., type /media)
- Convert image into link.
- URL input is not automatically focused when the image link popover opens.
- Popover remains open on Escape because it does not receive focus.

### Description of the issue/feature this PR addresses:

- Clicking `Discard` button kept the popover open. This happened because the original linkElement was disconnected and openLinkTools created a new empty anchor tag, causing a new popover to appear.
 - When converting an image into a link, the image link popover did not have a label input. As a result, the URL input did not receive focus by default.
- Pressing Escape key did not close the popover because it never gained focus.

### Desired behavior after PR is merged:

- If there is no valid link in selection, clicking `Discard` button closes the popover, and no new anchor tag is created.
- The URL input in the image link popover is now focused by default, and pressing the Escape key closes the popover.

task-4752206

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
