### PR TITLE
[FIX] mail: squashed message bubble fully rounded

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -68,11 +68,15 @@
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
-                                                <div t-if="message.bubbleColor" class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
+                                                <div t-if="message.bubbleColor" class="o-mail-Message-bubble position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
+                                                    'rounded-3': props.squashed,
+                                                    'rounded-bottom-3': !props.squashed,
+                                                    'rounded-start-3': !props.squashed and isAlignedRight,
+                                                    'rounded-end-3': !props.squashed and !isAlignedRight,
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',
-                                                    }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
+                                                }"/>
                                                 <MessageInReply t-if="message.parentMessage" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.is_note,
@@ -81,7 +85,8 @@
                                                             'py-2': !message.is_note and !state.isEditing,
                                                             'pt-2 pb-1': !message.is_note and state.isEditing,
                                                             'o-note': message.is_note,
-                                                            'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note,
+                                                            'rounded-3': props.squashed,
+                                                            'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note and !props.squashed,
                                                             'flex-grow-1': state.isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>


### PR DESCRIPTION
Before this commit, the top corner of a message bubble next to author avatar was always non-rounded, including squashed messages.

This non-rounded part represent the arrow of the bubble, to show visually that this user has spoken.

This is nice for non-squashed messages, i.e. messages next to avatar and header containing info like user name. For squashed messages, however, they are not next to an avatar, because this is the same as the parented oldest message with same author. The non-rounded corner can help for direction between self and others messages, but even there color of bubble is good enough, and since these are squashed messages it's easy to deduce the alignment of message.

This non-rounded corner doesn't look good on squashed messages, so this commit fixes the issue by making squashed messages fully rounded, without this non-rounded corner.