### PR TITLE
[FIX] sale_timesheet:  prevent traceback when creating product on-fly from SOL

### DIFF
--- a/addons/sale_timesheet/models/product_product.py
+++ b/addons/sale_timesheet/models/product_product.py
@@ -9,6 +9,13 @@ from odoo.exceptions import ValidationError
 class ProductProduct(models.Model):
     _inherit = 'product.product'
 
+    @api.model
+    def default_get(self, fields_list):
+        vals = super().default_get(fields_list)
+        if 'currency_id' in fields_list and not vals.get('currency_id'):
+            vals['currency_id'] = self.env.company.currency_id.id
+        return vals
+
     def _is_delivered_timesheet(self):
         """ Check if the product is a delivered timesheet """
         self.ensure_one()


### PR DESCRIPTION
Steps to Reproduce:
- Install sale_timesheet/ industry_fsm_sale/ helpdesk_sale_timesheet.
- Create a task or ticket and open it.
- Add a customer and create Sale Order line on the fly.
- Create product on the fly  click "Create and Edit"

Issue:
A traceback occurs when creating the product on the fly from SOL.

Root Cause:
When the `sale_timesheet` module is installed, the `currency_id` is not included
in the default values during on-the-fly product creation. This causes a missing
`currency_id`, leading to a singleton error during `tax_string` computation in
the `account` module.

Solution:
Override the `default_get` method in the `product.product` model to assign the
company’s `currency_id` if missing. This ensures the field is always set during
creation, preventing the traceback.

task-4668797