### PR TITLE
[FIX] l10n_fr_account: export FEC as .txt

### DIFF
--- a/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
+++ b/addons/l10n_fr_account/wizard/account_fr_fec_export_wizard.py
@@ -343,9 +343,9 @@ class L10n_FrFecExportWizard(models.TransientModel):
             self.env.company.write({'fiscalyear_lock_date': self.date_to})
 
         return {
-            'file_name': f"{company_legal_data}FEC{end_date}{suffix}.csv",
+            'file_name': f"{company_legal_data}FEC{end_date}{suffix}.txt",
             'file_content': content,
-            'file_type': 'csv'
+            'file_type': 'txt'
         }
 
     def create_fec_report_action(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In France, the FEC should be in .txt format. This PR fixes the FEC to be exported as .txt file instead of .csv file. Only the file extension changed, the file content structure is unchanged. Task id: 4687487

Current behavior before PR:
FEC document exported as .csv 

Desired behavior after PR is merged:
FEC document exported as .txt

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
