### PR TITLE
[FIX] point_of_sale: fix price_manually_set calculation

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1695,7 +1695,7 @@ class Product extends PosModel {
         const taxes = this.pos.get_taxes_after_fp(this.taxes_id, order && order.fiscal_position);
         const currentTaxes = this.pos.getTaxesByIds(this.taxes_id);
         const priceAfterFp = this.pos.computePriceAfterFp(unitPrice, currentTaxes);
-        const allPrices = this.pos.compute_all(taxes, priceAfterFp, 1, this.pos.currency.rounding);
+        const allPrices = this.pos.compute_all(taxes, priceAfterFp, quantity, this.pos.currency.rounding);
         return this.pos.config.iface_tax_included === 'total' ? allPrices.total_included : allPrices.total_excluded;
     }
 
@@ -1773,7 +1773,7 @@ class Orderline extends PosModel {
         this.refunded_orderline_id = json.refunded_orderline_id;
         this.price_manually_set = json.price_manually_set ||
             this.get_display_price() !==
-            this.product.get_display_price_discount(this.order.pricelist, this.get_quantity(), this.get_discount()) * this.get_quantity();
+            this.product.get_display_price_discount(this.order.pricelist, this.get_quantity(), this.get_discount());
     }
     clone(){
         var orderline = Orderline.create({},{


### PR DESCRIPTION
###Problem:
When applying a discount on a POS order line using a pricelist, if the unit price has more than two decimal places and the quantity is greater than one, the order line may be incorrectly flagged as manually set due to a rounding mismatch.

This logic was introduced by the following commit: https://github.com/odoo/odoo/commit/775c5c95cf763c14715fd0e82e88ff841371d212

The incorrect behavior is caused by computing the product display price by rounding the unit price first, then multiplying by the quantity, rather than rounding the total.

- Example:
    * Unit price = 30.47619047619047
    * Expected rounded price for 2 quantity: round(unit price * 2) = 60.95
    * Current rounded price for 2 quantity: round(unit price) * 2 = 60.96

The issue only occurs on V16 and V17

###How to reproduce:
    * Create a tax and check **Included in Price**.
    * Add a product with total price (the tax excluded price will be calculated).
    * Check flexible pricelist, and add one to the POS config in settings.
    * Check product prices settings as Tax-Execluded Price.
    * Open a restaurant pos config.
    * Add two units of the product.
    * Go back to main floor and access the table again.
    * Apply the discount (it will not apply).

opw-4731266
