### PR TITLE
[FIX] point_of_sale: prevent missing error on opening control

### DIFF
--- a/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.js
+++ b/addons/point_of_sale/static/src/app/store/opening_control_popup/opening_control_popup.js
@@ -6,6 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Input } from "@point_of_sale/app/generic_components/inputs/input/input";
 import { parseFloat } from "@web/views/fields/parsers";
 import { Dialog } from "@web/core/dialog/dialog";
+import { RPCError } from "@web/core/network/rpc";
 
 class CustomDialog extends Dialog {
     onEscape() {}
@@ -33,13 +34,24 @@ export class OpeningControlPopup extends Component {
         this.ui = useService("ui");
     }
     async confirm() {
-        await this.pos.data.call(
-            "pos.session",
-            "set_opening_control",
-            [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
-            {},
-            true
-        );
+        try {
+            await this.pos.data.call(
+                "pos.session",
+                "set_opening_control",
+                [this.pos.session.id, parseFloat(this.state.openingCash), this.state.notes],
+                {},
+                true
+            );
+        } catch (error) {
+            if (
+                error instanceof RPCError &&
+                error.data.name === "odoo.exceptions.MissingError" &&
+                (await this.pos.isSessionDeleted())
+            ) {
+                return window.location.reload();
+            }
+            throw error;
+        }
         this.pos.session.state = "opened";
         this.props.close();
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -2196,6 +2196,11 @@ export class PosStore extends Reactive {
     get showSaveOrderButton() {
         return this.isOpenOrderShareable();
     }
+
+    async isSessionDeleted() {
+        const session = await this.data.read("pos.session", [this.session.id]);
+        return session[0] === undefined;
+    }
 }
 
 PosStore.prototype.electronic_payment_interfaces = {};


### PR DESCRIPTION
Before this commit, if a POS session was open on two devices and the session was removed from one device, attempting to proceed with the opening control on the other device would result in a missing error.

Steps to reproduce:
1. Open a POS session on device 1 and 2 (both at the opening control)
2. On device 1, remove the session by clicking on backend
3. On device 2, attempt to set the opening control

After this commit, the system properly handles the case where the session has been removed, preventing the missing error and improving user experience.

opw-4775255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
