### PR TITLE
[FIX] pos_restaurant: test_devices_synchronization tour

### DIFF
--- a/addons/pos_restaurant/static/tests/tours/devices_synchronization_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/devices_synchronization_tour.js
@@ -85,6 +85,8 @@ registry.category("web_tour.tours").add("test_devices_synchronization", {
                 ],
                 false
             ),
+            ProductScreen.orderLineHas("Coca-Cola", "2"),
+            ProductScreen.orderLineHas("Water", "2"),
             ProductScreen.clickDisplayedProduct("Water"),
             ProductScreen.clickLine("Coca-Cola", 2),
             ProductScreen.clickLine("Coca-Cola", 1),


### PR DESCRIPTION
The error in the loop appears during the assertion in the last step. ProductScreen.clickLine("Water", 3) is missing.

Before the fix:
After creating the new order with 2 waters and 2 cokes, it clicks directly on clickDisplayedProduct("Water"), which creates an new orderline with only 1 water. So there are 4 lines, not 3... => Error

After the fix:
We wait for the 2 orders to be created and then
clickDisplayedProduct("Water"), which adds a water to the existing line.

runbot-error-id~190618

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
