### PR TITLE
[FIX] hr_holidays: hovering on presence status of 'on leave' employee...

### DIFF
--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -47,7 +47,7 @@ patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatus());
 patch(HrPresenceStatusPrivate.prototype, {
     get label() {
         return this.props.record.data.current_leave_id
-            ? this.props.record.data.current_leave_id.id + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
+            ? this.props.record.data.current_leave_id.display_name + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
                 {
                     day: 'numeric',
                     month: 'short',


### PR DESCRIPTION
...shows time off type ID and not the name

steps to reproduce:
- install  `hr_holidays`
- create a time off for today, and approve it
- go to Employees, and hover on the presence status widget
- it will show the ID of time off type entered for the leave

cause:
- this [PR](https://github.com/odoo/odoo/pull/205486) alters the `id` with display name (`[1]` should be `display_name`, and not `id`)

fix:
- changed `id` to `display_name`

task-4766668