### PR TITLE
[FIX] web: fixed integer field showing false in list view creation

### DIFF
--- a/addons/web/static/src/views/fields/integer/integer_field.js
+++ b/addons/web/static/src/views/fields/integer/integer_field.js
@@ -51,6 +51,9 @@ export class IntegerField extends Component {
             !this.props.formatNumber ||
             (!this.props.readonly && this.props.inputType === "number")
         ) {
+            if (this.value === false) {
+                return "";
+            }
             return this.value;
         }
         if (this.props.humanReadable && !this.state.hasFocus) {

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -833,7 +833,8 @@ export class ListRenderer extends Component {
     getFormattedValue(column, record) {
         const fieldName = column.name;
         if (column.options.enable_formatting === false) {
-            return record.data[fieldName];
+            const value = record.data[fieldName];
+            return value === false ? "" : value;
         }
         return getFormattedValue(record, fieldName, column);
     }

--- a/addons/web/static/tests/views/fields/integer_field.test.js
+++ b/addons/web/static/tests/views/fields/integer_field.test.js
@@ -276,3 +276,19 @@ test("value is formatted on click out (even if same value)", async () => {
     await contains(".o_control_panel").click();
     expect(".o_field_widget input").toHaveValue("8,069");
 });
+
+test("Value should not be a boolean when enable_formatting is false", async () => {
+    onRpc("has_group", () => true);
+    await mountView({
+        type: "list",
+        resModel: "product",
+        arch: `
+            <list editable="bottom">
+                <field name="id" options="{'enable_formatting': false}"/>
+                <field name="price"/>
+            </list>
+        `,
+    });
+    await contains(`.o_list_button_add`).click();
+    expect(".o_selected_row .o_field_integer").toHaveText("");
+});


### PR DESCRIPTION
Steps to reproduce:

- Open a list view in which integer field having default value as false like ID field which has enable_formatting option as False.
- Create a record

Issue:

- False is shown inside in integer field before saving.

Reason:

- When enable_formatting is False the value is returned and no checks are done.

Fix:

- A basic check to make sure we are sending out a number not a boolean.

task-4700791