### PR TITLE
[FIX] im_livechat: hide partner company in session views

### DIFF
--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -146,7 +146,10 @@
             <field name="view_mode">kanban,list,pivot,graph,form</field>
             <field name="search_view_id" ref="im_livechat.discuss_channel_view_search"/>
             <field name="domain">[('livechat_channel_id', '!=', None)]</field>
-            <field name="context">{'search_default_filter_session_date': 'custom_rated_on_last_30_days'}</field>
+            <field name="context">{
+                "search_default_filter_session_date": "custom_rated_on_last_30_days",
+                "im_livechat.hide_partner_company": True
+            }</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_empty_folder">
                     No data yet!


### PR DESCRIPTION
The agent company should be hidden in every live chat session view. This commit fixes the issue.

task-4775840

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
