### PR TITLE
[ADD] l10n_ar_website_sale: prices with and without taxes - legal req

### DIFF
--- a/addons/l10n_ar_website_sale/__init__.py
+++ b/addons/l10n_ar_website_sale/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_ar_website_sale/__manifest__.py
+++ b/addons/l10n_ar_website_sale/__manifest__.py
@@ -1,0 +1,26 @@
+{
+    'name': 'Argentinean eCommerce',
+    'version': '1.0',
+    'category': 'Accounting/Localizations/Website',
+    'countries': ['ar'],
+    'icon': '/base/static/img/country_flags/ar.png',
+    'description': """Bridge Website Sale for Argentina""",
+    'depends': [
+        'website_sale',
+        'l10n_ar',
+    ],
+    'data': [
+        'views/res_config_settings_views.xml',
+        'views/templates.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'l10n_ar_website_sale/static/src/js/*.js',
+            'l10n_ar_website_sale/static/src/scss/*.scss',
+        ]
+    },
+    'installable': True,
+    'auto_install': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ar_website_sale/i18n/es_419.po
+++ b/addons/l10n_ar_website_sale/i18n/es_419.po
@@ -1,0 +1,61 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ar_website_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.4a1+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-23 04:58+0000\n"
+"PO-Revision-Date: 2025-05-23 04:58+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_res_config_settings
+msgid "Config Settings"
+msgstr "Ajustes de Configuración"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_product_template__display_name
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__display_name
+msgid "Display Name"
+msgstr "Nombre Mostrado"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__l10n_ar_website_sale_show_both_prices
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__l10n_ar_website_sale_show_both_prices
+msgid "Display Price without National Taxes"
+msgstr "Mostrar Precio sin Impuestos Nacionales"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_product_template__id
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__id
+msgid "ID"
+msgstr "ID"
+
+#. module: l10n_ar_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.l10n_ar_website_sale_products_item_inherit
+msgid "Precio s/Imp. Nac."
+msgstr "Precio s/Imp. Nac."
+
+#. module: l10n_ar_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.l10n_ar_website_sale_product_price_inherit
+msgid "Precio s/Imp. Nac.:"
+msgstr "Precio s/Imp. Nac.:"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_product_template
+msgid "Product"
+msgstr "Producto"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_website
+msgid "Website"
+msgstr "Website"

--- a/addons/l10n_ar_website_sale/i18n/l10n_ar_website_sale.pot
+++ b/addons/l10n_ar_website_sale/i18n/l10n_ar_website_sale.pot
@@ -1,0 +1,61 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_ar_website_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.4a1+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-22 11:07+0000\n"
+"PO-Revision-Date: 2025-05-22 11:07+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_product_template__display_name
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__l10n_ar_website_sale_show_both_prices
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__l10n_ar_website_sale_show_both_prices
+msgid "Display Price without National Taxes"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_product_template__id
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_res_config_settings__id
+#: model:ir.model.fields,field_description:l10n_ar_website_sale.field_website__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.l10n_ar_website_sale_products_item_inherit
+msgid "Precio s/Imp. Nac."
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_ar_website_sale.l10n_ar_website_sale_product_price_inherit
+msgid "Precio s/Imp. Nac.:"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: l10n_ar_website_sale
+#: model:ir.model,name:l10n_ar_website_sale.model_website
+msgid "Website"
+msgstr ""

--- a/addons/l10n_ar_website_sale/models/__init__.py
+++ b/addons/l10n_ar_website_sale/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_template
+from . import res_config_settings
+from . import website

--- a/addons/l10n_ar_website_sale/models/product_template.py
+++ b/addons/l10n_ar_website_sale/models/product_template.py
@@ -1,0 +1,84 @@
+from odoo import models
+from odoo.http import request
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    def _get_sales_prices(self, website):
+        '''
+        Resolution 4/2025 requires us to display both prices on the e-commerce site:
+            - Price including taxes
+            - Price excluding taxes
+
+        If the website is configured to use tax-included pricing, we calculate the tax-excluded
+        price separately. This tax-excluded price is displayed on the shop page (on both list and grid views).
+        '''
+
+        res = super()._get_sales_prices(website)
+        fiscal_position_id = request.fiscal_position
+        pricelist_prices = request.pricelist._compute_price_rule(self, 1.0)
+
+        if (
+            website
+            and website.company_id.country_code == 'AR'
+            and website.l10n_ar_website_sale_show_both_prices
+            and website.show_line_subtotals_tax_selection == 'tax_included'
+        ):
+            for template_id, template_val in res.items():
+                # Get applicable taxes for the product and map them using the website's FPOS
+                template = self.env['product.template'].browse(template_id)
+                product_taxes = template.sudo().taxes_id._filter_taxes_by_company(self.env.company)
+                mapped_taxes = fiscal_position_id.map_tax(product_taxes)
+
+                # Compute the tax-excluded value
+                total_excluded_value = mapped_taxes.compute_all(
+                    price_unit=pricelist_prices[template.id][0],
+                    currency=website.currency_id,
+                    product=template,
+                )['total_excluded']
+
+                # Store the tax-excluded price in the res for use in showing both prices
+                res[template_id]['l10n_ar_price_tax_excluded'] = total_excluded_value
+
+        return res
+
+    def _get_additionnal_combination_info(self, product_or_template, quantity, date, website):
+        combination_info = super()._get_additionnal_combination_info(
+            product_or_template, quantity, date, website
+        )
+        pricelist_prices = request.pricelist._compute_price_rule(self, 1.0)
+
+        if (
+            website
+            and website.company_id.country_code == 'AR'
+            and website.l10n_ar_website_sale_show_both_prices
+            and website.show_line_subtotals_tax_selection == 'tax_included'
+        ):
+            # Get applicable taxes for the product and map them using the website's FPOS
+            product_taxes = product_or_template.sudo().taxes_id._filter_taxes_by_company(self.env.company)
+            mapped_taxes = request.fiscal_position.map_tax(product_taxes)
+
+            # Compute price per unit of product or template
+            unit_price = (
+                pricelist_prices[self.id][0]
+                if product_or_template._name == 'product.template'
+                else product_or_template.lst_price
+            )
+
+            # Compute the tax-excluded value
+            total_excluded_value = mapped_taxes.compute_all(
+                price_unit=unit_price,
+                currency=website.currency_id,
+                product=product_or_template,
+            )['total_excluded']
+
+            # Check if a discount is applied and adjust the tax-excluded price accordingly
+            if combination_info['has_discounted_price']:
+                discount_percent = (combination_info['list_price'] - combination_info['price']) / combination_info['list_price']
+                total_excluded_value = total_excluded_value * (1 - discount_percent)
+
+            # Store the tax-excluded price in the res for use in showing both prices
+            combination_info['l10n_ar_price_tax_excluded'] = total_excluded_value
+
+        return combination_info

--- a/addons/l10n_ar_website_sale/models/res_config_settings.py
+++ b/addons/l10n_ar_website_sale/models/res_config_settings.py
@@ -1,0 +1,11 @@
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = 'res.config.settings'
+
+    # Website Dependent Settings
+    l10n_ar_website_sale_show_both_prices = fields.Boolean(
+        related='website_id.l10n_ar_website_sale_show_both_prices',
+        readonly=False,
+    )

--- a/addons/l10n_ar_website_sale/models/website.py
+++ b/addons/l10n_ar_website_sale/models/website.py
@@ -1,0 +1,27 @@
+from odoo import api, fields, models
+
+
+class Website(models.Model):
+    _inherit = 'website'
+
+    l10n_ar_website_sale_show_both_prices = fields.Boolean(
+        string="Display Price without National Taxes",
+        compute='_compute_l10n_ar_website_sale_show_both_prices',
+        readonly=False,
+        store=True,
+    )
+
+    @api.depends('company_id')
+    def _compute_l10n_ar_website_sale_show_both_prices(self):
+        for website in self:
+            website.l10n_ar_website_sale_show_both_prices = (
+                website.company_id.account_fiscal_country_id.code == 'AR'
+            )
+
+    @api.depends('company_id.account_fiscal_country_id')
+    def _compute_show_line_subtotals_tax_selection(self):
+        # EXTENDS 'website_sale'
+        super()._compute_show_line_subtotals_tax_selection()
+        for website in self:
+            if website.company_id.account_fiscal_country_id.code == 'AR':
+                website.show_line_subtotals_tax_selection = 'tax_included'

--- a/addons/l10n_ar_website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/l10n_ar_website_sale/static/src/js/sale_variant_mixin.js
@@ -1,0 +1,16 @@
+import { WebsiteSale } from '@website_sale/js/website_sale';
+
+WebsiteSale.include({
+    /**
+     * @override
+     * Updates the product's excluded price based on the selected variant.
+     * Ensuring availability info stays accurate.
+     */
+    _onChangeCombination(ev, $parent, combination) {
+        this._super.apply(this, arguments);
+        if ($parent.find('.o_l10n_ar_price_tax_excluded .oe_currency_value').length != 0){
+            const $l10n_ar_price_tax_excluded = $parent.find('.o_l10n_ar_price_tax_excluded .oe_currency_value');
+            $l10n_ar_price_tax_excluded.text(this._priceToStr(combination.l10n_ar_price_tax_excluded));
+        }
+    },
+})

--- a/addons/l10n_ar_website_sale/static/src/scss/product_configurator.scss
+++ b/addons/l10n_ar_website_sale/static/src/scss/product_configurator.scss
@@ -1,0 +1,11 @@
+.o_wsale_layout_list{
+    .o_wsale_product_sub{
+        .o_wsale_product_btn:has(.btn) + .o_l10n_ar_product_price {
+            text-align: end;
+        }
+        .o_wsale_product_btn:not(:has(.btn)) + .o_l10n_ar_product_price {
+            text-align: start;
+        }
+    
+    }
+}

--- a/addons/l10n_ar_website_sale/tests/__init__.py
+++ b/addons/l10n_ar_website_sale/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_l10n_ar_website_sale

--- a/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
+++ b/addons/l10n_ar_website_sale/tests/test_l10n_ar_website_sale.py
@@ -1,0 +1,121 @@
+from datetime import datetime
+
+from odoo.addons.l10n_ar.tests.common import TestAr
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestL10nArWebsiteSale(WebsiteSaleCommon, TestAr):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Set up Argentina-specific test company and website
+        cls.ar_company = cls.company_data['company']
+        cls.ar_website = cls.env['website'].create({
+            'name': 'AR Website',
+            'company_id': cls.ar_company.id,
+        })
+
+        # Create a base product template with default tax
+        cls.product_1 = cls.env['product.template'].create({
+            'name': 'Product 1',
+            'is_published': True,
+            'list_price': 1000,
+            'taxes_id': cls.env['account.chart.template'].ref('ri_tax_vat_21_ventas'),
+        })
+
+        # Create color attribute and values
+        cls.color_attribute = cls.env['product.attribute'].create({
+            'name': 'Color',
+            'display_type': 'color',
+        })
+        cls.color_white = cls.env['product.attribute.value'].create({
+            'name': 'White',
+            'html_color': '#FFFFFF',
+            'attribute_id': cls.color_attribute.id,
+        })
+        cls.color_black = cls.env['product.attribute.value'].create({
+            'name': 'Black',
+            'html_color': '#000000',
+            'attribute_id': cls.color_attribute.id,
+        })
+
+    def assertDictContains(self, actual_dict, expected_subset):
+        """Assert that actual_dict contains all key-value pairs from expected_subset."""
+        for key, expected_value in expected_subset.items():
+            self.assertEqual(actual_dict.get(key), expected_value)
+
+    def _get_combination_info(self, product_id=None, quantity=1):
+        """Helper method to retrieve combination info for a product."""
+        with MockRequest(self.env, website=self.ar_website):
+            return self.product_1._get_additionnal_combination_info(
+                product_or_template=product_id or self.product_1,
+                quantity=quantity,
+                date=datetime(2025, 5, 21),
+                website=self.ar_website
+            )
+
+    def test_default_website_sale_legal_values(self):
+        """Ensure legal default values are applied on AR website."""
+        self.assertEqual(self.ar_website.l10n_ar_website_sale_show_both_prices, True)
+        self.assertEqual(self.ar_website.show_line_subtotals_tax_selection, 'tax_included')
+
+    def test_price_calculation_with_tax_changes(self):
+        """Test list price and tax excluded price calculations for various tax setups."""
+        with self.subTest(scenario="Single 21% VAT - tax excluded"):
+            combo = self._get_combination_info()
+            self.assertDictContains(combo, {
+                'list_price': 1210.00,  # 1000 + 21%
+                'l10n_ar_price_tax_excluded': 1000.00,
+            })
+
+        with self.cr.savepoint():
+            with self.subTest(scenario="Mixed taxes - 10.5% excluded + 27% included"):
+                template = self.env['account.chart.template']
+                tax_27_included = template.ref('ri_tax_vat_27_ventas')
+                tax_10_5_excluded = template.ref('ri_tax_vat_10_ventas')
+
+                tax_27_included.price_include = True
+                tax_10_5_excluded.price_include = False
+
+                self.product_1.taxes_id = (tax_27_included + tax_10_5_excluded).ids
+                combo = self._get_combination_info()
+                self.assertDictContains(combo, {
+                    'list_price': 1082.68,                 # Computed price including all taxes
+                    'l10n_ar_price_tax_excluded': 787.40,  # Reverse calculated base price
+                })
+
+    def test_product_variant_prices_with_attributes(self):
+        """Test variant-specific price calculation with color attribute values."""
+        self.product_1.taxes_id = self.env['account.chart.template'].ref('ri_tax_vat_21_ventas')
+
+        # Add attribute line and values to product template
+        attribute_line = self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': self.product_1.id,
+            'attribute_id': self.color_attribute.id,
+            'value_ids': [(6, 0, [self.color_white.id, self.color_black.id])]
+        })
+
+        # Set price extras for each variant
+        attribute_line.product_template_value_ids[0].price_extra = 100  # White
+        attribute_line.product_template_value_ids[1].price_extra = 200  # Black
+
+        white_variant = self.product_1.product_variant_ids[0]
+        black_variant = self.product_1.product_variant_ids[1]
+
+        with self.subTest(scenario="White variant with 100 extra + 21% VAT"):
+            combo = self._get_combination_info(product_id=white_variant)
+            self.assertDictContains(combo, {
+                'list_price': 1331.00,                # (1000+100) + 21%
+                'l10n_ar_price_tax_excluded': 1100.00,
+            })
+
+        with self.subTest(scenario="Black variant with 200 extra + 21% VAT"):
+            combo = self._get_combination_info(product_id=black_variant)
+            self.assertDictContains(combo, {
+                'list_price': 1452.00,                # (1000+200) + 21%
+                'l10n_ar_price_tax_excluded': 1200.00,
+            })

--- a/addons/l10n_ar_website_sale/views/res_config_settings_views.xml
+++ b/addons/l10n_ar_website_sale/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id='res_config_settings_view_form' model='ir.ui.view'>
+        <field name='name'>res.config.settings.view.form.inherit.website.sale</field>
+        <field name='model'>res.config.settings</field>
+        <field name='inherit_id' ref='website.res_config_settings_view_form'/>
+        <field name='arch' type='xml'>
+            <setting id='website_tax_inclusion_setting' position='inside'>
+                <div invisible='country_code != "AR" or show_line_subtotals_tax_selection != "tax_included"'>
+                    <field name='l10n_ar_website_sale_show_both_prices'/>
+                    <label for='l10n_ar_website_sale_show_both_prices'/>
+                </div>
+            </setting>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/l10n_ar_website_sale/views/templates.xml
+++ b/addons/l10n_ar_website_sale/views/templates.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id='l10n_ar_website_sale_product_price_inherit' inherit_id='website_sale.product_price'>
+        <xpath expr='//div[1]'>
+            <small t-if='combination_info.get("l10n_ar_price_tax_excluded")' class='h6 text-muted'>
+                Precio s/Imp. Nac.:
+                <span
+                    class='o_l10n_ar_price_tax_excluded'
+                    t-out='combination_info["l10n_ar_price_tax_excluded"]'
+                    t-options='{
+                        "widget": "monetary",
+                        "display_currency": website.currency_id,
+                    }'
+                />
+            </small>
+        </xpath>
+    </template>
+
+    <template id='l10n_ar_website_sale_products_item_inherit' inherit_id='website_sale.products_item'>
+        <xpath expr='//div[hasclass("product_price")]' position='attributes'>
+            <attribute name='t-attf-class' add='o_l10n_ar_product_price'/>
+        </xpath>
+        <xpath expr='//div[hasclass("product_price")]' position='inside'>
+            <small t-if='template_price_vals.get("l10n_ar_price_tax_excluded")' class='d-block mt-1 text-muted'>
+                Precio s/Imp. Nac.
+                <span
+                    class='o_l10n_ar_price_tax_excluded'
+                    t-out='template_price_vals["l10n_ar_price_tax_excluded"]'
+                    t-options='{
+                        "widget": "monetary",
+                        "display_currency": website.currency_id,
+                    }'
+                />
+            </small>
+        </xpath>
+    </template>
+
+</odoo>

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -67,8 +67,9 @@ class Website(models.Model):
             ('tax_excluded', "Tax Excluded"),
             ('tax_included', "Tax Included"),
         ],
-        required=True,
-        default='tax_excluded',
+        compute='_compute_show_line_subtotals_tax_selection',
+        readonly=False,
+        store=True,
     )
 
     add_to_cart_action = fields.Selection(
@@ -203,6 +204,11 @@ class Website(models.Model):
         for website in self:
             if website.send_abandoned_cart_email:
                 website.send_abandoned_cart_email_activation_time = fields.Datetime.now()
+
+    @api.depends('company_id.account_fiscal_country_id')
+    def _compute_show_line_subtotals_tax_selection(self):
+        for website in self:
+            website.show_line_subtotals_tax_selection = 'tax_excluded'
 
     #=== SELECTION METHODS ===#
 


### PR DESCRIPTION
Resolution 4/2025 requires us to display both prices on the e-commerce site:
- Price including taxes
- Price excluding taxes

If the website is configured to use `tax_included` pricing, we calculate the `tax_excluded` price separately. This `tax_excluded` price is displayed on the shop page (on both list and grid views).

Reference: https://www.argentina.gob.ar/normativa/nacional/resoluci%C3%B3n-4-2025-408455

Task-4765886

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
