### PR TITLE
[FIX] hr_holidays: exclude public holidays when flexible hours

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -427,9 +427,10 @@ class HolidaysRequest(models.Model):
                 days = (leave.date_to - leave.date_from).days + (1 if not leave.request_unit_half else 0.5)
                 public_holidays = self.env['resource.calendar.leaves'].search([
                     ('resource_id', '=', False),
-                    ('calendar_id', '=', calendar.id),
+                    ('calendar_id', 'in', [False, calendar.id]),
                     ('date_from', '<=', leave.date_to),
-                    ('date_to', '>=', leave.date_from)
+                    ('date_to', '>=', leave.date_from),
+                    ('company_id', '=', leave.company_id.id)
                 ])
                 excluded_days = sum(
                     (min(holiday.date_to, leave.date_to) - max(holiday.date_from, leave.date_from)).days + 1


### PR DESCRIPTION
<b>Steps to reproduce:</b>

1) Create a flexible working schedule
2) Assign this working schedule to one of the employees 
3) Create a public holiday with no calendar
4) Create a leave for the flexible employee where the public holiday
   will be during his leave
5) Notice the duration of the leave

<b>Issue:</b>
Previously, leave duration did not exclude public holidays without calendars
or holidays associated with a different company than the employee's
when using flexible schedules.

For example, if an employee took 5 days off and one of those days was
a public holiday without a calendar, the system would incorrectly count
all 5 days instead of excluding the public holiday.

<b>Cause:</b>
This issue occurs because the system only checks for public holidays
with calendars during the leave period and excludes those days from
the leave duration.

However, if the public holiday does not have a calendar or is assigned
to a different company than the employee's, it is not excluded from
the leave days/hours.
https://github.com/odoo/odoo/blob/7293a04bd90c26cb27669f5a1c9edd45c7e5c96c/addons/hr_holidays/models/hr_leave.py#L428-L438

<b>Fix:</b>
We now exclude public holidays from the leave duration even if they do
not have a calendar, as long as the holiday belongs to the same company
as the leave request.

opw-4711942

