### PR TITLE
[FIX] sale_pdf_quote_builder: reset headers and footers on template change

### DIFF
--- a/addons/sale_pdf_quote_builder/models/sale_order.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order.py
@@ -48,6 +48,15 @@ class SaleOrder(models.Model):
                 or order.order_line.available_product_document_ids
             )
 
+    # === ONCHANGE METHODS === #
+
+    @api.onchange('sale_order_template_id')
+    def _onchange_sale_order_template_id(self):
+        super()._onchange_sale_order_template_id()
+        for order in self:
+            # Remove documents which are no longer available.
+            order.quotation_document_ids &= order.available_product_document_ids
+
     # === ACTION METHODS === #
 
     def get_update_included_pdf_params(self):

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -165,6 +165,26 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
         self.assertEqual('Header', dialog_param['headers']['files'][0]['name'])
         self.assertEqual('Product > Test Product', dialog_param['lines'][0]['name'])
 
+    def test_quotation_document_is_removed_on_template_change(self):
+        so_tmpl = self.env['sale.order.template'].create({
+            'name': "test1",
+            'quotation_document_ids': [Command.link(self.header.id)],
+        })
+        so_tmpl_2 = self.env['sale.order.template'].create({'name': "test2"})
+
+        self.sale_order.write({
+            'sale_order_template_id': so_tmpl.id,
+            'quotation_document_ids': [Command.link(self.header.id)],
+        })
+
+        self.assertEqual(self.sale_order.quotation_document_ids, self.header)
+
+        so_form = Form(self.sale_order)
+        so_form.sale_order_template_id = so_tmpl_2
+        so_form.save()
+
+        self.assertNotEqual(self.sale_order.quotation_document_ids, self.header)
+
     def test_onchange_product_removes_previously_selected_documents(self):
         """ Check that changing a line that has a selected document unselect said document. """
 


### PR DESCRIPTION
## Version:
18.0 > 18.1 (test to fw up to master)
18.2+ fixed by https://github.com/odoo/odoo/pull/186649

## Issue:
Changing the `Quotation Template` on a quotation after

## Steps to reproduce:
*Ensure `PDF Quote builder` is checked in `Settings` app*
- In `Sales / Configuration / Sales Orders:Headers/Footers`:
  - Ensure there are at least 2 documents *(add them if needed)*;
  - Set their `Document type` to `Header`;
- Go to `Sales / Configuration / Sales Orders:Quotation Templates`:
  - Create 2 new templates (e.g. "test1" and "test2"):
    - In "test1", under the `Quote Builder`, add one of the documents;
    - In "test2", under the `Quote Builder`, add the second document;
- Create a new quote for any customer:
  - Select "test1" as `Quotation Template`;
  - Under the `Quote Builder`, select the header document;
  - Change the `Quotation Template` for "test2";
  - Select the header document;
  - Change back to "test1" and see the header document is still selected;
  - Print the quote via the action button;
  - The PDF contains both "test1" and "test2" document headers.

## Fix:
Partial backport of https://github.com/odoo/odoo/pull/186649

opw-4709144