### PR TITLE
[FIX] l10n_be_pos_sale: Fix pos opening pos_session

### DIFF
--- a/addons/l10n_be_pos_sale/models/pos_session.py
+++ b/addons/l10n_be_pos_sale/models/pos_session.py
@@ -7,7 +7,7 @@ class PosSession(models.Model):
     def _load_pos_data(self, data):
         data = super()._load_pos_data(data)
         if self.env.company.country_code == 'BE':
-            intracom_fpos = self.env["account.chart.template"].with_company(self.company_id.root_id).ref("fiscal_position_template_3", False)
+            intracom_fpos = self.env["account.chart.template"].with_company(self.company_id.root_id).sudo().ref("fiscal_position_template_3", False)
             if intracom_fpos:
                 data['data'][0]['_intracom_tax_ids'] = intracom_fpos.tax_ids.tax_dest_id.ids
         return data

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -83,7 +83,10 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
         })
 
         self.env.cr.precommit.run()
-        self.pos_user.company_ids = [Command.link(branch.id)]
+        self.pos_user.write({
+            'company_id': branch.id,
+            'company_ids': [Command.set([branch.id])],
+        })
 
         bank_payment_method = self.bank_payment_method.copy()
         bank_payment_method.company_id = branch.id


### PR DESCRIPTION
- Before this fix, when a user which have only access to a company branch (not access to the parent company), he was not able to open a POS session. This issue was only appearing when using a belgian company (with `l10n_be_pos_sale` installed). This error was raised becaues we try to load Intra-Community chart template which is defined on the parent company.
- Now we use `sudo()` to correctly load the Intra-Community chart template of the parent company, because if the user has permission to open a POS session on a company branch, he should be able to load its Intra-Community chart template (even if it's defined on the parent company).
- Update the test `test_pos_branch_company_access` so the `pos_user` have only access to the company branch (not the parent company anymore).

Steps to reproduce:
- Install ``l10_be_pos_sale` module
- Create a new belgian company with a branch
- Create a new user with access to this company branch (not the parent company)
- Create a new POS config for this company branch (with admin user)
- Try to open a POS session with the newly created user
- => Access error

opw: 4736949


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
