### PR TITLE
[FIX] website_sale_collect: calculate taxes based on selected location

### DIFF
--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -40,9 +40,23 @@ class TestSaleOrder(ClickAndCollectCommon):
         so = self._create_in_store_delivery_order(pickup_location_data={'id': warehouse_2.id})
         self.assertEqual(so.warehouse_id, warehouse_2)
 
+    def test_fiscal_position_id_is_computed_from_pickup_location_partner(self):
+        fp_be = self.env['account.fiscal.position'].create({
+            'name': "Test BE fiscal position",
+            'country_id': self.country_be.id,
+            'auto_apply': True,
+        })
+        self.default_partner.country_id = self.country_us
+        self.warehouse.partner_id.country_id = self.country_be
+        so = self._create_in_store_delivery_order(
+            partner_shipping_id=self.default_partner.id,
+            pickup_location_data={'id': self.warehouse.id},
+        )
+        self.assertEqual(so.fiscal_position_id, fp_be)
+
     def test_setting_pickup_location_assigns_correct_fiscal_position(self):
         fp_be = self.env['account.fiscal.position'].create({
-            'name': "Test US fiscal position",
+            'name': "Test BE fiscal position",
             'country_id': self.country_be.id,
             'auto_apply': True,
         })
@@ -55,7 +69,7 @@ class TestSaleOrder(ClickAndCollectCommon):
 
     def test_selecting_not_in_store_dm_resets_fiscal_position(self):
         fp_us = self.env['account.fiscal.position'].create({
-            'name': "Test US US fiscal position",
+            'name': "Test US fiscal position",
             'country_id': self.country_us.id,
             'auto_apply': True,
         })


### PR DESCRIPTION
Steps to reproduce:
1) Configure c&c and add a wh in belgium
2) As a public user on the product page, select the wh in belgium as a pickup location
3) Go to checkout and fill in the address with US as a country 4) Taxes will be recalculated based on partner_id of the order rather than on its pickup location

Reason: changing the partner_id of the order triggers the computation of fiscal position

Solution:
Calculate taxes based on pickup location for in-store orders
