### PR TITLE
[FIX] html_editor: allow pasting <ul> inside <pre>

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -1,4 +1,5 @@
 import { isTextNode, isParagraphRelatedElement } from "../utils/dom_info";
+import { transformListsInPreElement } from "../utils/list";
 import { Plugin } from "../plugin";
 import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents, wrapInlinesInBlocks, splitTextNode } from "../utils/dom";
@@ -88,6 +89,7 @@ export const CLIPBOARD_WHITELISTS = {
 };
 
 const ONLY_LINK_REGEX = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)?$/i;
+const UL_TAG_REGEX = /<ul\b[^>]*>[\s\S]*?<\/ul>/i;
 
 /**
  * @typedef {Object} ClipboardShared
@@ -277,6 +279,12 @@ export class ClipboardPlugin extends Plugin {
             const fragment = parseHTML(this.document, odooEditorHtml);
             this.dependencies.sanitize.sanitize(fragment);
             if (fragment.hasChildNodes()) {
+                if (UL_TAG_REGEX.test(odooEditorHtml)) {
+                    const selection = this.dependencies.selection.getEditableSelection();
+                    if (selection.anchorNode.nodeName === "PRE") {
+                        transformListsInPreElement(fragment);
+                    }
+                }
                 this.dependencies.dom.insert(fragment);
             }
             return true;

--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -30,3 +30,7 @@ ul.o_checklist {
         }
     }
 }
+
+pre > div ul.o_checklist > li.o_checked:after {
+    top: 2px;
+}

--- a/addons/html_editor/static/src/utils/list.js
+++ b/addons/html_editor/static/src/utils/list.js
@@ -70,3 +70,16 @@ export function convertList(node, newMode) {
     }
     return node;
 }
+/**
+ * There is a quirk in 'lxml' library that do not allow 'ul' directly inside <pre>.
+ * This method, wraps such ul containing fragment to div
+ *
+ * @param {DocumentFragment} fragment
+ */
+export function transformListsInPreElement(fragment) {
+    fragment.querySelectorAll("ul").forEach((list) => {
+        const wrapper = document.createElement("div");
+        list.replaceWith(wrapper);
+        wrapper.appendChild(list);
+    });
+}

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -2347,6 +2347,45 @@ describe("Special cases", () => {
         });
     });
 
+    describe("ul inside pre", () => {
+        test("wrap ul with div when inside pre", async () => {
+            await testEditor({
+                contentBefore: "<pre>[]<br></pre>",
+                stepFunction: async (editor) => {
+                    pasteOdooEditorHtml(editor, '<ul class="o_checklist"><li>item</li></ul>');
+                },
+                contentAfter:
+                    '<pre><div><ul class="o_checklist"><li>item</li></ul></div>[]<br></pre>',
+            });
+        });
+        test("wrap ul with div when inside pre (2)", async () => {
+            await testEditor({
+                contentBefore: "<pre>[]<br></pre>",
+                stepFunction: async (editor) => {
+                    pasteOdooEditorHtml(
+                        editor,
+                        '<ul class="o_checklist"><li>item</li><li>item2</li></ul><ol><li>item</li></ol>'
+                    );
+                },
+                contentAfter:
+                    '<pre><div><ul class="o_checklist"><li>item</li><li>item2</li></ul></div><ol><li>item[]</li></ol></pre>',
+            });
+        });
+        test("wrap ul with div when inside pre (3)", async () => {
+            await testEditor({
+                contentBefore: "<pre>[]<br></pre>",
+                stepFunction: async (editor) => {
+                    pasteOdooEditorHtml(
+                        editor,
+                        "textcontent1<ul><li>item</li></ul>textcontent2\ntextcontent3<ul><li>item1</li><li>item2</li></ul>"
+                    );
+                },
+                contentAfter:
+                    "<pre>textcontent1<div><ul><li>item</li></ul></div>textcontent2\ntextcontent3<div><ul><li>item1</li><li>item2</li></ul></div>[]<br></pre>",
+            });
+        });
+    });
+
     describe("paragraphs", () => {
         test("should paste multiple paragraphs into a list", async () => {
             await testEditor({


### PR DESCRIPTION

**Description**
there is quirk in lxml library which do not allow `<ul>` directly inside `<pre>`

currently

```
doc = html.fromstring("<pre><ul><li>item1</li></ul></pre>") 
html.tostring(doc)
```
results into
```
<div><pre></pre><ul><li>item1</li></ul></div>
```


**step to reproduce**
1. open a knowledge article
2. create a bullet list
3. create a code section
4. copy the list and paste it inside code section
5. save the article

observation: the list moved outside of code section

Desired behavior after PR is merged:
- this commit mitigates this by wrapping such ul's with a <div> when pasting such content inside <pre>





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
