### PR TITLE
[FIX] point_of_sale: enabling taxes after creation of product in active session

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -673,7 +673,7 @@ export class PosOrderline extends Base {
                     this.order_id.fiscal_position_id,
                     this.models
                 )
-                    ?.map((tax) => tax.tax_group_id.pos_receipt_label)
+                    ?.map((tax) => tax.tax_group_id?.pos_receipt_label)
                     .filter((label) => label)
             ),
         ].join(" ");


### PR DESCRIPTION
Steps to reproduce:
----
- From accounting disable taxes
- Create new product
- Open PoS UI and add product in orderline
- Go to backend and enable taxes
- Add tax in previously created product
- Open UI again

Issue:
----
- We will have traceback

Cause:
----
- undefined error as pos_receipt_label is undefined as we don't have chance to
reload data as product is already in orderline

Fix:
----
- added optional chaining so we don't have undefined error also we have to
reload data after enabling taxes from the configurations in the backend

----
task - 4762770