### PR TITLE
[FIX] im_livechat: group by "hour of day"

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -101,7 +101,7 @@
                         <filter name="group_by_expertise" string="Expertise" domain="[]" context="{'group_by':'session_expertises'}"/>
                         <filter name="group_by_customer" domain="[]" context="{'group_by':'visitor_partner_id'}"/>
                         <separator orientation="vertical" />
-                        <filter name="group_by_hour" string="Hour of Day" domain="[]" context="{'group_by':'start_date_hour'}"/>
+                        <filter name="group_by_hour" string="Hour of Day" domain="[]" context="{'group_by':'start_hour'}"/>
                         <filter name="group_by_day_of_week" string="Day of Week" domain="[]" context="{'group_by':'day_number'}"/>
                         <filter name="group_by_month" string="Date" domain="[]" context="{'group_by':'start_date:month'}" />
                     </group>


### PR DESCRIPTION
Before this PR, the "group by hour of day" in the live chat report views was wrong. It should group sessions by hours, days does not matter. This commit fixes the issue.

task-4589964

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
