### PR TITLE
[FIX] point_of_sale: fix datetime numbering system

### DIFF
--- a/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/store/devices_synchronisation.js
@@ -174,7 +174,9 @@ export default class DevicesSynchronisation {
             for (const record of serverRecs) {
                 const recordDate = DateTime.fromSQL(record.write_date);
                 const recordDateTime = recordDate.plus({ seconds: 1 });
-                const recordDateTimeString = recordDateTime.toFormat("yyyy-MM-dd HH:mm:ss");
+                const recordDateTimeString = recordDateTime.toFormat("yyyy-MM-dd HH:mm:ss", {
+                    numberingSystem: "latn",
+                });
                 domains.push(
                     new Domain([
                         ["id", "=", record.id],


### PR DESCRIPTION
When a database isn't in ltn format, the datetime numbering system is not set to the correct value. This commit fixes the issue by ensuring that the datetime numbering system is set to the correct value.


