### PR TITLE
[FIX] website_crm_partner_assign: allow filtering on all countries in /partners

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -48,8 +48,8 @@
                 </button>
                 <div class="dropdown-menu">
                     <t t-foreach="countries" t-as="country" t-if="country['country_id']">
-                        <a t-attf-href="/partners#{ current_grade and '/grade/%s' % slug(current_grade) or ''}#{country['country_id'][0] and '/country/%s' % slug(country['country_id']) or '' }?#{ keep_query('search', (country['country_id'][0] == 0 and 'country_all' or ''), 'industry')}"
-                        class="dropdown-item d-flex justify-content-between">
+                        <t t-set="all_countries" t-value="dict(country_all=1) if country['country_id'][0] == 0 else {} "/>
+                        <a t-attf-href="/partners#{ current_grade and '/grade/%s' % slug(current_grade) or ''}#{country['country_id'][0] and '/country/%s' % slug(country['country_id']) or '' }?#{ keep_query('search', 'industry', **all_countries)}" class="dropdown-item d-flex justify-content-between">
                             <t t-out="country['country_id'][1]"/>&amp;nbsp;&amp;nbsp;
                             <span class="badge text-white bg-secondary rounded-pill px-2 py-1" t-esc="country['country_id_count']"/>
                         </a>


### PR DESCRIPTION
[FIX] website_crm_partner_assign: allow filtering on all countries in /partners

During a recent refactoring to optimize how filters (notably industries) are
applied and URLs are generated on the `/partners` page, an unintended side
effect was introduced: it became impossible to view partners from *all
countries* when GeoIP was enabled.

Previously, when the user selected "All countries", the frontend explicitly
passed a parameter that told the backend not to apply any country filter.
However, after the refactoring, this parameter was omitted. As a result, the
backend interpreted the absence of a country as "no country specified", which
triggered the GeoIP fallback (if enabled), filtering partners by the
geolocated country of the user.

This behavior made it impossible to genuinely view partners across all
countries, since the server would silently apply a country filter based on
geolocation.

With this commit:  
- We explicitly restore the previous logic by passing a `country_all=1`
  parameter when the user selects "All countries".  
- The server now correctly distinguishes between:  
  - No country filter (→ use GeoIP if enabled),  
  - An explicit "all countries" filter (→ do not use GeoIP, return all
    partners).

This ensures a clear and consistent behavior for the user.

Note: This issue was not visible on runbot because GeoIP is not enabled there.