### PR TITLE
[FIX] acount: prevent error computing user_hard_lock_date for archived company

### DIFF
--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -390,7 +390,10 @@ class ResCompany(models.Model):
     @api.depends('hard_lock_date')
     def _compute_user_hard_lock_date(self):
         for company in self:
-            company.user_hard_lock_date = max(c.hard_lock_date or date.min for c in company.sudo().parent_ids)
+            company.user_hard_lock_date = max(
+                c.hard_lock_date or date.min
+                for c in company.with_context(active_test=False).sudo().parent_ids
+            )
 
     def _initiate_account_onboardings(self):
         account_onboarding_routes = [


### PR DESCRIPTION
Currently, when we are accessing the `parent_ids` of an archived company
with code `company.sudo().parent_ids`, it will return an empty record, and an
error will be generated when code tries to access `max()` from that empty
record at code line [1].

```
  >>> company = self.env['res.company'].browse(2)
  >>> company
  res.company(2,)
  >>> company.active
  False
  >>> company.sudo().parent_ids
  res.company()
  >>> max(c.hard_lock_date or date.min for c in company.sudo().parent_ids)
  Traceback (most recent call last):
    File "/usr/lib/python3.12/code.py", line 90, in runcode
      exec(code, self.locals)
    File "<console>", line 1, in <module>
  ValueError: max() iterable argument is empty
  >>> max(c.hard_lock_date or date.min for c in 
  company.sudo().with_context(active_test=False).parent_ids)
  datetime.date(1, 1, 1)
  >>> 
  >>> 
```
This commit fixes the above issue by setting `active_test=False`, which
allows access to `archived (inactive)` parent companies, ensuring that
`company.sudo().parent_ids` includes them and avoids passing an empty
sequence to max()

[1] - https://github.com/odoo/odoo/blob/ac3924508016178427c7962fa3b8e645e7e03835/addons/account/models/company.py#L393

sentry-6581609140