### PR TITLE
[FIX] payment_razorpay: prevent updates to provider reference and method in done or authorized state

### DIFF
--- a/addons/payment_razorpay/tests/common.py
+++ b/addons/payment_razorpay/tests/common.py
@@ -34,6 +34,13 @@ class RazorpayCommon(PaymentCommon):
             'id': cls.payment_id,
             'description': cls.reference,
             'status': 'captured',
+            'method': 'upi',
+        }
+        cls.payment_fail_data = {
+            'id': 'pay_987',
+            'description': cls.reference,
+            'status': 'failed',
+            'method': 'netbanking',
         }
         cls.tokenize_payment_data = {
             **cls.payment_data,


### PR DESCRIPTION
This measure prevents any accidental or unauthorized modifications to these critical fields after the transition has been done or authorized, thereby ensuring data accuracy and consistency.

task - 4680092

you can check this for reference 
![image](https://github.com/user-attachments/assets/c9e3b816-2b48-484a-b852-34ddbf07a93e)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
