### PR TITLE
[IMP] discuss: add missing comment

### DIFF
--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -142,6 +142,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (_author_to_store)
     #       - fetch user (_author_to_store)
     #       - _compute_rating_stats
+    #   1: filtering res_partner (_compute_im_status)
     _query_count_discuss_channels = 59
 
     def setUp(self):


### PR DESCRIPTION
Add a missing comment that was added in the 18.3 backport but was missing for master. The comment explains the increase in the number of res partner queries in discuss.