### PR TITLE
[FIX] stock: on hand qty can be set to zero on a product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -10,7 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import float_is_zero, check_barcode_encoding
-from odoo.tools.float_utils import float_round
+from odoo.tools.float_utils import float_round, float_compare
 from odoo.tools.mail import html2plaintext, is_html_empty
 from odoo.tools.misc import groupby
 
@@ -234,12 +234,13 @@ class ProductProduct(models.Model):
             return
         for product in self:
             if (
-                product.type == "consu" and product.is_storable and product.qty_available > 0
+                product.type == "consu" and product.is_storable and float_compare(product.qty_available,
+                     0.0, precision_rounding=product.uom_id.rounding) >= 0
             ):
                 warehouse = self.env['stock.warehouse'].search(
                     [('company_id', '=', self.env.company.id)], limit=1
                 )
-                self.env['stock.quant'].with_context(inventory_mode=True).create({
+                self.env['stock.quant'].with_context(inventory_mode=True, from_inverse_qty=True).create({
                     'product_id': product.id,
                     'location_id': warehouse.lot_stock_id.id,
                     'inventory_quantity': product.qty_available,

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -997,6 +997,12 @@ class StockQuant(models.Model):
         self.inventory_quantity_set = True
         move_vals = []
         for quant in self:
+            # if inventory applied from product's inverse_qty and the inventory_diff_quantity is 0,
+            # we skip creating a move with 0 quantity.
+            if quant._context.get('from_inverse_qty') and float_compare(
+                quant.inventory_diff_quantity, 0.0, precision_rounding=quant.product_uom_id.rounding
+            ) == 0:
+                continue
             # Create and validate a move so that the quant matches its `inventory_quantity`.
             if float_compare(quant.inventory_diff_quantity, 0, precision_rounding=quant.product_uom_id.rounding) > 0:
                 move_vals.append(

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -390,3 +390,22 @@ class TestVirtualAvailable(TestStockCommon):
 
         self.assertEqual(main_qty, 200)
         self.assertEqual(other_qty, 50)
+
+    def test_qty_available_values_on_product(self):
+        """
+        Test that qty_available can be set to 0.0 on a product
+        """
+        product = self.env['product.product'].create({
+            'name': 'Test Qty Available Product',
+            'type': 'consu',
+            'is_storable': True,
+        })
+        self.assertEqual(product.qty_available, 0.0)
+
+        with Form(product) as product_form:
+            product_form.qty_available = 10.0
+        self.assertEqual(product.qty_available, 10.0)
+
+        with Form(product) as product_form:
+            product_form.qty_available = 0.0
+        self.assertEqual(product.qty_available, 0.0)


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1) Install stocks
2) Create a product variant with storable true
3) Change the on-hand quantity to some positive value and save
4) Now update the on-hand quantity to 0 and refresh the page

<b>Issue:-</b> 
  The on-hand quantity doesn't update to 0. 

<b>Cause:-</b> 
When the user manually changes the on-hand quantity, an inverse method
`_inverse_qty_available` is triggered to create a new stock.quant, 
but because of this condition, no new quant is created.

https://github.com/odoo/odoo/blob/b2e845c46a0b152899ee630770abc15751493069/addons/stock/models/product.py#L236-L238

As a result, the qty_available value will remain same because it will
be updated based on the stock.quant's record from the below line.

https://github.com/odoo/odoo/blob/b2e845c46a0b152899ee630770abc15751493069/addons/stock/models/product.py#L185
https://github.com/odoo/odoo/blob/b2e845c46a0b152899ee630770abc15751493069/addons/stock/models/product.py#L217

<b>Solution:-</b> 
  We can resolve this issue by modifying the condition in the inverse method
to create a new stock.quant if the on-hand qty is 0 or more.
  Also skip creating a SM with 0 quantity when applying inventory from `_inverse_qty`

opw-4761491


