### PR TITLE
[FIX] point_of_sale: select orderline split bill

### DIFF
--- a/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
+++ b/addons/pos_restaurant/static/src/js/Screens/SplitBillScreen/SplitBillScreen.js
@@ -95,26 +95,20 @@ odoo.define('pos_restaurant.SplitBillScreen', function(require) {
         }
         _splitQuantity(line) {
             const split = this.splitlines[line.id];
+            const lineQty = line.get_quantity();
 
-            let totalQuantity = 0;
-
-            this.env.pos.get_order().get_orderlines().forEach(function(orderLine) {
-                if(orderLine.get_product().id === split.product)
-                    totalQuantity += orderLine.get_quantity();
-            });
-
-            if(line.get_quantity() > 0) {
+            if(lineQty > 0) {
                 if (!line.get_unit().is_pos_groupable) {
-                    if (split.quantity !== line.get_quantity()) {
-                        split.quantity = line.get_quantity();
+                    if (split.quantity !== lineQty) {
+                        split.quantity = lineQty;
                     } else {
                         split.quantity = 0;
                     }
                 } else {
-                    if (split.quantity < totalQuantity) {
+                    if (split.quantity < lineQty) {
                         split.quantity += line.get_unit().is_pos_groupable? 1: line.get_unit().rounding;
-                        if (split.quantity > line.get_quantity()) {
-                            split.quantity = line.get_quantity();
+                        if (split.quantity > lineQty) {
+                            split.quantity = lineQty;
                         }
                     } else {
                         split.quantity = 0;


### PR DESCRIPTION
Steps to reporduce:

- Make two orderlines that are cannot be merged with same product (add a comment, combo, etc ...)
- Open the split bill screen
- Selecet any of the orderlines and try to unselect it
- Impossible to unselect the orderlines with same product but different line

Fix:
Calculate the line quantity selected based on the linked order line quantity and not the total number of same product in the order.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
