### PR TITLE
[FIX] website_event: wait after redirect is needed

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -72,6 +72,10 @@ function websiteEditEventTourSteps() {
             trigger: "iframe span:contains('Back to events')",
             run: "click",
         },
+        {
+            content: "Wait for events list to load",
+            trigger: ":iframe .opt_events_list_columns small",
+        },
         ...wTourUtils.clickOnEditAndWaitEditMode(),
         {
             content: "edit the short description of the event",


### PR DESCRIPTION
So it appears from the tour build error screenshot that the redirect doesn’t happen that fast, so we need to wait for it to happen before checking the next step, which is 'Edit'—which overrides it and edits the event details instead of the events list. So, we need to wait for the redirect to happen before checking the next step

build_error-164184

referencing this commit : https://github.com/odoo/odoo/commit/b1e424bcd5e985b74496e409fb16c9529bbe848e


![image](https://github.com/user-attachments/assets/2b8e5396-4130-4704-b846-e04f6ad1e0f4)
