### PR TITLE
[FIX] account: propagate analytic distribution to discount lines in invoice journal entries

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1012,45 +1012,56 @@ class AccountMoveLine(models.Model):
             else:
                 line.discount_allocation_key = False
 
-    @api.depends('account_id', 'company_id', 'discount', 'price_unit', 'quantity', 'currency_rate')
+    @api.depends('account_id', 'company_id', 'discount', 'price_unit', 'quantity', 'currency_rate', 'analytic_distribution')
     def _compute_discount_allocation_needed(self):
+        line2discounted_amount = {
+            line: [
+                (line.account_id, amount),
+                (discount_allocation_account, -amount),
+            ]
+            for line in self.move_id.line_ids
+            if line.display_type == 'product'
+            and (discount_allocation_account := line.move_id._get_discount_allocation_account())
+            and (amount := line.currency_id.round(
+                line.move_id.direction_sign * line.quantity * line.price_unit * line.discount / 100
+            ))
+        }
+
+        distribution_totals = defaultdict(lambda: defaultdict(float))
+        for line, discounted_amounts in line2discounted_amount.items():
+            for account, amount in discounted_amounts:
+                for analytic_account_id in line.analytic_distribution or {}:
+                    distribution_totals[frozendict({
+                        'move_id': line.move_id.id,
+                        'account_id': account.id,
+                        'currency_rate': line.currency_rate,
+                    })][analytic_account_id] += amount
+
         for line in self:
             line.discount_allocation_dirty = True
-            discount_allocation_account = line.move_id._get_discount_allocation_account()
-
-            if not discount_allocation_account or line.display_type != 'product' or line.currency_id.is_zero(line.discount):
+            if line not in line2discounted_amount:
                 line.discount_allocation_needed = False
                 continue
 
-            discounted_amount_currency = line.currency_id.round(line.move_id.direction_sign * line.quantity * line.price_unit * line.discount/100)
             discount_allocation_needed = {}
-            discount_allocation_needed_vals = discount_allocation_needed.setdefault(
-                frozendict({
-                    'account_id': line.account_id.id,
+            for account, amount in line2discounted_amount[line]:
+                key = frozendict({
                     'move_id': line.move_id.id,
+                    'account_id': account.id,
                     'currency_rate': line.currency_rate,
-                }),
-                {
+                })
+                dist = distribution_totals[key]
+                total = sum(dist.values()) or 1  # avoid division by zero
+                discount_allocation_needed[key] = frozendict({
                     'display_type': 'discount',
                     'name': _("Discount"),
-                    'amount_currency': 0.0,
-                },
-            )
-            discount_allocation_needed_vals['amount_currency'] += discounted_amount_currency
-            discount_allocation_needed_vals = discount_allocation_needed.setdefault(
-                frozendict({
-                    'move_id': line.move_id.id,
-                    'account_id': discount_allocation_account.id,
-                    'currency_rate': line.currency_rate,
-                }),
-                {
-                    'display_type': 'discount',
-                    'name': _("Discount"),
-                    'amount_currency': 0.0,
-                },
-            )
-            discount_allocation_needed_vals['amount_currency'] -= discounted_amount_currency
-            line.discount_allocation_needed = {k: frozendict(v) for k, v in discount_allocation_needed.items()}
+                    'amount_currency': amount,
+                    'analytic_distribution': {
+                        account_id: 100 * value / total
+                        for account_id, value in dist.items()
+                    }
+                })
+            line.discount_allocation_needed = discount_allocation_needed
 
     @api.depends('tax_ids', 'account_id', 'company_id')
     def _compute_epd_key(self):

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -368,3 +368,69 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon):
             self.default_plan._column_name(): self.analytic_account_a.id,
             'partner_id': self.partner_b.id,
         }])
+
+    def test_analytic_distribution_with_discount(self):
+        """Ensure that discount lines include analytic distribution when a discount expense account is set."""
+
+        # Create discount expense account
+        self.company_data['company'].account_discount_expense_allocation_id = self.env['account.account'].create({
+            'name': 'Discount Expense',
+            'code': 'DIS',
+            'account_type': 'expense',
+            'reconcile': False,
+            'company_id': self.company_data['company'].id,
+        })
+
+        # Create invoice with 2 lines: each has a discount and analytic distribution
+        out_invoice = self.env['account.move'].create([{
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'invoice_line_ids': [Command.create({
+                'product_id': self.product_a.id,
+                'tax_ids': [Command.clear()],
+                'price_unit': 200.0,
+                'discount': 20,  # 40.0 discount
+                'analytic_distribution': {
+                    self.analytic_account_a.id: 100,
+                },
+            }), Command.create({
+                'product_id': self.product_b.id,
+                'tax_ids': [Command.clear()],
+                'price_unit': 200.0,
+                'discount': 10,  # 20.0 discount
+                'analytic_distribution': {
+                    self.analytic_account_b.id: 100,
+                },
+            })]
+        }])
+        out_invoice.action_post()
+        self.assertRecordValues(out_invoice.line_ids, [{
+            'display_type': 'product',
+            'balance': -160.0,
+            'analytic_distribution': {str(self.analytic_account_a.id): 100},
+        }, {
+            'display_type': 'product',
+            'balance': -180.0,
+            'analytic_distribution': {str(self.analytic_account_b.id): 100},
+        }, {
+            'display_type': 'discount',
+            'balance': -40.0,
+            'analytic_distribution': {str(self.analytic_account_a.id): 100}
+        }, {
+            'display_type': 'discount',
+            'balance': 60.0,
+            'analytic_distribution': {
+                str(self.analytic_account_a.id): 66.67,
+                str(self.analytic_account_b.id): 33.33,
+            }
+        }, {
+            'display_type': 'discount',
+            'balance': -20.0,
+            'analytic_distribution': {str(self.analytic_account_b.id): 100}
+        }, {
+            'display_type': 'payment_term',
+            'balance': 340.0,
+            'analytic_distribution': False,
+        }])


### PR DESCRIPTION

Ensure that automatically generated discount lines inherit the analytic distribution from the original invoice lines.
 This allows consistent reporting and accurate
profitability analysis in analytic accounting.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
