### PR TITLE
[IMP] web: Hide trailing zeros

### DIFF
--- a/addons/web/static/src/core/currency.js
+++ b/addons/web/static/src/core/currency.js
@@ -24,6 +24,8 @@ export function getCurrency(id) {
  * @param {boolean} [options.noSymbol] this currency has not a sympbol
  * @param {boolean} [options.humanReadable] if true, large numbers are formatted
  *   to a human readable format.
+ * @param {boolean} [options.trailingZeros] if false, numbers will have zeros
+ *  to the right of the last non-zero digit hidden
  * @param {[number, number]} [options.digits] the number of digits that should
  *   be used, instead of the default digits precision in the field.  The first
  *   number is always ignored (legacy constraint)
@@ -37,7 +39,7 @@ export function formatCurrency(amount, currencyId, options = {}) {
     if (options.humanReadable) {
         formattedAmount = humanNumber(amount, { decimals: digits ? digits[1] : 2 });
     } else {
-        formattedAmount = formatFloat(amount, { digits });
+        formattedAmount = formatFloat(amount, { digits, trailingZeros: options.trailingZeros });
     }
 
     if (!currency || options.noSymbol) {

--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -18,12 +18,14 @@ export class FloatField extends Component {
         digits: { type: Array, optional: true },
         humanReadable: { type: Boolean, optional: true },
         decimals: { type: Number, optional: true },
+        trailingZeros: { type: Boolean, optional: true },
     };
     static defaultProps = {
         formatNumber: true,
         inputType: "text",
         humanReadable: false,
         decimals: 0,
+        trailingZeros: true,
     };
 
     setup() {
@@ -60,6 +62,7 @@ export class FloatField extends Component {
         const options = {
             digits: this.props.digits,
             field: this.props.record.fields[this.props.name],
+            trailingZeros: this.props.trailingZeros,
         };
         if (this.props.humanReadable && !this.state.hasFocus) {
             return formatFloat(this.value, {
@@ -112,6 +115,12 @@ export const floatField = {
             help: _t("Use a human readable format (e.g.: 500G instead of 500,000,000,000)."),
         },
         {
+            label: _t("Hide trailing zeros"),
+            name: "hide_trailing_zeros",
+            type: "boolean",
+            help: _t("Hide zeros to the right of the last non-zero digit, e.g. 1.20 becomes 1.2"),
+        },
+        {
             label: _t("Decimals"),
             name: "decimals",
             type: "number",
@@ -141,6 +150,7 @@ export const floatField = {
             step: options.step,
             digits,
             decimals: options.decimals || 0,
+            trailingZeros: !options.hide_trailing_zeros,
         };
     },
 };

--- a/addons/web/static/src/views/fields/formatters.js
+++ b/addons/web/static/src/views/fields/formatters.js
@@ -138,7 +138,8 @@ formatFloat.extractOptions = ({ attrs, options }) => {
     }
     const humanReadable = !!options.human_readable;
     const decimals = options.decimals || 0;
-    return { decimals, digits, humanReadable };
+    const trailingZeros = !options.hide_trailing_zeros;
+    return { decimals, digits, humanReadable, trailingZeros };
 };
 
 /**
@@ -334,6 +335,7 @@ export function formatMonetary(value, options = {}) {
 formatMonetary.extractOptions = ({ options }) => ({
     noSymbol: options.no_symbol,
     currencyField: options.currency_field,
+    trailingZeros: !options.hide_trailing_zeros,
 });
 
 /**
@@ -379,7 +381,10 @@ function formatProperties(value, field) {
  * @returns {string}
  */
 export function formatReference(value, options) {
-    return formatMany2one(value ? { id: value.resId, display_name: value.displayName } : false, options);
+    return formatMany2one(
+        value ? { id: value.resId, display_name: value.displayName } : false,
+        options
+    );
 }
 
 /**

--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -18,10 +18,12 @@ export class MonetaryField extends Component {
         inputType: { type: String, optional: true },
         useFieldDigits: { type: Boolean, optional: true },
         hideSymbol: { type: Boolean, optional: true },
+        trailingZeros: { type: Boolean, optional: true },
     };
     static defaultProps = {
         hideSymbol: false,
         inputType: "text",
+        trailingZeros: true,
     };
 
     setup() {
@@ -85,6 +87,7 @@ export class MonetaryField extends Component {
             digits: this.currencyDigits,
             currencyId: this.currencyId,
             noSymbol: !this.props.readonly || this.props.hideSymbol,
+            trailingZeros: this.props.trailingZeros,
         });
     }
 
@@ -107,6 +110,12 @@ export const monetaryField = {
             type: "field",
             availableTypes: ["many2one"],
         },
+        {
+            label: _t("Hide trailing zeros"),
+            name: "hide_trailing_zeros",
+            type: "boolean",
+            help: _t("Hide zeros to the right of the last non-zero digit, e.g. 1.20 becomes 1.2"),
+        },
     ],
     supportedTypes: ["monetary", "float", "integer"],
     displayName: _t("Monetary"),
@@ -115,6 +124,7 @@ export const monetaryField = {
         inputType: attrs.type,
         useFieldDigits: options.field_digits,
         hideSymbol: options.no_symbol,
+        trailingZeros: !options.hide_trailing_zeros,
     }),
 };
 

--- a/addons/web/static/tests/views/fields/float_field.test.js
+++ b/addons/web/static/tests/views/fields/float_field.test.js
@@ -151,6 +151,19 @@ test("with 'step' option", async () => {
     });
 });
 
+test("with 'hide_trailing_zeros' option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 5,
+        arch: `<form><field name="float_field" options="{'hide_trailing_zeros': true}"/></form>`,
+    });
+
+    expect(".o_field_widget input").toHaveValue("9.1", {
+        message: "Input would show 9.10 without the option",
+    });
+});
+
 test("basic flow in form view", async () => {
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/fields/formatters.test.js
+++ b/addons/web/static/tests/views/fields/formatters.test.js
@@ -32,6 +32,8 @@ beforeEach(() => {
 
 test("formatFloat", () => {
     expect(formatFloat(false)).toBe("");
+    expect(formatFloat(200)).toBe("200.00");
+    expect(formatFloat(200, { trailingZeros: false })).toBe("200");
 });
 
 test("formatFloatFactor", () => {
@@ -99,7 +101,9 @@ test("formatMany2one", () => {
     expect(formatMany2one({ id: false, display_name: "M2O value" })).toBe("M2O value");
     expect(formatMany2one({ id: 1, display_name: false })).toBe("Unnamed");
     expect(formatMany2one({ id: 1, display_name: "M2O value" })).toBe("M2O value");
-    expect(formatMany2one({ id: 1, display_name: "M2O value" }, { escape: true })).toBe("M2O%20value");
+    expect(formatMany2one({ id: 1, display_name: "M2O value" }, { escape: true })).toBe(
+        "M2O%20value"
+    );
 });
 
 test("formatText", () => {
@@ -149,6 +153,9 @@ test("formatMonetary", () => {
         c_y: 12,
     };
     expect(formatMonetary(200, { field, currencyId: 10, data })).toBe("200.00\u00a0€");
+    expect(formatMonetary(200, { field, currencyId: 10, data, trailingZeros: false })).toBe(
+        "200\u00a0€"
+    );
     expect(formatMonetary(200, { field, data })).toBe("$\u00a0200.00");
     expect(formatMonetary(200, { field, currencyField: "c_y", data })).toBe("200.00\u00a0&");
 

--- a/addons/web/static/tests/views/fields/monetary_field.test.js
+++ b/addons/web/static/tests/views/fields/monetary_field.test.js
@@ -779,3 +779,18 @@ test("monetary field with pending onchange", async () => {
     await animationFrame();
     expect(".o_field_monetary .o_monetary_ghost_value").toHaveText("1");
 });
+
+test("with 'hide_trailing_zeros' option", async () => {
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 5,
+        arch: `
+            <form>
+                <field name="float_field" widget="monetary" options="{'hide_trailing_zeros': true}"/>
+                <field name="currency_id" invisible="1"/>
+            </form>`,
+    });
+    expect(".o_field_widget input").toHaveValue("9.1");
+    expect(".o_field_widget .o_input span:eq(0)").toHaveText("$");
+});


### PR DESCRIPTION
This commit makes the option to hide trailing zeros of formatted numbers available to float_field and monetary_field.

task-4626715
