### PR TITLE
[FIX] web: fix scroll CP on small screen

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.js
+++ b/addons/web/static/src/search/control_panel/control_panel.js
@@ -49,9 +49,12 @@ export class ControlPanel extends Component {
                 return;
             }
             const scrollingEl = this.getScrollingElement();
+            this.scrollingElementResizeObserver.observe(scrollingEl);
             scrollingEl.addEventListener("scroll", this.onScrollThrottledBound);
             this.root.el.style.top = "0px";
+            this.scrollingElementHeight = scrollingEl.scrollHeight;
             return () => {
+                this.scrollingElementResizeObserver.unobserve(scrollingEl);
                 scrollingEl.removeEventListener("scroll", this.onScrollThrottledBound);
             };
         });
@@ -93,6 +96,16 @@ export class ControlPanel extends Component {
             }
         });
     }
+
+    scrollingElementResizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+            if (this.scrollingElementHeight !== entry.target.scrollingElementHeight) {
+                this.oldScrollTop +=
+                    entry.target.scrollingElementHeight - this.scrollingElementHeight;
+                this.scrollingElementHeight = entry.target.scrollingElementHeight;
+            }
+        }
+    });
 
     getBreadcrumbTooltip({ name }) {
         return _t("Back to “%s”", name);


### PR DESCRIPTION
This commit, fixes the scroll of the control panel when we opened the search bar.
The bug happened because when we scroll we save the last scroll position into `oldScrollTop` variable. But when we "open" the search bar a "new line" (search input) is rendered so the height of the scrolling element is increase (by the height of the search input line). Also, a scroll is triggered so the view remains at the same position. But the `oldScrollTop` is not adapted to reflect the new height of the scrolling element.
When the new delta was calculated (in the scroll handler) to set the top position of the control panel, a wrong value was set as there was an additional offset of the height of the "search input line".

This commit adds an ResizeObserver to observe the scrolling element and so adapt the `oldScrollTop` variable to adapt the delta of its height.

task-4466063

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
