### PR TITLE
[FIX] mail: prevent nested MSO wrappers

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -567,7 +567,7 @@ export function classToStyle(element, cssRules) {
         ) {
             writes.push(() => {
                 node.before(
-                    _createMso(`<table align="center" border="0"
+                    createMso(`<table align="center" border="0"
                     role="presentation" cellpadding="0" cellspacing="0"
                     style="border-radius: 6px; border-collapse: separate !important;">
                         <tbody>
@@ -580,7 +580,7 @@ export function classToStyle(element, cssRules) {
                     `)
                 );
                 node.after(
-                    _createMso(`</td>
+                    createMso(`</td>
                         </tr>
                     </tbody>
                 </table>`)
@@ -668,16 +668,16 @@ function enforceTablesResponsivity(element) {
             td.removeAttribute("width");
             if (index === 0) {
                 div.before(
-                    _createMso(`
+                    createMso(`
                     <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="width: 100%;">
                         <tr>
                             <td valign="top" style="width: ${width};">`)
                 );
             } else {
-                div.before(_createMso(`</td><td valign="top" style="width: ${width};">`));
+                div.before(createMso(`</td><td valign="top" style="width: ${width};">`));
             }
             if (index === tds.length - 1) {
-                div.after(_createMso(`</td></tr></table>`));
+                div.after(createMso(`</td></tr></table>`));
             }
             index++;
         }
@@ -799,7 +799,7 @@ function enforceImagesResponsivity(element) {
     // Remove the height attribute in card images so they can resize
     // responsively, but leave it for Outlook.
     for (const image of element.querySelectorAll('img[width="100%"][height]')) {
-        image.before(_createMso(image.outerHTML));
+        image.before(createMso(image.outerHTML));
         image.classList.add("mso-hide");
         image.removeAttribute("height");
     }
@@ -830,7 +830,7 @@ export async function toInline(element, cssRules) {
         clone.setAttribute("width", width);
         clone.style.setProperty("width", width + "px");
         clone.style.removeProperty("max-width");
-        image.before(_createMso(clone.outerHTML));
+        image.before(createMso(clone.outerHTML));
         _hideForOutlook(image);
     }
 
@@ -908,7 +908,7 @@ function flattenBackgroundImages(element) {
         const vml = _backgroundImageToVml(backgroundImage);
         if (vml) {
             // Put the Outlook version after the original one in an mso conditional.
-            backgroundImage.after(_createMso(vml));
+            backgroundImage.after(createMso(vml));
             // Hide the original element for Outlook.
             backgroundImage.classList.add("mso-hide");
         }
@@ -1396,7 +1396,7 @@ function responsiveToStaticForOutlook(element) {
             }
         }
         // The opening tag of `outlookTd` is for Outlook.
-        td.before(_createMso(outlookTd.outerHTML.replace("</td>", "")));
+        td.before(createMso(outlookTd.outerHTML.replace("</td>", "")));
         // The opening tag of `td` is for the others.
         _hideForOutlook(td, "opening");
     }
@@ -1596,8 +1596,15 @@ function _createColumnGrid() {
  * @param {string} content
  * @returns {Comment}
  */
-function _createMso(content = "") {
-    return document.createComment(`[if mso]>${content}<![endif]`);
+export function createMso(content = "") {
+    // We remove comments having opposite condition from the one we will insert
+    // We remove comment tags having the same condition
+    const showRegex = /<!--\[if\s+mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    const hideRegex = /<!--\[if\s+!mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    let contentToInsert = content;
+    contentToInsert = contentToInsert.replace(showRegex, (matchedContent, group) => group);
+    contentToInsert = contentToInsert.replace(hideRegex, "");
+    return document.createComment(`[if mso]>${contentToInsert}<![endif]`);
 }
 /**
  * Return a table element, with its default styles and attributes, as well as

--- a/addons/mail/static/tests/inline/convert_inline.test.js
+++ b/addons/mail/static/tests/inline/convert_inline.test.js
@@ -3,6 +3,7 @@ import {
     bootstrapToTable,
     cardToTable,
     classToStyle,
+    createMso,
     formatTables,
     getCSSRules,
     listGroupToTable,
@@ -1419,5 +1420,26 @@ describe("Convert classes to inline styles", () => {
         );
 
         // @todo to adapt when hoot has a better way to remove it
+    });
+});
+
+describe("Properly add MSO conditions", () => {
+    test("Create mso properly", async () => {
+        expect(createMso("<div>abcde</div>").nodeValue).toEqual(
+            `[if mso]><div>abcde</div><![endif]`,
+            { message: "Should wrap the content in mso condition" }
+        );
+
+        expect(
+            createMso("<div>ef<!--[if mso]><div>abcd</div><![endif]-->gh</div>").nodeValue
+        ).toEqual(`[if mso]><div>ef<div>abcd</div>gh</div><![endif]`, {
+            message: "Should wrap the content inside one mso condition",
+        });
+
+        expect(
+            createMso("<div>ef<!--[if !mso]><div>abcd</div><![endif]-->gh</div>").nodeValue
+        ).toEqual(`[if mso]><div>efgh</div><![endif]`, {
+            message: "Should remove nested mso hide condition",
+        });
     });
 });


### PR DESCRIPTION
Problem:
Adding a document when creating a new email template using `/media`
results in duplicated content on save.

Cause:
During HTML processing on save, `flattenBackgroundImages` wraps
elements with inline background images (`style*=background-image`)
in MSO-specific comments: `<!--[if mso]><![endif]-->`.

However, if multiple such elements are nested, they are each wrapped,
resulting in invalid nested comments and broken layout.

Solution:
Since the two conditions are opposites, we remove completely the content
of the nested comment if it has oppisite condition otherwise we just
remove the comment tags since they will be replaced with the upper
comment

Fixed in `web_editor` in https://github.com/odoo/odoo/commit/fcedeb63f5b5da6758e75d02f0c1d4f3b965adc1

Steps to reproduce:
1. Create a new email template.
2. Add a document using `/media`.
3. Save.
→ The content is duplicated or layout is broken.

opw-4775908

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
