### PR TITLE
[FIX] web: remove useless z-index in kanban

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -224,7 +224,7 @@
         margin-top: -1px;
         margin-bottom: 0px;
         min-width: 9rem;
-    
+
         // Records colours
         @include o-kanban-record-color;
     }
@@ -287,7 +287,7 @@
                 cursor: default;
             }
         }
-       
+
         &.o_kanban_hover {
             background-color: var(--KanbanColumn__highlight-background) !important;
             box-shadow: -1px 0px 0px 0px var(--KanbanColumn__highlight-border) inset,
@@ -319,12 +319,6 @@
 
     .o_quick_create_folded {
         top: map-get($spacers, 3);
-    }
-
-    .o_column_quick_create,
-    .o_kanban_group:not(.o_column_folded) .o_kanban_header_title {
-        // Makes them come on top of the "no-content" background gradient.
-        z-index: calc(var(--o-view-nocontent-zindex) + 1);
     }
 
     .o_group_draggable .o_column_title {


### PR DESCRIPTION
This commit removes the z-index priority of kanban groups, headers and quick create over the no-content helper since it became useless with https://github.com/odoo/odoo/pull/148138 and can now cause display issues when these elements are on top of each other (which can happen with the quick create column).

task-4778356
