### PR TITLE
[IMP] website_livechat: clean up dead code

### DIFF
--- a/addons/website_livechat/static/src/common/@types/models.d.ts
+++ b/addons/website_livechat/static/src/common/@types/models.d.ts
@@ -1,6 +1,5 @@
 declare module "models" {
     export interface Thread {
         visitor: Persona;
-        visitorPartner: Persona;
     }
 }

--- a/addons/website_livechat/static/src/common/thread_model_patch.js
+++ b/addons/website_livechat/static/src/common/thread_model_patch.js
@@ -6,6 +6,5 @@ patch(Thread.prototype, {
     setup() {
         super.setup(...arguments);
         this.visitor = fields.One("Persona");
-        this.visitorPartner = fields.One("Persona");
     },
 });

--- a/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -35,9 +35,6 @@ export class DiscussChannel extends livechatModels.DiscussChannel {
                     id: visitor.id,
                     is_connected: visitor.is_connected,
                     lang_name: visitor.lang_id ? ResLang.read(visitor.lang_id)[0].name : false,
-                    visitorPartner: visitor.partner_id
-                        ? { id: visitor.partner_id, type: "partner" }
-                        : false,
                     type: "visitor",
                     website_name: visitor.website_id
                         ? Website.read(visitor.website_id)[0].name


### PR DESCRIPTION
The `visitorPartner` field was introduced in #141904, which apparently never 
worked, and the usage is removed in #142010. Also, the typescript related to 
thread model should be moved to the same folder as this model.
