### PR TITLE
[IMP] mail, website_livechat: flatten whatsapp_account_name

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -1922,7 +1922,7 @@ class MailCommon(MailCase):
                 data.pop("livechat_channel_id", None)
                 data.pop("operator", None)
             if "whatsapp.message" not in self.env:
-                data.pop("whatsapp_account_name", None)
+                data.pop("wa_account_id", None)
                 data.pop("whatsapp_channel_valid_until", None)
                 data.pop("whatsapp_partner_id", None)
         return list(channels_data)

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -211,7 +211,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "rtc_session_ids": [("ADD", [])],
                         "uuid": channel.uuid,
                         "visitor": {"id": self.visitor.id, "type": "visitor"},
-                        "whatsapp_account_name": False,
+                        "wa_account_id": False,
                         "whatsapp_channel_valid_until": False,
                         "whatsapp_partner_id": False,
                     }
@@ -330,7 +330,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                     "requested_by_operator": False,
                     "rtc_session_ids": [("ADD", [])],
                     "uuid": channel.uuid,
-                    "whatsapp_account_name": False,
+                    "wa_account_id": False,
                     "whatsapp_channel_valid_until": False,
                     "whatsapp_partner_id": False,
                 }


### PR DESCRIPTION
This commit converts `whatsapp_account_name` to it's record `wa_account_id`.

Related: https://github.com/odoo/enterprise/pull/84663

Task-4675978

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
