### PR TITLE
[IMP] *: prevent res.user creation via fields directly

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1425,7 +1425,7 @@
                                         <label for="ref" string="Customer Reference" />
                                         <field name="ref" nolabel="1"/>
                                         <field name="user_id" invisible="1" force_save="1"/>
-                                        <field name="invoice_user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                                        <field name="invoice_user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                                         <field name="invoice_origin" string="Source Document" force_save="1" invisible="1"/>
                                         <field name="partner_bank_id"
                                                context="{'default_partner_id': bank_partner_id, 'display_account_trust': True}"

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -212,7 +212,7 @@
                                         <field name="show_as" readonly="not user_can_edit" nolabel="1"/>
                                         <field name="privacy" readonly="not user_can_edit" nolabel="1" placeholder="Default"/>
                                     </div>
-                                    <field name="user_id" widget="many2one_avatar_user" readonly="not user_can_edit"/>
+                                    <field name="user_id" widget="many2one_avatar_user" readonly="not user_can_edit" options="{'no_quick_create': True}"/>
                                     <field name="description" options="{'height': 100}" placeholder="Add description" readonly="not user_can_edit"/>
                         </group>
                         <group>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -227,7 +227,7 @@
                             </group>
                             <field name="type" invisible="1"/>
                             <group invisible="type == 'lead'">
-                                <field name="user_id"
+                                <field name="user_id" options="{'no_quick_create': True}"
                                     context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
                                 <label for="date_deadline">Expected Closing</label>
                                 <div class="d-flex gap-3 align-items-center">
@@ -237,7 +237,7 @@
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>
                             <group invisible="type == 'opportunity'">
-                                <field name="user_id"
+                                <field name="user_id" options="{'no_quick_create': True}"
                                     context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
                                 <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                             </group>
@@ -357,7 +357,7 @@
                     <field name="partner_id" column_invisible="True"/>
                     <!-- Explicit domain due to multi edit -> real company domain would be complicated -->
                     <field name="user_id" optional="show"  widget="many2one_avatar_user"
-                        domain="[('share', '=', False)]"/>
+                        domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                     <field name="team_id" optional="show"/>
                     <field name="active" column_invisible="True"/>
                     <field name="campaign_id" optional="hide"/>
@@ -757,7 +757,7 @@
                     <field name="country_id" optional="hide" options="{'no_open': True, 'no_create': True}"/>
                     <!-- Explicit domain due to multi edit -> real company domain would be complicated -->
                     <field name="user_id" widget="many2one_avatar_user" optional="show"
-                        domain="[('share', '=', False)]"/>
+                        domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                     <field name="team_id" optional="hide"/>
                     <field name="priority" optional="hide" widget="priority"/>
                     <field name="activity_ids" optional="hide" widget="list_activity"/>

--- a/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_mass_views.xml
@@ -13,7 +13,8 @@
                 </group>
                 <group string="Assign these opportunities to">
                     <field name="team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
-                    <field name="user_ids" widget="many2many_avatar_user" domain="[('share', '=', False)]"/>
+                    <field name="user_ids" widget="many2many_avatar_user" domain="[('share', '=', False)]"
+                        options="{'no_quick_create': True}"/>
                     <field name="force_assignment"/>
                 </group>
                 <label for="duplicated_lead_ids" string="Leads with existing duplicates (for information)" help="Leads that you selected that have duplicates. If the list is empty, it means that no duplicates were found" invisible="not deduplicate"/>
@@ -27,7 +28,7 @@
                             <field name="country_id" column_invisible="context.get('invisible_country', True)" options="{'no_open': True, 'no_create': True}"/>
                             <field name="email_from" optional="show"/>
                             <field name="stage_id"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="team_id" optional="hide"/>
                         </list>
                     </field>

--- a/addons/crm/wizard/crm_lead_to_opportunity_views.xml
+++ b/addons/crm/wizard/crm_lead_to_opportunity_views.xml
@@ -9,7 +9,8 @@
                     <field name="name" widget="radio"/>
                 </group>
                 <group string="Assign this opportunity to">
-                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"
+                        options="{'no_quick_create': True}"/>
                     <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                 </group>
                 <group string="Opportunities" invisible="name != 'merge'" col="4">
@@ -24,7 +25,7 @@
                             <field name="country_id" column_invisible="context.get('invisible_country', True)" options="{'no_open': True, 'no_create': True}"/>
                             <field name="email_from" optional="show"/>
                             <field name="stage_id"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}" optional="hide"/>
                         </list>
                     </field>

--- a/addons/crm/wizard/crm_merge_opportunities_views.xml
+++ b/addons/crm/wizard/crm_merge_opportunities_views.xml
@@ -7,7 +7,8 @@
             <field name="arch" type="xml">
                 <form string="Merge Leads/Opportunities">
                     <group string="Assign opportunities to">
-                        <field name="user_id" class="oe_inline" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                        <field name="user_id" class="oe_inline" widget="many2one_avatar_user" domain="[('share', '=', False)]"
+                            options="{'no_quick_create': True}"/>
                         <field name="team_id" class="oe_inline" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                     </group>
                     <field name="opportunity_ids" nolabel="1">
@@ -19,7 +20,7 @@
                             <field name="email_from" optional="show"/>
                             <field name="phone" class="o_force_ltr" optional="hide"/>
                             <field name="stage_id"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="team_id" optional="hide"/>
                         </list>
                     </field>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -72,7 +72,7 @@
                         </group>
                         <group name="right_event_details">
                             <field name="organizer_id"/>
-                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                             <field name="company_id" groups="base.group_multi_company" placeholder="Visible to all"/>
                             <field name="address_id" context="{'show_address': 1}" placeholder="Online if not set"/>
                             <field name="event_url" invisible="address_id" widget="url" placeholder='e.g. "https://www.odoo.com"'/>

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -70,7 +70,7 @@
                         <group class="col">
                             <field name="lead_type" groups="crm.group_use_lead"/>
                             <field name="lead_sales_team_id"/>
-                            <field name="lead_user_id" widget="many2one_avatar_user"/>
+                            <field name="lead_user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                         </group>
                         <group class="col">
                             <field name="lead_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>

--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -27,7 +27,7 @@
                         <group col="2">
                             <field name="start_date"/>
                             <field name="expiration_date" required="cost_frequency != 'no'"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="purchaser_id" invisible="1"/>
                         </group>
                     </group>

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -106,7 +106,8 @@
                                 <field class="o_fleet_odometer_unit" name="odometer_unit"/>
                                 <button name="action_open_odometer_report" type="object" class="fa fa-line-chart me-1" title="Odometer Report"/>
                             </div>
-                            <field name="manager_id" domain="[('share', '=', False), ('company_id', '=', company_id)]" widget="many2one_avatar_user"/>
+                            <field name="manager_id" domain="[('share', '=', False), ('company_id', '=', company_id)]" widget="many2one_avatar_user"
+                                options="{'no_quick_create': True}"/>
                             <field name="location"/>
                             <label string="Make Vehicle Available" for="plan_to_change_car" class="text-nowrap" invisible="vehicle_type != 'car'"/>
                             <field name="plan_to_change_car" groups="fleet.fleet_group_manager" invisible="vehicle_type != 'car'" nolabel="1"

--- a/addons/gamification/views/gamification_karma_tracking_views.xml
+++ b/addons/gamification/views/gamification_karma_tracking_views.xml
@@ -36,7 +36,7 @@
                 <field name="origin_ref" options="{'no_create': True}" required="1"/>
                 <field name="reason"/>
                 <field name="user_id" widget="many2one_avatar_user" string="Karma Owner"
-                     readonly="id"/>
+                    readonly="id" options="{'no_quick_create': True}"/>
                 <field name="old_value" string="Previous Total" optional="hidden"/>
                 <field name="gain" readonly="id"/>
                 <field name="new_value" string="Total"  optional="show" readonly="1"/>
@@ -52,7 +52,7 @@
                 <sheet>
                     <group>
                         <field name="user_id" widget="many2one_avatar_user" string="Karma Owner"
-                            readonly="id"/>
+                            readonly="id" options="{'no_quick_create': True}"/>
                         <field name="tracking_date"/>
                         <field name="gain" readonly="id"/>
                         <field name="old_value"/>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -219,6 +219,7 @@
                                                 help=""
                                                 domain="[('company_ids', 'in', company_id)]"
                                                 context="{'default_create_employee_id': id}"
+                                                options="{'no_quick_create': True}"
                                                 widget="many2one_avatar_user"/>
                                             <button string="Create User"
                                                 class="btn btn-link"

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -55,7 +55,8 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"
+                    options="{'no_quick_create': True}"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>
@@ -107,7 +108,8 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" readonly="not can_edit" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" readonly="not can_edit" groups="hr_attendance.group_hr_attendance_manager"
+                    options="{'no_quick_create': True}"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -278,7 +278,8 @@
                         <group>
                             <field name="date" readonly="not is_editable" class="w-50"/>
                             <field name="company_id" groups="base.group_multi_company" readonly="state != 'draft'"/>
-                            <field name="manager_id" widget="many2one_avatar_user" readonly="state != 'draft'" placeholder="Auto-validation"/>
+                            <field name="manager_id" widget="many2one_avatar_user" readonly="state != 'draft'" placeholder="Auto-validation"
+                                options="{'no_quick_create': True}"/>
                             <field name="department_id" invisible="1" readonly="not is_editable"
                                    context="{'default_company_id': company_id}"/>
                             <field name="vendor_id" invisible="payment_mode != 'company_account'"/>

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -119,7 +119,8 @@
         <field name="priority" eval="20"/>
         <field name="arch" type="xml">
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"/>
+                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"
+                    options="{'no_quick_create': True}"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>
@@ -169,7 +170,8 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='coach_id']" position="after">
                 <field name="company_id" invisible="1"/>
-                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"/>
+                <field name="leave_manager_id" string="Time Off" widget="many2one_avatar_user"
+                    options="{'no_quick_create': True}"/>
             </xpath>
         </field>
     </record>

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -35,7 +35,7 @@
                 <field name="email_from" readonly="1" optional="hide"/>
                 <field name="partner_phone" widget="phone" readonly="1" optional="hide"/>
                 <field name="job_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
-                <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="show" options="{'no_quick_create': True}"/>
                 <field name="categ_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show"/>
                 <field name="stage_id" optional="show" column_invisible="context.get('default_talent_pool_ids')"/>
                 <field name="type_id" column_invisible="True"/>
@@ -159,7 +159,7 @@
                         <field name="priority" widget="priority"/>
                         <field name="job_id" invisible="is_pool_applicant"/>
                         <field name="talent_pool_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not is_pool_applicant"/>
-                        <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
+                        <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned" options="{'no_quick_create': True}"/>
                         <field name="interviewer_ids" options="{'no_create': True, 'no_create_edit': True}" widget="many2many_avatar_user" invisible="is_pool_applicant" placeholder="Who can access applicants" />
                         <field name="date_closed" invisible="not date_closed" />
                         <field name="categ_ids" placeholder="e.g. Trainee" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -263,7 +263,7 @@
                 <attribute name="invisible">0</attribute>
             </page>
              <div name="recruitment_target" position="after">
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="interviewer_ids" widget="many2many_tags_avatar" options="{'no_create': True, 'no_create_edit': True}" />
             </div>
             <xpath expr="//field[@name='department_id']" position="before">

--- a/addons/lunch/views/lunch_orders_views.xml
+++ b/addons/lunch/views/lunch_orders_views.xml
@@ -39,7 +39,7 @@
                 <field name='product_id'/>
                 <field name="display_toppings" class="o_text_overflow"/>
                 <field name='note' class="o_text_overflow"/>
-                <field name='user_id' widget='many2one_avatar_user' readonly="state != 'new'"/>
+                <field name='user_id' widget='many2one_avatar_user' readonly="state != 'new'" options="{'no_quick_create': True}"/>
                 <field name="lunch_location_id"/>
                 <field name="currency_id" column_invisible="True"/>
                 <field name='price' sum="Total" string="Price" widget="monetary"/>

--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -76,7 +76,7 @@
                                         <field name="summary" placeholder="e.g. Discuss Proposal"/>
                                         <field name="responsible_type"/>
                                         <field name="responsible_id" readonly="responsible_type != 'other'"
-                                               widget="many2one_avatar_user"/>
+                                            widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                                         <field name="delay_count"/>
                                         <field name="delay_unit" string="Unit"/>
                                         <field name="delay_from"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -160,7 +160,7 @@
                         <group>
                             <field name="date_deadline"/>
                         </group>
-                        <field name="user_id" widget="many2one_avatar_user"/>
+                        <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     </group>
                     <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
                     <footer>
@@ -284,7 +284,7 @@
                 </header>
                 <field name="res_name" string="Name"/>
                 <field name="activity_type_id"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="summary"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>

--- a/addons/mail/views/mail_canned_response_views.xml
+++ b/addons/mail/views/mail_canned_response_views.xml
@@ -23,7 +23,7 @@
                     <field name="source" readonly="not is_editable"/>
                     <field name="substitution" readonly="not is_editable"/>
                     <field name="description" readonly="not is_editable"/>
-                    <field name="create_uid" widget="many2one_avatar_user"/>
+                    <field name="create_uid" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="group_ids" widget="many2many_tags" readonly="not is_editable"/>
                     <field name="last_used" readonly="1"/>
                     <field name="is_editable" column_invisible="True"/>
@@ -42,7 +42,7 @@
                             <field name="source" readonly="not is_editable"/>
                             <field name="substitution" readonly="not is_editable"/>
                             <field name="description" readonly="not is_editable"/>
-                            <field name="create_uid" widget="many2one_avatar_user"/>
+                            <field name="create_uid" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="group_ids" widget="many2many_tags" readonly="not is_editable"/>
                             <field name="is_editable" invisible="True"/>
                         </group>

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -83,6 +83,7 @@
                                         <field name="user_id" widget="many2one_avatar_user"
                                             readonly="not is_template_editor"
                                             invisible="not is_template_editor"
+                                            options="{'no_quick_create': True}"
                                             placeholder="Shared with all users."
                                             help="If set, will restrict the template to this specific user.
                                                   If not set, shared with all users."/>
@@ -104,7 +105,8 @@
                     <field name="mail_server_id" column_invisible="True"/>
                     <field name="name"/>
                     <field name="model_id" groups="base.group_no_one"/>
-                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user"
+                        options="{'no_quick_create': True}"/>
                     <field name="description"/>
                     <field name="subject" optional="hidden"/>
                     <field name="email_from" optional="hidden"/>

--- a/addons/mail/views/res_role_views.xml
+++ b/addons/mail/views/res_role_views.xml
@@ -21,7 +21,7 @@
             <field name="arch" type="xml">
                 <list string="Role" editable="bottom" sample="1">
                     <field name="name" string="Role"/>
-                    <field name="user_ids" widget="many2many_avatar_user"/>
+                    <field name="user_ids" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
                 </list>
             </field>
         </record>

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -20,14 +20,15 @@
                         <group invisible="not plan_id">
                             <group>
                                 <field name="plan_date" placeholder="Default deadline for the activities..." string="Due Date"/>
-                                <field name="plan_on_demand_user_id" widget="many2one_avatar_user"
+                                <field name="plan_on_demand_user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"
                                        invisible="not plan_has_user_on_demand" string="Responsible"/>
                             </group>
                             <group>
                                 <label for="plan_schedule_line_ids" string="Plan Summary" class="o_form_label mb-n2" colspan="2"/>
                                 <field name="plan_schedule_line_ids" nolabel="1" class="text-muted mt-n2 small" colspan="2">
                                     <list edit="0" no_open="1" class="o_mail_activity_schedule_summary">
-                                        <field name="responsible_user_id" nolabel="1" widget="many2one_avatar_user" width="22px"/>
+                                        <field name="responsible_user_id" nolabel="1" widget="many2one_avatar_user" width="22px"
+                                            options="{'no_quick_create': True}"/>
                                         <field name="line_description" nolabel="1"/>
                                         <field name="line_date_deadline" nolabel="1"/>
                                     </list>
@@ -46,7 +47,8 @@
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')"/>
                                 <field name="date_deadline" string="Due Date"/>
-                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
+                                <field name="activity_user_id" widget="many2one_avatar_user" placeholder="Unassigned"
+                                    options="{'no_quick_create': True}"/>
                             </group>
                             <field name="note" class="oe-bordered-editor embedded-editor-height-4" placeholder="Log a note..."/>
                         </group>

--- a/addons/mail_group/views/mail_group_views.xml
+++ b/addons/mail_group/views/mail_group_views.xml
@@ -130,7 +130,8 @@
                                 <label for="moderator_ids" string="Moderators" invisible="not moderation"/>
                                 <label for="moderator_ids" string="Responsibles" invisible="moderation"/>
                             </td>
-                            <field name="moderator_ids" widget="many2many_avatar_user" class="oe_inline" nolabel="1" placeholder="Select users"/>
+                            <field name="moderator_ids" widget="many2many_avatar_user" class="oe_inline" nolabel="1" placeholder="Select users"
+                                options="{'no_quick_create': True}"/>
                             <field name="is_moderator" invisible="1"/>
                             <field name="can_manage_group" invisible="1"/>
                             <field name="is_member" invisible="1"/>

--- a/addons/mass_mailing/views/mailing_filter_views.xml
+++ b/addons/mass_mailing/views/mailing_filter_views.xml
@@ -26,7 +26,7 @@
         <field name="arch" type="xml">
             <list string="Mailing filters" sample="1">
                 <field name="name"/>
-                <field name="create_uid" string="Saved by" widget="many2one_avatar_user"/>
+                <field name="create_uid" string="Saved by" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="mailing_model_id" string="Recipients"/>
                 <field name="mailing_domain" string="Domain" optional="hide"/>
             </list>
@@ -45,7 +45,7 @@
                             <field name="mailing_model_id" placeholder="Select a Target Model..." options="{'no_create': True, 'no_open': True}"/>
                         </group>
                         <group>
-                            <field name="create_uid" widget="many2one_avatar_user"/>
+                            <field name="create_uid" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                         </group>
                     </group>
                     <group>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -39,7 +39,7 @@
                     <field name="calendar_date" string="Date" widget="datetime"/>
                     <field name="subject" readonly="state in ('sending', 'done')"/>
                     <field name="mailing_model_id" string="Recipients" optional="hide"/>
-                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="ab_testing_enabled" string="A/B Test" groups="mass_mailing.group_mass_mailing_campaign"/>
                     <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
                     <field name="sent" sum="Total" />
@@ -377,7 +377,7 @@
                                             readonly="1"
                                             required="False"/>
                                         <field name="user_id" widget="many2one_avatar_user"
-                                            domain="[('share', '=', False)]"/>
+                                            domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                                     </group>
                                     <group string="Advanced" groups="base.group_no_one">
                                         <field name="mail_server_available" invisible="1"/>

--- a/addons/mass_mailing/views/utm_campaign_views.xml
+++ b/addons/mass_mailing/views/utm_campaign_views.xml
@@ -28,7 +28,7 @@
                             <field name="calendar_date" string="Date"/>
                             <field name="subject" readonly="state in ('sending', 'done')"/>
                             <field name="mailing_model_id" string="Recipients" optional="hide"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="ab_testing_enabled" string="A/B Test"
                                 groups="mass_mailing.group_mass_mailing_campaign"
                                 column_invisible="parent.ab_testing_mailings_count == 0"/>

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -249,7 +249,7 @@
                 <field name="subject" string="Title"/>
                 <field name="mailing_type" column_invisible="True"/>
                 <field name="mailing_model_id" string="Recipients" optional="hide"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
                 <field name="ab_testing_enabled" string="A/B Test" groups="mass_mailing.group_mass_mailing_campaign"/>
                 <field name="sent" sum="Total Sent"/>

--- a/addons/mass_mailing_sms/views/utm_campaign_views.xml
+++ b/addons/mass_mailing_sms/views/utm_campaign_views.xml
@@ -32,7 +32,7 @@
                             <field name="subject" string="Title"/>
                             <field name="mailing_type" column_invisible="True"/>
                             <field name="mailing_model_id" string="Recipients" optional="hide"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                             <field name="campaign_id" string="Campaign" groups="mass_mailing.group_mass_mailing_campaign" optional="hide"/>
                             <field name="ab_testing_enabled" string="A/B Test"
                                 groups="mass_mailing.group_mass_mailing_campaign"

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -298,7 +298,7 @@
                 <field name="pos_reference"/>
                 <field name="tracking_number" optional="hide"/>
                 <field name="partner_id"/>
-                <field name="user_id" widget="many2one_avatar_user" readonly="account_move or state == 'done'"/>
+                <field name="user_id" widget="many2one_avatar_user" readonly="account_move or state == 'done'" options="{'no_quick_create': True}"/>
                 <field name="amount_total" sum="Amount total" widget="monetary" decoration-bf="1"/>
                 <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state not in ('draft','cancel')"/>
                 <field name="invoice_status" widget="badge" decoration-success="invoice_status == 'invoiced'" decoration-info="invoice_status == 'to_invoice'"/>

--- a/addons/point_of_sale/views/pos_session_view.xml
+++ b/addons/point_of_sale/views/pos_session_view.xml
@@ -85,7 +85,7 @@
             <list string="Point of Sale Session" create="0" sample="1">
                 <field name="name" decoration-bf="1"/>
                 <field name="config_id" />
-                <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'"/>
+                <field name="user_id" widget="many2one_avatar_user" readonly="state != 'opening_control'" options="{'no_quick_create': True}"/>
                 <field name="start_at" />
                 <field name="stop_at" />
                 <field name="cash_register_balance_start"/>

--- a/addons/privacy_lookup/views/privacy_log_views.xml
+++ b/addons/privacy_lookup/views/privacy_log_views.xml
@@ -8,7 +8,7 @@
                 <field name="date" />
                 <field name="anonymized_name"/>
                 <field name="anonymized_email"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="execution_details"/>
             </list>
         </field>
@@ -29,7 +29,7 @@
                         <group>
                             <field name="anonymized_email"/>
                             <field name="date"/>
-                            <field name="user_id" widget="many2one_avatar_user"/>
+                            <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                         </group>
                         <group>
                             <field name="records_description"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -484,7 +484,7 @@
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
                                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
-                                    <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                    <field name="user_ids" widget="many2many_avatar_user" optional="show" options="{'no_quick_create': True}"/>
                                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide" decoration-danger="date_deadline and date_deadline &lt; current_date"/>
@@ -529,7 +529,7 @@
                                         invisible="not allow_milestones"/>
                                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="has_template_ancestor"/>
                                     <field name="parent_id" optional="hide" groups="base.group_no_one"/>
-                                    <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
+                                    <field name="user_ids" widget="many2many_avatar_user" optional="show" options="{'no_quick_create': True}"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide" decoration-danger="date_deadline and date_deadline &lt; current_date"/>
@@ -733,7 +733,7 @@
                     <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}"/>
-                    <field name="user_ids" optional="show" widget="many2many_avatar_user"/>
+                    <field name="user_ids" optional="show" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="company_id" groups="base.group_multi_company" optional="show" column_invisible="context.get('default_project_id')" options="{'no_create': True}"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -105,7 +105,8 @@
         <field name="arch" type="xml">
             <list sample="1" js_class="project_update_list">
                 <field name="name"/>
-                <field name="user_id" widget="many2one_avatar_user" class="fw-bolder" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user" class="fw-bolder" optional="show"
+                    options="{'no_quick_create': True}"/>
                 <field name="date" optional="show"/>
                 <field name="progress" string="Progress" widget="progressbar" optional="show"/>
                 <field name="color" column_invisible="True"/>

--- a/addons/project_todo/wizard/mail_activity_todo_create.xml
+++ b/addons/project_todo/wizard/mail_activity_todo_create.xml
@@ -8,7 +8,7 @@
                 <group>
                     <field name="summary" placeholder="Reminder to..." required="1"/>
                     <field name="date_deadline"/>
-                    <field name="user_id" widget="many2one_avatar_user" options="{'no_open': 1}"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_open': 1, 'no_quick_create': True}"/>
                 </group>
                 <field name="note" class="oe-bordered-editor" placeholder="Add details about your to-do..."/>
                 <footer>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -374,7 +374,7 @@
                         <page string="Other Information" name="purchase_delivery_invoice">
                             <group>
                                 <group name="other_info">
-                                    <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                                    <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" readonly="state in ['cancel', 'purchase']"/>
                                     <field name="origin"/>
                                 </group>
@@ -579,7 +579,7 @@
                         groups="base.group_multi_company" optional="show"/>
                     <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
                     <field name="date_planned" column_invisible="context.get('quotation_only', False)" optional="show"/>
-                    <field name="user_id" optional="show" widget="many2one_avatar_user"/>
+                    <field name="user_id" optional="show" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="date_order"
                         invisible="state == 'purchase' or state == 'cancel'"
                         column_invisible="not context.get('quotation_only', False)"
@@ -620,7 +620,7 @@
                     <field name="partner_id" readonly="state in ['cancel', 'purchase']"/>
                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show" readonly="state in ['cancel', 'purchase']"/>
                     <field name="company_id" groups="!base.group_multi_company" column_invisible="True" readonly="state in ['cancel', 'purchase']"/>
-                    <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                    <field name="user_id" widget="many2one_avatar_user" optional="show" options="{'no_quick_create': True}"/>
                     <field name="date_order" column_invisible="not context.get('quotation_only', False)" readonly="state in ['cancel', 'purchase']" optional="show"/>
                     <field name="activity_ids" widget="list_activity" optional="show"/>
                     <field name="origin" optional="show"/>

--- a/addons/purchase/views/res_partner_views.xml
+++ b/addons/purchase/views/res_partner_views.xml
@@ -23,7 +23,7 @@
                     <field name="property_purchase_currency_id" options="{'no_create': True, 'no_open': True}" groups='base.group_multi_currency'/>
                 </group>
                 <field name="property_supplier_payment_term_id" position="before">
-                    <field name="buyer_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                    <field name="buyer_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 </field>
             </field>
     </record>

--- a/addons/purchase_requisition/views/purchase_requisition_views.xml
+++ b/addons/purchase_requisition/views/purchase_requisition_views.xml
@@ -125,7 +125,7 @@
                 <field name="name" decoration-bf="1"/>
                 <field name="vendor_id" optional="show"/>
                 <field name="requisition_type" optional="show"/>
-                <field name="user_id" optional="show" widget='many2one_avatar_user'/>
+                <field name="user_id" optional="show" widget='many2one_avatar_user' options="{'no_quick_create': True}"/>
                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="show"/>
                 <field name="date_start" optional="show"/>
                 <field name="date_end" optional="show" widget='remaining_days' decoration-danger="date_end and date_end&lt;current_date" invisible="state in ('done', 'cancel')"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -132,7 +132,7 @@
                 <field name="commitment_date" optional="hide"/>
                 <field name="expected_date" optional="hide"/>
                 <field name="partner_id" readonly="1"/>
-                <field name="user_id" widget="many2one_avatar_user" optional="show"/>
+                <field name="user_id" widget="many2one_avatar_user" optional="show" options="{'no_quick_create': True}"/>
                 <field name="activity_ids" widget="list_activity" optional="show"/>
                 <field name="team_id" optional="hide"/>
                 <field name="company_id" groups="!base.group_multi_company" column_invisible="True"/>
@@ -809,7 +809,7 @@
                     <page string="Other Info" name="other_information">
                         <group>
                             <group name="sales_person" string="Sales">
-                                <field name="user_id" widget="many2one_avatar_user"/>
+                                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                                 <field name="team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}" options="{'no_create': True}"/>
                                 <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                                 <field name="require_signature"

--- a/addons/sales_team/views/crm_team_views.xml
+++ b/addons/sales_team/views/crm_team_views.xml
@@ -46,7 +46,8 @@
                             <field name="active" invisible="1"/>
                             <field name="sequence" invisible="1"/>
                             <field name="is_membership_multi" invisible="1"/>
-                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"
+                                options="{'no_quick_create': True}"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company" placeholder="Visible to all"/>
                             <field name="currency_id" invisible="1"/>
                             <field name="member_company_ids" invisible="1"/>
@@ -100,7 +101,8 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name" readonly="1"/>
                 <field name="active" column_invisible="True"/>
-                <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"
+                    options="{'no_quick_create': True}"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </list>
         </field>

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -526,7 +526,8 @@
                     </button>
 
                     <xpath expr="//label[@for='weight']" position="before">
-                        <field name="responsible_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" groups="stock.group_stock_user"/>
+                        <field name="responsible_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" groups="stock.group_stock_user"
+                            options="{'no_quick_create': True}"/>
                     </xpath>
                 </data>
             </field>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -316,7 +316,8 @@
                                 <group string="Other Information" name="other_infos">
                                     <field name="picking_type_code" invisible="1"/>
                                     <field name="move_type" invisible="picking_type_code == 'incoming'" readonly="state in ['cancel', 'done']"/>
-                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" readonly="state in ['cancel', 'done']"/>
+                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" readonly="state in ['cancel', 'done']"
+                                        options="{'no_quick_create': True}"/>
                                     <field name="group_id" groups="base.group_no_one"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" force_save="1"/>
                                 </group>

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -138,7 +138,7 @@
                 <field name="name" decoration-bf="1"/>
                 <field name="description"/>
                 <field name="scheduled_date" readonly="state in ['cancel', 'done']"/>
-                <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']"/>
+                <field name="user_id" widget="many2one_avatar_user" readonly="state not in ['draft', 'in_progress']" options="{'no_quick_create': True}"/>
                 <field name="picking_type_id" readonly="state != 'draft'"/>
                 <field name="company_id" optional="hide" groups="base.group_multi_company"/>
                 <field name="state" widget="badge" decoration-success="state == 'done'" decoration-info="state in ('draft', 'in_progress')" decoration-danger="state == 'cancel'"/>

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -60,12 +60,13 @@
                     </div>
                     <group>
                         <group class="ps-md-0">
-                            <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                            <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"
+                                options="{'no_quick_create': True}"/>
                             <field name="active" invisible="1"/>
                             <field name="has_conditional_questions" invisible="1"/>
                         </group>
                         <group class="ps-3 ps-md-0 ps-lg-3">
-                            <field name="restrict_user_ids" widget="many2many_tags_avatar"/>
+                            <field name="restrict_user_ids" widget="many2many_tags_avatar" options="{'no_quick_create': True}"/>
                         </group>
                     </group>
                     <group>
@@ -215,7 +216,7 @@
                 <button name="certification" type="button" disabled="disabled"
                     icon="fa-trophy" title="Certification" aria-label="Certification"
                     invisible="not certification"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="answer_duration_avg" widget="float_time"/>
                 <field name="answer_count"/>
                 <field name="answer_done_count" optional="hide"/>

--- a/addons/utm/views/utm_campaign_views.xml
+++ b/addons/utm/views/utm_campaign_views.xml
@@ -41,7 +41,8 @@
                         <field name="active" invisible="1"/>
                         <field class="text-break" name="title" string="Campaign Name" placeholder="e.g. Black Friday"/>
                         <field name="name" invisible="1"/>
-                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                        <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"
+                            options="{'no_quick_create': True}"/>
                         <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>
                     <notebook>
@@ -58,7 +59,7 @@
             <list string="UTM Campaigns" multi_edit="1" sample="1">
                 <field name="title" string="Name" readonly="1"/>
                 <field name="name" column_invisible="True"/>
-                <field name="user_id" widget="many2one_avatar_user"/>
+                <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="stage_id" decoration-bf="1"/>
                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
             </list>
@@ -74,7 +75,7 @@
                 <group>
                     <field name="name" invisible="1"/>
                     <field class="o_text_overflow" name="title" string="Campaign Name" placeholder="e.g. Black Friday"/>
-                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                     <field name="tag_ids" widget="many2many_tags" class="o_field_highlight" options="{'color_field': 'color', 'no_create_edit': True}"/>
                 </group>
             </form>

--- a/addons/website_event_track/views/event_track_views.xml
+++ b/addons/website_event_track/views/event_track_views.xml
@@ -170,7 +170,8 @@
                         </group>
                         <group>
                             <field name="company_id" invisible="1"/>
-                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                            <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"
+                                options="{'no_quick_create': True}"/>
                             <field name="event_id" placeholder="All Events"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="color" widget="color_picker"/>

--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -96,7 +96,7 @@
                             <page name="options" string="Options">
                                 <group>
                                     <group name="course" string="Course">
-                                        <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
+                                        <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                                         <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                                     </group>
                                     <group name="access_rights" string="Access Rights">
@@ -161,7 +161,7 @@
                 <list string="Courses" sample="1" multi_edit="1">
                     <field name="sequence" widget="handle"/>
                     <field name="name" readonly="1"/>
-                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                     <field name="channel_type" string="Course Type"/>
                     <field name="visibility"/>
@@ -179,7 +179,7 @@
             <field name="arch" type="xml">
                 <list string="Courses" create="false" default_order="total_views desc" sample="1">
                     <field name="name"/>
-                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="total_views" string="# Views"/>
                     <field name="rating_avg_stars" string="Average Review"/>
                     <field name="total_time" string="Total Duration" widget="float_time" sum="Total Duration"/>

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -263,7 +263,7 @@
                     <field name="name" readonly="1"/>
                     <field name="channel_id" readonly="1"/>
                     <field name="category_id" readonly="1" optional="hide"/>
-                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="is_published"/>
                     <field name="date_published" readonly="1"/>
                     <field name="completion_time" sum="Total" readonly="1" widget="float_time"/>
@@ -278,7 +278,7 @@
             <field name="arch" type="xml">
                 <list string="Contents" sample="1">
                     <field name="name"/>
-                    <field name="user_id" widget="many2one_avatar_user"/>
+                    <field name="user_id" widget="many2one_avatar_user" options="{'no_quick_create': True}"/>
                     <field name="channel_id"/>
                     <field name="category_id" optional="hide"/>
                     <field name="date_published"/>

--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -17,7 +17,7 @@
                 <xpath expr="//notebook" position="before">
                     <group>
                         <group>
-                            <field name="user_id"/>
+                            <field name="user_id" options="{'no_quick_create': True}"/>
                             <label for="interval_number" string="Execute Every"/>
                             <div>
                                 <field name="interval_number" class="oe_inline"/>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -13,7 +13,8 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="user_ids" string="Shared with" widget="many2many_tags_avatar" placeholder="All users"/>
+                                <field name="user_ids" string="Shared with" widget="many2many_tags_avatar" placeholder="All users"
+                                    options="{'no_quick_create': True}"/>
                                 <field name="is_default" widget="boolean_toggle"/>
                                 <field name="model_id" groups="base.group_no_one"/>
                                 <field name="action_id" groups="base.group_no_one"/>
@@ -46,7 +47,7 @@
                 <list string="Filters">
                     <field name="name"/>
                     <field name="model_id"/>
-                    <field name="user_ids" widget="many2many_tags_avatar"/>
+                    <field name="user_ids" widget="many2many_tags_avatar" options="{'no_quick_create': True}"/>
                     <field name="is_default"/>
                     <field name="action_id"/>
                     <field name="domain" groups="base.group_no_one"/>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -276,7 +276,7 @@
                         <page name='sales_purchases' string="Sales &amp; Purchase">
                             <group name="container_row_2">
                                 <group string="Sales" name="sale" priority="1">
-                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]"/>
+                                    <field name="user_id" widget="many2one_avatar_user" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
                                 </group>
                                 <group string="Purchase" name="purchase" priority="2">
                                 </group>


### PR DESCRIPTION
```
* = {account, base, calendar, crm, event, event_crm, fleet, gamification, hr, 
hr_attendance, hr_expense, hr_holidays, hr_recruitment, lunch, mail, mail_group, 
mass_mailing, mass_mailing_sms, point_of_sale, privacy_lookup, project, 
project_todo, purchase, purchase_requisition, sale, sales_team, stock, 
stock_picking_batch, survey, utm, website_event_track, website_slides}
```

**Current behavior:**
When a field referencing the `res.users` model is included in an XML view, users are offered a "Create" and "Create and Edit" options. If "Create" is selected, it attempts to create the user without required fields like `login`, resulting in a database integrity error due to the NOT NULL constraint on `res_users.login`.

**Improved behavior:**
This commit disables the direct "Create" option for fields referencing `res.users`, preventing invalid record creation.

Sentry - 6263547789

Related Enterprise PR: https://github.com/odoo/enterprise/pull/84659