### PR TITLE
[FIX] repair: prevent propagation of "repair_id" to new moves

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -13,7 +13,7 @@ MAP_REPAIR_LINE_TYPE_TO_MOVE_LOCATIONS_FROM_REPAIR = {
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    repair_id = fields.Many2one('repair.order', check_company=True)
+    repair_id = fields.Many2one('repair.order', check_company=True, copy=False)
     repair_line_type = fields.Selection([
         ('add', 'Add'),
         ('remove', 'Remove'),

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -910,6 +910,9 @@ class TestRepair(common.TransactionCase):
             'quantity': 1.0,
         })]
         self.assertEqual(repair_order.lot_id, sn_1)
+        # duplicate the move and check that the link to the repair order is not copied
+        copied_move = repair_order.move_ids.copy()
+        self.assertFalse(copied_move.repair_id)
 
     def test_missing_production_location_raises_user_error(self):
         """


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable multi-steps route
- Set a remove destination location (e.g., WH/stock/shelf1) on the repair operation type.

- Create a new route:
    - name: Push route
    - Rule:
        - Action: push to
        - Operation type: internal transfer - Source location: WH/stock/shelf1 - Destination location: WH/stock/shelf2

- Create a storable product “P1”:
    - Update the Qty to one unit in WH/stock

- Create a sotrable product “C1”:
    - Route: select the new created route → “Push route”

- Create a repair order:
    - Customer: Azure interior
    - Product: P1
    - part:
        - Remove one unit of C1

- Confirm the repair
- Start the repair
- End the repair

Problem:
The move of “C1” is duplicated and added to the repair

When a push rule triggers an internal transfer for a component removed during a repair, the newly created stock move wrongly inherits the "repair_id" from the original move.

This happens because the "repair_id" field was not excluded from being copied, resulting in the duplicated move being incorrectly linked to the repair order.

https://github.com/odoo/odoo/blob/11e69870db1c49d9a6af79ffd263e4e162b34b6b/addons/stock/models/stock_move.py#L1854-L1855

https://github.com/odoo/odoo/blob/11e69870db1c49d9a6af79ffd263e4e162b34b6b/addons/stock/models/stock_move.py#L968-L969 https://github.com/odoo/odoo/blob/11e69870db1c49d9a6af79ffd263e4e162b34b6b/addons/stock/models/stock_rule.py#L212

https://github.com/odoo/odoo/blob/11e69870db1c49d9a6af79ffd263e4e162b34b6b/addons/stock/models/stock_rule.py#L240

Solution:
By setting copy=False on the repair_id field, we prevent this unintended propagation.

opw-4689206
