### PR TITLE
[FIX] bus: outdated page false positive

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -16,7 +16,7 @@ export class OutdatedPageWatcherService {
     setup(env, { bus_service, multi_tab, notification }) {
         this.notification = notification;
         this.multi_tab = multi_tab;
-        this.lastNotificationId = null;
+        this.lastNotificationId = multi_tab.getSharedValue("last_notification_id");
         /** @deprecated */
         this.lastDisconnectDt = null;
         this.closeNotificationFn;
@@ -29,7 +29,7 @@ export class OutdatedPageWatcherService {
             { once: true }
         );
         bus_service.addEventListener("disconnect", () => {
-            this.lastNotificationId = bus_service.lastNotificationId;
+            this.lastNotificationId = multi_tab.getSharedValue("last_notification_id");
             this.lastDisconnectDt = DateTime.now();
         });
         bus_service.addEventListener("connect", async () => {


### PR DESCRIPTION
The outdated page watcher checks whether bus notifications were missed when the bus reconnects after an unexpected disconnection. To do so, it checks if the last known notification id is still in the bus table.

However, it relies on the main tab's last received notification which might not be available when the main tab didn't receive notifications after being elected.

To fix this issue, this commit uses the global last notification stored in the local storage to ensure every tab has access to it.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
