### PR TITLE
[FIX] mail: slight unread indicator position adjustment

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -68,7 +68,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.4rem;
-    left: -2px;
+    left: -3px;
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
         left: map-get($spacers, 2) + map-get($spacers, 1) / 2;


### PR DESCRIPTION
Discuss sidebar in compact mode has a specific positioning of the unread indicator, i.e. the dot next to avatar of conversation.

The position was slightly off, especially on items that had an outline, i.e. with sub-threads or an ongoing call.

This commit slightly moves the indicator to left, so this is placed right on the outline, rather than off-centered to right.