### PR TITLE
[FIX] mail: better spacing between message cards

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,5 +1,6 @@
 .o-mail-Message.o-card {
     background-color: mix($gray-100, $gray-200);
+    --border-opacity: .15;
 }
 
 .o-mail-Message-actions {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -226,7 +226,7 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
-            "o-card p-2 ps-1 mx-1 mt-2 mb-2 border border-secondary rounded-3": this.props.asCard,
+            "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-secondary rounded-3": this.props.asCard,
             "pt-1": !this.props.asCard && !this.props.squashed,
             "o-pt-0_5": !this.props.asCard && this.props.squashed,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,


### PR DESCRIPTION
Before this commit, message in card visual like in mailboxes had too much spacing.

This commit reduces the spacing by half.

Also the dark theme had too distracting borders, their opacity have been changed to 0. The border is kept for exact same spacing as in white theme.