### PR TITLE
[FIX] html_editor: hide toolbar if it overflows scrollable area

### DIFF
--- a/addons/html_editor/static/src/core/overlay.js
+++ b/addons/html_editor/static/src/core/overlay.js
@@ -1,6 +1,7 @@
 import { Component, onWillDestroy, useEffect, useExternalListener, useRef, xml } from "@odoo/owl";
 import { usePosition } from "@web/core/position/position_hook";
 import { useActiveElement } from "@web/core/ui/ui_service";
+import { closestScrollableY } from "@web/core/utils/scrolling";
 
 export class EditorOverlay extends Component {
     static template = xml`
@@ -137,7 +138,8 @@ export class EditorOverlay extends Component {
         if (this.env.isSmall) {
             return;
         }
-        const containerRect = this.props.getContainer().getBoundingClientRect();
+        const container = closestScrollableY(this.props.editable) || this.props.getContainer();
+        const containerRect = container.getBoundingClientRect();
         overlayElement.style.visibility = solution.top > containerRect.top ? "visible" : "hidden";
     }
 }


### PR DESCRIPTION
Problem:
In a scrollable editable, the floating toolbar may overflow and appear
on top of fixed elements like headers.

Solution:
Detect overflow relative to the scrollable container and hide the
toolbar when it is no longer fully visible.

Before:
![image](https://github.com/user-attachments/assets/7e204481-8ff6-41e6-9486-2a615d4ea734)

After:
![image](https://github.com/user-attachments/assets/44eca207-040b-4d8c-b1ee-87621e00b36d)


Steps to reproduce:
1. Open the TODO app.
2. Add enough content to make the editable scrollable.
3. Open the floating toolbar on the first element.
4. Scroll down.
→ The toolbar overlaps with the page header.

opw-4770575

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
