### PR TITLE
Master l10n mx different account credit roto

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -289,7 +289,7 @@
                                             <label for="account_discount_expense_allocation_id" class="col-lg-5 o_light_label" string="Customer Invoices"/>
                                             <field name="account_discount_expense_allocation_id" placeholder="Same Account as product"/>
                                         </div>
-                                        <div class="row mt8">
+                                        <div class="row mt8" id="account_discount_income_allocation">
                                             <label for="account_discount_income_allocation_id" class="col-lg-5 o_light_label" string="Vendor Bills"/>
                                             <field name="account_discount_income_allocation_id" placeholder="Same Account as product"/>
                                         </div>

--- a/addons/l10n_mx/__manifest__.py
+++ b/addons/l10n_mx/__manifest__.py
@@ -38,6 +38,7 @@ With this module you will have:
         'views/res_bank_view.xml',
         'views/account_views.xml',
         'views/account_tax_view.xml',
+        'views/res_config_settings_views.xml',
         "data/l10n_mx_uom.xml",
     ],
     'demo': [

--- a/addons/l10n_mx/data/template/account.account-mx.csv
+++ b/addons/l10n_mx/data/template/account.account-mx.csv
@@ -63,6 +63,7 @@
 "cuenta305_01","Uncut results","305.01.01","equity_unaffected","False","l10n_mx.tag_credit_balance_account","","Resutado Integral"
 "cuenta401_01","Sales and/or services taxed at the general rate","401.01.01","income","False","l10n_mx.tag_credit_balance_account","","Ventas y/o servicios gravados a la tasa general"
 "cuenta402_01","Returns, discounts or bonuses over sales and/or services at the general rate","402.01.01","income_other","False","l10n_mx.tag_debit_balance_account","","Devoluciones, descuentos o bonificaciones sobre ventas y/o servicios a tarifa general"
+"cuenta402_04","Re-invoicing","402.04.01","income","False","l10n_mx.tag_credit_balance_account","","Refacturaciones"
 "cuenta501_01","Cost of sales","501.01.01","expense_direct_cost","False","l10n_mx.tag_debit_balance_account","","Costo de venta"
 "cuenta503_01","Returns, discounts or bonuses over purchases","503.01.01","income_other","False","l10n_mx.tag_credit_balance_account","","Devoluciones, descuentos o bonificaciones sobre compras"
 "cuenta601_01","Wages and salaries","601.01.01","expense_direct_cost","False","l10n_mx.tag_debit_balance_account","","Sueldos y salarios"

--- a/addons/l10n_mx/models/__init__.py
+++ b/addons/l10n_mx/models/__init__.py
@@ -3,3 +3,6 @@ from . import template_mx
 from . import account_account
 from . import account_tax
 from . import res_bank
+from . import res_company
+from . import res_config_settings
+from . import account_move_line

--- a/addons/l10n_mx/models/account_move_line.py
+++ b/addons/l10n_mx/models/account_move_line.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    def _compute_account_id(self):
+        # EXTENDS 'account'
+        super()._compute_account_id()
+        for line in self:
+            if (
+                line.move_id.country_code == 'MX'
+                and line.move_id.move_type == 'out_refund'
+                and line.display_type == 'product'
+                and line.company_id.l10n_mx_income_return_discount_account_id
+            ):
+                line.account_id = line.company_id.l10n_mx_income_return_discount_account_id

--- a/addons/l10n_mx/models/res_company.py
+++ b/addons/l10n_mx/models/res_company.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = 'res.company'
+
+    l10n_mx_income_return_discount_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Income account for returns and discounts'
+    )
+    l10n_mx_income_re_invoicing_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Income account for re-invoicing'
+    )

--- a/addons/l10n_mx/models/res_config_settings.py
+++ b/addons/l10n_mx/models/res_config_settings.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models, fields
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    l10n_mx_account_income_return_discount_id = fields.Many2one(
+        comodel_name="account.account",
+        string='Income Returns and Discounts Account',
+        readonly=False,
+        related='company_id.l10n_mx_income_return_discount_account_id',
+        domain="[('account_type', '=', 'income')]",
+    )

--- a/addons/l10n_mx/models/template_mx.py
+++ b/addons/l10n_mx/models/template_mx.py
@@ -39,6 +39,8 @@ class AccountChartTemplate(models.AbstractModel):
                 'expense_account_id': 'cuenta601_84',
                 'income_account_id': 'cuenta401_01',
                 'account_cash_basis_base_account_id': 'cuenta801_01_99',
+                'l10n_mx_income_return_discount_account_id': 'cuenta402_01',
+                'l10n_mx_income_re_invoicing_account_id': 'cuenta402_04',
             },
         }
 

--- a/addons/l10n_mx/tests/__init__.py
+++ b/addons/l10n_mx/tests/__init__.py
@@ -1,0 +1,2 @@
+from . import common
+from . import test_account_move

--- a/addons/l10n_mx/tests/common.py
+++ b/addons/l10n_mx/tests/common.py
@@ -1,0 +1,39 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+class TestMxCommon(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('mx')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # do not use demo data and avoid having duplicated companies
+        cls.env['res.company'].search([('vat', '=', "EKU9003173C9")]).write({'vat': False})
+        cls.env['res.company'].search([('name', '=', "ESCUELA KEMPER URGATE")]).name = "ESCUELA KEMPER URGATE (2)"
+
+        cls.company_data['company'].write({
+            'name': 'ESCUELA KEMPER URGATE',
+            'vat': 'EKU9003173C9',
+            'street': 'Campobasso Norte 3206 - 9000',
+            'street2': 'Fraccionamiento Montecarlo',
+            'zip': '20914',
+            'city': 'Jesús María',
+            'country_id': cls.env.ref('base.mx').id,
+            'state_id': cls.env.ref('base.state_mx_ags').id,
+        })
+
+        cls.partner_mx = cls.env['res.partner'].create({
+            'name': "INMOBILIARIA CVA",
+            'property_account_receivable_id': cls.company_data['default_account_receivable'].id,
+            'property_account_payable_id': cls.company_data['default_account_payable'].id,
+            'street': "Campobasso Sur 3201 - 9001",
+            'city': "Hidalgo del Parral",
+            'state_id': cls.env.ref('base.state_mx_chih').id,
+            'zip': '33826',
+            'country_id': cls.env.ref('base.mx').id,
+            'vat': 'ICV060329BY0',
+            'bank_ids': [Command.create({'acc_number': "0123456789"})],
+        })

--- a/addons/l10n_mx/tests/test_account_move.py
+++ b/addons/l10n_mx/tests/test_account_move.py
@@ -1,0 +1,29 @@
+from odoo.tests import tagged
+
+from odoo import Command
+from odoo.addons.l10n_mx.tests.common import TestMxCommon
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAccountMove(TestMxCommon):
+
+    def test_credit_note_assign_right_account_on_lines(self):
+        """
+        This test check if the lines of a credit note created for MX, reference the
+        right account id by default.
+        """
+        credit_note = self.env['account.move'].create({
+            'move_type': 'out_refund',
+            'company_id': self.company_data['company'].id,
+            'partner_id': self.partner_mx.id,
+            'invoice_line_ids': [Command.create({
+                'name': 'Test',
+                'quantity': 1,
+                'price_unit': 100,
+            })],
+        })
+
+        self.assertRecordValues(credit_note.line_ids, [
+            {'display_type': 'product', 'account_code': '402.01.01'},
+            {'display_type': 'payment_term', 'account_code': '105.01.01'},
+        ])

--- a/addons/l10n_mx/views/res_config_settings_views.xml
+++ b/addons/l10n_mx/views/res_config_settings_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record id="res_config_settings_view_form" model="ir.ui.view">
+            <field name="name">res.config.settings.view.form.inherit.account.mx</field>
+            <field name="model">res.config.settings</field>
+            <field name="priority" eval="40"/>
+            <field name="inherit_id" ref="account.res_config_settings_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//div[@id='account_discount_income_allocation']" position="after">
+                    <div class="row mt8" invisible="company_country_code != 'MX'">
+                        <label for="l10n_mx_account_income_return_discount_id" class="col-lg-5 o_light_label" string="Credit notes"/>
+                        <field name="l10n_mx_account_income_return_discount_id" placeholder="Returns and discounts"/>
+                    </div>
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -338,7 +338,7 @@
                                         </div>
                                     </div>
                                 </setting>
-                                <setting help="Print information on the receipt to allow the customer to easily access the invoice anytime, from Odoo's portal." documentation="/applications/sales/point_of_sale/receipts_invoices.html">
+                                <setting help="Print information on the receipt to allow the customer to easily access the invoice anytime, from Odoo's portal." documentation="/applications/sales/point_of_sale/receipts_invoices.html" id="pos_use_ticket_qr_code">
                                     <field name="point_of_sale_use_ticket_qr_code"/>
                                     <div class="content-group mt16" invisible="not point_of_sale_use_ticket_qr_code">
                                         <div class="col mt16">


### PR DESCRIPTION
[IMP] l10n_mx, *: provide different account for credit notes
modules = account, l10n_mx, point_of_sale

modules: l10n_mx_reports, l10n_mx_edi, l10n_mx_edi_pos
When handling credit notes for accounting purposes it's not correct (or
even legal in mexico) to use the same account for anything related to
credit notes (discounts, bonuses or returns). Instead, all of these are
accounted for in a different account that reduces the sales but also
tell us how much of the sales were reduced by this account.

This commit provide an account for these cases, and make it customizable
for the user to set the account he wants (with a setting in the 'Default
Accounting' section). Also, POS returns are now associated with this
account.

A second account is created to handle the "re-invoicing" concept: when a
pos order is done and the session is closed, if the customer wants to
self-invoice the system perform a reversal of the session and create 2
new invoices, 1 for the customer and 1 for all other orders from the
original session. The new account is associated to the debit lines of
the reversal (not vat), the credit lines of the customer invoice (not
vat)

Task-4576187