### PR TITLE
[FIX] web: correct many2many assignment mock server

### DIFF
--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -3061,7 +3061,7 @@ export class Model extends Array {
                         const inverseData = command[2]; // write in place instead of copy, because some tests rely on the object given being updated
                         const inverseFieldName = field.inverse_fname_by_model_name?.[coModel._name];
                         if (inverseFieldName) {
-                            inverseData[inverseFieldName] = id;
+                            inverseData[inverseFieldName] = field.type === "many2many" ? [id] : id;
                         }
                         const [newId] = coModel.create([inverseData]);
                         ids.push(newId);


### PR DESCRIPTION
Before this commit, using CREATE Command on a many2many field would result in an error.
This is because upon record creation the inverse field would be set to the single id, which is incorrect for a many2many field.

This commit fixes the issue by setting the inverse field of a many2many to a list containing the new id.
