### PR TITLE
[IMP] website_sale: order attributes by sequence on shop page

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -438,7 +438,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 ('visibility', '=', 'visible'),
             ]))
         else:
-            attributes = lazy(lambda: ProductAttribute.browse(attribute_ids))
+            attributes = lazy(lambda: ProductAttribute.browse(attribute_ids).sorted())
 
         if website.viewref('website_sale.products_list_view').active:
             layout_mode = 'list'

--- a/addons/website_sale_comparison/models/product_attribute.py
+++ b/addons/website_sale_comparison/models/product_attribute.py
@@ -5,7 +5,6 @@ from odoo import fields, models
 
 class ProductAttribute(models.Model):
     _inherit = 'product.attribute'
-    _order = 'category_id, sequence, id'
 
     category_id = fields.Many2one(
         comodel_name='product.attribute.category',


### PR DESCRIPTION
Attributes should be displayed in the same order on backend and frontend, and the `category_id` in `website_sale_comparison` should only impact the comparison page, not the generic order.

task-4747285

