### PR TITLE
[FIX] im_livechat: my sessions filter not working as intended

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -8,7 +8,7 @@
             <field name="arch" type="xml">
                 <search string="Search history">
                     <field name="name" string="Participant"/>
-                    <filter name="filter_my_sessions" domain="[('livechat_operator_id.user_id', '=', uid)]" string="My Sessions"/>
+                    <filter name="filter_my_sessions" domain="[('livechat_operator_id.user_ids', '=', uid)]" string="My Sessions"/>
                     <separator/>
                     <filter name="filter_session_date" date="create_date" string="Session Date"/>
                     <separator/>


### PR DESCRIPTION
**purpose of this PR:**

using `partner_id.user_id` only returns the salesperson assigned to the partner, which isn’t always the correct user. We now use `partner_id.user_ids` instead to resolve the issue.

task-4770457

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
