### PR TITLE
[IMP] point_of_sale: transfer course of combo product

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -302,6 +302,8 @@ export class PosOrder extends Base {
                     line.getQuantity();
                 this.last_order_preparation_change.lines[line.preparationKey]["note"] =
                     line.getNote();
+                this.last_order_preparation_change.lines[line.preparationKey]["course"] =
+                    line.course_id?.uuid;
             } else {
                 this.last_order_preparation_change.lines[line.preparationKey] = {
                     attribute_value_names: line.attribute_value_ids.map((a) => a.name),
@@ -313,6 +315,7 @@ export class PosOrder extends Base {
                     display_name: line.getProduct().display_name,
                     note: line.getNote(),
                     quantity: line.getQuantity(),
+                    course: line.course_id?.uuid,
                 };
             }
             line.setHasChange(false);

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -799,6 +799,7 @@ export class PosStore extends WithLazyGetterTrap {
             qty: this.getOrder().preset_id?.is_return ? -1 : 1,
             tax_ids: productTemplate.taxes_id.map((tax) => ["link", tax]),
             product_id: productTemplate.product_variant_ids[0],
+            note: vals.note || "[]",
             ...vals,
         };
 
@@ -930,6 +931,7 @@ export class PosStore extends WithLazyGetterTrap {
                         "link",
                         attr,
                     ]),
+                    note: "[]",
                     custom_attribute_value_ids: Object.entries(
                         comboItem.attribute_custom_values
                     ).map(([id, cus]) => [

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -438,6 +438,13 @@ patch(PosStore.prototype, {
         if (nbNoteChange) {
             categories["noteUpdate"] = { count: nbNoteChange, name: _t("Note") };
         }
+        const nbCourseUpdates = Object.values(orderChanges.courseUpdate).reduce(
+            (sum, change) => sum + change.quantity,
+            0
+        );
+        if (nbCourseUpdates) {
+            categories["courseUpdate"] = { count: nbCourseUpdates, name: _t("Course") };
+        }
         // Only send modeUpdate if there's already an older mode in progress.
         const currentOrder = this.getOrder();
         if (
@@ -854,14 +861,18 @@ patch(PosStore.prototype, {
         if (!destCourse) {
             return;
         }
+        const lines = [];
         if (selectedLine) {
-            selectedLine.course_id = destCourse.id;
+            lines.push(selectedLine);
+            if (selectedLine.combo_line_ids?.length) {
+                lines.push(...selectedLine.combo_line_ids);
+            }
         } else {
-            const lines = [...selectedCourse.lines];
-            lines.forEach((line) => {
-                line.course_id = destCourse.id;
-            });
+            lines.push(...selectedCourse.lines);
         }
+        lines.forEach((line) => {
+            line.course_id = destCourse.id;
+        });
         order.selectCourse(destCourse);
         order.recomputeOrderData();
     },


### PR DESCRIPTION
In this commit:
-------------------
- We set a default value for the note to ensure consistency, as it can be `""` initially or `"[]"`
after adding and removing notes. This avoids errors when filtering for lines with blank notes
by standardizing the format.
- When transferring a course for combo product, all combo lines from the parent should also
be transferred to the destination course.

task- 4752080
Related PR: https://github.com/odoo/enterprise/pull/84588
