### PR TITLE
[FIX] mail: message action next to image in chat window

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -6,8 +6,6 @@
             t-att-class="{
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
-                'me-2 pe-4': isInChatWindowAndIsAlignedLeft and !env.inComposer,
-                'ms-2 ps-4': isInChatWindowAndIsAlignedRight and !env.inComposer,
             }"
         >
             <div class="d-flex flex-grow-1 flex-wrap mx-1 align-items-center" t-att-class="{
@@ -43,8 +41,6 @@
                     t-foreach="cards" t-as="attachment" t-key="attachment.id"
                     class="o-mail-AttachmentCard d-flex rounded mb-1 me-1 mw-100 overflow-auto"
                     t-att-class="{
-                               'ms-1': isInChatWindowAndIsAlignedRight,
-                               'me-1': !isInChatWindowAndIsAlignedRight,
                                'o-viewable': attachment.isViewable,
                                'o-isUploading': attachment.uploading,
                                }"


### PR DESCRIPTION
Before this commit, when posting a message with a single image in a chat window, the spacing between the image and message actions was too big.

This happens because the attachment list container has a lot of margin/spacing for unknown reasons.

This commit removes this arbitrary margin/padding, so that the spacing is reduced. A consequence of it is that big images take more space in chat windows.

Note that when a message has more than 1 attachment, the message action is still far away from the attachments. This is unfortunately an issue with content wrapped in which container is not resized to match content width, which is a browser style limitation. This problem can only be tackled by adjusting in JS.