### PR TITLE
[FIX] mrp: BoM Overview Fixes

### DIFF
--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -25,7 +25,7 @@ export class BomOverviewComponent extends Component {
 
         this.state = useState({
             showOptions: {
-                mode: 'overview',
+                mode: this.props.action.context.mode || 'overview',
                 uom: false,
                 attachments: false,
             },

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -4,7 +4,7 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
-import { Component } from "@odoo/owl";
+import { Component, onMounted, useRef } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 export class BomOverviewControlPanel extends Component {
@@ -42,6 +42,12 @@ export class BomOverviewControlPanel extends Component {
     setup() {
         this.action = useService("action");
         this.controlPanelDisplay = {};
+        if(this.props.showOptions.mode == "forecast") {
+            this.quantity = useRef("quantity");
+            onMounted(() => {
+                this.quantity.el.focus();
+            });
+        }
     }
 
     //---- Handlers ----

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -39,7 +39,7 @@
                                 <label class="visually-hidden" for="bom_quantity"/>
                                 <div t-attf-class="input-group align-items-center">
                                     <div class="col-4 col-md-auto px-2 fw-bold">Quantity</div>
-                                    <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0"/>
+                                    <input id="bom_quantity" type="number" step="any" t-on-change="ev => this.updateQuantity(ev)" t-on-keypress="ev => this.onKeyPress(ev)" t-att-value="props.bomQuantity" min="1" size="7" class="o_input form-control rounded-0" t-ref="quantity"/>
                                     <div t-if="props.showOptions.uom" t-out="props.uomName" class="d-flex align-items-center text-muted small lh-sm"/>
                                 </div>
                             </form>
@@ -52,7 +52,7 @@
                     <t t-if="props.warehouses.length > 1" class="btn-group flex-grow-1 flex-md-grow-0">
                         <Dropdown items="warehousesItems">
                             <button class="btn btn-secondary o-dropdown-caret">
-                                <span class="fa fa-home"/> Warehouse
+                                <span class="fa fa-home"/> Warehouse: <t t-out="props.currentWarehouse.name"/>
                             </button>
                         </Dropdown>
                     </t>

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
@@ -18,7 +18,7 @@ patch(ForecastedButtons.prototype, {
                 active_id: this.bomId,
                 active_product_id: this.productId,
                 active_model: this.resModel,
-                activate_availabilities : true,
+                mode: "forecast",
             },
         });
     }

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.xml
@@ -3,7 +3,7 @@
     <t t-name="mrp.ForecastedButtons" t-inherit="stock.ForecastedButtons" t-inherit-mode="extension">
         <xpath expr="//button[@title='Replenish']" position="after">
             <button t-if="bomId" t-name="mrp_replenish_report_buttons"
-                class="btn btn-primary o_bom_overview_report"
+                class="btn btn-secondary o_bom_overview_report"
                 type="button" title="Manufacturing Forecast"
                 t-on-click="_onClickBom">
                 Manufacturing Forecast

--- a/addons/mrp/static/src/widgets/mrp_workcenter_capacity_product.js
+++ b/addons/mrp/static/src/widgets/mrp_workcenter_capacity_product.js
@@ -1,23 +1,17 @@
 import { Component } from "@odoo/owl";
 import { registry } from "@web/core/registry";
-import { createMany2OneValue } from "@web/model/relational_model/utils";
 import { computeM2OProps, Many2One } from "@web/views/fields/many2one/many2one";
 import { buildM2OFieldDescription, Many2OneField } from "@web/views/fields/many2one/many2one_field";
 
 export class WorkcenterCapacityProduct extends Many2One {
-
-    get value() {
-        let result = super.value;
-        if (result === null && this.props.readonly) {
-            result = createMany2OneValue([false, this.props.placeholder]);
-        }
-        return result;
-    }
+    static template = "mrp.WorkcenterCapacityProduct";
+    static components = { ...Many2One.components };
+    static props = { ...Many2One.props };
 }
 
 export class WorkcenterCapacityProductField extends Component {
-    static template = "web.Many2OneField";
-    static components = { Many2One: WorkcenterCapacityProduct };
+    static template = "mrp.WorkcenterCapacityProductField";
+    static components = { WorkcenterCapacityProduct };
     static props = { ...Many2OneField.props };
 
     get m2oProps() {

--- a/addons/mrp/static/src/widgets/mrp_workcenter_capacity_product.xml
+++ b/addons/mrp/static/src/widgets/mrp_workcenter_capacity_product.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+ <!-- t-inherit-mode="primary" -->
+
+     <t t-name="mrp.WorkcenterCapacityProductField">
+        <WorkcenterCapacityProduct t-props="m2oProps"/>
+    </t>
+
+    <t t-name="mrp.WorkcenterCapacityProduct" t-inherit="web.Many2One">
+        <xpath expr="//t[@t-if='props.value']" position="after">
+            <t t-else="">
+                <span t-esc="props.placeholder"/>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/mrp/views/mrp_workcenter_views.xml
+++ b/addons/mrp/views/mrp_workcenter_views.xml
@@ -344,7 +344,7 @@
                             <page string="Product Capacities" name="capacity">
                                 <field name="capacity_ids" context="{'default_workcenter_id': id}">
                                     <list editable="bottom">
-                                        <field name="product_id" widget="mrp_workcenter_capacity_product" placeholder="All Products"/>
+                                        <field name="product_id" widget="mrp_workcenter_capacity_product" placeholder="All Products" decoration-it="not product_id"/>
                                         <field name="capacity"/>
                                         <field name="product_uom_id" groups="uom.group_uom" widget="many2one_uom" readonly="product_id != False"/>
                                         <field name="time_start" widget="float_time"/>


### PR DESCRIPTION
- in workcenter's capacity tab, make All Products italic and not clickable
- selected warehouse name should appear like in forecast report
- make 'Manufacturing Forecast' button secondary and open the BoM overview in forecast mode with focus on quantity field

task: 4751983

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
