### PR TITLE
[IMP] mail: New chatter props hasParentReloadOnActivityChanged

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -47,6 +47,7 @@ Chatter.props.push(
     "compactHeight?",
     "has_activities?",
     "hasAttachmentPreview?",
+    "hasParentReloadOnActivityChanged?",
     "hasParentReloadOnAttachmentsChanged?",
     "hasParentReloadOnFollowersUpdate?",
     "hasParentReloadOnMessagePosted?",
@@ -62,6 +63,7 @@ Object.assign(Chatter.defaultProps, {
     compactHeight: false,
     has_activities: true,
     hasAttachmentPreview: false,
+    hasParentReloadOnActivityChanged: false,
     hasParentReloadOnAttachmentsChanged: false,
     hasParentReloadOnFollowersUpdate: false,
     hasParentReloadOnMessagePosted: false,
@@ -319,6 +321,9 @@ patch(Chatter.prototype, {
 
     onActivityChanged(thread) {
         this.load(thread, [...this.requestList, "messages"]);
+        if (this.props.hasParentReloadOnActivityChanged) {
+            this.reloadParentView();
+        }
     },
 
     onAddFollowers() {
@@ -415,6 +420,9 @@ patch(Chatter.prototype, {
         const schedule = async (thread) => {
             await this.store.scheduleActivity(thread.model, [thread.id]);
             this.load(thread, ["activities", "messages"]);
+            if (this.props.hasParentReloadOnActivityChanged) {
+                await this.reloadParentView();
+            }
         };
         if (this.state.thread.id) {
             schedule(this.state.thread);

--- a/addons/mail/static/src/chatter/web/form_compiler.js
+++ b/addons/mail/static/src/chatter/web/form_compiler.js
@@ -12,6 +12,7 @@ function compileChatter(node, params) {
         hasAttachmentPreview: Boolean(
             this.templates.FormRenderer.querySelector(".o_attachment_preview")
         ),
+        hasParentReloadOnActivityChanged: Boolean(node.getAttribute("reload_on_activity")),
         hasParentReloadOnAttachmentsChanged: Boolean(node.getAttribute("reload_on_attachment")),
         hasParentReloadOnFollowersUpdate: Boolean(node.getAttribute("reload_on_follower")),
         hasParentReloadOnMessagePosted: Boolean(node.getAttribute("reload_on_post")),


### PR DESCRIPTION
The aim of this commit is adding a new props for the chatter component.
By adding this props, the parent view will be reloaded when an activity is added, modified or deleted in the chatter. This change is necessary for the bank reconciliation widget where we want to update a specific record when a user adds a new activity in the chatter.

no task id


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
