### PR TITLE
[FIX] point_of_sale: 1 unit added on aborted weighing

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -827,6 +827,8 @@ export class PosStore extends Reactive {
                 const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen);
                 if (weight) {
                     values.qty = weight;
+                } else {
+                    return;
                 }
             } else {
                 await values.product_id._onScaleNotAvailable();


### PR DESCRIPTION
Steps to reproduce:
- Connect IoT box with scale to DB
- Configure PoS with the scale
- Configure product to be available in PoS and has to be weighed
- Make an order with the product
- Scale window pops up for weighing
- Close window directly
- One unit of product is still added, we expect nothing to be added

opw-4643243

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
