### PR TITLE
[FIX] web: stringify rows in export_xlsx export

### DIFF
--- a/addons/web/controllers/pivot.py
+++ b/addons/web/controllers/pivot.py
@@ -89,7 +89,7 @@ class TableExporter(http.Controller):
         # Step 4: writing data
         x = 0
         for row in jdata['rows']:
-            worksheet.write(y, x, row['indent'] * '     ' + row['title'], header_plain)
+            worksheet.write(y, x, f"{row['indent'] * '     '}{row['title']}", header_plain)
             for cell in row['values']:
                 x = x + 1
                 if cell.get('is_bold', False):

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -23,3 +23,4 @@ from . import test_res_users
 from . import test_webmanifest
 from . import test_ir_qweb
 from . import test_reports
+from . import test_pivot_export

--- a/addons/web/tests/test_pivot_export.py
+++ b/addons/web/tests/test_pivot_export.py
@@ -1,0 +1,50 @@
+import io
+import json
+from lxml import etree
+from zipfile import ZipFile
+
+from odoo import http
+from odoo.tests.common import HttpCase
+
+
+class TestPivotExport(HttpCase):
+
+    def test_export_xlsx_with_integer_column(self):
+        """ Test the export_xlsx method of the pivot controller with int columns """
+        self.authenticate('admin', 'admin')
+        jdata = {
+            'title': 'Sales Analysis',
+            'model': 'sale.report',
+            'measure_count': 1,
+            'origin_count': 1,
+            'col_group_headers': [
+                [{'title': 500, 'width': 1, 'height': 1}],
+            ],
+            'measure_headers': [],
+            'origin_headers': [],
+            'rows': [
+                {'title': 1, 'indent': 0, 'values': [{'value': 42}]},
+            ],
+        }
+        response = self.url_open(
+            '/web/pivot/export_xlsx',
+            data={
+                'data': json.dumps(jdata),
+                'csrf_token': http.Request.csrf_token(self),
+            },
+        )
+        response.raise_for_status()
+        zip_file = ZipFile(io.BytesIO(response.content))
+
+        with zip_file.open('xl/worksheets/sheet1.xml') as file:
+            sheet_tree = etree.parse(file)
+        xml_data = {}
+
+        for c in sheet_tree.iterfind('.//{http://schemas.openxmlformats.org/spreadsheetml/2006/main}c'):
+            cell_ref = c.attrib['r']
+            value = c.findtext('{http://schemas.openxmlformats.org/spreadsheetml/2006/main}v')
+            xml_data[cell_ref] = value
+
+        self.assertEqual(xml_data['B1'], '500')
+        self.assertEqual(xml_data['A2'], '0')
+        self.assertEqual(xml_data['B2'], '42')


### PR DESCRIPTION
Steps to reproduce:
- Go to any Report (Ex: Sale Analysis)
- Switch to the pivot view
- Add on y-column any **int** field
- Download as csv

Tracebrack is thrown, because the controller tries to concat int to str in the csv generated file.

opw-4762807

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
