### PR TITLE
[FIX] sale: Adapt `sale_signature` test for singleapp

### DIFF
--- a/addons/sale/static/tests/tours/sale_signature.js
+++ b/addons/sale/static/tests/tours/sale_signature.js
@@ -51,19 +51,20 @@ registry.category("web_tour.tours").add("sale_signature_without_name", {
     steps: () => [
         {
             content: "Sign & Pay",
-            trigger:
-                ".o_portal_sale_sidebar .btn-primary, iframe .o_portal_sale_sidebar .btn-primary",
+            trigger: ".o_portal_sale_sidebar .btn-primary",
+            alt_trigger: "iframe .o_portal_sale_sidebar .btn-primary",
             run: "click",
         },
         {
             content: "click submit",
-            trigger: ".o_portal_sign_submit:enabled, iframe .o_portal_sign_submit:enabled",
+            trigger: ".o_portal_sign_submit:enabled",
+            alt_trigger: "iframe .o_portal_sign_submit:enabled",
             run: "click",
         },
         {
             content: "check error because no name",
-            trigger:
-                '.o_portal_sign_error_msg:contains("Signature is missing."), iframe .o_portal_sign_error_msg:contains("Signature is missing.")',
+            trigger: '.o_portal_sign_error_msg:contains("Signature is missing.")',
+            alt_trigger: 'iframe .o_portal_sign_error_msg:contains("Signature is missing.")',
             run: () => {},
         },
     ],


### PR DESCRIPTION
Before this commit this test `test_04_portal_sale_signature_without_name_tour` was only working with all modules installed (classic runbot build) but was failing in singleapp mode (with just `sale_management`).

With this commit this test works as expected in both of them.

A solution was to use `alt_trigger` instead of "," to separate two css selector, as it was not working as expected inside tour triggers

runbot error linked: https://runbot.odoo.com/odoo/runbot.build.error/161357/runbot.build.error.content/runbot.build.error.content/162311