### PR TITLE
[FIX] mail: discuss mobile mailbox selection correct bg

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.Discuss">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
-    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
+    <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center': ui.isSmall }" t-ref="root">
         <DiscussSidebar t-if="!ui.isSmall and props.hasSidebar"/>
         <div t-if="!(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
             <div class="o-mail-Discuss-header px-3 d-flex flex-shrink-0 align-items-center border-bottom border-secondary z-1 flex-grow-0" t-ref="header">


### PR DESCRIPTION
Before this commit, the background color of discuss mobile mailbox selection was `.bg-view`. This is not a problem in white theme, but in dark theme this is too light, which makes it hard to see this is a button group.

This commit fixes the issue by removing this `.bg-view`, thus relying on the discuss app background that is already white or dark depending on the chosen web client theme.