### PR TITLE
[FIX] mail: channel create decoration style tweaks

### DIFF
--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -18,8 +18,8 @@
 }
 
 .o-mail-Thread-avatar {
-    --avatar-size: 64px;
-    --icon-font-size: 4.5em;
+    --avatar-size: 56px;
+    --icon-font-size: 4em;
 
     &.o-mail-Thread-avatarChatWindow {
         --avatar-size: 28px;

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -102,14 +102,12 @@
 
 <t t-name="mail.Thread.startMessage">
     <div class="pt-4" t-att-class="{ 'px-3': env.inChatWindow, 'px-1': !env.inChatWindow }">
-        <div class="d-flex align-items-end" t-att-class="{
+        <div class="d-flex align-items-end gap-2" t-att-class="{
             'mt-2 mb-1': !props.thread.parent_channel_id,
             'mt-1': props.thread.parent_channel_id,
-            'gap-1': env.inChatWindow,
-            'gap-2': !env.inChatWindow,
         }">
             <div class="o-mail-Thread-avatar d-inline" t-att-class="{'o-mail-Thread-avatarChatWindow': env.inChatWindow }">
-                <img t-if="!props.thread.parent_channel_id" class="rounded o_object_fit_cover" t-att-src="props.thread?.avatarUrl" alt="Thread Image"/>
+                <img t-if="!props.thread.parent_channel_id" class="rounded-3 o_object_fit_cover" t-att-src="props.thread?.avatarUrl" alt="Thread Image"/>
                 <i t-else="" class="fa fa-comments-o opacity-75"/>
             </div>
             <h1 class="opacity-75" t-att-class="{ 'fs-3': env.inChatWindow, 'mb-0': env.inChatWindow, 'mb-1': !env.inChatWindow }" t-esc="startMessageTitle"/>


### PR DESCRIPTION
When creating a new channel or sub-thread, it decorates the conversation with a welcome text with avatar / icon of conversation.

This commit make small tweaks to this part of UI:
- discuss app avatars / icons were too big, now reduced slightly
- chat window spacing with conversation name was too small, now made as big as in discuss app
- avatar was not as rounded as other avatars in discuss