### PR TITLE
[FIX] im_livechat: update empty record helper

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -148,9 +148,8 @@
             <field name="view_mode">graph,pivot</field>
             <field name="context">{"graph_measure": "time_to_answer", "search_default_last_week":1}</field>
             <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    No data yet!
-                </p>
+                <p class="o_view_nocontent_smiling_face">No data yet!</p>
+                <p>Track and improve live chat performance with insights on session activity, response times, customer ratings, and call interactions.</p>
             </field>
         </record>
 


### PR DESCRIPTION
Purpose of this commit:
Update the empty record helper for
im_livechat_report_channel_time_to_answer_action view.

