### PR TITLE
[IMP] *: domain selector: in operator for everyone

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -1,113 +1,55 @@
-export function getDomainDisplayedOperators(fieldDef, params = {}) {
-    if (!fieldDef) {
-        fieldDef = {};
-    }
+function getSpecificOperators(fieldDef, params) {
     const { type, is_property } = fieldDef;
 
     if (is_property) {
         switch (type) {
             case "many2many":
             case "tags":
-                return ["in", "not in", "set", "not_set"];
             case "many2one":
-            case "selection":
-                return ["=", "!=", "set", "not_set"];
+                return [];
         }
     }
+    const allowExpressions = "allowExpressions" in params ? params.allowExpressions : true;
     switch (type) {
-        case "boolean":
-            return ["set", "not_set"];
-        case "selection":
-            return ["=", "!=", "in", "not in", "set", "not_set"];
         case "char":
         case "text":
         case "html":
-            return [
-                "=",
-                "!=",
-                "ilike",
-                "not ilike",
-                "in",
-                "not in",
-                "set",
-                "not_set",
-                "starts_with",
-                "ends_with",
-            ];
+        case "many2one":
+        case "many2many":
+        case "one2many":
+            return ["ilike", "not ilike", "starts_with", "ends_with"];
         case "date":
         case "datetime":
             return [
-                ...("allowExpressions" in params && !params.allowExpressions
-                    ? []
-                    : ["today", "not_today"]),
-                "=",
-                "!=",
+                ...(allowExpressions ? ["today", "not_today"] : []),
                 ">",
                 "<",
                 "between",
                 "not_between",
-                ...("allowExpressions" in params && !params.allowExpressions
-                    ? []
-                    : ["next", "not_next", "last", "not_last"]),
-                "set",
-                "not_set",
+                ...(allowExpressions ? ["next", "not_next", "last", "not_last"] : []),
             ];
         case "integer":
         case "float":
         case "monetary":
-            return [
-                "=",
-                "!=",
-                ">",
-                "<",
-                "between",
-                "not_between",
-                "ilike",
-                "not ilike",
-                "set",
-                "not_set",
-            ];
-        case "many2one":
-        case "many2many":
-        case "one2many":
-            return [
-                "in",
-                "not in",
-                "=",
-                "!=",
-                "ilike",
-                "not ilike",
-                "set",
-                "not_set",
-                "starts_with",
-                "ends_with",
-            ];
+            return [">", "<", "between", "not_between", "ilike", "not ilike"];
         case "json":
-            return ["=", "!=", "ilike", "not ilike", "set", "not_set"];
-        case "properties":
-            return ["set", "not_set"];
+            return ["ilike", "not ilike"];
         case "date_option":
-        case "datetime_option":
         case "time_option":
-            return ["=", "!=", ">", "<", "between", "not_between", "set", "not_set"];
-        case undefined:
-            return ["="];
+        case "datetime_option":
+            return [">", "<", "between", "not_between"];
         default:
-            return [
-                "=",
-                "!=",
-                ">",
-                "<",
-                "ilike",
-                "not ilike",
-                "like",
-                "not like",
-                "=like",
-                "=ilike",
-                "in",
-                "not in",
-                "set",
-                "not_set",
-            ];
+            return [];
     }
+}
+
+export function getDomainDisplayedOperators(fieldDef, params = {}) {
+    fieldDef ||= {};
+    if (!fieldDef.type) {
+        return ["="];
+    }
+    if (fieldDef.type === "boolean") {
+        return ["set", "not_set"];
+    }
+    return ["in", "not in", ...getSpecificOperators(fieldDef, params), "set", "not_set"];
 }

--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -81,6 +81,10 @@ export class TreeEditor extends Component {
             this.previousTree = null;
         }
 
+        await this.prepareInfo(props);
+    }
+
+    async prepareInfo(props) {
         const [fieldDefs, getFieldDef] = await Promise.all([
             this.fieldService.loadFields(props.resModel),
             this.makeGetFieldDef(props.resModel, this.tree),
@@ -236,6 +240,7 @@ export class TreeEditor extends Component {
             // no interesting changes for parent
             // this means that the parent might not render the domain selector
             // but we need to udpate editors
+            await this.prepareInfo(this.props);
             this.render();
         }
         this.notifyChanges();

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -14,8 +14,11 @@
                             <span t-if="props.isSubTree">of:</span>
                             <span t-else="">of the following rules:</span>
                         </t>
-                        <t t-else="">
+                        <t t-elif="node.value === '|' ? node.negate : !node.negate">
                             <span><span t-if="!props.isSubTree">Match </span><strong>all records</strong></span>
+                        </t>
+                        <t t-else="">
+                            <span><span t-if="!props.isSubTree">Match </span><strong>no records</strong></span>
                         </t>
                     </div>
                     <t t-slot="default"/>

--- a/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
@@ -1,6 +1,6 @@
 import { localization } from "@web/core/l10n/localization";
 import { _t } from "@web/core/l10n/translation";
-import { Expression } from "@web/core/tree_editor/condition_tree";
+import { Expression, formatValue } from "@web/core/tree_editor/condition_tree";
 import { Select } from "@web/core/tree_editor/tree_editor_components";
 
 const { DateTime } = luxon;
@@ -93,6 +93,10 @@ export function getEditorInfoForOptionsWithSelect(name, params) {
         }),
         defaultValue: getCurrent(UNITS[name]),
         isSupported: (value) => typeof value !== "string" && getOption(value),
+        stringify: (value, disambiguate) => {
+            const option = getOption(value);
+            return option ? option[1] : disambiguate ? formatValue(value) : String(value);
+        },
         message: _t("Value not in selection"),
     };
 }

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -5,8 +5,8 @@ import { Select } from "@web/core/tree_editor/tree_editor_components";
 
 const OPERATOR_DESCRIPTIONS = {
     // valid operators (see TERM_OPERATORS in expression.py)
-    "=": _t("equals"),
-    "!=": _t("not equals"),
+    "=": _t("="),
+    "!=": _t("!="),
     "<=": _t("lower or equal"),
     "<": _t("lower"),
     ">": _t("greater"),
@@ -18,8 +18,8 @@ const OPERATOR_DESCRIPTIONS = {
     "not like": _t("not like"),
     ilike: _t("contains"),
     "not ilike": _t("not contains"),
-    in: _t("is in"),
-    "not in": _t("is not in"),
+    in: _t("equals"),
+    "not in": _t("not equals"),
     child_of: _t("child of"),
     parent_of: _t("parent of"),
 

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -215,8 +215,6 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "in":
         case "not in": {
             switch (fieldDef.type) {
-                case "tags":
-                    return STRING_EDITOR;
                 case "many2one":
                 case "many2many":
                 case "one2many":
@@ -242,6 +240,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                         },
                         isSupported: (value) => Array.isArray(value),
                         defaultValue: () => [],
+                        shouldResetValue: (value) => !value.every(editorInfo.isSupported),
                     };
                 }
             }
@@ -294,6 +293,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                         }
                         return (
                             Array.isArray(value) &&
+                            value.length === 2 &&
                             isTodayExpr(value[0], type) &&
                             isEndOfTodayExpr(value[1])
                         );
@@ -391,8 +391,8 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
             } else if (fieldDef.name === "__time") {
                 return {
                     component: TimePicker,
-                    extractProps: ({ value, update }) => ({
-                        value: parseTime(value, true),
+                    extractProps: ({ value, update, displayPlaceholder }) => ({
+                        value: params.startEmpty ? false : parseTime(value, true),
                         onChange: (time) =>
                             update(
                                 DateTime.fromObject(
@@ -400,6 +400,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
                                 ).toFormat("HH:mm:ss")
                             ),
                         showSeconds: true,
+                        placeholder: displayPlaceholder ? undefined : "",
                     }),
                     isSupported: (value) =>
                         typeof value === "string" && Boolean(parseTime(value, true)),

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -174,8 +174,6 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
     let { operator, negate, value, path } = node;
     if (["=", "!="].includes(operator) && value === false) {
         operator = operator === "=" ? "not_set" : "set";
-    } else if (["in", "not in"].includes(operator) && Array.isArray(value) && value.length === 0) {
-        operator = operator === "in" ? "not_set" : "set";
     }
     const fieldDef = getFieldDef(path);
     const operatorLabel = getOperatorLabel(operator, fieldDef?.type, negate, (operator) => {
@@ -233,7 +231,7 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
             break;
         case "in":
         case "not in":
-            addParenthesis = false;
+            addParenthesis = values.length === 0;
         // eslint-disable-next-line no-fallthrough
         default:
             join = _t("or");

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -728,7 +728,8 @@ export class SearchModel extends EventBus {
 
         const getFieldDef = await this.makeGetFieldDef(this.resModel, constructTree(domain));
         const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode, getFieldDef });
-        const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
+        const trees =
+            !tree.negate && tree.value === "&" && tree.children.length > 0 ? tree.children : [tree];
         const promises = trees.map(async (tree) => {
             const [description, tooltip] = await Promise.all([
                 this.getDomainTreeDescription(this.resModel, tree),

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -904,7 +904,7 @@ test("domain field with 'inDialog' options", async function () {
     await contains(`.modal ${SELECTORS.addNewRule}`).click();
     await contains(".modal-footer .btn-primary").click();
     expect(SELECTORS.condition).toHaveCount(1);
-    expect(getConditionText()).toBe("Id = 1");
+    expect(getConditionText()).toBe("Id = ( )");
 });
 
 test("invalid value in domain field with 'inDialog' options", async function () {
@@ -1121,7 +1121,7 @@ test("add condition in empty foldable domain", async function () {
     await contains(".o_domain_add_first_node_button").click();
     // Domain is now unfolded with the default condition
     expect(".o_model_field_selector").toHaveCount(1);
-    expect(SELECTORS.debugArea).toHaveValue('[("id", "=", 1)]');
+    expect(SELECTORS.debugArea).toHaveValue('[("id", "in", [])]');
 });
 
 test("foldable domain field unfolds and hides caret when domain is invalid", async function () {
@@ -1316,6 +1316,7 @@ test("hide today, last, next operators when allow_expressions = False", async fu
         "not between",
         "set",
         "not set",
+        "=",
     ]);
 
     await contains(SELECTORS.debugArea).edit(

--- a/addons/web/static/tests/core/expression_editor/expression_editor.test.js
+++ b/addons/web/static/tests/core/expression_editor/expression_editor.test.js
@@ -107,7 +107,7 @@ test("rendering of falsy values", async () => {
         await parent.set(expr);
         expect(getTreeEditorContent()).toEqual([
             { value: "all", level: 0 },
-            { value: ["0", "equals", "1"], level: 1 },
+            { value: ["0", "=", "1"], level: 1 },
         ]);
     }
 });
@@ -184,7 +184,7 @@ test("change path, operator and value", async () => {
     await makeExpressionEditor({ expression: `bar != "blabla"` });
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Bar", "not equals", "blabla"] },
+        { level: 1, value: ["Bar", "!=", "blabla"] },
     ]);
     const tree = getTreeEditorContent({ node: true });
     await openModelFieldSelectorPopover();
@@ -193,7 +193,7 @@ test("change path, operator and value", async () => {
     await editValue(["Doku", "Lukaku", "KDB"]);
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
-        { level: 1, value: ["Foo", "is not in", "Doku,Lukaku,KDB"] },
+        { level: 1, value: ["Foo", "not equals", "Doku,Lukaku,KDB"] },
     ]);
 });
 
@@ -217,8 +217,8 @@ test("rendering of a valid fieldName in fields", async () => {
 
     const toTests = [
         { expr: `foo`, condition: ["Foo", "set"] },
-        { expr: `foo == "a"`, condition: ["Foo", "equals", "a"] },
-        { expr: `foo != "a"`, condition: ["Foo", "not equals", "a"] },
+        { expr: `foo == "a"`, condition: ["Foo", "=", "a"] },
+        { expr: `foo != "a"`, condition: ["Foo", "!=", "a"] },
         // { expr: `foo is "a"`, complexCondition: `foo is "a"` },
         // { expr: `foo is not "a"`, complexCondition: `foo is not "a"` },
         { expr: `not foo`, condition: ["Foo", "not set"] },
@@ -248,10 +248,10 @@ test("rendering of simple conditions", async () => {
     const parent = await makeExpressionEditor({ fieldFilters: ["foo", "bar"] });
 
     const toTests = [
-        { expr: `bar == "a"`, condition: ["Bar", "equals", "a"] },
-        { expr: `foo == expr`, condition: ["Foo", "equals", "expr"] },
-        { expr: `"a" == foo`, condition: ["Foo", "equals", "a"] },
-        { expr: `expr == foo`, condition: ["Foo", "equals", "expr"] },
+        { expr: `bar == "a"`, condition: ["Bar", "=", "a"] },
+        { expr: `foo == expr`, condition: ["Foo", "=", "expr"] },
+        { expr: `"a" == foo`, condition: ["Foo", "=", "a"] },
+        { expr: `expr == foo`, condition: ["Foo", "=", "expr"] },
         { expr: `foo == bar`, complexCondition: `foo == bar` },
         { expr: `"a" == "b"`, complexCondition: `"a" == "b"` },
         { expr: `expr1 == expr2`, complexCondition: `expr1 == expr2` },
@@ -264,8 +264,8 @@ test("rendering of simple conditions", async () => {
         { expr: `"a" < "b"`, complexCondition: `"a" < "b"` },
         { expr: `expr1 < expr2`, complexCondition: `expr1 < expr2` },
 
-        { expr: `foo in ["a"]`, condition: ["Foo", "is in", "a"] },
-        { expr: `foo in [expr]`, condition: ["Foo", "is in", "expr"] },
+        { expr: `foo in ["a"]`, condition: ["Foo", "equals", "a"] },
+        { expr: `foo in [expr]`, condition: ["Foo", "equals", "expr"] },
         { expr: `"a" in foo`, complexCondition: `"a" in foo` },
         { expr: `expr in foo`, complexCondition: `expr in foo` },
         { expr: `foo in bar`, complexCondition: `foo in bar` },
@@ -298,7 +298,7 @@ test("rendering of connectors", async () => {
         { level: 0, value: "any" },
         { level: 1, value: "all" },
         { level: 2, value: "expr" },
-        { level: 2, value: ["Foo", "equals", "abc"] },
+        { level: 2, value: ["Foo", "=", "abc"] },
         { level: 1, value: ["Bar", "not set"] },
     ]);
 });
@@ -314,7 +314,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "none" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "equals", "abc"] },
+        { level: 1, value: ["Foo", "=", "abc"] },
     ]);
     expect.verifySteps([]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`not (expr or foo == "abc")`);
@@ -323,7 +323,7 @@ test("rendering of connectors (2)", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "all" },
         { level: 1, value: "expr" },
-        { level: 1, value: ["Foo", "equals", "abc"] },
+        { level: 1, value: ["Foo", "=", "abc"] },
     ]);
     expect.verifySteps([`expr and foo == "abc"`]);
     expect(queryOne(SELECTORS.debugArea)).toHaveValue(`expr and foo == "abc"`);
@@ -334,11 +334,11 @@ test("rendering of if else", async () => {
     expect(getTreeEditorContent()).toEqual([
         { level: 0, value: "any" },
         { level: 1, value: "all" },
-        { level: 2, value: ["0", "equals", "1"] },
-        { level: 2, value: ["1", "equals", "1"] },
+        { level: 2, value: ["0", "=", "1"] },
+        { level: 2, value: ["1", "=", "1"] },
         { level: 1, value: "all" },
-        { level: 2, value: ["1", "equals", "1"] },
-        { level: 2, value: ["0", "equals", "1"] },
+        { level: 2, value: ["1", "=", "1"] },
+        { level: 2, value: ["0", "=", "1"] },
     ]);
 });
 
@@ -370,9 +370,9 @@ test("allow selection of boolean field", async () => {
 
 test("render false and true leaves", async () => {
     await makeExpressionEditor({ expression: `False and True` });
-    expect(getOperatorOptions()).toEqual(["equals"]);
+    expect(getOperatorOptions()).toEqual(["="]);
     expect(getValueOptions()).toEqual(["1"]);
-    expect(getOperatorOptions(-1)).toEqual(["equals"]);
+    expect(getOperatorOptions(-1)).toEqual(["="]);
     expect(getValueOptions(-1)).toEqual(["1"]);
 });
 
@@ -397,7 +397,7 @@ test("no field of type properties in model field selector", async () => {
     ]);
     expect(isNotSupportedPath()).toBe(true);
     await clearNotSupported();
-    expect.verifySteps([`foo == ""`]);
+    expect.verifySteps([`foo in []`]);
 
     await openModelFieldSelectorPopover();
     expect(queryAllTexts(".o_model_field_selector_popover_item_name")).toEqual(["Bar", "Foo"]);
@@ -418,7 +418,7 @@ test("no special fields in fields", async () => {
         { level: 0, value: "all" },
         { level: 1, value: ["Foo", "equals", ""] },
     ]);
-    expect.verifySteps([`foo == ""`]);
+    expect.verifySteps([`foo in []`]);
 });
 
 test("between operator", async () => {
@@ -437,6 +437,7 @@ test("between operator", async () => {
         "not between",
         "set",
         "not set",
+        "=",
     ]);
     expect.verifySteps([]);
     await selectOperator("between");
@@ -451,10 +452,10 @@ test("next operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "today",
-        "not today",
         "equals",
         "not equals",
+        "today",
+        "not today",
         "greater",
         "lower",
         "between",
@@ -465,6 +466,7 @@ test("next operator", async () => {
         "not last",
         "set",
         "not set",
+        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("next");
@@ -481,10 +483,10 @@ test("not_next operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "today",
-        "not today",
         "equals",
         "not equals",
+        "today",
+        "not today",
         "greater",
         "lower",
         "between",
@@ -495,6 +497,7 @@ test("not_next operator", async () => {
         "not last",
         "set",
         "not set",
+        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("not_next");
@@ -511,10 +514,10 @@ test("last operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "today",
-        "not today",
         "equals",
         "not equals",
+        "today",
+        "not today",
         "greater",
         "lower",
         "between",
@@ -525,6 +528,7 @@ test("last operator", async () => {
         "not last",
         "set",
         "not set",
+        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("last");
@@ -541,10 +545,10 @@ test("not_last operator", async () => {
         },
     });
     expect(getOperatorOptions()).toEqual([
-        "today",
-        "not today",
         "equals",
         "not equals",
+        "today",
+        "not today",
         "greater",
         "lower",
         "between",
@@ -555,6 +559,7 @@ test("not_last operator", async () => {
         "not last",
         "set",
         "not set",
+        "!=",
     ]);
     expect.verifySteps([]);
     await selectOperator("not_last");

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1316,7 +1316,7 @@ test("search a property: definition record id in the context", async () => {
 
 test("edit a filter", async () => {
     onRpc("/web/domain/validate", () => true);
-    await mountWithSearch(SearchBar, {
+    const searchBar = await mountWithSearch(SearchBar, {
         resModel: "partner",
         searchMenuTypes: ["groupBy"], // we need it to have facet (see facets getter in search_model)
         searchViewId: false,
@@ -1355,11 +1355,12 @@ test("edit a filter", async () => {
     expect(SELECTORS.condition).toHaveCount(1);
     expect(getCurrentPath()).toBe("Id");
     expect(getCurrentOperator()).toBe("equals");
-    expect(getCurrentValue()).toBe("1");
+    expect(getCurrentValue()).toBe("");
 
     await contains(".modal footer button").click();
     expect(`.modal`).toHaveCount(0);
-    expect(getFacetTexts()).toEqual(["Id = 1", "Bool"]);
+    expect(getFacetTexts()).toEqual(["Id = ( )", "Bool"]);
+    expect(searchBar.env.searchModel.domain).toEqual([["id", "in", []]]);
 });
 
 test("edit a filter with context: context is kept after edition", async () => {

--- a/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
+++ b/addons/web/static/tests/search/search_bar_menu/filter_menu.test.js
@@ -700,17 +700,17 @@ test("Add a custom filter", async () => {
     await clickOnButtonAddBranch(-1);
     await clickOnButtonAddRule(-1);
     await contains(".modal footer button").click();
-    expect(getFacetTexts()).toEqual(["Filter", "Id = 1", "Id = 1", "Id = 1"]);
+    expect(getFacetTexts()).toEqual(["Filter", "Id = ( )", "Id = ( )", "Id = ( )"]);
     expect(searchBar.env.searchModel.domain).toEqual([
         "&",
         ["foo", "=", "abc"],
         "&",
-        ["id", "=", 1],
+        ["id", "in", []],
         "&",
-        ["id", "=", 1],
+        ["id", "in", []],
         "|",
-        ["id", "=", 1],
-        ["id", "=", 1],
+        ["id", "in", []],
+        ["id", "in", []],
     ]);
 
     // open again the search menu -> the custom filter should not be displayed

--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -65,6 +65,10 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             run: "click",
         },
         {
+            trigger: ".o_tree_editor_row .o_tree_editor_editor input",
+            run: "edit 1",
+        },
+        {
             trigger: ".o_form_button_save",
             run: "click",
         },

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -5220,7 +5220,7 @@ test("edit a favorite: group by = default_group_by", async () => {
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
     await contains("button:contains('Search')").click();
-    expect(getFacetTexts()).toEqual(["Id = 1"]);
+    expect(getFacetTexts()).toEqual(["Id = ( )"]);
 });
 
 test.tags("desktop");
@@ -5263,7 +5263,7 @@ test("edit a favorite: group by != default_group_by", async () => {
     await contains(".o_searchview_facet_label").click();
     await addNewRule();
     await contains("button:contains('Search')").click();
-    expect(getFacetTexts()).toEqual(["Id = 1", "Product"]);
+    expect(getFacetTexts()).toEqual(["Id = ( )", "Product"]);
 });
 
 test.tags("desktop");


### PR DESCRIPTION
The operators =/!= are no more proposed for selection in the tree editor.
Instead in/not in are proposed for almost all field types (but not for
boolean fields).

Task ID: 4610804