### PR TITLE
[FIX] purchase: fix tax-totals format in purchase report

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -124,7 +124,7 @@
             </table>
 
             <div id="total" class="row justify-content-end mt-n3">
-                <div class="col-4">
+                <div class="col-4 ms-auto">
                     <table class="o_total_table table table-borderless">
                         <t t-call="purchase.document_tax_totals">
                             <t t-set="tax_totals" t-value="o.tax_totals"/>


### PR DESCRIPTION
Steps to reproduce:

1. Go to Purchase > Open a purchase order record
2. Click on Print > Purchase Order

Issue:
The tax totals section of the table appears misaligned or on the incorrect side
 of the page in the generated PDF.

Solution:
Added class ms-auto to the tax totals element to ensure it aligns correctly to the right side.

opw: 4771854
