### PR TITLE
[IMP] l10n_my_edi_extended: self billed ID

### DIFF
--- a/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi_extended/models/account_edi_xml_ubl_my.py
@@ -20,6 +20,9 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
                 'industry_classification_code_attrs': {'name': invoice.partner_id.commercial_partner_id.l10n_my_edi_industrial_classification.name},
                 'industry_classification_code': invoice.partner_id.commercial_partner_id.l10n_my_edi_industrial_classification.code,
             })
+            # Self-billed invoices must use the number given by the supplier.
+            if invoice.ref:
+                vals['vals']['id'] = invoice.ref
         # Sometimes, a foreign customer is also a supplier.
         # To avoid needing to change the Generic TIN depending on what you do with your commercial partner, we will automatically switch
         # depending on the context.


### PR DESCRIPTION
Fixes an issue when issuing self-billed invoices
to the platform.
So far we have been using Odoo's bill name as ID,
but we should instead use the bill reference (if
set) to use the supplier number.

task-4777585

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
