### PR TITLE
[IMP] point_of_sale: remove manual warehouse setup while creating new pos

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -94,3 +94,13 @@ class TestPointOfSale(TransactionCase):
             "value": 0.005
         })
         self.assertEqual(coin.value, 0.005)
+
+    def test_pos_config_creates_warehouse(self):
+        warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)])
+        if warehouse:
+            warehouse.write({'active': False, 'name': 'Archived ' + warehouse[0].name})
+        pos_config = self.env['pos.config'].create({
+            'name': 'Shop',
+            'module_pos_restaurant': False,
+        })
+        self.assertEqual(pos_config.warehouse_id.code, 'Sho')


### PR DESCRIPTION
Before this commit:
====
- Creating a new POS requires setting up a warehouse beforehand.
- If no warehouse existed, the system would block POS creation, especially during scenario-based setups.

After this commit:
====
- POS creation no longer blocks the user if a warehouse is not already configured.
- A default warehouse is automatically created and linked during the first POS configuration.
- This improves the user experience, especially for first-time setups.

task-4761117
