### PR TITLE
[FIX] pos_self_order: avoid traceback for non-configurable combo with qty_max>1

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.js
@@ -192,6 +192,7 @@ export class ComboPage extends Component {
         const combo = this.props.productTemplate.combo_ids;
         return combo.filter(
             (c) =>
+                c.qty_max > 1 ||
                 c.combo_item_ids.length > 1 ||
                 (c.combo_item_ids.some((c) => c.product_id.attribute_line_ids.length !== 0) &&
                     !c.combo_item_ids.every((c) => c.product_id.isCombo()))

--- a/addons/pos_self_order/static/src/app/pages/kiosk_combo_page/kiosk_combo_page.js
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_combo_page/kiosk_combo_page.js
@@ -90,6 +90,7 @@ export class KioskComboPage extends Component {
         const combo = this.props.productTemplate.combo_ids;
         return combo.filter(
             (c) =>
+                c.qty_max > 1 ||
                 c.combo_item_ids.length > 1 ||
                 (c.combo_item_ids.some((c) => c.product_id.attribute_line_ids.length !== 0) &&
                     !c.combo_item_ids.every((c) => c.product_id.isCombo()))

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -178,3 +178,16 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
         Utils.clickBtn("Add to cart"),
     ],
 });
+
+registry.category("web_tour.tours").add("test_self_order_kiosk_combo_qty_max_free", {
+    steps: () => [
+        Utils.clickBtn("Order Now"),
+        LandingPage.selectKioskLocation("Test-In"),
+        CategoryPage.clickKioskCategory("Category 2"),
+        ProductPage.clickKioskProduct("Office Combo"),
+        ProductPage.clickKioskProduct("Combo Product 4"),
+        ...Utils.increaseComboItemQty("Combo Product 4", 3),
+        Utils.clickBtn("Next"),
+        Utils.clickBtn("Add to cart"),
+    ],
+});

--- a/addons/pos_self_order/static/tests/tours/utils/common.js
+++ b/addons/pos_self_order/static/tests/tours/utils/common.js
@@ -79,3 +79,28 @@ export function checkQRCodeGenerated() {
         trigger: "h1:contains('Scan the QR code to pay')",
     };
 }
+
+export function increaseComboItemQty(productName, qty) {
+    const steps = [
+        {
+            content: `Check product name`,
+            trigger: `.o_kiosk_product_box span:contains("${productName}")`,
+        },
+    ];
+
+    for (let i = 1; i < qty; i++) {
+        steps.push(
+            {
+                content: `Verify the quantity of "${productName}" is updated to ${i}.`,
+                trigger: `.item_qty_container h2:contains("${i}")`,
+            },
+            {
+                content: `Increase the quantity of "${productName}" by clicking the "+" button.`,
+                trigger: `.item_qty_container button:eq(1)`,
+                run: "click",
+            }
+        );
+    }
+
+    return steps;
+}

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -3,6 +3,7 @@
 
 import odoo.tests
 from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+from odoo.addons.point_of_sale.tests.common_setup_methods import setup_product_combo_items
 from odoo import Command
 
 
@@ -156,3 +157,16 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
         self.pos_config.current_session_id.set_opening_control(0, "")
         self_route = self.pos_config._get_self_order_route()
         self.start_tour(self_route, "test_self_order_kiosk_combo_sides")
+
+    def test_self_order_kiosk_combo_qty_max_free(self):
+        setup_product_combo_items(self)
+        self.desks_combo.write({'combo_item_ids': [Command.unlink(item.id) for item in self.desks_combo.combo_item_ids[1:]], 'qty_max': 3})
+        self.office_combo.write({'combo_ids': [Command.unlink(item.id) for item in self.office_combo.combo_ids if item.id != self.desks_combo.id]})
+        self.pos_config.write({
+            'self_ordering_mode': 'kiosk',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self.start_tour(self.pos_config._get_self_order_route(), "test_self_order_kiosk_combo_qty_max_free")


### PR DESCRIPTION
Steps:
=======
- Define a combo choice for a single non-configurable product.
- Set max_qty for the combo item to a value greater than 1.
- Try adding the combo to the cart in the self-order flow. A traceback occurs when the combo is added to the cart.

Cause:
=======
combo choices only considered cases where comboItem_ids.length > 1 and the product is configurable. It did not account for qty_max, which led to empty combo choice data being sent for valid single-product combos with qty_max > 1.

FIX:
======
Extended the condition to include qty_max > 1.

Task-4762775


