### PR TITLE
[FIX] l10n_in_ewaybill:  Prevent duplicate e-way bills during demo data load

### DIFF
--- a/addons/l10n_in_ewaybill/models/account_move.py
+++ b/addons/l10n_in_ewaybill/models/account_move.py
@@ -40,7 +40,7 @@ class AccountMove(models.Model):
     def _compute_l10n_in_ewaybill_details(self):
         for move in self:
             ewaybill = move.l10n_in_ewaybill_ids and move.l10n_in_ewaybill_ids[0]
-            if move.country_code == 'IN' and move.l10n_in_ewaybill_ids.state == 'generated':
+            if move.country_code == 'IN' and ewaybill.state == 'generated':
                 move.l10n_in_ewaybill_name = ewaybill.name
                 move.l10n_in_ewaybill_expiry_date = ewaybill.ewaybill_expiry_date
             else:


### PR DESCRIPTION
[FIX] l10n_in_ewaybill:  Prevent duplicate e-way bills during demo data load

Steps to Reproduce:
    1. Run the Odoo app from the terminal without installing demo data.
    2. Install the l10n_in_ewaybill module.
    3. Load demo data from the App Settings.
    4. Select the IN Company.
    5. Open any invoice.

Issue:
    - An error occurs when opening the invoice page.

Reason:
    - The method that generates demo data was being called twice during demo data loading.
    - As a result, two e-way bills were created per invoice instead of one, which led to errors.
    - Additionally, the condition in the account.move model was assuming only one e-way bill per invoice, causing incorrect logic.

Fix:
    - Added a check before creating the e-way bill to verify whether it has already been created or not
    - Also fixed the logic in the account.move model to properly handle the e-way bill state check.

task: 4777642
