### PR TITLE
[FIX] core: prevent property override with defaults during create

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1941,7 +1941,7 @@ class BaseModel(metaclass=MetaModel):
 
         # delegate the default properties to the properties field
         for field in self._fields.values():
-            if field.type == 'properties':
+            if field.type == 'properties' and field.name not in defaults:
                 defaults[field.name] = field._add_default_values(self.env, defaults)
 
         return defaults


### PR DESCRIPTION
When importing records that include values for "properties" fields, the current logic in `_add_missing_default_values` overwrites those values with defaults, even if the user explicitly provided them.

After this commit we'll only use defaults if the value is not already set.

opw-4714901