### PR TITLE
[FIX] pos_self_order: prevent displaying unavailable products in PoS

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -54,7 +54,7 @@ class ProductProduct(models.Model):
         return AND([domain, [('self_order_available', '=', True)]])
 
     def _load_pos_self_data(self, data):
-        domain = self._load_pos_data_domain(data)
+        domain = self._load_pos_self_data_domain(data)
         config_id = data['pos.config']['data'][0]['id']
 
         # Add custom fields for 'formula' taxes.

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -428,7 +428,11 @@ export class SelfOrder extends Reactive {
             const productTmplIds = new Set();
             this.productByCategIds[category_id] = this.productByCategIds[category_id].filter(
                 (p) => {
-                    if (!isSpecialProduct(p) && !productTmplIds.has(p.raw.product_tmpl_id)) {
+                    if (
+                        !isSpecialProduct(p) &&
+                        p.self_order_available &&
+                        !productTmplIds.has(p.raw.product_tmpl_id)
+                    ) {
                         productTmplIds.add(p.raw.product_tmpl_id);
                         p.available_in_pos = false;
                         return true;


### PR DESCRIPTION
Before this commit, products that were not available for self-ordering were still loaded into the PoS and displayed as "Out of stock." This could cause confusion for users.

After this commit, unavailable products are no longer loaded or displayed in the PoS, ensuring that only available products are shown to customers.

opw-4764785

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
