### PR TITLE
[IMP] hw_drivers: query escpos status

### DIFF
--- a/addons/hw_drivers/event_manager.py
+++ b/addons/hw_drivers/event_manager.py
@@ -61,7 +61,7 @@ class EventManager(object):
                 **data,
             })
         else:
-            data = json.loads(request.params['data']) if request and 'data' in request.params else {}
+            data = request.params.get('data', {}) if request else {}
 
         # Make notification available to longpolling event route
         event = {

--- a/addons/iot_box_image/configuration/requirements.txt
+++ b/addons/iot_box_image/configuration/requirements.txt
@@ -8,6 +8,7 @@ netifaces==0.11.0; sys_platform == "win32"
 num2words==0.5.13
 polib
 pycups; sys_platform == "linux"
+python-escpos==3.1
 PyKCS11==1.5.16
 PyPDF2==1.26.0
 pyOpenssl==23.0.0; sys_platform == "win32" # installed with apt on Linux


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/85573

ESCPOS printers support commands to query the status of the printer,
specifically whether the paper is OK, running low or empty, as well as
if the printer is ready to print.

Before this commit, the IoT box could not take advantage of these
commands, and would assume all prints that were sent to the receipt
printer were successful.

After this commit, we use the `python-escpos` library to communicate
with the receipt printers by either network or USB*. This bypasses CUPS
and allows us to receive responses from the printer. If anything goes
wrong with the new functionality, the ESCPOS connection is disabled and
we fallback to just using CUPS like before.

The driver will send error or warning events depending on the printer
status, and will not send the document to the printer if there are any
errors.

*Querying the status over USB does not work on Windows

task-4756311

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
