### PR TITLE
[IMP] mrp: introduce Standard Batch Size on BOM

### DIFF
--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -159,6 +159,12 @@
                                                 help="Compute the days required to resupply all components from BoM, by either buying or manufacturing the components and/or subassemblies."
                                                 class="oe_link pt-0"/>
                                     </div>
+                                    <label for="batch_size" invisible="type != 'normal'"/>
+                                    <div class="o_row" invisible="type != 'normal'">
+                                        <field name="enable_batch_size"/>
+                                        <field name="batch_size" class="w-50" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
+                                        <field name="product_uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size"/>
+                                    </div>
                                 </group>
                             </group>
                         </page>

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -26,7 +26,7 @@ class MrpProductionSplit(models.TransientModel):
         'mrp.production.split.line', 'mrp_production_split_id',
         'Split Details', compute="_compute_details", store=True, readonly=False)
     valid_details = fields.Boolean("Valid", compute="_compute_valid_details")
-    max_batch_size = fields.Float("Max Batch Size", compute="_compute_max_batch_size", readonly=False)
+    max_batch_size = fields.Float("Max Batch Size", compute="_compute_max_batch_size", digits='Product Unit', readonly=False)
     num_splits = fields.Integer("# Splits", compute="_compute_num_splits", readonly=True)
 
     @api.depends('production_id')
@@ -37,11 +37,13 @@ class MrpProductionSplit(models.TransientModel):
 
     @api.depends('max_batch_size')
     def _compute_num_splits(self):
+        self.num_splits = 0
         for wizard in self:
-            wizard.num_splits = float_round(
-                wizard.product_qty / wizard.max_batch_size,
-                precision_digits=0,
-                rounding_method='UP')
+            if wizard.product_uom_id.compare(self.max_batch_size, 0) > 0:
+                wizard.num_splits = float_round(
+                    wizard.product_qty / wizard.max_batch_size,
+                    precision_digits=0,
+                    rounding_method='UP')
 
     @api.depends('num_splits')
     def _compute_details(self):

--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -32,7 +32,8 @@ class MrpProductionSplit(models.TransientModel):
     @api.depends('production_id')
     def _compute_max_batch_size(self):
         for wizard in self:
-            wizard.max_batch_size = wizard.product_qty
+            bom_id = wizard.production_id.bom_id
+            wizard.max_batch_size = bom_id.batch_size if bom_id.enable_batch_size else wizard.product_qty
 
     @api.depends('max_batch_size')
     def _compute_num_splits(self):

--- a/addons/mrp/wizard/mrp_production_split.xml
+++ b/addons/mrp/wizard/mrp_production_split.xml
@@ -59,7 +59,7 @@
                     </field>
                     <field name="production_split_multi_id" invisible="1"/>
                     <field name="valid_details" invisible="1"/>
-                    <div class="alert alert-danger" role="alert" invisible="valid_details or max_batch_size &lt;= 0">
+                    <div class="alert alert-danger" role="alert" invisible="valid_details and max_batch_size &gt; 0">
                         The total should be equal to the quantity to produce.
                     </div>
                     <footer>


### PR DESCRIPTION
Introduce a new `Batch Size` field on the Bill of Materials to define a standard production batch size.

This feature helps users control manufacturing orders more effectively, particularly when there is a known maximum production capacity. When enabled, the system will automatically split and generate MOs based on the defined batch size for scenarios like MTO, MTSO, MPS, and replenishment.

Manual MO creation remains unaffected. However, for automatically generated MOs, the system will ensure the quantity never exceeds the configured batch size. Additionally, when splitting an MO, the batch size will be pre-filled with the value from the BOM.

Task ID: [4395548](https://www.odoo.com/odoo/project/966/tasks/4395548)