### PR TITLE
[FIX] l10n_ch: added missing translations in fr and de

### DIFF
--- a/addons/l10n_ch/i18n/de.po
+++ b/addons/l10n_ch/i18n/de.po
@@ -185,67 +185,67 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_sale_26
 #: model:account.tax.template,name:l10n_ch.vat_sale_26
 msgid "2.6% Sales"
-msgstr ""
+msgstr "UST 2.6% Lief./DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_26_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_26_incl
 msgid "2.6% Sales (incl.)"
-msgstr ""
+msgstr "UST 2.6% Lief./DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_sale_26_incl
 #: model:account.tax.template,description:l10n_ch.vat_sale_26_incl
 msgid "2.6% incl."
-msgstr ""
+msgstr "2.6% Inkl."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26_invest
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26_invest
 msgid "2.6% invest."
-msgstr ""
+msgstr "2.6% Invest"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26_invest_incl
 msgid "2.6% invest. Incl."
-msgstr ""
+msgstr "2.6% Invest. Inkl"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26
 msgid "2.6% on goods and services"
-msgstr ""
+msgstr "VST 2.6% Mat.-/DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_incl
 msgid "2.6% on goods and services (incl.)"
-msgstr ""
+msgstr "VST 2.6% Mat.-/DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_invest
 msgid "2.6% on invest. and others expenses"
-msgstr ""
+msgstr "VST 2.6% Inv./übr.BA (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_invest_incl
 msgid "2.6% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "VST 2.6% Inv./übr.BA (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26
 msgid "2.6% purch."
-msgstr ""
+msgstr "2.6% Einkauf"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26_incl
 msgid "2.6% purch. Incl."
-msgstr ""
+msgstr "2.6% Einkauf Inkl"
 
 #. module: l10n_ch
 #: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_200
@@ -411,13 +411,13 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_sale_38
 #: model:account.tax.template,name:l10n_ch.vat_sale_38
 msgid "3.8% Sales"
-msgstr ""
+msgstr "UST 3.8% Lief./DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_38_incl
 msgid "3.8% Sales (incl.)"
-msgstr ""
+msgstr "UST 3.8% Lief./DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38_invest
@@ -435,37 +435,37 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38
 msgid "3.8% on goods and services"
-msgstr ""
+msgstr "VST 3.8% Mat.-/DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_incl
 msgid "3.8% on goods and services (incl.)"
-msgstr ""
+msgstr "VST 3.8% Mat.-/DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_invest
 msgid "3.8% on invest. and others expenses"
-msgstr ""
+msgstr "VST 3.8% Inv./übr.BA (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_invest_incl
 msgid "3.8% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "VST 3.8% Inv./übr.BA (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38
 #: model:account.tax.template,description:l10n_ch.vat_purchase_38
 msgid "3.8% purch."
-msgstr ""
+msgstr "3.8% Einkauf"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_38_incl
 msgid "3.8% purch. Incl."
-msgstr ""
+msgstr "3.8% Einkauf Inkl."
 
 #. module: l10n_ch
 #: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_302a
@@ -720,61 +720,61 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_sale_81
 #: model:account.tax.template,name:l10n_ch.vat_sale_81
 msgid "8.1% Sales"
-msgstr ""
+msgstr "UST 8.1% Lief./DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_81_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_81_incl
 msgid "8.1% Sales (incl.)"
-msgstr ""
+msgstr "UST 8.1% Lief./DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_invest
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81_invest
 msgid "8.1% invest."
-msgstr ""
+msgstr "8.1% Invest."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81_invest_incl
 msgid "8.1% invest. Incl."
-msgstr ""
+msgstr "8.1% Invest. Inkl."
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81
 msgid "8.1% on goods and services"
-msgstr ""
+msgstr "VST 8.1% Mat.-/DL (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_incl
 msgid "8.1% on goods and services (incl.)"
-msgstr ""
+msgstr "VST 8.1% Mat.-/DL (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_invest
 msgid "8.1% on invest. and others expenses"
-msgstr ""
+msgstr "VST 8.1% Inv./übr.BA (exkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_invest_incl
 msgid "8.1% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "VST 8.1% Inv./übr.BA (inkl. MWST)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_reverse
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_reverse
 msgid "8.1% on purchase of service abroad (reverse charge)"
-msgstr ""
+msgstr "BZS 8.1% Bezugssteuer"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81
 msgid "8.1% purch."
-msgstr ""
+msgstr "8.1% Einkauf"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_return
@@ -786,7 +786,7 @@ msgstr ""
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81_incl
 msgid "8.1% purch. Incl."
-msgstr ""
+msgstr "8.1% Einkauf Inkl"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_reverse

--- a/addons/l10n_ch/i18n/fr.po
+++ b/addons/l10n_ch/i18n/fr.po
@@ -185,13 +185,13 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_sale_26
 #: model:account.tax.template,name:l10n_ch.vat_sale_26
 msgid "2.6% Sales"
-msgstr ""
+msgstr "TVA due à 2.6% (TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_26_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_26_incl
 msgid "2.6% Sales (incl.)"
-msgstr ""
+msgstr "TVA due à 2.6% (Incl. TR)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_sale_26_incl
@@ -209,43 +209,43 @@ msgstr ""
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26_invest_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26_invest_incl
 msgid "2.6% invest. Incl."
-msgstr ""
+msgstr "TVA 2.6% sur achat B&S (TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26
 msgid "2.6% on goods and services"
-msgstr ""
+msgstr "TVA 2.6% sur achat B&S (TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_incl
 msgid "2.6% on goods and services (incl.)"
-msgstr ""
+msgstr "TVA 2.6% sur achat B&S (Incl. TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_invest
 msgid "2.6% on invest. and others expenses"
-msgstr ""
+msgstr "TVA 2.6% sur invest. et autres ch. (TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_26_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_26_invest_incl
 msgid "2.6% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "TVA 2.6% sur invest. et autres ch. (Incl. TR)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26
 msgid "2.6% purch."
-msgstr ""
+msgstr "2.6% achat."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_26_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_26_incl
 msgid "2.6% purch. Incl."
-msgstr ""
+msgstr "2.6% achat. Incl."
 
 #. module: l10n_ch
 #: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_200
@@ -413,13 +413,13 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_sale_38
 #: model:account.tax.template,name:l10n_ch.vat_sale_38
 msgid "3.8% Sales"
-msgstr ""
+msgstr "TVA due à 3.8% (TS)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_38_incl
 msgid "3.8% Sales (incl.)"
-msgstr ""
+msgstr "TVA due à 3.8% (Incl. TS)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38_invest
@@ -437,37 +437,37 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38
 msgid "3.8% on goods and services"
-msgstr ""
+msgstr "TVA 3.8% sur achat B&S (TR)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_incl
 msgid "3.8% on goods and services (incl.)"
-msgstr ""
+msgstr "TVA 3.8% sur achat B&S (Incl. TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_invest
 msgid "3.8% on invest. and others expenses"
-msgstr ""
+msgstr "TVA 3.8% sur invest. et autres ch. (TS)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_38_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_38_invest_incl
 msgid "3.8% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "TVA 3.8% sur invest. et autres ch. (Incl. TS)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38
 #: model:account.tax.template,description:l10n_ch.vat_purchase_38
 msgid "3.8% purch."
-msgstr ""
+msgstr "3.8% achat."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_38_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_38_incl
 msgid "3.8% purch. Incl."
-msgstr ""
+msgstr "3.8% achat. Incl."
 
 #. module: l10n_ch
 #: model:account.report.line,name:l10n_ch.account_tax_report_line_chtax_302a
@@ -731,19 +731,19 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_return
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_return
 msgid "8.1% Purchase (reverse)"
-msgstr ""
+msgstr "8.1 % d'achat (inverse)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_81
 #: model:account.tax.template,name:l10n_ch.vat_sale_81
 msgid "8.1% Sales"
-msgstr ""
+msgstr "TVA due à 8.1% (TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_sale_81_incl
 #: model:account.tax.template,name:l10n_ch.vat_sale_81_incl
 msgid "8.1% Sales (incl.)"
-msgstr ""
+msgstr "TVA due à 8.1% (Incl. TN)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_invest
@@ -761,37 +761,37 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81
 msgid "8.1% on goods and services"
-msgstr ""
+msgstr "TVA 8.1% sur achat B&S (TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_incl
 msgid "8.1% on goods and services (incl.)"
-msgstr ""
+msgstr "TVA 8.1% sur achat B&S (Incl. TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_invest
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_invest
 msgid "8.1% on invest. and others expenses"
-msgstr ""
+msgstr "TVA 8.1% sur invest. et autres ch. (TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_invest_incl
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_invest_incl
 msgid "8.1% on invest. and others expenses (incl.)"
-msgstr ""
+msgstr "TVA 8.1% sur invest. et autres ch. (Incl. TN)"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_purchase_81_reverse
 #: model:account.tax.template,name:l10n_ch.vat_purchase_81_reverse
 msgid "8.1% on purchase of service abroad (reverse charge)"
-msgstr ""
+msgstr "TVA 8.1% sur achat service a l'étranger (reverse charge)"
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81
 msgid "8.1% purch."
-msgstr ""
+msgstr "8.1% achat."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_return
@@ -803,7 +803,7 @@ msgstr ""
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_incl
 #: model:account.tax.template,description:l10n_ch.vat_purchase_81_incl
 msgid "8.1% purch. Incl."
-msgstr ""
+msgstr "8.1% achat Incl."
 
 #. module: l10n_ch
 #: model:account.tax,description:l10n_ch.1_vat_purchase_81_reverse
@@ -1309,7 +1309,7 @@ msgstr ""
 #: model:account.tax,name:l10n_ch.1_vat_100_import
 #: model:account.tax.template,name:l10n_ch.vat_100_import
 msgid "Customs VAT on goods and services"
-msgstr ""
+msgstr "TVA douanière sur les biens et services"
 
 #. module: l10n_ch
 #: model:account.tax,name:l10n_ch.1_vat_100_import_invest


### PR DESCRIPTION
Steps to reproduce:

1. Install l10n_ch
2. Switch company country to Switzerland (CH)
3. Change language to French or German (CH)
2. Go to Invoicing  > Configuration > Navigate to Taxes.

Issue:
Translation were missing for some texts in account taxes.

Cause:
Outdated translations were removed
Reference Commit: https://github.com/odoo/odoo/commit/7a06ed07814ab8d9192d3a7ec15aba7f90f7294d

Solution:
Added missing translation for french and German(CH)

opw : 4712337

