### PR TITLE
[FIX] mail: correctly reload parent record when using full composer

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -376,10 +376,12 @@ patch(Chatter.prototype, {
         this.onFollowerChanged(thread);
     },
 
-    onCloseFullComposerCallback() {
+    onCloseFullComposerCallback(isDiscard) {
         this.toggleComposer();
         super.onCloseFullComposerCallback();
-        this.props.record?.load();
+        if (!isDiscard) {
+            this.reloadParentView();
+        }
     },
 
     onFollowerChanged(thread) {

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -446,9 +446,9 @@ export class Composer extends Component {
         }
     }
 
-    onCloseFullComposerCallback() {
+    onCloseFullComposerCallback(isDiscard) {
         if (this.props.onCloseFullComposerCallback) {
-            this.props.onCloseFullComposerCallback();
+            this.props.onCloseFullComposerCallback(isDiscard);
         } else {
             this.thread?.fetchNewMessages();
         }
@@ -613,7 +613,7 @@ export class Composer extends Component {
                     this.clear();
                 }
                 this.props.messageToReplyTo?.cancel();
-                this.onCloseFullComposerCallback();
+                this.onCloseFullComposerCallback(isDiscard);
                 this.state.isFullComposerOpen = false;
                 // Use another event bus so that no message is sent to the
                 // closed composer.

--- a/addons/mail/static/tests/tours/mail_composer_autosave_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_autosave_tour.js
@@ -1,0 +1,41 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_autosave_tour.js", {
+    steps: () => [
+        {
+            content: "Edit the function field",
+            trigger: ".o_field_widget[name='function'] > .o_input",
+            run: "edit Director",
+        },
+        {
+            trigger: ".o_form_sheet_bg",
+            run: "click",
+        },
+        {
+            content: "Click on Send Message",
+            trigger: ".o-mail-Chatter-sendMessage",
+            run: "click",
+        },
+        {
+            content: "Open the full composer",
+            trigger: ".o-small[name='open-full-composer']",
+            run: "click",
+        },
+        {
+            content: "Edit the body",
+            trigger: ".o-wysiwyg div[contenteditable='true']",
+            run: "editor Hello-- Mitchell Admin",
+        },
+        {
+            content: "Click on Send Message",
+            trigger: ".o_mail_send[name='action_send_mail']",
+            run: "click",
+        },
+        {
+            content: "Check message is shown",
+            trigger: '.o-mail-Message-body:contains("Hello")',
+        },
+        ...stepUtils.toggleHomeMenu(),
+    ],
+});

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -321,3 +321,14 @@ class TestMailComposerUI(MailCommon, HttpCase):
 
     def test_send_attachment_without_body(self):
         self.start_tour("/odoo/discuss", "create_thread_for_attachment_without_body",login="admin")
+
+    def test_mail_composer_autosave_tour(self):
+        partner = self.env["res.partner"].create(
+            {"name": "Jane", "email": "jane@example.com"})
+        with self.mock_mail_app():
+            self.start_tour(
+                f"/odoo/res.partner/{partner.id}",
+                "mail/static/tests/tours/mail_composer_autosave_tour.js",
+                login=self.user_employee.login
+            )
+        self.assertEqual(partner.function, "Director")


### PR DESCRIPTION
Steps to reproduce:
- Go to any form view with a chatter
- Make a change in the form view
- Open the chatter composer
- Click on the "Send" button => The parent record is reloaded, but the changes made in the form view are lost.

This happens since 94088d18879a6a634077908e494483cbd0cc1a28, which introduced a `load` call in the `onCloseFullComposerCallback` method without taking into account the fact that the parent record might already be in a dirty state.

This commit fixes the issue by saving the record before reloading it.

OPW-4762965

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
