### PR TITLE
[FIX] mail: keep composer template dropdown in viewport

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_template_selector.scss
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.scss
@@ -1,0 +1,11 @@
+.mail-composer-template-dropdown {
+    max-width: 250px !important;
+
+    @include media-breakpoint-up(sm) {
+        max-width: 400px !important;
+    }
+
+    @include media-breakpoint-up(md) {
+        max-width: 500px !important;
+    }
+}

--- a/addons/mail/static/src/core/web/mail_composer_template_selector.xml
+++ b/addons/mail/static/src/core/web/mail_composer_template_selector.xml
@@ -8,7 +8,7 @@
             <t t-set-slot="content">
                 <div class="px-3 pb-1 text-muted">Insert Template</div>
                 <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                    <DropdownItem onSelected="() => this.onLoadTemplate(template)">
+                    <DropdownItem class="'text-truncate'" onSelected="() => this.onLoadTemplate(template)">
                         <t t-if="template.display_name" t-out="template.display_name"/>
                         <span t-else="" class="fst-italic">Untitled</span>
                     </DropdownItem>
@@ -20,12 +20,12 @@
                     <a href="#">Search More...</a>
                 </DropdownItem>
                 <div class="dropdown-divider"/>
-                <Dropdown>
+                <Dropdown menuClass="'mail-composer-template-dropdown'">
                     <div>Save as Template</div>
                     <t t-set-slot="content">
                         <div class="px-3 pb-1 text-muted">Overwrite Template</div>
                         <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                            <DropdownItem onSelected="() => this.onOverwriteTemplate(template)">
+                            <DropdownItem class="'text-truncate'" onSelected="() => this.onOverwriteTemplate(template)">
                                 <t t-if="template.display_name" t-out="template.display_name"/>
                                 <span t-else="" class="fst-italic">Untitled</span>
                             </DropdownItem>
@@ -43,12 +43,12 @@
                     </t>
                 </Dropdown>
                 <div class="dropdown-divider"/>
-                <Dropdown>
+                <Dropdown menuClass="'mail-composer-template-dropdown'">
                     <div>Delete Template</div>
                     <t t-set-slot="content">
                         <div class="px-3 pb-1 text-muted">Delete Template</div>
                         <t t-foreach="state.templates" t-as="template" t-key="template_index">
-                            <DropdownItem onSelected="() => this.onDeleteTemplate(template)">
+                            <DropdownItem class="'text-truncate'" onSelected="() => this.onDeleteTemplate(template)">
                                 <t t-if="template.display_name" t-out="template.display_name"/>
                                 <span t-else="" class="fst-italic">Untitled</span>
                             </DropdownItem>


### PR DESCRIPTION
Steps to reproduce
==================

- Use a mobile device/viewport
- Go to any record with a chatter
- Click on Log note
- Expand the composer
- Click on the template dropdown
- Save the current content as a template with a long name
- Open the dropdown again

=> The dropdown is almost entirely off screen

Cause of the issue
==================

The Dropdown component uses the usePosition hook.
It works by doing the following:
- It tries the fit the content using the position props (or it's default value)
- If it doesn't fit, it tries the four other corners
- If it's still doesn't fit, it gives up and uses the first one again

Solution
========

Since we cannot show too much content inside a dropdown, we set a max-width on the dropdown content, and truncate the template names.

Another possibility would be to allow an horizontal overflow.

opw-4675320
opw-4674341
opw-4656725