### PR TITLE
[REM] *: checkDelay is no longer used

### DIFF
--- a/addons/barcodes/static/src/barcode_handlers.js
+++ b/addons/barcodes/static/src/barcode_handlers.js
@@ -27,7 +27,6 @@ function updatePager(position) {
         return;
     }
     new Macro({
-        checkDelay: 16,
         name: "updating pager",
         timeout: 1000,
         steps: [

--- a/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/chrome_tour.js
@@ -11,7 +11,6 @@ import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 
 registry.category("web_tour.tours").add("ChromeTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -124,7 +123,6 @@ registry.category("web_tour.tours").add("ChromeTour", {
 });
 
 registry.category("web_tour.tours").add("OrderModificationAfterValidationError", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -147,7 +145,6 @@ registry.category("web_tour.tours").add("OrderModificationAfterValidationError",
 });
 
 registry.category("web_tour.tours").add("test_tracking_number_closing_session", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -173,7 +170,6 @@ registry.category("web_tour.tours").add("test_tracking_number_closing_session", 
 });
 
 registry.category("web_tour.tours").add("test_reload_page_before_payment_with_customer_account", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -192,7 +188,6 @@ registry.category("web_tour.tours").add("test_reload_page_before_payment_with_cu
 });
 
 registry.category("web_tour.tours").add("test_cash_in_out", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -212,7 +207,6 @@ registry.category("web_tour.tours").add("test_cash_in_out", {
 });
 
 registry.category("web_tour.tours").add("test_zero_decimal_places_currency", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/fake_tours.js
+++ b/addons/point_of_sale/static/tests/pos/tours/fake_tours.js
@@ -4,7 +4,6 @@ import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_
 import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
 
 registry.category("web_tour.tours").add("PoSFakeTourSimpleOrder", {
-    checkDelay: 50,
     steps: () =>
         [
             ProductScreen.clickDisplayedProduct("Desk Pad"),

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -14,7 +14,6 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
-    checkDelay: 50,
     steps: () =>
         [
             // Go by default to home category
@@ -164,7 +163,6 @@ registry.category("web_tour.tours").add("ProductScreenTour", {
 });
 
 registry.category("web_tour.tours").add("FloatingOrderTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -184,7 +182,6 @@ registry.category("web_tour.tours").add("FloatingOrderTour", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionNoTax", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -202,7 +199,6 @@ registry.category("web_tour.tours").add("FiscalPositionNoTax", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionIncl", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -223,7 +219,6 @@ registry.category("web_tour.tours").add("FiscalPositionIncl", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionExcl", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -241,7 +236,6 @@ registry.category("web_tour.tours").add("FiscalPositionExcl", {
 });
 
 registry.category("web_tour.tours").add("CashClosingDetails", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -264,7 +258,6 @@ registry.category("web_tour.tours").add("CashClosingDetails", {
 });
 
 registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -277,7 +270,6 @@ registry.category("web_tour.tours").add("ShowTaxExcludedTour", {
 });
 
 registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -299,7 +291,6 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
 });
 
 registry.category("web_tour.tours").add("MultiProductOptionsTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -315,7 +306,6 @@ registry.category("web_tour.tours").add("MultiProductOptionsTour", {
 });
 
 registry.category("web_tour.tours").add("TranslateProductNameTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -326,7 +316,6 @@ registry.category("web_tour.tours").add("TranslateProductNameTour", {
 });
 
 registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -341,7 +330,6 @@ registry.category("web_tour.tours").add("DecimalCommaOrderlinePrice", {
 });
 
 registry.category("web_tour.tours").add("SearchProducts", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -362,7 +350,6 @@ registry.category("web_tour.tours").add("SearchProducts", {
 });
 
 registry.category("web_tour.tours").add("CheckProductInformation", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -385,7 +372,6 @@ registry.category("web_tour.tours").add("CheckProductInformation", {
 });
 
 registry.category("web_tour.tours").add("PosCustomerAllFieldsDisplayed", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -440,7 +426,6 @@ registry.category("web_tour.tours").add("PosCategoriesOrder", {
 });
 
 registry.category("web_tour.tours").add("AutofillCashCount", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -461,7 +446,6 @@ registry.category("web_tour.tours").add("AutofillCashCount", {
 });
 
 registry.category("web_tour.tours").add("ProductSearchTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -553,7 +537,6 @@ registry.category("web_tour.tours").add("test_pricelist_multi_items_different_qt
 });
 
 registry.category("web_tour.tours").add("ProductCardUoMPrecision", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -16,7 +16,6 @@ import { renderToElement } from "@web/core/utils/render";
 import { formatCurrency } from "@web/core/currency";
 
 registry.category("web_tour.tours").add("ReceiptScreenTour", {
-    checkDelay: 50,
     steps: () =>
         [
             // press close button in receipt screen
@@ -114,7 +113,6 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
 });
 
 registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -143,7 +141,6 @@ registry.category("web_tour.tours").add("ReceiptScreenDiscountWithPricelistTour"
 });
 
 registry.category("web_tour.tours").add("OrderPaidInCash", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -168,7 +165,6 @@ registry.category("web_tour.tours").add("OrderPaidInCash", {
 });
 
 registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -183,7 +179,6 @@ registry.category("web_tour.tours").add("ReceiptTrackingMethodTour", {
 });
 
 registry.category("web_tour.tours").add("point_of_sale.test_printed_receipt_tour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -164,7 +164,6 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
 });
 
 registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -189,7 +188,6 @@ registry.category("web_tour.tours").add("FiscalPositionNoTaxRefund", {
 });
 
 registry.category("web_tour.tours").add("LotRefundTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -214,7 +212,6 @@ registry.category("web_tour.tours").add("LotRefundTour", {
 });
 
 registry.category("web_tour.tours").add("RefundFewQuantities", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -243,7 +240,6 @@ registry.category("web_tour.tours").add("RefundFewQuantities", {
 });
 
 registry.category("web_tour.tours").add("LotTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/e_wallet_program_tour.js
@@ -7,7 +7,6 @@ import * as PartnerList from "@point_of_sale/../tests/pos/tours/utils/partner_li
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("EWalletProgramTour1", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -33,7 +32,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour1", {
 
 const getEWalletText = (suffix) => "eWallet" + (suffix !== "" ? ` ${suffix}` : "");
 registry.category("web_tour.tours").add("EWalletProgramTour2", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -114,7 +112,6 @@ registry.category("web_tour.tours").add("EWalletProgramTour2", {
 });
 
 registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -129,7 +126,6 @@ registry.category("web_tour.tours").add("ExpiredEWalletProgramTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyPointsEwallet", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -149,7 +145,6 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsEwallet", {
 });
 
 registry.category("web_tour.tours").add("EWalletLoyaltyHistory", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -6,7 +6,6 @@ import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selecti
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -127,7 +126,6 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -145,7 +143,6 @@ registry.category("web_tour.tours").add("PosLoyaltyFreeProductTour2", {
 });
 
 registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_2", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -160,7 +157,6 @@ registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_2", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -185,7 +181,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProductTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -205,7 +200,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithFreeProdu
 });
 
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardProductDomainTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -222,7 +216,6 @@ registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountWithRewardPro
 });
 
 registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -255,7 +248,6 @@ registry.category("web_tour.tours").add("PosLoyaltyRewardProductTag", {
 });
 
 registry.category("web_tour.tours").add("test_loyalty_on_order_with_fixed_tax", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/fake_tours.js
+++ b/addons/pos_restaurant/static/tests/tours/fake_tours.js
@@ -37,7 +37,6 @@ const getRandomProduct = () => {
 };
 
 registry.category("web_tour.tours").add("PoSFakeTourRestaurant", {
-    checkDelay: 50,
     steps: () =>
         [
             FloorScreen.clickTable(getRandomTable()),
@@ -57,7 +56,6 @@ registry.category("web_tour.tours").add("PoSFakeTourRestaurant", {
 });
 
 registry.category("web_tour.tours").add("PoSFakeTourTransferOrder", {
-    checkDelay: 50,
     steps: () =>
         [
             FloorScreen.clickTable(getRandomTableWithOrder()),

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -433,7 +433,6 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
 });
 
 registry.category("web_tour.tours").add("test_combo_preparation_receipt", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -499,7 +498,6 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt", {
 });
 
 registry.category("web_tour.tours").add("MultiPreparationPrinter", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -513,7 +511,6 @@ registry.category("web_tour.tours").add("MultiPreparationPrinter", {
 });
 
 registry.category("web_tour.tours").add("LeaveResidualOrder", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -535,7 +532,6 @@ registry.category("web_tour.tours").add("LeaveResidualOrder", {
 });
 
 registry.category("web_tour.tours").add("FinishResidualOrder", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -555,7 +551,6 @@ registry.category("web_tour.tours").add("FinishResidualOrder", {
 });
 
 registry.category("web_tour.tours").add("test_multiple_preparation_printer_different_categories", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/ticket_screen_tour.js
@@ -8,7 +8,6 @@ import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("PosResTicketScreenTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),
@@ -34,7 +33,6 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
 });
 
 registry.category("web_tour.tours").add("OrderNumberConflictTour", {
-    checkDelay: 50,
     steps: () =>
         [
             Chrome.startPoS(),

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -8,7 +8,6 @@ import * as CategoryPage from "@pos_self_order/../tests/tours/utils/category_pag
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -29,7 +28,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -47,7 +45,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_table_takeaway_out", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -75,7 +72,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_in", {
 });
 
 registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -97,7 +93,6 @@ registry.category("web_tour.tours").add("self_kiosk_each_counter_takeaway_out", 
 });
 
 registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -117,7 +112,6 @@ registry.category("web_tour.tours").add("self_order_kiosk_cancel", {
 });
 
 registry.category("web_tour.tours").add("kiosk_simple_order", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -131,7 +125,6 @@ registry.category("web_tour.tours").add("kiosk_simple_order", {
 });
 
 registry.category("web_tour.tours").add("kiosk_order_price_null", {
-    checkDelay: 100,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),
@@ -145,7 +138,6 @@ registry.category("web_tour.tours").add("kiosk_order_price_null", {
 });
 
 registry.category("web_tour.tours").add("self_order_language_changes", {
-    checkDelay: 100,
     steps: () => [
         Utils.clickBtn("Order Now"),
 

--- a/addons/test_website/static/tests/tours/website_settings.js
+++ b/addons/test_website/static/tests/tours/website_settings.js
@@ -5,7 +5,6 @@ const websiteName = "Website Test Settings";
 
 registry.category("web_tour.tours").add("website_settings_m2o_dirty", {
     url: "/odoo",
-    checkDelay: 500,
     steps: () => [
         stepUtils.showAppsMenuItem(),
         {

--- a/addons/web/static/src/core/macro.js
+++ b/addons/web/static/src/core/macro.js
@@ -4,7 +4,6 @@ import { validate } from "@odoo/owl";
 
 const macroSchema = {
     name: { type: String, optional: true },
-    checkDelay: { type: Number, optional: true }, //Delay before checking if element is in DOM.
     timeout: { type: Number, optional: true },
     steps: {
         type: Array,

--- a/addons/web_tour/static/src/tour_service/tour_automatic.js
+++ b/addons/web_tour/static/src/tour_service/tour_automatic.js
@@ -106,7 +106,6 @@ export class TourAutomatic {
 
         this.macro = new Macro({
             name: this.name,
-            checkDelay: this.checkDelay || 200,
             steps: macroSteps,
             onError: (error) => {
                 if (error.type === "Timeout") {

--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -62,7 +62,6 @@ const StepSchema = {
 };
 
 const TourSchema = {
-    checkDelay: { type: Number, optional: true },
     name: { type: String, optional: true },
     steps: Function,
     url: { type: String, optional: true },

--- a/addons/website/static/tests/tours/client_action_iframe_fallback.js
+++ b/addons/website/static/tests/tours/client_action_iframe_fallback.js
@@ -2,7 +2,6 @@ import { registerWebsitePreviewTour } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('client_action_iframe_fallback', {
     url: '/',
-    checkDelay: 500,
 },
 () => [
     {

--- a/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
+++ b/addons/website/static/tests/tours/dropdowns_and_header_hide_on_scroll.js
@@ -34,7 +34,6 @@ const scrollDownToMediaList = function () {
 registerWebsitePreviewTour("dropdowns_and_header_hide_on_scroll", {
     url: "/",
     edition: true,
-    checkDelay: 100,
 }, () => [
     ...insertSnippet({id: "s_media_list", name: "Media List", groupName: "Content"}),
     selectHeader(),

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -10,7 +10,6 @@ import {
 } from '@website/js/tours/tour_utils';
 
 registerWebsitePreviewTour('edit_menus', {
-    checkDelay: 100,
     url: '/',
 }, () => [
     // Add a megamenu item from the menu.

--- a/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
+++ b/addons/website/static/tests/tours/editable_root_as_custom_snippet.js
@@ -10,7 +10,6 @@ import {
 registerWebsitePreviewTour("editable_root_as_custom_snippet", {
     edition: true,
     url: '/custom-page',
-    checkDelay: 400,
 }, () => [
     ...clickOnSnippet('.s_title.custom[data-oe-model][data-oe-id][data-oe-field][data-oe-xpath]'),
     changeOption('SnippetSave', 'we-button'),

--- a/addons/website/static/tests/tours/link_tools.js
+++ b/addons/website/static/tests/tours/link_tools.js
@@ -17,7 +17,6 @@ const clickOnImgStep = {
 registerWebsitePreviewTour('link_tools', {
     url: '/',
     edition: true,
-    checkDelay: 50,
 }, () => [
     // 1. Create a new link from scratch.
     ...insertSnippet({

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -12,7 +12,6 @@ const coverSnippet = {id: "s_cover", name: "Cover", groupName: "Intro"};
 registerWebsitePreviewTour("test_parallax", {
     url: "/",
     edition: true,
-    checkDelay: 500,
 }, () => [
     ...insertSnippet(coverSnippet),
     ...clickOnSnippet(coverSnippet),

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -11,7 +11,6 @@ registerWebsitePreviewTour('rte_translator', {
     url: '/',
     edition: true,
     wait_for: whenReady(),
-    checkDelay: 100,
 }, () => [
 ...goToTheme(),
 {

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -100,7 +100,6 @@ function updateAndCheckCustomGradient({updateStep, checkGradient}) {
 registerWebsitePreviewTour('snippet_background_edition', {
     url: '/',
     edition: true,
-    checkDelay: 100,
 },
 () => [
 ...insertSnippet(snippets[0]),

--- a/addons/website/static/tests/tours/snippet_editor_panel_options.js
+++ b/addons/website/static/tests/tours/snippet_editor_panel_options.js
@@ -10,7 +10,6 @@ import { browser } from '@web/core/browser/browser';
 registerWebsitePreviewTour('snippet_editor_panel_options', {
     url: '/',
     edition: true,
-    checkDelay: 100,
 }, () => [
 ...insertSnippet({
     id: 's_text_image',

--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -126,7 +126,6 @@ for (let snippet of snippetsNames) {
 }
 
 registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
-    checkDelay: 100,
     // To run the tour locally, you need to insert the URL sent by the python
     // tour here. There is currently an issue with tours which don't have an URL
     // url: '/?enable_editor=1&snippets_names=s_process_steps:columns,s_website_form:,s_...',

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -142,7 +142,6 @@ const addExistingField = function (name, type, label, required, display) {
 registerWebsitePreviewTour("website_form_editor_tour", {
     url: '/',
     edition: true,
-    checkDelay: 100,
 }, () => [
     // Drop a form builder snippet and configure it
     {

--- a/addons/website/static/tests/tours/website_navbar_menu.js
+++ b/addons/website/static/tests/tours/website_navbar_menu.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add("website_navbar_menu", {
     url: "/",
-    checkDelay: 50,
     steps: () => [
         {
             content: "Ensure menus are in DOM",

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_last_ticket.js
@@ -3,7 +3,6 @@ import * as wsTourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add('event_buy_last_ticket', {
     url: '/event',
-    checkDelay: 100,
     steps: () => [{
         content: "Open the Last ticket test event page",
         trigger: '.o_wevent_events_list a:contains("Last ticket test")',

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_flow.js
@@ -7,7 +7,6 @@ import { Chatbot } from "@im_livechat/core/common/chatbot_model";
 const messagesContain = (text) => `.o-livechat-root:shadow .o-mail-Message:contains("${text}")`;
 
 registry.category("web_tour.tours").add("website_livechat_chatbot_flow_tour", {
-    checkDelay: 50,
     steps: () => {
         patchWithCleanup(window, {
             debounceAnswerCount: 0,

--- a/addons/website_sale/static/tests/tours/website_free_delivery.js
+++ b/addons/website_sale/static/tests/tours/website_free_delivery.js
@@ -3,7 +3,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("check_free_delivery", {
     url: "/shop",
-    checkDelay: 50,
     steps: () => [
         // Part 1: Check free delivery
         ...tourUtils.addToCart({ productName: "Office Chair Black TEST" }),

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -3,7 +3,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
 registry.category("web_tour.tours").add("website_sale_cart_notification", {
     url: "/shop",
-    checkDelay: 100,
     steps: () => [
         ...tourUtils.addToCart({ productName: "website_sale_cart_notification_product_1" }),
         {

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
     registry.category("web_tour.tours").add('website_sale_tour_1', {
-        checkDelay: 150,
         url: '/shop?search=Storage Box Test',
         steps: () => [
     // Testing b2c with Tax-Excluded Prices
@@ -438,7 +437,6 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
 
     registry.category("web_tour.tours").add('website_sale_tour_2', {
         url: '/shop/cart',
-        checkDelay: 150,
         steps: () => [
     {
         trigger: '.o_wizard:contains("Extra Info")',

--- a/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
+++ b/addons/website_sale/static/tests/tours/website_sale_zero_priced_product.js
@@ -1,7 +1,6 @@
 import { registry } from '@web/core/registry';
 
 registry.category('web_tour.tours').add('website_sale_contact_us_button', {
-    checkDelay: 500,
     steps: () => [
         {
             content: "Check that the red color attribute is selected",

--- a/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
+++ b/addons/website_sale_autocomplete/static/tests/autocomplete_tour.js
@@ -4,7 +4,6 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 
 registry.category("web_tour.tours").add('autocomplete_tour', {
-    checkDelay: 100,
     url: '/shop', // /shop/address is redirected if no sales order
     steps: () => [
     ...tourUtils.addToCart({productName: "A test product"}),

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -3,7 +3,6 @@ import * as tourUtils from '@website_sale/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewards', {
     url: '/shop?search=Super%20Chair',
-    checkDelay: 100,
     steps: () => [
         {
             trigger: ".oe_search_found:not(:visible)",

--- a/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_website_sale_free_shipping_discount_line.js
@@ -37,7 +37,6 @@ const webTours = registry.category("web_tour.tours");
 
 webTours.add("check_shipping_discount", {
     url: "/shop?search=Plumbus",
-    checkDelay: 50,
     steps: () => [
         {
             content: "select Plumbus",
@@ -83,7 +82,6 @@ webTours.add("check_shipping_discount", {
 
 webTours.add("update_shipping_after_discount", {
     url: "/shop",
-    checkDelay: 100,
     steps: () => [
         ...addToCart({ productName: "Plumbus" }),
         goToCart(),

--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { clickOnElement } from '@website/js/tours/tour_utils';
 
 registry.category("web_tour.tours").add('shop_wishlist', {
-    checkDelay: 250,
     url: '/shop?search=Customizable Desk',
     steps: () => [
         {


### PR DESCRIPTION
In this commit we remove checkDelay from codebase because it is no longer used since https://github.com/odoo/odoo/pull/194508 has been merged.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
