### PR TITLE
[IMP] base: server actions: add sequence support

### DIFF
--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -382,12 +382,14 @@
                                 <span invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']">by</span>
                                 <field name="update_m2m_operation" class="oe_inline" invisible="evaluation_type != 'value' or update_field_type not in ['one2many', 'many2many']" required="update_field_type in ['one2many', 'many2many']"/>
                                 <span invisible="evaluation_type != 'value' or update_field_type in ['one2many', 'many2many']">to</span>
+                                <span invisible="evaluation_type != 'sequence'">with</span>
                                 <field name="value" class="oe_inline" placeholder="Set a value..." invisible="update_field_id == False or value_field_to_show != 'value' or evaluation_type != 'value'" string="Custom Value"/>
                                 <field name="html_value" class="w-100" placeholder="Set a value..." invisible="update_field_id == False or value_field_to_show != 'html_value' or evaluation_type != 'value'" string="Custom Value"/>
+                                <field name="sequence_id" class="oe_inline" placeholder="Select a sequence..." invisible="evaluation_type != 'sequence'" required="evaluation_type == 'sequence'"/>
                                 <field name="resource_ref" class="oe_inline" placeholder="Choose a value..." string="Custom Value" options="{'model_field': 'update_related_model_id', 'no_create': True, 'no_open': True}" invisible="update_field_id == False or value_field_to_show != 'resource_ref' or evaluation_type == 'equation' or update_m2m_operation == 'clear'"/>
                                 <field name="selection_value" class="oe_inline" placeholder="Choose a value..." options="{'no_create': True, 'no_open': True}" invisible="update_field_id == False or value_field_to_show != 'selection_value' or evaluation_type == 'equation'"/>
                                 <field name="update_boolean_value" class="oe_inline" invisible="evaluation_type != 'value' or value_field_to_show != 'update_boolean_value'" required="value_field_to_show == 'update_boolean_value'"/>
-                                <span invisible="update_field_id != False or evaluation_type == 'equation'" class="o_actions_server_set_a_value text-muted">Set a value...</span>
+                                <span invisible="update_field_id != False or evaluation_type != 'value'" class="o_actions_server_set_a_value text-muted">Set a value...</span>
                                 <span invisible="evaluation_type != 'equation'">
                                     to this Python expression:
                                 </span>


### PR DESCRIPTION
In order to update a record using a sequence:
- before this commit one would have to use a python expression like `env['ir.sequence'].next_by_code('the_sequence_code')` which was not very discoverable.
- after this commit there is a standard way to select a sequence through the server action's form view.

Task id: opw-4689501

![image](https://github.com/user-attachments/assets/000d1ca9-d554-44ae-9da6-587cdfe5b484)
