### PR TITLE
[FIX] l10n_es_edi_tbai: fw-port simplified wrongly merged

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -425,7 +425,7 @@ class L10nEsEdiTbaiDocument(models.Model):
         return sale_values
 
     def _get_regime_code_value(self, taxes, is_simplified):
-        return {'regime_key': taxes._l10n_es_get_regime_code()}
+        return {'regime_key': [taxes._l10n_es_get_regime_code()]}
 
     @api.model
     def _add_base_lines_tax_amounts(self, base_lines, company, tax_lines=None):

--- a/addons/l10n_es_edi_tbai/tests/document_xmls/xml_post.xml
+++ b/addons/l10n_es_edi_tbai/tests/document_xmls/xml_post.xml
@@ -60,7 +60,6 @@
                                         <BaseImponible>4000.00</BaseImponible>
                                         <TipoImpositivo>21.00</TipoImpositivo>
                                         <CuotaImpuesto>840.00</CuotaImpuesto>
-                                        <OperacionEnRecargoDeEquivalenciaORegimenSimplificado>N</OperacionEnRecargoDeEquivalenciaORegimenSimplificado>
                                     </DetalleIVA>
                                 </DesgloseIVA>
                             </DetalleNoExenta>

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -126,7 +126,6 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
                         <BaseImponible>984.00</BaseImponible>
                         <TipoImpositivo>21.00</TipoImpositivo>
                         <CuotaImpuesto>206.64</CuotaImpuesto>
-                        <OperacionEnRecargoDeEquivalenciaORegimenSimplificado>N</OperacionEnRecargoDeEquivalenciaORegimenSimplificado>
                       </DetalleIVA>
                     </DesgloseIVA>
                 </xpath>


### PR DESCRIPTION
The fw-port in https://github.com/odoo/odoo/pull/208205 was not changed correctly as the method on the taxes returned one element, but the calling method needed to return a list and as such the string was interpreted as a list giving two claves for e.g. 01.

In the meantime, the tests are adapted as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
