### PR TITLE
[FIX] purchase_stock: inflated unit cost due to rounding method

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -72,15 +72,19 @@ class StockMove(models.Model):
                     invoice_line_value = price_unit * invoice_line.quantity
                 total_invoiced_value += invoice_line.currency_id._convert(
                         invoice_line_value, order.currency_id, order.company_id, invoice_line.move_id.invoice_date, round=False)
-                invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)
+                invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id, rounding_method="HALF-UP")
             # TODO currency check
             remaining_value = total_invoiced_value - receipt_value
             # TODO qty_received in product uom
-            remaining_qty = invoiced_qty - line.product_uom._compute_quantity(received_qty, line.product_id.uom_id)
-            if order.currency_id != order.company_id.currency_id and remaining_value and remaining_qty:
+            remaining_qty = invoiced_qty - line.product_uom._compute_quantity(received_qty, line.product_id.uom_id, rounding_method="HALF-UP")
+            has_remaining = (
+                not order.currency_id.is_zero(remaining_value)
+                and not float_is_zero(remaining_qty, precision_rounding=line.product_id.uom_id.rounding)
+            )
+            if order.currency_id != order.company_id.currency_id and has_remaining:
                 # will be rounded during currency conversion
                 price_unit = remaining_value / remaining_qty
-            elif remaining_value and remaining_qty:
+            elif has_remaining:
                 price_unit = float_round(remaining_value / remaining_qty, precision_digits=price_unit_prec)
             else:
                 price_unit = line._get_gross_price_unit()

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -749,3 +749,117 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         lc.button_validate()
         self.assertEqual(lc.amount_total, -20)
         self.assertEqual(lc.stock_valuation_layer_ids.value, -20)
+
+    def test_landed_cost_avco_partial_bill_rounding(self):
+        """Tests landed cost calculation for an AVCO product with partial
+        billing and backorders, ensuring correct stock valuation and handling
+        of rounding with decimal precision.
+        """
+        decimal_price = self.env.ref('product.decimal_price')
+        decimal_price.digits = 5
+        decimal_product_uom = self.env.ref('product.decimal_product_uom')
+        decimal_product_uom.digits = 5
+
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.purchase_method = 'purchase'
+        self.product1.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        self.landed_cost.categ_id = self.product1.categ_id.id
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product1.name,
+                    'product_id': self.product1.id,
+                    'product_qty': 190.0,
+                    'product_uom': self.product1.uom_po_id.id,
+                    'price_unit': 110.0,
+                })
+            ],
+        })
+        purchase_order.button_confirm()
+
+        self.assertEqual(purchase_order.state, 'purchase')
+        picking = purchase_order.picking_ids[0]
+        picking.action_assign()
+
+        # Receive 70 items and create a backorder
+        picking.move_ids.quantity_done = 70
+        picking.button_validate()
+        picking._action_done()
+
+        backorder_picking = purchase_order.picking_ids.filtered(lambda p: p.backorder_id == picking)
+        self.assertTrue(backorder_picking, "Backorder picking was not created or not found.")
+
+        bill = self.env["account.move"].browse(purchase_order.action_create_invoice()["res_id"])
+        bill.invoice_date = fields.Date.today()
+        bill.invoice_line_ids.quantity = 70
+        bill.action_post()
+
+        svl_initial_receipt = self.env['stock.valuation.layer'].search([
+            ('product_id', '=', self.product1.id),
+            ('stock_move_id', '=', picking.move_ids.id)
+        ])
+        self.assertEqual(len(svl_initial_receipt), 1)
+        self.assertAlmostEqual(svl_initial_receipt.quantity, 70)
+        self.assertAlmostEqual(svl_initial_receipt.unit_cost, 110, msg="SVL unit cost for initial receipt should match PO price.")
+        self.assertAlmostEqual(svl_initial_receipt.value, 70 * 110)
+        self.assertAlmostEqual(self.product1.standard_price, 110, msg="Product AVCO should be 110 after first receipt.")
+        self.assertAlmostEqual(purchase_order.order_line[0].qty_invoiced, 70)
+
+        # Add a landed cost to the first picking
+        landed_cost = self.env['stock.landed.cost'].create({
+            'picking_ids': [(6, 0, [picking.id])],
+            'account_journal_id': self.stock_journal.id,
+            'cost_lines': [(0, 0, {
+                'name': 'landed cost',
+                'split_method': 'equal',
+                'price_unit': 95,
+                'product_id': self.landed_cost.id,
+            })],
+        })
+        landed_cost.compute_landed_cost()
+        landed_cost.button_validate()
+
+        # Create a draft bill for the remaining 120 units
+        bill2 = self.env["account.move"].browse(purchase_order.action_create_invoice()["res_id"])
+        bill2.invoice_date = fields.Date.today()
+        self.assertAlmostEqual(bill2.invoice_line_ids[0].quantity, 120, msg="Bill 2 should be for the remaining 120 units.")
+        self.assertAlmostEqual(bill2.invoice_line_ids[0].price_unit, 110, msg="Bill 2 unit price should match PO price.")
+        self.assertAlmostEqual(purchase_order.order_line[0].qty_invoiced, 190, msg="Total 190 units should be invoiced on PO line.")
+
+        # Receive the remaining 120 quantities in the backorder.
+        backorder_picking.action_assign()
+        backorder_picking.move_ids[0].quantity_done = 120
+        backorder_picking.button_validate()  # This should not create another backorder
+
+        # Check that the valuation layers of the backorder matches the bill
+        svl_backorder_receipt = self.env['stock.valuation.layer'].search([
+            ('product_id', '=', self.product1.id),
+            ('stock_move_id', '=', backorder_picking.move_ids[0].id)
+        ])
+
+        self.assertEqual(len(svl_backorder_receipt), 1)
+        self.assertAlmostEqual(svl_backorder_receipt.quantity, 120)
+        # The unit cost for AVCO on receipt is taken from the purchase order line price.
+        self.assertAlmostEqual(svl_backorder_receipt.unit_cost, 110, msg="SVL unit cost for backorder receipt should match PO price.")
+        self.assertAlmostEqual(svl_backorder_receipt.value, 120 * 110)
+
+        # Final check on product's AVCO and total quantity/value
+        # Total quantity received is 120 + 70 = 190
+        self.assertAlmostEqual(self.product1.qty_available, 190)
+
+        # For AVCO, the standard_price should reflect the average. Since all units came at
+        # the same price, it's 110, plus the landed cost (95 / 190)
+        # 110 + 95 / 190 = 110.5
+        self.assertAlmostEqual(self.product1.standard_price, 110.5)
+
+        # Check total value in SVL:
+        # 120 * 110 + 95 + 70 * 110 = 20995
+        self.assertAlmostEqual(self.product1.value_svl, 20995)


### PR DESCRIPTION
## Before this commit:
When calculating the `price_unit` for stock moves from purchase order lines, the `remaining_qty` and `remaining_value` could be imprecise. Standard float comparisons for these remaining amounts could lead to incorrect `price_unit` calculations if, for example, `remaining_qty` was a small float near zero. This could result in inaccurate stock valuations, particularly when currency conversions were involved or when landed costs were applied.

For example, 70.00000003 is rounded **up** to 70.00001 (with 5 digits), resulting in a quantity difference of 0.00001, which incorrectly inflates the unit cost.

## After this commit:
Change the rounding method to 'HALF-UP' instead of the default 'UP' to improve precise result for quantities.

## Steps to reproduce:
1. Configure a product with AVCO real time. Set decimal precision for price and UoM to 5 digits.
2. Create a Purchase Order (e.g., 190 units @ $110/unit).
3. Receive 70 units and create a backorder
4. Create and post a bill for the initially received quantity.
5. Apply a landed cost to the picking of the first 70 units.
6. Create a draft bill for the remaining quantity on the PO.
7. Receive the remaining 120 units from the backorder.
8. The product's cost explodes

opw-4705224