### PR TITLE
[FIX] mail: better size for chat window im status

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -63,7 +63,7 @@
 }
 
 .o-mail-ChatWindow-imStatus {
-    bottom: -2px;
+    bottom: 2px;
     right: -2px;
 }
 

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -132,7 +132,7 @@
         'ps-2': !hasActionsMenu,
     }">
         <img t-if="thread" class="rounded-3 o_object_fit_cover" t-att-src="thread.parent_channel_id?.avatarUrl ?? thread.avatarUrl" alt="Thread Image"/>
-        <ImStatus t-if="showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="thread.correspondent"/>
+        <ImStatus t-if="showImStatus" className="'o-mail-ChatWindow-imStatus position-absolute'" member="thread.correspondent" size="'sm'"/>
     </div>
     <t t-if="thread?.parent_channel_id">
         <span class="fw-bold small ms-1 p-1 opacity-75 opacity-100-hover cursor-pointer o-hover-text-underline rounded fs-6" t-esc="thread.parent_channel_id.displayName" title="Open Channel" t-ref="parentChannel" t-on-click.stop="() => this.thread.parent_channel_id.open({ focus: true })"/>

--- a/addons/mail/static/src/core/common/im_status.scss
+++ b/addons/mail/static/src/core/common/im_status.scss
@@ -7,8 +7,8 @@
     }
 
     &.o-sm i {
-        width: $font-size-sm;
-        height: $font-size-sm;
+        width: 0.65rem; // matches .o-xsmaller
+        height: 0.65rem;
     }
 
     .o-away {

--- a/addons/mail/static/src/core/common/im_status.xml
+++ b/addons/mail/static/src/core/common/im_status.xml
@@ -23,7 +23,7 @@
                     </t>
                     <div t-if="props.member?.isTyping" class="rounded-pill" style="padding: 1px;" t-att-class="{ 'bg-300': env.inChatBubble, 'bg-inherit': !env.inChatBubble }">
                         <div class="bg-success rounded-pill" style="padding: 3px;">
-                            <Typing member="props.member" channel="props.member.threadAsTyping" size="'md'" displayText="false" />
+                            <Typing member="props.member" channel="props.member.threadAsTyping" size="['sm', 'smaller'].includes(props.size) ? 'sm' : 'md'" displayText="false" />
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
Before this commit, the size of im status in chat window was too big, making the avatar hard to see and also it overlaps with the bottom of chat window header.

This comes from avatar being small, and the IM status is using the default `md` size, which makes it too big.

This commit fixes the issue by using `sm` size for better size. The position of IM status as been adjusted as a consequence, and also the around master + "..." typing status have been adjusted to take into account the smaller version of IM status.