### PR TITLE
[FIX] account: multivat tax fiscal positions

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -994,7 +994,7 @@ class AccountChartTemplate(models.AbstractModel):
             for _command, _id, rep_line in tax_template.get('repartition_line_ids', []):
                 rep_line['account_id'] = existing_accounts.get(rep_line.get('account_id'))
 
-            # Since Foreign Fiscal Positions and Replacement Taxes are not relevant to the OSS company
+            # Template fiscal positions should not be applied, and the tax mappings cannot be determined
             tax_template.pop('fiscal_position_ids', None)
             tax_template.pop('original_tax_ids', None)
 
@@ -1021,7 +1021,7 @@ class AccountChartTemplate(models.AbstractModel):
                 for idx, child_tax in enumerate(children_taxes):
                     children_taxes[idx] = f"{chart_template_code}_{child_tax}"
                 tax_data['children_tax_ids'] = ','.join(children_taxes)
-        self._load_data(data)
+        return self._load_data(data)
 
     # --------------------------------------------------------------------------------
     # Root template functions

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -300,7 +300,8 @@ class AccountFiscalPosition(models.Model):
         if not template['installed']:
             localization_module = self.env['ir.module.module'].search([('name', '=', template['module'])])
             localization_module.sudo().button_immediate_install()
-        self.env["account.chart.template"]._instantiate_foreign_taxes(self.country_id, self.company_id)
+        created_records = self.env["account.chart.template"]._instantiate_foreign_taxes(self.country_id, self.company_id)
+        created_records.get('account.tax', self.env['account.tax']).fiscal_position_ids += self
 
 
 class AccountFiscalPositionAccount(models.Model):


### PR DESCRIPTION
When using multivat, the taxes imported from another l10n should be assigned to fiscal position creating those taxes.
