### PR TITLE
[FIX] sale_loyalty: prevent gift card mail access error

### DIFF
--- a/addons/sale_loyalty/models/loyalty_card.py
+++ b/addons/sale_loyalty/models/loyalty_card.py
@@ -20,8 +20,8 @@ class LoyaltyCard(models.Model):
         return super()._get_mail_partner() or self.order_id.partner_id
 
     def _get_mail_author(self):
-        """Default author is the order's salesperson if set, otherwise the order's company."""
-        if not self.order_id:
+        """Default author is the order's salesperson if available, else the order's company."""
+        if not self.order_id or self.order_id.sudo().company_id not in self.env.companies:
             return super()._get_mail_author()
         self.ensure_one()
         return (self.order_id.user_id or self.order_id.company_id).partner_id

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -487,7 +487,7 @@ class SaleOrder(models.Model):
         Returns all programs that give points on the current order.
         """
         self.ensure_one()
-        return self.coupon_point_ids.coupon_id.program_id
+        return self.coupon_point_ids.filtered('points').coupon_id.program_id
 
     def _get_reward_programs(self):
         """
@@ -501,7 +501,9 @@ class SaleOrder(models.Model):
         Returns all coupons that are a reward.
         """
         self.ensure_one()
-        return self.coupon_point_ids.coupon_id.filtered(lambda c: c.program_id.applies_on == 'future')
+        return self.coupon_point_ids.filtered('points').coupon_id.filtered(
+            lambda c: c.program_id.applies_on == 'future',
+        )
 
     def _get_applied_programs(self):
         """

--- a/addons/sale_loyalty/tests/test_buy_gift_card.py
+++ b/addons/sale_loyalty/tests/test_buy_gift_card.py
@@ -68,7 +68,7 @@ class TestBuyGiftCard(TestSaleCouponCommon):
 
         # Confirm order as Public User to trigger loyalty mail
         public_user = self.env.ref('base.public_user')
-        orders.with_context({}).with_user(public_user).sudo().action_confirm()
+        orders.with_user(public_user).with_company(order.company_id).sudo().action_confirm()
 
         mails = self.env['mail.mail'].search([])
         self.assertEqual(len(mails), 2)


### PR DESCRIPTION
Versions
--------
- 16.0+

Steps
-----
1. Have multiple companies;
2. create an eWallet program available to all companies;
3. set its email template to "Gift Card: Gift Card Information";
4. create & confirm an order containing the "Top-up eWallet" product;
5. switch to a different company;
6. create an new order for the same client.

Issue
-----
Access Error

Cause
-----
Commit eaa6f6c5a415f added the `_get_mail_author` method to ensure gift card emails always have an author. When using the gift card template for eWallets, this can cause an issue for 2 reasons:

1. When creating an eWallet via the top-up product, its `order_id` is the order that created the eWallet. This order may belong to a different company than the one it is getting used for.
2. The `send_reward_coupon_mail` method fetches its coupons by calling `_get_reward_coupons` on the order. This returns any applied eWallets, therefore calling `_send_creation_communication` whenever the eWallet gets used. The reason it returns applied eWallets as a "reward coupon" is because `_update_programs_and_rewards` creates `sale.order.coupon.points` records with 0 points when applying a `loyalty.card`, which then get assumed to be a reward, despite not granting any points: https://github.com/odoo/odoo/blob/9e22dbb7b6fb581d2f11bf0ec48b230047686050/addons/sale_loyalty/models/sale_order.py#L499-L504

Solution
--------
1. In the `_get_mail_author` yield to `super` if the order's company isn't in `self.env.companies`.
2. In the `_get_points_programs` and `_get_reward_coupons` methods, filter out `coupon_point_ids` that don't grant any points. (Alternatively, we could avoid creating `sale.order.coupon.points` records with 0 points, but this might be risky for stable.)


opw-4731588