### PR TITLE
[FIX] purchase: prevent cancellation of locked purchase orders

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -553,6 +553,10 @@ class PurchaseOrder(models.Model):
         return True
 
     def button_cancel(self):
+        locked_purchase_orders = self.filtered(lambda po: po.locked)
+        if locked_purchase_orders:
+            raise UserError(self.env._("Unable to cancel purchase order(s): %s. You must first unlock them.", locked_purchase_orders.mapped('display_name')))
+
         purchase_orders_with_invoices = self.filtered(lambda po: any(i.state not in ('cancel', 'draft') for i in po.invoice_ids))
         if purchase_orders_with_invoices:
             raise UserError(_("Unable to cancel purchase order(s): %s. You must first cancel their related vendor bills.", purchase_orders_with_invoices.mapped('display_name')))

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -1133,3 +1133,25 @@ class TestPurchase(AccountTestInvoicingCommon):
             uom_test.unlink()
 
         self.assertEqual(po.order_line[0].product_uom_id, uom_test)
+
+    def test_locked_purchase_order_cannot_cancel(self):
+        """Test that a locked purchase order cannot be cancelled.
+        A purchase order must be unlocked before it can be cancelled.
+        """
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+        po.button_confirm()
+        self.assertFalse(po.locked)
+        # Lock the purchase order.
+        po.button_lock()
+        self.assertTrue(po.locked, "The purchase order should be locked.")
+
+        # Try to cancel the locked PO, should raise a UserError.
+        with self.assertRaises(UserError):
+            po.button_cancel()
+
+        # Unlock the PO and then cancel it, should succeed.
+        po.button_unlock()
+        po.button_cancel()
+        self.assertEqual(po.state, 'cancel', "The purchase order should be cancelled.")

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -142,7 +142,7 @@
                     <button name="button_draft" invisible="state != 'cancel'" string="Set to Draft" type="object" data-hotkey="o"/>
                     <button name="print_quotation" string="Print" type="object" groups="base.group_user" data-hotkey="k" invisible="state == 'purchase'"/>
                     <button name="%(purchase.action_report_purchase_order)d" string="Print" type="action" groups="base.group_user" data-hotkey="k" invisible="state != 'purchase'"/>
-                    <button name="button_cancel" invisible="state not in ('draft', 'to approve', 'sent', 'purchase')" string="Cancel" type="object" data-hotkey="x" />
+                    <button name="button_cancel" invisible="state not in ('draft', 'to approve', 'sent', 'purchase') or locked" string="Cancel" type="object" data-hotkey="x"/>
                     <button name="button_lock" type="object" string="Lock" invisible="locked or state != 'purchase' or not lock_confirmed_po == 'lock'" data-hotkey="l"/>
                     <button name="button_unlock" type="object" string="Unlock" invisible="not locked" groups="purchase.group_purchase_manager" data-hotkey="l"/>
                     <field name="state" widget="statusbar" statusbar_visible="draft,sent,purchase" readonly="1"/>


### PR DESCRIPTION
Issue before this commit:
==========================
Locked purchase orders could still be cancelled, which defeats
the purpose of locking them.

Steps to reproduce:
==========================
1. Install the `purchase` module.
2. Enable "Lock Confirmed Orders" in the configuration.
3. Create and confirm a purchase order.
4. Lock the purchase order.
5. Try to cancel it → the PO still gets cancelled despite being locked.

After this commit:
===========================
Cancelling a locked purchase order is no longer allowed. If a user tries to
cancel a locked PO, a UserError will be raised instructing them to unlock
it first. Locking a purchase order is intended to prevent accidental
changes, including edits and cancellations, once the order is confirmed.

With this change, users must explicitly unlock a purchase order
before cancelling it, ensuring better control and data integrity.

TaskId: 4760864