### PR TITLE
[FIX] im_livechat: match rule expects country id, not country

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -36,7 +36,7 @@ class WebClient(WebclientController):
                 return
             country_id = (
                 # sudo - res.country: accessing user country is allowed.
-                request.env["res.country"].sudo().search([("code", "=", code)])
+                request.env["res.country"].sudo().search([("code", "=", code)]).id
                 if (code := request.geoip.country_code)
                 else None
             )


### PR DESCRIPTION
Livechat initialization checks if any rule matches on the page based on the country detected by geoip if any. The "_match" method expects an id, not a recordset which lead to an error when initializating the page. This commit fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
