### PR TITLE
[FIX] project: fix crash on optional column in blocked-by notebook

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -527,7 +527,7 @@
                                         context="{'default_project_id': project_id}"
                                         column_invisible="not parent.allow_milestones"
                                         invisible="not allow_milestones"/>
-                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="has_template_ancestor"/>
+                                    <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" column_invisible="parent.has_template_ancestor"/>
                                     <field name="parent_id" optional="hide" groups="base.group_no_one"/>
                                     <field name="user_ids" widget="many2many_avatar_user" optional="show"/>
                                     <field name="company_id" optional="hide" groups="base.group_multi_company" />


### PR DESCRIPTION
**Steps to reproduce:**
- Install project
- Enable task dependencies
- Go to the blocked-by notebook
- Click the optional column dropdown

**Issue:**
when clicking on optional column in blocked-by notebook a traceback occurs

**Fix:**
Used parent.has_template_ancestor instead of has_template_ancestor to explicitly access the field from the parent record .

task-4764758

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
