### PR TITLE
[FIX] point_of_sale: fix error when updating multiple pos configs

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -522,8 +522,9 @@ class PosConfig(models.Model):
 
         result = super(PosConfig, self).write(vals)
 
-        if self.use_presets and self.default_preset_id.id not in self.available_preset_ids.ids:
-            self.available_preset_ids |= self.default_preset_id
+        for config in self:
+            if config.use_presets and config.default_preset_id.id not in config.available_preset_ids.ids:
+                config.available_preset_ids |= config.default_preset_id
 
         self.sudo()._set_fiscal_position()
         self.sudo()._check_modules_to_install()

--- a/addons/point_of_sale/tests/test_res_config_settings.py
+++ b/addons/point_of_sale/tests/test_res_config_settings.py
@@ -122,3 +122,18 @@ class TestConfigureShops(TestPoSCommon):
 
         self.assertTrue(second_id not in pos_config.payment_method_ids.ids)
         self.assertTrue(len(pos_config.payment_method_ids) == 2)
+
+    def test_write_default_and_available_presets_on_multiple_pos_configs(self):
+        preset = self.env['pos.preset'].create({'name': 'Preset 1'})
+
+        pos_config1 = self.env['pos.config'].create({'name': 'Shop 1', 'module_pos_restaurant': False})
+        pos_config2 = self.env['pos.config'].create({'name': 'Shop 2', 'module_pos_restaurant': False})
+        pos_config3 = self.env['pos.config'].create({'name': 'Shop 3', 'module_pos_restaurant': False})
+
+        pos_configs = pos_config1 | pos_config2 | pos_config3
+
+        pos_configs.write({
+            'use_presets': True,
+            'available_preset_ids': [(6, 0, [preset.id])],
+            'default_preset_id': preset.id,
+        })


### PR DESCRIPTION
Issue:
=
- Updating presets on multiple POS setups at once caused a singleton error.

Fix:
=
- Now processes each POS configuration individually to prevent the error.

Related PR: https://github.com/odoo/odoo/pull/196800
Task: 4523232
