### PR TITLE
[FIX] website_hr_recruitment: keep button editable when cleared

### DIFF
--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -158,7 +158,7 @@
                                 <div class="col-md-3">
                                     <div class="text-center">
                                         <br/>
-                                        <a role="button" t-attf-href="/jobs/apply/#{slug(job)}" class="btn btn-primary btn-lg">Apply Now!</a>
+                                        <a role="button" t-attf-href="/jobs/apply/#{slug(job)}" class="btn btn-primary btn-lg d-block">Apply Now!</a>
                                     </div>
                                 </div>
                             </div>
@@ -170,7 +170,7 @@
                 <div class="oe_structure">
                     <section class="o_job_bottom_bar mt24 mb48">
                         <div class="text-center">
-                            <a role="button" t-attf-href="/jobs/apply/#{slug(job)}" class="btn btn-primary btn-lg">Apply Now!</a>
+                            <a role="button" t-attf-href="/jobs/apply/#{slug(job)}" class="btn btn-primary btn-lg d-block">Apply Now!</a>
                         </div>
                     </section>
                 </div>


### PR DESCRIPTION
Problem:
When the "Apply Now!" button text is deleted (e.g., on `jobs/experienced-developer-4`), it becomes uneditable after saving.

Cause:
Deleting all text inserts a zero-width space (ZWNS) with `data-oe-zws-empty-inline` attribute. This is removed during save. Since the button has `data-oe-field="arch"` and no content, it's excluded from editable areas in `_getContentEditableAreas`, making it uneditable.

This used to work in 17.0 due to the button inheriting `display: block` from its floated parent, adds `br` once content is cleared.

Solution:
Force `display: block` on the button so that when its text is deleted, a `<br>` is inserted, maintaining its editability.

Steps to reproduce:
1. Go to `/jobs/experienced-developer-4`.
2. Open the web editor.
3. Delete the text "Apply Now!" inside the button.
4. Save the page.
5. Reopen the web editor. → The button is now uneditable.

opw-4737255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
