### PR TITLE
[FIX] base: support optional error raising when view is not found

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -377,7 +377,7 @@ class IrUiView(models.Model):
 
     @api.model
     @tools.ormcache('self.env.uid', 'self.env.su', 'xml_id', 'self._context.get("website_id")', cache='templates')
-    def _get_view_id(self, xml_id):
+    def _get_view_id(self, xml_id, raise_if_not_found=True):
         """If a website_id is in the context and the given xml_id is not an int
         then try to get the id of the specific view for that website, but
         fallback to the id of the generic view if there is no specific.
@@ -399,7 +399,7 @@ class IrUiView(models.Model):
                 _logger.warning("Could not find view object with xml_id '%s'", xml_id)
                 raise ValueError('View %r in website %r not found' % (xml_id, self._context['website_id']))
             return view.id
-        return super(IrUiView, self.sudo())._get_view_id(xml_id)
+        return super(IrUiView, self.sudo())._get_view_id(xml_id, raise_if_not_found=raise_if_not_found)
 
     @tools.ormcache('self.id', cache='templates')
     def _get_cached_visibility(self):

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2136,7 +2136,7 @@ actual arch.
         return etree.tostring(arch_tree, encoding='unicode')
 
     @api.model
-    def _get_view_id(self, template):
+    def _get_view_id(self, template, raise_if_not_found=True):
         """ Return the view ID corresponding to ``template``, which may be a
         view ID or an XML ID. Note that this method may be overridden for other
         kinds of template values.
@@ -2148,16 +2148,17 @@ actual arch.
         view = self.sudo().search([('key', '=', template)], limit=1)
         if view:
             return view.id
-        res_model, res_id = self.env['ir.model.data']._xmlid_to_res_model_res_id(template, raise_if_not_found=True)
-        assert res_model == self._name, "Call _get_view_id, expected %r, got %r" % (self._name, res_model)
+        res_model, res_id = self.env['ir.model.data']._xmlid_to_res_model_res_id(template, raise_if_not_found=raise_if_not_found)
+        if res_model:
+            assert res_model == self._name, "Call _get_view_id, expected %r, got %r" % (self._name, res_model)
         return res_id
 
     @api.model
-    def _get(self, view_ref):
+    def _get(self, view_ref, raise_if_not_found=True):
         """ Return the view corresponding to ``view_ref``, which may be a
         view ID or an XML ID.
         """
-        return self.browse(self._get_view_id(view_ref))
+        return self.browse(self._get_view_id(view_ref, raise_if_not_found=raise_if_not_found))
 
     def _contains_branded(self, node):
         return node.tag == 't'\


### PR DESCRIPTION
**Before Commit:**
Previously, the `_get_view_id` and `_get` methods would always raise an exception when the view reference could not be found.

**After Commit:**
This commit adds `raise_if_not_found` parameter (default: True) to both methods. If `raise_if_not_found=False` is passed, the methods return `None` instead of raising an error, allowing to handle the case where the view is missing.

Sentry - 5715762959