### PR TITLE
[IMP] mail: remove /mail/thread/recipients/fields route

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4749,6 +4749,7 @@ class MailThread(models.AbstractModel):
     # ------------------------------------------------------
 
     def _thread_to_store(self, store: Store, fields, *, request_list=None):
+        request_list = request_list or []
         store.add_records_fields(self, fields, as_thread=True)
         for thread in self:
             res = {}
@@ -4762,16 +4763,15 @@ class MailThread(models.AbstractModel):
                 except AccessError:
                     pass
             if (
-                request_list
-                and "activities" in request_list
+               "activities" in request_list
                 and isinstance(self.env[self._name], self.env.registry["mail.activity.mixin"])
             ):
                 res["activities"] = Store.Many(thread.with_context(active_test=True).activity_ids)
-            if request_list and "attachments" in request_list:
+            if "attachments" in request_list:
                 res["attachments"] = Store.Many(thread._get_mail_thread_data_attachments())
                 res["areAttachmentsLoaded"] = True
                 res["isLoadingAttachments"] = False
-            if request_list and "followers" in request_list:
+            if "followers" in request_list:
                 res["followersCount"] = self.env["mail.followers"].search_count(
                     [("res_id", "=", thread.id), ("res_model", "=", self._name)]
                 )
@@ -4795,13 +4795,13 @@ class MailThread(models.AbstractModel):
                     ]
                 )
                 thread._message_followers_to_store(store, filter_recipients=True, reset=True)
-            if request_list and "display_name" in request_list:
+            if "display_name" in request_list:
                 res["display_name"] = thread.display_name
-            if request_list and "scheduledMessages" in request_list:
+            if "scheduledMessages" in request_list:
                 res["scheduledMessages"] = Store.Many(self.env['mail.scheduled.message'].search([
                     ['model', '=', self._name], ['res_id', '=', thread.id]
                 ]))
-            if request_list and "suggestedRecipients" in request_list:
+            if "suggestedRecipients" in request_list:
                 res["suggestedRecipients"] = thread._message_get_suggested_recipients(
                     reply_discussion=True, no_create=True,
                 )

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4771,6 +4771,9 @@ class MailThread(models.AbstractModel):
                 res["attachments"] = Store.Many(thread._get_mail_thread_data_attachments())
                 res["areAttachmentsLoaded"] = True
                 res["isLoadingAttachments"] = False
+            if "contact_fields" in request_list:
+                res["primary_email_field"] = thread._mail_get_primary_email_field()
+                res["partner_fields"] = thread._mail_get_partner_fields()
             if "followers" in request_list:
                 res["followersCount"] = self.env["mail.followers"].search_count(
                     [("res_id", "=", thread.id), ("res_model", "=", self._name)]

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -96,11 +96,11 @@ export class Chatter extends Component {
      * @param {import("models").Thread} thread
      * @param {string[]} requestList
      */
-    load(thread, requestList) {
+    async load(thread, requestList) {
         if (!thread.id || !this.state.thread?.eq(thread)) {
             return;
         }
-        thread.fetchThreadData(requestList);
+        await thread.fetchThreadData(requestList);
     }
 
     onCloseFullComposerCallback() {

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -267,6 +267,10 @@ export class Thread extends Record {
             }
         },
     });
+    /** @type {String[]|undefined} */
+    partner_fields;
+    /** @type {String|undefined} */
+    primary_email_field;
     hasLoadingFailed = false;
     canPostOnReadonly;
     /** @type {luxon.DateTime} */

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -934,6 +934,14 @@ async function search(request) {
     return store.get_result();
 }
 
+registerRoute("/mail/thread/recipients/get_suggested_recipients", get_suggested_recipients);
+/** @type {RouteCallback} */
+async function get_suggested_recipients(request) {
+    const { thread_model, thread_id, partner_ids, main_email } = await parseRequestParams(request);
+    const MailThread = this.env[thread_model];
+    return MailThread._message_get_suggested_recipients([thread_id], partner_ids, main_email);
+}
+
 /** @type {RouteCallback} */
 async function processRequest(request) {
     /** @type {import("mock_models").DiscussChannel} */

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -373,7 +373,7 @@ export class MailThread extends models.ServerModel {
     }
 
     /** @param {number[]} ids */
-    _message_get_suggested_recipients(ids) {
+    _message_get_suggested_recipients(ids, additional_partners = [], primary_email = false) {
         /** @type {import("mock_models").MailThread} */
         const MailThread = this.env["mail.thread"];
         /** @type {import("mock_models").ResFake} */
@@ -384,7 +384,11 @@ export class MailThread extends models.ServerModel {
         const ResUsers = this.env["res.users"];
 
         if (this._name === "res.fake") {
-            return ResFake._message_get_suggested_recipients(ids);
+            return ResFake._message_get_suggested_recipients(
+                ids,
+                additional_partners,
+                primary_email
+            );
         }
         const result = ids.reduce((result, id) => (result[id] = []), {});
         const model = this.env[this._name];
@@ -632,6 +636,10 @@ export class MailThread extends models.ServerModel {
                     makeKwArgs({ only_id: true })
                 );
             }
+        }
+        if (request_list.includes("contact_fields")) {
+            res.primary_email_field = this.env[this._name]._primary_email;
+            res.partner_fields = this.env[this._name]._mail_get_partner_fields?.();
         }
         if (request_list.includes("display_name")) {
             res.display_name = thread.display_name;


### PR DESCRIPTION
This PR removes `/mail/thread/recipients/fields` by embedding the value inside `/mail/data`. This removes up to 2 RPCs done inside chatter `onWillStart` and `updateRecipients`. 

PR enterprise: https://github.com/odoo/enterprise/pull/84661

Task-4685400
