### PR TITLE
[FIX] point_of_sale: ensure order session remplacement

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -19,7 +19,7 @@ export class PosOrder extends Base {
     setup(vals) {
         super.setup(vals);
 
-        if (!this.session_id && (!this.finalized || typeof this.id !== "number")) {
+        if (!this.session_id?.id && (!this.finalized || typeof this.id !== "number")) {
             this.update({ session_id: this.session });
 
             if (this.state === "draft" && this.lines.length == 0 && this.payment_ids.length == 0) {


### PR DESCRIPTION
When working with trusted config loading an order from another config lead to an unknown session in the order. So no payment method can be used to pay the order.

Now when loading an order from another config, the session is replaced by the current session.

