### PR TITLE
[FIX] point_of_sale: correctly delete orderlines in sanitize data cache

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -301,7 +301,9 @@ export class PosData extends Reactive {
             order.lines.some((line) => line.is_reward_line && !line.coupon_id)
         );
         for (const order of order_to_delete) {
-            order.lines.forEach((line) => line.delete());
+            for (let i = order.lines.length - 1; i >= 0; i--) {
+                order.lines[i].delete();
+            }
         }
     }
 


### PR DESCRIPTION
Before this commit, clearing lines in the sanitize data cache used a forward iteration, which caused some lines to be skipped due to index shifting when deleting items. This could result in only half of the lines being removed and potentially lead to errors.

After this commit, order lines are deleted using a backward iteration, ensuring that all lines are properly removed without skipping any.

opw-4770945


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
