### PR TITLE
[IMP] account,sale: add new section settings in SO and invoices

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -353,7 +353,7 @@ class AccountMove(models.Model):
         'move_id',
         string='Invoice lines',
         copy=False,
-        domain=[('display_type', 'in', ('product', 'line_section', 'line_note'))],
+        domain=[('display_type', 'in', ('product', 'line_section', 'line_subsection', 'line_note'))],
     )
 
     # === Date fields === #

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -37,6 +37,11 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
         return record.data.display_type === "line_section";
     }
 
+    isSubsection(record = null) {
+        record = record || this.props.record;
+        return record.data.display_type === "line_subsection";
+    }
+
     isNote(record = null) {
         record = record || this.props.record;
         return record.data.display_type === "line_note";
@@ -44,10 +49,11 @@ export class ProductLabelSectionAndNoteField extends ProductNameAndDescriptionFi
 
     shouldShowWarning() {
         return (
-            !this.productName &&
-            this.props.show_label_warning &&
-            !this.isSection() &&
-            !this.isNote()
+            !this.productName
+            && this.props.show_label_warning
+            && !this.isSection()
+            && !this.isSubsection()
+            && !this.isNote()
         );
     }
 }

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -15,10 +15,10 @@
                     t-ref="labelNodeRef"
                 />
             </t>
-            <t t-elif="isSection()">
+            <t t-elif="isSection() || isSubsection()">
                 <input
                     type="text"
-                    class="o_input text-wrap border-0 fst-italic fw-bold"
+                    class="o_input text-wrap border-0 fst-italic"
                     placeholder="Enter a description"
                     t-att-class="sectionAndNoteClasses"
                     t-att-readonly="sectionAndNoteIsReadonly"

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m.js
@@ -12,6 +12,7 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
         super.setup();
         this.descriptionColumn = "name";
         this.productColumns = ["product_id", "product_template_id"];
+        this.sectionCols.push("price_total", "price_subtotal");
     }
 
     processAllColumn(allColumns, list) {

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_backend.scss
@@ -10,16 +10,24 @@ div.o_is_line_note {
 table.o_section_and_note_list_view tr.o_data_row.o_is_line_section,
 div.o_is_line_section {
     font-weight: bold;
-    background-color: #DDDDDD;
+    --table-bg: var(--gray-black-25);
 }
-table.o_section_and_note_list_view tr.o_data_row.o_is_line_section {
-    border-top: 1px solid #BBB;
-    border-bottom: 1px solid #BBB;
+table.o_section_and_note_list_view tr.o_data_row.o_is_line_subsection,
+div.o_is_line_subsection {
+    --table-bg: var(--gray-black-15);
+}
+table.o_section_and_note_list_view tr.o_data_row {
+    &.o_is_line_section
+    &.o_is_line_subsection {
+        border-top: 1px solid #BBB;
+        border-bottom: 1px solid #BBB;
+    }
 }
 
 table.o_section_and_note_list_view tr.o_data_row {
     &.o_is_line_note,
-    &.o_is_line_section {
+    &.o_is_line_section
+    &.o_is_line_subsection {
         td {
             // There is an undeterministic CSS behaviour in Chrome related to
             // the combination of the row's and its children's borders.

--- a/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
+++ b/addons/account/static/src/components/section_and_note_fields_backend/section_and_note_fields_backend.js
@@ -1,10 +1,44 @@
+import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { TextField, ListTextField } from "@web/views/fields/text/text_field";
 import { CharField } from "@web/views/fields/char/char_field";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
-import { Component, useEffect } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { Component, useEffect, useSubEnv } from "@odoo/owl";
+import { x2ManyCommands } from "@web/core/orm_service";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+
+function findSectionTargetRecord(records, currentIndex, direction, isDisplayType) {
+    if(direction == 'up') {
+        let prevSectionIndex = -1;
+
+        for (let i=currentIndex-1; i>=0; i--) {
+            if (isDisplayType(records[i])) {
+                prevSectionIndex = i;
+                break;
+            }
+        }
+        if(prevSectionIndex == -1) return null;
+
+        return records[prevSectionIndex -1]; // For moving up we expect the line before previous header
+    }
+
+    if(direction == 'down') {
+        let nextSectionIndex = -1;
+
+        for (let i=currentIndex+1; i<records.length; i++) {
+            if (isDisplayType(records[i])) {
+                nextSectionIndex = i;
+                break;
+            }
+        }
+        if(nextSectionIndex == -1) return null;
+
+        return records[nextSectionIndex]; // For moving down we expect the line of header
+    }
+}
 
 export class SectionAndNoteListRenderer extends ListRenderer {
     static template = "account.sectionAndNoteListRenderer";
@@ -18,10 +52,19 @@ export class SectionAndNoteListRenderer extends ListRenderer {
     setup() {
         super.setup();
         this.titleField = "name";
+        this.sectionCols = ['section_settings'];
+        this.dialogService = useService('dialog');
+
         useEffect(
             (editedRecord) => this.focusToName(editedRecord),
             () => [this.editedRecord]
         )
+        useSubEnv({
+            onSectionDelete: async (sectionId) => await this.onSectionDelete(sectionId),
+            onSectionDuplicate: async (record) => await this.onSectionDuplicate(record),
+            onSectionMoveUp: async (record) => await this.onSectionMoveUp(record),
+            onSectionMoveDown: async (record) => await this.onSectionMoveDown(record),
+        });
     }
 
     focusToName(editRec) {
@@ -31,9 +74,18 @@ export class SectionAndNoteListRenderer extends ListRenderer {
         }
     }
 
-    isSectionOrNote(record=null) {
+    isSectionOrNote(record = null) {
+        return this.isSection(record) || this.isNote(record);
+    }
+
+    isSection(record = null) {
         record = record || this.record;
-        return ['line_section', 'line_note'].includes(record.data.display_type);
+        return ['line_subsection', 'line_section'].includes(record.data.display_type);
+    }
+
+    isNote(record = null) {
+        record = record || this.record;
+        return record.data.display_type === 'line_note';
     }
 
     getRowClass(record) {
@@ -43,7 +95,11 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     getCellClass(column, record) {
         const classNames = super.getCellClass(column, record);
-        if (this.isSectionOrNote(record) && column.widget !== "handle" && column.name !== this.titleField) {
+        if (
+            (this.isSection(record) && !this.sectionCols.includes(column.name) || this.isNote(record))
+            && column.widget !== "handle"
+            && column.name !== this.titleField
+        ) {
             return `${classNames} o_hidden`;
         }
         return classNames;
@@ -51,21 +107,129 @@ export class SectionAndNoteListRenderer extends ListRenderer {
 
     getColumns(record) {
         const columns = super.getColumns(record);
-        if (this.isSectionOrNote(record)) {
-            return this.getSectionColumns(columns);
+        if (this.isSection(record)) {
+            return this.getSectionColumns(super.getActiveColumns());
+        } else if (this.isNote(record)) {
+            return this.getNoteColumns(columns);
         }
         return columns;
     }
 
     getSectionColumns(columns) {
-        const sectionCols = columns.filter((col) => col.widget === "handle" || col.type === "field" && col.name === this.titleField);
+        const sectionCols = columns.filter(
+            (col) =>
+                col.widget === "handle"
+                || (col.name === this.titleField || this.sectionCols.includes(col.name))
+        );
         return sectionCols.map((col) => {
             if (col.name === this.titleField) {
-                return { ...col, colspan: columns.length - sectionCols.length + 1 };
+                return { ...col, colspan: this.columns.length - sectionCols.length + 1 };
             } else {
                 return { ...col };
             }
         });
+    }
+
+    getNoteColumns(columns) {
+        const noteCols = columns.filter((col) =>
+            col.widget === "handle"
+            || (col.type === "field" && col.name === this.titleField)
+        );
+        return noteCols.map((col) => {
+            if (col.name === this.titleField) {
+                return { ...col, colspan: columns.length - noteCols.length + 1 };
+            } else {
+                return { ...col };
+            }
+        });
+    }
+
+    getSectionBlock(sectionLine) {
+        const childSubsectionsId = this.props.list.records.filter(
+            (r) => r.data.linked_section_line_id.id === sectionLine.resId
+                && r.data.display_type == 'line_subsection'
+        );
+
+        const childLinesId = this.props.list.records.filter(
+            (r) => [...childSubsectionsId.map((r) => r.resId), sectionLine.resId].includes(
+                r.data.linked_section_line_id.id
+            )
+                && r.data.display_type != 'line_subsection'
+        );
+
+        return [sectionLine, ...childSubsectionsId, ...childLinesId];
+    }
+
+    async onSectionDelete(sectionLine) {
+        this.dialogService.add(ConfirmationDialog, {
+            title: _t("Delete Section?"),
+            body: _t("Are you sure you want to delete this section and all its components?"),
+            confirm: async () => {
+                await this.props.list._applyCommands(
+                    this.getSectionBlock(sectionLine).map((r) => r.resId).map(
+                        (id) => [x2ManyCommands.DELETE, id]
+                    )
+                );
+                await this.props.list._onUpdate();
+            },
+            cancel: () => { },
+            confirmLabel: _t("Delete"),
+            cancelLabel: _t("Cancel"),
+        });
+    }
+
+    async onSectionDuplicate(sectionLine) {
+        await this.props.list._applyCommands(
+            this.getSectionBlock(sectionLine).map(
+                (record) => [x2ManyCommands.CREATE, false, {
+                    display_type: record.data.display_type,
+                    product_id: { id: record.data.product_id.id },
+                    quantity: record.data.quantity,
+                    name: record.data.name,
+                    currency_id: { id: record.data.currency_id.id },
+                }]
+            )
+        );
+        await this.props.list._onUpdate();
+    }
+
+    async onSectionMoveUp(sectionLine) {
+        const isDisplayType = (r) => r.data.display_type === sectionLine.data.display_type;
+        const targetLine = findSectionTargetRecord(
+            this.props.list.records,
+            this.props.list.records.findIndex((r) => r.id === sectionLine.id),
+            'up',
+            isDisplayType
+        );
+
+        if (!targetLine) {
+            return;
+        }
+
+        await this.props.list._resequenceMultiple(
+            this.getSectionBlock(sectionLine).map((r) => r.id),
+            targetLine.id
+        )
+    }
+
+    async onSectionMoveDown(sectionLine) {
+        const isDisplayType = (r) => r.data.display_type === sectionLine.data.display_type;
+        const sectionBlock = this.getSectionBlock(sectionLine);
+        const targetLine = findSectionTargetRecord(
+            this.props.list.records,
+            this.props.list.records.findIndex((r) => r.id === sectionBlock[sectionBlock.length - 1].id),
+            'down',
+            isDisplayType
+        );
+
+        if (!targetLine) {
+            return;
+        }
+
+        await this.props.list._resequenceMultiple(
+            this.getSectionBlock(sectionLine).map((r) => r.id),
+            targetLine.id
+        )
     }
 }
 
@@ -81,13 +245,13 @@ export class SectionAndNoteText extends Component {
     static props = { ...standardFieldProps };
 
     get componentToUse() {
-        return this.props.record.data.display_type === 'line_section' ? CharField : TextField;
+        return ['line_section', 'line_subsection'].includes(this.props.record.data.display_type) ? CharField : TextField;
     }
 }
 
 export class ListSectionAndNoteText extends SectionAndNoteText {
     get componentToUse() {
-        return this.props.record.data.display_type !== "line_section"
+        return !['line_section', 'line_subsection'].includes(this.props.record.data.display_type)
             ? ListTextField
             : super.componentToUse;
     }

--- a/addons/account/static/src/components/section_settings/section_setting.xml
+++ b/addons/account/static/src/components/section_settings/section_setting.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+
+    <t t-name="account.SectionSettings">
+        <t t-if="['line_section', 'line_subsection'].includes(props.record.data.display_type)">        
+            <Dropdown>
+                <button
+                    class="d-print-none btn lh-sm p-0 border-0'"
+                    data-tooltip="Section Settings"
+                >
+                    <i class="fa fa-fw fa-cog"/>
+                </button>
+
+                <t t-set-slot="content">
+                    <DropdownItem
+                        t-foreach="sortedActions"
+                        t-as="action"
+                        t-if="action.visible"
+                        t-key="action.id"
+                        onSelected="action.onSelected"
+                        class="'o_menu_item'"
+                    >
+                        <i t-att-class="action.icon" class="me-2"/>
+                        <t t-esc="action.label"/>
+                    </DropdownItem>
+                </t>
+            </Dropdown>
+        </t>
+    </t>
+
+</templates>

--- a/addons/account/static/src/components/section_settings/section_settings.js
+++ b/addons/account/static/src/components/section_settings/section_settings.js
@@ -1,0 +1,120 @@
+import { _t } from "@web/core/l10n/translation";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { Component } from "@odoo/owl";
+import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
+import { registry } from '@web/core/registry';
+
+export class SectionSettings extends Component {
+    static template = "account.SectionSettings";
+    static props = {
+        ...standardWidgetProps,
+    };
+    static components = {
+        Dropdown,
+        DropdownItem,
+    };
+
+    setup() {
+        super.setup();
+        this.actions = [
+            {
+                id: "line_add",
+                label: _t("Add Line"),
+                icon: "fa fa-plus",
+                visible: true,
+                sequence: 10,
+                onSelected: () => this.onLineAdd(),
+            },
+            {
+                id: "subsection_add",
+                label: _t("Add Subsection"),
+                icon: "fa fa-folder",
+                visible: this.props.record.data.display_type === "line_section",
+                sequence: 20,
+                onSelected: () => this.onSubsectionAdd(),
+            },
+            {
+                id: "price_hide",
+                label: this.props.record.data.show_section_line_amount ? _t("Hide Prices") : _t("Show Prices"),
+                icon: this.props.record.data.show_section_line_amount ? "fa fa-eye-slash" : "fa fa-eye",
+                visible: true,
+                sequence: 30,
+                onSelected: async () => await this.onPricesToggle(),
+            },
+            {
+                id: "composition_hide",
+                label: this.props.record.data.show_composition ? _t("Hide Composition") : _t("Show Composition"),
+                icon: this.props.record.data.show_composition ? "fa fa-eye-slash" : "fa fa-eye",
+                visible: true,
+                sequence: 40,
+                onSelected: async () => await this.onCompositionToggle(),
+            },
+            {
+                id: "section_up",
+                label: _t("Move Up"),
+                icon: "fa fa-arrow-up",
+                visible: true,
+                sequence: 50,
+                onSelected: async () => await this.env.onSectionMoveUp(this.props.record),
+            },
+            {
+                id: "section_down",
+                label: _t("Move Down"),
+                icon: "fa fa-arrow-down",
+                visible: true,
+                sequence: 60,
+                onSelected: async () => await this.env.onSectionMoveDown(this.props.record)
+            },
+            {
+                id: "section_duplicate",
+                label: _t("Duplicate"),
+                icon: "fa fa-copy",
+                visible: true,
+                sequence: 70,
+                onSelected: async () => await this.env.onSectionDuplicate(this.props.record),
+            },
+            {
+                id: "section_delete",
+                label: _t("Delete"),
+                icon: "fa fa-trash",
+                visible: true,
+                sequence: 80,
+                onSelected: async () => await this.env.onSectionDelete(this.props.record),
+            },
+        ]
+    }
+
+    onLineAdd() {
+        alert("Please Wait I am Working On it 😓");
+    }
+
+    onSubsectionAdd() {
+        alert("Please Wait I am Working On it 😓");
+    }
+
+    async onPricesToggle() {
+        const changes = { show_section_line_amount: !this.props.record.data.show_section_line_amount };
+        await this.props.record.update(changes, { save: true });
+    }
+
+    async onCompositionToggle() {
+        const changes = { show_composition: !this.props.record.data.show_composition };
+        await this.props.record.update(changes, { save: true });
+    }
+
+    onDuplicate() {
+        alert("Please Wait I am Working On it 😓");
+    }
+
+    get sortedActions() {
+        return this.actions.sort((a, b) => a.sequence - b.sequence);
+    }
+}
+
+export const sectionSettingsWidget = {
+    component: SectionSettings,
+    listViewWidth: 20,
+};
+
+registry.category("view_widgets").add("section_settings", sectionSettingsWidget);

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1141,10 +1141,17 @@
                                            'default_display_type': 'product',
                                            'quick_encoding_vals': quick_encoding_vals,
                                        }" readonly="state != 'draft'">
-                                    <list name="journal_items" editable="bottom" string="Journal Items" default_order="sequence, id">
+                                    <list
+                                        name="journal_items"
+                                        editable="bottom"
+                                        string="Journal Items"
+                                        default_order="sequence, id"
+                                        decoration-muted="move_type == 'out_invoice' and is_linked_section_hidden"
+                                    >
                                         <control>
                                             <create name="add_line_control" string="Add a line"/>
                                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                                            <create name="add_subsection_control" string="Add a subsection" context="{'default_display_type': 'line_subsection'}"/>
                                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                                             <button name="action_add_from_catalog" string="Catalog" type="object" class="btn-link" context="{'order_id': parent.id}"/>
                                         </control>
@@ -1184,8 +1191,18 @@
                                         <!-- /l10n_in_edi.test_edi_json -->
                                         <!-- required for @api.onchange('product_id') -->
                                         <field name="product_uom_id" column_invisible="True"/>
-                                        <field name="price_unit" string="Price"/>
-                                        <field name="discount" width="50px" string="Disc.%" optional="hide"/>
+                                        <field
+                                            name="price_unit"
+                                            string="Price"
+                                            decoration-muted="is_linked_section_amount_hidden"
+                                        />
+                                        <field
+                                            name="discount"
+                                            width="50px"
+                                            string="Disc.%"
+                                            optional="hide"
+                                            decoration-muted="is_linked_section_amount_hidden"
+                                        />
                                         <field name="tax_ids" widget="many2many_tax_tags"
                                                domain="[('type_tax_use', '=?', parent.invoice_filter_type_domain), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                                context="{
@@ -1199,18 +1216,30 @@
                                                column_invisible="parent.move_type not in ['in_invoice', 'in_refund']"
                                                string="Professional %"
                                                optional="hide"/>
-                                        <field name="price_subtotal"
-                                               column_invisible="parent.move_type not in ['in_invoice', 'in_refund', 'in_receipt'] and parent.company_price_include == 'tax_included'"
-                                               string="Amount"/>
-                                        <field name="price_total"
-                                               column_invisible="parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] or parent.company_price_include == 'tax_excluded'"
-                                               string="Amount"/>
+                                        <field
+                                            name="price_subtotal"
+                                            column_invisible="parent.move_type not in ['in_invoice', 'in_refund', 'in_receipt'] and parent.company_price_include == 'tax_included'"
+                                            invisible="display_type in ('line_section', 'line_subsection') and (move_type != 'out_invoice' or show_section_line_amount)"
+                                            decoration-muted="is_linked_section_amount_hidden or (display_type == 'line_section' and not show_section_line_amount)"
+                                            string="Amount"
+                                        />
+                                        <field
+                                            name="price_total"
+                                            column_invisible="parent.move_type in ['in_invoice', 'in_refund', 'in_receipt'] or parent.company_price_include == 'tax_excluded'"
+                                            invisible="display_type in ('line_section', 'line_subsection') and (move_type != 'out_invoice' or show_section_line_amount)"
+                                            decoration-muted="is_linked_section_amount_hidden or (display_type == 'line_section' and not show_section_line_amount)"
+                                            string="Amount"
+                                        />
                                         <!-- Others fields -->
                                         <field name="partner_id" column_invisible="True"/>
                                         <field name="currency_id" column_invisible="True"/>
                                         <field name="company_id" column_invisible="True"/>
                                         <field name="company_currency_id" column_invisible="True"/>
                                         <field name="display_type" force_save="1" column_invisible="True"/>
+                                        <field name="show_composition" column_invisible="True"/>
+                                        <field name="show_section_line_amount" column_invisible="True"/>
+                                        <field name="linked_section_line_id" column_invisible="True"/>
+                                        <widget name="section_settings"/>
                                     </list>
                                     <kanban class="o_kanban_mobile">
                                         <!-- Displayed fields -->

--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -173,50 +173,145 @@
                                     <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                     <t t-set="current_total" t-value="current_total + line.price_total"/>
 
-                                    <tr t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
-                                        <t t-if="line.display_type == 'product'" name="account_invoice_line_accountable">
-                                            <td name="account_invoice_line_name">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
-                                            </td>
-                                            <td name="td_quantity" class="text-end text-nowrap">
-                                                <span t-field="line.quantity">3.00</span>
-                                                <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
-                                                <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
-                                                    <br/>
-                                                    <t t-set="product_uom_qty" t-value="line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)"/>
-                                                    <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
-                                                </span>
-                                            </td>
-                                            <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span class="text-nowrap" t-field="line.price_unit">9.00</span>
-                                            </td>
-                                            <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                                <span class="text-nowrap" t-field="line.discount">0</span>
-                                            </td>
-                                            <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
-                                            <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                                <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
-                                            </td>
-                                            <td name="td_subtotal" class="text-end o_price_total">
-                                                <span t-if="o.company_price_include == 'tax_excluded'" class="text-nowrap" t-field="line.price_subtotal">27.00</span>
-                                                <span t-if="o.company_price_include == 'tax_included'" class="text-nowrap" t-field="line.price_total">31.05</span>
-                                            </td>
-                                        </t>
-                                        <t t-elif="line.display_type == 'line_section'">
-                                            <td colspan="99">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A section title</span>
-                                            </td>
-                                            <t t-set="current_section" t-value="line"/>
-                                            <t t-set="current_subtotal" t-value="0"/>
-                                        </t>
-                                        <t t-elif="line.display_type == 'line_note'">
-                                            <td colspan="99">
-                                                <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
-                                            </td>
-                                        </t>
-                                    </tr>
+                                    <t t-if="line.display_type != 'line_section' or not line.is_linked_section_hidden">
+                                        <tr
+                                            t-att-class="'fw-bold o_line_section' if line.display_type == 'line_section'
+                                            else 'o_line_subsection' if line.display_type == 'line_subsection'
+                                            else 'fst-italic o_line_note' if line.display_type == 'line_note'
+                                            else ''"
+                                        >
+                                            <t
+                                                t-if="line.display_type == 'product' and not line.is_linked_section_hidden"
+                                                name="account_invoice_line_accountable"
+                                            >
+                                                <td name="account_invoice_line_name">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">Bacon Burger</span>
+                                                </td>
+                                                <td name="td_quantity" class="text-end text-nowrap">
+                                                    <span t-field="line.quantity">3.00</span>
+                                                    <span t-field="line.product_uom_id"  groups="uom.group_uom">units</span>
+                                                    <span t-if="line.product_uom_id != line.product_id.uom_id" groups="uom.group_uom" class="text-muted small">
+                                                        <br/>
+                                                        <t t-set="product_uom_qty" t-value="line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)"/>
+                                                        <span t-out="product_uom_qty" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}" data-oe-demo="3.00"/> <span t-field="line.product_id.uom_id" data-oe-demo="units"/>
+                                                    </span>
+                                                </td>
+                                                <td name="td_price_unit" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                    <span
+                                                        class="text-nowrap"
+                                                        t-field="line.price_unit"
+                                                        t-if="not line.is_linked_section_amount_hidden"
+                                                    >
+                                                        9.00
+                                                    </span>
+                                                </td>
+                                                <td name="td_discount" t-if="display_discount" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                                    <span
+                                                        class="text-nowrap" 
+                                                        t-field="line.discount"
+                                                        t-if="not line.is_linked_section_amount_hidden"
+                                                    >
+                                                        0
+                                                    </span>
+                                                </td>
+                                                <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
+                                                <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                                    <span t-out="taxes" id="line_tax_ids">Tax 15%</span>
+                                                </td>
+                                                <td name="td_subtotal" class="text-end o_price_total">
+                                                    <t t-if="not line.is_linked_section_amount_hidden">
+                                                        <span
+                                                            t-if="o.company_price_include == 'tax_excluded'"
+                                                            class="text-nowrap"
+                                                            t-field="line.price_subtotal"
+                                                        >
+                                                            27.00
+                                                        </span>
+                                                        <span
+                                                            t-if="o.company_price_include == 'tax_included'"
+                                                            class="text-nowrap"
+                                                            t-field="line.price_total"
+                                                        >
+                                                            31.05
+                                                        </span>
+                                                    </t>
+                                                </td>
+                                            </t>
+                                            <t t-elif="line.display_type == 'line_section'">
+                                                <td t-att-colspan="99">
+                                                    <span
+                                                        t-if="line.name"
+                                                        t-field="line.name"
+                                                        t-options="{'widget': 'text'}"
+                                                    >
+                                                        A section title
+                                                    </span>
+                                                </td>
+                                                <t t-set="current_section" t-value="line"/>
+                                                <t t-set="current_subtotal" t-value="0"/>
+                                            </t>
+                                            <t t-elif="line.display_type == 'line_note' and show_section_details">
+                                                <td colspan="99">
+                                                    <span t-if="line.name" t-field="line.name" t-options="{'widget': 'text'}">A note, whose content usually applies to the section or product above.</span>
+                                                </td>
+                                            </t>
+                                        </tr>
+                                    </t>
 
-                                    <t t-if="current_section and (line_last or lines[line_index+1].display_type == 'line_section')">
+                                    <t t-else="">
+                                        <t t-foreach="line._get_grouped_section_summary()" t-as="section_line">
+                                            <tr class="o_line_section">
+                                                <td name="account_invoice_line_name">
+                                                    <span t-out="section_line['name']">
+                                                        A section title
+                                                    </span>
+                                                </td>
+                                                <td name="td_quantity" class="text-end text-nowrap">
+                                                    <span>1 Unit</span>
+                                                </td>
+                                                <td
+                                                    name="td_price_unit"
+                                                    t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
+                                                >
+                                                    <span t-out="section_line['price_subtotal']"/>
+                                                </td>
+                                                <td name="td_discount" t-if="display_discount"/>
+                                                <td
+                                                    name="td_taxes"
+                                                    t-if="display_taxes"
+                                                    t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }} {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                                >
+                                                    <span t-out="', '.join(section_line['taxes'])" id="line_tax_ids">
+                                                        Tax 15%
+                                                    </span>
+                                                </td>
+                                                <td class="text-end o_price_total">
+                                                    <span
+                                                        t-if="o.company_price_include == 'tax_excluded'"
+                                                        class="text-nowrap"
+                                                        t-out="section_line['price_subtotal']"
+                                                    >
+                                                        27.00
+                                                    </span>
+                                                    <span
+                                                        t-if="o.company_price_include == 'tax_included'"
+                                                        class="text-nowrap"
+                                                        t-out="section_line['price_total']"
+                                                    >
+                                                        31.05
+                                                    </span>
+                                                </td>
+                                            </tr>
+                                        </t>
+                                        <t t-set="current_section" t-value="line"/>
+                                        <t t-set="current_subtotal" t-value="0"/>
+                                    </t>
+
+                                    <t
+                                        t-if="current_section
+                                            and show_section_details
+                                            and (line_last or lines[line_index+1].display_type == 'line_section')"
+                                    >
                                         <tr class="is-subtotal text-end">
                                             <td colspan="99">
                                                 <strong class="mr16">Subtotal</strong>

--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -298,7 +298,11 @@ class AccountMoveLine(models.Model):
             global discount line. These can be created either manually, or through a promotions program.
         """
         self.ensure_one()
-        return not self._get_downpayment_lines() and self.price_subtotal < 0
+        return (
+            not self._get_downpayment_lines()
+            and self.price_subtotal < 0
+            and self.display_type != 'line_section'
+        )
 
     @api.depends('price_subtotal', 'price_total')
     def _compute_tax_amount(self):

--- a/addons/purchase/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m_purchase.js
+++ b/addons/purchase/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m_purchase.js
@@ -1,0 +1,30 @@
+import {
+    ProductLabelSectionAndNoteListRender,
+    productLabelSectionAndNoteOne2Many,
+    ProductLabelSectionAndNoteOne2Many,
+} from '@account/components/product_label_section_and_note_field/product_label_section_and_note_field_o2m';
+import { registry } from '@web/core/registry';
+
+export class PurchaseOrderLineListRenderer extends ProductLabelSectionAndNoteListRender {
+    static rowsTemplate = "web.ListRenderer.Rows";
+    setup() {
+        super.setup();
+        this.sectionCols = [];
+    }
+}
+
+export class PurchaseProductLabelSectionAndNoteOne2Many extends ProductLabelSectionAndNoteOne2Many {
+    static components = {
+        ...ProductLabelSectionAndNoteOne2Many.components,
+        ListRenderer: PurchaseOrderLineListRenderer,
+    };
+}
+
+export const purchaseProductLabelSectionAndNoteOne2Many = {
+    ...productLabelSectionAndNoteOne2Many,
+    component: PurchaseProductLabelSectionAndNoteOne2Many,
+};
+
+registry
+    .category("fields")
+    .add("purchase_product_label_section_and_note_field_o2m", purchaseProductLabelSectionAndNoteOne2Many);

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -239,7 +239,7 @@
                         <page string="Products" name="products">
                             <field name="tax_country_id" invisible="1"/>
                             <field name="order_line"
-                                widget="product_label_section_and_note_field_o2m"
+                                widget="purchase_product_label_section_and_note_field_o2m"
                                 mode="list,kanban"
                                 context="{'default_state': 'draft'}"
                                 readonly="state == 'cancel' or locked">

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -94,56 +94,105 @@
                 <tbody class="sale_tbody">
 
                     <t t-set="current_subtotal" t-value="0"/>
+                    <t t-set="show_section_details" t-value="true"/>
 
                     <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
+                        <t
+                            t-if="line.display_type == 'line_section'"
+                            t-set="show_section_details"
+                            t-value="line.print_details"
+                        />
 
-                        <tr
-                            t-att-class="'fw-bold o_line_section' if (
-                                line.display_type == 'line_section'
+                        <t
+                            t-if="line.display_type != 'line_section'
                                 or line.product_type == 'combo'
-                            )
-                            else 'fst-italic o_line_note' if line.display_type == 'line_note'
-                            else ''"
+                                or show_section_details"
                         >
-                            <t t-if="not line.display_type and line.product_type != 'combo'">
-                                <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
-                                <td name="td_quantity" class="text-end text-nowrap">
-                                    <span t-field="line.product_uom_qty">3</span>
-                                    <span t-field="line.product_uom_id">units</span>
-                                    <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
-                                        <t t-set="quantity_in_product_uom" t-value="line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)"/>
-                                        <br/><span t-esc="quantity_in_product_uom" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="line.product_id.uom_id"/>
-                                    </span>
-                                </td>
-                                <td name="td_priceunit" class="text-end text-nowrap">
-                                    <span t-field="line.price_unit">3</span>
-                                </td>
-                                <td name="td_discount" t-if="display_discount" class="text-end">
-                                    <span t-field="line.discount">-</span>
-                                </td>
-                                <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
-                                <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                    <span t-out="taxes">Tax 15%</span>
-                                </td>
-                                <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
-                                    <span t-field="line.price_subtotal">27.00</span>
-                                </td>
+                            <tr
+                                t-att-class="'fw-bold o_line_section' if (
+                                    line.display_type == 'line_section'
+                                    or line.product_type == 'combo'
+                                )
+                                else 'fst-italic o_line_note' if line.display_type == 'line_note'
+                                else ''"
+                            >
+                                <t
+                                    t-if="not line.display_type
+                                        and line.product_type != 'combo'
+                                        and show_section_details"
+                                >
+                                    <td name="td_name"><span t-field="line.name">Bacon Burger</span></td>
+                                    <td name="td_quantity" class="text-end text-nowrap">
+                                        <span t-field="line.product_uom_qty">3</span>
+                                        <span t-field="line.product_uom_id">units</span>
+                                        <span t-if="line.product_uom_id != line.product_id.uom_id" class="text-muted small">
+                                            <t t-set="quantity_in_product_uom" t-value="line.product_uom_id._compute_quantity(line.product_uom_qty, line.product_id.uom_id)"/>
+                                            <br/><span t-esc="quantity_in_product_uom" t-options="{'widget': 'float', 'decimal_precision': 'Product Unit'}"/> <span t-field="line.product_id.uom_id"/>
+                                        </span>
+                                    </td>
+                                    <td name="td_priceunit" class="text-end text-nowrap">
+                                        <span t-field="line.price_unit">3</span>
+                                    </td>
+                                    <td name="td_discount" t-if="display_discount" class="text-end">
+                                        <span t-field="line.discount">-</span>
+                                    </td>
+                                    <t t-set="taxes" t-value="', '.join(tax.tax_label for tax in line.tax_ids if tax.tax_label)"/>
+                                    <td name="td_taxes" t-if="display_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                        <span t-out="taxes">Tax 15%</span>
+                                    </td>
+                                    <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
+                                        <span t-field="line.price_subtotal">27.00</span>
+                                    </td>
+                                </t>
+                                <t t-elif="line.display_type == 'line_section' or line.product_type == 'combo'">
+                                    <td name="td_section_line" colspan="99">
+                                        <span t-field="line.name">A section title</span>
+                                    </td>
+                                    <t t-set="current_section" t-value="line"/>
+                                    <t t-set="current_subtotal" t-value="0"/>
+                                </t>
+                                <t t-elif="line.display_type == 'line_note' and show_section_details">
+                                    <td name="td_note_line" colspan="99">
+                                        <span t-field="line.name">A note, whose content usually applies to the section or product above.</span>
+                                    </td>
+                                </t>
+                            </tr>
+                        </t>
+
+                        <t t-else="">
+                            <t t-foreach="line._get_grouped_section_summary()" t-as="section_line">
+                                <tr class="o_line_section">
+                                    <td name="td_name">
+                                        <span t-out="section_line['name']">Section Summary</span>
+                                    </td>
+                                    <td name="td_quantity" class="text-end text-nowrap">
+                                        <span>1 Unit</span>
+                                    </td>
+                                    <td name="td_priceunit" class="text-end text-nowrap">
+                                        <span t-out="section_line['price_subtotal']"/>
+                                    </td>
+                                    <td name="td_discount" t-if="display_discount"/>
+                                    <td
+                                        name="td_taxes"
+                                        t-if="display_taxes"
+                                        t-attf-class="text-end {{ 'text-nowrap' if len(section_line['taxes']) &lt; 10 else '' }}"
+                                    >
+                                        <span t-out="', '.join(section_line['taxes'])">
+                                            Tax 15%
+                                        </span>
+                                    </td>
+                                    <td class="text-end o_price_total">
+                                        <span t-out="section_line['price_subtotal']">
+                                            31.05
+                                        </span>
+                                    </td>
+                                </tr>
                             </t>
-                            <t t-elif="line.display_type == 'line_section' or line.product_type == 'combo'">
-                                <td name="td_section_line" colspan="99">
-                                    <span t-field="line.name">A section title</span>
-                                </td>
-                                <t t-set="current_section" t-value="line"/>
-                                <t t-set="current_subtotal" t-value="0"/>
-                            </t>
-                            <t t-elif="line.display_type == 'line_note'">
-                                <td name="td_note_line" colspan="99">
-                                    <span t-field="line.name">A note, whose content usually applies to the section or product above.</span>
-                                </td>
-                            </t>
-                        </tr>
+                            <t t-set="current_section" t-value="line"/>
+                            <t t-set="current_subtotal" t-value="0"/>
+                        </t>
 
                         <t
                             t-if="current_section and (
@@ -154,7 +203,10 @@
                                     line.combo_item_id
                                     and not lines_to_report[line_index+1].combo_item_id
                                 )
-                            ) and not line.is_downpayment"
+                            )
+                            and not line.is_downpayment
+                            and show_section_details
+                            "
                         >
                             <t t-set="current_section" t-value="None"/>
                             <tr class="is-subtotal text-end">

--- a/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
+++ b/addons/sale/static/src/js/sale_order_line_field/sale_order_line_field.js
@@ -46,16 +46,16 @@ export class SaleOrderLineListRenderer extends ProductLabelSectionAndNoteListRen
      */
 
     /**
-     * Whether the provided record is a section, a note, or a combo.
+     * Whether the provided record is a note or a combo.
      *
      * This method's name isn't ideal since it doesn't mention combos, but we'd have to override a
      * few other methods to fix this, and the added complexity isn't worth it.
      *
      * @param record The record to check
-     * @return {Boolean} Whether the record is a section, a note, or a combo.
+     * @return {Boolean} Whether the record is a note or a combo.
      */
-    isSectionOrNote(record=null) {
-        return super.isSectionOrNote(record) || this.isCombo(record);
+    isNote(record=null) {
+        return super.isNote(record) || this.isCombo(record);
     }
 
     getRowClass(record) {

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -135,7 +135,11 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return {
             ...super.sectionAndNoteClasses,
             "text-warning":
-                !this.isSection() && !this.isNote() && !this.productName && !this.isDownpayment,
+                !this.isSection()
+                && !this.isSubsection()
+                && !this.isNote()
+                && !this.productName
+                && !this.isDownpayment,
         };
     }
 

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -582,10 +582,12 @@
                                 editable="bottom"
                                 limit="200"
                                 decoration-warning="(state in ['draft', 'sent'] and is_product_archived) or sale_line_warn_msg"
+                                decoration-muted="is_linked_section_hidden"
                             >
                                 <control>
                                     <create name="add_product_control" string="Add a product"/>
                                     <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
+                                    <create name="add_subsection_control" string="Add a subsection" context="{'default_display_type': 'line_subsection'}"/>
                                     <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
                                     <button
                                         string="Catalog"
@@ -611,6 +613,9 @@
                                 <field name="selected_combo_items" column_invisible="1"/>
                                 <field name="virtual_id" column_invisible="1"/>
                                 <field name="linked_virtual_id" column_invisible="1"/>
+                                <field name="show_composition" column_invisible="1"/>
+                                <field name="show_section_line_amount" column_invisible="1"/>
+                                <field name="linked_section_line_id" column_invisible="1"/>
 
                                 <!-- Currency, needed for monetary widgets to display the currency symbol -->
                                 <field name="currency_id" column_invisible="True"/>
@@ -692,7 +697,11 @@
                                     optional="hide"
                                     width="80px"
                                     readonly="parent.state not in ['draft', 'sent', 'sale'] or is_downpayment or product_type != 'consu'"/>
-                                <field name="price_unit" readonly="qty_invoiced &gt; 0"/>
+                                <field
+                                    name="price_unit"
+                                    readonly="qty_invoiced &gt; 0"
+                                    decoration-muted="is_linked_section_amount_hidden"
+                                />
                                 <field
                                     name="tax_ids"
                                     widget="many2many_tax_tags"
@@ -705,32 +714,41 @@
                                     string="Disc.%"
                                     groups="sale.group_discount_per_so_line"
                                     width="50px"
-                                    optional="show"/>
+                                    optional="show"
+                                    decoration-muted="is_linked_section_amount_hidden"
+                                />
                                 <field
                                     name="price_subtotal"
                                     string="Amount"
                                     column_invisible="parent.company_price_include == 'tax_included'"
-                                    invisible="is_downpayment"/>
+                                    invisible="is_downpayment or (display_type in ('line_section', 'line_subsection') and show_section_line_amount)"
+                                    decoration-muted="is_linked_section_amount_hidden"
+                                />
                                 <field
                                     name="price_total"
                                     string="Amount"
                                     column_invisible="parent.company_price_include == 'tax_excluded'"
-                                    invisible="is_downpayment"/>
+                                    invisible="is_downpayment or (display_type in ('line_section', 'line_subsection') and show_section_line_amount)"
+                                    decoration-muted="is_linked_section_amount_hidden"
+                                />
                                 <!-- Optional amounts columns -->
                                 <field
                                     name="price_total"
                                     string="Tax Incl."
                                     column_invisible="parent.company_price_include == 'tax_included'"
-                                    invisible="is_downpayment"
+                                    invisible="is_downpayment or (display_type in ('line_section', 'line_subsection') and show_section_line_amount)"
                                     optional="hide"
+                                    decoration-muted="is_linked_section_amount_hidden"
                                 />
                                 <field
                                     name="price_subtotal"
                                     string="Tax Excl."
                                     column_invisible="parent.company_price_include == 'tax_excluded'"
-                                    invisible="is_downpayment"
+                                    invisible="is_downpayment or (display_type in ('line_section', 'line_subsection') and show_section_line_amount)"
                                     optional="hide"
+                                    decoration-muted="is_linked_section_amount_hidden"
                                 />
+                                <widget name="section_settings"/>
                             </list>
                             <kanban class="o_kanban_mobile">
                                 <field name="display_type"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -717,68 +717,114 @@
 
                             <t t-set="current_subtotal" t-value="0"/>
                             <t t-set="lines_to_report" t-value="sale_order._get_order_lines_to_report()"/>
+                            <t t-set="show_section_details" t-value="true"/>
 
                             <t t-foreach="lines_to_report" t-as="line">
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
                                 <t t-set="is_note" t-value="line.display_type == 'line_note'"/>
-                                <tr
-                                    t-att-class="'fw-bold o_line_section' if (
-                                        line.display_type == 'line_section'
+                                <t
+                                    t-set="show_section_details"
+                                    t-value="line.print_details"
+                                    t-if="line.display_type == 'line_section'"
+                                />
+
+                                <t
+                                    t-if="line.display_type != 'line_section'
                                         or line.product_type == 'combo'
-                                    )
-                                    else 'fst-italic o_line_note' if is_note
-                                    else ''"
+                                        or show_section_details"
                                 >
-                                    <t
-                                        name="product_line_row"
-                                        t-if="not line.display_type and line.product_type != 'combo'"
+                                    <tr
+                                        t-att-class="'fw-bold o_line_section' if (
+                                            line.display_type == 'line_section'
+                                            or line.product_type == 'combo'
+                                        )
+                                        else 'fst-italic o_line_note' if is_note
+                                        else ''"
                                     >
-                                        <td id="product_name">
-                                            <span t-field="line.name"/>
-                                        </td>
-                                        <td class="text-end" id="quote_qty_td">
-                                            <div id="quote_qty">
-                                                <span t-field="line.product_uom_qty"/>
-                                                <span t-field="line.product_uom_id"/>
-                                            </div>
-                                        </td>
-                                        <td t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <div
-                                                t-if="line.discount &gt;= 0"
-                                                t-field="line.price_unit"
-                                                t-att-style="line.discount and 'text-decoration: line-through' or None"
-                                                t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
-                                            />
-                                            <div t-if="line.discount">
-                                                <t t-out="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'/>
-                                            </div>
-                                        </td>
-                                        <td t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
-                                            <strong t-if="line.discount &gt; 0" class="text-info">
-                                                <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
-                                            </strong>
-                                        </td>
-                                        <td t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
-                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
-                                        </td>
-                                        <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
-                                        <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
-                                        </td>
+                                        <t
+                                            name="product_line_row"
+                                            t-if="not line.display_type
+                                                and line.product_type != 'combo'
+                                                and show_section_details"
+                                        >
+                                            <td id="product_name">
+                                                <span t-field="line.name"/>
+                                            </td>
+                                            <td class="text-end" id="quote_qty_td">
+                                                <div id="quote_qty">
+                                                    <span t-field="line.product_uom_qty"/>
+                                                    <span t-field="line.product_uom_id"/>
+                                                </div>
+                                            </td>
+                                            <td t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                                <div
+                                                    t-if="line.discount &gt;= 0"
+                                                    t-field="line.price_unit"
+                                                    t-att-style="line.discount and 'text-decoration: line-through' or None"
+                                                    t-att-class="(line.discount and 'text-danger' or '') + ' text-end'"
+                                                />
+                                                <div t-if="line.discount">
+                                                    <t t-out="(1-line.discount / 100.0) * line.price_unit" t-options='{"widget": "float", "decimal_precision": "Product Price"}'/>
+                                                </div>
+                                            </td>
+                                            <td t-if="display_discount" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                                <strong t-if="line.discount &gt; 0" class="text-info">
+                                                    <t t-out="((line.discount % 1) and '%s' or '%d') % line.discount"/>%
+                                                </strong>
+                                            </td>
+                                            <td t-if="display_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
+                                                <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
+                                            </td>
+                                            <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
+                                            <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
+                                            </td>
+                                        </t>
+                                        <t t-if="line.display_type == 'line_section' or line.product_type == 'combo'">
+                                            <td name="td_section_line" colspan="99">
+                                                <span t-field="line.name"/>
+                                            </td>
+                                            <t t-set="current_section" t-value="line"/>
+                                            <t t-set="current_subtotal" t-value="0"/>
+                                        </t>
+                                        <t t-if="is_note and show_section_details">
+                                            <td colspan="99">
+                                                <span t-field="line.name"/>
+                                            </td>
+                                        </t>
+                                    </tr>
+                                </t>
+
+                                <t t-else="">
+                                    <t t-foreach="line._get_grouped_section_summary()" t-as="section_line">
+                                        <tr>
+                                            <td name="td_section_line" colspan="3">
+                                                <span t-out="section_line['name']"/>
+                                            </td>
+                                            <td name="td_quantity" class="text-end text-nowrap">
+                                                <span>1 Unit</span>
+                                            </td>
+                                            <td name="td_priceunit" class="text-end text-nowrap">
+                                                <span t-out="section_line['price_subtotal']"/>
+                                            </td>
+                                            <td name="td_discount" t-if="display_discount"/>
+                                            <td
+                                                t-if="display_taxes"
+                                                t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"
+                                                id="taxes"
+                                            >
+                                                <span t-out="', '.join(section_line['taxes'])"/>
+                                            </td>
+                                            <td class="text-end">
+                                                <span
+                                                    class="oe_order_line_price_subtotal"
+                                                    t-out="section_line['price_subtotal']"
+                                                />
+                                            </td>
+                                        </tr>
                                     </t>
-                                    <t t-if="line.display_type == 'line_section' or line.product_type == 'combo'">
-                                        <td colspan="99">
-                                            <span t-field="line.name"/>
-                                        </td>
-                                        <t t-set="current_section" t-value="line"/>
-                                        <t t-set="current_subtotal" t-value="0"/>
-                                    </t>
-                                    <t t-if="is_note">
-                                        <td colspan="99">
-                                            <span t-field="line.name"/>
-                                        </td>
-                                    </t>
-                                </tr>
+                                </t>
+
                                 <tr
                                     t-if="current_section and (
                                         line_last
@@ -788,7 +834,8 @@
                                             line.combo_item_id
                                             and not lines_to_report[line_index+1].combo_item_id
                                         )
-                                    ) and not line.is_downpayment"
+                                    ) and not line.is_downpayment
+                                    and show_section_details"
                                     class="is-subtotal text-end"
                                 >
                                     <t t-set="current_section" t-value="None"/>

--- a/addons/sale_management/models/sale_order_template_line.py
+++ b/addons/sale_management/models/sale_order_template_line.py
@@ -58,6 +58,12 @@ class SaleOrderTemplateLine(models.Model):
         ('line_section', "Section"),
         ('line_note', "Note")], default=False)
 
+    print_details = fields.Boolean(
+        string="Print Details",
+        default=True,
+        help="Show and print the sale order template lines under particular section.",
+    )
+
     #=== COMPUTE METHODS ===#
 
     @api.depends('product_id', 'product_id.uom_id', 'product_id.uom_ids')


### PR DESCRIPTION
To improve document clarity, subtotaling, and modularity in sales and invoicing,
we introduce a new `display_type='line_subsection'` alongside the existing
section and note types.

This allows nesting of lines into sections > subsections > lines,
enabling better visual grouping and control in both backend and reports/portal.

Key features:
- New display type `line_subsection` in sale/invoice lines
- Gear menu on sections/subsections with the following actions:
  - **Add Line**: inserts a line after section/subsection block
  - **Add Subsection**: inserts a new subsection after current section
  - **Hide Prices**: hides unit & line price from PDF/portal
  - **Hide Composition**: collapses internal lines in report to a single summary
  - **Move Up/Down**: resequence sections/subsections with their children
  - **Duplicate**: duplicates section/subsection with lines
  - **Delete**: removes section/subsection and all nested lines
- Sections and subsections styled differently with background/bold headers
- Amount now includes totals from all nested lines and subsections
- Same logic reused in invoice form (purchase orders are excluded)

This update improves control over grouping and visibility of sale order content
in backend, reports, and portal.

task-4669991