### PR TITLE
[FIX] point_of_sale: instant reflection edit product from PoS

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -302,7 +302,7 @@ export function createRelatedModels(modelDefs, modelClasses = {}, opts = {}) {
     }, {});
     const [inverseMap, processedModelDefs] = processModelDefs(modelDefs);
     const records = mapObj(processedModelDefs, () => reactive({}));
-    const orderedRecords = mapObj(processedModelDefs, () => reactive([]));
+    const orderedRecords = reactive(mapObj(processedModelDefs, () => []));
     const callbacks = mapObj(processedModelDefs, () => []);
     const commands = mapObj(processedModelDefs, () => ({
         delete: new Map(),

--- a/addons/point_of_sale/static/tests/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/product_screen_tour.js
@@ -451,3 +451,30 @@ registry.category("web_tour.tours").add("AddMultipleSerialsAtOnce", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("ProductEditionTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickInfoProduct("Desk Pad"),
+            Dialog.clickButton("Edit"),
+            {
+                content: "Change product name",
+                trigger: "input[id='name_0']",
+                run: "edit Test Desk",
+            },
+            Dialog.confirm(),
+            ProductScreen.productIsDisplayed("Test Desk"),
+            ProductScreen.clickSubcategory("Desk test"),
+            ProductScreen.clickInfoProduct("Test Desk"),
+            Dialog.clickButton("Edit"),
+            {
+                content: "Change product name",
+                trigger: "input[id='name_0']",
+                run: "edit Test Desk 2",
+            },
+            Dialog.confirm(),
+            ProductScreen.productIsDisplayed("Test Desk 2"),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
+++ b/addons/point_of_sale/static/tests/tours/utils/dialog_util.js
@@ -28,6 +28,14 @@ export function discard() {
         run: "click",
     };
 }
+export function clickButton(name) {
+    return {
+        content: "click button",
+        trigger: `.modal-footer button:contains("${name}")`,
+        in_modal: true,
+        run: "click",
+    };
+}
 export function is({ title } = {}) {
     let trigger = ".modal .modal-content";
     if (title) {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -543,6 +543,13 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
 
 @tagged('post_install', '-at_install')
 class TestUi(TestPointOfSaleHttpCommon):
+    def test_product_edition(self):
+        product = self.env['product.product'].search([('name', '=', 'Desk Pad')])
+        self.main_pos_config.iface_available_categ_ids = [(6, 0, product.pos_categ_ids.ids)]
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour("ProductEditionTour", login="pos_admin")
+        self.assertEqual(product.name, 'Test Desk 2')
+
     def test_01_pos_basic_order(self):
         self.tip.write({
             'taxes_id': False


### PR DESCRIPTION
Before this commit, when a product was edited from the PoS, the changes were not reflected in the PoS interface until the user reloaded the page

This commit ensures that any changes made to a product are instantly reflected in the PoS interface without requiring a page reload.

taskId: 4431596

