### PR TITLE
[IMP] web: domain selector: This day/This month options

### DIFF
--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -27,8 +27,8 @@ import {
 } from "@web/core/tree_editor/tree_editor_autocomplete";
 import { Input, List, Range, Select, Within } from "@web/core/tree_editor/tree_editor_components";
 import {
-    get_OPTIONS_WITH_INPUT,
-    get_OPTIONS_WITH_SELECT,
+    OPTIONS_WITH_INPUT,
+    OPTIONS_WITH_SELECT,
 } from "@web/core/tree_editor/tree_editor_datetime_options";
 import { disambiguate, getResModel, isId } from "@web/core/tree_editor/utils";
 import { unique } from "@web/core/utils/arrays";
@@ -363,10 +363,8 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "date_option":
         case "datetime_option":
         case "time_option": {
-            if (fieldDef.name in get_OPTIONS_WITH_SELECT()) {
-                const { options, defaultValue, isSupported } =
-                    get_OPTIONS_WITH_SELECT()[fieldDef.name];
-                return { ...makeSelectEditor(options, params), defaultValue, isSupported };
+            if (fieldDef.name in OPTIONS_WITH_SELECT) {
+                return OPTIONS_WITH_SELECT[fieldDef.name];
             } else if (fieldDef.name === "__time") {
                 return {
                     component: TimePicker,
@@ -393,7 +391,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
             } else if (fieldDef.name === "__date") {
                 return getValueEditorInfo({ type: "date" }, operator, params);
             }
-            const { defaultValue, isSupported } = get_OPTIONS_WITH_INPUT()[fieldDef.name];
+            const { defaultValue, isSupported } = OPTIONS_WITH_INPUT[fieldDef.name];
             return {
                 ...getValueEditorInfo({ type: "integer" }, operator, params),
                 defaultValue,

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -3197,6 +3197,14 @@ test("date options (readonly)", async () => {
             domain: `[("date.day_of_week", "=", 3)]`,
             text: `Date ➔ Weekday is equal Wednesday`,
         },
+        {
+            domain: `[("date.month_number", "=", context_today().month)]`,
+            text: `Date ➔ Month is equal This month`,
+        },
+        {
+            domain: `[("date.day_of_month", "=", context_today().day)]`,
+            text: `Date ➔ Day of month is equal This day`,
+        },
     ];
     for (const { domain, text } of toTest) {
         await parent.set(domain);
@@ -3240,4 +3248,25 @@ test("date options (edit)", async () => {
     await selectValue(5);
     expect(getCurrentValue()).toBe("May");
     expect.verifySteps([`[("date.month_number", "=", 5)]`]);
+});
+
+test("date options (edit): This day/This month", async () => {
+    mockDate("2025-03-24 17:00:00");
+    await makeDomainSelector({
+        domain: `[("date.month_number", "=", 5)]`,
+        update(domain) {
+            expect.step(domain);
+        },
+    });
+    expect(getCurrentValue()).toBe("May");
+    await selectValue("context_today().month");
+    expect(getCurrentValue()).toBe("This month");
+    expect.verifySteps([`[("date.month_number", "=", context_today().month)]`]);
+    await openModelFieldSelectorPopover();
+    await contains(`.o_model_field_selector_popover_item[data-name='day_of_month'] button`).click();
+    expect.verifySteps([`[("date.day_of_month", "=", 24)]`]);
+    expect(getCurrentValue()).toBe("24");
+    await selectValue("context_today().day");
+    expect(getCurrentValue()).toBe("This day");
+    expect.verifySteps([`[("date.day_of_month", "=", context_today().day)]`]);
 });


### PR DESCRIPTION
For the date options month_number and day_of_month, we introduce the possibility to select the dynamic values "This month" and "This day". This should allow users to launch campaigns based on customer birthday dates for example.

Task ID: 4659055