### PR TITLE
[IMP] hr_skills: ui updates to certification reporting section

### DIFF
--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -48,8 +48,12 @@
                             <field name="display_type" required="1"/>
                         </group>
                         <group>
-                            <field name="date_start" string="Duration" widget="daterange" options="{'end_date_field': 'date_end'}"/>
-                            <field name="date_end" invisible="1"/>
+                            <label for="date_start" string="Validity"/>
+                            <div class="o_row">
+                                <field name="date_start"/>
+                                <i class="fa fa-long-arrow-right mx-2" aria-label="Arrow icon" title="Arrow"/>
+                                <field name="date_end" placeholder="Never Expires"/>
+                            </div>
                         </group>
                     </group>
                     <field name="description" placeholder="Description"/>

--- a/addons/hr_skills_survey/models/hr_resume_line.py
+++ b/addons/hr_skills_survey/models/hr_resume_line.py
@@ -25,3 +25,7 @@ class HrResumeLine(models.Model):
                     line.expiration_status = 'expired'
                 elif line.date_end + relativedelta(months=-3) <= fields.Date.today():
                     line.expiration_status = 'expiring'
+
+    def copy_data(self, default=None):
+        vals_list = super().copy_data(default=default)
+        return [dict(vals, name=self.env._("%s (copy)", resume_line.name)) for resume_line, vals in zip(self, vals_list)]


### PR DESCRIPTION
- certification record is duplicated, append the suffix '(copy)' to the title 
- rename the field 'Duration'  to  'Validity' for clarity 
- end date placeholder set to 'Never Expires'
- default value of the display type field to 'certification'

task-4766705
