### PR TITLE
[FIX] l10n_de: relax write condition on acccount code for mapping

### DIFF
--- a/addons/l10n_de/models/account_account.py
+++ b/addons/l10n_de/models/account_account.py
@@ -8,8 +8,11 @@ class AccountAccount(models.Model):
     def write(self, vals):
         if (
             'code' in vals
-            and 'DE' in self.company_ids.account_fiscal_country_id.mapped('code')
-            and any(a.code != vals['code'] for a in self)
+            and self.env.company.account_fiscal_country_id.code == 'DE'
+            and any(
+                self.env.company in a.company_ids and a.code != vals['code']
+                for a in self
+            )
         ):
             if self.env['account.move.line'].search_count([('account_id', 'in', self.ids)], limit=1):
                 raise UserError(_("You can not change the code of an account."))


### PR DESCRIPTION
Writing the account code is restricted on l10n_de accounts. Odoo checks that the code we write is different from the old one, and if so it checks of there are already some entries for that accounts. If any of the condition is met, the write is prevented.

When we try to map an account from another company to a l10n_de company, the _inverse_code function from the account mapping will try and update the account code in the other company, as the code is company dependent.

The issue is that we check that the l10n_de code remains the same, even if we are in another, non l10n_de company.

This PR adapts the check to l10n_de account to only check the code if we are writing it from the l10n_de company.

opw-4711417
