### PR TITLE
[FIX] sale_purchase: propagate service tax from SOL to POL

### DIFF
--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -141,7 +141,7 @@ class SaleOrderLine(models.Model):
         }
 
     def _purchase_service_get_price_unit_and_taxes(self, supplierinfo, purchase_order):
-        supplier_taxes = self.product_id.supplier_taxes_id.filtered(lambda t: t.company_id == purchase_order.company_id)
+        supplier_taxes = self.product_id.supplier_taxes_id.filtered(lambda t: t.company_id in purchase_order.company_id.parent_ids)
         taxes = purchase_order.fiscal_position_id.map_tax(supplier_taxes)
         if supplierinfo:
             price_unit = self.env['account.tax'].sudo()._fix_tax_included_price_company(supplierinfo.price, supplier_taxes, taxes, purchase_order.company_id)

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -364,3 +364,36 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         # FIXME: same sudo issue as above
         order2.sudo().with_company(company_2).action_confirm()
         self.assertTrue(order2.purchase_order_count)
+
+    def test_service_to_purchase_branch_tax_propagation(self):
+        """
+        Ensure that SO/PO of a branch can use root company's taxes
+        """
+        branch = self.env['res.company'].create({
+            'name': "Branch Company",
+            'parent_id': self.env.company.id,
+        })
+        self.env.user.company_id = branch
+        service_product = self.env['product.product'].create({
+            'name': "Branch Out-sourced Service",
+            'standard_price': 200.0,
+            'type': 'service',
+            'invoice_policy': 'delivery',
+            'taxes_id': self.company_data['default_tax_sale'],
+            'supplier_taxes_id': self.company_data['default_tax_purchase'],
+            'service_to_purchase': True,
+            'seller_ids': [Command.create({
+                'partner_id': self.partner_b.id,
+                'min_qty': 1,
+                'price': 100,
+            })],
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [Command.create({
+                'product_id': service_product.id,
+            })],
+        })
+        self.assertEqual(so.order_line.tax_id, self.company_data['default_tax_sale'])
+        so.action_confirm()
+        self.assertEqual(so.order_line.purchase_line_ids.taxes_id, self.company_data['default_tax_purchase'])


### PR DESCRIPTION
Issue
-----
For subcontracted services, branch companies don't have taxes on PO lines when it is created by a SO.

Steps to reproduce
-----
- Install MRP, Sale, Purchase apps
- Create a branch company and switch to the branch
- In the settings, enable subcontracting
- Create a product
    - Type: service
    - Add a vendor for the product, with some tax applied
    - Tick the "Subcontract Service" box
- Create & confirm a sale for the product
- Open the linked PO

-> The PO doesn't have the tax specified on the product page

Cause
-----
The tax is defined in the parent, but when applied to the POL it is matched to the PO's company.
