### PR TITLE
[FIX] account: less restrictive readonly on sections and notes

### DIFF
--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.js
@@ -46,6 +46,13 @@ export class ProductLabelSectionAndNoteListRender extends SectionAndNoteListRend
 
         return activeColumns;
     }
+
+    isCellReadonly(column, record) {
+        // The isCellReadonly method from the ListRenderer is used to determine the classes to apply to the cell.
+        // We need this override to make sure some readonly classes are not applied to the cell if it is still editable.
+        let isReadonly = super.isCellReadonly(column, record);
+        return ["cancel", "done", "posted"].includes(record.evalContext.parent.state) && isReadonly;
+    }
 }
 
 export class ProductLabelSectionAndNoteOne2Many extends X2ManyField {
@@ -205,6 +212,10 @@ export class ProductLabelSectionAndNoteField extends Many2OneField {
             return "fst-italic";
         }
         return "";
+    }
+
+    get sectionAndNoteIsReadonly() {
+        return ["cancel", "done", "posted"].includes(this.props.record.evalContext.parent.state)
     }
 
     isSection(record = null) {

--- a/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
+++ b/addons/account/static/src/components/product_label_section_and_note_field/product_label_section_and_note_field.xml
@@ -55,7 +55,7 @@
                         <input
                             class="o_input text-wrap border-0 fst-italic"
                             placeholder="Enter a description"
-                            readonly="1"
+                            t-att-readonly="sectionAndNoteIsReadonly"
                             type="text"
                             t-att-class="sectionAndNoteClasses"
                             t-att-value="label"
@@ -67,7 +67,7 @@
                         <textarea
                             class="o_input d-print-none border-0 fst-italic"
                             placeholder="Enter a description"
-                            readonly="1"
+                            t-att-readonly="sectionAndNoteIsReadonly"
                             rows="1"
                             type="text"
                             t-att-class="sectionAndNoteClasses"


### PR DESCRIPTION
Description of the issue this commit addresses:

In the move form view, the sections and notes are made readonly too soon. For example in a purchase order form, when the PO is confirmed, it is still possible to add notes and sections but not to edit them so they are locked once the focus is lost. As it is intended to be able to add notes at such point so it should be possible to edit them too.

---

Desired behavior after this commit is merged:

This commit makes it so that the readonly attribute of the sections and notes depends on the state of the move of the form. Currently, we want the readonly only if the parent is cancelled (cancel), locked (done) or posted (posted).

---

Note on the fix:

The addition of the sectionAndNoteIsReadonly() getter is the part of the fix
that really allows the user to edit text that was previously uneditable. On the
other hand, the override of the isCellReadonly method is only here to make sure
no readonly classes like text-muted are applied if the cell is still editable.

---

opw-4744367

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr