### PR TITLE
[FIX] base: remove unnecessary index on `res.users.settings.user_id`

### DIFF
--- a/odoo/addons/base/models/res_users_settings.py
+++ b/odoo/addons/base/models/res_users_settings.py
@@ -9,7 +9,7 @@ class ResUsersSettings(models.Model):
     _description = 'User Settings'
     _rec_name = 'user_id'
 
-    user_id = fields.Many2one("res.users", string="User", required=True, index=True, ondelete="cascade", domain=[("res_users_settings_id", "=", False)])
+    user_id = fields.Many2one("res.users", string="User", required=True, index=False, ondelete="cascade", domain=[("res_users_settings_id", "=", False)])
 
     _unique_user_id = models.Constraint(
         'UNIQUE(user_id)',

--- a/odoo/addons/test_lint/tests/test_index.py
+++ b/odoo/addons/test_lint/tests/test_index.py
@@ -24,6 +24,7 @@ BTREE_INDEX_IGNORE_FIELDS = {  # str(field)  (fully-qualified field name)
     'hr.appraisal.skill.appraisal_id',                  # covered by first key of __unique_skill
     'mail.presence.user_id',                            # covered by _user_unique
     'mail.presence.guest_id',                           # covered by _guest_unique
+    'res.users.settings.user_id',                       # covered by _unique_user_id
 }
 
 @common.tagged('post_install', '-at_install')


### PR DESCRIPTION
There is already a unique constraint `_unique_user_id` which is implicitly creating an index in the database, no need to index the field.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
