### PR TITLE
[FIX] hr_work_entry{_contract}: fix work entry duration rounding

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -103,7 +103,7 @@ class HrWorkEntry(models.Model):
                 result[work_entry.id] = cached_periods[(date_start, date_stop)]
             else:
                 dt = date_stop - date_start
-                duration = dt.days * 24 + dt.seconds / 3600  # Number of hours
+                duration = dt.days * 24 + round(dt.total_seconds()) / 3600  # Number of hours
                 cached_periods[(date_start, date_stop)] = duration
                 result[work_entry.id] = duration
         return result

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -324,3 +324,15 @@ class TestWorkEntry(TestWorkEntryBase):
         work_entry_types = [entry.work_entry_type_id for entry in result_entries]
         self.assertEqual(len(result_entries), 4, 'A shift should be created for each attendance')
         self.assertEqual(work_entry_types, [entry_type_1, entry_type_1, entry_type_1, entry_type_2])
+
+    def test_work_entry_duration(self):
+        """ Test the duration of a work entry is rounded to the nearest minute """
+        work_entry = self.env['hr.work.entry'].create({
+            'name': 'Test Work Entry',
+            'employee_id': self.richard_emp.id,
+            'contract_id': self.richard_emp.contract_id.id,
+            'date_start': datetime(2023, 10, 1, 9, 0, 0),
+            'date_stop': datetime(2023, 10, 1, 9, 59, 59, 999999),
+            'work_entry_type_id': self.work_entry_type.id,
+        })
+        self.assertEqual(work_entry.duration, 1, "The duration should be 1 hour")


### PR DESCRIPTION
To reproduce:
=============
- have an employee with a working schedule of night shifts like 18:00 to 00:00 break to 01:00 then continue to 03:00
- create payslip for this employee for January 2025
- print the payslip, the working hours will be 183.9936

The problem:
============
00:00 is represented as 23:59:59.99999 in python, that missing
microsecond impacts the computation of the duration of the work entry.

The solution:
=============
round the total seconds

opw-4702410
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
