### PR TITLE
[16.0][FIX] hr_holidays: Define the correct hours in the leaves if the calendar has defined dates (date_from and date_to)

### DIFF
--- a/addons/hr_holidays/tests/test_holidays_flow.py
+++ b/addons/hr_holidays/tests/test_holidays_flow.py
@@ -286,3 +286,74 @@ class TestHolidaysFlow(TestHrHolidaysCommon):
                         'date_from': datetime.today().strftime('%Y-%m-11 19:00:00'),
                         'date_to': datetime.today().strftime('%Y-%m-10 10:00:00'),
                     })
+
+    @freeze_time("2025-05-02")
+    def test_leave_calendar_date_from_to(self):
+        calendar = self.env["resource.calendar"].create({
+            "name": "Test calendar",
+            "attendance_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Friday Morning",
+                        "dayofweek": "4",
+                        "day_period": "morning",
+                        "hour_from": 9,
+                        "hour_to": 14,
+                        "date_from": "2025-01-02",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Friday Afternoon",
+                        "dayofweek": "4",
+                        "day_period": "afternoon",
+                        "hour_from": 17,
+                        "hour_to": 20,
+                        "date_from": "2025-01-02",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Friday Morning (old)",
+                        "dayofweek": "4",
+                        "day_period": "morning",
+                        "hour_from": 8,
+                        "hour_to": 13,
+                        "date_to": "2025-01-01",
+                    },
+                ),
+                (
+                    0,
+                    0,
+                    {
+                        "name": "Friday Afternoon (old)",
+                        "dayofweek": "4",
+                        "day_period": "afternoon",
+                        "hour_from": 19,
+                        "hour_to": 21,
+                        "date_to": "2025-01-01",
+                    },
+                )
+            ]
+        })
+        self.employee_emp.resource_calendar_id = calendar
+        self.holidays_status_hr = self.env["hr.leave.type"].with_user(self.user_hrmanager_id).create({
+            "name": "NotLimitedHR",
+            "requires_allocation": "no",
+            "leave_validation_type": "hr",
+        })
+        holidays = self.env["hr.leave"].with_user(self.user_employee_id).create({
+            "name": "Hol11",
+            "employee_id": self.employee_emp.id,
+            "holiday_status_id": self.holidays_status_hr.id,
+            "request_date_from": "2025-05-02",
+            "request_date_to": "2025-05-02",
+        })
+        self.assertEqual(holidays.date_from.hour, 7)
+        self.assertEqual(holidays.date_to.hour, 18)


### PR DESCRIPTION
Define the correct hours in the leaves if the calendar has defined dates (`date_from` and `date_to`)

Use case example:
- Create a calendar and define on Friday (Morning: from 08:00 to 13.00, Afternoon: from 19:00 to 21:00) with date_to=2025-01-01.
- Define another specific Friday (Morning: from 09:00 to 14.00, Afternoon: from 17:00 to 20:00) in the same calendar with date_from=2025-01-01.
- Create an employee and define the calendar created for him/her.
- Create a leaves for the employee and select a Friday (2025-05-02).
- The start hour of the leave must be 2025-05-02 09:00:00
- The end hour of the leave must be 2025-05-02 20:00:00

![ejemplo-1](https://github.com/user-attachments/assets/e7f6bcf9-73f2-4412-840c-cbe42e5e9200)
![ejemplo-2](https://github.com/user-attachments/assets/211c07c8-c068-4137-b032-e26f9567e8b3)

Please @pedrobaeza can you review it?

@Tecnativa TT56218


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
