### PR TITLE
[FIX] l10n_es_pos: not override manually set pricelist with simplified invoice

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -26,7 +26,14 @@ patch(PaymentScreen.prototype, {
                     return false;
                 }
                 if (!order.partner_id) {
+                    const setPricelist =
+                        this.pos.config.pricelist_id?.id != order.pricelist_id?.id
+                            ? order.pricelist_id.id
+                            : false;
                     order.set_partner(this.pos.config.simplified_partner_id);
+                    if (setPricelist) {
+                        order.set_pricelist(setPricelist);
+                    }
                 }
             }
         }

--- a/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
+++ b/addons/l10n_es_pos/static/tests/tours/spanish_pos_tour.js
@@ -76,3 +76,17 @@ registry.category("web_tour.tours").add("l10n_es_pos_settle_account_due", {
             ReceiptScreen.isShown(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_simplified_invoice_not_override_set_pricelist", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.addOrderline("Desk Pad", "1"),
+            ProductScreen.clickPriceList("Test pricelist"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+        ].flat(),
+});

--- a/addons/l10n_es_pos/tests/test_frontend.py
+++ b/addons/l10n_es_pos/tests/test_frontend.py
@@ -142,3 +142,14 @@ class TestUi(TestPointOfSaleHttpCommon):
         invoice_str = str(self.pos_order_pos0.account_move._get_invoice_legal_documents('pdf', allow_fallback=True).get('content'))
         self.assertTrue("invoice" in invoice_str)
         self.assertTrue("proforma" not in invoice_str)
+
+    def test_simplified_invoice_not_override_set_pricelist(self):
+        """Checks that when the simplified invoice parter is automatically set
+        on the order it does not override the pricelist that was manually selected
+        during the order"""
+        self.assertTrue(len(self.main_pos_config.available_pricelist_ids.ids) > 1)
+        self.main_pos_config.l10n_es_simplified_invoice_journal_id = self.main_pos_config.journal_id
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_simplified_invoice_not_override_set_pricelist', login="pos_user")
+        order = self.env['pos.order'].search([('partner_id', '=', self.main_pos_config.simplified_partner_id.id)])
+        self.assertNotEqual(order.pricelist_id, self.main_pos_config.simplified_partner_id.property_product_pricelist)


### PR DESCRIPTION
Currently, when you make a simplified invoice in pos, the pricelist will always be set to the simplified invoice partner pricelist, even if you had specifically set another pricelist during the order.

Steps to reproduce:
-------------------
* Create 2 pricelists, A and B, let's say A always adds a 10$ fee
* Set both as available in the POS, with A being the default one
* On the contact "Simplified invoice parner", set the pricelist A
* Open pos
* Change pricelist to B
* Pay and validate order
> Observation: Order is not validated, 10$ left to pay

Why the fix:
------------
Prior to the use of `set_partner`, we used to simply write the partner field of the order when using the simplified invoice partner.

Now we are using `set_partner` which is a generic function that handles everything related to changing partners, such as updating pricelist. https://github.com/odoo/odoo/blob/69057e41fb4cd800d23401ead8ae11bf7cba7c64/addons/point_of_sale/static/src/app/models/pos_order.js#L941-L948

In our example since the default pos pricelist was manually changed it means that the intention was to use this set pricelist.

What we do now in this case is to check if the pricelist was purposefully changed (it differs from the default pricelist), and in this case we want to use this pricelist on the order.

opw-4662248