### PR TITLE
[FIX] mail: correct width for messaging menu item mark as read btn

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -24,7 +24,7 @@
                     <span class="flex-grow-1"/>
                     <div class="d-flex align-items-center">
                         <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 badge rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
                     </div>
                 </div>
                 <div class="d-flex">


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/203142

PR above made several style improvements, one of which is to make the "mark as read" button on messaging menu item look more like a button: it looks like an icon, now this outline and squared like other buttons.

To have a similar size as the counter, it had the `.badge` classname. The `.badge` classname has to do some shenanigans to have constant width for 1-digit values, one of which is to set a minimum width of `2.7ch`.

When the "mark as read" button was changed, this become a button but the `.badge` classname was mistakenly kept. As a result, it kept `min-width: 2.7ch`, which made the width too large on this button. `min-width: 2.7ch` should not be used on the same node as `.fa`, as the width of font-awesome glyph is bigger than badge numbers.

This commit fixes by removing the `.badge` classname altogether, so the button is sized properly. Another fix could have been to put the `.fa.fa-check` in child-node, but that results in the same visual so removing `.badge` results in simpler template. As the "mark as read" is a button with outline, there's also no longer need to have exact width as a badge.

Task-4770926

Before
<img width="478" alt="Screenshot 2025-05-05 at 16 55 22" src="https://github.com/user-attachments/assets/dc5ca989-be1d-436e-84e4-57b450f66908" />

After
<img width="476" alt="Screenshot 2025-05-05 at 16 54 32" src="https://github.com/user-attachments/assets/06f99cb0-4ab4-4090-80ea-48e71970e80a" />

