### PR TITLE
[FIX] google_calendar: Prevent sending notification for old events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -918,6 +918,22 @@ class Meeting(models.Model):
             '&', ('privacy', '=', False), ('user_id.res_users_settings_id', 'in', public_calendars_settings)
         ]
 
+    def _is_event_over(self):
+        """Check if the event is over. This method is used to check if the event
+        should trigger invitations with Google Calendar.
+        :return: True if the event is over, False otherwise
+        """
+        self.ensure_one()
+        now = fields.Datetime.now()
+        today = fields.Date.today()
+
+        # For all-day events
+        if self.allday:
+            return self.stop_date and self.stop_date < today
+
+        # For timed events
+        return self.stop and self.stop < now
+
     # ------------------------------------------------------------
     # ACTIONS
     # ------------------------------------------------------------

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -603,3 +603,19 @@ class RecurrenceRule(models.Model):
         return rrule.rrule(
             freq_to_rrule(freq), **rrule_params
         )
+
+    def _is_event_over(self):
+        """Check if all events in this recurrence are in the past.
+        :return: True if all events are over, False otherwise
+        """
+        self.ensure_one()
+        if not self.calendar_event_ids:
+            return False
+
+        now = fields.Datetime.now()
+        today = fields.Date.today()
+
+        return all(
+            (event.stop_date < today if event.allday else event.stop < now)
+            for event in self.calendar_event_ids
+        )

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -280,6 +280,8 @@ class GoogleSync(models.AbstractModel):
         with google_calendar_token(self.env.user.sudo()) as token:
             if token:
                 try:
+                    send_updates = not self._is_event_over()
+                    google_service.google_service = google_service.google_service.with_context(send_updates=send_updates)
                     google_service.patch(google_id, values, token=token, timeout=timeout)
                 except HTTPError as e:
                     if e.response.status_code in (400, 403):
@@ -309,7 +311,7 @@ class GoogleSync(models.AbstractModel):
         with google_calendar_token(self.env.user.sudo()) as token:
             if token:
                 try:
-                    send_updates = self._context.get('send_updates', True)
+                    send_updates = self._context.get('send_updates', True) and not self._is_event_over()
                     google_service.google_service = google_service.google_service.with_context(send_updates=send_updates)
                     google_values = google_service.insert(values, token=token, timeout=timeout, need_video_call=self._need_video_call())
                     self.with_context(dont_notify=True).write(self._get_post_sync_values(values, google_values))

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -603,33 +603,6 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'transparency': 'opaque',
         }, timeout=3)
 
-    def test_send_update_do_request(self):
-        self.env.cr.postcommit.clear()
-        with self.mock_google_service():
-            event = self.env['calendar.event'].create({
-                'name': "Event",
-                'allday': True,
-                'start': datetime(2020, 1, 15),
-                'stop': datetime(2020, 1, 15),
-                'need_sync': False,
-            })
-            event.with_context(send_updates=True)._sync_odoo2google(self.google_service)
-            self.call_post_commit_hooks()
-        self.assertGoogleEventSendUpdates('all')
-
-    def test_not_send_update_do_request(self):
-        with self.mock_google_service():
-            event = self.env['calendar.event'].create({
-                'name': "Event",
-                'allday': True,
-                'start': datetime(2020, 1, 15),
-                'stop': datetime(2020, 1, 15),
-                'need_sync': False,
-            })
-            event.with_context(send_updates=False)._sync_odoo2google(self.google_service)
-            self.call_post_commit_hooks()
-        self.assertGoogleEventSendUpdates('none')
-
     @patch_api
     def test_recurrence_delete_single_events(self):
         """
@@ -1015,6 +988,89 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                             ],
                 'extendedProperties': {'shared': {'%s_odoo_id' % self.env.cr.dbname: record.id}},
             })
+
+    def test_event_over_send_updates(self):
+        """Test that events that are over don't sent updates to attendees."""
+        with self.mock_datetime_and_now("2023-01-10"):
+            self.env.cr.postcommit.clear()
+            with self.mock_google_service():
+                past_event = self.env['calendar.event'].create({
+                    'name': "Event",
+                    'start': datetime(2020, 1, 15, 8, 0),
+                    'stop': datetime(2020, 1, 15, 9, 0),
+                    'need_sync': False,
+                })
+                past_event._sync_odoo2google(self.google_service)
+                self.call_post_commit_hooks()
+            self.assertTrue(past_event._is_event_over(), "Event should be considered over")
+            self.assertGoogleEventSendUpdates('none')
+
+    def test_event_not_over_send_updates(self):
+        """Test that events that are not over send updates to attendees."""
+        with self.mock_datetime_and_now("2023-01-10"):
+            self.env.cr.postcommit.clear()
+            with self.mock_google_service():
+                future_date = datetime(2023, 1, 20, 8, 0)  # Fixed date instead of datetime.now()
+                future_event = self.env['calendar.event'].create({
+                    'name': "Future Event",
+                    'start': future_date,
+                    'stop': future_date + relativedelta(hours=1),
+                    'need_sync': False,
+                })
+                # Sync the event and verify send_updates is set to 'all'
+                future_event._sync_odoo2google(self.google_service)
+                self.call_post_commit_hooks()
+            self.assertFalse(future_event._is_event_over(), "Future event should not be considered over")
+            self.assertGoogleEventSendUpdates('all')
+
+    def test_recurrence_over_send_updates(self):
+        """Test that recurrences that are over don't send updates to attendees."""
+        with self.mock_datetime_and_now("2023-01-10"):
+            self.env.cr.postcommit.clear()
+            with self.mock_google_service():
+                past_event = self.env['calendar.event'].create({
+                    'name': "Past Recurring Event",
+                    'start': datetime(2020, 1, 15, 8, 0),
+                    'stop': datetime(2020, 1, 15, 9, 0),
+                    'need_sync': False,
+                })
+                past_recurrence = self.env['calendar.recurrence'].create({
+                    'rrule': 'FREQ=WEEKLY;COUNT=2;BYDAY=WE',
+                    'base_event_id': past_event.id,
+                    'need_sync': False,
+                })
+                past_recurrence._apply_recurrence()
+                # Sync the recurrence and verify send_updates is set to 'none'
+                past_recurrence._sync_odoo2google(self.google_service)
+                self.call_post_commit_hooks()
+            self.assertTrue(past_recurrence._is_event_over(), "Past recurrence should be considered over")
+            self.assertGoogleEventSendUpdates('none')
+
+    def test_recurrence_not_over_send_updates(self):
+        """Test that recurrences that are not over send updates to attendees."""
+        with self.mock_datetime_and_now("2023-01-10"):
+            self.env.cr.postcommit.clear()
+            with self.mock_google_service():
+                future_date = datetime(2023, 1, 20, 8, 0)
+                future_event = self.env['calendar.event'].create({
+                    'name': "Future Recurring Event",
+                    'start': future_date,
+                    'stop': future_date + relativedelta(hours=1),
+                    'need_sync': False,
+                })
+                future_recurrence = self.env['calendar.recurrence'].create(
+                    {
+                        'rrule': 'FREQ=WEEKLY;COUNT=2;BYDAY=WE',
+                        'base_event_id': future_event.id,
+                        'need_sync': False,
+                    }
+                )
+                future_recurrence._apply_recurrence()
+                # Sync the recurrence and verify send_updates is set to 'all'
+                future_recurrence._sync_odoo2google(self.google_service)
+                self.call_post_commit_hooks()
+            self.assertFalse(future_recurrence._is_event_over(), "Future recurrence should not be considered over")
+            self.assertGoogleEventSendUpdates('all')
 
 @tagged('odoo2google')
 class TestSyncOdoo2GoogleMail(TestTokenAccess, TestSyncGoogle, MailCommon):

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -83,7 +83,8 @@ class GoogleCalendarService():
 
     @requires_auth_token
     def patch(self, event_id, values, token=None, timeout=TIMEOUT):
-        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=all" % event_id
+        send_updates = self.google_service._context.get('send_updates', True)
+        url = "/calendar/v3/calendars/primary/events/%s?sendUpdates=%s" % (event_id, "all" if send_updates else "none")
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         self.google_service._do_request(url, json.dumps(values), headers, method='PATCH', timeout=timeout)
 


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
Prevent sending unnecessary invitation or update emails for events that have already ended by introducing a method to check if an event is over.

### Current behavior before PR:
Event updates/ new syncs with google_calendar might trigger email notifications, even for past events, causing useless invitations/ updated invitations to users.

### Desired behavior after PR is merged:
Email notifications are only sent for active or future events. Creation-from-sync / Updates to past events that have already ended are no longer triggering emails.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
task-4684432
