### PR TITLE
[FIX] hr_holidays : Keep the order of the sub-queries the same

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -49,8 +49,8 @@ class LeaveReport(models.Model):
                 leaves.date_from as date_from,
                 leaves.date_to as date_to, leaves.company_id
                 from (select
-                    allocation.id as allocation_id,
                     null as leave_id,
+                    allocation.id as allocation_id,
                     allocation.employee_id as employee_id,
                     allocation.name as name,
                     allocation.number_of_days as number_of_days,


### PR DESCRIPTION
### Steps to reproduce:
	- Navigate to Time off app -> Reporting -> By type
	- Access any leave record
	- Notice it will open an allocation record form

### Cause:
This is happening as the query we are using to fetch hr.leave.report is not ordered correctly when it comes to fetching the columns.

https://github.com/odoo/odoo/blob/c0f3bff835cc8dbe63d5369de43c76e83ca0018e/addons/hr_holidays/report/hr_leave_report.py#L51-L53

https://github.com/odoo/odoo/blob/c0f3bff835cc8dbe63d5369de43c76e83ca0018e/addons/hr_holidays/report/hr_leave_report.py#L68-L70

in those two sub-queries the order of fetching the allocation_id and leave_id is not the same which cause that leave_id column will be always null and every id value -either leave_id or allocation_id- will be stored in allocation_id column.

### Fix:
Since columns' order matter when fetching sub-queries we unified the order in both queries.

opw-4723952