### PR TITLE
[FIX] im_livechat: remove (String) from chatbot answer path groupby

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -72,7 +72,7 @@
                     <field name="livechat_channel_id" string="Channel"/>
                     <field name="country_id" string="Country"/>
                     <field name="chatbot_script_id"/>
-                    <field name="chatbot_answers_path_str"/>
+                    <field name="chatbot_answers_path_str" string="Chatbot Answers"/>
                     <field name="session_expertises" string="Expertise"/>
                     <field name="visitor_partner_id"/>
                     <filter name="my_session" domain="[('partner_id.user_id', '=', uid)]" string="My Sessions"/>


### PR DESCRIPTION
Purpose of this commit:
Remove the '(String)' from the chatbot answer path groupby

task-4775412
