### PR TITLE
[IMP] web, *: rework empty grouped kanban views

### DIFF
--- a/addons/crm/static/src/views/forecast_kanban/forecast_kanban_renderer.xml
+++ b/addons/crm/static/src/views/forecast_kanban/forecast_kanban_renderer.xml
@@ -7,7 +7,6 @@
                     folded="true"
                     onFoldChange="() => {}"
                     onValidate.bind="addForecastColumn"
-                    exampleData="exampleData"
                     groupByField="props.list.groupByField"
                 />
             </t>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.js
@@ -11,6 +11,6 @@ export class ProjectTaskKanbanController extends KanbanController {
 
     setup() {
         super.setup();
-        this.hideGhostColumns = this.props.context.hide_kanban_ghost_columns;
+        this.hideKanbanStagesNocontent = this.props.context.hide_kanban_stages_nocontent;
     }
 }

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_controller.xml
@@ -10,7 +10,7 @@
             />
         </button>
         <t t-component="props.Renderer" position="attributes">
-            <attribute name="hideGhostColumns">hideGhostColumns</attribute>
+            <attribute name="hideKanbanStagesNocontent">hideKanbanStagesNocontent</attribute>
         </t>
     </t>
 </templates>

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_examples.js
@@ -9,7 +9,6 @@ const star = markup(`<a style="color: gold;" class="fa fa-star"></a>`);
 const clock = markup(`<a class="fa fa-clock-o"></a>`);
 
 const exampleData = {
-    ghostColumns: [_t('New'), _t('Assigned'), _t('In Progress'), _t('Done')],
     applyExamplesText: _t("Use This For My Project"),
     allowedGroupBys: ['stage_id'],
     foldField: "fold",

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.js
@@ -13,7 +13,7 @@ export class ProjectTaskKanbanRenderer extends KanbanRenderer {
         KanbanHeader: ProjectTaskKanbanHeader,
     };
 
-    static props = [...KanbanRenderer.props, "hideGhostColumns?"];
+    static props = [...KanbanRenderer.props, "hideKanbanStagesNocontent?"];
 
     setup() {
         super.setup();

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.xml
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_renderer.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="project.ProjectTaskKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary">
-        <xpath expr="//div[hasclass('o_kanban_example_background_container')]" position="attributes">
-            <attribute name="t-if">props.list.groups.length === 0 &amp;&amp; !props.hideGhostColumns</attribute>
+        <xpath expr="//div[hasclass('o_kanban_stages_nocontent')]" position="attributes">
+            <attribute name="t-if">props.list.groups.length === 0 &amp;&amp; !props.hideKanbanStagesNocontent</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/project/static/tests/project_task_kanban_view.test.js
+++ b/addons/project/static/tests/project_task_kanban_view.test.js
@@ -26,7 +26,7 @@ const viewParams = {
     groupBy: ["stage_id"],
 };
 
-test("shadow stages should be displayed in the project Kanban", async () => {
+test("stages nocontent helper should be displayed in the project Kanban", async () => {
     ProjectTask._records = [];
 
     await mountView({
@@ -48,7 +48,7 @@ test("shadow stages should be displayed in the project Kanban", async () => {
     });
 
     expect(".o_kanban_header").toHaveCount(1);
-    expect(".o_kanban_example_background_container").toHaveCount(1);
+    expect(".o_kanban_stages_nocontent").toHaveCount(1);
 });
 
 test("quick create button is visible when the user has access rights.", async () => {

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -1345,7 +1345,7 @@
             <field name="res_model">project.task</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="domain">[('is_template', '=', True)]</field>
-            <field name="context">{'default_is_template': True, 'hide_kanban_ghost_columns': True}</field>
+            <field name="context">{'default_is_template': True, 'hide_kanban_stages_nocontent': True}</field>
             <field name="search_view_id" ref="view_task_template_search_form"/>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">

--- a/addons/utm/static/src/js/utm_campaign_kanban_examples.js
+++ b/addons/utm/static/src/js/utm_campaign_kanban_examples.js
@@ -2,7 +2,6 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 
 const exampleData = {
-    ghostColumns: [_t('Ideas'), _t('Design'), _t('Review'), _t('Send'), _t('Done')],
     applyExamplesText: _t("Use This For My Campaigns"),
     allowedGroupBys: ['stage_id'],
     examples: [{

--- a/addons/web/static/src/views/kanban/kanban_column_examples_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_examples_dialog.xml
@@ -19,7 +19,7 @@
 
     <!-- Note: this dialog isn't responsive, but it is not accessible on mobile -->
     <t t-name="web.KanbanColumnExamplesDialog">
-        <Dialog contentClass="'o_kanban_examples_dialog'" title.translate="Kanban Examples">
+        <Dialog contentClass="'o_kanban_examples_dialog'" title.translate="Kanban Examples" size="'xl'">
             <Notebook orientation="'vertical'" pages="pages" onPageUpdate.bind="onPageUpdate" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="applyExamples" t-esc="props.applyExamplesText"/>

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.js
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.js
@@ -1,14 +1,11 @@
-import { _t } from "@web/core/l10n/translation";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { useAutofocus, useService } from "@web/core/utils/hooks";
-import { KanbanColumnExamplesDialog } from "./kanban_column_examples_dialog";
 
 import { Component, useExternalListener, useState, useRef, onPatched } from "@odoo/owl";
 
 export class KanbanColumnQuickCreate extends Component {
     static template = "web.KanbanColumnQuickCreate";
     static props = {
-        exampleData: [Object, { value: null }],
         onFoldChange: Function,
         onValidate: Function,
         folded: Boolean,
@@ -54,12 +51,6 @@ export class KanbanColumnQuickCreate extends Component {
         });
     }
 
-    get canShowExamples() {
-        const { allowedGroupBys = [], examples = [] } = this.props.exampleData || {};
-        const hasExamples = Boolean(examples.length);
-        return hasExamples && allowedGroupBys.includes(this.props.groupByField.name);
-    }
-
     get relatedFieldName() {
         return this.props.groupByField.string;
     }
@@ -80,24 +71,6 @@ export class KanbanColumnQuickCreate extends Component {
             this.inputRef.el.focus();
             this.state.hasInputFocused = true;
         }
-    }
-
-    showExamples() {
-        this.dialog.add(KanbanColumnExamplesDialog, {
-            examples: this.props.exampleData.examples,
-            applyExamplesText:
-                this.props.exampleData.applyExamplesText || _t("Use This For My Kanban"),
-            applyExamples: (index) => {
-                const { examples, foldField } = this.props.exampleData;
-                const { columns, foldedColumns = [] } = examples[index];
-                for (const groupName of columns) {
-                    this.props.onValidate(groupName);
-                }
-                for (const groupName of foldedColumns) {
-                    this.props.onValidate(groupName, foldField);
-                }
-            },
-        });
     }
 
     onInputKeydown(ev) {

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
@@ -23,15 +23,12 @@
                             t-on-keydown="onInputKeydown"
                         />
                         <button class="btn btn-primary o_kanban_add" type="button" t-on-click="validate">
-                            Add
+                            <i class="fa fa-check"/>
+                        </button>
+                        <button class="btn btn-danger o_kanban_remove" type="button" t-on-click="fold">
+                            <i class="fa fa-times"/>
                         </button>
                     </div>
-                    <div t-if="!env.isSmall and state.hasInputFocused" t-attf-class="o_discard_msg small text-muted {{ canShowExamples ? 'float-end' : 'text-end'}}">
-                        Press <kbd>Esc</kbd> to discard
-                    </div>
-                    <t t-if="canShowExamples and !env.isSmall">
-                        <button type="button" class="btn btn-link o_kanban_examples p-0" t-on-click="showExamples">See examples</button>
-                    </t>
                 </div>
                 <div t-foreach="[,,,]" t-as="i" t-key="i_index" class="o_kanban_muted_record mb-2 py-5 bg-300 opacity-50" />
             </div>

--- a/addons/web/static/src/views/kanban/kanban_examples_dialog.scss
+++ b/addons/web/static/src/views/kanban/kanban_examples_dialog.scss
@@ -33,19 +33,6 @@
     }
 }
 
-// container ghost card in background
-.o_kanban_example_background_container {
-
-    // content
-    .o_kanban_example_background {
-        flex-basis: 100%;
-
-        .o_kanban_examples .o_kanban_examples_group .o_kanban_examples_ghost {
-            width: var(--KanbanRecord--small-width);
-        }
-    }
-}
-
 // kanban ghost card
 .o_kanban_examples .o_kanban_examples_group .o_kanban_examples_ghost {
     &.o_collapse {

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -93,24 +93,16 @@
                         folded="state.columnQuickCreateIsFolded"
                         onFoldChange="folded => state.columnQuickCreateIsFolded = folded"
                         onValidate="props.list.createGroup.bind(props.list)"
-                        exampleData="exampleData"
                         groupByField="props.list.groupByField"
                     />
-                    <!-- Kanban Example Background -->
-                    <div t-if="props.list.groups.length === 0" class="o_kanban_example_background_container d-flex opacity-50">
-                        <div class="o_kanban_example_background flex-grow-1">
-                            <div class="o_kanban_examples d-flex p-2">
-                                <div t-foreach="ghostColumns" t-as="column" t-key="column.name" class="o_kanban_examples_group flex-grow-1 m-3">
-                                    <h6><b t-esc="column.name"/></h6>
-                                    <div t-foreach="column.cards" t-as="card" t-key="card_index" class="o_kanban_examples_ghost d-flex flex-wrap justify-content-between mb-3 p-2 border bg-light">
-                                        <div class="o_ghost_content w-100 pb-3 bg-300"/>
-                                        <div class="o_ghost_content o_ghost_tag d-inline-block w-50 mt-3 pb-3 bg-300"/>
-                                        <span class="mt-2 rounded-circle bg-300">
-                                            <img class="o_ghost_avatar" src="/base/static/img/avatar.png" alt="Avatar"/>
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
+                    <div t-if="props.list.groups.length === 0" class="o_view_nocontent o_kanban_stages_nocontent">
+                        <div class="o_nocontent_help">
+                            <p class="o_view_nocontent_smiling_face">
+                                No stages yet, let's create some!
+                            </p>
+                            <p t-if="canShowExamples">
+                                Lack of inspiration? <button type="button" class="btn btn-link o_kanban_examples p-0" t-on-click="showExamples">See examples</button>
+                            </p>
                         </div>
                     </div>
                 </t>


### PR DESCRIPTION
This commit applies several improvements to the UI of grouped empty kanban views:
- Removes ghost example records for grouped kanbans with no stage, replacing them with a dedicated no-content helper that links to the kanban examples dialog.
- Enlarges the kanban examples dialog to improve readability.
- Updates the kanban_column_quick_create behavior: it no longer links to the kanban examples, and the ESC helper has been removed. The "Add" button now uses an icon instead of text and is accompanied by a new cancel button with a cross icon.

task-4762308
