### PR TITLE
[FIX] l10n_it_edi_ndd: recompute l10n_it_document_type for credit note

### DIFF
--- a/addons/l10n_it_edi_ndd/models/account_move.py
+++ b/addons/l10n_it_edi_ndd/models/account_move.py
@@ -77,9 +77,10 @@ class AccountMove(models.Model):
             But when reversing the move, the document type of the original move is copied and so it isn't recomputed.
         """
         # EXTENDS account
+        default_values_list = default_values_list or [{}] * len(self)
+        for default_values in default_values_list:
+            default_values.update({'l10n_it_document_type': False})
         reverse_moves = super()._reverse_moves(default_values_list, cancel)
-        for move in reverse_moves:
-            move.l10n_it_document_type = False
         return reverse_moves
 
     def _l10n_it_edi_import_invoice(self, invoice, data, is_new):

--- a/addons/l10n_it_edi_ndd/tests/__init__.py
+++ b/addons/l10n_it_edi_ndd/tests/__init__.py
@@ -1,2 +1,3 @@
+from . import test_account_move_document_type
 from . import test_account_move_payment_method
 from . import test_edi_import

--- a/addons/l10n_it_edi_ndd/tests/test_account_move_document_type.py
+++ b/addons/l10n_it_edi_ndd/tests/test_account_move_document_type.py
@@ -1,0 +1,41 @@
+from odoo.tests import tagged
+from odoo.addons.l10n_it_edi.tests.common import TestItEdi
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestItAccountMoveDocumentType(TestItEdi):
+
+    def test_account_move_document_type(self):
+        # l10n_it_document_type_01: "TD01 - Invoice (Immediate or Accompanying if <DatiTrasporto> or <DatiDDT> are completed)"
+        # l10n_it_document_type_04: "TD04 - Credit note"
+        dt_invoice = self.env.ref('l10n_it_edi_ndd.l10n_it_document_type_01')
+        dt_credit_note = self.env.ref('l10n_it_edi_ndd.l10n_it_document_type_04')
+
+        invoice_x = self.init_invoice("out_invoice", amounts=[1000])
+        # the compute method does nothing for moves that are not posted
+        self.assertFalse(invoice_x.l10n_it_document_type)
+
+        invoice_x.action_post()
+        self.assertEqual(invoice_x.l10n_it_document_type, dt_invoice)
+        # create a draft credit note
+        reversal_wizard = self.env['account.move.reversal'].with_context(active_model='account.move', active_ids=invoice_x.ids).create({
+            'reason': 'XXX',
+            'journal_id': invoice_x.journal_id.id,
+        })
+        reversal = reversal_wizard.refund_moves()
+        credit_note_x = self.env['account.move'].browse(reversal['res_id'])
+        self.assertFalse(credit_note_x.l10n_it_document_type)
+        # post the credit note
+        credit_note_x.action_post()
+        self.assertEqual(credit_note_x.l10n_it_document_type, dt_credit_note)
+
+        invoice_y = self.init_invoice("out_invoice", amounts=[2000], post=True)
+        self.assertEqual(invoice_y.l10n_it_document_type, dt_invoice)
+        # create a credit note that is posted directly
+        reversal_wizard = self.env['account.move.reversal'].with_context(active_model='account.move', active_ids=invoice_y.ids).create({
+            'reason': 'YYY',
+            'journal_id': invoice_y.journal_id.id,
+        })
+        reversal_wizard.modify_moves()
+        credit_note_y = invoice_y.reversal_move_id
+        self.assertEqual(credit_note_y.l10n_it_document_type, dt_credit_note)


### PR DESCRIPTION
**Steps to reproduce:**
- Install l10n_it_edi_ndd
- Switch to an Italian company (e.g. IT Company)
- Create an invoice
- Confirm the invoice
=> Document Type (in "Electronic Invoicing" tab) is computed
- Create a credit note from the invoice
- On credit note wizard, click on "Reverse and Create Invoice"
- Check the created credit note

**Issue:**
The credit note is posted but its Document Type field (l10n_it_document_type) is empty.
l10n_it_document_type should be computed when it doesn't have a value already and the state of the move is "posted".
The credit note will be rejected when sent to SDI because this field is empty.

**Cause:**
In the reverse method, the field is set to False in order to be recomputed.
However, the compute method is triggered when the state changes, but the credit note not is already posted.
Therefore the field will not be recomputed.

**Solution:**
Set the value to False before the creation of the credit note.
So that, the field will be recomputed when posting the credit note.

opw-4689755




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
