### PR TITLE
[FIX] website: avoid infinite wait for carousel slide operation

### DIFF
--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -116,7 +116,18 @@ patch(Colibri.prototype, {
         };
     },
     addListener(target, event, fn, options) {
-        fn = fn.bind(this.interaction);
+        const boundFn = fn.bind(this.interaction);
+        if (event.startsWith("slide.bs.carousel")) {
+            // Never allow cancelling this event in edit mode.
+            fn = (...args) => {
+                const ev = args[0];
+                ev.preventDefault = () => {};
+                ev.stopPropagation = () => {};
+                return boundFn(...args);
+            };
+        } else {
+            fn = boundFn;
+        }
         let stealth = true;
         const parts = event.split(".");
         if (parts.includes("keepInHistory") || options?.keepInHistory) {

--- a/addons/website/static/src/interactions/carousel/carousel_slider.js
+++ b/addons/website/static/src/interactions/carousel/carousel_slider.js
@@ -1,5 +1,6 @@
 import { Interaction } from "@web/public/interaction";
 import { registry } from "@web/core/registry";
+import { onceAllImagesLoaded } from "@website/utils/images";
 
 export class CarouselSlider extends Interaction {
     static selector = ".carousel";
@@ -97,6 +98,11 @@ export class CarouselSlider extends Interaction {
             // If images are loading, prevent the slide transition. It will
             // slide once the next images are loaded.
             ev.preventDefault();
+            onceAllImagesLoaded(this.carouselInnerEl).then(
+                () => {
+                    window.Carousel.getOrCreateInstance(this.el).to(ev.to);
+                }
+            );
             return;
         }
         if (this.options.scrollMode === "single") {


### PR DESCRIPTION
Since [1] when the single-scroll mode was introduced on carousel dynamic snippets, sliding is prevented until images are loaded. Unfortunately, carousel sliding is expected to produce two events: `slide.bs.carousel` brefore, and `slid.bs.carousel` after. Because of this, operations that wait for a slide operation to be completed might end up waiting forever.
This is the case of the "Add Slide" button while editing a carousel.

This commit fixes this in two ways:
- the prevented slide operation is re-requested once images are loaded
- to be safe, for edit mode, Colibri is patched in order to globally forbid cancelling a carousel slide event.

Steps to reproduce:
- Enable transition effects on operating system
- Disable caches in browser
- Drop a `s_carousel_cards` block inside the page
- Click on the "Add Slide" button

=> Editor was frozen.

[1]: https://github.com/odoo/odoo/commit/08d837e70f28a84a9bd97974f5d15d387a42b7c0#diff-93ad57658344d264f69d8417a25a1b711257028165d6cfed6601a1fb8fb2ce61R81

task-4778838
