### PR TITLE
[FIX] mrp: exclude other no-variant attributes

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -565,11 +565,17 @@ class MrpBom(models.Model):
         bom_values_by_attribute = no_variant_bom_attributes.grouped('attribute_id')
         never_values_by_attribute = never_attribute_values.grouped('attribute_id')
 
-        for attribute, values in bom_values_by_attribute.items():
-            if any(val.id in never_values_by_attribute[attribute].ids for val in values):
-                continue
+        # Or if there is no overlap between given line values attributes and the ones on on the bom
+        if not any(never_att_id in no_variant_bom_attributes.attribute_id.ids for never_att_id in never_attribute_values.attribute_id.ids):
             return True
-        return not other_attribute_valid
+
+        # Check that at least one variant attribute is correct
+        for attribute, values in bom_values_by_attribute.items():
+            if never_values_by_attribute.get(attribute) and any(val.id in never_values_by_attribute[attribute].ids for val in values):
+                return not other_attribute_valid
+
+        # None were found, so we skip the line
+        return True
 
 
 class MrpBomLine(models.Model):


### PR DESCRIPTION
Steps to reproduce:
- Create a product with two separate 'no-variant' attributes
- Set that product as MTO / Manufacture
- Create a BoM for that product, with a single component
- Set that component as limited to the first 'no-variant' attribute
- Create a Sale Order for that product, and select the second 'no-variant' attribute
- Confirm the Sale Order

Issue:
A traceback will be raised, as the given attribute won't be found within the attributes set on the bom.

When chekcing if we should skip the bom line, there will be an issue if there's a miss-match between the attributes written on a line and the ones given to the MO.
To avoid this, we now directly exclude a line when there's no common attribute between the two, then validate it once at least one match was found.

opw-4758951

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
