### PR TITLE
[IMP] web: Mark blank elements in reports

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/layout_assets/layout_bubble.scss
+++ b/addons/web/static/src/webclient/actions/reports/layout_assets/layout_bubble.scss
@@ -5,6 +5,11 @@
         border-radius: $border-radius-lg;
         padding: map-get($spacers, 2) $table-cell-padding-y;
 
+        &.o_blank {
+            padding: 0;
+            border: 0;
+        }
+
         // In pdf it overlaps with existing margin, set to 0 to replicate in HTML
         div:first-child {
             padding-left: 0;

--- a/addons/web/static/src/webclient/actions/reports/layout_assets/layout_wave.scss
+++ b/addons/web/static/src/webclient/actions/reports/layout_assets/layout_wave.scss
@@ -4,6 +4,10 @@
         border-radius: $border-radius-lg;
         padding: map-get($spacers, 2) $table-cell-padding-y;
 
+        &.o_blank {
+            padding: 0;
+        }
+
         // In pdf it overlaps with existing margin, set to 0 to replicate in HTML
         div:first-child {
             padding-left: 0;

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -269,6 +269,15 @@
             </head>
             <body t-attf-class="o_body_pdf {{env['ir.actions.report'].get_paperformat_by_xmlid(report_xml_id).css_margins and 'o_css_margins'}} container overflow-hidden" t-att-data-report-id="report_xml_id" t-att-onload="subst and 'subst()'" t-att-dir="env['res.lang']._get_data(code=lang or env.user.lang).direction or 'ltr'">
                 <t t-out="body"/>
+                <script>
+                    var elements = document.getElementsByTagName('*');
+                    for (var i = 0; i &lt; elements.length; i++) {
+                        var element = elements[i];
+                        if (!element.innerText.trim()) {
+                            element.classList.add('o_blank');
+                        }
+                    }
+                </script>
             </body>
         </html>
     </template>


### PR DESCRIPTION
Problem:
Consider a report element that is styled to have padding and backgroud color. When such an element has no content (or only whitespaces), it would show an undesired colored strip.

Problem example:
Invoice Wavy & Bubble reports for a draft invoice that has no date, the div with id=informations would show a colored strip when it has no content.

Solution:
This commit adds a tiny JS snippet that marks empty elements in reports with a class, similar to the new css `:blank` selector: https://developer.mozilla.org/en-US/docs/Web/CSS/:blank This way, such elements can be selected and styled as desired in css.

task-4670747



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
