### PR TITLE
[FIX] mail: isMobileOs typo

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -18,7 +18,7 @@ class ImageActions extends Component {
     setup() {
         super.setup();
         this.actionsMenuState = useDropdownState();
-        this.isMobileOS = isMobileOS;
+        this.isMobileOS = isMobileOS();
     }
 }
 
@@ -43,7 +43,7 @@ export class AttachmentList extends Component {
         this.dialog = useService("dialog");
         this.fileViewer = useFileViewer();
         this.actionsMenuState = useDropdownState();
-        this.isMobileOS = isMobileOS;
+        this.isMobileOS = isMobileOS();
     }
 
     /**


### PR DESCRIPTION
This commit fixes wrongly used `isMobileOs` in attachment list.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
