### PR TITLE
[FIX] im_livechat: group by rating should show rating text, not value

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -82,11 +82,15 @@ Help your customers with this chat, and analyse their feedback.
             'im_livechat/static/src/js/im_livechat_chatbot_steps_one2many.js',
             'im_livechat/static/src/js/im_livechat_chatbot_script_answers_m2m.js',
             'im_livechat/static/src/views/**/*',
+            ('remove', 'im_livechat/static/src/views/discuss_channel_pivot/**/*'),
             'im_livechat/static/src/scss/im_livechat_history.scss',
             'im_livechat/static/src/scss/im_livechat_form.scss',
             'im_livechat/static/src/core/common/**/*',
             'im_livechat/static/src/core/public_web/**/*',
             'im_livechat/static/src/core/web/**/*',
+        ],
+        'web.assets_backend_lazy': [
+            'im_livechat/static/src/views/discuss_channel_pivot/**/*',
         ],
         'web.assets_unit_tests': [
             'im_livechat/static/tests/**/*',

--- a/addons/im_livechat/static/src/views/discuss_channel_kanban/discuss_channel_kanban_view.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_kanban/discuss_channel_kanban_view.js
@@ -1,13 +1,16 @@
+import { DiscussChannelRelationalModel } from "@im_livechat/views/discuss_channel_relational_model";
+import { LivechatViewControllerMixin } from "@im_livechat/views/livechat_view_controller_mixin";
+
+import { registry } from "@web/core/registry";
 import { KanbanController } from "@web/views/kanban/kanban_controller";
 import { kanbanView } from "@web/views/kanban/kanban_view";
-import { registry } from "@web/core/registry";
-import { LivechatViewControllerMixin } from "../livechat_view_controller_mixin";
 
 class DiscussChannelKanbanController extends LivechatViewControllerMixin(KanbanController) {}
 
 const discussChannelKanbanView = {
     ...kanbanView,
     Controller: DiscussChannelKanbanController,
+    Model: DiscussChannelRelationalModel,
 };
 
 registry.category("views").add("im_livechat.discuss_channel_kanban", discussChannelKanbanView);

--- a/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view.js
@@ -1,13 +1,16 @@
-import { ListController } from "@web/views/list/list_controller";
-import { LivechatViewControllerMixin } from "../livechat_view_controller_mixin";
-import { listView } from "@web/views/list/list_view";
+import { DiscussChannelRelationalModel } from "@im_livechat/views/discuss_channel_relational_model";
+import { LivechatViewControllerMixin } from "@im_livechat/views/livechat_view_controller_mixin";
+
 import { registry } from "@web/core/registry";
+import { ListController } from "@web/views/list/list_controller";
+import { listView } from "@web/views/list/list_view";
 
 class DiscussChannelListController extends LivechatViewControllerMixin(ListController) {}
 
 const discussChannelListView = {
     ...listView,
     Controller: DiscussChannelListController,
+    Model: DiscussChannelRelationalModel,
 };
 
 registry.category("views").add("im_livechat.discuss_channel_list", discussChannelListView);

--- a/addons/im_livechat/static/src/views/discuss_channel_pivot/discuss_channel_pivot_model.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_pivot/discuss_channel_pivot_model.js
@@ -1,0 +1,28 @@
+import { _t } from "@web/core/l10n/translation";
+import { PivotModel } from "@web/views/pivot/pivot_model";
+
+export class DiscussChannelPivotModel extends PivotModel {
+    _prepareData(group, groupSubdivisions, config) {
+        for (const groupSubdivision of groupSubdivisions) {
+            if (groupSubdivision.rowGroupBy?.[0] === "rating_last_value") {
+                groupSubdivision.subGroups.forEach((subGroup) => {
+                    switch (subGroup.rating_last_value) {
+                        case 0:
+                            subGroup.rating_last_value = _t("Unrated");
+                            break;
+                        case 1:
+                            subGroup.rating_last_value = _t("Unhappy");
+                            break;
+                        case 3:
+                            subGroup.rating_last_value = _t("Neutral");
+                            break;
+                        case 5:
+                            subGroup.rating_last_value = _t("Happy");
+                            break;
+                    }
+                });
+            }
+        }
+        super._prepareData(group, groupSubdivisions, config);
+    }
+}

--- a/addons/im_livechat/static/src/views/discuss_channel_pivot/discuss_channel_pivot_view.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_pivot/discuss_channel_pivot_view.js
@@ -1,0 +1,8 @@
+import { DiscussChannelPivotModel } from "@im_livechat/views/discuss_channel_pivot/discuss_channel_pivot_model";
+
+import { registry } from "@web/core/registry";
+import { pivotView } from "@web/views/pivot/pivot_view";
+
+const discussChannelPivotView = { ...pivotView, Model: DiscussChannelPivotModel };
+
+registry.category("views").add("im_livechat.discuss_channel_pivot", discussChannelPivotView);

--- a/addons/im_livechat/static/src/views/discuss_channel_relational_model.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_relational_model.js
@@ -1,0 +1,26 @@
+import { _t } from "@web/core/l10n/translation";
+import { RelationalModel } from "@web/model/relational_model/relational_model";
+
+export class DiscussChannelRelationalModel extends RelationalModel {
+    async _loadGroupedList(config) {
+        const { groups, length } = await super._loadGroupedList(config);
+        if (config.groupBy[0] === "rating_last_value") {
+            for (const group of groups) {
+                switch (group.value) {
+                    case 1:
+                        group.displayName = _t("Unhappy");
+                        break;
+                    case 3:
+                        group.displayName = _t("Neutral");
+                        break;
+                    case 5:
+                        group.displayName = _t("Happy");
+                        break;
+                    default:
+                        group.displayName = _t("Unrated");
+                }
+            }
+        }
+        return { groups, length };
+    }
+}

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -121,7 +121,7 @@
             <field name="name">discuss.channel.pivot</field>
             <field name="model">discuss.channel</field>
             <field name="arch" type="xml">
-                <pivot string="Sessions" display_quantity="1" sample="1">
+                <pivot js_class="im_livechat.discuss_channel_pivot" string="Sessions" display_quantity="1" sample="1">
                     <field name="livechat_operator_id" type="row"/>
                     <field name="create_date" interval="day" type="col"/>
                     <field name="rating_last_value" type="measure" string="Rating (%)" widget="im_livechat.rating_percentage"/>


### PR DESCRIPTION
The group by rating in the live chat session views shows the last rating value instead of the rating text. This commit fixes the issue.

task-4770430

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
