### PR TITLE
[FIX] pos_self_order: fix blocked user in self order

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -53,7 +53,9 @@ class PosSelfOrderController(http.Controller):
             'amount_total': amount_total,
         })
 
-        order_ids.send_table_count_notification(order_ids.mapped('table_id'))
+        for config in order_ids.config_id:
+            config.notify_synchronisation(config.current_session_id.id, 0)
+
         return self._generate_return_values(order_ids, pos_config)
 
     def _generate_return_values(self, order, config_id):

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -59,6 +59,9 @@ class PosOrder(models.Model):
     def remove_from_ui(self, server_ids):
         order_ids = self.env['pos.order'].browse(server_ids)
         order_ids.state = 'cancel'
+        for config in order_ids.config_id:
+            config.notify_synchronisation(config.current_session_id.id, 0)
+
         self._send_notification(order_ids)
         return super().remove_from_ui(server_ids)
 

--- a/addons/pos_self_order/static/src/app/data_service.js
+++ b/addons/pos_self_order/static/src/app/data_service.js
@@ -4,6 +4,14 @@ import { session } from "@web/session";
 import { rpc } from "@web/core/network/rpc";
 
 patch(PosData.prototype, {
+    async setup() {
+        await super.setup(...arguments);
+
+        // Override Point of Sale deviceSync object to avoid errors
+        this.deviceSync = {
+            dispatch: () => void 0,
+        };
+    },
     async loadInitialData() {
         const configId = session.data.config_id;
         return await rpc(`/pos-self/data/${parseInt(configId)}`);

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -3,7 +3,10 @@
     <t t-name="pos_self_order.CartPage">
         <div class="order-cart-content d-flex flex-column flex-grow-1 justify-content-between overflow-y-auto">
             <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 p-3 w-100 bg-view border-bottom overflow-x-auto z-1">
-                <h1 class="mb-0 fw-bolder text-nowrap">Your Order</h1>
+                <h1 class="mb-0 fw-bolder text-nowrap flex-grow-1">Your Order</h1>
+                <button t-if="showCancelButton" t-on-click="() => this.cancelOrder()" class="btn btn-secondary px-3" type="button">
+                    <span>Cancel</span>
+                </button>
             </div>
             <div class="order-content flex-grow-1 overflow-auto pb-4">
                 <t t-foreach="linesToDisplay" t-as="line" t-key="line.uuid">


### PR DESCRIPTION
When configuring a self-ordering PoS in pay after each, if the user made an error in the order and wants to modify it, the user is blocked and cannot modify the order.

This commit fixes this behavior by allowing the user to cancel the order and recreate it if needed.

