### PR TITLE
[FIX] hw_drivers: parigin code generation fix

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -68,12 +68,15 @@ class ConnectionManager(Thread):
         return 14 + 1.01 ** self.n_times_polled
 
     def run(self):
-        while self._should_poll_to_connect_database():
-            if not self.iot_box_registered:
-                self._register_iot_box()
+        # Double loop is needed in case the IoT Box isn't initially connected to the internet
+        while True:
+            while self._should_poll_to_connect_database():
+                if not self.iot_box_registered:
+                    self._register_iot_box()
 
-            self._poll_pairing_result()
-            time.sleep(self._get_next_polling_interval())
+                self._poll_pairing_result()
+                time.sleep(self._get_next_polling_interval())
+            time.sleep(5)
 
     def _should_poll_to_connect_database(self):
         return (

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -628,15 +628,14 @@ def get_conf(key=None, section='iot.box'):
 
 
 def disconnect_from_server():
-    """Disconnect the IoT Box from the server, clears associated caches"""
-    get_odoo_server_url.cache_clear()
+    """Disconnect the IoT Box from the server"""
     update_conf({
         'remote_server': '',
         'token': '',
         'db_uuid': '',
         'enterprise_code': '',
     })
-
+    odoo_restart()
 
 def save_browser_state(url=None, orientation=None):
     """Save the browser state to the file


### PR DESCRIPTION
PR https://github.com/odoo/odoo/pull/207213 modified the logic which was used to fetch a new pairing code from iot proxy.
It made it so that if the IoT Box doesn't initially have internet access it never fetches a pairing code unless you restart odoo.

This PR fixes the logic so that the pairing code is fetched when needed no matter the initial state of the IoT Box
