### PR TITLE
[FIX] point_of_sale: fix floating order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -774,7 +774,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
                 return records;
             },
             get orderedRecords() {
-                return Array.from(records[model].values());
+                return Array.from(this.records[model].values());
             },
             get indexedRecords() {
                 return indexedRecords;


### PR DESCRIPTION
Before this commit, when an user was ordering from self-order in picking mode, the order was not automatically displayed in the POS.

This was because of related models that was trying to access records variable with a wrong way.

This commit fixes this issue by using the correct way to access the records variable.

