### PR TITLE
[IMP] purchase_stock: allow received purchase orders to be cancelled

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order_process.py
+++ b/addons/purchase_stock/tests/test_purchase_order_process.py
@@ -1,4 +1,5 @@
 from odoo import Command, fields
+from odoo.tests import Form
 from odoo.tests import tagged
 from odoo.tools import float_compare
 from .common import PurchaseTestCommon
@@ -67,3 +68,82 @@ class TestPurchaseOrderProcess(PurchaseTestCommon):
         purchase_order.picking_ids.move_ids.flush_recordset()
         delay_reports = self.env['vendor.delay.report']._read_group([('partner_id', '=', partner.id)], ['product_id'], ['on_time_rate:sum'])
         self.assertEqual([rec[1] for rec in delay_reports], [100.0])
+
+    def test_cancel_redraft_fulfilled(self):
+        """Test whether cancelling a fulfilled purchase order will leave
+           the done picking intact and redrafting it will not create a new
+           picking."""
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_1.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_1.id,
+                    'product_qty': 2.0,
+                }),
+            ],
+        })
+        po.button_confirm()
+
+        picking = po.picking_ids[0]
+        picking.button_validate()
+
+        po.button_cancel()
+        self.assertEqual(po.state, 'cancel')
+        self.assertEqual(picking.state, 'done', "Done pickings should not change state.")
+
+        po.button_draft()
+        self.assertEqual(po.state, 'draft', "The PO should gracefully return to draft state.")
+        self.assertEqual(picking.state, 'done', "Done pickings should not change state.")
+
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')
+        self.assertEqual(len(po.picking_ids), 1, "No new pickings should be created for a fulfilled PO.")
+
+    def test_cancel_redraft_backordered(self):
+        """Test whether cancelling a partially fulfilled purchase order and
+           redrafting it will create a backorder with the remaining undelivered
+           quantity, and that cancelling the order will propagate to the
+           unfulfilled backorder as well. Redrafting the PO should create a
+           new picking to compensate for the quantity left undelivered."""
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_1.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_1.id,
+                    'product_qty': 5.0,
+                }),
+            ],
+        })
+        po.button_confirm()
+
+        # Receive less than the expected amount.
+        picking = po.picking_ids[0]
+        move = picking.move_ids[0]
+        move.quantity = 3.0
+        action = picking.button_validate()
+
+        # Create a backorder for the rest.
+        Form(self.env['stock.backorder.confirmation'].with_context(action['context'])).save().process()
+        remainder_qty = po.order_line.product_qty - move.quantity
+        backorder = picking.backorder_ids[0]
+        self.assertEqual(po.order_line.qty_received, move.quantity, "Only the quantity set in the picking should be received.")
+        self.assertEqual(backorder.move_ids.quantity, remainder_qty, "The backorder should contain the unreceived quantity.")
+
+        po.button_cancel()
+        self.assertEqual(po.state, 'cancel')
+        self.assertEqual(picking.state, 'done', "Done pickings should not change state.")
+        self.assertEqual(backorder.state, 'cancel', "The backorder should be cancelled with the PO, as it was not validated.")
+
+        po.button_draft()
+        self.assertEqual(po.state, 'draft', "The PO should gracefully return to draft state.")
+
+        po.button_confirm()
+        self.assertEqual(po.state, 'purchase')
+        self.assertEqual(len(po.picking_ids), 3, "A new picking should be created to compensate for the cancelled backorder.")
+
+        new_picking = po.picking_ids - picking - backorder
+        self.assertEqual(new_picking.move_ids.quantity, remainder_qty, "The newly created picking should contain the amount left undelivered.")
+
+        new_picking.move_ids.picked = True
+        new_picking.button_validate()
+        self.assertEqual(po.order_line.qty_received, po.order_line.product_qty, "We should have received the entire quantity specified in the PO.")


### PR DESCRIPTION
Unlike sales orders, purchase orders cannot be cancelled once the moves are done, and they cannot be deleted unless they're cancelled first. This is frustrating for users who create test purchase orders and find themselves unable to get rid of them.

Thus, we allow the user to cancel the purchase order if the linked moves are either not done (ie no delivery took place) or at net zero (ie 0 quantity delivered), for example by returning the moves. Since this allows the user to indefinitely receive, cancel and redraft a purchase order, we make sure, as a precaution, that no new picking is automatically created if the purchase order is in a 'dirty' state (ie not all moves were returned/cancelled or some quantity was delivered before the order was redrafted).

Whenever a purchase order gets cancelled, all its associated pickings receive
a log message indicating this if they were done (since we cannot cancel them).

Task ID: [4762100](https://www.odoo.com/odoo/project/966/tasks/4762100)
