### PR TITLE
[IMP] l10n_jo_edi: Restrict sending independent credit notes

### DIFF
--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -49,6 +49,7 @@ class AccountMove(models.Model):
         depends=["l10n_jo_edi_xml_attachment_file"],
         help="Jordan: e-invoice XML.",
     )
+    reversed_entry_id = fields.Many2one(tracking=True)
 
     @api.depends("country_code", "move_type")
     def _compute_l10n_jo_edi_is_needed(self):
@@ -197,6 +198,9 @@ class AccountMove(models.Model):
 
         supplier = self.company_id.partner_id.commercial_partner_id
         error_msg += has_non_digit_vat(supplier, 'supplier')
+
+        if self.move_type == 'out_refund' and not self.reversed_entry_id:
+            error_msg += _('Please use "Reversal of" to link this credit note with an Invoice\n')
 
         if any(
             line.display_type not in ('line_note', 'line_section')

--- a/addons/l10n_jo_edi/views/account_move_views.xml
+++ b/addons/l10n_jo_edi/views/account_move_views.xml
@@ -17,6 +17,12 @@
                 </xpath>
                 <xpath expr="//group[@name='sale_info_group']" position="inside">
                     <field name="l10n_jo_edi_state" invisible="not l10n_jo_edi_state"/>
+                    <field name="l10n_jo_edi_is_needed" invisible="1"/>
+                    <field name="reversed_entry_id"
+                        invisible="move_type != 'out_refund' or not l10n_jo_edi_is_needed"
+                        domain="[('move_type', '=', 'out_invoice')]"
+                        readonly="l10n_jo_edi_state == 'sent'"
+                        groups="base.group_no_one"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
When an independent (not linked to an invoice) credit note is submitted to JoFotara, the portal would throw an error
because the original invoice number, UUID, and amount are required.
This commit restricts the users from sending independent credit notes to JoFotara.
It also gives the users the flexibility (in debug mode) to link an invoice to an independent credit note.

task-4756603




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
