### PR TITLE
[IMP] core: decouple sanitize and translate for html fields

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -4,7 +4,7 @@ from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_date, formatLang, frozendict, date_utils
 from odoo.tools.float_utils import float_round
-
+from odoo.tools.translate import html_translate
 from dateutil.relativedelta import relativedelta
 
 
@@ -22,7 +22,7 @@ class AccountPaymentTerm(models.Model):
 
     name = fields.Char(string='Payment Terms', translate=True, required=True)
     active = fields.Boolean(default=True, help="If the active field is set to False, it will allow you to hide the payment terms without removing it.")
-    note = fields.Html(string='Description on the Invoice', translate=True)
+    note = fields.Html(string='Description on the Invoice', translate=html_translate)
     line_ids = fields.One2many('account.payment.term.line', 'payment_id', string='Terms', copy=True, default=_default_line_ids)
     company_id = fields.Many2one('res.company', string='Company')
     fiscal_country_codes = fields.Char(compute='_compute_fiscal_country_codes')

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -4,7 +4,6 @@ from odoo import api, fields, models, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools import format_date, formatLang, frozendict, date_utils
 from odoo.tools.float_utils import float_round
-from odoo.tools.translate import html_translate
 from dateutil.relativedelta import relativedelta
 
 
@@ -22,7 +21,7 @@ class AccountPaymentTerm(models.Model):
 
     name = fields.Char(string='Payment Terms', translate=True, required=True)
     active = fields.Boolean(default=True, help="If the active field is set to False, it will allow you to hide the payment terms without removing it.")
-    note = fields.Html(string='Description on the Invoice', translate=html_translate)
+    note = fields.Html(string='Description on the Invoice', translate=True)
     line_ids = fields.One2many('account.payment.term.line', 'payment_id', string='Terms', copy=True, default=_default_line_ids)
     company_id = fields.Many2one('res.company', string='Company')
     fiscal_country_codes = fields.Char(compute='_compute_fiscal_country_codes')

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -6,7 +6,6 @@ from odoo.fields import Domain
 from odoo.tools import frozendict, groupby, html2plaintext, is_html_empty, split_every, SQL
 from odoo.tools.float_utils import float_repr, float_round, float_compare
 from odoo.tools.misc import clean_context, formatLang
-from odoo.tools.translate import html_translate
 
 from collections import defaultdict
 from collections.abc import Iterable
@@ -129,7 +128,7 @@ class AccountTax(models.Model):
     sequence = fields.Integer(required=True, default=1,
         help="The sequence field is used to define order in which the tax lines are applied.")
     amount = fields.Float(required=True, digits=(16, 4), default=0.0, tracking=True)
-    description = fields.Html(string='Description', translate=html_translate)
+    description = fields.Html(string='Description', translate=True)
     invoice_label = fields.Char(string='Label on Invoices', translate=True)
     price_include = fields.Boolean(
         compute='_compute_price_include',
@@ -200,7 +199,7 @@ class AccountTax(models.Model):
     country_code = fields.Char(related='country_id.code', readonly=True)
     is_used = fields.Boolean(string="Tax used", compute='_compute_is_used')
     repartition_lines_str = fields.Char(string="Repartition Lines", tracking=True, compute='_compute_repartition_lines_str')
-    invoice_legal_notes = fields.Html(string="Legal Notes", translate=html_translate, help="Legal mentions that have to be printed on the invoices.")
+    invoice_legal_notes = fields.Html(string="Legal Notes", translate=True, help="Legal mentions that have to be printed on the invoices.")
     # Technical field depicting if the tax has at least one repartition line with a percentage below 0.
     # Used for the taxes computation to manage the reverse charge taxes having a repartition +100 -100.
     has_negative_factor = fields.Boolean(compute='_compute_has_negative_factor')

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -200,7 +200,7 @@ class AccountTax(models.Model):
     country_code = fields.Char(related='country_id.code', readonly=True)
     is_used = fields.Boolean(string="Tax used", compute='_compute_is_used')
     repartition_lines_str = fields.Char(string="Repartition Lines", tracking=True, compute='_compute_repartition_lines_str')
-    invoice_legal_notes = fields.Html(string="Legal Notes", translate=True, help="Legal mentions that have to be printed on the invoices.")
+    invoice_legal_notes = fields.Html(string="Legal Notes", translate=html_translate, help="Legal mentions that have to be printed on the invoices.")
     # Technical field depicting if the tax has at least one repartition line with a percentage below 0.
     # Used for the taxes computation to manage the reverse charge taxes having a repartition +100 -100.
     has_negative_factor = fields.Boolean(compute='_compute_has_negative_factor')

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -9,7 +9,6 @@ from odoo.exceptions import LockError, ValidationError, UserError, RedirectWarni
 from odoo.tools import date_utils, format_list, SQL
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
-from odoo.tools.translate import html_translate
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
 from odoo.addons.account.models.product import ACCOUNT_DOMAIN
 from odoo.addons.account.models.partner import _ref_company_registry
@@ -173,10 +172,10 @@ class ResCompany(models.Model):
     account_opening_journal_id = fields.Many2one(string='Opening Journal', comodel_name='account.journal', related='account_opening_move_id.journal_id', help="Journal where the opening entry of this company's accounting has been posted.", readonly=False)
     account_opening_date = fields.Date(string='Opening Entry', help="That is the date of the opening entry.")
 
-    invoice_terms = fields.Html(string='Default Terms and Conditions', translate=html_translate)
+    invoice_terms = fields.Html(string='Default Terms and Conditions', translate=True)
     terms_type = fields.Selection([('plain', 'Add a Note'), ('html', 'Add a link to a Web Page')],
                                   string='Terms & Conditions format', default='plain')
-    invoice_terms_html = fields.Html(string='Default Terms and Conditions as a Web page', translate=html_translate,
+    invoice_terms_html = fields.Html(string='Default Terms and Conditions as a Web page', translate=True,
                                      sanitize_attributes=False,
                                      compute='_compute_invoice_terms_html', store=True, readonly=False)
 

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -9,6 +9,7 @@ from odoo.exceptions import LockError, ValidationError, UserError, RedirectWarni
 from odoo.tools import date_utils, format_list, SQL
 from odoo.tools.mail import is_html_empty
 from odoo.tools.misc import format_date
+from odoo.tools.translate import html_translate
 from odoo.addons.account.models.account_move import MAX_HASH_VERSION
 from odoo.addons.account.models.product import ACCOUNT_DOMAIN
 from odoo.addons.account.models.partner import _ref_company_registry
@@ -172,10 +173,10 @@ class ResCompany(models.Model):
     account_opening_journal_id = fields.Many2one(string='Opening Journal', comodel_name='account.journal', related='account_opening_move_id.journal_id', help="Journal where the opening entry of this company's accounting has been posted.", readonly=False)
     account_opening_date = fields.Date(string='Opening Entry', help="That is the date of the opening entry.")
 
-    invoice_terms = fields.Html(string='Default Terms and Conditions', translate=True)
+    invoice_terms = fields.Html(string='Default Terms and Conditions', translate=html_translate)
     terms_type = fields.Selection([('plain', 'Add a Note'), ('html', 'Add a link to a Web Page')],
                                   string='Terms & Conditions format', default='plain')
-    invoice_terms_html = fields.Html(string='Default Terms and Conditions as a Web page', translate=True,
+    invoice_terms_html = fields.Html(string='Default Terms and Conditions as a Web page', translate=html_translate,
                                      sanitize_attributes=False,
                                      compute='_compute_invoice_terms_html', store=True, readonly=False)
 

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -10,6 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import LockError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, SQL, mute_logger, unique
+from odoo.tools.translate import html_translate
 from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 _logger = logging.getLogger(__name__)
@@ -46,7 +47,7 @@ class AccountFiscalPosition(models.Model):
         context={'active_test': False},
     )
     tax_map = fields.Binary(compute='_compute_tax_map')
-    note = fields.Html('Notes', translate=True, help="Legal mentions that have to be printed on the invoices.")
+    note = fields.Html('Notes', translate=html_translate, help="Legal mentions that have to be printed on the invoices.")
     auto_apply = fields.Boolean(string='Detect Automatically', help="Apply tax & account mappings on invoices automatically if the matching criterias (VAT/Country) are met.")
     vat_required = fields.Boolean(string='VAT required', help="Apply only if partner has a VAT number.")
     company_country_id = fields.Many2one(string="Company Country", related='company_id.account_fiscal_country_id')

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -10,7 +10,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import LockError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, SQL, mute_logger, unique
-from odoo.tools.translate import html_translate
 from odoo.addons.base_vat.models.res_partner import _ref_vat
 
 _logger = logging.getLogger(__name__)
@@ -47,7 +46,7 @@ class AccountFiscalPosition(models.Model):
         context={'active_test': False},
     )
     tax_map = fields.Binary(compute='_compute_tax_map')
-    note = fields.Html('Notes', translate=html_translate, help="Legal mentions that have to be printed on the invoices.")
+    note = fields.Html('Notes', translate=True, help="Legal mentions that have to be printed on the invoices.")
     auto_apply = fields.Boolean(string='Detect Automatically', help="Apply tax & account mappings on invoices automatically if the matching criterias (VAT/Country) are met.")
     vat_required = fields.Boolean(string='VAT required', help="Apply only if partner has a VAT number.")
     company_country_id = fields.Many2one(string="Company Country", related='company_id.account_fiscal_country_id')

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -16,7 +16,6 @@ from odoo.fields import Domain
 from odoo.tools import format_date, format_datetime, format_time, frozendict
 from odoo.tools.mail import is_html_empty, html_to_inner_content
 from odoo.tools.misc import formatLang
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +67,7 @@ class EventEvent(models.Model):
 
     name = fields.Char(string='Event', translate=True, required=True)
     note = fields.Html(string='Note', store=True, compute="_compute_note", readonly=False)
-    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, default=_default_description)
+    description = fields.Html(string='Description', translate=True, sanitize_attributes=False, sanitize_form=False, default=_default_description)
     active = fields.Boolean(default=True)
     user_id = fields.Many2one(
         'res.users', string='Responsible', tracking=True,
@@ -192,7 +191,7 @@ class EventEvent(models.Model):
             ('96x82', '96x82mm (Badge Printer)'),
         ], default='A6', required=True)
     badge_image = fields.Image('Badge Background', max_width=1024, max_height=1024)
-    ticket_instructions = fields.Html('Ticket Instructions', translate=html_translate,
+    ticket_instructions = fields.Html('Ticket Instructions', translate=True,
         compute='_compute_ticket_instructions', store=True, readonly=False,
         help="This information will be printed on your tickets.")
     # questions

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -192,7 +192,7 @@ class EventEvent(models.Model):
             ('96x82', '96x82mm (Badge Printer)'),
         ], default='A6', required=True)
     badge_image = fields.Image('Badge Background', max_width=1024, max_height=1024)
-    ticket_instructions = fields.Html('Ticket Instructions', translate=True,
+    ticket_instructions = fields.Html('Ticket Instructions', translate=html_translate,
         compute='_compute_ticket_instructions', store=True, readonly=False,
         help="This information will be printed on your tickets.")
     # questions

--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -1,5 +1,6 @@
 from odoo import _, api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
+from odoo.tools.translate import html_translate
 
 
 class EventType(models.Model):
@@ -53,7 +54,7 @@ class EventType(models.Model):
         'event.type.mail', 'event_type_id', string='Mail Schedule',
         default=_default_event_mail_type_ids)
     # ticket reports
-    ticket_instructions = fields.Html('Ticket Instructions', translate=True,
+    ticket_instructions = fields.Html('Ticket Instructions', translate=html_translate,
         help="This information will be printed on your tickets.")
     question_ids = fields.One2many(
         'event.question', 'event_type_id', default=_default_question_ids,

--- a/addons/event/models/event_type.py
+++ b/addons/event/models/event_type.py
@@ -1,6 +1,5 @@
 from odoo import _, api, fields, models
 from odoo.addons.base.models.res_partner import _tz_get
-from odoo.tools.translate import html_translate
 
 
 class EventType(models.Model):
@@ -54,7 +53,7 @@ class EventType(models.Model):
         'event.type.mail', 'event_type_id', string='Mail Schedule',
         default=_default_event_mail_type_ids)
     # ticket reports
-    ticket_instructions = fields.Html('Ticket Instructions', translate=html_translate,
+    ticket_instructions = fields.Html('Ticket Instructions', translate=True,
         help="This information will be printed on your tickets.")
     question_ids = fields.One2many(
         'event.question', 'event_type_id', default=_default_question_ids,

--- a/addons/event_booth/models/event_booth_category.py
+++ b/addons/event_booth/models/event_booth_category.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.tools.translate import html_translate
 
 
 class EventBoothCategory(models.Model):
@@ -13,6 +14,6 @@ class EventBoothCategory(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(string='Name', required=True, translate=True)
     sequence = fields.Integer(string='Sequence', default=10)
-    description = fields.Html(string='Description', translate=True, sanitize_attributes=False)
+    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False)
     booth_ids = fields.One2many(
         'event.booth', 'booth_category_id', string='Booths', groups='event.group_event_registration_desk')

--- a/addons/event_booth/models/event_booth_category.py
+++ b/addons/event_booth/models/event_booth_category.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.tools.translate import html_translate
 
 
 class EventBoothCategory(models.Model):
@@ -14,6 +13,6 @@ class EventBoothCategory(models.Model):
     active = fields.Boolean(default=True)
     name = fields.Char(string='Name', required=True, translate=True)
     sequence = fields.Integer(string='Sequence', default=10)
-    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False)
+    description = fields.Html(string='Description', translate=True, sanitize_attributes=False)
     booth_ids = fields.One2many(
         'event.booth', 'booth_category_id', string='Booths', groups='event.group_event_registration_desk')

--- a/addons/gamification/models/gamification_badge.py
+++ b/addons/gamification/models/gamification_badge.py
@@ -6,7 +6,7 @@ from datetime import date
 
 from odoo import api, fields, models, _, exceptions
 from odoo.tools import SQL
-
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -26,7 +26,7 @@ class GamificationBadge(models.Model):
 
     name = fields.Char('Badge', required=True, translate=True)
     active = fields.Boolean('Active', default=True)
-    description = fields.Html('Description', translate=True, sanitize_attributes=False)
+    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False)
     level = fields.Selection([
         ('bronze', 'Bronze'), ('silver', 'Silver'), ('gold', 'Gold')],
         string='Forum Badge Level', default='bronze')

--- a/addons/gamification/models/gamification_badge.py
+++ b/addons/gamification/models/gamification_badge.py
@@ -6,7 +6,6 @@ from datetime import date
 
 from odoo import api, fields, models, _, exceptions
 from odoo.tools import SQL
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -26,7 +25,7 @@ class GamificationBadge(models.Model):
 
     name = fields.Char('Badge', required=True, translate=True)
     active = fields.Boolean('Active', default=True)
-    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False)
+    description = fields.Html('Description', translate=True, sanitize_attributes=False)
     level = fields.Selection([
         ('bronze', 'Bronze'), ('silver', 'Silver'), ('gold', 'Gold')],
         string='Forum Badge Level', default='bronze')

--- a/addons/gamification/models/gamification_karma_rank.py
+++ b/addons/gamification/models/gamification_karma_rank.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models
-from odoo.tools.translate import html_translate
 
 
 class GamificationKarmaRank(models.Model):
@@ -11,9 +10,9 @@ class GamificationKarmaRank(models.Model):
     _order = 'karma_min'
 
     name = fields.Text(string='Rank Name', translate=True, required=True)
-    description = fields.Html(string='Description', translate=html_translate, sanitize_attributes=False,)
+    description = fields.Html(string='Description', translate=True, sanitize_attributes=False)
     description_motivational = fields.Html(
-        string='Motivational', translate=html_translate, sanitize_attributes=False, sanitize_overridable=True,
+        string='Motivational', translate=True, sanitize_attributes=False, sanitize_overridable=True,
         help="Motivational phrase to reach this rank on your profile page")
     karma_min = fields.Integer(
         string='Required Karma', required=True, default=1)

--- a/addons/hr_skills/models/hr_resume_line.py
+++ b/addons/hr_skills/models/hr_resume_line.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.tools.translate import html_translate
 
 
 class HrResumeLine(models.Model):
@@ -14,7 +13,7 @@ class HrResumeLine(models.Model):
     name = fields.Char(required=True, translate=True)
     date_start = fields.Date(required=True)
     date_end = fields.Date()
-    description = fields.Html(string="Description", translate=html_translate)
+    description = fields.Html(string="Description", translate=True)
     line_type_id = fields.Many2one('hr.resume.line.type', string="Type")
 
     # Used to apply specific template on a line

--- a/addons/hr_skills/models/hr_resume_line.py
+++ b/addons/hr_skills/models/hr_resume_line.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.tools.translate import html_translate
 
 
 class HrResumeLine(models.Model):
@@ -13,7 +14,7 @@ class HrResumeLine(models.Model):
     name = fields.Char(required=True, translate=True)
     date_start = fields.Date(required=True)
     date_end = fields.Date()
-    description = fields.Html(string="Description", translate=True)
+    description = fields.Html(string="Description", translate=html_translate)
     line_type_id = fields.Many2one('hr.resume.line.type', string="Type")
 
     # Used to apply specific template on a line

--- a/addons/l10n_gcc_invoice/models/account_move.py
+++ b/addons/l10n_gcc_invoice/models/account_move.py
@@ -4,7 +4,7 @@
 import logging
 
 from odoo import fields, models, api
-
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -18,7 +18,7 @@ except ImportError:
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    narration = fields.Html(translate=True)
+    narration = fields.Html(translate=html_translate)
 
     def _get_name_invoice_report(self):
         self.ensure_one()

--- a/addons/l10n_gcc_invoice/tests/test_gcc_invoice.py
+++ b/addons/l10n_gcc_invoice/tests/test_gcc_invoice.py
@@ -23,7 +23,7 @@ class TestGccInvoice(AccountTestInvoicingCommon):
             'terms_type': 'plain',
         })
         # Add translation to invoice terms
-        self.env.company.update_field_translations('invoice_terms', {'en_US': {'English Terms': 'English Terms'}, 'ar_001': {'English Terms': 'Arabic Terms'}})
+        self.env.company.update_field_translations('invoice_terms', {'en_US': 'English Terms', 'ar_001': 'Arabic Terms'})
         invoice = self.init_invoice('out_invoice', products=self.product_a)
 
         self.assertEqual(invoice.narration, Markup('<p>English Terms</p>'), 'Original narration not correct')

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -4,7 +4,6 @@ import logging
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
-from odoo.tools.translate import html_translate
 
 from .lunch_supplier import float_to_time
 from datetime import datetime, timedelta
@@ -25,7 +24,7 @@ class LunchAlert(models.Model):
     _order = 'write_date desc, id'
 
     name = fields.Char('Alert Name', required=True, translate=True)
-    message = fields.Html('Message', required=True, translate=html_translate)
+    message = fields.Html('Message', required=True, translate=True)
 
     mode = fields.Selection([
         ('alert', 'Alert in app'),

--- a/addons/lunch/models/lunch_alert.py
+++ b/addons/lunch/models/lunch_alert.py
@@ -4,6 +4,7 @@ import logging
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
+from odoo.tools.translate import html_translate
 
 from .lunch_supplier import float_to_time
 from datetime import datetime, timedelta
@@ -24,7 +25,7 @@ class LunchAlert(models.Model):
     _order = 'write_date desc, id'
 
     name = fields.Char('Alert Name', required=True, translate=True)
-    message = fields.Html('Message', required=True, translate=True)
+    message = fields.Html('Message', required=True, translate=html_translate)
 
     mode = fields.Selection([
         ('alert', 'Alert in app'),

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
-from odoo.tools.translate import html_translate
 
 
 class LunchProduct(models.Model):
@@ -21,7 +20,7 @@ class LunchProduct(models.Model):
 
     name = fields.Char('Product Name', required=True, translate=True)
     category_id = fields.Many2one('lunch.product.category', 'Product Category', check_company=True, required=True)
-    description = fields.Html('Description', translate=html_translate)
+    description = fields.Html('Description', translate=True)
     price = fields.Float('Price', digits='Account', required=True)
     supplier_id = fields.Many2one('lunch.supplier', 'Vendor', check_company=True, required=True)
     active = fields.Boolean(default=True)

--- a/addons/lunch/models/lunch_product.py
+++ b/addons/lunch/models/lunch_product.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
+from odoo.tools.translate import html_translate
 
 
 class LunchProduct(models.Model):
@@ -20,7 +21,7 @@ class LunchProduct(models.Model):
 
     name = fields.Char('Product Name', required=True, translate=True)
     category_id = fields.Many2one('lunch.product.category', 'Product Category', check_company=True, required=True)
-    description = fields.Html('Description', translate=True)
+    description = fields.Html('Description', translate=html_translate)
     price = fields.Float('Price', digits='Account', required=True)
     supplier_id = fields.Many2one('lunch.supplier', 'Vendor', check_company=True, required=True)
     active = fields.Boolean(default=True)

--- a/addons/lunch/models/res_company.py
+++ b/addons/lunch/models/res_company.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
+from odoo.tools.translate import html_translate
 
 
 class ResCompany(models.Model):
@@ -9,5 +10,5 @@ class ResCompany(models.Model):
 
     lunch_minimum_threshold = fields.Float()
     lunch_notify_message = fields.Html(
-        default="""Your lunch has been delivered.
-Enjoy your meal!""", translate=True)
+        default="""Your lunch has been delivered.\nEnjoy your meal!""",
+        translate=html_translate)

--- a/addons/lunch/models/res_company.py
+++ b/addons/lunch/models/res_company.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, fields
-from odoo.tools.translate import html_translate
 
 
 class ResCompany(models.Model):
@@ -11,4 +10,4 @@ class ResCompany(models.Model):
     lunch_minimum_threshold = fields.Float()
     lunch_notify_message = fields.Html(
         default="""Your lunch has been delivered.\nEnjoy your meal!""",
-        translate=html_translate)
+        translate=True)

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -5,7 +5,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import html_translate
 
 
 class MailActivityType(models.Model):
@@ -74,7 +73,7 @@ class MailActivityType(models.Model):
         help='Actions may trigger specific behavior like opening calendar view or automatically mark as done when a document is uploaded')
     mail_template_ids = fields.Many2many('mail.template', string='Email templates')
     default_user_id = fields.Many2one("res.users", string="Default User")
-    default_note = fields.Html(string="Default Note", translate=html_translate)
+    default_note = fields.Html(string="Default Note", translate=True)
 
     #Fields for display purpose only
     initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,

--- a/addons/mail/models/mail_activity_type.py
+++ b/addons/mail/models/mail_activity_type.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools import html_translate
 
 
 class MailActivityType(models.Model):
@@ -73,7 +74,7 @@ class MailActivityType(models.Model):
         help='Actions may trigger specific behavior like opening calendar view or automatically mark as done when a document is uploaded')
     mail_template_ids = fields.Many2many('mail.template', string='Email templates')
     default_user_id = fields.Many2one("res.users", string="Default User")
-    default_note = fields.Html(string="Default Note", translate=True)
+    default_note = fields.Html(string="Default Note", translate=html_translate)
 
     #Fields for display purpose only
     initial_res_model = fields.Selection(selection=_get_model_selection, string='Initial model', compute="_compute_initial_res_model", store=False,

--- a/addons/mail/models/mail_alias.py
+++ b/addons/mail/models/mail_alias.py
@@ -10,6 +10,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Domain
 from odoo.tools import is_html_empty, remove_accents
+from odoo.tools.translate import html_translate
 
 # see rfc5322 section 3.2.3
 atext = r"[a-zA-Z0-9!#$%&'*+\-/=?^_`{|}~]"
@@ -83,7 +84,7 @@ class MailAlias(models.Model):
              "- followers: only followers of the related document or members of following channels\n")
     alias_incoming_local = fields.Boolean('Local-part based incoming detection', default=False)
     alias_bounced_content = fields.Html(
-        "Custom Bounced Message", translate=True,
+        "Custom Bounced Message", translate=html_translate,
         help="If set, this content will automatically be sent out to unauthorized users instead of the default message.")
     alias_status = fields.Selection(
         [

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -5,6 +5,7 @@ from dateutil.relativedelta import relativedelta
 from odoo.exceptions import ValidationError
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
+from odoo.tools.translate import html_translate
 
 
 class MaintenanceStage(models.Model):
@@ -37,7 +38,7 @@ class MaintenanceEquipmentCategory(models.Model):
         default=lambda self: self.env.company)
     technician_user_id = fields.Many2one('res.users', 'Responsible', default=lambda self: self.env.uid)
     color = fields.Integer('Color Index')
-    note = fields.Html('Comments', translate=True)
+    note = fields.Html('Comments', translate=html_translate)
     equipment_ids = fields.One2many('maintenance.equipment', 'category_id', string='Equipment', copy=False)
     equipment_count = fields.Integer(string="Equipment Count", compute='_compute_equipment_count')
     maintenance_ids = fields.One2many('maintenance.request', 'category_id', copy=False)

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -5,7 +5,6 @@ from dateutil.relativedelta import relativedelta
 from odoo.exceptions import ValidationError
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.translate import html_translate
 
 
 class MaintenanceStage(models.Model):
@@ -38,7 +37,7 @@ class MaintenanceEquipmentCategory(models.Model):
         default=lambda self: self.env.company)
     technician_user_id = fields.Many2one('res.users', 'Responsible', default=lambda self: self.env.uid)
     color = fields.Integer('Color Index')
-    note = fields.Html('Comments', translate=html_translate)
+    note = fields.Html('Comments', translate=True)
     equipment_ids = fields.One2many('maintenance.equipment', 'category_id', string='Equipment', copy=False)
     equipment_count = fields.Integer(string="Equipment Count", compute='_compute_equipment_count')
     maintenance_ids = fields.One2many('maintenance.request', 'category_id', copy=False)

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -4,6 +4,7 @@ import logging
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.translate import html_translate
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING
@@ -128,25 +129,25 @@ class PaymentProvider(models.Model):
     # Message fields
     pre_msg = fields.Html(
         string="Help Message", help="The message displayed to explain and help the payment process",
-        translate=True)
+        translate=html_translate)
     pending_msg = fields.Html(
         string="Pending Message",
         help="The message displayed if the order pending after the payment process",
         default=lambda self: _(
             "Your payment has been processed but is waiting for approval."
-        ), translate=True)
+        ), translate=html_translate)
     auth_msg = fields.Html(
         string="Authorize Message", help="The message displayed if payment is authorized",
-        default=lambda self: _("Your payment has been authorized."), translate=True)
+        default=lambda self: _("Your payment has been authorized."), translate=html_translate)
     done_msg = fields.Html(
         string="Done Message",
         help="The message displayed if the order is successfully done after the payment process",
         default=lambda self: _("Your payment has been processed."),
-        translate=True)
+        translate=html_translate)
     cancel_msg = fields.Html(
         string="Cancelled Message",
         help="The message displayed if the order is cancelled during the payment process",
-        default=lambda self: _("Your payment has been cancelled."), translate=True)
+        default=lambda self: _("Your payment has been cancelled."), translate=html_translate)
 
     # Feature support fields
     support_tokenization = fields.Boolean(

--- a/addons/point_of_sale/models/product_tag.py
+++ b/addons/point_of_sale/models/product_tag.py
@@ -1,13 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models
 from odoo.tools import is_html_empty
+from odoo.tools.translate import html_translate
 
 
 class ProductTag(models.Model):
     _name = 'product.tag'
     _inherit = ['product.tag', 'pos.load.mixin']
 
-    pos_description = fields.Html(string='Description', translate=True)
+    pos_description = fields.Html(string='Description', translate=html_translate)
 
     @api.model
     def _load_pos_data_fields(self, config_id):

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -3,7 +3,6 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from collections import defaultdict
 from odoo.tools import SQL, is_html_empty
-from odoo.tools.translate import html_translate
 from itertools import groupby
 from operator import itemgetter
 from datetime import date
@@ -28,7 +27,7 @@ class ProductTemplate(models.Model):
         help="Category used in the Point of Sale.")
     public_description = fields.Html(
         string="Product Description",
-        translate=html_translate,
+        translate=True,
     )
     pos_optional_product_ids = fields.Many2many(
         comodel_name='product.template',

--- a/addons/point_of_sale/models/product_template.py
+++ b/addons/point_of_sale/models/product_template.py
@@ -3,6 +3,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from collections import defaultdict
 from odoo.tools import SQL, is_html_empty
+from odoo.tools.translate import html_translate
 from itertools import groupby
 from operator import itemgetter
 from datetime import date
@@ -27,7 +28,7 @@ class ProductTemplate(models.Model):
         help="Category used in the Point of Sale.")
     public_description = fields.Html(
         string="Product Description",
-        translate=True
+        translate=html_translate,
     )
     pos_optional_product_ids = fields.Many2many(
         comodel_name='product.template',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -9,7 +9,6 @@ from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.image import is_image_size_above
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 PRICE_CONTEXT_KEYS = ['pricelist', 'quantity', 'uom', 'date']
@@ -43,7 +42,7 @@ class ProductTemplate(models.Model):
     name = fields.Char('Name', index='trigram', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1, help='Gives the sequence order when displaying a product list')
     description = fields.Html(
-        'Description', translate=html_translate)
+        'Description', translate=True)
     description_purchase = fields.Text(
         'Purchase Description', translate=True)
     description_sale = fields.Text(

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -9,6 +9,7 @@ from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.image import is_image_size_above
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 PRICE_CONTEXT_KEYS = ['pricelist', 'quantity', 'uom', 'date']
@@ -42,7 +43,7 @@ class ProductTemplate(models.Model):
     name = fields.Char('Name', index='trigram', required=True, translate=True)
     sequence = fields.Integer('Sequence', default=1, help='Gives the sequence order when displaying a product list')
     description = fields.Html(
-        'Description', translate=True)
+        'Description', translate=html_translate)
     description_purchase = fields.Text(
         'Purchase Description', translate=True)
     description_sale = fields.Text(

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -3,6 +3,7 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
+from odoo.tools.translate import html_translate
 
 
 class SaleOrderTemplate(models.Model):
@@ -16,7 +17,7 @@ class SaleOrderTemplate(models.Model):
     company_id = fields.Many2one(comodel_name='res.company', default=lambda self: self.env.company)
 
     name = fields.Char(string="Quotation Template", required=True)
-    note = fields.Html(string="Terms and conditions", translate=True)
+    note = fields.Html(string="Terms and conditions", translate=html_translate)
     sequence = fields.Integer(default=10)
 
     mail_template_id = fields.Many2one(

--- a/addons/sale_management/models/sale_order_template.py
+++ b/addons/sale_management/models/sale_order_template.py
@@ -3,7 +3,6 @@
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
-from odoo.tools.translate import html_translate
 
 
 class SaleOrderTemplate(models.Model):
@@ -17,7 +16,7 @@ class SaleOrderTemplate(models.Model):
     company_id = fields.Many2one(comodel_name='res.company', default=lambda self: self.env.company)
 
     name = fields.Char(string="Quotation Template", required=True)
-    note = fields.Html(string="Terms and conditions", translate=html_translate)
+    note = fields.Html(string="Terms and conditions", translate=True)
     sequence = fields.Integer(default=10)
 
     mail_template_id = fields.Many2one(

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -10,6 +10,7 @@ from textwrap import shorten
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
+from odoo.tools.translate import html_translate
 
 
 class SurveyQuestion(models.Model):
@@ -61,7 +62,7 @@ class SurveyQuestion(models.Model):
     # question generic data
     title = fields.Char('Title', required=True, translate=True)
     description = fields.Html(
-        'Description', translate=True, sanitize=True, sanitize_overridable=True,
+        'Description', translate=html_translate, sanitize=True, sanitize_overridable=True,
         help="Use this field to add additional explanations about your question or to illustrate it with pictures or a video")
     question_placeholder = fields.Char("Placeholder", translate=True, compute="_compute_question_placeholder", store=True, readonly=False)
     background_image = fields.Image("Background Image", compute="_compute_background_image", store=True, readonly=False)

--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -10,7 +10,6 @@ from textwrap import shorten
 
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.translate import html_translate
 
 
 class SurveyQuestion(models.Model):
@@ -62,7 +61,7 @@ class SurveyQuestion(models.Model):
     # question generic data
     title = fields.Char('Title', required=True, translate=True)
     description = fields.Html(
-        'Description', translate=html_translate, sanitize=True, sanitize_overridable=True,
+        'Description', translate=True, sanitize=True, sanitize_overridable=True,
         help="Use this field to add additional explanations about your question or to illustrate it with pictures or a video")
     question_placeholder = fields.Char("Placeholder", translate=True, compute="_compute_question_placeholder", store=True, readonly=False)
     background_image = fields.Image("Background Image", compute="_compute_background_image", store=True, readonly=False)

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -11,7 +11,6 @@ from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import is_html_empty
-from odoo.tools.translate import html_translate
 
 
 class SurveySurvey(models.Model):
@@ -55,10 +54,10 @@ class SurveySurvey(models.Model):
     title = fields.Char('Survey Title', required=True, translate=True)
     color = fields.Integer('Color Index', default=0)
     description = fields.Html(
-        "Description", translate=html_translate, sanitize=True, sanitize_overridable=True,
+        "Description", translate=True, sanitize=True, sanitize_overridable=True,
         help="The description will be displayed on the home page of the survey. You can use this to give the purpose and guidelines to your candidates before they start it.")
     description_done = fields.Html(
-        "End Message", translate=html_translate,
+        "End Message", translate=True,
         help="This message will be displayed when survey is completed")
     background_image = fields.Image("Background Image")
     background_image_url = fields.Char('Background Url', compute="_compute_background_image_url")

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -11,6 +11,7 @@ from odoo import api, exceptions, fields, models, _
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import is_html_empty
+from odoo.tools.translate import html_translate
 
 
 class SurveySurvey(models.Model):
@@ -54,10 +55,10 @@ class SurveySurvey(models.Model):
     title = fields.Char('Survey Title', required=True, translate=True)
     color = fields.Integer('Color Index', default=0)
     description = fields.Html(
-        "Description", translate=True, sanitize=True, sanitize_overridable=True,
+        "Description", translate=html_translate, sanitize=True, sanitize_overridable=True,
         help="The description will be displayed on the home page of the survey. You can use this to give the purpose and guidelines to your candidates before they start it.")
     description_done = fields.Html(
-        "End Message", translate=True,
+        "End Message", translate=html_translate,
         help="This message will be displayed when survey is completed")
     background_image = fields.Image("Background Image")
     background_image_url = fields.Char('Background Url', compute="_compute_background_image_url")

--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -2,8 +2,6 @@ from odoo import api, fields, models, Command
 import json
 import base64
 
-from odoo.tools import html_translate
-
 
 class Web_TourTour(models.Model):
     _name = 'web_tour.tour'
@@ -14,7 +12,7 @@ class Web_TourTour(models.Model):
     step_ids = fields.One2many("web_tour.tour.step", "tour_id")
     url = fields.Char(string="Starting URL", default="/odoo")
     sharing_url = fields.Char(compute="_compute_sharing_url", string="Sharing URL")
-    rainbow_man_message = fields.Html(default="<b>Good job!</b> You went through all steps of this tour.", translate=html_translate)
+    rainbow_man_message = fields.Html(default="<b>Good job!</b> You went through all steps of this tour.", translate=True)
     sequence = fields.Integer(default=1000)
     custom = fields.Boolean(string="Custom")
     user_consumed_ids = fields.Many2many("res.users")

--- a/addons/web_tour/models/tour.py
+++ b/addons/web_tour/models/tour.py
@@ -2,6 +2,8 @@ from odoo import api, fields, models, Command
 import json
 import base64
 
+from odoo.tools import html_translate
+
 
 class Web_TourTour(models.Model):
     _name = 'web_tour.tour'
@@ -12,7 +14,7 @@ class Web_TourTour(models.Model):
     step_ids = fields.One2many("web_tour.tour.step", "tour_id")
     url = fields.Char(string="Starting URL", default="/odoo")
     sharing_url = fields.Char(compute="_compute_sharing_url", string="Sharing URL")
-    rainbow_man_message = fields.Html(default="<b>Good job!</b> You went through all steps of this tour.", translate=True)
+    rainbow_man_message = fields.Html(default="<b>Good job!</b> You went through all steps of this tour.", translate=html_translate)
     sequence = fields.Integer(default=1000)
     custom = fields.Boolean(string="Custom")
     user_consumed_ids = fields.Many2many("res.users")

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -15,7 +15,7 @@ from odoo import api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools.mail import email_normalize, html_to_inner_content, is_html_empty
-from odoo.tools.translate import _, html_translate
+from odoo.tools.translate import _
 
 _logger = logging.getLogger(__name__)
 
@@ -53,7 +53,7 @@ class EventTrack(models.Model):
     user_id = fields.Many2one('res.users', 'Responsible', tracking=True, default=lambda self: self.env.user)
     company_id = fields.Many2one('res.company', related='event_id.company_id')
     tag_ids = fields.Many2many('event.track.tag', string='Tags')
-    description = fields.Html(translate=html_translate, sanitize_attributes=False, sanitize_form=False)
+    description = fields.Html(translate=True, sanitize_attributes=False, sanitize_form=False)
     color = fields.Integer('Agenda Color')
     priority = fields.Selection([
         ('0', 'Low'), ('1', 'Medium'),

--- a/addons/website_forum/models/forum_forum.py
+++ b/addons/website_forum/models/forum_forum.py
@@ -8,7 +8,6 @@ from operator import itemgetter
 from markupsafe import Markup
 
 from odoo import _, api, fields, models
-from odoo.tools.translate import html_translate
 
 MOST_USED_TAGS_COUNT = 5  # Number of tags to track as "most used" to display on frontend
 
@@ -65,11 +64,11 @@ class ForumForum(models.Model):
     authorized_group_id = fields.Many2one('res.groups', 'Authorized Group')
     active = fields.Boolean(default=True)
     faq = fields.Html(
-        'Guidelines', translate=html_translate,
+        'Guidelines', translate=True,
         sanitize=True, sanitize_overridable=True)
     description = fields.Text('Description', translate=True)
     welcome_message = fields.Html(
-        'Welcome Message', translate=html_translate,
+        'Welcome Message', translate=True,
         default=_get_default_welcome_message,
         sanitize_attributes=False, sanitize_form=False)
     default_order = fields.Selection([

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -32,7 +32,7 @@ class HrJob(models.Model):
         """)
 
     description = fields.Html(
-        'Job Description', translate=html_translate,
+        'Job Description', translate=True,
         prefetch=False,
         sanitize_overridable=True,
         sanitize_attributes=False, sanitize_form=False)
@@ -44,7 +44,7 @@ class HrJob(models.Model):
         sanitize_attributes=False, sanitize_form=False)
     job_details = fields.Html(
         'Process Details',
-        translate=html_translate,
+        translate=True,
         help="Complementary information that will appear on the job submission page",
         sanitize_attributes=False,
         default=_get_default_job_details)

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -44,7 +44,7 @@ class HrJob(models.Model):
         sanitize_attributes=False, sanitize_form=False)
     job_details = fields.Html(
         'Process Details',
-        translate=True,
+        translate=html_translate,
         help="Complementary information that will appear on the job submission page",
         sanitize_attributes=False,
         default=_get_default_job_details)

--- a/addons/website_sale_stock/models/product_template.py
+++ b/addons/website_sale_stock/models/product_template.py
@@ -2,7 +2,6 @@
 
 from odoo import api, fields, models
 from odoo.http import request
-from odoo.tools.translate import html_translate
 
 from odoo.addons.website.models import ir_http
 
@@ -14,7 +13,7 @@ class ProductTemplate(models.Model):
 
     available_threshold = fields.Float(string="Show Threshold", default=5.0)
     show_availability = fields.Boolean(string="Show availability Qty", default=False)
-    out_of_stock_message = fields.Html(string="Out-of-Stock Message", translate=html_translate)
+    out_of_stock_message = fields.Html(string="Out-of-Stock Message", translate=True)
 
     def _is_sold_out(self):
         """Return whether the product is sold out (no available quantity).

--- a/addons/website_sale_stock/tests/test_website_sale_stock_multilang.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_multilang.py
@@ -25,6 +25,6 @@ class TestWebsiteSaleStockMultilang(HttpCase):
             'out_of_stock_message': 'Out of stock',
         })
         unavailable_product.update_field_translations('out_of_stock_message', {
-            'fr_FR': {'Out of stock': 'Hors-stock'},
+            'fr_FR': 'Hors-stock',
         })
         self.start_tour("/fr/shop?search=unavailable", 'website_sale_stock_multilang')

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -13,6 +13,7 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.osv import expression
 from odoo.tools import is_html_empty
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -313,8 +314,8 @@ class SlideChannel(models.Model):
     # description
     name = fields.Char('Name', translate=True, required=True)
     active = fields.Boolean(default=True, tracking=100)
-    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
-    description_short = fields.Html('Short Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
+    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
+    description_short = fields.Html('Short Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
     description_html = fields.Html('Detailed Description', translate=tools.html_translate, sanitize_attributes=False, sanitize_form=False)
     channel_type = fields.Selection([
         ('training', 'Training'), ('documentation', 'Documentation')],

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -13,7 +13,6 @@ from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.fields import Domain
 from odoo.osv import expression
 from odoo.tools import is_html_empty
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -314,9 +313,9 @@ class SlideChannel(models.Model):
     # description
     name = fields.Char('Name', translate=True, required=True)
     active = fields.Boolean(default=True, tracking=100)
-    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
-    description_short = fields.Html('Short Description', translate=html_translate, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
-    description_html = fields.Html('Detailed Description', translate=tools.html_translate, sanitize_attributes=False, sanitize_form=False)
+    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on top of the course page, just below the title")
+    description_short = fields.Html('Short Description', translate=True, sanitize_attributes=False, sanitize_form=False, help="The description that is displayed on the course card")
+    description_html = fields.Html('Detailed Description', translate=True, sanitize_attributes=False, sanitize_form=False)
     channel_type = fields.Selection([
         ('training', 'Training'), ('documentation', 'Documentation')],
         string="Course type", default="training", required=True)
@@ -384,7 +383,7 @@ class SlideChannel(models.Model):
         help='Defines how people can enroll to your Course.', copy=False)
     enroll_msg = fields.Html(
         'Enroll Message', help="Message explaining the enroll process",
-        default=_get_default_enroll_msg, translate=tools.html_translate, sanitize_attributes=False)
+        default=_get_default_enroll_msg, translate=True, sanitize_attributes=False)
     enroll_group_ids = fields.Many2many('res.groups', string='Auto Enroll Groups', help="Members of those groups are automatically added as members of the channel.")
     visibility = fields.Selection([
         ('public', 'Everyone'),

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -17,6 +17,7 @@ from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
 from odoo.tools.pdf import PdfFileReader
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -118,7 +119,7 @@ class SlideSlide(models.Model):
     active = fields.Boolean(default=True, tracking=100)
     sequence = fields.Integer('Sequence', default=0)
     user_id = fields.Many2one('res.users', string='Uploaded by', default=lambda self: self.env.uid)
-    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_overridable=True)
+    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False, sanitize_overridable=True)
     channel_id = fields.Many2one('slide.channel', string="Course", required=True, index=True, ondelete='cascade')
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
     is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
@@ -173,7 +174,7 @@ class SlideSlide(models.Model):
     google_drive_id = fields.Char('Google Drive ID of the external URL', compute='_compute_google_drive_id')
     # content - webpage
     html_content = fields.Html(
-        "HTML Content", translate=True,
+        "HTML Content", translate=html_translate,
         sanitize_attributes=False, sanitize_form=False, sanitize_overridable=True,
         help="Custom HTML content for slides of category 'Article'.")
     # content - images

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -17,7 +17,6 @@ from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
 from odoo.tools import html2plaintext, sql
 from odoo.tools.pdf import PdfFileReader
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -119,7 +118,7 @@ class SlideSlide(models.Model):
     active = fields.Boolean(default=True, tracking=100)
     sequence = fields.Integer('Sequence', default=0)
     user_id = fields.Many2one('res.users', string='Uploaded by', default=lambda self: self.env.uid)
-    description = fields.Html('Description', translate=html_translate, sanitize_attributes=False, sanitize_overridable=True)
+    description = fields.Html('Description', translate=True, sanitize_attributes=False, sanitize_overridable=True)
     channel_id = fields.Many2one('slide.channel', string="Course", required=True, index=True, ondelete='cascade')
     tag_ids = fields.Many2many('slide.tag', 'rel_slide_tag', 'slide_id', 'tag_id', string='Tags')
     is_preview = fields.Boolean('Allow Preview', default=False, help="The course is accessible by anyone : the users don't need to join the channel to access the content of the course.")
@@ -174,7 +173,7 @@ class SlideSlide(models.Model):
     google_drive_id = fields.Char('Google Drive ID of the external URL', compute='_compute_google_drive_id')
     # content - webpage
     html_content = fields.Html(
-        "HTML Content", translate=html_translate,
+        "HTML Content", translate=True,
         sanitize_attributes=False, sanitize_form=False, sanitize_overridable=True,
         help="Custom HTML content for slides of category 'Article'.")
     # content - images

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -19,6 +19,7 @@ from odoo.tools import _, frozendict
 from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import unquote
 from odoo.tools.safe_eval import safe_eval, test_python_expr
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 _server_action_logger = _logger.getChild("server_action_safe_eval")
@@ -67,7 +68,7 @@ class IrActionsActions(models.Model):
     path = fields.Char(string="Path to show in the URL")
     help = fields.Html(string='Action Description',
                        help='Optional help text for the users with a description of the target view, such as its usage and purpose.',
-                       translate=True)
+                       translate=html_translate)
     binding_model_id = fields.Many2one('ir.model', ondelete='cascade',
                                        help="Setting a value makes this action available in the sidebar for the given model.")
     binding_type = fields.Selection([('action', 'Action'),

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -19,7 +19,6 @@ from odoo.tools import _, frozendict
 from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import unquote
 from odoo.tools.safe_eval import safe_eval, test_python_expr
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 _server_action_logger = _logger.getChild("server_action_safe_eval")
@@ -68,7 +67,7 @@ class IrActionsActions(models.Model):
     path = fields.Char(string="Path to show in the URL")
     help = fields.Html(string='Action Description',
                        help='Optional help text for the users with a description of the target view, such as its usage and purpose.',
-                       translate=html_translate)
+                       translate=True)
     binding_model_id = fields.Many2one('ir.model', ondelete='cascade',
                                        help="Setting a value makes this action available in the sidebar for the given model.")
     binding_type = fields.Selection([('action', 'Action'),

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -9,6 +9,7 @@ from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command, Domain
 from odoo.tools import html2plaintext, file_open, ormcache
 from odoo.tools.image import image_process
+from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -40,9 +41,9 @@ class ResCompany(models.Model):
     parent_ids = fields.Many2many('res.company', compute='_compute_parent_ids', compute_sudo=True)
     root_id = fields.Many2one('res.company', compute='_compute_parent_ids', compute_sudo=True)
     partner_id = fields.Many2one('res.partner', string='Partner', required=True, index=True)
-    report_header = fields.Html(string='Company Tagline', translate=True, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")
-    report_footer = fields.Html(string='Report Footer', translate=True, help="Footer text displayed at the bottom of all reports.")
-    company_details = fields.Html(string='Company Details', translate=True, help="Header text displayed at the top of all reports.")
+    report_header = fields.Html(string='Company Tagline', translate=html_translate, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")
+    report_footer = fields.Html(string='Report Footer', translate=html_translate, help="Footer text displayed at the bottom of all reports.")
+    company_details = fields.Html(string='Company Details', translate=html_translate, help="Header text displayed at the top of all reports.")
     is_company_details_empty = fields.Boolean(compute='_compute_empty_company_details')
     logo = fields.Binary(related='partner_id.image_1920', default=_get_logo, string="Company Logo", readonly=False)
     # logo_web: do not store in attachments, since the image is retrieved in SQL for

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -9,7 +9,6 @@ from odoo.exceptions import ValidationError, UserError
 from odoo.fields import Command, Domain
 from odoo.tools import html2plaintext, file_open, ormcache
 from odoo.tools.image import image_process
-from odoo.tools.translate import html_translate
 
 _logger = logging.getLogger(__name__)
 
@@ -41,9 +40,9 @@ class ResCompany(models.Model):
     parent_ids = fields.Many2many('res.company', compute='_compute_parent_ids', compute_sudo=True)
     root_id = fields.Many2one('res.company', compute='_compute_parent_ids', compute_sudo=True)
     partner_id = fields.Many2one('res.partner', string='Partner', required=True, index=True)
-    report_header = fields.Html(string='Company Tagline', translate=html_translate, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")
-    report_footer = fields.Html(string='Report Footer', translate=html_translate, help="Footer text displayed at the bottom of all reports.")
-    company_details = fields.Html(string='Company Details', translate=html_translate, help="Header text displayed at the top of all reports.")
+    report_header = fields.Html(string='Company Tagline', translate=True, help="Company tagline, which is included in a printed document's header or footer (depending on the selected layout).")
+    report_footer = fields.Html(string='Report Footer', translate=True, help="Footer text displayed at the bottom of all reports.")
+    company_details = fields.Html(string='Company Details', translate=True, help="Header text displayed at the top of all reports.")
     is_company_details_empty = fields.Boolean(compute='_compute_empty_company_details')
     logo = fields.Binary(related='partner_id.image_1920', default=_get_logo, string="Company Logo", readonly=False)
     # logo_web: do not store in attachments, since the image is retrieved in SQL for

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -1773,42 +1773,6 @@ class TestXMLDuplicateTranslations(TransactionCase):
         self.assertEqual(view1_en_copy.with_context(lang='es_ES').arch_db, self.xml % ('una estudiante', 'una estudiante'))  # 'un estudiante' is dropped
 
 
-class TestHTMLTranslation(TransactionCase):
-    def test_write_non_existing(self):
-        html = '''
-<h1>My First Heading</h1>
-<p>My first paragraph.</p>
-'''
-        company = self.env['res.company'].browse(9999)
-        company.report_footer = html
-        self.assertHTMLEqual(company.report_footer, html)
-        # flushing on non-existing records does not break for scalar fields; the
-        # same behavior is expected for translated fields
-        company.flush_recordset()
-
-    def test_delay_translations_no_term(self):
-        self.env['res.lang']._activate_lang('fr_FR')
-        self.env['res.lang']._activate_lang('nl_NL')
-        Company = self.env['res.company']
-        company0 = Company.create({'name': 'company_1', 'report_footer': '<h1>Knife</h1>'})
-        company0.update_field_translations('report_footer', {'fr_FR': {'Knife': 'Couteau'}})
-
-        for html in ('<h1></h1>', '', False):
-            # delay_translations only works when the written value has at least one translatable term
-            company0.with_context(lang='en_US', delay_translations=True).report_footer = html
-            for lang in ('en_US', 'fr_FR', 'nl_NL'):
-                self.assertEqual(
-                    company0.with_context(lang=lang).report_footer,
-                    html,
-                    f'report_footer for {lang} should be {html}'
-                )
-                self.assertEqual(
-                    company0.with_context(lang=lang, check_translations=True).report_footer,
-                    html,
-                    f'report_footer for {lang} should be {html} when check_translations'
-                )
-
-
 @tagged('post_install', '-at_install')
 class TestLanguageInstallPerformance(TransactionCase):
     def test_language_install(self):

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -2007,9 +2007,9 @@ class TestOrmPrefetch(models.Model):
 
     name = fields.Char('Name', translate=True)
     description = fields.Char('Description', translate=True)
-    html_description = fields.Html('Styled description', translate=True)
+    html_description = fields.Html('Styled description', translate=html_translate)
     rare_description = fields.Char('Rare Description', translate=True, prefetch=False)
-    rare_html_description = fields.Html('Rare Styled description', translate=True, prefetch=False)
+    rare_html_description = fields.Html('Rare Styled description', translate=html_translate, prefetch=False)
     harry = fields.Integer('Harry Potter', prefetch='Harry Potter')
     hermione = fields.Char('Hermione Granger', prefetch='Harry Potter')
     ron = fields.Float('Ron Weasley', prefetch='Harry Potter')

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -571,7 +571,6 @@ class Html(BaseString):
             if not name.startswith('x_') and name_ not in self._tmp:
                 _logger.warning("convert translate to html_translate for field %s", name_)
                 self._tmp.add(name_)
-            attrs['translate'] = html_translate
         return attrs
 
     _related_sanitize = property(attrgetter('sanitize'))

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -544,6 +544,8 @@ class Html(BaseString):
     strip_style: bool = False                 # whether to strip style attributes (removed and therefore not sanitized)
     strip_classes: bool = False               # whether to strip classes attributes
 
+    _tmp = set()
+
     def _get_attrs(self, model_class, name):
         # called by _setup_attrs__(), working together with BaseString._setup_attrs__()
         attrs = super()._get_attrs(model_class, name)
@@ -565,6 +567,10 @@ class Html(BaseString):
         # where not using `html_translate` before and they must remain without `html_translate`.
         # Otherwise, breaks `--test-tags .test_render_field`, for instance.
         elif attrs.get('translate') is True and attrs.get('sanitize', True):
+            name_ = f'{model_class._name}.{name}'
+            if not name.startswith('x_') and name_ not in self._tmp:
+                _logger.warning("convert translate to html_translate for field %s", name_)
+                self._tmp.add(name_)
             attrs['translate'] = html_translate
         return attrs
 

--- a/odoo/orm/fields_textual.py
+++ b/odoo/orm/fields_textual.py
@@ -568,8 +568,8 @@ class Html(BaseString):
         # Otherwise, breaks `--test-tags .test_render_field`, for instance.
         elif attrs.get('translate') is True and attrs.get('sanitize', True):
             name_ = f'{model_class._name}.{name}'
-            if not name.startswith('x_') and name_ not in self._tmp:
-                _logger.warning("convert translate to html_translate for field %s", name_)
+            if not name.startswith('x_') and name_ not in self._tmp and name_ not in KNOWN_TRANSLATE_FIELDS:
+                _logger.warning("HTML field with translate=True and sanitize=True %s", name_)
                 self._tmp.add(name_)
         return attrs
 
@@ -735,3 +735,87 @@ class LangProxyDict(collections.abc.MutableMapping):
 
     def __repr__(self):
         return f"<LangProxyDict lang={self._lang!r} size={len(self._cache)} at {hex(id(self))}>"
+
+
+KNOWN_TRANSLATE_FIELDS = {
+    'account.fiscal.position.note',
+    'account.payment.term.note',
+    'account.tax.description',
+    'account.tax.invoice_legal_notes',
+    'res.company.invoice_terms',
+    'res.company.invoice_terms_html',
+    'appointment.resource.description',
+    'appointment.type.message_confirmation',
+    'appointment.type.message_intro',
+    'ir.actions.act_url.help',
+    'ir.actions.act_window.help',
+    'ir.actions.act_window_close.help',
+    'ir.actions.actions.help',
+    'ir.actions.client.help',
+    'ir.actions.report.help',
+    'ir.actions.server.help',
+    'res.company.company_details',
+    'res.company.report_footer',
+    'res.company.report_header',
+    'event.booth.category.description',
+    'event.event.description',
+    'event.event.ticket_instructions',
+    'event.type.ticket_instructions',
+    'gamification.badge.description',
+    'gamification.karma.rank.description',
+    'gamification.karma.rank.description_motivational',
+    'helpdesk.sla.description',
+    'helpdesk.team.description',
+    # 'hr.appraisal.template.appraisal_employee_feedback_template',  # html_translate
+    # 'hr.appraisal.template.appraisal_manager_feedback_template',  # html_translate
+    'hr.contract.salary.benefit.description',
+    'hr.salary.rule.note',
+    'hr.resume.line.description',
+    'lunch.alert.message',
+    'lunch.product.description',
+    'res.company.lunch_notify_message',
+    'mail.activity.type.default_note',
+    'mail.alias.alias_bounced_content',  # html_translate
+    'mail.template.body_html',  # double check this
+    'maintenance.equipment.category.note',
+    # 'payment.provider.auth_msg',  # html_translate
+    # 'payment.provider.cancel_msg',  # html_translate
+    # 'payment.provider.done_msg',  # html_translate
+    # 'payment.provider.pending_msg',  # html_translate
+    # 'payment.provider.pre_msg',  # html_translate
+    'product.template.public_description',
+    'product.template.description',
+    'room.room.description',
+    'sale.order.template.note',
+    'sale.order.close.reason.retention_message',
+    'res.company.sign_terms',
+    'res.company.sign_terms_html',
+    'survey.question.description',
+    'survey.survey.description',
+    'survey.survey.description_done',
+    # 'test_orm.prefetch.html_description',  html_translate
+    # 'test_orm.prefetch.rare_html_description',  html_translate
+    # 'test_orm.related_translation_1.html',  html_translate
+    # 'test.model.website_description',  html_translate
+    'web_tour.tour.rainbow_man_message',
+    # 'event.sponsor.website_description',  html_translate
+    'event.track.description',
+    'forum.forum.faq',
+    'forum.forum.welcome_message',
+    'hr.job.description',
+    'hr.job.job_details',
+    # 'hr.job.website_description', html_translate
+    # 'im_livechat.channel.website_description', removed
+    # 'res.partner.website_description', html_translate
+    'product.template.out_of_stock_message',
+    # 'product.public.category.website_description', html_translate
+    # 'product.public.category.website_footer', html_translate
+    # 'product.template.description_ecommerce', html_translate
+    # 'product.template.website_description', html_translate
+    'slide.channel.description',
+    'slide.channel.description_html',
+    'slide.channel.description_short',
+    'slide.channel.enroll_msg',
+    'slide.slide.description',
+    'slide.slide.html_content',
+}

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -19,6 +19,7 @@ from odoo.tools import (
     sql,
 )
 from odoo.tools.misc import ReadonlyDict
+from odoo.tools.translate import html_translate
 
 if typing.TYPE_CHECKING:
     from odoo.api import Environment
@@ -381,7 +382,8 @@ def _setup(model: BaseModel):
             if not translate:
                 # patch the field definition by adding an override
                 _logger.debug("Patching %s.%s with translate=True", model_cls._name, name)
-                fields_.append(type(fields_[0])(translate=True))
+                translate = html_translate if fields_[0].type == 'html' else True
+                fields_.append(type(fields_[0])(translate=translate))
         if len(fields_) == 1 and fields_[0]._direct and fields_[0].model_name == model_cls._name:
             model_cls._fields._data__[name] = fields_[0]
         else:

--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -3269,6 +3269,7 @@ class BaseModel(metaclass=MetaModel):
             # falsy values (except emtpy str) are used to void the corresponding translation
             if any(translation and not isinstance(translation, str) for translation in translations.values()):
                 raise UserError(_("Translations for model translated fields only accept falsy values and str"))
+            translations = {k: field.convert_to_cache(v, self) for k, v in translations.items()}
             value_en = translations.get('en_US', True)
             if not value_en and value_en != '':
                 translations.pop('en_US')


### PR DESCRIPTION
Before this PR:

``Fields.Html(translate=True, sanitize=True)``

will be automatically converted to

``Fields.Html(translate=html_translate, sanitize=True)``

After this PR:

Developers always have to explicitly set the ``translate`` attribute to ``True``
or ``html_translate``

As an expected side effect, all manual sanitized translated html fields will be
converted from ``translate=html_translate`` to ``translate=True``

odoo/upgrade#7648
odoo/enterprise#84857
odoo/documentation#13231

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
