### PR TITLE
[FIX] mail: reduce message author avatar size

### DIFF
--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -11,7 +11,7 @@
     }
 
     .o-mail-Composer-sidebarMain {
-        padding-top: 0.125rem; // avatar centered with composer text input: 38px (avatar) + 2*2px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
+        padding-top: 0.3125rem; // avatar centered with composer text input: 32px (avatar) + 2*5px (this value) = 20px + 2 * { 10px (padding) + 1px (border) }
         width: $o-mail-Message-sidebarWidth;
     }
 

--- a/addons/mail/static/src/core/common/primary_variables.scss
+++ b/addons/mail/static/src/core/common/primary_variables.scss
@@ -1,5 +1,5 @@
-$o-mail-Avatar-size: 38px !default;
-$o-mail-Avatar-sizeSmall: 28px !default;
+$o-mail-Avatar-size: 32px !default;
+$o-mail-Avatar-sizeSmall: 24px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-ChatHub-bubblesWidth: 56px !default; // same value as BUBBLE
 $o-mail-ChatHub-bubblesMargin: 10px !default; // same value as BUBBLE_OUTER
@@ -15,8 +15,8 @@ $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;
 $o-mail-LinkPreviewCard-height: 80px !default;
 
-$o-mail-Message-sidebarSmallWidth: 40px !default;
-$o-mail-Message-sidebarWidth: 60px !default;
+$o-mail-Message-sidebarSmallWidth: 36px !default;
+$o-mail-Message-sidebarWidth: 48px !default;
 $o-mail-NavigableList-zIndex: 21;
 $o-mail-Chatter-minWidth: 530px !default;
 $o-mail-Discuss-inspector: 300px !default; // same value as INSPECTOR_WIDTH

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -6,9 +6,9 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
+            <div class="o-mail-Discuss-header px-2 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">
                 <t t-if="thread">
-                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center ms-1 me-2 my-1">
+                    <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mx-2 my-1">
                         <img class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="!thread.parent_channel_id and thread.is_editable and thread.channel_type !== 'chat'" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">

--- a/addons/mail/static/src/scss/variables/primary_variables.scss
+++ b/addons/mail/static/src/scss/variables/primary_variables.scss
@@ -1,4 +1,4 @@
-$o-mail-Avatar-size: 42px !default;
+$o-mail-Avatar-size: 32px !default;
 $o-mail-ChatWindow-width: 380px !default; // same value as WINDOW
 $o-mail-Discuss-inspector: 300px !default;
 $o-mail-Avatar-sizeSmall: 24px !default;
@@ -6,7 +6,7 @@ $o-mail-Avatar-sizeSmall: 24px !default;
 $o-RoundedRectangle-small: .2rem !default;
 $o-RoundedRectangle-large: 3 * $o-RoundedRectangle-small !default;
 
-$o-mail-Message-sidebarWidth: 60px !default;
+$o-mail-Message-sidebarWidth: 48px !default;
 
 $o-mail-LinkPreview-width: 320px !default;
 $o-mail-LinkPreview-height: 240px !default;

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -416,7 +416,7 @@ test("should not scroll on receiving new message if the list is initially scroll
             Command.create({ partner_id: partnerId }),
         ],
     });
-    for (let i = 0; i <= 10; i++) {
+    for (let i = 0; i <= 20; i++) {
         pyEnv["mail.message"].create({
             body: "not empty",
             model: "discuss.channel",
@@ -426,7 +426,7 @@ test("should not scroll on receiving new message if the list is initially scroll
     await start();
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem");
-    await contains(".o-mail-Message", { count: 11 });
+    await contains(".o-mail-Message", { count: 21 });
     await contains(".o-mail-Thread", { scroll: 0 });
     // simulate receiving a message
     withUser(userId, () =>
@@ -436,7 +436,7 @@ test("should not scroll on receiving new message if the list is initially scroll
             thread_model: "discuss.channel",
         })
     );
-    await contains(".o-mail-Message", { count: 12 });
+    await contains(".o-mail-Message", { count: 22 });
     await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
 });
 


### PR DESCRIPTION
Before this commit, message author avatars had a size of 38px. This made them so big, to other avatars of 32px, which made them too distracting compared to message content.

This commit fixes the issue by reducing them to 32px, matching their size to other avatars, giving a better balance with the message bubbles.

Some other related changes were made:
- Message and composer sidebar width have been reduced.
- Discuss app header avatar has its size matched to the new reduced size of message avatar its start padding has been adjusted to align with avatar in conversation
- Avatar size and sidebars have also been slightly reduced in chat window again to give more room for message content
