### PR TITLE
[FIX] survey: make sure survey is fully translated in frontend

### DIFF
--- a/addons/survey/models/ir_http.py
+++ b/addons/survey/models/ir_http.py
@@ -4,6 +4,19 @@ import re
 from odoo import api, models
 from odoo.http import request
 
+SURVEY_URL_PREFIX_REGEX = re.compile(r"""
+    ^
+    (                            # Optional locale part of the URL
+        /[a-z]{2,3}              # Language (only 2- or 3-letter ISO 639 code)
+                                 #     e.g. fr, kab
+        (_([A-Z]{2}|[0-9]{3}))?  # [Optional] Region (2-letter ISO 3166-1 code or 3-digit UN M.49 code)
+                                 #     e.g. fr_BE, es_419
+        (@[a-zA-Z]+)?            # [Optional] Script (ISO 15924 code)
+                                 #     e.g. sr@Cyrl
+    )?
+    /survey/
+""", re.VERBOSE)
+
 
 class IrHttp(models.AbstractModel):
     _inherit = 'ir.http'
@@ -14,6 +27,11 @@ class IrHttp(models.AbstractModel):
             return super(IrHttp, self.with_context(web_force_installed_langs=True)).get_nearest_lang(lang_code)
         return super().get_nearest_lang(lang_code)
 
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ['survey']
+
     @api.model
     def _is_survey_frontend(self, path):
-        return bool(re.match('/survey/|/[a-z]{2}/survey/|/[a-z]{2}_[A-Z]{2}/survey/', path))
+        return bool(SURVEY_URL_PREFIX_REGEX.match(path))

--- a/addons/survey/static/tests/tours/survey.js
+++ b/addons/survey/static/tests/tours/survey.js
@@ -71,7 +71,7 @@ const survey_steps = (checkPageTranslation) => [
         run: "click",
     }, {
         content: "Click on Submit",
-        trigger: 'button.btn-primary:contains("Submit")',
+        trigger: ".modal-footer button.btn-primary",
         run: "click",
     },
     // Final page


### PR DESCRIPTION
After [this commit][1], a warning message was added when trying to submit a survey. However, its content was not translated because the `survey` module didn't load its translations on the frontend.

This fix makes the translations available in the frontend.

Another bug we encountered is that the regex to determine a survey frontend URL (added in [this commit][2]) did not take into account all possible language codes in Odoo. Therefore, some languages resulted in a 404 page when trying to use them.

This fix adapts the regex to support all language codes in Odoo.

[1]: https://github.com/odoo/odoo/commit/d8ba7013b0f059c157ee172088200c6fc99e0c26
[2]: https://github.com/odoo/odoo/commit/4b4bf6a121d0eb66267b10cb9bafb04c9d3a72ff

[opw-4747797](https://www.odoo.com/odoo/project.task/4747797)