### PR TITLE
[FIX] l10n_ae: division by 0 when printing invoice

### DIFF
--- a/addons/l10n_ae/views/report_invoice_templates.xml
+++ b/addons/l10n_ae/views/report_invoice_templates.xml
@@ -36,8 +36,8 @@
     <template id="document_tax_totals_company_currency_template" inherit_id="account.document_tax_totals_company_currency_template">
         <xpath expr="//p[hasclass('tax_computation_company_currency')]" position="after">
             <tr t-if="o.company_id.country_id.code == 'AE'">
-                <t t-set="exchange_rate"
-                   t-value="abs(o.amount_total_signed) / o.amount_total"/>
+                <t t-set="exchange_rate" t-if="o.amount_total" t-value="abs(o.amount_total_signed) / o.amount_total"/>
+                <t t-set="exchange_rate" t-else="" t-value="o.env['res.currency']._get_conversion_rate(o.currency_id, o.company_id.currency_id, o.company_id, o.invoice_date or datetime.date.today())"/>
                 <td>Exchange Rate</td>
                 <td class="text-end" t-out="exchange_rate" t-options='{"widget": "float", "precision": 5}'/>
             </tr>


### PR DESCRIPTION
Steps to reproduce:
- With an AE Company
- Enable Multicurrency (USD)
- Create an invoice in USD with total 0.00
- Print

Issue: Traceback will raise
"""
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template ZeroDivisionError: float division by zero
Template: account.document_tax_totals_company_currency_template Path: /t/div/table/tr[1]/td[2]
Node: <td class="text-end" t-out="exchange_rate" t-options="{&quot;widget&quot;: &quot;float&quot;, &quot;precision&quot;: 5}"/>
"""

opw-4724401
