### PR TITLE
[FIX] website: fix submenu accordion colors on mobile

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -361,7 +361,7 @@ body {
 // the selector is probably too specific and should rather be about extending
 // bootstrap if possible.
 #wrapwrap:not(.o_header_overlay) header, header.o_header_is_scrolled, header .o_navbar_mobile {
-    .nav-item > .nav-link > *, .nav-item > .nav-link::after, .js_language_selector span, .badge {
+    .nav-item > .nav-link > *, .nav-item > .nav-link::after, .js_language_selector span, .badge, .nav-item > .accordion-item * {
         $header-text-color: o-website-value('header-text-color');
         // Check if the value is wrapped in quotes (initially it wasn't, and it
         // didn't work) because we don't want the text color of the navbar to
@@ -387,12 +387,34 @@ body {
 
 // Apply background color to the offcanvas menu
 .o_navbar_mobile {
+    $-navbar-mobile-bg-color: o-color('menu-custom') or o-color('menu');
     height: 100dvh;
-    background-color: o-color('menu-custom') or o-color('menu');
+    background-color: $-navbar-mobile-bg-color;
 
     // Make offcanvas close btn above mega menu
     .btn-close {
         z-index: $o-mega-menu-btn-close-zindex;
+    }
+
+    .top_menu > .accordion {
+        ul > li > a.nav-link {
+            background-color: inherit;
+        }
+
+        .accordion-button {
+            &:not(.collapsed) {
+                background-color: shade-color($-navbar-mobile-bg-color, 5%);
+            }
+
+            // Replace the default chevron with our Odoo UI icon so it adapts to
+            // the theme colors.
+            &:after {
+                height: 100%;
+                background: none;
+                font-family: 'odoo_ui_icons';
+                content: '\e839';
+            }
+        }
     }
 }
 
@@ -1656,6 +1678,7 @@ header {
     .o_mega_nav {
         padding-left: $grid-gutter-width * .5;
         height: $o-mega-menu-nav-height;
+        background-color: inherit;
     }
 
     // Div needed for selector specificity to apply mh


### PR DESCRIPTION
Steps to reproduce:

- Install the "Website" app.
- Go to the homepage.
- Click on "Site > Menu Editor" in the backend navbar.
- Create a submenu.
- Add a "Mega Menu Item" to the menu.
- Save the dialog.
- Enter edit mode.
- Click on the header.
- Choose a dark background in the header options.
- Click the "Mobile Preview" button to switch to mobile view.
- Click the toggler button to open the menu.
- Open the "Mega Menu".
- Bug 1: The "close" and "back" icons are not visible.
- Close the "Mega Menu".
- Open the submenu.
- Bug 2: The submenu is not visible because the background and text have the same light color, so nothing can be seen.

The bug was introduced by commit [1], which made visual improvements to the menu. This commit fixes it by making sure the colors of the problematic elements adapt to the theme colors.

[1]: https://github.com/odoo/odoo/commit/dc1a15539227c4c21837a7bce3fc4d81858d60b9

opw-4716573