### PR TITLE
[FIX] point_of_sale: prevent error while creating invoices with multi user

### DIFF
--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -7,6 +7,7 @@ from . import test_point_of_sale_ui
 from . import test_anglo_saxon
 from . import test_point_of_sale
 from . import test_pos_controller
+from . import test_pos_invoice_consolidation
 from . import test_pos_cash_rounding
 from . import test_pos_setup
 from . import test_pos_simple_orders

--- a/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
+++ b/addons/point_of_sale/tests/test_pos_invoice_consolidation.py
@@ -1,0 +1,56 @@
+from odoo import Command
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon, TestPoSCommon
+from odoo.tests.common import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestPosInvoiceConsolidation(TestPoSCommon, TestPointOfSaleCommon):
+
+    def setUp(cls):
+        super().setUp()
+        cls.config = cls.basic_config
+        cls.user1 = cls.env.user
+        cls.user2 = cls.simple_accountman
+        cls.user2.group_ids = [Command.link(cls.env.ref('point_of_sale.group_pos_user').id)]
+
+    def test_invoice_grouped_by_user_id(self):
+        self.open_new_session()
+
+        with self.with_user(self.user1.login):
+            orders_user1 = self._create_orders([{
+                'pos_order_lines_ui_args': [(self.product3, 1)],
+                'customer': self.customer,
+                'is_invoiced': False,
+                'uuid': 'u1-order',
+            }])
+            # This flattens the dict into the recordset
+            orders_user1 = sum(orders_user1.values(), self.env['pos.order'])
+
+        with self.with_user(self.user2.login):
+            orders_user2 = self._create_orders([
+                {
+                    'pos_order_lines_ui_args': [(self.product3, 2)],
+                    'customer': self.customer,
+                    'is_invoiced': False,
+                }, {
+                    'pos_order_lines_ui_args': [(self.product4, 1)],
+                    'customer': self.customer,
+                    'is_invoiced': False,
+                }
+            ])
+            # This flattens the dict into the recordset
+            orders_user2 = sum(orders_user2.values(), self.env['pos.order'])
+
+        all_orders = orders_user1 + orders_user2
+
+        # create consolidated invoice
+        self.env['pos.make.invoice'].create({'consolidated_billing': True}).with_context(active_ids=all_orders.ids).action_create_invoices()
+
+        invoice_user1 = orders_user1.account_move
+        invoice_user2 = orders_user2.account_move
+
+        self.assertEqual(len(invoice_user1), 1, "User 1 should have one invoice")
+        self.assertEqual(orders_user1.amount_total, invoice_user1.amount_total)
+
+        self.assertEqual(len(invoice_user2), 1, "User 2 should have one invoice")
+        self.assertEqual(sum(orders_user2.mapped('amount_total')), invoice_user2.amount_total)

--- a/addons/point_of_sale/wizard/pos_make_invoice.py
+++ b/addons/point_of_sale/wizard/pos_make_invoice.py
@@ -64,8 +64,9 @@ class PosMakeInvoice(models.TransientModel):
                     if not partner:
                         raise UserError(_("Kindly ensure that each order contains a customer."))
 
-                    for fiscal_position, fiscal_position_orders in partner_orders.grouped('fiscal_position_id').items():
-                        grouped_orders.append(((config, partner, fiscal_position), fiscal_position_orders))
+                    for user, user_orders in partner_orders.grouped('user_id').items():
+                        for fiscal_position, fiscal_position_orders in user_orders.grouped('fiscal_position_id').items():
+                            grouped_orders.append(((config, partner, user, fiscal_position), fiscal_position_orders))
 
             for _key, orders in grouped_orders:
                 invoices |= orders._generate_pos_order_invoice()


### PR DESCRIPTION
The error occurred because multiple POS orders with different `user_id` were grouped together for invoice creation, and the code attempted to access `self.user_id.id`, which expects a single record but received multiple (`res.users(1, 2)`).

Steps to Replicate:
- Open any POS shop (Ex: Furniture Shop) and select a Customer.
- Add any item to the order and complete the order.
- Close the session, go to Backend and open POS orders.
- Make sure the states of the orders are all in `to invoice` state, and check that salesperson should not be all the same (atleast one salesperson should be different and the customer should be same).
- Select all the Orders, click `Create Invoices` and click Create and see the error.

Error:
`ValueError: Expected singleton: res.users(1, 2)`

Solution:
-  Solved the error by grouping the POS orders by both `user_id` and `fiscal_position_id`, ensuring each group contains orders from only one user, which prevents the singleton error when accessing `user_id.id` during invoice creation.

sentry-6590469396
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
