### PR TITLE
[FIX] hr_holidays: Unable to Save Public Holiday

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -77,7 +77,7 @@ class ResourceCalendarLeaves(models.Model):
                     and (not sick_time_status or leave.holiday_status_id not in sick_time_status):
                 message = _("Due to a change in global time offs, %s extra day(s) have been taken from your allocation. Please review this leave if you need it to be changed.", -1 * duration_difference)
             try:
-                leave.write({'state': state})
+                leave.sudo().write({'state': state})  # sudo in order to skip _check_approval_update
                 leave._check_validity()
                 if leave.state == 'validate':
                     # recreate the resource leave that were removed by writing state to draft


### PR DESCRIPTION
## Steps to Reproduce:
- Create a new time-off request for a specific date range using the admin panel.
- Try creating public holidays that overlap with the selected date range.

## Fix:
- To resolve the above issue, we will pass a context variable to skip the thrown error.

Task: 4770292

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
