### PR TITLE
[FIX] mail: fold the chat window when clicking odoo links in mobile

### DIFF
--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -392,6 +392,7 @@ export class Store extends BaseStore {
     handleClickOnLink(ev, thread) {
         const model = ev.target.dataset.oeModel;
         const id = Number(ev.target.dataset.oeId);
+        let handled = false;
         if (ev.target.closest(".o_channel_redirect") && model && id) {
             ev.preventDefault();
             this.Thread.getOrFetch({ model, id }).then((thread) => {
@@ -399,13 +400,31 @@ export class Store extends BaseStore {
                     thread.open({ focus: true });
                 }
             });
-            return true;
+            handled = true;
         } else if (ev.target.closest(".o_mail_redirect") && id) {
             ev.preventDefault();
             this.openChat({ partnerId: id });
-            return true;
+            handled = true;
         }
-        return false;
+        if (!handled && this.env.services.ui.isSmall && ev.target.closest(".o-mail-ChatWindow")) {
+            const link = ev.target.closest("a");
+            if (link?.href && !link.href.startsWith("#")) {
+                let url;
+                try {
+                    url = new URL(link.href);
+                } catch {
+                    // Ignore invalid URLs
+                    return handled;
+                }
+                if (
+                    browser.location.host === url.host &&
+                    browser.location.pathname.startsWith("/odoo")
+                ) {
+                    this.ChatWindow.get({ thread })?.fold();
+                }
+            }
+        }
+        return handled;
     }
 
     setup() {

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -789,17 +789,17 @@ test("folded chat window should hide member-list and settings buttons", async ()
     await contains(".o-dropdown-item", { text: "Call Settings" });
 });
 
-test("Chat window in mobile are not foldable", async () => {
+test("chat window: fold (mobile)", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({});
     patchUiSize({ size: SIZES.SM });
-    setupChatHub({ opened: [channelId] });
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-ChatWindow");
-    await contains(".o-mail-ChatWindow-header.cursor-pointer", { count: 0 });
-    await click(".o-mail-ChatWindow-header");
-    await contains(".o-mail-Thread"); // content => non-folded
+    await contains(".o-mail-ChatBubble", { count: 0 });
+    await click(".o-mail-ChatWindow-command[title='Fold']");
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-mail-ChatBubble");
 });
 
 test("Synced chat windows should open at page load on mobile", async () => {

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -13,6 +13,7 @@ import {
 import { describe, test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { Deferred } from "@odoo/hoot-mock";
+import { browser } from "@web/core/browser/browser";
 
 describe.current.tags("mobile");
 defineMailModels();
@@ -101,4 +102,19 @@ test.skip("can add message reaction (mobile)", async () => {
     await click(".modal .o-EmojiPicker .o-Emoji:contains('🤣')");
     await contains(".o-mail-MessageReaction:contains('🤣')");
     await contains(".o-mail-MessageReaction:contains('😀')");
+});
+
+test("click on an odoo link should fold the chat window (mobile)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({});
+    patchUiSize({ size: SIZES.SM });
+    await start();
+    await openDiscuss(channelId);
+    await insertText(".o-mail-Composer-input", `http://${browser.location.host}/odoo.com`);
+    await click(".o-mail-Composer button[title='Send']");
+    await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-ChatBubble", { count: 0 });
+    await click(`a[href="http://${browser.location.host}/odoo.com"]`);
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-mail-ChatBubble");
 });


### PR DESCRIPTION
Clicking on an odoo link in the chat window will take the user to the related page in odoo. However, in mobile view, the chat window remains unfolded and covers the entire page, so the user can't see the newly opened page below the chat window unless they fold the chat window.
This change fixes this by folding the chat window in mobile view when clicking an odoo link inside the chat window.

task-4762503

