### PR TITLE
[IMP] project, sale_project: add task template on product 

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -841,7 +841,8 @@ class ProjectTask(models.Model):
                 vals['stage_id'] = task.stage_id.id
             if 'active' not in default and not task['active'] and not self.env.context.get('copy_project'):
                 vals['active'] = True
-            vals['name'] = task.name if self.env.context.get('copy_project') or self.env.context.get('copy_from_template') else _("%s (copy)", task.name)
+            if not default.get('name'):
+                vals['name'] = task.name if self.env.context.get('copy_project') or self.env.context.get('copy_from_template') else _("%s (copy)", task.name)
             if task.recurrence_id and not default.get('recurrence_id'):
                 vals['recurrence_id'] = task.recurrence_id.copy().id
             if task.allow_milestones:
@@ -1987,8 +1988,9 @@ class ProjectTask(models.Model):
             "partner_id",
         ]
 
-    def action_create_from_template(self):
+    def action_create_from_template(self, values=None):
         self.ensure_one()
+        values = values or {}
         default = {
             key[8:]: value
             for key, value in self.env.context.items()
@@ -1996,7 +1998,7 @@ class ProjectTask(models.Model):
         } | {
             field: False
             for field in self._get_template_field_blacklist()
-        }
+        } | values
         return self.with_context(copy_from_template=True).copy(default=default).id
 
     def action_archive(self):

--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -201,7 +201,7 @@ class SaleOrder(models.Model):
         return action
 
     def _tasks_ids_domain(self):
-        return ['&', ('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids), ('has_template_ancestor', '=', False)]
+        return ['&', ('is_template', '=', False), ('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids), ('has_template_ancestor', '=', False)]
 
     def action_create_project(self):
         self.ensure_one()

--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -21,6 +21,22 @@
                     <label for='project_template_id'/>
                 </div>
                 <field name="project_template_id" context="{'active_test': False, 'default_allow_billable': True, 'default_is_template': True}" invisible="service_tracking not in ['task_in_project', 'project_only']" nolabel="1" placeholder="Empty project"/>
+                <div class="o_td_label d-inline-flex"
+                    invisible="not project_id or service_tracking != 'task_global_project'">
+                    <label for="task_template_id" />
+                </div>
+                <!-- field for project manager -->
+                <field name="task_template_id"
+                    groups="project.group_project_manager"
+                    context="{'default_is_template': True, 'default_project_id': project_id or project_template_id}"
+                    invisible="not project_id or service_tracking != 'task_global_project'"
+                    nolabel="1" />
+                <!-- field for non-project manager -->
+                <field name="task_template_id"
+                    groups="!project.group_project_manager"
+                    options="{'no_open': True, 'no_create_edit': True, 'no_create': True}"
+                    invisible="not project_id or service_tracking != 'task_global_project'"
+                    nolabel="1" />
                 <field name="service_policy"
                     string="Invoicing Policy"
                     invisible="type != 'service' or sale_ok == False"

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -194,3 +194,7 @@ class SaleOrderLine(models.Model):
             if sol.is_service and len(timesheet_ids) > 0:
                 action_per_sol[sol.id] = timesheet_action, timesheet_ids[0] if len(timesheet_ids) == 1 else False
         return action_per_sol
+
+    @api.model
+    def _get_product_service_policy(self):
+        return super()._get_product_service_policy() + ['delivered_timesheet']


### PR DESCRIPTION
- Add a new 'Task Template' field under 'Project' in the product form.
  - Shown only for service products that can be sold and set to create tasks.
- All users can read/edit the field; only project admins can
  create templates.

On sale order confirm:
-----------
- If set, copy the task template into the project with name. EX- 'SO123 - task template name'.
- If many lines share the same task template:
  - Only one task is created.
  - Sum ordered quantity as allocated hours (if invoicing is prepaid or timesheet based).

task-4369824