### PR TITLE
[IMP] (website_)sale,*: increase uom support

### DIFF
--- a/addons/l10n_ar_website_sale/models/product_template.py
+++ b/addons/l10n_ar_website_sale/models/product_template.py
@@ -43,9 +43,9 @@ class ProductTemplate(models.Model):
 
         return res
 
-    def _get_additionnal_combination_info(self, product_or_template, quantity, date, website):
+    def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
         combination_info = super()._get_additionnal_combination_info(
-            product_or_template, quantity, date, website
+            product_or_template, quantity, uom, date, website
         )
         pricelist_prices = request.pricelist._compute_price_rule(self, 1.0)
 

--- a/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
+++ b/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
@@ -54,6 +54,7 @@ class TestL10nArWebsiteSale(WebsiteSaleCommon, TestAr):
             return self.product_1._get_additionnal_combination_info(
                 product_or_template=product_id or self.product_1,
                 quantity=quantity,
+                uom=self.uom_unit,
                 date=datetime(2025, 5, 21),
                 website=self.ar_website
             )

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -1449,6 +1449,31 @@ class ProductTemplate(models.Model):
             ])
         ])
 
+    def _get_list_price(self, price):
+        """ Get the product sales price from a public price based on taxes defined on the product.
+        To be overridden in accounting module."""
+        self.ensure_one()
+        return price
+
+    @api.model
+    def _service_tracking_blacklist(self) -> list:
+        """ Service tracking field is used to distinguish some specific categories of products.
+        Those products shouldn't be displayed or used in unrelated applications.
+        This method returns a domain targeting all those specific products (events, courses, ...).
+        """
+        return []
+
+    def _has_multiple_uoms(self) -> bool:
+        if self.type == 'combo':
+            return False
+        return self.env['res.groups']._is_feature_enabled('uom.group_uom') and len(
+            self._get_available_uoms()
+        ) > 1
+
+    def _get_available_uoms(self):
+        self.ensure_one()
+        return self.uom_id | self.uom_ids
+
     ###################
     # DEMO DATA SETUP #
     ###################
@@ -1466,17 +1491,3 @@ class ProductTemplate(models.Model):
                 'record': acoustic_bloc_screens.product_variant_ids[1],
                 'noupdate': True,
             }])
-
-    def _get_list_price(self, price):
-        """ Get the product sales price from a public price based on taxes defined on the product.
-        To be overridden in accounting module."""
-        self.ensure_one()
-        return price
-
-    @api.model
-    def _service_tracking_blacklist(self):
-        """ Service tracking field is used to distinguish some specific categories of products.
-        Those products shouldn't be displayed or used in unrelated applications.
-        This method returns a domain targeting all those specific products (events, courses, ...).
-        """
-        return []

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -292,10 +292,9 @@ class ProductTemplate(models.Model):
 
     @api.model
     def _get_additional_configurator_data(
-        self, product_or_template, date, currency, pricelist, **kwargs
+        self, product_or_template, date, currency, pricelist, *, uom=None, **kwargs
     ):
-        """ Return additional data about the specified product, to be used by the product and combo
-        configurators.
+        """Return additional data about the specified product.
 
         This is a hook meant to append module-specific data in overriding modules.
 
@@ -304,6 +303,7 @@ class ProductTemplate(models.Model):
         :param datetime date: The date to use to compute prices.
         :param res.currency currency: The currency to use to compute prices.
         :param product.pricelist pricelist: The pricelist to use to compute prices.
+        :param uom.uom uom: The uom to use to compute prices.
         :param dict kwargs: Locally unused data passed to overrides.
         :rtype: dict
         :return: A dict containing additional data about the specified product.

--- a/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
+++ b/addons/sale/static/src/js/combo_configurator_dialog/combo_configurator_dialog.js
@@ -78,7 +78,12 @@ export class ComboConfiguratorDialog extends Component {
                 currencyId: this.props.currency_id,
                 soDate: this.props.date,
                 edit: true, // Hide the optional products, if any.
-                options: { canChangeVariant: false, showQuantity: false, showPrice: false },
+                options: {
+                    canChangeVariant: false,
+                    showQuantity: false,
+                    showPrice: false,
+                    showPackaging: false,
+                },
                 save: async configuredProduct => {
                     const selectedComboItem = comboItem.deepCopy();
                     selectedComboItem.product.ptals = configuredProduct.attribute_lines.map(

--- a/addons/sale/static/src/js/product/product.js
+++ b/addons/sale/static/src/js/product/product.js
@@ -6,6 +6,7 @@ import {
 } from "../product_template_attribute_line/product_template_attribute_line";
 import { QuantityButtons } from '../quantity_buttons/quantity_buttons';
 import { getSelectedCustomPtav } from "../sale_utils";
+import { _t } from "@web/core/l10n/translation";
 
 export class Product extends Component {
     static components = { PTAL, QuantityButtons };
@@ -17,6 +18,8 @@ export class Product extends Component {
         description_sale: [Boolean, String], // backend sends 'false' when there is no description
         price: Number,
         quantity: Number,
+        uom: { type: Object, optional: true },
+        available_uoms: { type: Object, optional: true },
         attribute_lines: Object,
         optional: Boolean,
         imageURL: { type: String, optional: true },
@@ -71,4 +74,14 @@ export class Product extends Component {
             || ptal.create_variant === 'no_variant'
             || !!getSelectedCustomPtav(ptal);
     }
+
+
+    get UoMTitle() {
+        return _t("Packaging");
+    }
+
+    async selectUoM(event) {
+        this.env.setUoM(this.props.product_tmpl_id, parseInt(event.target.value));
+    }
+
 }

--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -34,3 +34,11 @@
         margin-right: -9rem;
     }
 }
+
+.o_sale_product_configurator_uom_choice.active label {
+    $-btn-secondary-design: map-get($o-btns-bs-override, "secondary");
+
+    background-color: map-get($-btn-secondary-design, active-background);
+    border-color: map-get($-btn-secondary-design, active-border);
+    color: map-get($-btn-secondary-design, active-color);
+}

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -27,6 +27,7 @@
             <div t-if="!this.env.isPossibleCombination(this.props)" class="alert alert-warning impossible_combination_alert mt-3">
                 <span>This option or combination of options is not available</span>
             </div>
+            <t t-if="this.props.available_uoms" t-call="sale.uom_selector"/>
         </td>
         <t t-if="!this.props.optional">
             <td
@@ -85,5 +86,35 @@
             class="h5 text-nowrap"
             t-out="getFormattedPrice()"/>
         <div t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
+    </t>
+
+    <t t-name="sale.uom_selector">
+        <div class="d-flex flex-column flex-lg-row align-items-center gap-2 mb-2">
+            <label t-out="UoMTitle" class="fw-bold text-break col-lg-3"/>
+            <ul class="list-inline list-unstyled flex-grow-1 mb-0">
+                <li
+                    t-foreach="this.props.available_uoms"
+                    t-as="uom"
+                    t-key="`${this.props.product_tmpl_id}-${uom.id}`"
+                    t-att-class="{'active': uom.id == props.uom.id}"
+                    class="o_sale_product_configurator_uom_choice list-inline-item"
+                >
+                    <label
+                        class="btn btn-outline-secondary"
+                        t-attf-for="{{this.props.product_tmpl_id}}-{{uom.id}}-input"
+                        t-out="uom.display_name"
+                    />
+                    <input
+                        class="btn-check"
+                        type="radio"
+                        t-attf-id="{{this.props.product_tmpl_id}}-{{uom.id}}-input"
+                        t-att-value="uom.id"
+                        t-attf-name="uom-{{this.props.product_tmpl_id}}"
+                        t-att-checked="uom.id == props.uom.id"
+                        t-on-change="selectUoM"
+                    />
+                </li>
+            </ul>
+        </div>
     </t>
 </templates>

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -41,12 +41,18 @@ async function applyProduct(record, product) {
 
     // We use `_update` (not locked) instead of `update` (locked) so that multiple records can be
     // updated in parallel (for performance).
-    await record._update({
+    const update_values = {
         product_id: { id: product.id, display_name: product.display_name },
         product_uom_qty: product.quantity,
         product_no_variant_attribute_value_ids: [x2ManyCommands.set(noVariantPTAVIds)],
         product_custom_attribute_value_ids: customAttributesCommands,
-    });
+    }
+    if (product.uom) {
+        // only update uom field if uom are enabled (uom_data provided), otherwise we don't have the display_name
+        // and the value isn't expected to change anyway.
+        update_values.product_uom_id = product.uom;
+    }
+    await record._update(update_values);
 }
 
 export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -46,6 +46,18 @@ function removeOptionalProduct(productName) {
     };
 }
 
+function decreaseProductQuantity(productName) {
+    return {
+        content: `Decrease the quantity of ${productName}`,
+        trigger: `
+            ${productSelector(productName)}
+            td.o_sale_product_configurator_qty
+            button:has(i.fa-minus)
+        `,
+        run: 'click',
+    };
+}
+
 function increaseProductQuantity(productName) {
     return {
         content: `Increase the quantity of ${productName}`,
@@ -67,6 +79,18 @@ function setProductQuantity(productName, quantity) {
             input[name="sale_quantity"]
         `,
         run: `edit ${quantity} && click .modal-body`,
+    };
+}
+
+function setProductUoM(productName, uomName) {
+    // UoM must be enabled
+    return {
+        content: `Set the uom of ${productName} to ${uomName}`,
+        trigger: `
+            ${productSelector(productName)}
+            label:contains("${uomName}")
+        `,
+        run: `click && click .modal-body`,
     };
 }
 
@@ -219,7 +243,9 @@ export default {
     addOptionalProduct,
     removeOptionalProduct,
     increaseProductQuantity,
+    decreaseProductQuantity,
     setProductQuantity,
+    setProductUoM,
     assertProductQuantity,
     selectAttribute,
     setCustomAttribute,

--- a/addons/sale/tests/product_configurator_common.py
+++ b/addons/sale/tests/product_configurator_common.py
@@ -6,10 +6,10 @@ from odoo.fields import Command
 from odoo.tests import HttpCase
 from odoo.tools.misc import file_open
 
-from odoo.addons.base.tests.common import BaseCommon
+from odoo.addons.uom.tests.common import UomCommon
 
 
-class TestProductConfiguratorCommon(BaseCommon, HttpCase):
+class TestProductConfiguratorCommon(UomCommon, HttpCase):
 
     @classmethod
     def setUpClass(cls):
@@ -52,19 +52,17 @@ class TestProductConfiguratorCommon(BaseCommon, HttpCase):
             'name': 'Customizable Desk (TEST)',
             'standard_price': 500.0,
             'list_price': 750.0,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': cls.product_attribute_1.id,
+                    'value_ids': [Command.link(product_attribute_value_1.id), Command.link(product_attribute_value_2.id)],
+                }),
+                Command.create({
+                    'attribute_id': product_attribute_2.id,
+                    'value_ids': [Command.link(product_attribute_value_3.id), Command.link(product_attribute_value_4.id)],
+                })
+            ]
         })
-
-        # Generate variants
-        cls.env['product.template.attribute.line'].create([{
-            'product_tmpl_id': cls.product_product_custo_desk.id,
-            'attribute_id': cls.product_attribute_1.id,
-            'value_ids': [(4, product_attribute_value_1.id), (4, product_attribute_value_2.id)],
-        }, {
-            'product_tmpl_id': cls.product_product_custo_desk.id,
-            'attribute_id': product_attribute_2.id,
-            'value_ids': [(4, product_attribute_value_3.id), (4, product_attribute_value_4.id)],
-
-        }])
 
         # Apply a price_extra for the attribute Aluminium
         cls.product_product_custo_desk.attribute_line_ids[0].product_template_value_ids[1].price_extra = 50.40

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_uom_choice.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_uom_choice.js
@@ -1,0 +1,59 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+import configuratorTourUtils from "@sale/js/tours/product_configurator_tour_utils";
+import tourUtils from "@sale/js/tours/tour_utils";
+
+registry.category("web_tour.tours").add('sale_product_configurator_uom_tour', {
+    url: '/odoo',
+    steps: () => [
+        ...stepUtils.goToAppSteps("sale.sale_menu_root", "Go to the Sales App"),
+        ...tourUtils.createNewSalesOrder(),
+        ...tourUtils.selectCustomer('Tajine Saucisse'),
+        {
+            content: "search the pricelist",
+            trigger: 'input[id="pricelist_id_0"]',
+            // Wait for onchange to come back
+            run: "edit Test",
+        },
+        {
+            content: "search the pricelist",
+            trigger: 'input[id="pricelist_id_0"]',
+            run: "edit Custo",
+        },
+        {
+            content: "select the pricelist",
+            trigger: 'ul.ui-autocomplete > li > a:contains(Custom pricelist (TEST))',
+            run: "click",
+        },
+        ...tourUtils.addProduct("Customizable Desk (TEST)"),
+        configuratorTourUtils.assertProductPrice("Customizable Desk (TEST)", "750.00"),
+        configuratorTourUtils.increaseProductQuantity("Customizable Desk (TEST)"),
+        configuratorTourUtils.assertProductPrice("Customizable Desk (TEST)", "600.00"),
+        configuratorTourUtils.decreaseProductQuantity("Customizable Desk (TEST)"),
+        configuratorTourUtils.assertProductPrice("Customizable Desk (TEST)", "750.00"),
+        configuratorTourUtils.setProductUoM("Customizable Desk (TEST)", "Dozens"),
+        configuratorTourUtils.assertProductPrice("Customizable Desk (TEST)", "7,200.00"),
+        configuratorTourUtils.addOptionalProduct("Conference Chair"),
+        configuratorTourUtils.assertProductPrice("Conference Chair", "16.50"),
+        configuratorTourUtils.increaseProductQuantity("Conference Chair"),
+        configuratorTourUtils.assertProductPrice("Conference Chair", "16.50"),
+        configuratorTourUtils.setProductUoM("Conference Chair", "Dozens"),
+        configuratorTourUtils.assertProductPrice("Conference Chair", "198.00"),
+        configuratorTourUtils.addOptionalProduct("Chair floor protection"),
+        configuratorTourUtils.assertProductPrice("Chair floor protection", "12.00"),
+        configuratorTourUtils.increaseProductQuantity("Chair floor protection"),
+        configuratorTourUtils.assertPriceTotal("7,620.00"),
+        ...configuratorTourUtils.saveConfigurator(),
+        {
+            content: "verify SO final price excluded",
+            trigger: 'span[name="Untaxed Amount"]:contains("7,620.00")',
+            run: "click",
+        },
+        {
+            content: "verify SO final price included",
+            trigger: 'span[name="amount_total"]:contains("8,700.00")',
+            run: "click",
+        },
+        ...stepUtils.saveForm()
+    ]
+});

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -19,7 +19,7 @@ class UomUom(models.Model):
     _description = 'Product Unit of Measure'
     _parent_name = 'relative_uom_id'
     _parent_store = True
-    _order = "relative_uom_id, name, id"
+    _order = 'sequence, relative_uom_id, id'
 
     def _unprotected_uom_xml_ids(self):
         return [
@@ -29,6 +29,7 @@ class UomUom(models.Model):
         ]
 
     name = fields.Char('Unit Name', required=True, translate=True)
+    sequence = fields.Integer(compute="_compute_sequence", store=True, readonly=False, precompute=True)
     relative_factor = fields.Float(
         'Contains', default=1.0, digits=0, required=True,  # force NUMERIC with unlimited precision
         help='How much bigger or smaller this unit is compared to the reference UoM for this unit')
@@ -43,6 +44,34 @@ class UomUom(models.Model):
         'CHECK (relative_factor!=0)',
         'The conversion ratio for a unit of measure cannot be 0!',
     )
+
+    # === COMPUTE METHODS === #
+
+    @api.depends('relative_factor')
+    def _compute_sequence(self):
+        for uom in self:
+            if uom.id and uom.sequence:
+                # Only set a default sequence before the record creation, or on module update if
+                # there is no value.
+                continue
+            uom.sequence = int(uom.relative_factor * 100.0)
+
+    def _compute_rounding(self):
+        """ All Units of Measure share the same rounding precision defined in 'Product Unit'.
+            Set in a compute to ensure compatibility with previous calls to `uom.rounding`.
+        """
+        decimal_precision = self.env['decimal.precision'].precision_get('Product Unit')
+        self.rounding = 10 ** -decimal_precision
+
+    @api.depends('relative_factor', 'relative_uom_id', 'relative_uom_id.factor')
+    def _compute_factor(self):
+        for uom in self:
+            if uom.relative_uom_id:
+                uom.factor = uom.relative_factor * uom.relative_uom_id.factor
+            else:
+                uom.factor = uom.relative_factor
+
+    # === ONCHANGE METHODS === #
 
     @api.onchange('relative_factor')
     def _onchange_critical_fields(self):
@@ -60,11 +89,15 @@ class UomUom(models.Model):
                 }
             }
 
+    # === CONSTRAINT METHODS === #
+
     @api.constrains('relative_factor', 'relative_uom_id')
     def _check_factor(self):
         for uom in self:
             if not uom.relative_uom_id and uom.relative_factor != 1.0:
                 raise UserError(_("Reference unit of measure is missing."))
+
+    # === CRUD METHODS === #
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_master_data(self):
@@ -74,6 +107,8 @@ class UomUom(models.Model):
                 "The following units of measure are used by the system and cannot be deleted: %s\nYou can archive them instead.",
                 ", ".join(locked_uoms.mapped('name')),
             ))
+
+    # === BUSINESS METHODS === #
 
     def round(self, value: float, rounding_method: RoundingMethod = 'HALF-UP') -> float:
         """Round the value using the 'Product Unit' precision"""
@@ -161,21 +196,6 @@ class UomUom(models.Model):
         if to_unit:
             amount = amount / self.factor
         return amount
-
-    @api.depends('relative_factor', 'relative_uom_id', 'relative_uom_id.factor')
-    def _compute_factor(self):
-        for uom in self:
-            if uom.relative_uom_id:
-                uom.factor = uom.relative_factor * uom.relative_uom_id.factor
-            else:
-                uom.factor = uom.relative_factor
-
-    def _compute_rounding(self):
-        """ All Units of Measure share the same rounding precision defined in 'Product Unit'.
-            Set in a compute to ensure compatibility with previous calls to `uom.rounding`.
-        """
-        decimal_precision = self.env['decimal.precision'].precision_get('Product Unit')
-        self.rounding = 10 ** -decimal_precision
 
     def _filter_protected_uoms(self):
         """Verifies self does not contain protected uoms."""

--- a/addons/uom/tests/common.py
+++ b/addons/uom/tests/common.py
@@ -15,6 +15,7 @@ class UomCommon(BaseCommon):
         cls.uom_ton = cls.quick_ref('uom.product_uom_ton')
         cls.uom_unit = cls.quick_ref('uom.product_uom_unit')
         cls.uom_dozen = cls.quick_ref('uom.product_uom_dozen')
+        cls.uom_dozen.active = True
         cls.uom_hour = cls.quick_ref('uom.product_uom_hour')
 
         cls.group_uom = cls.quick_ref('uom.group_uom')

--- a/addons/uom/views/uom_uom_views.xml
+++ b/addons/uom/views/uom_uom_views.xml
@@ -5,6 +5,7 @@
         <field name="model">uom.uom</field>
         <field name="arch" type="xml">
             <list string="Units &amp; Packagings">
+                <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="relative_factor" invisible="relative_factor == 1 and not relative_uom_id" digits="[12, 3]"/>
                 <field name="relative_uom_id"/>

--- a/addons/website_event_booth_sale/models/sale_order.py
+++ b/addons/website_event_booth_sale/models/sale_order.py
@@ -7,11 +7,11 @@ from odoo.fields import Command
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def _cart_find_product_line(self, product_id, *, event_booth_pending_ids=None, **kwargs):
+    def _cart_find_product_line(self, *args, event_booth_pending_ids=None, **kwargs):
         """Check if there is another sale order line which already contains the requested event_booth_pending_ids
         to overwrite it with the newly requested booths to avoid having multiple so_line related to the same booths"""
         lines = super()._cart_find_product_line(
-            product_id, event_booth_pending_ids=event_booth_pending_ids, **kwargs,
+            *args, event_booth_pending_ids=event_booth_pending_ids, **kwargs,
         )
 
         if not event_booth_pending_ids:
@@ -21,19 +21,24 @@ class SaleOrder(models.Model):
             lambda line: any(booth.id in event_booth_pending_ids for booth in line.event_booth_pending_ids)
         )
 
-    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **kwargs):
         """Forbid quantity updates on event booth lines."""
         product = self.env['product.product'].browse(product_id)
         if product.service_tracking == 'event_booth' and new_qty > 1:
             return 1, _('You cannot manually change the quantity of an Event Booth product.')
-        return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)
+        return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)
 
     def _prepare_order_line_values(
-        self, product_id, quantity, *, event_booth_pending_ids=False, registration_values=None,
+        self, *args, event_booth_pending_ids=False, registration_values=None,
         **kwargs
     ):
         """Add corresponding event to the SOline creation values (if booths are provided)."""
-        values = super()._prepare_order_line_values(product_id, quantity, **kwargs)
+        values = super()._prepare_order_line_values(
+            *args,
+            event_booth_pending_ids=event_booth_pending_ids,
+            registration_values=registration_values,
+            **kwargs,
+        )
 
         if not event_booth_pending_ids:
             return values

--- a/addons/website_sale/controllers/variant.py
+++ b/addons/website_sale/controllers/variant.py
@@ -16,17 +16,19 @@ class WebsiteSaleVariantController(Controller):
         readonly=True,
     )
     def get_combination_info_website(
-        self, product_template_id, product_id, combination, add_qty, **kwargs
+        self, product_template_id, product_id, combination, add_qty, uom_id=None, **kwargs
     ):
         product_template_id = product_template_id and int(product_template_id)
         product_id = product_id and int(product_id)
+        add_qty = (add_qty and float(add_qty)) or 1.0
 
         product_template = request.env['product.template'].browse(product_template_id)
 
         combination_info = product_template._get_combination_info(
             combination=request.env['product.template.attribute.value'].browse(combination),
             product_id=product_id,
-            add_qty=add_qty and float(add_qty) or 1.0,
+            add_qty=add_qty,
+            uom_id=uom_id,
         )
 
         # Pop data only computed to ease server-side computations.

--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -300,7 +300,11 @@ class ProductProduct(models.Model):
         combination_info = self.with_context(
             **price_context,
         ).product_tmpl_id._get_additionnal_combination_info(
-            self, 1.0, fields.Date.context_today(self), request.website,
+            self,
+            quantity=1.0,
+            uom=self.uom_id,
+            date=fields.Date.context_today(self),
+            website=request.website,
         )
         if combination_info['prevent_zero_price_sale']:
             return {}

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -25,6 +25,15 @@ class SaleOrderLine(models.Model):
     def get_description_following_lines(self):
         return self.name.splitlines()[1:]
 
+    def _get_combination_name(self):
+        return self.product_id.product_template_attribute_value_ids._get_combination_name()
+
+    def _get_line_header(self):
+        if not self.product_template_attribute_value_ids:
+            return self.name_short
+        # not display_name because we don't want the combination name or the code.
+        return self.product_id.name
+
     def _get_order_date(self):
         self.ensure_one()
         if self.order_id.website_id and self.state == 'draft':

--- a/addons/website_sale/security/ir.model.access.csv
+++ b/addons/website_sale/security/ir.model.access.csv
@@ -41,14 +41,20 @@ access_product_template_attribute_exclusion_employee,product.template.attribute 
 access_product_template_attribute_line_public_public,product.template.attribute line public,product.model_product_template_attribute_line,base.group_public,1,0,0,0
 access_product_template_attribute_line_public_portal,product.template.attribute line public,product.model_product_template_attribute_line,base.group_portal,1,0,0,0
 access_product_template_attribute_line_public_employee,product.template.attribute line public,product.model_product_template_attribute_line,base.group_user,1,0,0,0
+
 access_fiscal_position_public,fiscal position public,account.model_account_fiscal_position,base.group_portal,1,0,0,0
 access_payment_term,payment term public,account.model_account_payment_term,base.group_portal,1,0,0,0
 access_account_tax_user,account.tax,account.model_account_tax,base.group_public,1,0,0,0
+
 access_product_image_public_public,product.image public,model_product_image,base.group_public,1,0,0,0
 access_product_image_public_portal,product.image public,model_product_image,base.group_portal,1,0,0,0
 access_product_image_public_employee,product.image public,model_product_image,base.group_user,1,0,0,0
-access_product_image_restricted_editor,product.image wbesite restricted_editor,model_product_image,website.group_website_restricted_editor,1,1,1,1
+access_product_image_restricted_editor,product.image website restricted_editor,model_product_image,website.group_website_restricted_editor,1,1,1,1
 access_product_image_sale,product.image sale,model_product_image,sales_team.group_sale_manager,1,1,1,1
+
+access_uom_public,uom.uom public,uom.model_uom_uom,base.group_public,1,0,0,0
+access_uom_portal,uom.uom portal,uom.model_uom_uom,base.group_portal,1,0,0,0
+
 access_ecom_extra_fields_public_public,access_ecom_extra_field public,model_website_sale_extra_field,base.group_public,1,0,0,0
 access_ecom_extra_fields_public_portal,access_ecom_extra_field public,model_website_sale_extra_field,base.group_portal,1,0,0,0
 access_ecom_extra_fields_public_employee,access_ecom_extra_field public,model_website_sale_extra_field,base.group_user,1,0,0,0

--- a/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.js
@@ -13,6 +13,8 @@ export class AddToCartNotification extends Component {
                     linked_line_id: { type: Number, optional: true },
                     image_url: String,
                     quantity: Number,
+                    uom_name: { type: String, optional: true },
+                    combination_name: { type: String, optional: true },
                     name: String,
                     description: { type: String, optional: true },
                     line_price_total: Number,
@@ -55,16 +57,4 @@ export class AddToCartNotification extends Component {
         return formatCurrency(price, this.props.currency_id);
     }
 
-    /**
-     * Return the product summary based on the line information.
-     *
-     * The product summary is computed based on the line quantity and name, separated by the symbol
-     * 'x' (e.g.: 1 x Chair Floor Protection).
-     *
-     * @param {Object} line - The line element for which to return the product summary.
-     * @return {String} - The product summary.
-     */
-    getProductSummary(line) {
-        return line.quantity + " x " + line.name;
-    }
 }

--- a/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.xml
+++ b/addons/website_sale/static/src/js/notification/add_to_cart_notification/add_to_cart_notification.xml
@@ -2,7 +2,12 @@
 <templates xml:space="preserve">
 
     <t t-name="website_sale.addToCartNotification">
-        <div class="row g-2 mb-2" t-foreach="mainLines" t-as="line" t-key="line.id">
+        <div
+            class="d-flex flex-column gap-2 mb-2 mt-1"
+            t-foreach="mainLines"
+            t-as="line"
+            t-key="line.id"
+        >
             <t t-call="website_sale.cartLine"/>
         </div>
         <a role="button" class="w-100 btn btn-primary" href="/shop/cart">
@@ -11,25 +16,36 @@
     </t>
 
     <t t-name="website_sale.cartLine">
-        <div class="col-2" t-if="line.linked_line_id"/>
-        <div class="col-3">
-            <img
-                class="img o_image_64_max rounded mb-2 img-fluid"
-                t-att-src="line.image_url"
-                t-att-alt="line.name"
+        <div class="d-flex gap-3">
+            <div class="position-relative">
+                <img
+                    class="img o_image_64_max rounded mb-2 img-fluid"
+                    t-att-src="line.image_url"
+                    t-att-alt="line.name"
+                />
+                <span
+                    class="o_cart_item_count badge bg-secondary position-absolute top-0 start-100 translate-middle"
+                    t-out="line.quantity"
+                />
+            </div>
+            <div class="d-flex flex-column align-items-start flex-grow-1">
+                <span t-out="line.name"/>
+                <span
+                    t-if="line.combination_name"
+                    class="text-muted small"
+                    t-out="line.combination_name"
+                />
+                <span t-if="line.description" class="text-muted small" t-out="line.description"/>
+                <span t-out="line.uom_name" class="badge mt-1 bg-light"/>
+            </div>
+            <div
+                class="col-3 d-flex flex-column align-items-end gap-1"
+                t-if="!line.linked_line_id"
+                t-out="getFormattedPrice(line)"
             />
         </div>
-        <div class="col-6 d-flex flex-column align-items-start">
-            <span t-out="getProductSummary(line)"/>
-            <span class="text-muted small" t-if="line.description" t-out="line.description"/>
-        </div>
         <div
-            class="col-3 d-flex flex-column align-items-end gap-1"
-            t-if="!line.linked_line_id"
-            t-out="getFormattedPrice(line)"
-        />
-        <div
-            class="row"
+            class="d-flex ps-5"
             t-foreach="getLinkedLines(line.id)"
             t-as="linkedLine"
             t-key="linkedLine.id"

--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.js
@@ -7,7 +7,7 @@ export class CartNotification extends Component {
     static template = "website_sale.cartNotification";
     static props = {
         message: [String, { toString: Function }],
-        warning: {type : [String, { toString: Function }],optional: true},
+        warning: {type : [String, { toString: Function }], optional: true},
         lines: {
             type: Array,
             optional: true,
@@ -18,7 +18,9 @@ export class CartNotification extends Component {
                     linked_line_id: { type: Number, optional: true },
                     image_url: String,
                     quantity: Number,
+                    uom_name: { type: String, optional: true },
                     name: String,
+                    combination_name: { type: String, optional: true },
                     description: { type: String, optional: true },
                     line_price_total: Number,
                 },

--- a/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.xml
+++ b/addons/website_sale/static/src/js/notification/cart_notification/cart_notification.xml
@@ -7,13 +7,6 @@
              role="alert"
              aria-live="assertive"
              aria-atomic="true">
-            <div class="toast-header justify-content-between">
-                <strong t-if="props.message" t-out="props.message"/>
-                <button class="btn-close"
-                        type="button"
-                        t-on-click="props.close"
-                        aria-label="Close"/>
-            </div>
             <div class="toast-body">
                 <WarningNotification t-if="this.props.warning" warning="this.props.warning"/>
                 <AddToCartNotification

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -62,6 +62,7 @@ var VariantMixin = {
             'product_id': this._getProductId($parent),
             'combination': combination,
             'add_qty': parseInt($parent.find('input[name="add_qty"]').val()),
+            'uom_id': this._getUoMId($parent[0]),
             'context': this.context,
             ...this._getOptionalCombinationInfoParam($parent),
         }).then((combinationData) => {
@@ -71,6 +72,10 @@ var VariantMixin = {
             this._onChangeCombination(ev, $parent, combinationData);
             this._checkExclusions($parent, combination);
         });
+    },
+
+    _getUoMId: function (element) {
+        return parseInt(element.querySelector('input[name="uom_id"]:checked')?.value)
     },
 
     /**

--- a/addons/website_sale/static/src/js/tours/tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/tour_utils.js
@@ -57,16 +57,26 @@ export function assertCartAmounts({taxes = false, untaxed = false, total = false
     return steps
 }
 
-export function assertCartContains({productName, backend, notContains = false} = {}) {
+export function assertCartContains({productName, backend, notContains = false, combinationName = false} = {}) {
     let trigger = `h6:contains(${productName})`;
 
     if (notContains) {
         trigger = `:not(${trigger})`;
     }
-    return {
+    let steps = [{
         content: `Checking if ${productName} is in the cart`,
         trigger: `${backend ? ":iframe" : ""} ${trigger}`,
-    };
+    }];
+
+    if (combinationName) {
+        const combination_trigger = `span[class*=h6]:contains(${combinationName})`;
+        steps.push({
+            content: `Checking if ${combinationName} is the chosen combination in the cart`,
+            trigger: `${backend ? ":iframe" : ""} ${combination_trigger}`,
+        })
+    }
+
+    return steps;
 }
 
 /**

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -571,6 +571,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             'input[type="radio"][name="product_id"]:checked',
         ].join(','))?.value);
         const quantity = parseFloat(form.querySelector('input[name="add_qty"]')?.value);
+        const uomId = this._getUoMId(form);
         const isCombo = form.querySelector(
             'input[type="hidden"][name="product_type"]'
         )?.value === 'combo';
@@ -580,6 +581,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
                 'input[type="hidden"][name="product_template_id"]',
             ).value),
             ...(quantity ? {quantity: quantity} : {}),
+            ...(uomId ? {uomId: uomId} : {}),
             ptavs: this._getSelectedPTAV(form),
             productCustomAttributeValues: this._getCustomPTAVValues(form),
             noVariantAttributeValues: this._getSelectedNoVariantPTAV(form),

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -79,8 +79,8 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
             content: "Wait for the redirection to the cart page",
             trigger: ":iframe h4:contains(order summary)",
         },
-        assertCartContains({productName: 'Product No Variant', backend: true}),
-        assertCartContains({productName: 'Product Yes Variant 1 (Red)', backend: true}),
-        assertCartContains({productName: 'Product Yes Variant 2 (Pink)', backend: true}),
+        ...assertCartContains({productName: 'Product No Variant', backend: true}),
+        ...assertCartContains({productName: 'Product Yes Variant 1', combinationName: 'Red', backend: true}),
+        ...assertCartContains({productName: 'Product Yes Variant 2', combinationName: 'Pink', backend: true}),
     ],
 );

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -10,25 +10,15 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
         }),
         {
             content: "check that 1 website_sale_cart_notification_product_1 was added",
-            trigger: '.toast-body span:contains("1 x website_sale_cart_notification_product_1")',
+            trigger: '.toast-body span:contains("website_sale_cart_notification_product_1")',
+        },
+        {
+            content: "check that 1 website_sale_cart_notification_product_1 was added",
+            trigger: '.toast-body span:contains("1")',
         },
         {
             content: "check the price of 1 website_sale_cart_notification_product_1",
             trigger: '.toast-body div:contains("$ 1,000.00")',
-        },
-        {
-            content: "close the notification",
-            trigger: ".toast-header button.btn-close",
-            run: "click",
-        },
-        {
-            content: "check that the notification is closed",
-            trigger: "div.position-fixed.w-100.h-100.top-0.pe-none",
-            run() {
-                if (this.anchor.querySelectorAll("div").length !== 1) {
-                    console.error("The cart notification is not closed!");
-                }
-            },
         },
         ...tourUtils.searchProduct("website_sale_cart_notification_product_2", { select: true }),
         {
@@ -46,7 +36,11 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
         },
         {
             content: "check that 3 website_sale_cart_notification_product_2 was added",
-            trigger: '.toast-body span:contains("3 x website_sale_cart_notification_product_2")',
+            trigger: '.toast-body span:contains("website_sale_cart_notification_product_2")',
+        },
+        {
+            content: "check that 3 website_sale_cart_notification_product_2 was added",
+            trigger: '.toast-body span:contains("3")',
         },
         {
             content: "check that the novariants/custom attributes are displayed.",
@@ -62,11 +56,11 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
             run: "click",
             expectUnloadPage: true,
         },
-        tourUtils.assertCartContains({
+        ...tourUtils.assertCartContains({
             productName: "website_sale_cart_notification_product_1",
             backend: false,
         }),
-        tourUtils.assertCartContains({
+        ...tourUtils.assertCartContains({
             productName: "website_sale_cart_notification_product_2",
             backend: false,
         }),

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -26,9 +26,9 @@ registry
                 run: 'click',
                 expectUnloadPage: true,
             },
-            wsTourUtils.assertCartContains({ productName: "Combo product" }),
-            wsTourUtils.assertCartContains({ productName: "3 x Product A1" }),
-            wsTourUtils.assertCartContains({ productName: "3 x Product B2" }),
+            ...wsTourUtils.assertCartContains({ productName: "Combo product" }),
+            ...wsTourUtils.assertCartContains({ productName: "3 x Product A1" }),
+            ...wsTourUtils.assertCartContains({ productName: "3 x Product B2" }),
             {
                 content: "Verify the first combo item's attributes",
                 trigger: 'div.o_cart_product:contains("No variant attribute: B: Some custom value")',
@@ -51,8 +51,8 @@ registry
                 trigger: 'div[name="website_sale_cart_line_quantity"] input.quantity',
                 run: "edit 2 && click body",
             },
-            wsTourUtils.assertCartContains({ productName: "2 x Product A1" }),
-            wsTourUtils.assertCartContains({ productName: "2 x Product B2" }),
+            ...wsTourUtils.assertCartContains({ productName: "2 x Product A1" }),
+            ...wsTourUtils.assertCartContains({ productName: "2 x Product B2" }),
             {
                 content: "Verify the combo product's price",
                 trigger: 'h6[name="website_sale_cart_line_price"]:contains(62.00)',

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configuration.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator_single_configuration.js
@@ -9,7 +9,7 @@ registry
             ...wsTourUtils.addToCart({ productName: "Combo product", search: false, expectUnloadPage: true }),
             wsTourUtils.goToCart(),
             // Assert that the combo configurator wasn't shown.
-            wsTourUtils.assertCartContains({ productName: "Combo product" }),
-            wsTourUtils.assertCartContains({ productName: "1 x Test product" }),
+            ...wsTourUtils.assertCartContains({ productName: "Combo product" }),
+            ...wsTourUtils.assertCartContains({ productName: "1 x Test product" }),
         ],
    });

--- a/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
+++ b/addons/website_sale/static/tests/tours/website_sale_reorder_from_portal.js
@@ -19,8 +19,8 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             run: "click",
             expectUnloadPage: true,
         },
-        assertCartContains({productName: 'Reorder Product 1'}),
-        assertCartContains({productName: 'Reorder Product 2'}),
+        ...assertCartContains({productName: 'Reorder Product 1'}),
+        ...assertCartContains({productName: 'Reorder Product 2'}),
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",
@@ -53,8 +53,8 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             run: "click",
             expectUnloadPage: true,
         },
-        assertCartContains({productName: 'Reorder Product 1'}),
-        assertCartContains({productName: 'Reorder Product 2'}),
+        ...assertCartContains({productName: 'Reorder Product 1'}),
+        ...assertCartContains({productName: 'Reorder Product 2'}),
         {
             content: "Check that quantity is 2",
             trigger: ".js_quantity[value='2']",
@@ -87,8 +87,8 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             run: "click",
             expectUnloadPage: true,
         },
-        assertCartContains({productName: 'Reorder Product 1'}),
-        assertCartContains({productName: 'Reorder Product 2'}),
+        ...assertCartContains({productName: 'Reorder Product 1'}),
+        ...assertCartContains({productName: 'Reorder Product 2'}),
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",
@@ -127,7 +127,7 @@ registry.category("web_tour.tours").add('website_sale_reorder_from_portal', {
             run: "click",
             expectUnloadPage: true,
         },
-        assertCartContains({productName: 'Reorder Product 1'}),
+        ...assertCartContains({productName: 'Reorder Product 1'}),
         {
             content: "Check that quantity is 1",
             trigger: ".js_quantity[value='1']",

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -48,7 +48,7 @@ configuratorTourUtils.assertPriceTotal("1,228.50"),
     run: 'click',
     expectUnloadPage: true,
 },
-tourUtils.assertCartContains({
+...tourUtils.assertCartContains({
     productName: "Customizable Desk (TEST)",
     backend: false,
 }),

--- a/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_dynamic_variants.js
@@ -28,9 +28,9 @@ registry.category("web_tour.tours").add('tour_shop_dynamic_variants', {
         trigger: '#add_to_cart',
         run: "click",
     },
-        tourUtils.goToCart(),
-    {
-        content: "check the variant is in the cart",
-        trigger: 'div>a>h6:contains(Dynamic Product (Dynamic Value 2))',
-    },
+    tourUtils.goToCart(),
+    ...tourUtils.assertCartContains({
+        productName: 'Dynamic Product',
+        combinationName: 'Dynamic Value 2',
+    }),
 ]});

--- a/addons/website_sale/static/tests/tours/website_sale_update_cart.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_cart.js
@@ -35,6 +35,7 @@ registry.category('web_tour.tours').add('shop_update_cart', {
             run: "click",
             expectUnloadPage: true,
         },
+        ...tourUtils.assertCartContains({productName: 'Conference Chair', combinationName: 'Steel'}),
         {
             content: "add suggested",
             trigger: '.js_cart_lines:has(a:contains("Storage Box")) button:contains("Add to cart")',
@@ -46,12 +47,11 @@ registry.category('web_tour.tours').add('shop_update_cart', {
         },
         {
             content: "add one more",
-            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Steel")) a.js_add_cart_json:eq(1)',
+            trigger: '#cart_products div:has(a[name="o_cart_line_product_link"]>h6:contains("Conference Chair")) a.js_add_cart_json:eq(1)',
             run: "click",
         },
         {
-            trigger:
-                '#cart_products div:has(div>a>h6:contains("Steel")) input.js_quantity:value(2)',
+            trigger: '#cart_products div:has(div>a>h6:contains("Conference Chair")) input.js_quantity:value(2)',
         },
         {
             content: "remove Storage Box",

--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -55,11 +55,11 @@
         },
         {
             content: "Check always variant",
-            trigger: 'div>a>h6:contains(M always)',
+            trigger: 'span[class*=h6]:contains(M always)',
         },
         {
             content: "Check dynamic variant",
-            trigger: 'div>a>h6:contains(M dynamic)',
+            trigger: 'span[class*=h6]:contains(M dynamic)',
         },
         {
             content: "Check never variant",

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -91,30 +91,25 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
         product_short = self.env['product.template'].create({
             'name': 'Short (TEST)',
             'website_published': True,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': always_attribute.id,
+                    'value_ids': [(4, always_S.id), (4, always_M.id)],
+                }),
+                Command.create({
+                    'attribute_id': dynamic_attribute.id,
+                    'value_ids': [(4, dynamic_S.id), (4, dynamic_M.id)],
+                }),
+                Command.create({
+                    'attribute_id': never_attribute.id,
+                    'value_ids': [(4, never_S.id), (4, never_M.id)],
+                }),
+                Command.create({
+                    'attribute_id': never_attribute_custom.id,
+                    'value_ids': [(4, never_custom_no.id), (4, never_custom_yes.id)],
+                }),
+            ]
         })
-
-        self.env['product.template.attribute.line'].create([
-            {
-                'product_tmpl_id': product_short.id,
-                'attribute_id': always_attribute.id,
-                'value_ids': [(4, always_S.id), (4, always_M.id)],
-            },
-            {
-                'product_tmpl_id': product_short.id,
-                'attribute_id': dynamic_attribute.id,
-                'value_ids': [(4, dynamic_S.id), (4, dynamic_M.id)],
-            },
-            {
-                'product_tmpl_id': product_short.id,
-                'attribute_id': never_attribute.id,
-                'value_ids': [(4, never_S.id), (4, never_M.id)],
-            },
-            {
-                'product_tmpl_id': product_short.id,
-                'attribute_id': never_attribute_custom.id,
-                'value_ids': [(4, never_custom_no.id), (4, never_custom_yes.id)],
-            },
-        ])
 
         # Add an optional product to trigger the modal window
         optional_product = self.env['product.template'].create({

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1850,8 +1850,12 @@
 
     <!-- /shop/product page -->
     <template id="base_unit_price" name="Product Base unit price">
-        (<span class="o_base_unit_price" t-esc="base_unit_price" t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"/>
-         / <span class="oe_custom_base_unit" t-field="product.base_unit_name"/>)
+        <span
+            class="o_base_unit_price"
+            t-esc="base_unit_price"
+            t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"
+        />
+         / <span class="oe_custom_base_unit" t-field="product.base_unit_name"/>
     </template>
 
     <template id="product" name="Product" track="1">
@@ -2739,12 +2743,30 @@
                         <div class="d-flex gap-3">
                             <div class="flex-grow-1 text-wrap w-100">
                                 <div class="d-flex justify-content-between">
-                                    <t t-call="website_sale.cart_line_product_link">
-                                        <h6
-                                            t-field="line.name_short"
-                                            class="d-inline align-top fw-bold text-wrap small"
-                                        />
-                                    </t>
+                                    <div class="d-md-flex flex-md-wrap column-gap-md-2 align-items-md-center">
+                                        <t t-call="website_sale.cart_line_product_link">
+                                            <h6
+                                                t-out="line._get_line_header()"
+                                                class="mb-0 fw-bold text-wrap small"
+                                            />
+                                        </t>
+                                        <t t-set="combination_name" t-value="line._get_combination_name()"/>
+                                        <div
+                                            t-if="combination_name or line.product_template_id._has_multiple_uoms()"
+                                            class="d-inline-flex flex-wrap column-gap-2 row-gap-1 align-items-center my-1 my-md-0 w-100 w-md-auto"
+                                        >
+                                            <span
+                                                t-if="combination_name"
+                                                class="h6 text-muted small mb-0"
+                                                t-out="combination_name"
+                                            />
+                                            <span
+                                                t-if="line.product_template_id._has_multiple_uoms()"
+                                                class="badge bg-light"
+                                                t-out="line.product_uom_id.name"
+                                            />
+                                        </div>
+                                    </div>
                                     <div
                                         t-attf-class="{{'d-block d-md-none' if not is_combo else ''}}"
                                         t-call="website_sale.cart_lines_price"
@@ -2781,7 +2803,7 @@
                             <div t-if="not is_combo" class="d-none d-md-block">
                                 <t t-call="website_sale.cart_lines_price"/>
                                 <div
-                                    class="d-none d-md-block"
+                                    class="d-none d-md-block mt-2"
                                     t-call="website_sale.cart_lines_quantity"
                                 />
                             </div>
@@ -2869,7 +2891,7 @@
 
     <template id="cart_lines_price" name="Shopping Cart Line Price">
         <h6
-            class="d-flex flex-column flex-md-row align-items-end align-items-md-start justify-content-md-end small fw-bold"
+            class="d-flex flex-column flex-md-row align-items-end align-items-md-start justify-content-md-end mb-0 small fw-bold"
             name="website_sale_cart_line_price"
         >
             <t t-if="line.discount and line._is_sellable() and line._get_displayed_unit_price()">
@@ -2881,20 +2903,20 @@
             </t>
             <t t-set="product_price" t-value="line._get_cart_display_price()"/>
             <t t-call="website_sale.cart_product_price"/>
-            <small
-                t-if="line._is_sellable() and line.env['res.groups']._is_feature_enabled('website_sale.group_show_uom_price') and line.product_id.base_unit_price"
-                class="cart_product_base_unit_price d-block text-muted"
-                groups="website_sale.group_show_uom_price"
-            >
-                <t t-call="website_sale.base_unit_price">
-                    <t t-set="product" t-value="line.product_id"/>
-                    <t
-                        t-set="base_unit_price"
-                        t-value="product._get_base_unit_price(product_price/line.product_uom_qty)"
-                    />
-                </t>
-            </small>
         </h6>
+        <small
+            t-if="line._is_sellable() and line.env['res.groups']._is_feature_enabled('website_sale.group_show_uom_price') and line.product_id.base_unit_price"
+            class="cart_product_base_unit_price d-block text-muted text-end"
+            groups="website_sale.group_show_uom_price"
+        >
+            <t t-call="website_sale.base_unit_price">
+                <t t-set="product" t-value="line.product_id"/>
+                <t
+                    t-set="base_unit_price"
+                    t-value="product._get_base_unit_price(product_price/line.product_uom_qty)"
+                />
+            </t>
+        </small>
     </template>
 
     <template id="cart_combo_item_line">
@@ -3632,9 +3654,13 @@
                                 class="td-product_name td-qty w-100 pt-3"
                                 name="website_sale_cart_summary_product_name"
                             >
-                                <span class="text-wrap">
-                                    <t t-out="line.name_short"/>
-                                </span>
+                                <span class="text-wrap" t-out="line._get_line_header()"/>
+                                <p class="text-muted small mb-0" t-out="line._get_combination_name()"/>
+                                <span
+                                    t-if="line.product_template_id._has_multiple_uoms()"
+                                    class="badge mt-1 bg-light"
+                                    t-out="line.product_uom_id.name"
+                                />
                             </td>
                             <td class="td-price pe-0 pt-3 text-end"
                                 name="website_sale_cart_summary_line_price">

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -158,6 +158,36 @@
                 </li>
             </t>
         </ul>
+        <ul
+            t-if="product._has_multiple_uoms()"
+            t-attf-class="o_wsale_product_page_variants d-flex flex-column gap-4 list-unstyled js_add_cart_variants mt-4 pt-3 #{ul_class}"
+            t-att-data-attribute_exclusions="json.dumps(attribute_exclusions)"
+        >
+            <!-- NOTE: the t-att-data-attribute_exclusions is only there to match existing events selectors -->
+            <li>
+                <!-- Separate template to reduce views duplication -->
+                <t t-call="website_sale.packaging_title"/>
+                <ul class="btn-group-toggle list-inline list-unstyled" data-bs-toggle="buttons">
+                    <t t-set="product_uoms" t-value="product._get_available_uoms()"/>
+                    <t t-foreach="product_uoms" t-as="uom">
+                        <t t-set="is_main_uom" t-value="uom.id == product.uom_id.id"/>
+                        <li t-attf-class="o_variant_pills border btn m-0 cursor-pointer #{'active border-primary text-primary-emphasis bg-primary-subtle' if is_main_uom else ''}">
+                            <input
+                                class="position-absolute opacity-0 cursor-pointer"
+                                type="radio"
+                                t-att-checked="is_main_uom"
+                                name="uom_id"
+                                t-att-value="uom.id"
+                                t-attf-id="uom-{{uom.id}}"
+                                t-att-autocomplete="off"/>
+                            <label class="radio_input_value cursor-pointer" t-attf-for="uom-{{uom.id}}">
+                                <span t-field="uom.name"/>
+                            </label>
+                        </li>
+                    </t>
+                </ul>
+            </li>
+        </ul>
     </template>
     <template id="badge_extra_price" name="Badge Extra Price">
         <t t-set="price_extra" t-value="ptav._get_extra_price(combination_info)"/>
@@ -181,6 +211,9 @@
                 "display_currency": website.currency_id
             }'/><t t-if="attribute.display_type in ['pills', 'select']">)</t>
         </span>
+    </template>
+    <template id="website_sale.packaging_title" name="Packaging title">
+        <h6 class="attribute_name mb-2">Packaging</h6>
     </template>
     <template
         id="variants_separator"

--- a/addons/website_sale_collect/models/product_template.py
+++ b/addons/website_sale_collect/models/product_template.py
@@ -9,11 +9,11 @@ from odoo.addons.website_sale_collect import utils
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    def _get_additionnal_combination_info(self, product_or_template, quantity, date, website):
+    def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
         """ Override of `website_sale` to add information on whether Click & Collect is enabled and
         on the stock of the product. """
         res = super()._get_additionnal_combination_info(
-            product_or_template, quantity, date, website
+            product_or_template, quantity, uom, date, website
         )
         if (
             bool(website.sudo().in_store_dm_id)  # Click & Collect is enabled.

--- a/addons/website_sale_collect/models/sale_order.py
+++ b/addons/website_sale_collect/models/sale_order.py
@@ -152,7 +152,7 @@ class SaleOrder(models.Model):
                     unavailable_order_lines |= ol
         return unavailable_order_lines
 
-    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **kwargs):
         """ Override of `website_sale_stock` to skip the verification when click and collect
         is activated. The quantity is verified later. """
         product = self.env['product.product'].browse(product_id)
@@ -162,4 +162,4 @@ class SaleOrder(models.Model):
             and self.website_id.in_store_dm_id
         ):
             return new_qty, ''
-        return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)
+        return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)

--- a/addons/website_sale_gelato/models/sale_order.py
+++ b/addons/website_sale_gelato/models/sale_order.py
@@ -6,7 +6,7 @@ from odoo import _, models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **kwargs):
         """ Override of `website_sale` to prevent mixing Gelato and non-Gelato products in the cart.
 
         This check is not redundant with the constraint on `sale.order` in `sale_gelato` because the
@@ -33,4 +33,4 @@ class SaleOrder(models.Model):
                 " shipping. Please place your order for the current cart first.",
                 product_name=product.name,
             )
-        return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)
+        return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -248,9 +248,9 @@ class SaleOrder(models.Model):
                         res[coupon] = reward
         return res
 
-    def _cart_find_product_line(self, product_id, **kwargs):
+    def _cart_find_product_line(self, *args, **kwargs):
         # Filter out reward lines, they shouldn't be modified by standard _cart_add logic.
         # This kind of lines is handled by _update_programs_and_rewards and _auto_apply_rewards.
-        return super()._cart_find_product_line(product_id, **kwargs).filtered(
+        return super()._cart_find_product_line(*args, **kwargs).filtered(
             lambda sol: not sol.is_reward_line
         )

--- a/addons/website_sale_loyalty/models/sale_order_line.py
+++ b/addons/website_sale_loyalty/models/sale_order_line.py
@@ -8,6 +8,11 @@ from odoo import models
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
+    def _get_line_header(self):
+        if self.is_reward_line:
+            return self.name
+        return super()._get_line_header()
+
     def _show_in_cart(self):
         # Hide discount lines from website_order_line, see `order._compute_website_order_line`
         return self.reward_id.reward_type != 'discount' and super()._show_in_cart()

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -220,10 +220,6 @@
 
 
     <template id="cart_line_product_no_link" inherit_id="website_sale.cart_lines">
-        <xpath expr="//h6[@t-field='line.name_short']" position="replace">
-            <h6 t-if="line.is_reward_line" class="d-inline align-top fw-bold text-wrap small" t-field="line.name"/>
-            <t t-else="">$0</t>
-        </xpath>
         <xpath expr="//div[@name='o_wsale_cart_line_button_container']" position="before">
             <t t-if="line.is_reward_line" t-call="sale_loyalty.used_gift_card"/>
         </xpath>

--- a/addons/website_sale_slides/models/sale_order.py
+++ b/addons/website_sale_slides/models/sale_order.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, _
+from odoo import _, models
 
 
 class SaleOrder(models.Model):
@@ -33,9 +32,9 @@ class SaleOrder(models.Model):
 
         return result
 
-    def _verify_updated_quantity(self, order_line, product_id, new_qty, **kwargs):
+    def _verify_updated_quantity(self, order_line, product_id, new_qty, uom_id, **kwargs):
         """Forbid quantity updates on courses lines."""
         product = self.env['product.product'].browse(product_id)
         if product.service_tracking == 'course' and new_qty > 1:
             return 1, _('You can only add a course once in your cart.')
-        return super()._verify_updated_quantity(order_line, product_id, new_qty, **kwargs)
+        return super()._verify_updated_quantity(order_line, product_id, new_qty, uom_id, **kwargs)

--- a/addons/website_sale_stock/tests/test_website_sale_stock_product_template.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_product_template.py
@@ -63,7 +63,11 @@ class TestWebsiteSaleStockProductTemplate(HttpCase, WebsiteSaleStockCommon):
             combination_info = self.env['product.template'].with_context(
                 website_sale_stock_get_quantity=True
             )._get_additionnal_combination_info(
-                combo_product, quantity=3, date=datetime(2000, 1, 1), website=self.website
+                combo_product,
+                quantity=3,
+                uom=combo_product.uom_id,
+                date=datetime(2000, 1, 1),
+                website=self.website
             )
 
         self.assertEqual(combination_info['max_combo_quantity'], 2)
@@ -79,7 +83,11 @@ class TestWebsiteSaleStockProductTemplate(HttpCase, WebsiteSaleStockCommon):
             combination_info = self.env['product.template'].with_context(
                 website_sale_stock_get_quantity=True
             )._get_additionnal_combination_info(
-                combo_product, quantity=3, date=datetime(2000, 1, 1), website=self.website
+                combo_product,
+                quantity=3,
+                uom=combo_product.uom_id,
+                date=datetime(2000, 1, 1),
+                website=self.website
             )
 
         self.assertNotIn('max_combo_quantity', combination_info)

--- a/addons/website_sale_stock_wishlist/models/product_template.py
+++ b/addons/website_sale_stock_wishlist/models/product_template.py
@@ -6,8 +6,8 @@ from odoo import models
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
-    def _get_additionnal_combination_info(self, product_or_template, quantity, date, website):
-        res = super()._get_additionnal_combination_info(product_or_template, quantity, date, website)
+    def _get_additionnal_combination_info(self, product_or_template, quantity, uom, date, website):
+        res = super()._get_additionnal_combination_info(product_or_template, quantity, uom, date, website)
 
         if not self.env.context.get('website_sale_stock_wishlist_get_wish'):
             return res


### PR DESCRIPTION
Allow users & customers to select the unit of measure in the product configurator (backend & frontend) and the product page on the ecommerce.

Also includes a redesign of the quantities display on the ecommerce (cart notifications, cart summary, cart page).

task-4485463




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
