### PR TITLE
[FIX] l10n_eu_oss: oss tax name already exists

### DIFF
--- a/addons/l10n_eu_oss/i18n/cs.po
+++ b/addons/l10n_eu_oss/i18n/cs.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Kopie)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Společnosti"

--- a/addons/l10n_eu_oss/i18n/de.po
+++ b/addons/l10n_eu_oss/i18n/de.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Kopie)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Unternehmen"

--- a/addons/l10n_eu_oss/i18n/es.po
+++ b/addons/l10n_eu_oss/i18n/es.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Copia)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Compañías"

--- a/addons/l10n_eu_oss/i18n/fr.po
+++ b/addons/l10n_eu_oss/i18n/fr.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Copie)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Entreprises"

--- a/addons/l10n_eu_oss/i18n/it.po
+++ b/addons/l10n_eu_oss/i18n/it.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Copia)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Aziende"

--- a/addons/l10n_eu_oss/i18n/l10n_eu_oss.pot
+++ b/addons/l10n_eu_oss/i18n/l10n_eu_oss.pot
@@ -16,6 +16,13 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr ""
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr ""

--- a/addons/l10n_eu_oss/i18n/nl.po
+++ b/addons/l10n_eu_oss/i18n/nl.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Kopie)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Bedrijven"

--- a/addons/l10n_eu_oss/i18n/pl.po
+++ b/addons/l10n_eu_oss/i18n/pl.po
@@ -17,6 +17,13 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
 #. module: l10n_eu_oss
+#. odoo-python
+#: code:addons/l10n_eu_oss/models/res_company.py:0
+#, python-format
+msgid "%(tax_name)s (Copy)"
+msgstr "%(tax_name)s (Kopiuj)"
+
+#. module: l10n_eu_oss
 #: model:ir.model,name:l10n_eu_oss.model_res_company
 msgid "Companies"
 msgstr "Firmy"

--- a/addons/l10n_eu_oss/models/res_company.py
+++ b/addons/l10n_eu_oss/models/res_company.py
@@ -3,7 +3,7 @@
 import re
 from itertools import product
 
-from odoo import Command, api, models
+from odoo import Command, _, api, models
 from .eu_tag_map import EU_TAG_MAP
 from .eu_tax_map import EU_TAX_MAP
 
@@ -82,8 +82,16 @@ class Company(models.Model):
                                     }).id,
                                     'noupdate': True,
                                 })
+                            foreign_tax_name = f'{tax_amount}% {destination_country.code} {destination_country.vat_label}'
+                            existing_foreign_tax = self.env['account.tax'].search([
+                                ('company_id', 'child_of', company.root_id.id),
+                                ('name', 'like', foreign_tax_name),
+                                ('type_tax_use', '=', 'sale'),
+                                ('country_id', '=', company.account_fiscal_country_id.id),
+                            ], order='sequence,id desc', limit=1)
+                            foreign_tax_copy_name = existing_foreign_tax and _('%(tax_name)s (Copy)', tax_name=existing_foreign_tax.name)
                             foreign_taxes[tax_amount] = self.env['account.tax'].create({
-                                'name': f'{tax_amount}% {destination_country.code} {destination_country.vat_label}',
+                                'name': foreign_tax_copy_name or foreign_tax_name,
                                 'amount': tax_amount,
                                 'invoice_repartition_line_ids': invoice_repartition_lines,
                                 'refund_repartition_line_ids': refund_repartition_lines,

--- a/addons/l10n_eu_oss/tests/test_oss.py
+++ b/addons/l10n_eu_oss/tests/test_oss.py
@@ -79,6 +79,22 @@ class TestOSSBelgium(OssTemplateTestCase):
 
                 self.assertIn(expected_tag_id, oss_tag_id, f"{doc_type} tag from Belgian CoA not correctly linked")
 
+    def test_oss_tax_copied_name(self):
+        """
+        This test ensures that when refreshing the mapping, if a tax that already exists has to be created, it is created
+        with (Copy) in the name instead of stopping the refresh process.
+        """
+        self.sub_child_company._map_eu_taxes()
+        # get the fiscal position for another eu country
+        another_eu_country = (self.env.ref('base.europe').country_ids - self.company_data['company'].country_id)[0]
+        fpos = self.env['account.fiscal.position'].search([('country_id', '=', another_eu_country.id)], limit=1)
+        original_name = fpos.tax_ids.tax_dest_id[0].name
+        fpos.unlink()
+        self.sub_child_company._map_eu_taxes()
+        fpos = self.env['account.fiscal.position'].search([('country_id', '=', another_eu_country.id)], limit=1)
+        new_name = fpos.tax_ids.tax_dest_id[0].name
+        self.assertEqual(new_name, f"{original_name} (Copy)", "The tax name should be the same as the original one with (Copy) appended to it.")
+
 
 @tagged('post_install', 'post_install_l10n', '-at_install')
 class TestOSSSpain(OssTemplateTestCase):


### PR DESCRIPTION
Description of the issue this commit addresses:

When creating the OSS fiscal positions, if the system creates a tax with a name already used by another tax, the entire mapping process stops due to a unique name constraint resulting in only the countries that have already been done to have the OSS fiscal positions. A solution would be to delete the tax but in the eventuality that it has already been used, it is impossible to delete it hence refreshing the oss fiscal positions becoming totally impossible.

---

Steps to reproduce:

1. Install l10n_eu_oss and any oss member loca (be for example)
2. Use the company of the loca installed
3. Go to Accouting, Settings, click Refresh tax mapping.
4. Go to the fiscal positions and delete any oss fiscal position.
5. Go back to Accoutning, Settings, click Refresh tax mapping.
6. "Tax names must be unique!" error shows up.

---

Desired behavior after this commit is merged:

When creating the oss fiscal positions, a search is performed to gather the tax and its copies that use the desired name. The name of the new tax will be the name of the one with the most " (Copy)" in its name with one more " (Copy)".

---

no-task

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr