### PR TITLE
[IMP] hr_holidays: Align leave_type display name

### DIFF
--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -62,8 +62,7 @@ class Department(models.Model):
         action['context'] = {
             **self._get_action_context(),
             'search_default_active_time_off': 3,
-            'hide_employee_name': 1,
-            'holiday_status_display_name': False
+            'hide_employee_name': 1
         }
         return action
 

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -347,14 +347,14 @@ class HolidaysType(models.Model):
         return self._context.get('holiday_status_display_name', True) and self._context.get('employee_id')
 
     @api.depends('requires_allocation', 'virtual_remaining_leaves', 'max_leaves', 'request_unit')
-    @api.depends_context('holiday_status_display_name', 'employee_id', 'from_manager_leave_form')
+    @api.depends_context('holiday_status_display_name', 'employee_id')
     def _compute_display_name(self):
         if not self.requested_display_name():
             # leave counts is based on employee_id, would be inaccurate if not based on correct employee
             return super()._compute_display_name()
         for record in self:
             name = record.name
-            if record.requires_allocation == "yes" and not self._context.get("from_manager_leave_form"):
+            if record.requires_allocation == "yes":
                 remaining_time = float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0
                 maximum = float_round(record.max_leaves, precision_digits=2) or 0.0
 

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -676,7 +676,8 @@
             'search_default_waiting_for_me_manager': 2,
             'search_default_current_year': 3,
             'hide_employee_name': 1,
-            'holiday_status_display_name': False}</field>
+            }
+        </field>
         <field name="domain">[('employee_id.company_id', 'in', allowed_company_ids)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
@@ -694,7 +695,7 @@
         <field name="search_view_id" ref="hr_holidays.hr_leave_view_search_manager"/>
         <field name="context">{
             'hide_employee_name': 1,
-            'holiday_status_display_name': False}
+            }
         </field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
- in the management form view, the leave type display name is diffrent than dash borad one which is not the best for UX. So, remove the restriction on the display name as multiple request is handeled on its own wizard now.

Task: 4774751

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
