### PR TITLE
[FIX] stock_account: added company context to products in fifo svls

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -440,7 +440,7 @@ class ProductProduct(models.Model):
         new_svl_vals_manual = []
         real_time_svls_to_vacuum = ValuationLayer
 
-        for product in self:
+        for product in self.with_company(company.id):
             all_candidates = all_candidates_by_product[product.id]
             current_real_time_svls = ValuationLayer
             for svl_to_vacuum in svls_to_vacuum_by_product[product.id]:


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting + Inventory + Sales apps
- Enable Automatic Accounting in Settings
- Ensure two companies are available
- Set one product category (same for both companies)
    - For company 1 (current) -> FIFO + automatic valuation (`'real_time'`)
    - For company 2 -> FIFO + manual valuation (`'manual_periodic'`)
- Create a storable product for this category
- From company 1:
    - Buy 10 products at 10$ each and receive them (Purchase + Delivery)
    - Sell 15 products at 10$ each and deliver them (Sale + Delivery)
    - Buy 10 products at 10$ (Purchase)
- Switch to company 2 (keep company 1 checked)
- From company 2:
    - Validate the third delivery order (WH/IN)
- Go to Inventory/Reporting/Valuation
- One journal entry is missing for the last move

**Issue:**
During the processing of the SVL in `_run_fifo_vacuum`, the product used its current env context company instead of the one provided explicitly in the parameters. This caused inconsistencies in valuation logic when the method used differed between the given companies, which results in a missing `account_move_id`.

**Fix:**
Ensure that the product is evaluated in the correct company context by using `product.with_company(company.id)` before the valuation logic.

opw-4732067

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
