### PR TITLE
[FIX] hw_drivers: fix report printing in windows

### DIFF
--- a/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
+++ b/addons/hw_drivers/iot_handlers/drivers/PrinterDriver_W.py
@@ -112,7 +112,7 @@ class PrinterDriver(Driver):
         printer = self.device_name
 
         args = [
-            "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT", "-dNORANGEPAGESIZE",
+            "-dPrinted", "-dBATCH", "-dNOPAUSE", "-dNOPROMPT",
             "-q",
             "-sDEVICE#mswinpr2",
             f'-sOutputFile#%printer%{printer}',


### PR DESCRIPTION
In odoo/odoo#192634, the `-dNORANGEPAGESIZE` option was added to the Ghostscript call used when printing PDF reports. This fixed the orientation of landscape reports.

However, recently this option seems to be causing a crash, reproducible by running Ghostscript directly:

> .\gswin64c.exe -dNORANGEPAGESIZE .\test.pdf

This happens for all PDF files, and occurs in both the Ghostscript version used by Odoo (10.01.2) and the latest version (10.05.1). However it doesn't seem to happen for everyone, as it was not reported as an issue when this task was first implemented. The version has not changed so it may be an issue caused by a Windows update or similar.

Regardless, this is a blocking issue that is preventing clients from printing, so for now we will just revert the support for landscape printing.

opw-4666794

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
