### PR TITLE
[IMP] payment_mercado_pago: support more than one installment

### DIFF
--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -96,9 +96,6 @@ class PaymentTransaction(models.Model):
                     'street_name': self.partner_address,
                 },
             },
-            'payment_methods': {
-                'installments': 1,  # Prevent MP from proposing several installments for a payment.
-            },
         }
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):

--- a/addons/payment_mercado_pago/tests/test_payment_transaction.py
+++ b/addons/payment_mercado_pago/tests/test_payment_transaction.py
@@ -42,7 +42,6 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
                 'name': tx.partner_name,
                 'phone': {'number': tx.partner_phone},
             },
-            'payment_methods': {'installments': 1},
         })
 
     @mute_logger('odoo.addons.payment.models.payment_transaction')


### PR DESCRIPTION
Right now we restrict Mercado Pago to only allow one installment in the payloads we send to them. However, they support more than one installment on their side out of the box with no configuration from ourselves. Customers when configuring their Mercado Pago setup in Mercado Pago can choose how many interest free installments they want to offer to their customers, but without sending this key, there will always be some installment option available.

Within LATAM countries, it is reported that 60% of ecommerce transactions are done via installments. Right now, our Stripe Affirm integration works for installments but no others, which is why enabling it for Mercado Pago will improve our reachability and can allow for companies to sell more than if they didn't have it before.

Nothing special needs to occur on Odoo's side, because from our viewpoint the order is paid immediately, which is the same workflow as with our current Stripe + Affirm integration.

task-3616470
