### PR TITLE
[FIX] sale: adjust sale order line display name

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -315,7 +315,11 @@ class SaleOrderLine(models.Model):
     def _compute_display_name(self):
         name_per_id = self._additional_name_per_id()
         for so_line in self.sudo():
-            name = '{} - {}'.format(so_line.order_id.name, so_line.name and so_line.name.split('\n')[0] or so_line.product_id.name)
+            product = so_line.product_id
+            parts = (so_line.name or "").split('\n', 2)
+            # if there's a description, use the first line (skipping the product name)
+            description = (parts[1:2] and parts[1]) or product.name if product else parts[0]
+            name = f"{so_line.order_id.name} - {description}"
             additional_name = name_per_id.get(so_line.id)
             if additional_name:
                 name = f'{name} {additional_name}'

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -339,6 +339,36 @@ class TestSaleOrder(SaleCommon):
             self.sale_order.partner_id.name,
             self.sale_order.with_context(sale_show_partner_name=True).display_name)
 
+    def test_sol_names(self):
+        """Check that the SOL description gets used for the display name."""
+        self.sale_order.order_line = [
+            Command.create({'is_downpayment': True}),
+            Command.create({'display_type': 'line_note', 'name': "Foo\nBar\nBaz"}),
+        ]
+        sol1, sol2, sol3, sol4 = self.sale_order.order_line
+        sol1.name += "\nOK THANK YOU\nGOOD BYE"
+
+        self.assertEqual(
+            sol1.display_name,
+            f"{self.sale_order.name} - OK THANK YOU ({self.partner.name})",
+            "Product line with description should display the first line of description",
+        )
+        self.assertEqual(
+            sol2.display_name,
+            f"{self.sale_order.name} - {sol2.product_id.name} ({self.partner.name})",
+            "Product line without description should display the product name",
+        )
+        self.assertEqual(
+            sol3.display_name,
+            f"{self.sale_order.name} - {sol3.name} ({self.partner.name})",
+            "Down payment line should display the down payment name",
+        )
+        self.assertEqual(
+            sol4.display_name,
+            f"{self.sale_order.name} - Foo ({self.partner.name})",
+            "Multi-line note should display the first line only",
+        )
+
     def test_state_changes(self):
         """Test some untested state changes methods & logic."""
         self.sale_order.action_quotation_sent()


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a service product that creates a task;
2. add product to an order;
3. add an extra description to the sale order line;
4. confirm the order;
5. go to the task.

Issue
-----
The name of the sale order item linked to the task displays the product name instead of the extra line description.

Cause
-----
As 18.0, the first line of the sale order line name is always the product name. In earlier versions, the product name was only used as a fall-back value when no extra description was added to the line.

Solution
--------
Account for the guaranteed addition of the product name in the SOL name, and instead use the second line for the display name if it exists and is non-empty, else fall back on the product name as intended.

opw-4634149