### PR TITLE
[FIX] l10n_in: fix error for vendor bill scan

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -100,7 +100,7 @@ class ResPartner(models.Model):
     @api.model
     def _l10n_in_get_partner_vals_by_vat(self, vat):
         partner_data = self.enrich_by_gst(vat)
-        for fname in partner_data:
+        for fname in list(partner_data.keys()):
             if fname not in self.env['res.partner']._fields:
                 partner_data.pop(fname, None)
         partner_data.update({


### PR DESCRIPTION
When user tries to scan Vendor Bill, a traceback will appear.

Traceback:
```
File "/home/odoo/src/odoo/saas-18.2/addons/l10n_in/models/res_partner.py", line 219, in _l10n_in_get_partner_vals_by_vat
    for fname in partner_data:
RuntimeError: dictionary changed size during iteration
```

https://github.com/odoo/odoo/blob/ac3924508016178427c7962fa3b8e645e7e03835/addons/l10n_in/models/res_partner.py#L103-L105
Here, this method modifies the ``partner_data`` dictionary
(using pop()) while iterating over it,
which leads to the above traceback.

To resolve this, the loop now iterates over a list of keys from ``partner_data``. 
[ref](https://github.com/odoo/enterprise/blob/6f5e6a43f6149b4a8418d78a457f543de2dcfea3/l10n_in_qr_code_bill_scan/models/account_move.py#L90)

sentry-6586138810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
