### PR TITLE
[IMP] l10n_sa_edi_pos: Added Phase 2 QR code to POS

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="after">
-            <t t-if="props.data.is_gcc_country">
+            <t t-if="props.data.is_gcc_country and props.data.show_title">
                 <br/>
                 <br/>
                 <div class="pos-receipt-header">

--- a/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
+++ b/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
@@ -9,6 +9,7 @@ patch(PosStore.prototype, {
                 this.company.country_id?.code
             ),
             gcc_cashier: order?.getCashierName() || this.get_cashier()?.name,
+            show_title: Boolean(order),
         };
     },
 });

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -2,6 +2,14 @@
 <odoo>
     <template id="arabic_english_invoice" inherit_id="l10n_gcc_invoice.arabic_english_invoice">
         <xpath expr="//div[@name='due_date']" position="after">
+            <t t-if="o.company_id.country_id.code == 'SA' and o.edi_state != 'sent' and o.move_type in ('out_invoice', 'out_refund')" t-set="custom_header">
+                <div class="fw-bold text-center mt-2">
+                    <h5>THIS IS NOT A LEGAL DOCUMENT</h5>
+                    <h5>هذا المستند ليس مستنداً قانونياً</h5>
+                </div>
+                <!-- To help with centering the previous div in flex justify between-->
+                <div t-if="is_html_empty(o.company_id.report_header)" class="col-1"/>
+            </t>
             <div class="row" t-if="o.delivery_date" name="delivery_date">
                 <div class="col-6"></div>
                 <div class="col-2">
@@ -22,9 +30,9 @@
             <t t-set="information_block">
                 <div class="row">
                     <p class="col-6 me-3">
-                        <img t-if="o.l10n_sa_qr_code_str"
-                            style="display:block;"
-                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
+                        <img t-if="o.l10n_sa_qr_code_str and o.edi_state == 'sent'"
+                             class="d-block"
+                             t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
                     </p>
                     <div class="col-6" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)" groups="account.group_delivery_invoice_address" name="shipping_address_block">
                         <strong class="d-block mt-3">Shipping Address:</strong>

--- a/addons/l10n_sa/views/report_templates_views.xml
+++ b/addons/l10n_sa/views/report_templates_views.xml
@@ -4,36 +4,64 @@
         <span t-if="report_type == 'pdf' and additional_footer_text" class="text-muted text-center" t-out="additional_footer_text"/><br/>
     </template>
     <template id="l10n_sa_external_layout_standard" inherit_id="web.external_layout_standard">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_boxed" inherit_id="web.external_layout_boxed">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_bold" inherit_id="web.external_layout_bold">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_striped" inherit_id="web.external_layout_striped">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_folder" inherit_id="web.external_layout_folder">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_wave" inherit_id="web.external_layout_wave">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>
     </template>
     <template id="l10n_sa_external_layout_bubble" inherit_id="web.external_layout_bubble">
+        <!-- support for custom header -->
+        <xpath expr="//img" position="after">
+            <t t-if="custom_header" t-out="custom_header"/>
+        </xpath>
         <xpath expr="//span[hasclass('page')]/.." position="before">
             <t t-call="l10n_sa.l10n_sa_additional_footer"/>
         </xpath>

--- a/addons/l10n_sa_edi_pos/__manifest__.py
+++ b/addons/l10n_sa_edi_pos/__manifest__.py
@@ -3,7 +3,7 @@
 {
     'name': 'Saudi Arabia - E-invoicing (Simplified)',
     'countries': ['sa'],
-    'version': '0.1',
+    'version': '0.2',
     'depends': [
         'l10n_sa_pos',
         'l10n_sa_edi',
@@ -18,7 +18,7 @@ E-invoice implementation for Saudi Arabia; Integration with ZATCA (POS)
     'license': 'LGPL-3',
     'assets': {
         'point_of_sale._assets_pos': [
-            'l10n_sa_edi_pos/static/src/overrides/**/*.js',
+            'l10n_sa_edi_pos/static/src/**/*',
         ],
     }
 }

--- a/addons/l10n_sa_edi_pos/i18n/ar.po
+++ b/addons/l10n_sa_edi_pos/i18n/ar.po
@@ -1,0 +1,95 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sa_edi_pos
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-02 07:26+0000\n"
+"PO-Revision-Date: 2025-07-02 11:39+0400\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : "
+"n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid "%s by going to Backend > Orders > Invoice"
+msgstr "%s عن طريق الذهاب إلى الواجهة الخلفية > الطلبات > الفواتير"
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,field_description:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_edi_state
+msgid "Electronic invoicing"
+msgstr "الفوترة الإلكترونية "
+
+#. module: l10n_sa_edi_pos
+#. odoo-python
+#: code:addons/l10n_sa_edi_pos/models/pos_config.py:0
+msgid "Go to Journal configuration"
+msgstr "الذهاب إلى تهيئة دفتر اليومية "
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_account_move
+msgid "Journal Entry"
+msgstr "قيد دفتر اليومية "
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_pos_config
+msgid "Point of Sale Configuration"
+msgstr "تهيئة نقطة البيع "
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_pos_order
+msgid "Point of Sale Orders"
+msgstr "طلبات نقطة البيع "
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid ""
+"The Receipt and Invoice generated here are not valid documents as there is "
+"an error in their processing. You need to resolve the errors first in %s. "
+"Upon Successful submission, you can reprint the Invoice and the Receipt."
+msgstr ""
+"الإيصال والفاتورة اللذان تم إنشاؤهما هنا غير صالحين نظراً لوجود خطأ في "
+"معالجتهما. تحتاج إلى تصحيح الأخطاء أولاً في %s. عند الإرسال بنجاح، يمكنك "
+"إعادة طباعة الفاتورة والإيصال. "
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,help:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_edi_state
+msgid "The aggregated state of all the EDIs with web-service of this move"
+msgstr ""
+"تجميع كافة عمليات تبادل البيانات إلكترونياً (EDI) مع خدمة الويب لهذه الحركة "
+
+#. module: l10n_sa_edi_pos
+#. odoo-python
+#: code:addons/l10n_sa_edi_pos/models/pos_config.py:0
+msgid ""
+"The invoice journal of the point of sale %s must be properly onboarded "
+"according to ZATCA specifications.\n"
+msgstr ""
+"يجب أن تتم تهيئة دفتر يومية الفواتير الخاص بنقاط البيع %s بشكل صحيح وفقًا "
+"لمواصفات ZATCA.\n"
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_account_edi_xml_ubl_21_zatca
+msgid "UBL 2.1 (ZATCA)"
+msgstr "UBL 2.1 (ZATCA)"
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,field_description:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_qr_code_str
+msgid "ZATCA QR Code"
+msgstr "رمز QR الخاص بـ ZATCA "
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid "ZATCA Validation Error"
+msgstr "خطأ في التحقق من صحة ZATCA "

--- a/addons/l10n_sa_edi_pos/i18n/l10n_sa_edi_pos.pot
+++ b/addons/l10n_sa_edi_pos/i18n/l10n_sa_edi_pos.pot
@@ -1,0 +1,86 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_sa_edi_pos
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-07-03 13:05+0000\n"
+"PO-Revision-Date: 2025-07-03 13:05+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid "%s by going to Backend > Orders > Invoice"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,field_description:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_edi_state
+msgid "Electronic invoicing"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#. odoo-python
+#: code:addons/l10n_sa_edi_pos/models/pos_config.py:0
+msgid "Go to Journal configuration"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_pos_config
+msgid "Point of Sale Configuration"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_pos_order
+msgid "Point of Sale Orders"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid ""
+"The Receipt and Invoice generated here are not valid documents as there is "
+"an error in their processing. You need to resolve the errors first in %s. "
+"Upon Successful submission, you can reprint the Invoice and the Receipt."
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,help:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_edi_state
+msgid "The aggregated state of all the EDIs with web-service of this move"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#. odoo-python
+#: code:addons/l10n_sa_edi_pos/models/pos_config.py:0
+msgid ""
+"The invoice journal of the point of sale %s must be properly onboarded "
+"according to ZATCA specifications.\n"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model,name:l10n_sa_edi_pos.model_account_edi_xml_ubl_21_zatca
+msgid "UBL 2.1 (ZATCA)"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#: model:ir.model.fields,field_description:l10n_sa_edi_pos.field_pos_order__l10n_sa_invoice_qr_code_str
+msgid "ZATCA QR Code"
+msgstr ""
+
+#. module: l10n_sa_edi_pos
+#. odoo-javascript
+#: code:addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js:0
+msgid "ZATCA Validation Error"
+msgstr ""

--- a/addons/l10n_sa_edi_pos/models/__init__.py
+++ b/addons/l10n_sa_edi_pos/models/__init__.py
@@ -1,3 +1,4 @@
 from . import pos_config
 from . import account_edi_xml_ubl_21_zatca
 from . import account_move
+from . import pos_order

--- a/addons/l10n_sa_edi_pos/models/pos_order.py
+++ b/addons/l10n_sa_edi_pos/models/pos_order.py
@@ -1,0 +1,8 @@
+from odoo import fields, models
+
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    l10n_sa_invoice_qr_code_str = fields.Char(related="account_move.l10n_sa_qr_code_str", string="ZATCA QR Code")
+    l10n_sa_invoice_edi_state = fields.Selection(related="account_move.edi_state", string="Electronic invoicing")

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-inherit="point_of_sale.ReceiptHeader" t-name="l10n_sa_edi_pos.ReceiptHeader" t-inherit-mode="extension">
+        <xpath expr="//img[hasclass('pos-receipt-qrcode')]" position="after">
+            <div t-if="props.data.not_legal" class="text-center mt-3">
+                <p>THIS IS NOT A LEGAL DOCUMENT</p>
+                <p>هذا المستند ليس مستنداً قانونياً</p>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -1,0 +1,33 @@
+import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+import { markup } from "@odoo/owl";
+
+patch(PaymentScreen.prototype, {
+    //@Override
+    async _finalizeValidation() {
+        await super._finalizeValidation(...arguments);
+        const order = this.currentOrder;
+        // note: isSACompany guarantees order.is_to_invoice()
+        if (order.isSACompany && order.finalized && order.l10n_sa_invoice_edi_state !== "sent") {
+            const orderError = _t("%s by going to Backend > Orders > Invoice", order.pos_reference);
+            const href = `/odoo/customer-invoices/${this.currentOrder?.raw?.account_move}`;
+            const link = markup(
+                `<a target="_blank" href=${href} class="text-info fw-bolder">${_t("Invoice")}</a>`
+            );
+            const errorInfo = this.currentOrder.raw.account_move ? link : orderError;
+            const message = _t(
+                `The Receipt and Invoice generated here are not valid documents as there is ` +
+                    `an error in their processing. You need to resolve the errors first in %s` +
+                    `. Upon Successful submission, you can reprint the Invoice and the Receipt.`,
+                errorInfo
+            );
+
+            this.dialog.add(ConfirmationDialog, {
+                title: _t("ZATCA Validation Error"),
+                body: message,
+            });
+        }
+    },
+});

--- a/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_sa_edi_pos/static/src/overrides/models/pos_store.js
@@ -1,0 +1,16 @@
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { qrCodeSrc } from "@point_of_sale/utils";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosStore.prototype, {
+    getReceiptHeaderData(order) {
+        const result = super.getReceiptHeaderData(...arguments);
+        if (order && order.isSACompany && !result.is_settlement) {
+            // is_settlement is assigned in super l10n_sa_pos
+            result.not_legal =
+                !order.l10n_sa_invoice_qr_code_str || order.l10n_sa_invoice_edi_state !== "sent";
+            result.qr_code = result.not_legal ? "" : qrCodeSrc(order.l10n_sa_invoice_qr_code_str);
+        }
+        return result;
+    },
+});

--- a/addons/l10n_sa_pos/static/src/overrides/components/order_receipt/order_receipt.xml
+++ b/addons/l10n_sa_pos/static/src/overrides/components/order_receipt/order_receipt.xml
@@ -9,14 +9,20 @@
         </xpath>
 
         <xpath expr="//span[@id='title_english']" position="replace">
-            <t t-if="!props.data.is_settlement">
-                <span id="title_english">Simplified Tax Invoice</span>
+            <t t-if="!props.data.is_settlement and props.data.is_simplified">
+                <span id="title_english" t-translation="off">Simplified Tax Invoice</span>
+            </t>
+            <t t-else="">
+                <span id="title_english" t-translation="off">Tax Invoice</span>
             </t>
         </xpath>
 
         <xpath expr="//span[@id='title_arabic']" position="replace">
-            <t t-if="!props.data.is_settlement">
-                <span id="title_arabic">فاتورة ضريبية مبسطة</span>
+            <t t-if="!props.data.is_settlement and props.data.is_simplified">
+                <span id="title_arabic" t-translation="off">فاتورة ضريبية مبسطة</span>
+            </t>
+            <t t-else="">
+                <span id="title_arabic" t-translation="off">الفاتورة الضريبية</span>
             </t>
         </xpath>
     </t>

--- a/addons/l10n_sa_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_sa_pos/static/src/overrides/models/pos_store.js
@@ -5,6 +5,9 @@ patch(PosStore.prototype, {
     getReceiptHeaderData(order) {
         const result = super.getReceiptHeaderData(...arguments);
         const company = this.company;
+        result.is_simplified =
+            (order?.partner_id?.company_type === "person" || !order?.partner_id) &&
+            company.country_id?.code === "SA";
         if (order && company?.country_id?.code === "SA") {
             result.is_settlement = order.is_settlement();
             if (!result.is_settlement) {


### PR DESCRIPTION
Adds phase 2 QR code on POS receipts and shows it as a non-legal document if we are unable to verify the QR code on invoices and POS receipts.

This change is done to accommodate for ZATCA compliance in Saudi Arabia (ZATCA)

task-4646326

Description of the issue/feature this PR addresses:
Adds phase 2 ZATCA QR code and hides unverified QR codes

Current behavior before PR:
Always shows Phase 1 ZATCA QR Code

Desired behaviour after PR is merged:
Showing ZATCA phase 2 QR code when required and hiding un-submitted QR Codes, adds text of "Not a Legal Document" to unsubmitted docs


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
