### PR TITLE
[FIX] web: make debouncing test more robust

### DIFF
--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -2488,9 +2488,12 @@ describe("debounced (2)", () => {
     });
 
     test("debounced is not called if the interaction is destroyed in the meantime", async () => {
+        let debounceTimer;
+
         class Test extends Interaction {
             static selector = ".test";
             setup() {
+                debounceTimer = Date.now() + 50;
                 const fn = this.debounced(() => expect.step("debounced"), 50);
                 fn();
             }
@@ -2513,7 +2516,13 @@ describe("debounced (2)", () => {
         }
         const { core } = await startInteraction(Test, TemplateTest, { waitForStart: false });
         expect.verifySteps(["willstart"]);
-        await advanceTime(25);
+        const now = Date.now();
+        if (now > debounceTimer) {
+            console.log("code took too long...");
+        }
+        // compute the step to get between now and debouncetimer
+        const step = (debounceTimer - now) / 2;
+        await advanceTime(step);
         expect.verifySteps([]);
         core.stopInteractions();
         expect.verifySteps(["destroy"]);


### PR DESCRIPTION
The modified test in this commit would occasionally fail at random. This appears to happen only if some code unexpectedly takes a long time to execute. As a result, when we advance the time, it overshoots the debounce function.

The underlying issue seems to be an assumption that virtually no time passes between the start of the test and a specific point where only microtasks should run. However, if the testing infrastructure is under heavy load, it's possible for that delay to exceed 25ms.

A more robust fix is needed long-term, but for now, this commit only addresses the issue in this specific test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
