### PR TITLE
[FIX] mail: link preview deletable for non-editable messages

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -116,7 +116,7 @@
                                     unlinkAttachment.bind="onClickAttachmentUnlink"
                                     imagesHeight="message.attachments.length === 1 ? 300 : 75"
                                     messageSearch="props.messageSearch"/>
-                                <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="deletable"/>
+                                <LinkPreviewList t-if="message.linkPreviews.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="message.isSelfAuthored or store.user?.isAdmin"/>
                             </div>
                             <t t-if="!message.hasTextContent or env.inChatWindow" t-call="mail.Message.actions"/>
                         </div>

--- a/addons/mail/static/tests/message/link_preview_test.js
+++ b/addons/mail/static/tests/message/link_preview_test.js
@@ -379,3 +379,24 @@ QUnit.test("Delete all link previews at once", async () => {
     await contains(".o-mail-LinkPreviewCard", { count: 0 });
     await contains(".o-mail-LinkPreviewImage", { count: 0 });
 });
+
+QUnit.test("Delete link preview of a non-editable (email) message", async () => {
+    const pyEnv = await startServer();
+    const linkPreviewId = pyEnv["mail.link.preview"].create({
+        og_description: "Description",
+        og_title: "Article title 1",
+        og_type: "article",
+        source_url: "https://www.odoo.com",
+    });
+    const channelId = pyEnv["discuss.channel"].create({ name: "wololo" });
+    pyEnv["mail.message"].create({
+        body: "not empty",
+        link_preview_ids: [linkPreviewId],
+        model: "discuss.channel",
+        res_id: channelId,
+        message_type: "email",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-mail-LinkPreviewCard button[aria-label='Remove']");
+});


### PR DESCRIPTION
**Current behavior before PR:**

Link Preview is deletable for only editable messages

**Desired behavior after PR is merged:**

Link Preview will be deletable for all messages

task-[4690326](https://www.odoo.com/odoo/all-tasks/4690326)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
