### PR TITLE
[IMP] website_sale_collect: re-compute so's warehouse from pickup data

### DIFF
--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -19,6 +19,8 @@ class SaleOrder(models.Model):
             )
         )
         super(SaleOrder, self - in_store_orders_with_pickup_data)._compute_warehouse_id()
+        for order in in_store_orders_with_pickup_data:
+            order.warehouse_id = order.pickup_location_data['id']
 
     def set_delivery_line(self, carrier, amount):
         """ Override of `website_sale` to recompute warehouse and fiscal position when a new

--- a/addons/website_sale_collect/tests/test_sale_order.py
+++ b/addons/website_sale_collect/tests/test_sale_order.py
@@ -35,6 +35,11 @@ class TestSaleOrder(ClickAndCollectCommon):
         so.partner_id = self.partner.id
         self.assertEqual(so.warehouse_id, warehouse_2)
 
+    def test_warehouse_is_computed_based_on_pickup_location(self):
+        warehouse_2 = self._create_warehouse()
+        so = self._create_in_store_delivery_order(pickup_location_data={'id': warehouse_2.id})
+        self.assertEqual(so.warehouse_id, warehouse_2)
+
     def test_setting_pickup_location_assigns_correct_fiscal_position(self):
         fp_us = self.env['account.fiscal.position'].create({
             'name': "Test US fiscal position",


### PR DESCRIPTION
### Issue:

Since 6243dd1f5bfef6a23620a0b06610d6f42ef5ede3, the `warehouse_id` of a picked up in stora so with `pickup_location_data` will not be computed: https://github.com/odoo/odoo/blob/406dc2fd1ee5110c2565c1d4b6d88f6bf0277fc8/addons/website_sale_collect/models/sale_order.py#L13-L22 In fact, it is expected to be set manually via the `_set_pickup_location` and then stay untouched. However, certain flow might want to rely on the compute method to set the warehouse from the `pickup_location_data`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
