### PR TITLE
[IMP] sms: Allow passing additional context to sms composed body.

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -167,7 +167,7 @@ class SendSMS(models.TransientModel):
     def _compute_body(self):
         for record in self:
             if record.template_id and record.composition_mode == 'comment' and record.res_id:
-                additional_context = record._get_additional_render_context(record.template_id.body)
+                additional_context = record._get_additional_render_context().get('body', {})
                 record.body = record.template_id._render_field('body', [record.res_id], compute_lang=True, add_context=additional_context)[record.res_id]
             elif record.template_id:
                 record.body = record.template_id.body
@@ -291,7 +291,7 @@ class SendSMS(models.TransientModel):
         return recipients_info
 
     def _prepare_body_values(self, records):
-        additional_context = self._get_additional_render_context(self.body)
+        additional_context = self._get_additional_render_context().get('body', {})
         if self.template_id and self.body == self.template_id.body:
             all_bodies = self.template_id._render_field('body', records.ids, compute_lang=True, add_context=additional_context)
         else:
@@ -355,7 +355,12 @@ class SendSMS(models.TransientModel):
     # Render
     # ------------------------------------------------------------
 
-    def _get_additional_render_context(self, body):
+    def _get_additional_render_context(self):
+        """
+        Return a dict associating fields with their relevant render context if any.
+
+        e.g. {'body': {'additional_value': self.env.context.get('additional_value')}}
+        """
         return {}
 
     # ------------------------------------------------------------
@@ -367,7 +372,7 @@ class SendSMS(models.TransientModel):
         if composition_mode == 'comment':
             if not body and template_id and res_id:
                 template = self.env['sms.template'].browse(template_id)
-                additional_context = self._get_additional_render_context(template.body)
+                additional_context = self._get_additional_render_context().get('body', {})
                 result['body'] = template._render_template(template.body, res_model, [res_id], add_context=additional_context)[res_id]
             elif template_id:
                 template = self.env['sms.template'].browse(template_id)

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -166,8 +166,8 @@ class SendSMS(models.TransientModel):
     @api.depends('composition_mode', 'res_model', 'res_id', 'template_id')
     def _compute_body(self):
         for record in self:
-            additional_context = record._get_additional_render_context()
             if record.template_id and record.composition_mode == 'comment' and record.res_id:
+                additional_context = record._get_additional_render_context(record.template_id.body)
                 record.body = record.template_id._render_field('body', [record.res_id], compute_lang=True, add_context=additional_context)[record.res_id]
             elif record.template_id:
                 record.body = record.template_id.body
@@ -291,7 +291,7 @@ class SendSMS(models.TransientModel):
         return recipients_info
 
     def _prepare_body_values(self, records):
-        additional_context = self._get_additional_render_context()
+        additional_context = self._get_additional_render_context(self.body)
         if self.template_id and self.body == self.template_id.body:
             all_bodies = self.template_id._render_field('body', records.ids, compute_lang=True, add_context=additional_context)
         else:
@@ -355,8 +355,8 @@ class SendSMS(models.TransientModel):
     # Render
     # ------------------------------------------------------------
 
-    def _get_additional_render_context(self):
-        return dict()
+    def _get_additional_render_context(self, body):
+        return {}
 
     # ------------------------------------------------------------
     # Tools
@@ -366,8 +366,8 @@ class SendSMS(models.TransientModel):
         result = {}
         if composition_mode == 'comment':
             if not body and template_id and res_id:
-                additional_context = self._get_additional_render_context()
                 template = self.env['sms.template'].browse(template_id)
+                additional_context = self._get_additional_render_context(template.body)
                 result['body'] = template._render_template(template.body, res_model, [res_id], add_context=additional_context)[res_id]
             elif template_id:
                 template = self.env['sms.template'].browse(template_id)

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -289,11 +289,15 @@ class SendSMS(models.TransientModel):
         recipients_info = records._sms_get_recipients_info(force_field=self.number_field_name)
         return recipients_info
 
+    def _get_body_additional_context(self):
+        return dict()
+
     def _prepare_body_values(self, records):
+        additional_context = self._get_body_additional_context()
         if self.template_id and self.body == self.template_id.body:
-            all_bodies = self.template_id._render_field('body', records.ids, compute_lang=True)
+            all_bodies = self.template_id._render_field('body', records.ids, compute_lang=True, add_context=additional_context)
         else:
-            all_bodies = self.env['mail.render.mixin']._render_template(self.body, records._name, records.ids)
+            all_bodies = self.env['mail.render.mixin']._render_template(self.body, records._name, records.ids, add_context=additional_context)
         return all_bodies
 
     def _prepare_mass_sms_values(self, records):

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -166,8 +166,9 @@ class SendSMS(models.TransientModel):
     @api.depends('composition_mode', 'res_model', 'res_id', 'template_id')
     def _compute_body(self):
         for record in self:
+            additional_context = record._get_additional_render_context()
             if record.template_id and record.composition_mode == 'comment' and record.res_id:
-                record.body = record.template_id._render_field('body', [record.res_id], compute_lang=True)[record.res_id]
+                record.body = record.template_id._render_field('body', [record.res_id], compute_lang=True, add_context=additional_context)[record.res_id]
             elif record.template_id:
                 record.body = record.template_id.body
 
@@ -289,11 +290,8 @@ class SendSMS(models.TransientModel):
         recipients_info = records._sms_get_recipients_info(force_field=self.number_field_name)
         return recipients_info
 
-    def _get_body_additional_context(self):
-        return dict()
-
     def _prepare_body_values(self, records):
-        additional_context = self._get_body_additional_context()
+        additional_context = self._get_additional_render_context()
         if self.template_id and self.body == self.template_id.body:
             all_bodies = self.template_id._render_field('body', records.ids, compute_lang=True, add_context=additional_context)
         else:
@@ -354,6 +352,13 @@ class SendSMS(models.TransientModel):
         }
 
     # ------------------------------------------------------------
+    # Render
+    # ------------------------------------------------------------
+
+    def _get_additional_render_context(self):
+        return dict()
+
+    # ------------------------------------------------------------
     # Tools
     # ------------------------------------------------------------
 
@@ -361,8 +366,9 @@ class SendSMS(models.TransientModel):
         result = {}
         if composition_mode == 'comment':
             if not body and template_id and res_id:
+                additional_context = self._get_additional_render_context()
                 template = self.env['sms.template'].browse(template_id)
-                result['body'] = template._render_template(template.body, res_model, [res_id])[res_id]
+                result['body'] = template._render_template(template.body, res_model, [res_id], add_context=additional_context)[res_id]
             elif template_id:
                 template = self.env['sms.template'].browse(template_id)
                 result['body'] = template.body


### PR DESCRIPTION
In add-ons may need to pass additional context to body render function, both `_render_field`, and `_render_template` support this but the `sms.composer` didn't implement a proper way to pass additional context to them.

overwrite `_prepare_body_values` for just passing `add_context` to render functions is not a good practice.

In this PR I add a `_get_body_additional_context` to it, so any module can overwrite that function to pass additional context to render functions.
