### PR TITLE
[IMP] website: make getSearchDomain async

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/dynamic_snippet.js
@@ -91,7 +91,7 @@ export class DynamicSnippet extends Interaction {
                     "filter_id": parseInt(nodeData.filterId),
                     "template_key": nodeData.templateKey,
                     "limit": parseInt(nodeData.numberOfRecords),
-                    "search_domain": this.getSearchDomain(),
+                    "search_domain": await this.getSearchDomain(),
                     "with_sample": this.withSample,
                 },
                     this.getRpcParameters(),


### PR DESCRIPTION
Make the getSearchDomain function async, allowing us to be sure that the domain is entirely computed before fetching the data.

task-4461289