### PR TITLE
[ADD] ai: backport of the AI module

### DIFF
--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -109,7 +109,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @users('__system__', 'demo')
     @warmup
     def test_leave_im_status_performance_partner_offline(self):
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(__system__=4, demo=4):
             self.assertEqual(self.employer_partner.im_status, 'offline')
 
     @users('__system__', 'demo')
@@ -123,7 +123,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     @warmup
     def test_leave_im_status_performance_partner_leave_offline(self):
         self.leave.write({'state': 'validate'})
-        with self.assertQueryCount(__system__=3, demo=3):
+        with self.assertQueryCount(__system__=4, demo=4):
             self.assertEqual(self.hr_partner.im_status, 'leave_offline')
 
     def test_search_absent_employee(self):

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -31,7 +31,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search im_livechat_expertise_res_users_settings_rel (_format_settings)
     #       - search mail_canned_response
     #       - fetch res_groups_users_rel (for search mail_canned_response that user can use)
-    _query_count_init_store = 14
+    _query_count_init_store = 15
     # Queries for _query_count_init_messaging (in order):
     #   1: insert res_device_log
     #   1: fetch res_users (for current user, first occurence _get_channels_as_member of _init_messaging)
@@ -142,7 +142,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (_author_to_store)
     #       - fetch user (_author_to_store)
     #       - _compute_rating_stats
-    _query_count_discuss_channels = 58
+    #   1: filtering res_partner (_compute_im_status)
+    _query_count_discuss_channels = 59
 
     def setUp(self):
         super().setUp()

--- a/addons/web/tests/test_perf_load_menu.py
+++ b/addons/web/tests/test_perf_load_menu.py
@@ -43,8 +43,8 @@ class TestPerfSessionInfo(common.HttpCase):
 
         # cold fields cache - warm ormcache:
         # - Only web: 5
-        # - All modules: 25
-        with self.assertQueryCount(25):
+        # - All modules: 26
+        with self.assertQueryCount(26):
             self.url_open(
                 "/web/session/get_session_info",
                 data=json.dumps({'jsonrpc': "2.0", 'method': "call", 'id': str(uuid4())}),

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -368,3 +368,6 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 # Whitelist the shop floor module
 !mrp_workorder
 !mrp_workorder/**
+
+!ai
+!ai/**


### PR DESCRIPTION
This PR is a follow-up on the implementation of the new AI features.

It back-ports modifications to discuss that adds override points in three discuss objects `composer_actions`, `message_actions`, and `thread_actions`, fixes to tests, and addition of linting for the ai module.

Enterprise PR: https://github.com/odoo/enterprise/pull/84610

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
