### PR TITLE
[FIX] base: session token compute crash when using invalid values

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -837,6 +837,8 @@ class ResUsers(models.Model):
         return tuple((column.name, data_fields[index]) for index, column in enumerate(cr_description))
 
     def _session_token_hash_compute(self, sid, field_values):
+        if not field_values:
+            return False
         # Generate hmac key using the column name and its value, only if the value is not None
         # To avoid invalidating sessions when installing a new feature modifying the session token computation
         # while not still being used.
@@ -851,6 +853,8 @@ class ResUsers(models.Model):
 
     def _legacy_session_token_hash_compute(self, sid):
         field_values = self._session_token_get_values()
+        if not field_values:
+            return False
         # generate hmac key
         key = ('%s' % (tuple(f[1] for f in field_values),)).encode()
         # hmac the session id

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -278,6 +278,15 @@ class TestUsers(UsersCommonCase):
             "The phone of the partner_id shall be updated."
         )
 
+    def test_session_non_existing_user(self):
+        """
+        Test to check the invalidation of session bound to non existing (or deleted) users.
+        """
+        User = self.env['res.users']
+        last_user_id = User.with_context(active_test=False).search([], limit=1, order="id desc")
+        non_existing_user = User.browse(last_user_id.id + 1)
+        self.assertFalse(non_existing_user._compute_session_token('session_id'))
+
 @tagged('post_install', '-at_install', 'groups')
 class TestUsers2(UsersCommonCase):
 


### PR DESCRIPTION
  - In the case `_session_token_get_values` returns `False`, before this commit the code crashes as it wasn't expecting to handle something else than an iterable as `field_values`.

    The bug was introduced by the commit 3fbd74b3bb7af2b9bc9c86fddc78771ec97ce740 Before this commit, falsy values where correctly handled. We introduce the same behavior to fix the issue.

  - Added a test to check that computing session on non existing user do not crash and correctly expires the session.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
