### PR TITLE
[FIX] l10n_us_check_printing: align check format with the expected

### DIFF
--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -232,6 +232,7 @@ class AccountPayment(models.Model):
             'date': format_date(self.env, self.date),
             'partner_id': self.partner_id,
             'partner_name': self.partner_id.name,
+            'company': self.company_id.name,
             'currency': self.currency_id,
             'state': self.state,
             'amount': formatLang(self.env, self.amount, currency_obj=self.currency_id) if i == 0 else 'VOID',


### PR DESCRIPTION
Steps to print the check:
1. Ensure l10n_us_check_printing is installed
2. Set the check layout to Print Check (Middle) - US
3. Create a PO and a bill from it.
4. Create a payment for the bill using checks as your payment method
5. Click Print Check on the payment

Current behavior before PR:
The checks would print the vendor's name in the stubs, and the date alignment in the (middle) format was overlapping with the check number.

Description of the issue/feature this PR addresses:
The checks are aligned with the expected format and conditionally render the correct fields in the document's intended areas.

Desired behavior after PR is merged:
The printed check will now match the format and alignment of the templates used here:
https://checkdepot.net/collections/odoo-checks/products/odoo-checks-top- format. 

Additionally, the check will now avoid printing the issuing company name on the stubs when the manual numbering setting on the bank journal is switched off. This assumes that the checks are preprinted with the company name and check number.

opw-4557006
opw-4738359
Enterprise PR: https://github.com/odoo/enterprise/pull/84644
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
