### PR TITLE
[FIX] stock: prevent error when creating custom serial/lots

### DIFF
--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -42,7 +42,7 @@ export class GenerateDialog extends Component {
         });
     }
     async _onGenerateCustomSerial() {
-        const product = (await this.orm.searchRead("product.product", [["id", "=", this.props.move.data.product_id[0]]], ["lot_sequence_id"]))[0];
+        const product = (await this.orm.searchRead("product.product", [["id", "=", this.props.move.data.product_id.id]], ["lot_sequence_id"]))[0];
         this.sequence = product.lot_sequence_id;
         if (product.lot_sequence_id) {
             this.sequence = (await this.orm.searchRead("ir.sequence", [["id", "=", this.sequence[0]]], ["number_next_actual"]))[0];


### PR DESCRIPTION
Issue Before This Commit:
============================

When generating custom serial/lot numbers in a receipt, clicking the 'New' button in the 'Generate Lot Numbers' wizard(dialog) throws the following error: 'Cannot read properties of undefined (reading 'lot_sequence_id')'.

Steps to Reproduce:
============================

- Install the stock module.
- Create a receipt for a product with lot/serial tracking.
- Confirm the receipt & click the "Details" button.
- Click the "Generate Serials/Lots" button.
- Then click the "New" button.

With This Commit:
============================

This issue was introduced by this
PR [205486](https://github.com/odoo/odoo/pull/205486), as that PR did not cover this case. This commit ensures that lot_sequence_id is correctly initialized and available when the "New" button is clicked during serial/lot number generation.

task - [4770391](https://www.odoo.com/odoo/project/49/tasks/4770391)
