### PR TITLE
[FIX] mail: correct size for 'start a meeting' btn

### DIFF
--- a/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_patch.xml
@@ -15,6 +15,6 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.startMeetingButton">
-        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'px-1 py-2': store.discuss.isSidebarCompact, 'btn-s mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
+        <button class="btn btn-primary rounded-3 d-flex align-items-center gap-1" t-att-class="{ 'px-1 py-2': store.discuss.isSidebarCompact, 'btn-sm mx-5': !store.discuss.isSidebarCompact }" t-on-click="store.startMeeting" data-hotkey="m" t-ref="meeting-btn"><i class="fa fa-fw fa-users opacity-75" t-att-class="{ 'fa-lg': store.discuss.isSidebarCompact }"/><span t-if="!store.discuss.isSidebarCompact" t-esc="startMeetingText"/></button>
     </t>
 </templates>


### PR DESCRIPTION
Button was mistakenly too big, due to typo with `.btn-s` instead of `.btn-sm`.