### PR TITLE
[FIX] mail: prevent traceback on activity overview

### DIFF
--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -274,7 +274,7 @@
         <field name="model">mail.activity</field>
         <field name="arch" type="xml">
             <list string="Next Activities"
-                    default_order="date_deadline" create="true" js_class="">
+                    default_order="date_deadline" create="true">
                 <header>
                     <button name="action_done" type="object" string="Done" icon="fa-check"/>
                     <button name="action_cancel" type="object" string="Cancel" icon="fa-times"/>


### PR DESCRIPTION
This fix addresses a traceback that occurred when accessing the Activity Overview from the Settings menu in debug mode.

Steps to reproduce:
1.Enable debug mode.
2. Go to Settings > Technical > Activities > Activity Overview.
3. Click on the "Activity Overview"  a traceback appears.

The issue was caused by an empty js_class being passed in the mail_activity_view_tree.

Task-4770921