### PR TITLE
[IMP] web: domain selector: no technical operators

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -14,7 +14,6 @@ export function getDomainDisplayedOperators(fieldDef) {
                 return ["=", "!=", "set", "not_set"];
         }
     }
-    const hierarchyOperators = fieldDef.allow_hierachy_operators ? ["child_of", "parent_of"] : [];
     switch (type) {
         case "boolean":
             return ["set", "not_set"];
@@ -82,13 +81,10 @@ export function getDomainDisplayedOperators(fieldDef) {
                 "!=",
                 "ilike",
                 "not ilike",
-                ...hierarchyOperators,
                 "set",
                 "not_set",
                 "starts_with",
                 "ends_with",
-                "any",
-                "not any",
             ];
         case "json":
             return ["=", "!=", "ilike", "not ilike", "set", "not_set"];


### PR DESCRIPTION
We no longer propose the operators any, not any, child_of, and parent_of for selection in the domain selector. Nevertheless, it is still possible to present/manipulate them if they are introduced via the debug area in debug mode.

Part of task ID: 4610804