### PR TITLE
[FIX] account: fix error when opening accrued expense entry

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -167,7 +167,7 @@ class AccruedExpenseRevenue(models.TransientModel):
                 lines = o.order_line.filtered(
                     # We only want lines that are not sections or notes and include all lines
                     # for purchase orders but exclude downpayment lines for sales orders.
-                    lambda l: l.display_type not in ['line_section', 'line_note'] and (is_purchase or not l.is_downpayment) and
+                    lambda l: l.display_type not in ['line_section', 'line_note'] and not l.is_downpayment and
                     fields.Float.compare(
                         l.qty_to_invoice,
                         0,


### PR DESCRIPTION
When user tries to open accrued expense entry in purchase order,
A traceback will appear.

Steps to reproduce the error:
- Install ``accountant`` and ``purchase`` module
- Create a new Bill > Add a line > Don't add a product > Save >
  Purchase matching > Select your bill > Add to PO > Add Down Payment >
  New PO will be created
- Actions > Accrued Expense Entry

Traceback:
```
AssertionError: precision_rounding must be positive, got 0.0
```

https://github.com/odoo/odoo/blob/834eff6e770280e911bb99e2abab4ea42d4ca8ff/addons/account/wizard/accrued_orders.py#L170
Here, when ``is_purchase`` is true, ``is_downpayment`` will not be evaluated.
As a result, down payment lines in purchase orders are not excluded.
Since down payment lines do not have a ``product_uom``.
so ``rounding`` will be 0.0
So, it will lead to the above traceback.

sentry-6576645089

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
