### PR TITLE
[IMP] im_livechat: add livechat username in the invitation list

### DIFF
--- a/addons/im_livechat/models/res_partner.py
+++ b/addons/im_livechat/models/res_partner.py
@@ -43,6 +43,8 @@ class ResPartner(models.Model):
                     # sudo: res.users.settings - operator can access other operators expertises
                     "livechat_expertise": partner.user_ids.sudo().livechat_expertise_ids.mapped("name"),
                     "livechat_languages": languages[1:],
+                    # sudo: res.users.settings - operator can access other operators livechat usernames
+                    "user_livechat_username": partner.sudo().user_livechat_username,
                 },
             )
 

--- a/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
+++ b/addons/im_livechat/static/src/core/web/channel_invitation_patch.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-inherit="discuss.ChannelInvitation.main" t-inherit-mode="extension">
+        <xpath expr="//*[@name='selectablePartnerDetail']//*" position="inside">
+            <span t-if="props.thread?.channel_type === 'livechat' and selectablePartner.user_livechat_username" t-esc="selectablePartner.user_livechat_username" class="text-truncate text-muted smaller mx-2"/>
+        </xpath>
         <xpath expr="//*[@name='selectablePartnerDetail']" position="replace">
             <t t-if="props.thread?.channel_type !== 'livechat' or !selectablePartner.lang_name">$0</t>
-            <div t-else="" class="d-flex flex-column flex-grow-1">
+            <div t-else="" class="d-flex flex-column flex-grow-1 overflow-hidden">
                 <t>$0</t>
                 <div class="d-flex flex-wrap align-items-center gap-1 ms-2">
                     <span class="d-flex text-start fs-6 gap-1">

--- a/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/res_partner.js
@@ -1,6 +1,6 @@
 import { mailModels } from "@mail/../tests/mail_test_helpers";
 
-import { getKwArgs, serverState } from "@web/../tests/web_test_helpers";
+import { getKwArgs, serverState, makeKwArgs } from "@web/../tests/web_test_helpers";
 
 export class ResPartner extends mailModels.ResPartner {
     /**
@@ -55,6 +55,7 @@ export class ResPartner extends mailModels.ResPartner {
                     );
                 }
             }
+            store.add(this.browse(partner.id), makeKwArgs({ fields: ["user_livechat_username"] }));
             store.add(this.browse(partner.id), data);
         }
     }

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -27,7 +27,9 @@
                                 </div>
                             </div>
                             <t name="selectablePartnerDetail">
-                                <span class="flex-grow-1 mx-2 text-truncate text-start" t-esc="selectablePartner.name"/>
+                                <div class="d-flex flex-grow-1 mx-2 overflow-hidden align-items-baseline">
+                                    <span class="text-truncate" t-esc="selectablePartner.name"/>
+                                </div>
                             </t>
                             <input class="form-check-input flex-shrink-0 me-1" type="checkbox" t-att-checked="selectablePartner.in(selectedPartners) ? 'checked' : undefined"/>
                         </li>


### PR DESCRIPTION
This commit adds the livechat username of the users next to their real names when choosing to invite them. This is to avoid having a leak of the real name when inviting new operators.

task-4775090

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
