### PR TITLE
[IMP] html_editor: traceback while saving empty link

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -83,7 +83,9 @@ export class LinkPopover extends Component {
             }
         });
         useExternalListener(document, "pointerdown", (ev) => {
-            if (
+            if (!this.state.url) {
+                this.onClickRemove();
+            } else if (
                 this.editingWrapper?.el &&
                 !this.state.isImage &&
                 !this.editingWrapper.el.contains(ev.target)
@@ -133,7 +135,7 @@ export class LinkPopover extends Component {
 
     onKeydownEnter(ev) {
         const isAutoCompleteDropdownOpen = document.querySelector(".o-autocomplete--dropdown-menu");
-        if (ev.key === "Enter" && !isAutoCompleteDropdownOpen) {
+        if (ev.key === "Enter" && !isAutoCompleteDropdownOpen && this.state.url) {
             ev.preventDefault();
             this.onClickApply();
         }

--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -42,7 +42,7 @@
                                     </t>
                                 </t>
                             </select>
-                            <button class="o_we_apply_link btn btn-sm btn-primary" t-on-click="onClickApply">Apply</button>
+                            <button class="o_we_apply_link btn btn-sm btn-primary" t-att-disabled="!state.url" t-on-click="onClickApply">Apply</button>
                             <button class="o_we_discard_link btn btn-sm btn-dark ms-1" t-on-click="props.onDiscard">Discard</button>
                         </div>
                     </div>

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -134,6 +134,7 @@ describe("popover should switch UI depending on editing state", () => {
         await click(".o_we_href_input_link");
         await tick();
         await fill("test-href.com");
+        await waitFor(".o_we_apply_link:not([disabled])");
         await click(".o_we_apply_link");
         await waitFor(".o_we_edit_link");
         expect(".o-we-linkpopover").toHaveCount(1);
@@ -151,29 +152,6 @@ describe("popover should edit,copy,remove the link", () => {
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p>this is a <a href="http://test.com/">li[]nk</a></p>'
         );
-    });
-    test("after apply empty url on a link, the link element should not have href (1)", async () => {
-        const { el } = await setupEditor("<p>this is a <a>li[]nk</a></p>");
-        await waitFor(".o-we-linkpopover");
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
-        await click(".o_we_apply_link");
-        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>this is a <a>li[]nk</a></p>");
-    });
-    test("after apply empty url on a link, the link element should not have href (2)", async () => {
-        const { el } = await setupEditor('<p>this is a <a href="">li[]nk</a></p>');
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
-        await click(".o_we_apply_link");
-        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>this is a <a>li[]nk</a></p>");
-    });
-    test("after apply empty url on a link, the link element should not have href (3)", async () => {
-        const { el } = await setupEditor('<p>this is a <a href="exiting">li[]nk</a></p>');
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
-        await click(".o_we_apply_link");
-        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>this is a <a>li[]nk</a></p>");
     });
     test("after clicking on remove button, the link element should be unwrapped", async () => {
         const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
@@ -215,15 +193,6 @@ describe("popover should edit,copy,remove the link", () => {
         await animationFrame();
         expect(".o-we-linkpopover").toHaveCount(0);
         await expect(navigator.clipboard.readText()).resolves.toBe("http://test.com/");
-    });
-    test("when edit a link's label and URL to '', the link should be removed", async () => {
-        const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
-        await waitFor(".o-we-linkpopover");
-        await click(".o_we_edit_link");
-
-        await contains(".o-we-linkpopover input.o_we_label_link").clear();
-        await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
-        expect(getContent(el)).toBe("<p>this is a&nbsp;[]</p>");
     });
 });
 
@@ -324,7 +293,7 @@ describe("Link creation", () => {
             await animationFrame();
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[]ab</p>");
         });
-        test("when create a new link by powerbox and not input anything, then validate, the link should be removed", async () => {
+        test("when create a new link by powerbox and not input anything, the apply link button should be disable", async () => {
             const { editor, el } = await setupEditor("<p>ab[]</p>");
             await insertText(editor, "/link");
             await animationFrame();
@@ -332,10 +301,7 @@ describe("Link creation", () => {
             await waitFor(".o-we-linkpopover");
             expect(".o-we-linkpopover").toHaveCount(1);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>ab</p>");
-            // simulate click validate
-            await click(".o-we-linkpopover .o_we_apply_link");
-            await animationFrame();
-            expect(cleanLinkArtifacts(getContent(el))).toBe("<p>ab[]</p>");
+            expect(".o_we_apply_link").toHaveAttribute("disabled");
         });
         test("when create a new link by powerbox and only input the URL, the link should be created with corrected https URL", async () => {
             const { editor, el } = await setupEditor("<p>ab[]</p>");
@@ -538,6 +504,7 @@ describe("Link creation", () => {
 
             queryOne(".o-we-linkpopover input.o_we_href_input_link").focus();
             await fill("test.com");
+            await waitFor(".o_we_apply_link:not([disabled])");
             await click(".o_we_apply_link");
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 '<p><a href="https://test.com">Hello[]</a></p>'
@@ -1181,5 +1148,40 @@ describe("upload file via link popover", () => {
         );
         const favIcon = await waitFor(".o_we_preview_favicon span.o_image");
         expect(favIcon).toHaveAttribute("data-mimetype", "text/plain");
+    });
+});
+
+describe("apply button should be disabled when the URL is empty", () => {
+    test("when URL on link is empty, the apply link button should be disabled (1)", async () => {
+        await setupEditor("<p>this is a <a>li[]nk</a></p>");
+        await waitFor(".o-we-linkpopover");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
+        await tick();
+        expect(".o_we_apply_link").toHaveAttribute("disabled");
+    });
+    test("when URL on link is empty, the apply link button should be disabled (2)", async () => {
+        await setupEditor('<p>this is a <a href="">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
+        await tick();
+        expect(".o_we_apply_link").toHaveAttribute("disabled");
+    });
+    test("when URL on link is empty, the apply link button should be disabled (3)", async () => {
+        await setupEditor('<p>this is a <a href="exiting">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("");
+        await tick();
+        expect(".o_we_apply_link").toHaveAttribute("disabled");
+    });
+    test("when edit a link's label and URL to '', the apply link button should be disabled", async () => {
+        await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await contains(".o-we-linkpopover input.o_we_label_link").clear();
+        await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
+        await tick();
+        expect(".o_we_apply_link").toHaveAttribute("disabled");
     });
 });


### PR DESCRIPTION
**Current behavior before PR:**

- Removing the label and url from the link popover and attempting to save the link would trigger a traceback.

**Desired behavior after PR is merged:**

- The Apply button is disabled when the URL field is empty.
- Pressing Enter no longer creates or saves a link if the url is missing.
- Clicking outside the popover after clearing the label and url will now remove the link.

task: 4766687