### PR TITLE
[FIX] web_editor: handled connection error while accessing media

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -511,11 +511,14 @@ class Web_Editor(http.Controller):
         ICP = request.env['ir.config_parameter'].sudo()
         endpoint = ICP.get_param('web_editor.media_library_endpoint', DEFAULT_LIBRARY_ENDPOINT)
         params['dbuuid'] = ICP.get_param('database.uuid')
-        response = requests.post('%s/media-library/1/search' % endpoint, data=params)
-        if response.status_code == requests.codes.ok and response.headers['content-type'] == 'application/json':
-            return response.json()
-        else:
-            return {'error': response.status_code}
+        try:
+            response = requests.post('%s/media-library/1/search' % endpoint, data=params)
+            if response.status_code == requests.codes.ok and response.headers['content-type'] == 'application/json':
+                return response.json()
+            else:
+                return {'error': response.status_code}
+        except requests.exceptions.RequestException as e:
+            return {'error': 'Request failed: ' + str(e)}
 
     @http.route('/web_editor/tests', type='http', auth="user")
     def test_suite(self, mod=None, **kwargs):


### PR DESCRIPTION
The error was probably caused by a temporary failure in DNS resolution, preventing the domain `media-api.odoo.com` from being translated into an IP address.

Error:
`ConnectionError: HTTPSConnectionPool(host='media-api.odoo.com', port=443): Max retries exceeded with url: /media-library/1/search (Caused by NameResolutionError('<urllib3.connection.HTTPSConnection object at 0x72ea796dfce0>: Failed to resolve 'media-api.odoo.com' ([Errno -2] Name or service not known)'))`

Solution:
- Wrapped the HTTP request in a `try-except` block to catch and handle request-related exceptions.

sentry-6544378472

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
