### PR TITLE
[FIX] calendar: fix privacy field lable in user form

### DIFF
--- a/addons/calendar/views/res_users_views.xml
+++ b/addons/calendar/views/res_users_views.xml
@@ -18,9 +18,11 @@
             <field name="model">res.users</field>
             <field name="inherit_id" ref="base.view_users_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='signature']" position="after">
-                    <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
-                </xpath>
+                <field name="signature" position="after">
+                    <group string="Calendar" name="calendar">
+                        <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
+                    </group>
+                </field>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Version:
- master

Steps to reproduce:
- Open the user form view.
- Click on preferences.
- The default privacy label is not displaying.

issue:
- There is no label for a group.

solution:
- Add a group to fix this issue.

task-4748282