### PR TITLE
[FIX] product: fix `_compute_cost_currency_id` in multi-company

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -255,7 +255,7 @@ class ProductTemplate(models.Model):
     def _compute_cost_currency_id(self):
         env_currency_id = self.env.company.currency_id.id
         for template in self:
-            template.cost_currency_id = template.company_id.currency_id.id or env_currency_id
+            template.cost_currency_id = template.company_id.sudo().currency_id.id or env_currency_id
 
     def _compute_template_field_from_variant_field(self, fname, default=False):
         """Sets the value of the given field based on the template variant values


### PR DESCRIPTION
Similar fix as what has already be done in this following commit: https://github.com/odoo/odoo/commit/483024d122565523a8f1788201ecce47c6d1dfd0 In multi-company setups, `product.template` records can be shared, but access to `res.company` may be restricted. To avoid access errors when computing `product.template.cost_currency_id`, use `sudo()` when reading `company_id.currency_id`.

opw: 4744418


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
