### PR TITLE
[REF] hw_drivers: rename drivers/interfaces using snake_case

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/display_driver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/display_driver_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
@@ -150,9 +149,12 @@ class DisplayDriver(Driver):
             subprocess.run(['wlr-randr', '--output', self.device_identifier, '--transform', orientation.value], check=True)
             # Update touchscreen mapping to this display
             with helpers.writable():
-                subprocess.run(['sed', '-i', f's/HDMI-A-[12]/{self.device_identifier}/', '/home/odoo/.config/labwc/rc.xml'])
+                subprocess.run(
+                    ['sed', '-i', f's/HDMI-A-[12]/{self.device_identifier}/', '/home/odoo/.config/labwc/rc.xml'],
+                    check=False,
+                )
             # Tell labwc to reload its configuration
-            subprocess.run(['pkill', '-HUP', 'labwc'])
+            subprocess.run(['pkill', '-HUP', 'labwc'], check=False)
         else:
             subprocess.run(['xrandr', '-o', orientation.name.lower()], check=True)
             subprocess.run([file_path('hw_drivers/tools/sync_touchscreen.sh'), str(int(self._x_screen) + 1)], check=False)

--- a/addons/hw_drivers/iot_handlers/drivers/keyboard_usb_driver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/keyboard_usb_driver_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import ctypes
@@ -62,7 +61,7 @@ class KeyboardUSBDriver(Driver):
             54: 'right_shift',
             58: 'caps_lock',
             69: 'num_lock',
-            100: 'alt_gr', # right alt
+            100: 'alt_gr',  # right alt
         }
         self._tracked_modifiers = {modifier: False for modifier in self._scancode_to_modifier.values()}
 
@@ -152,7 +151,7 @@ class KeyboardUSBDriver(Driver):
                         elif data.keystate == 1:
                             self.key_input(data.scancode)
 
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             _logger.warning(err)
 
     def _change_keyboard_layout(self, new_layout):
@@ -368,6 +367,7 @@ class KeyboardUSBDriver(Driver):
                     return barcode
             except Empty:
                 return ''
+
 
 proxy_drivers['scanner'] = KeyboardUSBDriver
 

--- a/addons/hw_drivers/iot_handlers/drivers/l10n_eg_drivers.py
+++ b/addons/hw_drivers/iot_handlers/drivers/l10n_eg_drivers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import base64
 import json
@@ -113,7 +112,7 @@ class EtaUsbController(http.Controller):
         try:
             session = pkcs11.openSession(slots[0], PyKCS11.CKF_SERIAL_SESSION | PyKCS11.CKF_RW_SESSION)
             session.login(pin)
-        except Exception as ex:
+        except Exception as ex:  # noqa: BLE001
             error = self._get_error_template(str(ex))
         return session, error
 

--- a/addons/hw_drivers/iot_handlers/drivers/l10n_ke_edi_serial_driver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/l10n_ke_edi_serial_driver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -9,7 +8,7 @@ import json
 from functools import reduce
 
 from odoo import http
-from odoo.addons.hw_drivers.iot_handlers.drivers.SerialBaseDriver import SerialDriver, SerialProtocol, serial_connection
+from odoo.addons.hw_drivers.iot_handlers.drivers.serial_base_driver import SerialDriver, SerialProtocol, serial_connection
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import route
 

--- a/addons/hw_drivers/iot_handlers/drivers/printer_driver_L.py
+++ b/addons/hw_drivers/iot_handlers/drivers/printer_driver_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from base64 import b64decode
@@ -14,7 +13,7 @@ from odoo import http
 from odoo.addons.hw_drivers.connection_manager import connection_manager
 from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.hw_drivers.iot_handlers.drivers.printer_driver_base import PrinterDriverBase
-from odoo.addons.hw_drivers.iot_handlers.interfaces.PrinterInterface_L import PPDs, conn, cups_lock
+from odoo.addons.hw_drivers.iot_handlers.interfaces.printer_interface_L import PPDs, conn, cups_lock
 from odoo.addons.hw_drivers.main import iot_devices
 from odoo.addons.hw_drivers.tools import helpers, wifi, route
 
@@ -99,7 +98,7 @@ class PrinterDriver(PrinterDriverBase):
     def get_device_model(cls, device):
         device_model = ""
         if device.get('device-id'):
-            for device_id in [device_lo for device_lo in device['device-id'].split(';')]:
+            for device_id in device['device-id'].split(';'):
                 if any(x in device_id for x in ['MDL', 'MODEL']):
                     device_model = device_id.split(':')[1]
                     break
@@ -109,11 +108,11 @@ class PrinterDriver(PrinterDriverBase):
 
     def disconnect(self):
         self.send_status('disconnected', 'Printer was disconnected')
-        super(PrinterDriver, self).disconnect()
+        super().disconnect()
 
     def print_raw(self, data):
-        """
-        Print raw data to the printer
+        """Print raw data to the printer
+
         :param data: The data to print
         """
         if not self.check_printer_status():

--- a/addons/hw_drivers/iot_handlers/drivers/printer_driver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/printer_driver_W.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -62,7 +61,7 @@ class PrinterDriver(PrinterDriverBase):
 
     def disconnect(self):
         self.send_status('disconnected', 'Printer was disconnected')
-        super(PrinterDriver, self).disconnect()
+        super().disconnect()
 
     def print_raw(self, data):
         if not self.check_printer_status():
@@ -97,7 +96,7 @@ class PrinterDriver(PrinterDriverBase):
             self.send_status(status='success')
         except Exception:
             _logger.exception("Error while printing report, ghostscript args: %s, error buffer: %s", args, stderr_buf.getvalue())
-            stdout_log_level = logging.ERROR # some stdout value might contains relevant error information
+            stdout_log_level = logging.ERROR  # some stdout value might contains relevant error information
             self.send_status(status='error', message='ERROR_FAILED')
             raise
         finally:
@@ -124,9 +123,9 @@ class PrinterDriver(PrinterDriverBase):
             commands = self.RECEIPT_PRINTER_COMMANDS[self.receipt_protocol]
             self.print_raw(commands['center'] + (commands['title'] % b'IoT Box Test Receipt') + commands['cut'])
         elif self.device_type == "label_printer":
-            self.print_raw("^XA^CI28 ^FT35,40 ^A0N,30 ^FDIoT Box Test Label^FS^XZ".encode())
+            self.print_raw("^XA^CI28 ^FT35,40 ^A0N,30 ^FDIoT Box Test Label^FS^XZ".encode())  # noqa: UP012
         else:
-            self.print_raw("IoT Box Test Page".encode())
+            self.print_raw("IoT Box Test Page".encode())  # noqa: UP012
 
     def _cancel_job_with_error(self, job_id, error_message):
         self.job_ids.remove(job_id)

--- a/addons/hw_drivers/iot_handlers/drivers/serial_base_driver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/serial_base_driver.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from collections import namedtuple
+from typing import NamedTuple
 from contextlib import contextmanager
 import logging
 import serial
@@ -14,11 +13,23 @@ from odoo.addons.hw_drivers.driver import Driver
 
 _logger = logging.getLogger(__name__)
 
-SerialProtocol = namedtuple(
-    'SerialProtocol',
-    "name baudrate bytesize stopbits parity timeout writeTimeout measureRegexp statusRegexp "
-    "commandTerminator commandDelay measureDelay newMeasureDelay "
-    "measureCommand emptyAnswerValid")
+
+class SerialProtocol(NamedTuple):
+    name: any
+    baudrate: any
+    bytesize: any
+    stopbits: any
+    parity: any
+    timeout: any
+    writeTimeout: any
+    measureRegexp: any
+    statusRegexp: any
+    commandTerminator: any
+    commandDelay: any
+    measureDelay: any
+    newMeasureDelay: any
+    measureCommand: any
+    emptyAnswerValid: any
 
 
 @contextmanager
@@ -87,7 +98,7 @@ class SerialDriver(Driver):
 
         try:
             name = ('%s serial %s' % (self._protocol.name, self.device_type)).title()
-        except Exception:
+        except Exception:  # noqa: BLE001
             name = 'Unknown Serial Device'
         self.device_name = name
 

--- a/addons/hw_drivers/iot_handlers/drivers/serial_scale_driver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/serial_scale_driver.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -10,7 +9,7 @@ import time
 from odoo import http
 from odoo.addons.hw_drivers.controllers.proxy import proxy_drivers
 from odoo.addons.hw_drivers.event_manager import event_manager
-from odoo.addons.hw_drivers.iot_handlers.drivers.SerialBaseDriver import SerialDriver, SerialProtocol, serial_connection
+from odoo.addons.hw_drivers.iot_handlers.drivers.serial_base_driver import SerialDriver, SerialProtocol, serial_connection
 
 
 _logger = logging.getLogger(__name__)
@@ -90,7 +89,7 @@ class ScaleDriver(SerialDriver):
 
         # The HW Proxy can only expose one scale,
         # only the last scale connected is kept
-        global ACTIVE_SCALE
+        global ACTIVE_SCALE  # noqa: PLW0603
         ACTIVE_SCALE = self
         proxy_drivers['scale'] = ACTIVE_SCALE
 
@@ -99,7 +98,7 @@ class ScaleDriver(SerialDriver):
         """Allows `hw_proxy.Proxy` to retrieve the status of the scales"""
 
         status = self._status
-        return {'status': status['status'], 'messages': [status['message_title'], ]}
+        return {'status': status['status'], 'messages': [status['message_title']]}
 
     def _set_actions(self):
         """Initializes `self._actions`, a map of action keys sent by the frontend to backend action methods."""
@@ -178,7 +177,7 @@ class Toledo8217Driver(ScaleDriver):
     _protocol = Toledo8217Protocol
 
     def __init__(self, identifier, device):
-        super(Toledo8217Driver, self).__init__(identifier, device)
+        super().__init__(identifier, device)
         self.device_manufacturer = 'Toledo'
 
     @classmethod
@@ -204,7 +203,7 @@ class Toledo8217Driver(ScaleDriver):
         except serial.serialutil.SerialTimeoutException:
             pass
         except Exception:
-            _logger.exception('Error while probing %s with protocol %s' % (device, protocol.name))
+            _logger.exception('Error while probing %s with protocol %s', device, protocol.name)
         return False
 
 

--- a/addons/hw_drivers/iot_handlers/interfaces/display_interface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/display_interface_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
@@ -14,6 +13,7 @@ _logger = logging.getLogger(__name__)
 
 MIN_IMAGE_VERSION_WAYLAND = 25.03
 
+
 class DisplayInterface(Interface):
     _loop_delay = 3
     connection_type = 'display'
@@ -27,7 +27,7 @@ class DisplayInterface(Interface):
         }
 
         if float(helpers.get_version()[1:]) >= MIN_IMAGE_VERSION_WAYLAND:
-            randr_result = subprocess.run(['wlr-randr'], capture_output=True, text=True)
+            randr_result = subprocess.run(['wlr-randr'], capture_output=True, text=True, check=False)
             if randr_result.returncode != 0:
                 return {}
             displays = re.findall(r"\((HDMI-A-\d)\)", randr_result.stdout)

--- a/addons/hw_drivers/iot_handlers/interfaces/printer_interface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/printer_interface_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from cups import Connection as CupsConnection

--- a/addons/hw_drivers/iot_handlers/interfaces/printer_interface_W.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/printer_interface_W.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging

--- a/addons/hw_drivers/iot_handlers/interfaces/serial_interface.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/serial_interface.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import platform

--- a/addons/hw_drivers/iot_handlers/interfaces/usb_interface_L.py
+++ b/addons/hw_drivers/iot_handlers/interfaces/usb_interface_L.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from usb import core


### PR DESCRIPTION
Drivers/interfaces files were still named using CamelCase instead of python standard snake_case. This commit fixes it.

Enterprise PR: odoo/enterprise#84611