### PR TITLE
[FIX] stock,mrp: allow warehouse creation with company-specific routes

### DIFF
--- a/addons/mrp/tests/test_multicompany.py
+++ b/addons/mrp/tests/test_multicompany.py
@@ -250,3 +250,35 @@ class TestMrpMulticompany(common.TransactionCase):
         new_company = self.env['res.company'].create({'name': 'Super Company'})
         new_warehouse = self.env['stock.warehouse'].search([('company_id', '=', new_company.id)], limit=1)
         self.assertEqual(new_warehouse.manufacture_pull_id.route_id.company_id, new_company)
+
+    def test_company_specific_routes_and_warehouse_creation(self):
+        """ Check that we are able to create a new warehouse when the generic manufacture route
+        is in a different company. """
+        group_stock_manager = self.env.ref('stock.group_stock_manager')
+        self.user_a.write({'groups_id': [(4, group_stock_manager.id)]})
+
+        manufacture_route = self.env.ref('mrp.route_warehouse0_manufacture')
+        for rule in manufacture_route.rule_ids.sudo():
+            rule_company = rule.company_id
+            if not rule_company or rule_company == self.company_a:
+                continue
+            manufacture_route.copy({
+                'company_id': rule_company.id,
+                'rule_ids': [(4, rule.id)],
+            })
+        manufacture_route.company_id = self.company_a
+
+        # Enable multi warehouse
+        group_user = self.env.ref('base.group_user')
+        group_stock_multi_warehouses = self.env.ref('stock.group_stock_multi_warehouses')
+        group_stock_multi_locations = self.env.ref('stock.group_stock_multi_locations')
+        self.env['res.config.settings'].create({
+            'group_stock_multi_locations': True,
+        }).execute()
+        group_user.write({'implied_ids': [(4, group_stock_multi_warehouses.id), (4, group_stock_multi_locations.id)]})
+
+        new_warehouse = self.env['stock.warehouse'].with_user(self.user_a).with_context(allowed_company_ids=[self.company_b.id]).create({
+            'name': 'Warehouse #2',
+            'code': 'WH2',
+        })
+        self.assertEqual(new_warehouse.manufacture_pull_id.route_id.company_id, self.company_b)

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -382,7 +382,7 @@ class Warehouse(models.Model):
         """ return a route record set from an xml_id or its name. """
         data_route = route = self.env.ref(xml_id, raise_if_not_found=False)
         company = self.company_id[:1] or self.env.company
-        if not route or (route.company_id and route.company_id != company):
+        if not route or (route.sudo().company_id and route.sudo().company_id != company):
             route = self.env['stock.route'].with_context(active_test=False).search([
                 ('name', 'like', route_name), ('company_id', 'in', [False, company.id])
             ], order='company_id', limit=1)


### PR DESCRIPTION
Before this commit, if the generic manufacture route was in a different company, the user won't be able to create a new warehouse.

Steps to reproduce
-----
1. Set the company of the Manufacture route to company A
2. Switch to company B
3. Create a new warehouse
4. Access Error `Due to security restrictions, you are not allowed to access 'Inventory Routes' (stock.route) records.`

Cause
-----
There is an if-statement to check if the found global route is of the same company. https://github.com/odoo/odoo/blob/856409a1fb35c6c49fe4c404931587a95d99d370/addons/stock/models/stock_warehouse.py#L385 But this conditional is likely to raise an access error if the route is in a different company, since we don't have read access to `route`.

Solution
-----
Use `route.sudo()` to read the route without an access error.

opw-4725501