### PR TITLE
[FIX] website_sale: set salesperson on payment confirmation

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -222,6 +222,12 @@ class SaleOrder(models.Model):
         carts.with_context(force_user_recomputation=True)._compute_user_id()
         return super().action_confirm()
 
+    def _send_payment_succeeded_for_order_mail(self):
+        carts = self.filtered('website_id')
+        # Assign a salesman before sending payment confirmation mail.
+        carts.with_context(force_user_recomputation=True)._compute_user_id()
+        return super()._send_payment_succeeded_for_order_mail()
+
     @api.model
     def _get_note_url(self):
         website_id = self._context.get('website_id')


### PR DESCRIPTION
Versions
--------
- saas-18.1+

Steps
-----
1. Ensure admin gets auto-assigned as salesperson to eCommerce orders;
2. open an eCommerce cart and go to checkout;
3. using Demo payment provider, create a "pending" payment.

Issue
-----
Payment confirmation mail is sent from OdooBot instead of admin.

Cause
-----
Commit 27bf2e55810b automatically adds admin as salesperson to eCommerce orders, but only on order confirmation. This means that salesperson does not get notified about pending payments, and the client receives an email from OdooBot instead of a salesperson.

Solution
--------
Set the order's `user_id` before sending the payment confirmation mail.

opw-4765346