### PR TITLE
[FIX] website_event: wait after redirect in needed

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -72,6 +72,10 @@ function websiteEditEventTourSteps() {
             trigger: "iframe span:contains('Back to events')",
             run: "click",
         },
+        {
+            content: "Wait for events list to load",
+            trigger: "iframe .o_wevent_events_list",
+        },
         ...wTourUtils.clickOnEditAndWaitEditMode(),
         {
             content: "edit the short description of the event",


### PR DESCRIPTION
So it appears from the tour build error screenshot that the redirect doesn’t happen that fast, so we need to wait for it to happen before checking the next step, which is 'Edit'—which overrides it and edits the event details instead of the events list. So, we need to wait for the redirect to happen before checking the next step

build_error-164184

referencing this commit : https://github.com/odoo/odoo/commit/b1e424bcd5e985b74496e409fb16c9529bbe848e

![image](https://github.com/user-attachments/assets/7ff2d9ce-fd9a-4e34-a71b-b1d465e45a95)

