### PR TITLE
[FIX] point_of_sale, pos_event, pos_loyalty, pos_sale: improve pos sync

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -224,16 +224,29 @@ class PosConfig(models.Model):
                 'records': records
             })
 
-    def read_config_open_orders(self, domain, record_ids):
-        all_domain = expression.OR([domain, [('id', 'in', record_ids.get('pos.order')), ('config_id', '=', self.id)]])
-        all_orders = self.env['pos.order'].search(all_domain)
+    def read_config_open_orders(self, domain, record_ids=[]):
         delete_record_ids = {}
+        dynamic_records = {}
 
-        for model, ids in record_ids.items():
+        for model, domain in domain.items():
+            ids = record_ids[model]
             delete_record_ids[model] = [id for id in ids if not self.env[model].browse(id).exists()]
+            dynamic_records[model] = self.env[model].search(domain)
+
+        pos_order_data = dynamic_records.get('pos.order') or self.env['pos.order']
+        data = pos_order_data.read_pos_data([], self.id)
+
+        for key, records in dynamic_records.items():
+            fields = self.env[key]._load_pos_data_fields(self.id)
+            ids = list(set(records.ids + [record['id'] for record in data.get(key, [])]))
+            dynamic_records[key] = self.env[key].browse(ids).read(fields, load=False)
+
+        for key, value in data.items():
+            if key not in dynamic_records:
+                dynamic_records[key] = value
 
         return {
-            'dynamic_records': all_orders.filtered_domain(domain).read_pos_data([], self.id),
+            'dynamic_records': dynamic_records,
             'deleted_record_ids': delete_record_ids,
         }
 

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1347,7 +1347,7 @@ class PosOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
+            'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type', 'write_date',
             'product_id', 'discount', 'tax_ids', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_item_id', 'refund_orderline_ids'
         ]
 
@@ -1687,7 +1687,7 @@ class PosOrderLineLot(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['lot_name', 'pos_order_line_id']
+        return ['lot_name', 'pos_order_line_id', 'write_date']
 
 class AccountCashRounding(models.Model):
     _name = 'account.cash.rounding'

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -269,7 +269,7 @@ class ProductAttributeCustomValue(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['custom_value', 'custom_product_template_attribute_value_id', 'pos_order_line_id']
+        return ['custom_value', 'custom_product_template_attribute_value_id', 'pos_order_line_id', 'write_date']
 
 
 class ProductTemplateAttributeLine(models.Model):

--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -1,7 +1,5 @@
 import { _t } from "@web/core/l10n/translation";
 
-const { DateTime } = luxon;
-
 export default class IndexedDB {
     constructor(dbName, dbVersion, dbStores) {
         this.db = null;
@@ -61,11 +59,7 @@ export default class IndexedDB {
                         delete alreadyExists.write_date;
                     }
 
-                    if (!alreadyExists || JSON.stringify(alreadyExists) !== JSON.stringify(data)) {
-                        arrData[idx].write_date = DateTime.now().toFormat("yyyy-MM-dd HH:mm:ss", {
-                            numberingSystem: "latn",
-                        });
-                    } else {
+                    if (alreadyExists && JSON.stringify(alreadyExists) !== JSON.stringify(data)) {
                         delete arrData[idx];
                     }
                 }
@@ -86,9 +80,7 @@ export default class IndexedDB {
             });
         });
 
-        return Promise.allSettled(promises).then((results) => {
-            return results;
-        });
+        return Promise.allSettled(promises).then((results) => results);
     }
     getNewTransaction(dbStore) {
         try {
@@ -142,15 +134,15 @@ export default class IndexedDB {
                 })
         );
 
-        return Promise.allSettled(promises).then((results) => {
-            return results.reduce((acc, result) => {
+        return Promise.allSettled(promises).then((results) =>
+            results.reduce((acc, result) => {
                 if (result.status === "fulfilled") {
                     return { ...acc, ...result.value };
                 } else {
                     return acc;
                 }
-            }, {});
-        });
+            }, {})
+        );
     }
 
     delete(storeName, uuids) {

--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -85,13 +85,11 @@ export default class DevicesSynchronisation {
      * and synchronize the records with other devices.
      */
     async readDataFromServer() {
-        const serverOpenOrders = this.pos.get_open_orders().filter((o) => typeof o.id === "number");
-        const recordIds = this.getDynamicRecordServerIds();
-        const domain = this.constructOrdersDomain(serverOpenOrders);
+        const { domain, recordsIds } = this.constructOrdersDomain();
         const response = await this.pos.data.call("pos.config", "read_config_open_orders", [
             odoo.pos_config_id,
             domain,
-            recordIds,
+            recordsIds,
         ]);
 
         if (Object.keys(response.dynamic_records).length) {
@@ -152,38 +150,57 @@ export default class DevicesSynchronisation {
      * This method will get local open orders with a server id.
      * @returns {Array} - Array of domain conditions.
      */
-    constructOrdersDomain(serverOpenOrders) {
-        const localDomain = serverOpenOrders.map((o) => {
-            const dateTime = DateTime.fromSQL(o.write_date);
-            const newDateTime = dateTime.plus({ seconds: 1 });
-            return new Domain([
-                "&",
-                ["id", "=", o.id],
-                "|",
-                [
-                    "write_date",
-                    ">",
-                    newDateTime.toFormat("yyyy-MM-dd HH:mm:ss", { numberingSystem: "latn" }),
-                ],
-                ["state", "!=", o.state],
-            ]);
-        });
-        const localIds = serverOpenOrders.map((o) => o.id);
-        let domain = new Domain(["&", ["state", "=", "draft"], ["id", "not in", localIds]]);
-        domain = Domain.or([domain, ...localDomain]);
-        domain = Domain.and([
-            domain,
-            new Domain([
-                "|",
-                ["config_id", "=", odoo.pos_config_id],
-                [
-                    "config_id",
-                    "in",
-                    this.models["pos.config"].get(odoo.pos_config_id).raw.trusted_config_ids,
-                ],
-            ]),
-        ]);
-        return domain.toList();
+    constructOrdersDomain() {
+        const dynamicModels = this.dynamicModels;
+        const recordsToCheck = Array.from(dynamicModels).reduce((acc, model) => {
+            acc[model] = this.models[model].filter(
+                (r) => !this.pos.data.opts.databaseTable[model]?.condition(r)
+            );
+            return acc;
+        }, {});
+
+        const recordIdsByModel = {};
+        const domainByModel = Object.entries(recordsToCheck).reduce((acc, [model, records]) => {
+            const serverRecs = records.filter((r) => typeof r.id === "number");
+            const ids = serverRecs.map((r) => r.id);
+            const config = this.pos.config;
+            const domains = [];
+
+            if (ids.length === 0 && model !== "pos.order") {
+                return acc;
+            }
+
+            recordIdsByModel[model] = ids;
+            for (const record of serverRecs) {
+                const recordDate = DateTime.fromSQL(record.write_date);
+                const recordDateTime = recordDate.plus({ seconds: 1 });
+                const recordDateTimeString = recordDateTime.toFormat("yyyy-MM-dd HH:mm:ss");
+                domains.push(
+                    new Domain([
+                        ["id", "=", record.id],
+                        ["write_date", ">", recordDateTimeString],
+                    ])
+                );
+            }
+
+            let domain = Domain.or(domains);
+            if (model === "pos.order") {
+                domain = Domain.or([
+                    domain,
+                    new Domain([
+                        ["id", "not in", ids],
+                        ["state", "=", "draft"],
+                        ["config_id", "in", [config.id, ...config.trusted_config_ids]],
+                    ]),
+                ]);
+
+                acc[model] = domain.toList();
+            }
+
+            return acc;
+        }, {});
+
+        return { domain: domainByModel, recordsIds: recordIdsByModel };
     }
 
     /**

--- a/addons/pos_event/models/event_registration.py
+++ b/addons/pos_event/models/event_registration.py
@@ -15,7 +15,8 @@ class EventRegistration(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'event_id', 'event_ticket_id', 'pos_order_line_id', 'pos_order_id', 'phone', 'email', 'name', 'registration_answer_ids', 'registration_answer_choice_ids']
+        return ['id', 'event_id', 'event_ticket_id', 'pos_order_line_id', 'pos_order_id', 'phone', 'email', 'name',
+                'registration_answer_ids', 'registration_answer_choice_ids', 'write_date']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/pos_event/models/event_registration_answer.py
+++ b/addons/pos_event/models/event_registration_answer.py
@@ -9,7 +9,8 @@ class EventRegistrationAnswer(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['question_id', 'registration_id', 'value_answer_id', 'value_text_box', 'partner_id', 'event_id']
+        return ['question_id', 'registration_id', 'value_answer_id', 'value_text_box', 'partner_id',
+                'write_date', 'event_id']
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/pos_loyalty/models/loyalty_card.py
+++ b/addons/pos_loyalty/models/loyalty_card.py
@@ -16,7 +16,7 @@ class LoyaltyCard(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['partner_id', 'code', 'points', 'program_id', 'expiration_date']
+        return ['partner_id', 'code', 'points', 'program_id', 'expiration_date', 'write_date']
 
     def _has_source_order(self):
         return super()._has_source_order() or bool(self.source_pos_order_id)

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -24,7 +24,7 @@ class SaleOrder(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['name', 'state', 'user_id', 'order_line', 'partner_id', 'pricelist_id', 'fiscal_position_id', 'amount_total', 'amount_untaxed', 'amount_unpaid',
-            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order']
+            'picking_ids', 'partner_shipping_id', 'partner_invoice_id', 'date_order', 'write_date']
 
     def _count_pos_order(self):
         for order in self:
@@ -83,7 +83,7 @@ class SaleOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['discount', 'display_name', 'price_total', 'price_unit', 'product_id', 'product_uom_qty', 'qty_delivered',
-            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_id', 'is_downpayment']
+            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_id', 'is_downpayment', 'write_date']
 
     @api.depends('pos_order_line_ids.qty', 'pos_order_line_ids.order_id.picking_ids', 'pos_order_line_ids.order_id.picking_ids.state')
     def _compute_qty_delivered(self):


### PR DESCRIPTION
Previously, record synchronization was based on the pos.order model, so if the write_date of the order was more recent on the server, it was re-downloaded with its sub-records. The problem was that by changing an orderline, the order object was not necessarily updated, so its write_date remained the same.

Now all records and their write_dates are compared, so that records can be re-downloaded independently of their order. Trusted config commands are also re-downloaded.

The records compared are only those that can be created from the PoS frontend.
