### PR TITLE
[FIX] product: fix error when opening combo product on website

### DIFF
--- a/addons/product/models/product_combo_item.py
+++ b/addons/product/models/product_combo_item.py
@@ -14,7 +14,7 @@ class ProductComboItem(models.Model):
     product_id = fields.Many2one(
         string="Product",
         comodel_name='product.product',
-        ondelete='cascade',
+        ondelete='restrict',
         domain=[('type', '!=', 'combo')],
         required=True,
         check_company=True,


### PR DESCRIPTION
If a user tries to open a combo product on the website and the combo item
has been deleted, a traceback will appear.

Steps to reproduce the error:
- Install ``website_sale_stock`` module
- Create ``Product A`` > product type: ``Goods`` > Save
- Go to Website > eCommerce > Combo choices > Create New(``Combo choice A``) >
  Add ``Product A`` in combo item
- Create ``Product Combo A`` > product type: ``combo`` > Combo Choices: ``Combo choice A``
- Delete ``Product A``
- Go to Website > Shop > Open ``Product Combo A``

Traceback:
```
File "/home/odoo/src/odoo/addons/website_sale_stock/models/product_combo.py", line 25, in _get_max_quantity
    return max(max_quantities) if (None not in max_quantities) else None
ValueError: max() iterable argument is empty
```

https://github.com/odoo/odoo/blob/4d3b220b0ec6e718f962979b3f271ea161997322/addons/website_sale_stock/models/product_combo.py#L21-L24
Here, when the user deletes the product, ``self.combo_item_ids`` becomes empty,
resulting in ``max_quantities`` being an empty list ([]),
which causes the above traceback.

sentry-6589160704

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
