### PR TITLE
[FIX] mail: chatter composer is aligned with message avatars

### DIFF
--- a/addons/mail/static/src/chatter/web_portal/chatter.scss
+++ b/addons/mail/static/src/chatter/web_portal/chatter.scss
@@ -21,6 +21,12 @@
     padding-right: var(--Chatter-default-padding-x);
 }
 
+.o-mail-Chatter-top .o-mail-Composer {
+    --Chatter-default-padding-x: #{$o-spacer};
+    --mail-Chatter-contentPaddingLeft: var(--ChatterAsideForm-padding-left, calc(var(--Chatter-default-padding-x) / 2));
+    margin-left: calc((var(--mail-Chatter-contentPaddingLeft)) * -1);
+}
+
 .o-mail-Chatter-top {
     padding-left: var(--ChatterAsideForm-padding-left, var(--Chatter-default-padding-x));
 }

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -21,7 +21,7 @@
                     'o-chatWindow mx-2': env.inChatWindow,
                     'mb-3': env.inChatWindow and !props.composer.message,
                     'o-discussApp pt-1': env.inDiscussApp,
-                    'm-1': !env.inDiscussApp,
+                    'm-1': env.inChatWindow,
                 }" t-attf-class="{{ props.className }}">
             <FileUploader t-if="allowUpload" multiUpload="isMultiUpload" onUploaded.bind="(data) => { attachmentUploader.uploadData(data) }">
                 <t t-set-slot="toggler">


### PR DESCRIPTION
Before this commit, chatter composer had too much left padding, which made it unaligned with message author avatars.

This happens because the chatter top has some left padding when aside, so that the top buttons are aligned with message author avatars.

This commit fixes the issue by having a negative left margin in composer of chatter to compensate. The computation relies on the chatter top and content left paddings, both of which differ when chatter is either aside or non-aside.
