### PR TITLE
[FIX] mail: Handle transient records when sending multiple invoices

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1950,9 +1950,11 @@ class MailThread(models.AbstractModel):
         generic tool method, without any record-based context values propagation. """
         if self:  # void recordset allowed as tool mixin method
             self.ensure_one()
-        return self._partner_find_from_emails(
+        result = self._partner_find_from_emails(
             {self: emails}, avoid_alias=avoid_alias, filter_found=filter_found, additional_values=additional_values, no_create=no_create
-        )[self.id]
+        )
+        # fallback for unsaved (transient) records: check for current or original id
+        return result.get(self.id) or result.get(self._origin.id)
 
     def _partner_find_from_emails(self, records_emails, avoid_alias=True, ban_emails=None,
                                   filter_found=None, additional_values=None, no_create=False):


### PR DESCRIPTION
Steps to reproduce:

- Inside accounting/invoicing module navigate to invoices list view
- Select more than one invoices
- Click send button

Error:- KeyError: `<NewId origin=2>`

Cause:
Before this pr, in mail_thread model the method named _partner_find_from_emails_single() is using self.id as a key for finding value from dictionary returned by _partner_find_from_emails() method. But when calling
 this method via account_move_send_wizard the self.id contains transient ids.
This is not handled here.

Solution:
After this pr, added fallback for transient ids also.