### PR TITLE
[FIX] html_editor: do not allow links within pre and blockquote

### DIFF
--- a/addons/html_editor/static/tests/normalize.test.js
+++ b/addons/html_editor/static/tests/normalize.test.js
@@ -1,4 +1,4 @@
-import { test } from "@odoo/hoot";
+import { describe, test } from "@odoo/hoot";
 import { testEditor } from "./_helpers/editor";
 
 test("should remove empty class attribute", async () => {
@@ -6,5 +6,23 @@ test("should remove empty class attribute", async () => {
     await testEditor({
         contentBefore: '<div class=""></div>',
         contentAfter: "<div><br></div>",
+    });
+});
+
+describe("blockquote", () => {
+    test("should unwrap links within blockquote", async () => {
+        await testEditor({
+            contentBefore: `<blockquote>a <a href="https://www.google.com">b</a> <a href="https://www.test.com">c</a></blockquote>`,
+            contentAfter: "<blockquote>a b c</blockquote>",
+        });
+    });
+});
+
+describe("pre", () => {
+    test("should unwrap links within pre", async () => {
+        await testEditor({
+            contentBefore: `<pre>a <a href="https://www.google.com">b</a> <a href="https://www.test.com">c</a></pre>`,
+            contentAfter: "<pre>a b c</pre>",
+        });
     });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

It was possible to paste links within pre and blockquote elements.

Desired behavior after PR is merged:

Links pasted within pre and blockquote should be pasted as plain text.

task-4766648

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
