### PR TITLE
[IMP] l10n_lu: Added translations for VAT report

### DIFF
--- a/addons/l10n_lu/i18n_extra/de.po
+++ b/addons/l10n_lu/i18n_extra/de.po
@@ -228,11 +228,13 @@ msgstr ""
 msgid ""
 "188 - Appendix A - Expenses for other work carried out by third parties"
 msgstr ""
+"188 - Anhang A - Kosten für sonstige Arbeiten, die von Dritten ausgeführt "
+"werden"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_190
 msgid "190 - Appendix A - Car expenses"
-msgstr ""
+msgstr "190 - Anhang A - Kfz-Kosten"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
@@ -272,17 +274,17 @@ msgstr "228 - Berichtigte Steuer - Sonderregelung zur Steueraussetzung"
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_239
 msgid "239 - Appendix A - Gross salaries"
-msgstr ""
+msgstr "239 - Anhang A - Bruttolöhne"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_244
 msgid "244 - Appendix A - Gross wages"
-msgstr ""
+msgstr "244 - Anhang A - Bruttolöhne"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_247
 msgid "247 - Appendix A - Occasional salaries"
-msgstr ""
+msgstr "247 - Anhang A - Gelegentliche Gehälter"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_250
@@ -290,46 +292,48 @@ msgid ""
 "250 - Appendix A - Compulsory social security contributions (employer's "
 "share)"
 msgstr ""
+"250 - Anhang A - Obligatorische Sozialversicherungsbeiträge "
+"(Arbeitgeberanteil)"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_253
 msgid "253 - Appendix A - Accident insurance"
-msgstr ""
+msgstr "253 - Anhang A - Unfallversicherung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_260
 msgid "260 - Appendix A - Staff travel and representation expenses"
-msgstr ""
+msgstr "260 - Anhang A - Reise- und Repräsentationskosten des Personals"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_269
 msgid "269 - Appendix A - Accounting and bookkeeping fees"
-msgstr ""
+msgstr "269 - Anhang A - Rechnungslegungs- und Buchführungskosten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_283
 msgid "283 - Appendix A - Employer's travel and representation expenses"
-msgstr ""
+msgstr "283 - Anhang A - Reise- und Repräsentationskosten des Arbeitgebers"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_285
 msgid "285 - Appendix A - Electricity"
-msgstr ""
+msgstr "285 - Anhang A - Elektrizität"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_289
 msgid "289 - Appendix A - Gas"
-msgstr ""
+msgstr "289 - Anhang A - Gas"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_293
 msgid "293 - Appendix A - Employer's travel and representation expenses"
-msgstr ""
+msgstr "293 - Anhang A - Reise- und Repräsentationskosten des Arbeitgebers"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_301
 msgid "301 - Appendix A - Telecommunications"
-msgstr ""
+msgstr "301 - Anhang A - Telekommunikation"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_305
@@ -337,6 +341,8 @@ msgid ""
 "305 - Appendix A - Renting/leasing of immovable property with application of"
 " VAT"
 msgstr ""
+"305 - Anhang A - Vermietung/Verpachtung von Grundstücken mit Anwendung der "
+"Mehrwertsteuer"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_307
@@ -344,6 +350,8 @@ msgid ""
 "307 - Appendix A - Renting/leasing of immovable property with no application"
 " of VAT"
 msgstr ""
+"307 - Anhang A - Vermietung/Verpachtung von Grundstücken ohne Anwendung der "
+"Mehrwertsteuer"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_310
@@ -351,47 +359,49 @@ msgid ""
 "310 - Appendix A - Renting/leasing of permanently installed equipment and "
 "machinery"
 msgstr ""
+"310 - Anhang A - Vermietung/Leasing von fest installierten Anlagen und "
+"Maschinen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_316
 msgid "316 - Appendix A - Property tax"
-msgstr ""
+msgstr "316 - Anhang A - Grundsteuer"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_324
 msgid "324 - Appendix A - Business tax"
-msgstr ""
+msgstr "324 - Anhang A - Gewerbesteuer"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_326
 msgid "326 - Appendix A - Interest paid for long-term debts"
-msgstr ""
+msgstr "326 - Anhang A - Zinszahlungen für langfristige Verbindlichkeiten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_327
 msgid "327 - Appendix A - Interest paid for short-term debts"
-msgstr ""
+msgstr "327 - Anhang A - Zinszahlungen für kurzfristige Verbindlichkeiten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_328
 msgid "328 - Appendix A - Other financial costs"
-msgstr ""
+msgstr "328 - Anhang A - Sonstige finanzielle Aufwendungen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_330
 msgid "330 - Appendix A - Stock and business equipment insurance"
-msgstr ""
+msgstr "330 - Anhang A - Versicherung von Vorräten und Geschäftsausstattung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_331
 msgid ""
 "331 - Appendix A - Public and professional third party liability insurance"
-msgstr ""
+msgstr "331 - Anhang A - Betriebs- und Berufshaftpflichtversicherung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_332
 msgid "332 - Appendix A - Office expenses"
-msgstr ""
+msgstr "332 - Anhang A - Bürokosten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_336
@@ -399,41 +409,43 @@ msgid ""
 "336 - Appendix A - Fees and subscriptions paid to professional associations "
 "and learned societies"
 msgstr ""
+"336 - Anhang A - Gebühren und Mitgliedsbeiträge an Berufsverbände und "
+"Fachgesellschaften"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_337
 msgid "337 - Appendix A - Papers and periodicals for business purposes"
-msgstr ""
+msgstr "337 - Anhang A - Zeitungen und Zeitschriften für Geschäftszwecke"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_343
 msgid "343 - Appendix A - Shipping and transport expenses"
-msgstr ""
+msgstr "343 - Anhang A - Versand- und Transportkosten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_345
 msgid "345 - Appendix A - Work clothes"
-msgstr ""
+msgstr "345 - Anhang A - Arbeitskleidung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_347
 msgid "347 - Appendix A - Advertising and publicity"
-msgstr ""
+msgstr "347 - Anhang A - Werbung und Öffentlichkeitsarbeit"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_349
 msgid "349 - Appendix A - Packaging"
-msgstr ""
+msgstr "349 - Anhang A - Verpackung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_351
 msgid "351 - Appendix A - Repair and maintenance of equipment and machinery"
-msgstr ""
+msgstr "351 - Anhang A - Reparatur und Wartung von Geräten und Maschinen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_353
 msgid "353 - Appendix A - Other repairs"
-msgstr ""
+msgstr "353 - Anhang A - Sonstige Reparaturen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_355
@@ -441,16 +453,19 @@ msgid ""
 "355 - Appendix A - New acquisitions (tools and equipment) if their cost can "
 "be fully allocated to the year of acquisition or creation"
 msgstr ""
+"355 - Anhang A - Neuanschaffungen (Werkzeuge und Ausrüstungen), wenn ihre "
+"Kosten vollständig dem Jahr der Anschaffung oder Herstellung zugeordnet "
+"werden können"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_358
 msgid "358 - Appendix A - Custom (value)"
-msgstr ""
+msgstr "358 - Anhang A - Zoll (Wert)"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_361
 msgid "361 - Appendix A - Total 'Appendix to Operational expenditures'"
-msgstr ""
+msgstr "361 - Anhang A - Insgesamt \"Anhang zu den operationellen Ausgaben\"."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
@@ -624,6 +639,8 @@ msgid ""
 "481 - Supplies carried out within the scope of the domestic SME scheme of "
 "article 57bis (7)"
 msgstr ""
+"481 - Lieferungen, die im Rahmen der inländischen KMU-Regelung nach Artikel "
+"57bis Absatz 7 erfolgen"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border
@@ -631,6 +648,8 @@ msgid ""
 "482 - Supplies carried out within the scope of the cross-border SME scheme "
 "of article 57quater "
 msgstr ""
+"482 - Lieferungen, die im Rahmen der grenzüberschreitenden KMU-Regelung des "
+"Artikels 57quater erfolgen"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
@@ -896,12 +915,12 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_17
 msgid "769 - base 17%"
-msgstr ""
+msgstr "769 - 17% Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_17
 msgid "770 - tax 17%"
-msgstr ""
+msgstr "770 - Steuer 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_16
@@ -1129,7 +1148,7 @@ msgstr "Kontenplanvorlage"
 #: model:account.report.column,name:l10n_lu.tax_report_section_2_balance
 #: model:account.report.column,name:l10n_lu.tax_report_sections_3_4_balance
 msgid "Balance"
-msgstr ""
+msgstr "Waage"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.l10n_lu_tax_report_assessment_turnover
@@ -1139,7 +1158,7 @@ msgstr "I. BERECHNUNG DES STEUERPFLICHTIGEN UMSATZES"
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.l10n_lu_tax_report_assessment_tax_due
 msgid "II. ASSESSMENT OF TAX DUE"
-msgstr ""
+msgstr "II. FESTSETZUNG DER GESCHULDETEN STEUER"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
@@ -1154,24 +1173,24 @@ msgstr "IV. BERECHNUNG DES ÜBERSCHUSSES"
 #. module: l10n_lu
 #: model:ir.ui.menu,name:l10n_lu.account_reports_lu_statements_menu
 msgid "Luxembourg"
-msgstr ""
+msgstr "Luxemburg"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_section_1
 msgid "Section I"
-msgstr ""
+msgstr "Abschnitt I"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_section_2
 msgid "Section II"
-msgstr ""
+msgstr "Abschnitt II"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_sections_3_4
 msgid "Sections III, IV"
-msgstr ""
+msgstr "Abschnitte III, IV"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.tax_report
 msgid "Tax Report"
-msgstr ""
+msgstr "Steuerbericht"

--- a/addons/l10n_lu/i18n_extra/lb.po
+++ b/addons/l10n_lu/i18n_extra/lb.po
@@ -4,13 +4,12 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~12.5+e\n"
+"Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-19 13:53+0000\n"
-"PO-Revision-Date: 2019-08-30 08:44+0000\n"
+"POT-Creation-Date: 2025-05-06 13:55+0000\n"
+"PO-Revision-Date: 2025-05-06 13:55+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -19,22 +18,22 @@ msgstr ""
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_overall_turnover
 msgid "012 - Overall turnover"
-msgstr "012 - Chiffre d'affaires global"
+msgstr "012 - Ganzen Ëmsaz"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_2_export
 msgid "014 - Exports"
-msgstr "014 - Exportations"
+msgstr "014 - Exporter"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_3_other_exemptions_art_43
 msgid "015 - Other exemptions"
-msgstr "015 - Autres exonérations"
+msgstr "015 - Aner Ausnahmen"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_4_other_exemptions_art_44_et_56quater
 msgid "016 - Other exemptions"
-msgstr "016 - Autres exonérations"
+msgstr "016 - Aner Ausnahmen"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_5_manufactured_tobacco_vat_collected
@@ -42,8 +41,8 @@ msgid ""
 "017 - Manufactured tobacco whose VAT was collected at the source or at the "
 "exit of the tax..."
 msgstr ""
-"017 - Tabacs fabriqués dont la TVA a été perçue à la source respectivement à"
-" la sortie de l'entrepôt fiscal..."
+"017 - Tubak fabrizéiert, deem seng TVA bei der Quell oder beim Austrëtt vun "
+"der Steier gesammelt gouf..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_a_subsequent_to_intra_community
@@ -51,114 +50,117 @@ msgid ""
 "018 - Supply, subsequent to intra-Community acquisitions of goods, in the "
 "context of triangular transactions, when the customer identified,..."
 msgstr ""
-"018 - Livraisons subséquentes à des acqu. Intra. dans le cadre d'opérations "
-"triangulaires…"
+"018 - Versuergung, no intra-Communautéit Acquisitioune vu Wueren, am Kontext"
+" vun dräieckeger Transaktiounen, wann de Client identifizéiert, ..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_d_supplies_other_referred
 msgid ""
 "019 - Other supplies carried out (for which the place of supply is) abroad"
-msgstr "019 - Autres opérations réalisées (imposables) à l'étranger"
+msgstr ""
+"019 - Aner Liwwerungen duerchgefouert (fir déi Plaz vun der Versuergung ass)"
+" am Ausland"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_exemptions_deductible_amounts
 msgid "021 - Exemptions and deductible amounts"
-msgstr "021 - Exonérations et montants déductibles"
+msgstr "021 - Ausnahmen an deductible Quantitéiten"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1c_taxable_turnover
 msgid "022 - Taxable turnover"
-msgstr "022 - Chiffre d'affaires imposable"
+msgstr "022 - Besteierbaren Ëmsaz"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_3
 msgid "031 - base 3%"
-msgstr ""
+msgstr "031 - Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_0
 msgid "033 - base 0%"
-msgstr ""
+msgstr "033 - Basis 0%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_base
 msgid "037 - Breakdown of taxable turnover – base"
-msgstr "037 - Chiffre d'affaires imposable – base"
+msgstr "037 - Ënnerdeelung vum besteierbaren Ëmsaz - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_3
 msgid "040 - tax 3%"
-msgstr "040 - taxe 3%"
+msgstr "040 - Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_breakdown_taxable_turnover_tax
 msgid "046 - Breakdown of taxable turnover – tax"
-msgstr "046 - Chiffre d'affaires imposable – taxe"
+msgstr "046 - Ënnerdeelung vun besteierbaren Ëmsaz - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_3
 msgid "049 - base 3%"
-msgstr ""
+msgstr "049 - Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acqui_of_goods_base
 msgid "051 - Intra-Community acquisitions of goods – base"
-msgstr "051 - Acquisitions intracommunautaires de biens - base"
+msgstr "051 - Intra-Communautéit Acquisitioun vu Wueren - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_3
 msgid "054 - tax 3%"
-msgstr "054 - taxe 3%"
+msgstr "054 - Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_intra_community_acquisitions_goods_tax
 msgid "056 - Intra-Community acquisitions of goods – tax"
-msgstr "056 - Acquisitions intracommunautaires de biens - taxe"
+msgstr "056 - Intra-Communautéit Acquisitioun vu Wueren - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_3
 msgid "059 - for business purposes: base 3%"
-msgstr "059 - à des fins de l'entreprise: base 3%"
+msgstr "059 - fir Geschäftszwecker: Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_3
 msgid "063 - for non-business purposes: base 3%"
-msgstr "063 - à des fins étrangères à l'entreprise: base 3%"
+msgstr "063 - fir net-geschäftlech Zwecker: Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_base
 msgid "065 - Importation of goods – base"
-msgstr "065 - Importations de biens - base"
+msgstr "065 - Import vu Wueren - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_3
 msgid "068 - for business purposes: tax 3%"
-msgstr "068 - à des fins de l'entreprise: taxe de 3%"
+msgstr "068 - fir Geschäftszwecker: Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_3
 msgid "073 - for non-business purposes: tax 3%"
-msgstr "073 - à des fins étrangères à l'entreprise: taxe de 3%"
+msgstr "073 - fir net-geschäftlech Zwecker: Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2h_total_tax_due
 msgid "076 - Total tax due"
-msgstr "076 - Total de la taxe en aval"
+msgstr "076 - Ganzen Steier wéinst"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_4_due_respect_application_goods
 msgid "090 - Due in respect of the application of goods for business purposes"
-msgstr "090 - Taxe déclarée pour l'affectation de biens à l'entreprise"
+msgstr ""
+"090 - Wéinst am Respekt vun der Uwendung vu Wueren fir Geschäftszwecker"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_6_paid_joint_several_guarantee
 msgid "092 - Paid as joint and several guarantee"
-msgstr "092 - Taxe acquittée comme caution solidaire"
+msgstr "092 - Bezuelt als gemeinsame Garantie"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_total_input_tax
 msgid "093 - Total input tax"
-msgstr "093 - Total de la taxe en amont"
+msgstr "093 - Ganzen Input Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b1_rel_trans
@@ -166,8 +168,8 @@ msgid ""
 "094 - relating to transactions which are exempt pursuant to articles 44 and "
 "56quater"
 msgstr ""
-"094 - Taxe non déductible en rapport avec des opérations exonérées en vertu "
-"des articles 44 et 56quater"
+"094 - betreffend Transaktiounen déi befreit sinn no den Artikelen 44 a "
+"56quater"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_ded_prop
@@ -175,7 +177,8 @@ msgid ""
 "095 - where the deductible proportion determined in accordance to article 50"
 " is applied"
 msgstr ""
-"095 - Taxe non déductible en application du prorata visé à l'article 50"
+"095 - wou den ofzuchbaren Undeel, deen am Aklang mam Artikel 50 bestëmmt "
+"ass, applizéiert gëtt"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b2_input_tax_margin
@@ -183,64 +186,66 @@ msgid ""
 "096 - Non recoverable input tax in accordance with Art. 56ter-1(7) and "
 "56ter-2(7) (when applying the margin scheme)"
 msgstr ""
-"096 - Taxe non déductible en application des articles 56ter-1/7 et 56ter-2/7"
-" (en cas d'option pour le régime d'imposition de la marge bénéficiaire)"
+"096 - Net recuperable Input Steier am Aklang mat Art. 56ter-1 (7) an 56ter-2"
+" (7) (wann Dir de Marginschema applizéiert)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3b_total_input_tax_nd
 msgid "097 - Total input tax non-deductible"
-msgstr "097 - Total de la taxe en amont non déductible"
+msgstr "097 - Ganzen Input Steier net ofgezu"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3c_total_input_tax_deductible
 msgid "102 - Total input tax deductible"
-msgstr "102 - Total de la taxe en amont déductible"
+msgstr "102 - Ganzen Input Steier ofgezu"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_tax_due
 msgid "103 - Total tax due"
-msgstr "103 - Total de la taxe en aval"
+msgstr "103 - Ganzen Steier wéinst"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_4a_total_input_tax_deductible
 msgid "104 - Total input tax deductible"
-msgstr "104 - Total de la taxe en amont déductible"
+msgstr "104 - Ganzen Input Steier ofgezu"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_4c_exceeding_amount
 msgid "105 - Exceeding amount"
-msgstr "105 - Excédent"
+msgstr "105 - Iwwerschreiden Betrag"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2c_acquisitions_triangular_transactions_base
 msgid "152 - Acquisitions, in the context of triangular transactions – base"
-msgstr "152 - Acquisitions triangulaires – base"
+msgstr ""
+"152 - Acquisitioune, am Kontext vun dräieckeger Transaktiounen - Basis"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_188
 msgid ""
 "188 - Appendix A - Expenses for other work carried out by third parties"
-msgstr "188 - Annexe A - Frais pour d'autres travaux effectués par des tiers"
+msgstr ""
+"188 - Appendix A - Käschte fir aner Aarbechten, déi vun Drëtte gemaach ginn"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_190
 msgid "190 - Appendix A - Car expenses"
-msgstr "190 - Annexe A - Frais de voiture"
+msgstr "190 - Anhang A - Auto Käschten"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_exempt
 msgid "194 - base exempt"
-msgstr "194 - base exonérée"
+msgstr "194 - Basis befreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_exempt
 msgid "195 - for business purposes: base exempt"
-msgstr "195 - à des fins de l'entreprise: base exonérée"
+msgstr "195 - fir Geschäftszwecker: Basis befreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_exempt
 msgid "196 - for non-business purposes: base exempt"
-msgstr "196 - à des fins étrangères à l'entreprise: base exonérée"
+msgstr "196 - fir net-Geschäftszwecker: Basis befreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_c_supplies_scope_special_arrangement
@@ -248,83 +253,80 @@ msgid ""
 "226 - Supplies carried out within the scope of the special arrangement of "
 "art. 56sexies"
 msgstr ""
-"226 - Opérations réalisées dans le cadre du régime particulier de l'article "
-"56sexies"
+"226 - Liwwerungen am Kader vun der spezieller Arrangement vun Art "
+"duerchgefouert. 56 sexy"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2g_special_arrangement
 msgid "227 - Special arrangement for tax suspension: adjustment"
-msgstr "227 - Régime particulier suspensif: régularisation"
+msgstr "227 - Special Arrangement fir Steier Suspensioun: Upassung"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_7_adjusted_tax_special_arrangement
 msgid "228 - Adjusted tax - special arrangement for tax suspension"
-msgstr "228 - Taxe régularisée - régime particulier suspensif"
+msgstr "228 - Ajustéiert Steier - speziell Arrangement fir Steier Suspensioun"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_239
 msgid "239 - Appendix A - Gross salaries"
-msgstr "239 - Annexe A - Salaires bruts"
+msgstr "239 - Anhang A - Brutto Gehälter"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_244
 msgid "244 - Appendix A - Gross wages"
-msgstr "244 - Annexe A - Salaires bruts"
+msgstr "244 - Anhang A - Brutto Léin"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_247
 msgid "247 - Appendix A - Occasional salaries"
-msgstr "247 - Annexe A - Salaires occasionnels"
+msgstr "247 - Anhang A - Geleeëntlech Gehälter"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_250
 msgid ""
 "250 - Appendix A - Compulsory social security contributions (employer's "
 "share)"
-msgstr ""
-"250 - Annexe A - Cotisations obligatoires de sécurité sociale (part "
-"patronale)"
+msgstr "250 - Anhang A - Obligatoresch Sozialbeiträg (Patronatdeel)"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_253
 msgid "253 - Appendix A - Accident insurance"
-msgstr "253 - Annexe A - Assurance accidents"
+msgstr "253 - Unhang A - Accident Versécherung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_260
 msgid "260 - Appendix A - Staff travel and representation expenses"
-msgstr "260 - Annexe A - Frais de voyage et de représentation du personnel"
+msgstr "260 - Appendix A - Personal Rees- a Representatiounskäschte"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_269
 msgid "269 - Appendix A - Accounting and bookkeeping fees"
-msgstr "269 - Annexe A - Frais de comptabilité et de tenue de livres"
+msgstr "269 ​​- Appendix A - Comptabilitéits- a Buchhaltungsgebühren"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_283
 msgid "283 - Appendix A - Employer's travel and representation expenses"
-msgstr "283 - Annexe A - Frais de déplacement et de représentation de l'employeur"
+msgstr "283 - Appendix A - Employeur Rees- a Representatiounskäschten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_285
 msgid "285 - Appendix A - Electricity"
-msgstr "285 - Annexe A - Électricité"
+msgstr "285 - Unhang A - Elektrizitéit"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_289
 msgid "289 - Appendix A - Gas"
-msgstr "289 - Annexe A - Gaz"
+msgstr "289 - Unhang A - Gas"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_293
 msgid "293 - Appendix A - Employer's travel and representation expenses"
-msgstr ""
-"293 - Annexe A - Frais de déplacement et de représentation de l'employeur"
+msgstr "293 - Appendix A - Employeur Rees- a Representatiounskäschten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_301
 msgid "301 - Appendix A - Telecommunications"
-msgstr "301 - Annexe A - Télécommunications"
+msgstr "301 - Unhang A - Telekommunikatioun"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_305
@@ -332,8 +334,7 @@ msgid ""
 "305 - Appendix A - Renting/leasing of immovable property with application of"
 " VAT"
 msgstr ""
-"305 - Annexe A - Location/affermage de biens immobiliers avec application de"
-" la TVA"
+"305 - Appendix A - Locatioun/Locatioun vun Immobilien mat Applikatioun TVA"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_307
@@ -341,8 +342,7 @@ msgid ""
 "307 - Appendix A - Renting/leasing of immovable property with no application"
 " of VAT"
 msgstr ""
-"307 - Annexe A - Location/affermage de biens immobiliers sans application de"
-" la TVA"
+"307 - Appendix A - Locatioun / Locatioun vun Immobilien ouni TVA-Uwendung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_310
@@ -350,50 +350,50 @@ msgid ""
 "310 - Appendix A - Renting/leasing of permanently installed equipment and "
 "machinery"
 msgstr ""
-"310 - Annexe A - Location/leasing d'équipements et de machines installés de "
-"façon permanente"
+"310 - Anhang A - Locatioun / Locatioun vun permanent installéiert Ausrüstung"
+" a Maschinnen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_316
 msgid "316 - Appendix A - Property tax"
-msgstr "316 - Annexe A - Impôt foncier"
+msgstr "316 - Unhang A - Grondsteier"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_324
 msgid "324 - Appendix A - Business tax"
-msgstr "324 - Annexe A - Taxe professionnelle"
+msgstr "324 - Unhang A - Betrib Steier"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_326
 msgid "326 - Appendix A - Interest paid for long-term debts"
-msgstr "326 - Annexe A - Intérêts payés pour les dettes à long terme"
+msgstr "326 - Anhang A - Zënse bezuelt fir laangfristeg Scholden"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_327
 msgid "327 - Appendix A - Interest paid for short-term debts"
-msgstr "327 - Annexe A - Intérêts payés pour les dettes à court terme"
+msgstr "327 - Anhang A - Zënse bezuelt fir kuerzfristeg Scholden"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_328
 msgid "328 - Appendix A - Other financial costs"
-msgstr "328 - Annexe A - Autres coûts financiers"
+msgstr "328 - Unhang A - Aner finanziell Käschten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_330
 msgid "330 - Appendix A - Stock and business equipment insurance"
-msgstr "330 - Annexe A - Assurance du stock et du matériel d'entreprise"
+msgstr "330 - Unhang A - Stock a Betrib Equipement Versécherung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_331
 msgid ""
 "331 - Appendix A - Public and professional third party liability insurance"
 msgstr ""
-"331 - Annexe A - Assurance responsabilité civile publique et professionnelle"
+"331 - Appendix A - Ëffentlech a berufflech Drëtt Partei Haftung Versécherung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_332
 msgid "332 - Appendix A - Office expenses"
-msgstr "332 - Annexe A - Frais de bureau"
+msgstr "332 - Anhang A - Büro Käschten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_336
@@ -401,44 +401,43 @@ msgid ""
 "336 - Appendix A - Fees and subscriptions paid to professional associations "
 "and learned societies"
 msgstr ""
-"336 - Annexe A - Cotisations versées aux associations professionnelles et "
-"aux sociétés savantes"
+"336 - Appendix A - Fraisen an Abonnementer bezuelt fir Beruffsverbänn a "
+"geléiert Gesellschaften"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_337
 msgid "337 - Appendix A - Papers and periodicals for business purposes"
-msgstr "337 - Annexe A - Papiers et périodiques à usage professionnel"
+msgstr "337 - Appendix A - Pabeieren an Zäitschrëften fir Geschäftszwecker"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_343
 msgid "343 - Appendix A - Shipping and transport expenses"
-msgstr "343 - Annexe A - Frais d'expédition et de transport"
+msgstr "343 - Appendix A - Versand- an Transportkäschten"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_345
 msgid "345 - Appendix A - Work clothes"
-msgstr "345 - Annexe A - Vêtements de travail"
+msgstr "345 - Unhang A - Aarbechtskleedung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_347
 msgid "347 - Appendix A - Advertising and publicity"
-msgstr "347 - Annexe A - Publicité et annonce"
+msgstr "347 - Appendix A - Publicitéit a Publizitéit"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_349
 msgid "349 - Appendix A - Packaging"
-msgstr "349 - Annexe A - Emballage"
+msgstr "349 - Unhang A - Verpakung"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_351
 msgid "351 - Appendix A - Repair and maintenance of equipment and machinery"
-msgstr ""
-"351 - Annexe A - Réparation et entretien des équipements et des machines"
+msgstr "351 - Appendix A - Reparatur an Ënnerhalt vun Ausrüstung a Maschinnen"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_353
 msgid "353 - Appendix A - Other repairs"
-msgstr "353 - Annexe A - Autres réparations"
+msgstr "353 - Anhang A - Aner Fléckaarbechte"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_355
@@ -446,23 +445,24 @@ msgid ""
 "355 - Appendix A - New acquisitions (tools and equipment) if their cost can "
 "be fully allocated to the year of acquisition or creation"
 msgstr ""
-"355 - Annexe A - Nouvelles acquisitions (outils et équipements) si leur coût"
-" peut être entièrement imputé à l'année d'acquisition ou de création"
+"355 - Appendix A - Nei Acquisitioune (Tools an Ausrüstung) wann hir Käschte "
+"komplett un d'Joer vun der Acquisitioun oder der Schafung zougedeelt kënne "
+"ginn"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_358
 msgid "358 - Appendix A - Custom (value)"
-msgstr "358 - Annexe A - Personnalisation (valeur)"
+msgstr "358 - Appendix A - Benotzerdefinéiert (Wäert)"
 
 #. module: l10n_lu
 #: model:account.account.tag,name:l10n_lu.account_tag_appendix_361
 msgid "361 - Appendix A - Total 'Appendix to Operational expenditures'"
-msgstr "361 - Annexe A - Total \"Annexe aux dépenses opérationnelles\"."
+msgstr "361 - Appendix A - Gesamt 'Anhang fir Operatiounsausgaben'"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_importation_of_goods_tax
 msgid "407 - Importation of goods – tax"
-msgstr "407 - Importations de biens - taxe"
+msgstr "407 - Import vu Wueren - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer
@@ -470,8 +470,8 @@ msgid ""
 "409 - Supply of services for which the customer is liable for the payment of"
 " VAT – base"
 msgstr ""
-"409 - Prestations de services à déclarer par le preneur redevable de la taxe"
-" - base"
+"409 - Liwwerung vu Servicer, fir déi de Client fir d'Bezuelung vun der TVA "
+"verantwortlech ass - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_supply_of_service_for_customer_liable_for_payment_tax
@@ -479,8 +479,8 @@ msgid ""
 "410 - Supply of services for which the customer is liable for the payment of"
 " VAT – tax"
 msgstr ""
-"410 - Prestations de services à déclarer par le preneur redevable de la taxe"
-" - taxe"
+"410 - Liwwerung vu Servicer, fir déi de Client fir d'Bezuelung vun der TVA "
+"verantwortlech ass - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_7_inland_supplies_for_customer
@@ -488,82 +488,74 @@ msgid ""
 "419 - Inland supplies for which the customer is liable for the payment of "
 "VAT"
 msgstr ""
-"419 - Opérations à l'intérieur du pays pour lesquelles le preneur est le "
-"redevable"
+"419 - Inland Liwwerungen, fir déi de Client fir d'Bezuelung vun der TVA "
+"haftbar ass"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b1_non_exempt_customer_vat
 msgid ""
 "423 - not exempt in the MS where the customer is liable for payment of VAT"
 msgstr ""
-"423 - Prestations de services non exonérées dans l'Etat membre du preneur "
-"redevable"
+"423 - net befreit an der MS wou de Client fir d'Bezuelung vun der TVA "
+"haftbar ass"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_6_b2_exempt_ms_customer
 msgid "424 - exempt in the MS where the customer is identified"
-msgstr "424 - Prestations de services exonérées dans l'Etat membre du preneur"
+msgstr "424 - befreit an der MS wou de Client identifizéiert ass"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_3
 msgid "431 - not exempt within the territory: base 3%"
-msgstr "431 - non exonérées à l'intérieur du pays: base 3%"
+msgstr "431 - net befreit am Territoire: Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_3
 msgid "432 - not exempt within the territory: tax 3%"
-msgstr "432 - non exonérées à l'intérieur du pays: tax 3%"
+msgstr "432 - net befreit am Territoire: Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_b_exempt
 msgid "435 - exempt within the territory: exempt"
-msgstr "435 - exonérées à l'intérieur du pays: exonérées"
+msgstr "435 - befreit am Territoire: befreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_base
 msgid "436 - base"
-msgstr ""
+msgstr "436 - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_3
 msgid "441 - not established or residing within the Community: base 3%"
-msgstr ""
-"441 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 3%"
+msgstr "441 - net etabléiert oder an der Gemeinschaft wunnen: Basis 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_3
 msgid "442 - not established or residing within the Community: tax 3%"
-msgstr ""
-"442 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: tax 3%"
+msgstr "442 - net etabléiert oder wunnen an der Gemeinschaft: Steier 3%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_exempt
 msgid "445 - not established or residing within the Community: exempt"
-msgstr ""
-"445 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: exonérées"
+msgstr "445 - net etabléiert oder an der Gemeinschaft wunnen: befreit"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_total_sale
 msgid "454 - Total Sales / Receipts"
-msgstr "454 - Total Ventes / Recettes"
+msgstr "454 - Ganzen Ofsaz / Recetten"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_app_goods_non_bus
 msgid ""
 "455 - Application of goods for non-business use and for business purposes"
 msgstr ""
-"455 - Application de biens de l'utilisation privée et à des fins de "
-"l'entreprise"
+"455 - Uwendung vu Wueren fir net-geschäftlech Notzung a fir Geschäftszwecker"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_non_bus_gs
 msgid "456 - Non-business use of goods and supply of services free of charge"
 msgstr ""
-"456 - Prestations de services effectuées à des fins étrangères à "
-"l'entreprise"
+"456 - Net-geschäftlech Notzung vu Wueren a Versuergung vu Servicer gratis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_1_intra_community_goods_pi_vat
@@ -571,68 +563,66 @@ msgid ""
 "457 - Intra-Community supply of goods to persons identified for VAT purposes"
 " in another Member State (MS)"
 msgstr ""
-"457 - Livraisons intracommunautaires de biens à des personnes identifiées à "
-"la TVA dans un autre État membre"
+"457 - Intracommunautéit Versuergung vu Wueren u Persounen, déi fir TVA "
+"Zwecker an engem anere Memberstaat (MS) identifizéiert sinn"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_1_invoiced_by_other_taxable_person
 msgid "458 - Invoiced by other taxable persons for goods or services supplied"
 msgstr ""
-"458 - Taxe facturée par d'autres assujettis pour des biens et des services "
-"fournis"
+"458 - Rechnung vun anere besteierbaren Persoune fir geliwwert Wueren oder "
+"Servicer"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_2_due_respect_intra_comm_goods
 msgid "459 - Due in respect of intra-Community acquisitions of goods"
-msgstr ""
-"459 - Taxe déclarée ou payée sur des acquisitions intracommunautaires de "
-"biens"
+msgstr "459 - Wéinst am Respekt vun intra-Gemeinschaft Acquisitioun vu Wueren"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_3_due_paid_respect_importation_goods
 msgid "460 - Due or paid in respect of importation of goods"
-msgstr "460 - Taxe déclarée ou payée sur des biens importés"
+msgstr "460 - Wéinst oder bezuelt am Bezuch op den Import vu Wueren"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3a_5_due_under_reverse_charge
 msgid "461 - Due under the reverse charge (see points II.E and F)"
-msgstr "461 - Taxe déclarée comme débiteur (cf points II.E et F)"
+msgstr "461 - Wéinst ënner der ëmgedréint Charge (kuckt Punkten II.E an F)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax
 msgid "462 - tax"
-msgstr "462 - taxe"
+msgstr "462 - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base
 msgid "463 - base"
-msgstr ""
+msgstr "463 - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax
 msgid "464 - tax"
-msgstr "464 - taxe"
+msgstr "464 - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_telecom_service
 msgid ""
 "471 - Telecommunications services, radio and television broadcasting "
 "services..."
-msgstr "471 - Prestations de services de télécom., de radio et de tv..."
+msgstr ""
+"471 - Telekommunikatiounsservicer, Radio- an Fernsehsendéngschtleeschtungen "
+"..."
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1a_other_sales
 msgid "472 - Other sales / receipts"
-msgstr "472 - Autres Ventes / Recettes"
+msgstr "472 - Aner Ofsaz / Empfang"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_8_supplies_carried_out_domestic
 msgid ""
 "481 - Supplies carried out within the scope of the domestic SME scheme of "
 "article 57bis (7)"
-msgstr ""
-"481 - Fournitures effectuées dans le cadre du régime national des PME de "
-"l'article 57bis (7)"
+msgstr "481 - Ëmgeréits am Kader vum Haus-SME Schema vum Artikel 57bis (7)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_1b_9_supplies_carried_out_cross_border
@@ -640,68 +630,68 @@ msgid ""
 "482 - Supplies carried out within the scope of the cross-border SME scheme "
 "of article 57quater "
 msgstr ""
-"482 - Fournitures effectuées dans le cadre du régime des PME "
-"transfrontalières de l'article 57 quater"
+"482 - Liwwerungen duerchgefouert am Kader vum grenziwwerschreidend PME "
+"Schema vum Artikel 57quater"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_17
 msgid "701 - base 17%"
-msgstr ""
+msgstr "701 - Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_17
 msgid "702 - tax 17%"
-msgstr "702 - taxe 17%"
+msgstr "702 - Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_14
 msgid "703 - base 14%"
-msgstr ""
+msgstr "703 - Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_14
 msgid "704 - tax 14%"
-msgstr "704 - taxe 14%"
+msgstr "704 - Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_8
 msgid "705 - base 8%"
-msgstr ""
+msgstr "705 - Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_8
 msgid "706 - tax 8%"
-msgstr "706 - taxe 8%"
+msgstr "706 - Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_17
 msgid "711 - base 17%"
-msgstr ""
+msgstr "711 - Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_17
 msgid "712 - tax 17%"
-msgstr "712 - taxe 17%"
+msgstr "712 - Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_14
 msgid "713 - base 14%"
-msgstr ""
+msgstr "713 - Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_14
 msgid "714 - tax 14%"
-msgstr "714 - taxe 14%"
+msgstr "714 - Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_8
 msgid "715 - base 8%"
-msgstr ""
+msgstr "715 - Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_8
 msgid "716 - tax 8%"
-msgstr "716 - taxe 8%"
+msgstr "716 - Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_manufactured_tobacco
@@ -709,38 +699,38 @@ msgid ""
 "719 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
-"719 - de tabacs fabriqués dont la TVA est perçue à la sortie de l'entrepôt "
-"fiscal conjointement avec les accises"
+"719 - vun hiergestallten Tubak (TVA gëtt um Sortie vum Steierlager mat "
+"Akzisen gesammelt)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_17
 msgid "721 - for business purposes: base 17%"
-msgstr "721 - à des fins de l'entreprise: base 17%"
+msgstr "721 - fir Geschäftszwecker: Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_17
 msgid "722 - for business purposes: tax 17%"
-msgstr "722 - à des fins de l'entreprise: taxe 17%"
+msgstr "722 - fir Geschäftszwecker: Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_14
 msgid "723 - for business purposes: base 14%"
-msgstr "723 - à des fins de l'entreprise: base 14%"
+msgstr "723 - fir Geschäftszwecker: Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_14
 msgid "724 - for business purposes: tax 14%"
-msgstr "724 - à des fins de l'entreprise: taxe 14%"
+msgstr "724 - fir Geschäftszwecker: Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_8
 msgid "725 - for business purposes: base 8%"
-msgstr "725 - à des fins de l'entreprise: base 8%"
+msgstr "725 - fir Geschäftszwecker: Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_8
 msgid "726 - for business purposes: tax 8%"
-msgstr "726 - à des fins de l'entreprise: taxe 8%"
+msgstr "726 - fir Geschäftszwecker: Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_manufactured_tobacco
@@ -748,144 +738,128 @@ msgid ""
 "729 - of manufactured tobacco (VAT is collected at the exit of the tax "
 "warehouse with excise duties)"
 msgstr ""
-"729 - de tabacs fabriqués dont la TVA est perçue à la sortie de l'entrepôt "
-"fiscal conjointement avec les accises"
+"729 - vun hiergestallten Tubak (TVA gëtt bei der Sortie vum Steierlager mat "
+"Akzisen gesammelt)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_17
 msgid "731 - for non-business purposes: base 17%"
-msgstr "731 - à des fins étrangères à l'entreprise: base 17%"
+msgstr "731 - fir net-geschäftlech Zwecker: Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_17
 msgid "732 - for non-business purposes: tax 17%"
-msgstr "732 - à des fins étrangères à l'entreprise: taxe 17%"
+msgstr "732 - fir net-Geschäftszwecker: Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_14
 msgid "733 - for non-business purposes: base 14%"
-msgstr "733 - à des fins étrangères à l'entreprise: base 14%"
+msgstr "733 - fir net-geschäftlech Zwecker: Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_14
 msgid "734 - for non-business purposes: tax 14%"
-msgstr "734 - à des fins étrangères à l'entreprise: taxe 14%"
+msgstr "734 - fir net-geschäftlech Zwecker: Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_8
 msgid "735 - for non-business purposes: base 8%"
-msgstr "735 - à des fins étrangères à l'entreprise: base 8%"
+msgstr "735 - fir net-geschäftlech Zwecker: Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_8
 msgid "736 - for non-business purposes: tax 8%"
-msgstr "736 - à des fins étrangères à l'entreprise: taxe 8%"
+msgstr "736 - fir net-Geschäftszwecker: Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_17
 msgid "741 - not exempt within the territory: base 17%"
-msgstr "741 - non exonérées à l'intérieur du pays: base 17%"
+msgstr "741 - net befreit am Territoire: Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_17
 msgid "742 - not exempt within the territory: tax 17%"
-msgstr "742 - non exonérées à l'intérieur du pays: taxe 17%"
+msgstr "742 - net befreit am Territoire: Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_14
 msgid "743 - not exempt within the territory: base 14%"
-msgstr "743 - non exonérées à l'intérieur du pays: base 14%"
+msgstr "743 - net befreit am Territoire: Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_14
 msgid "744 - not exempt within the territory: tax 14%"
-msgstr "744 - non exonérées à l'intérieur du pays: taxe 14%"
+msgstr "744 - net befreit am Territoire: Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_8
 msgid "745 - not exempt within the territory: base 8%"
-msgstr "745 - non exonérées à l'intérieur du pays: base 8%"
+msgstr "745 - net befreit am Territoire: Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_8
 msgid "746 - not exempt within the territory: tax 8%"
-msgstr "746 - non exonérées à l'intérieur du pays: taxe 8%"
+msgstr "746 - net befreit am Territoire: Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_17
 msgid "751 - not established or residing within the Community: base 17%"
-msgstr ""
-"751 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 17%"
+msgstr "751 - net etabléiert oder an der Gemeinschaft wunnen: Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_17
 msgid "752 - not established or residing within the Community: tax 17%"
-msgstr ""
-"752 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 17%"
+msgstr "752 - net etabléiert oder an der Gemeinschaft wunnen: Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_14
 msgid "753 - not established or residing within the Community: base 14%"
-msgstr ""
-"753 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 14%"
+msgstr "753 - net etabléiert oder an der Gemeinschaft wunnen: Basis 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_14
 msgid "754 - not established or residing within the Community: tax 14%"
-msgstr ""
-"754 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 14%"
+msgstr "754 - net etabléiert oder an der Gemeinschaft wunnen: Steier 14%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_8
 msgid "755 - not established or residing within the Community: base 8%"
-msgstr ""
-"755 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 8%"
+msgstr "755 - net etabléiert oder an der Gemeinschaft wunnen: Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_8
 msgid "756 - not established or residing within the Community: tax 8%"
-msgstr ""
-"756 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 8%"
+msgstr "756 - net etabléiert oder an der Gemeinschaft wunnen: Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_17
 msgid "761 - suppliers established within the territory: base 17%"
-msgstr ""
-"761 - effectuées au déclarant par des assujettis établis à l'intérieur du "
-"pays: base 17%"
+msgstr "761 - Fournisseuren am Territoire etabléiert: Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_17
 msgid "762 - suppliers established within the territory: tax 17%"
-msgstr ""
-"762 - effectuées au déclarant par des assujettis établis à l'intérieur du "
-"pays: taxe 17%"
+msgstr "762 - Fournisseuren am Territoire etabléiert: Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_8
 msgid "763 - base 8%"
-msgstr ""
+msgstr "763 - Basis 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_8
 msgid "764 - tax 8%"
-msgstr "764 - taxe 8%"
+msgstr "764 - Steier 8%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base
 msgid "765 - base"
-msgstr ""
+msgstr "765 - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax
 msgid "766 - tax"
-msgstr "766 - taxe"
+msgstr "766 - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base
@@ -893,8 +867,8 @@ msgid ""
 "767 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - base"
 msgstr ""
-"767 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - "
-"base"
+"767 - Liwwerung vu Wueren, fir déi de Keefer fir d'Bezuelung vun der TVA "
+"haftbar ass - Basis"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax
@@ -902,288 +876,272 @@ msgid ""
 "768 - Supply of goods for which the purchaser is liable for the payment of "
 "VAT - tax"
 msgstr ""
-"768 - Livraisons de biens à déclarer par l'acquéreur redevable de la taxe - "
-"taxe"
+"768 - Liwwerung vu Wueren, fir déi de Keefer fir d'Bezuelung vun der TVA "
+"haftbar ass - Steier"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_17
 msgid "769 - base 17%"
-msgstr ""
+msgstr "769 - Basis 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_17
 msgid "770 - tax 17%"
-msgstr "770 - taxe 17%"
+msgstr "770 - Steier 17%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_16
 msgid "901 - base 16%"
-msgstr ""
+msgstr "901 - Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_16
 msgid "902 - tax 16%"
-msgstr "902 - taxe 16%"
+msgstr "902 - Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_13
 msgid "903 - base 13%"
-msgstr ""
+msgstr "903 - Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_13
 msgid "904 - tax 13%"
-msgstr "904 - taxe 13%"
+msgstr "904 - Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_base_7
 msgid "905 - base 7%"
-msgstr ""
+msgstr "905 - Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2a_tax_7
 msgid "906 - tax 7%"
-msgstr "906 - taxe 7%"
+msgstr "906 - Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_16
 msgid "911 - base 16%"
-msgstr ""
+msgstr "911 - Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_16
 msgid "912 - tax 16%"
-msgstr "912 - taxe 16%"
+msgstr "912 - Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_13
 msgid "913 - base 13%"
-msgstr ""
+msgstr "913 - Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_13
 msgid "914 - tax 13%"
-msgstr "914 - taxe 13%"
+msgstr "914 - Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_base_7
 msgid "915 - base 7%"
-msgstr ""
+msgstr "915 - Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2b_tax_7
 msgid "916 - tax 7%"
-msgstr "916 - taxe 7%"
+msgstr "916 - Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_16
 msgid "921 - for business purposes: base 16%"
-msgstr "921 - à des fins de l'entreprise: base 16%"
+msgstr "921 - fir Geschäftszwecker: Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_16
 msgid "922 - for business purposes: tax 16%"
-msgstr "922 - à des fins de l'entreprise: taxe 16%"
+msgstr "922 - fir Geschäftszwecker: Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_13
 msgid "923 - for business purposes: base 13%"
-msgstr "923 - à des fins de l'entreprise: base 13%"
+msgstr "923 - fir Geschäftszwecker: Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_13
 msgid "924 - for business purposes: tax 13%"
-msgstr "924 - à des fins de l'entreprise: taxe 13%"
+msgstr "924 - fir Geschäftszwecker: Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_base_7
 msgid "925 - for business purposes: base 7%"
-msgstr "925 - à des fins de l'entreprise: base 7%"
+msgstr "925 - fir Geschäftszwecker: Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_1_tax_7
 msgid "926 - for business purposes: tax 7%"
-msgstr "926 - à des fins de l'entreprise: taxe 7%"
+msgstr "926 - fir Geschäftszwecker: Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_16
 msgid "931 - for non-business purposes: base 16%"
-msgstr "931 - à des fins étrangères à l'entreprise: base 16%"
+msgstr "931 - fir net-geschäftlech Zwecker: Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_16
 msgid "932 - for non-business purposes: tax 16%"
-msgstr "932 - à des fins étrangères à l'entreprise: taxe 16%"
+msgstr "932 - fir net-geschäftlech Zwecker: Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_13
 msgid "933 - for non-business purposes: base 13%"
-msgstr "933 - à des fins étrangères à l'entreprise: base 13%"
+msgstr "933 - fir net-geschäftlech Zwecker: Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_13
 msgid "934 - for non-business purposes: tax 13%"
-msgstr "934 - à des fins étrangères à l'entreprise: taxe 13%"
+msgstr "934 - fir net-geschäftlech Zwecker: Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_base_7
 msgid "935 - for non-business purposes: base 7%"
-msgstr "935 - à des fins étrangères à l'entreprise: base 7%"
+msgstr "935 - fir net-geschäftlech Zwecker: Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2d_2_tax_7
 msgid "936 - for non-business purposes: tax 7%"
-msgstr "936 - à des fins étrangères à l'entreprise: taxe 7%"
+msgstr "936 - fir net-Geschäftszwecker: Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_16
 msgid "941 - not exempt within the territory: base 16%"
-msgstr "941 - non exonérées à l'intérieur du pays: base 16%"
+msgstr "941 - net befreit am Territoire: Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_16
 msgid "942 - not exempt within the territory: tax 16%"
-msgstr "942 - non exonérées à l'intérieur du pays: taxe 16%"
+msgstr "942 - net befreit am Territoire: Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_13
 msgid "943 - not exempt within the territory: base 13%"
-msgstr "943 - non exonérées à l'intérieur du pays: base 13%"
+msgstr "943 - net befreit am Territoire: Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_13
 msgid "944 - not exempt within the territory: tax 13%"
-msgstr "944 - non exonérées à l'intérieur du pays: taxe 13%"
+msgstr "944 - net befreit am Territoire: Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_base_7
 msgid "945 - not exempt within the territory: base 7%"
-msgstr "945 - non exonérées à l'intérieur du pays: base 7%"
+msgstr "945 - net befreit am Territoire: Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_1_a_tax_7
 msgid "946 - not exempt within the territory: tax 7%"
-msgstr "946 - non exonérées à l'intérieur du pays: taxe 7%"
+msgstr "946 - net befreit am Territoire: Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_16
 msgid "951 - not established or residing within the Community: base 16%"
-msgstr ""
-"951 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 16%"
+msgstr "951 - net etabléiert oder an der Gemeinschaft wunnen: Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_16
 msgid "952 - not established or residing within the Community: tax 16%"
-msgstr ""
-"952 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 16%"
+msgstr "952 - net etabléiert oder an der Gemeinschaft wunnen: Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_13
 msgid "953 - not established or residing within the Community: base 13%"
-msgstr ""
-"953 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 13%"
+msgstr "953 - net etabléiert oder an der Gemeinschaft wunnen: Basis 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_13
 msgid "954 - not established or residing within the Community: tax 13%"
-msgstr ""
-"954 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 13%"
+msgstr "954 - net etabléiert oder an der Gemeinschaft wunnen: Steier 13%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_base_7
 msgid "955 - not established or residing within the Community: base 7%"
-msgstr ""
-"955 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: base 7%"
+msgstr "955 - net etabléiert oder an der Gemeinschaft wunnen: Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_2_tax_7
 msgid "956 - not established or residing within the Community: tax 7%"
-msgstr ""
-"956 - effectuées au déclarant par des assujettis établis en dehors de la "
-"Communauté: taxe 7%"
+msgstr "956 - net etabléiert oder an der Gemeinschaft wunnen: Steier 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_base_16
 msgid "961 - suppliers established within the territory: base 16%"
-msgstr ""
-"961 - effectuées au déclarant par des assujettis établis à l'intérieur du "
-"pays: base 16%"
+msgstr "961 - Fournisseuren am Territoire etabléiert: Basis 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2e_3_tax_16
 msgid "962 - suppliers established within the territory: tax 16%"
-msgstr ""
-"962 - effectuées au déclarant par des assujettis établis à l'intérieur du "
-"pays: taxe 16%"
+msgstr "962 - Fournisseuren am Territoire etabléiert: Steier 16%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_base_7
 msgid "963 - base 7%"
-msgstr ""
+msgstr "963 - Basis 7%"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_2f_supply_goods_tax_7
 msgid "964 - tax 7%"
-msgstr "964 - taxe 7%"
+msgstr "964 - Steier 7%"
 
 #. module: l10n_lu
 #: model:ir.model,name:l10n_lu.model_account_chart_template
 msgid "Account Chart Template"
-msgstr "Modèle de plan comptable"
+msgstr "Kont Chart Schabloun"
 
 #. module: l10n_lu
 #: model:account.report.column,name:l10n_lu.tax_report_section_1_balance
 #: model:account.report.column,name:l10n_lu.tax_report_section_2_balance
 #: model:account.report.column,name:l10n_lu.tax_report_sections_3_4_balance
 msgid "Balance"
-msgstr ""
+msgstr "Gläichgewiicht"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.l10n_lu_tax_report_assessment_turnover
 msgid "I. ASSESSMENT OF TAXABLE TURNOVER"
-msgstr "I. ÉVALUATION DU CHIFFRE D'AFFAIRES IMPOSABLE"
+msgstr "I. Aschätzung vum besteierbaren Ëmsaz"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.l10n_lu_tax_report_assessment_tax_due
 msgid "II. ASSESSMENT OF TAX DUE"
-msgstr "II. ÉVALUATION DE LA TAXE DUE"
+msgstr "II. ASSESSMENT VUN STEIER DUE"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_3_assessment_deducible_tax
 msgid "III. ASSESSMENT OF DEDUCTIBLE TAX (input tax)"
-msgstr "III. CALCUL DE LA TAXE DEDUCTIBLE (taxe en amont)"
+msgstr "III. ASSESSMENT VUN DEDUCTIBLE TAX (Input Steier)"
 
 #. module: l10n_lu
 #: model:account.report.line,name:l10n_lu.account_tax_report_line_4_tax_tobe_paid_or_reclaimed
 msgid "IV. TAX TO BE PAID OR TO BE RECLAIMED"
-msgstr "IV. CALCUL DE L'EXCEDENT"
+msgstr "IV. STEIER ZE BEZUELT ODER ZE RECLAIMED"
 
 #. module: l10n_lu
 #: model:ir.ui.menu,name:l10n_lu.account_reports_lu_statements_menu
 msgid "Luxembourg"
-msgstr ""
+msgstr "Lëtzebuerg"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_section_1
 msgid "Section I"
-msgstr ""
+msgstr "Abschnitt I"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_section_2
 msgid "Section II"
-msgstr ""
+msgstr "Abschnitt II"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.l10n_lu_tax_report_sections_3_4
 msgid "Sections III, IV"
-msgstr ""
+msgstr "Abschnitt III, IV"
 
 #. module: l10n_lu
 #: model:account.report,name:l10n_lu.tax_report
 msgid "Tax Report"
-msgstr "Rapport fiscal"
+msgstr "Steier Rapport"


### PR DESCRIPTION
This commit adds translations for Luxembourg VAT report in the official languages of Luxembourg. The translation is added for languages Luxembourgish, German, and French.

task-4717339




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
