### PR TITLE
[FIX] account: hide Preview button for draft invoices

### DIFF
--- a/addons/account/static/tests/tours/account_invoice_tour.js
+++ b/addons/account/static/tests/tours/account_invoice_tour.js
@@ -1,0 +1,36 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('account_invoice_create', {
+    test: true,
+    url: "/web",
+    steps: () => [
+        {
+            trigger: '.o_app:contains("Accounting")',
+            content: 'Click the Accounting app',
+            run: 'click',
+        },
+        {
+            content: "Go to Customer Invoices",
+            trigger: 'span:contains("Customer")',
+            run: 'click',
+        },
+        {
+            content: "Go to Invoices",
+            trigger: 'a:contains("Invoices")',
+            run: 'click',
+        },
+        {
+            extra_trigger: '.o_breadcrumb .text-truncate:contains("Invoices")',
+            content: "Create new bill",
+            trigger: '.o_control_panel_main_buttons .d-none .o_list_button_add',
+            run: 'click',
+        },
+        {
+            content: 'Ensure Preview button is not visible',
+            trigger: '.o_statusbar_buttons:not(:has(button[name="preview_invoice"]))',
+            run: () => {},
+        },
+    ],
+});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -80,3 +80,7 @@ class TestUi(AccountTestInvoicingCommon, odoo.tests.HttpCase):
         product.supplier_taxes_id = new_tax
 
         self.start_tour("/web", 'account_tax_group', login="admin")
+
+    def test_02_account_invoice(self):
+        """ Test the tour for the invoice creation """
+        self.start_tour("/web", "account_invoice_create", login="admin")

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -694,7 +694,7 @@
                         <!-- Preview (only customer invoices) -->
                         <button name="preview_invoice" type="object" string="Preview" data-hotkey="o"
                                 title="Preview invoice"
-                                invisible="move_type not in ('out_invoice', 'out_refund') or state == 'cancel'"/>
+                                invisible="move_type not in ('out_invoice', 'out_refund') or state in ('draft', 'cancel')"/>
                         <!-- Reverse -->
                         <button name="%(action_view_account_move_reversal)d" string="Reverse Entry"
                                 type="action" groups="account.group_account_invoice" data-hotkey="z"


### PR DESCRIPTION
The "Preview" button was visible even when the invoice was still in draft state, which could mislead users as the feature isn't meant for unposted entries. This fix updates the button visibility condition to exclude both cancelled and draft invoices.

Steps to reproduce:
Go to Invoices
New Invoice
You can see the preview button and if you click on it an error occurs

OPW-4749877

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
