### PR TITLE
[FIX] mrp: test without demo

### DIFF
--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5331,7 +5331,10 @@ class TestTourMrpOrder(HttpCase):
             'product_id': product.id,
             'product_uom_qty': 1.0,
         })
-
+        self.env['product.product'].create({
+            'name': 'Component',
+            'is_storable': True,
+        })
         self.assertEqual(len(mo.move_raw_ids), 0)
         url = f'/odoo/action-mrp.mrp_production_action/{mo.id}'
 

--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -102,9 +102,13 @@ class TestProcurement(TestMrpCommon):
     def test_procurement_2(self):
         """Check that a manufacturing order create the right procurements when the route are set on
         a parent category of a product"""
-        # find a child category id
-        child_categ_id = self.env['product.category'].search([('parent_id', '!=', False)], limit=1)
-        all_categ_id = child_categ_id.parent_id
+        all_categ_id = self.env['product.category'].create({
+            'name': 'All',
+        })
+        child_categ_id = self.env['product.category'].create({
+            'name': 'Child',
+            'parent_id': all_categ_id.id,
+        })
 
         # set the product of `self.bom_1` to this child category
         for bom_line_id in self.bom_1.bom_line_ids:

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -14,6 +14,7 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         super().setUpClass()
         # Required for `uom_id` to be visible in the view
         cls.env.user.group_ids += cls.env.ref('uom.group_uom')
+        cls.env.user.group_ids += cls.env.ref('product.group_product_variant')
         # Required for `manufacture_steps` to be visible in the view
         cls.env.user.group_ids += cls.env.ref('stock.group_adv_location')
         # Create warehouse


### PR DESCRIPTION
-test_order: Create a product to have at least one in the catalog and be able to select it in the tour
-test_procurement: Create the category for the test -test_warehouse_mutlistep: Enable variant in setup to run the same way than with demo

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
