### PR TITLE
[IMP] mail: AvatarCardPopover partner record support

### DIFF
--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -1,9 +1,11 @@
+import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 
 export const patchAvatarCardPopover = {
     setup() {
         super.setup();
+        this.orm = useService("orm");
         this.userInfoTemplate = "hr.avatarCardUserInfos";
     },
     get fieldNames() {

--- a/addons/hr/static/tests/web/m2x_avatar_user.test.js
+++ b/addons/hr/static/tests/web/m2x_avatar_user.test.js
@@ -31,9 +31,12 @@ test("avatar card preview with hr", async () => {
         employee_id: employeeId,
     });
     env["m2x.avatar.user"].create({ user_id: userId });
-    onRpc("res.users", "read", (request) => {
-        expect.step("user read");
-        expect(request.args[1]).toEqual([
+    onRpc("/discuss/avatar_card", async (request) => {
+        expect.step("/discuss/avatar_card");
+        const args = Object.values((await request.json()).params);
+        expect(args[0]).toEqual(userId);
+        expect(args[1]).toEqual(false);
+        expect(args[2]).toEqual([
             "name",
             "email",
             "phone",
@@ -61,7 +64,7 @@ test("avatar card preview with hr", async () => {
         </kanban>`,
     });
     await contains(".o_m2o_avatar > img").click();
-    expect.verifySteps(["user read"]);
+    expect.verifySteps(["/discuss/avatar_card"]);
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card span[data-tooltip='Work Location'] .fa-building-o").toHaveCount(1);
     expect(queryAllTexts(".o_card_user_infos > *:not(.o_avatar_card_buttons)")).toEqual([

--- a/addons/mail/controllers/discuss/__init__.py
+++ b/addons/mail/controllers/discuss/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import avatar_card
 from . import channel
 from . import gif
 from . import mail

--- a/addons/mail/controllers/discuss/avatar_card.py
+++ b/addons/mail/controllers/discuss/avatar_card.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+from odoo.addons.mail.tools.discuss import add_guest_to_context
+
+
+class AvatarCardController(http.Controller):
+    @http.route("/discuss/avatar_card", methods=["POST"], type="jsonrpc", auth="public")
+    @add_guest_to_context
+    def avatar_card(self, user_id, partner_id, fields):
+        if not user_id and partner_id:
+            if partner_id == request.env["ir.model.data"]._xmlid_to_res_id("base.partner_root"):
+                return request.env.ref("base.user_root").read(fields)[0]
+            partner = request.env["res.partner"].search([("id", "=", partner_id)])
+            if not partner:
+                return False
+            user_id = partner.user_ids.sorted(lambda u: (not u.share, -u.id), reverse=True)[:1].id
+        if user := request.env["res.users"].search_read([("id", "=", user_id)], fields):
+            return user[0]
+        return False

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -6,7 +6,7 @@
                 <div class="d-flex align-items-start gap-2 bg-inherit">
                     <span class="o_avatar pt-1 position-relative o_card_avatar bg-inherit">
                         <img t-if="props.id"
-                            t-attf-src="/web/image/res.users/{{props.id}}/avatar_128"
+                            t-attf-src="/web/image/{{props.model}}/{{props.id}}/avatar_128"
                             class="rounded"
                         />
                         <span t-if="user.im_status" name="icon" class="o_card_avatar_im_status position-absolute d-flex align-items-center justify-content-center bg-inherit">

--- a/addons/mail/static/src/views/web/fields/avatar/avatar.js
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.js
@@ -29,6 +29,7 @@ export class Avatar extends Component {
     get popoverProps() {
         return {
             id: this.props.resId,
+            model: this.props.resModel,
         };
     }
 

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
@@ -29,12 +29,13 @@ const WithUserChatter = (T) =>
         }
 
         displayAvatarCard(record) {
-            return this.relation === "res.users";
+            return ["res.users", "res.partner"].includes(this.relation);
         }
 
         getAvatarCardProps(record) {
             return {
                 id: record.resId,
+                model: this.relation,
             };
         }
 

--- a/addons/mail/static/tests/mock_server/mock_models/m2x_avatar_user.js
+++ b/addons/mail/static/tests/mock_server/mock_models/m2x_avatar_user.js
@@ -4,5 +4,6 @@ export class M2xAvatarUser extends models.Model {
     _name = "m2x.avatar.user";
 
     user_id = fields.Many2one({ relation: "res.users" });
+    partner_id = fields.Many2one({ relation: "res.partner" });
     user_ids = fields.Many2many({ relation: "res.users", string: "Users" });
 }

--- a/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
+++ b/addons/mail/static/tests/web/fields/many2many_avatar_user.test.js
@@ -10,7 +10,7 @@ import {
     triggerHotkey,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
-import { asyncStep, onRpc, waitForSteps } from "@web/../tests/web_test_helpers";
+import { onRpc } from "@web/../tests/web_test_helpers";
 import { registry } from "@web/core/registry";
 import { getOrigin } from "@web/core/utils/urls";
 
@@ -296,16 +296,12 @@ test("avatar card preview", async () => {
         }),
         im_status: "online",
     });
-    onRpc("res.users", "read", (params) => {
-        expect(params.args[1]).toEqual([
-            "name",
-            "email",
-            "phone",
-            "im_status",
-            "share",
-            "partner_id",
-        ]);
-        asyncStep("user read");
+    onRpc("/discuss/avatar_card", async (request) => {
+        const args = Object.values((await request.json()).params);
+        expect(args[0]).toEqual(userId);
+        expect(args[1]).toEqual(false);
+        expect(args[2]).toEqual(["name", "email", "phone", "im_status", "share", "partner_id"]);
+        expect.step("/discuss/avatar_card");
     });
     const avatarUserId = pyEnv["m2x.avatar.user"].create({ user_id: userId });
     await start();
@@ -327,7 +323,63 @@ test("avatar card preview", async () => {
     await contains(".o_card_user_infos > span", { text: "Mario" });
     await contains(".o_card_user_infos > a", { text: "Mario@odoo.test" });
     await contains(".o_card_user_infos > a", { text: "+78786987" });
-    await waitForSteps(["user read"]);
+    expect.verifySteps(["/discuss/avatar_card"]);
+    // Close card
+    await click(".o_action_manager");
+    await contains(".o_avatar_card", { count: 0 });
+});
+
+test("avatar card preview (partner_id field)", async () => {
+    registry.category("services").add(
+        "im_status",
+        {
+            start() {
+                return {
+                    registerToImStatus() {},
+                    unregisterFromImStatus() {},
+                };
+            },
+        },
+        { force: true }
+    );
+    const pyEnv = await startServer();
+    const userId = pyEnv["res.users"].create({
+        im_status: "online",
+    });
+    const partnerId = pyEnv["res.partner"].create({
+        email: "Mario@odoo.test",
+        name: "Mario",
+        phone: "+78786987",
+        user_ids: [userId],
+    });
+    onRpc("/discuss/avatar_card", async (request) => {
+        const args = Object.values((await request.json()).params);
+        expect(args[0]).toEqual(false);
+        expect(args[1]).toEqual(partnerId);
+        expect(args[2]).toEqual(["name", "email", "phone", "im_status", "share", "partner_id"]);
+        expect.step("/discuss/avatar_card");
+    });
+    const avatarUserId = pyEnv["m2x.avatar.user"].create({ partner_id: partnerId });
+    await start();
+    await openKanbanView("m2x.avatar.user", {
+        res_id: avatarUserId,
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="partner_id" widget="many2one_avatar_user"/>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+    });
+    // Open card
+    await click(".o_m2o_avatar > img");
+    await contains(".o_avatar_card");
+    await contains(".o_card_user_infos > span", { text: "Mario" });
+    await contains(".o_card_user_infos > a", { text: "Mario@odoo.test" });
+    await contains(".o_card_user_infos > a", { text: "+78786987" });
+    expect.verifySteps(["/discuss/avatar_card"]);
     // Close card
     await click(".o_action_manager");
     await contains(".o_avatar_card", { count: 0 });

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -8,6 +8,7 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
 
     static props = {
         ...AvatarCardPopover.props,
+        model: { type: String, optional: true },
         recordModel: {
             type: String,
             optional: true,


### PR DESCRIPTION
With this commit, the AvatarCardPopover supports having an id of a `res.partner` record in the props.
This allows components like KanbanMany2ManyTagsAvatarUserField (that use AvatarCardPopover) to be used with a Many2Many field related to `res.partner`.
In such cases, the avatars will now be clickable and will display the avatar card popover.

fixes: task-4640810
