### PR TITLE
[FIX] purchase: relocate tax total block in report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -123,9 +123,10 @@
                 </tbody>
             </table>
 
-            <div id="total" class="row justify-content-end mt-n3">
-                <div class="col-4">
+            <div id="total" class="row mt-n3" name="total">
+                <div t-attf-class="#{'col-6' if report_type != 'html' else 'col-sm-7 col-md-6'} ms-auto">
                     <table class="o_total_table table table-borderless">
+                        <!--Tax totals -->
                         <t t-call="purchase.document_tax_totals">
                             <t t-set="tax_totals" t-value="o.tax_totals"/>
                             <t t-set="currency" t-value="o.currency_id"/>


### PR DESCRIPTION
-> Issue:
- PDF purchase order on the total table on the right side of the page encounters a display issue.

-> Steps to reproduce:
- Install the Purchase app
- Navigate to the Purchase app
- Open any purchase order
- Then navigate to the settings
- Click to Print
- Print the Purchase Order report

-> Cause:
- The issue is caused because of this #204575 new commit.

OPW: 4754858

Current behavior before PR:
![2025-05-02_18-24](https://github.com/user-attachments/assets/8dd8e238-9745-48f3-8e92-4d97fe442958)

Desired behavior after PR is merged:
![2025-05-02_18-27](https://github.com/user-attachments/assets/2a3570ff-d22b-4654-addd-1d343856598b)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
