### PR TITLE
[FIX] mail: correct message action position for non-bubble msg

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -53,7 +53,7 @@
                                 </span>
                             </div>
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
-                            <t t-if="message.is_note" t-call="mail.Message.actions"/>
+                            <t t-if="!message.bubbleColor" t-call="mail.Message.actions"/>
                         </div>
                         <div
                             class="o-mail-Message-contentContainer position-relative d-flex"
@@ -104,7 +104,7 @@
                                             </div>
                                         </t>
                                     </t>
-                                    <t t-if="!message.is_note and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
+                                    <t t-if="message.bubbleColor and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
                                 </div>
                                 <div class="position-relative">
                                     <AttachmentList
@@ -116,7 +116,7 @@
                                 </div>
                                 <LinkPreviewList t-if="message.link_preview_ids.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="props.message.editable"/>
                             </div>
-                            <t t-if="!message.is_note and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
+                            <t t-if="message.bubbleColor and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
                         </div>
                         <MessageReactions message="message" openReactionMenu="openReactionMenu" t-if="message.reactions.length"/>
                     </div>
@@ -134,8 +134,8 @@
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,
-            'mt-1': !message.is_note,
-            'my-n2': message.is_note,
+            'mt-1': message.bubbleColor,
+            'my-n2': !message.bubbleColor,
             'invisible': !isActive and !isMobileOS,
             'o-expanded': optionsDropdown.isOpen
         }"

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -170,6 +170,9 @@ export class Message extends Record {
     }
 
     get bubbleColor() {
+        if (this.message_type === "notification") {
+            return undefined;
+        }
         if (!this.isSelfAuthored && !this.is_note && !this.isHighlightedFromMention) {
             return "blue";
         }


### PR DESCRIPTION
Before this commit, position of message action position was sometimes in message header and sometimes next to message content.

This happens because the condition was relying on `message.is_note` that works for logged notes but doesn't work with other non-bubble layout messages, such as tracked values.

This commit fixes the issue by using `message.bubbleColor` instead of `message.is_note`, and the `bubbleColor` condition has been adjusted to not wrongly set a bubble color for notification messages.