### PR TITLE
[FIX] sale: restrict access to portal button in email for non-portal …

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1266,17 +1266,6 @@ class SaleOrder(models.Model):
             elif self.state in ('draft', 'sent'):
                 access_opt['title'] = _("View Quotation")
 
-        # enable followers that have access through portal
-        follower_group = next(group for group in groups if group[0] == 'follower')
-        follower_group[2]['active'] = True
-        follower_group[2]['has_button_access'] = True
-        access_opt = follower_group[2].setdefault('button_access', {})
-        if self.state in ('draft', 'sent'):
-            access_opt['title'] = _("View Quotation")
-        else:
-            access_opt['title'] = _("View Order")
-        access_opt['url'] = self._notify_get_action_link('view', **local_msg_vals)
-
         return groups
 
     def _notify_by_email_prepare_rendering_context(self, message, msg_vals=False, model_description=False,

--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -22,3 +22,4 @@ Bernat Puig bernat.puig@forgeflow.com https://github.com/BernatPForgeFlow
 Joan Sisquella joan.sisquella@forgeflow.com https://github.com/JoanSForgeFlow
 Laura Cazorla laura.cazorla@forgeflow.com https://github.com/LauraCForgeFlow
 Arnau Cruz arnau.cruz@forgeflow.com https://github.com/ArnauCForgeFlow
+Marina Alapont marina.alapont@forgeflow.com https://github.com/MarinaAForgeFlow


### PR DESCRIPTION
…followers

**Description of the issue/feature this PR addresses:**

Currently all followers without portal access are able to see the button, in the email notification, that redirects to the portal (to see the quotation or sale order). This may be confusing and misleading, as the button will redirect them to the login page of the portal, to which they do not have access. This PR leaves the followers group options as default (button access disabled for followers) which ensures that only portal users have access.

**Current behavior before PR:**
The 'follower' group in _notify_get_recipients_groups is being explicitly marked with 'has_button_access': True. Therefore followers without portal access are having access to the button.

**Steps to reproduce:**

1. Configure odoo to be able to send out emails.
2. Install sale_management.
3. Create a sale order for a customer and add as follower another partner that has no portal access. This follower needs to have an email you have access to.
4. Send a message to the follower.
5. Test in the received email that the "View Quotation/Order" button is shown and when clicked, the user is redirected to the login page.

**Desired behavior after PR is merged:**
Only followers with portal access will have access to the button.

Note that followers with portal access are directly categorized as 'portal_customer', so that is why it would make sense to simply remove the code where the followers without portal access are given access to the button.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
