### PR TITLE
[FIX] im_livechat: redirect from report graph to channel view list

### DIFF
--- a/addons/im_livechat/__manifest__.py
+++ b/addons/im_livechat/__manifest__.py
@@ -83,11 +83,15 @@ Help your customers with this chat, and analyse their feedback.
             'im_livechat/static/src/js/im_livechat_chatbot_steps_one2many.js',
             'im_livechat/static/src/js/im_livechat_chatbot_script_answers_m2m.js',
             'im_livechat/static/src/views/**/*',
+            ('remove', 'im_livechat/static/src/views/lazy/**/*'),
             'im_livechat/static/src/scss/im_livechat_history.scss',
             'im_livechat/static/src/scss/im_livechat_form.scss',
             'im_livechat/static/src/core/common/**/*',
             'im_livechat/static/src/core/public_web/**/*',
             'im_livechat/static/src/core/web/**/*',
+        ],
+        'web.assets_backend_lazy': [
+            "im_livechat/static/src/views/lazy/**/*",
         ],
         'web.assets_unit_tests': [
             'im_livechat/static/tests/**/*',

--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -272,3 +272,14 @@ class Im_LivechatReportChannel(models.Model):
                 for answer_id in id_list
             )
         return result
+
+    @api.model
+    def action_open_discuss_channel_list_view(self, report_channels_domain=()):
+        discuss_channels = self.search_fetch(report_channels_domain, ["channel_id"]).channel_id
+        action = self.env["ir.actions.act_window"]._for_xml_id("im_livechat.discuss_channel_action")
+        action["context"] = {}
+        action["domain"] = [("id", "in", discuss_channels.ids)]
+        action["mobile_view_mode"] = "list"
+        action["view_mode"] = "list"
+        action["views"] = [view for view in action["views"] if view[1] in ("list", "form")]
+        return action

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -52,7 +52,7 @@
             <field name="name">im_livechat.report.channel.graph</field>
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
-                <graph string="Livechat Support Statistics" type="line" stacked="1" sample="1">
+                <graph js_class="im_livechat.channel_report_graph_views" string="Livechat Support Statistics" type="line" stacked="1" sample="1">
                     <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="has_call" invisible="1"/>
                     <field name="percentage_of_calls" type="measure" widget="percentage"/>

--- a/addons/im_livechat/static/src/views/lazy/im_livechat_channel_report_graph_view.js
+++ b/addons/im_livechat/static/src/views/lazy/im_livechat_channel_report_graph_view.js
@@ -1,0 +1,20 @@
+import { registry } from "@web/core/registry";
+import { GraphRenderer } from "@web/views/graph/graph_renderer";
+import { graphView } from "@web/views/graph/graph_view";
+
+class ImLivechatChannelReportGraphRenderer extends GraphRenderer {
+    async onGraphClickedFinal(domain) {
+        const action = this.env.services.orm.call(
+            "im_livechat.report.channel",
+            "action_open_discuss_channel_list_view",
+            [],
+            { report_channels_domain: domain }
+        );
+        this.env.services.action.doAction(action);
+    }
+}
+
+registry.category("views").add("im_livechat.channel_report_graph_views", {
+    ...graphView,
+    Renderer: ImLivechatChannelReportGraphRenderer,
+});


### PR DESCRIPTION
Clicking on the report channel graph view should redirect to the discuss channels list, not the report one.

task-4775828

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
