### PR TITLE
[FIX] html_editor: prevent backtick loss on Firefox during typing

### DIFF
--- a/addons/html_editor/static/src/main/inline_code.js
+++ b/addons/html_editor/static/src/main/inline_code.js
@@ -33,10 +33,13 @@ export class InlineCodePlugin extends Plugin {
             sibling.remove();
             sibling = textNode.nextSibling;
         }
-        this.dependencies.selection.setSelection({ anchorNode: textNode, anchorOffset: offset });
         const textHasTwoTicks = /`.*`/.test(textNode.textContent);
         // We don't apply the code tag if there is no content between the two `
         if (textHasTwoTicks && textNode.textContent.replace(/`/g, "").length) {
+            this.dependencies.selection.setSelection({
+                anchorNode: textNode,
+                anchorOffset: offset,
+            });
             this.dependencies.history.addStep();
             const insertedBacktickIndex = offset - 1;
             const textBeforeInsertedBacktick = textNode.textContent.substring(


### PR DESCRIPTION
Problem:
In Firefox, typing the backtick character "`" can cause it to be automatically deleted.

Cause:
Typing "`" initiates a composition session. If the selection is changed while `isComposing` is true, Firefox cancels the session and deletes the character.

Solution:
In `InlineCodePlugin.onInput`, the selection is now modified only when the `<code>` tag is applied. This intentional change ends the composition safely. In all other cases, we avoid changing the selection during composition to preserve user input.

Steps to reproduce:
1. Open the HTML editor in Firefox.
2. Type "`". → The character disappears unexpectedly.

opw-4760478

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
