### PR TITLE
[FIX] pos_event:  only show ticket old price when manually modified

### DIFF
--- a/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_event/static/src/app/screens/product_screen/product_screen.js
@@ -81,6 +81,7 @@ patch(ProductScreen.prototype, {
                 product_id: ticket.product_id,
                 product_tmpl_id: ticket.product_id.product_tmpl_id,
                 price_unit: ticket.price,
+                price_type: "original",
                 qty: data.length,
                 event_ticket_id: ticket,
             });


### PR DESCRIPTION
Before this commit, when adding an event ticket in a French company to an order, the strikethrough "Old unit price" was displayed even though the price had not been manually modified.

After this commit, the "Old unit price" is only displayed when the event price is manually modified.

Steps to reproduce:
- Install pos_event and l10n_fr_pos_cert
- Create a French company
- Create a new event
- Open the POS
- Add the event ticket to the order
- The old unit price is displayed

opw-4761498



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
