### PR TITLE
[IMP] im_livechat: add livechat username in the invitation list

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -46,6 +46,7 @@ class ResPartner(models.Model):
                     # sudo: res.users.settings - operator can access other operators expertises
                     "livechat_expertise": partner.user_ids.sudo().livechat_expertise_ids.mapped("name"),
                     "livechat_languages": languages[1:],
+                    "livechat_username": partner.user_livechat_username,
                 },
                 # sudo - res.partner: checking if operator is in call for live
                 # chat invitation is acceptable.

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -6,6 +6,9 @@
                 <i class="fa fa-volume-up o-discuss-inCallIconColor me-1"/>
                 <span class="o-discuss-ChannelInvitation-inCallTextColor">in a call</span>
             </span>
+            <span t-if="props.thread?.channel_type === 'livechat' and selectablePartner.livechat_username" class="overflow-hidden opacity-75 smaller mx-2">
+                <span class="text-truncate" t-esc="selectablePartner.livechat_username"/>
+            </span>
         </xpath>
         <xpath expr="//*[@name='selectablePartnerDetail']" position="replace">
             <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -186,3 +186,32 @@ test("shows operators are in call", async () => {
         count: 0,
     });
 });
+
+
+test("Operator invite shows livechat_username", async () => {
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].create({
+        name: "John",
+        im_status: "offline",
+        user_ids: [pyEnv["res.users"].create({ name: "John", livechat_username: "Johnny" })],
+    });
+    const guestId_1 = pyEnv["mail.guest"].create({ name: "Visitor #1" });
+    pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor #1",
+        channel_type: "livechat",
+        channel_member_ids: [
+            Command.create({
+                partner_id: serverState.partnerId,
+                last_interest_dt: "2021-01-03 12:00:00",
+            }),
+            Command.create({ guest_id: guestId_1, last_interest_dt: "2021-01-03 12:00:00" }),
+        ],
+        livechat_operator_id: serverState.partnerId,
+        livechat_active: true,
+    });
+    await start();
+    await openDiscuss();
+    await click(".o-mail-DiscussSidebarChannel", { text: "Visitor #1" });
+    await click("button[title='Invite People']");
+    await contains("input", { parent: [".o-discuss-ChannelInvitation-selectable", { text: "Johnny" }] });
+});

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -53,6 +53,7 @@ export class ResPartner extends mailModels.ResPartner {
                     data.livechat_expertise = user.livechat_expertise_ids.map(
                         (expId) => Im_LivechatExpertise.browse(expId)[0].name
                     );
+                    data.livechat_username = user.livechat_username;
                 }
             }
             store.add(this.browse(partner.id), data);


### PR DESCRIPTION
This commit adds the livechat username of the users next to their real names when choosing to invite them. This is to avoid having a leak of the real name when inviting new operators.

task-4775090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
