### PR TITLE
[FIX] base,test_import_export: handled error when field is not in converters

### DIFF
--- a/addons/test_import_export/tests/test_properties.py
+++ b/addons/test_import_export/tests/test_properties.py
@@ -436,3 +436,30 @@ class TestPropertiesExportImport(HttpCase):
             {'bool_prop': True, 'tags_prop': ['bb'], 'm2m_prop': self.partners[1:].ids},
             {'bool_prop': False, 'tags_prop': ['bb', 'cc'], 'm2m_prop': False},
         ])
+
+    def test_import_field_with_missing_converter(self):
+        values_list = [
+            ["properties_definition"],
+            ["test property"],
+        ]
+        csv_data = '\n'.join([';'.join(row) for row in values_list])
+
+        import_wizard = self.env['base_import.import'].create({
+            'res_model': 'import.properties.definition',
+            'file': csv_data,
+            'file_type': 'text/csv',
+        })
+
+        opts = {'quoting': '"', 'separator': ';', 'has_headers': True}
+
+        preview = import_wizard.parse_preview(opts)
+        self.assertIn('headers', preview)
+        self.assertIn('preview', preview)
+
+        result = import_wizard.execute_import(
+            preview.get("matches", {}).get(0, ['properties_definition']),
+            [], opts,
+        )
+
+        self.assertIn('messages', result)
+        self.assertTrue(len(result['messages']) > 0)

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -133,7 +133,7 @@ class IrFieldsConverter(models.AbstractModel):
                         log(field, w)
                 except (UnicodeEncodeError, UnicodeDecodeError) as e:
                     log(field, ValueError(str(e)))
-                except ValueError as e:
+                except (ValueError, TypeError) as e:
                     if import_file_context:
                         # if the error is linked to a matching error, the error is a tuple
                         # E.g.:("Value X cannot be found for field Y at row 1", {


### PR DESCRIPTION
The system will crash when we import a CSV with a field `employee_properties_definition` and click on `Test`.

Steps to Produce:
1. Install `Employees`.
2. Go to Settings > User & Companies > Companies > Import Records.
3. Upload a file with the column title `employee_properties_definition` and provide any data.
4. Click on `Test`.

Error:-
`TypeError: 'NoneType' object is not callable`.

Solution:-
   - To handle the case where the converter is `None`, resulting in a `TypeError`, I included TypeError in the `except` block. This ensures graceful handling when a field's converter is not properly defined.

Sentry - 5854109138

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
