### PR TITLE
[REF] web: navigation hook refactor

### DIFF
--- a/addons/mail/static/src/core/common/quick_reaction_menu.js
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.js
@@ -130,7 +130,11 @@ export class QuickReactionMenu extends Component {
     get navigationOptions() {
         return {
             // Bypass nested dropdown behavior to allow initial focus.
-            onEnabled: null,
+            onUpdated: (navigator) => {
+                if (!navigator.activeItem) {
+                    navigator.items[0]?.setActive();
+                }
+            },
             hotkeys: {
                 arrowright: (navigator) => navigator.next(),
                 arrowleft: (navigator) => navigator.previous(),

--- a/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
+++ b/addons/web/static/src/core/dropdown/_behaviours/dropdown_nesting.js
@@ -105,40 +105,41 @@ export function useDropdownNesting(state) {
         current.remove();
     });
 
+    const isDropdown = (target) => target && target.classList.contains("o-dropdown");
+    const isRTL = () => localization.direction === "rtl";
+
     return {
         get hasParent() {
             return Boolean(current.parent);
         },
         /**@type {import("@web/core/navigation/navigation").NavigationOptions} */
         navigationOptions: {
-            onEnabled: (navigator) => {
-                if (current.parent) {
+            onUpdated: (navigator) => {
+                if (current.parent && !navigator.activeItem) {
                     navigator.items[0]?.setActive();
-                }
-            },
-            onMouseEnter: (item) => {
-                if (item.target.classList.contains("o-dropdown")) {
-                    item.select();
                 }
             },
             hotkeys: {
                 escape: () => current.close(),
-                arrowleft: (navigator) => {
-                    if (
-                        localization.direction === "rtl" &&
-                        navigator.activeItem?.target.classList.contains("o-dropdown")
-                    ) {
-                        navigator.activeItem?.select();
-                    } else if (current.parent) {
-                        current.close();
-                    }
+                arrowleft: {
+                    isAvailable: ({ target }) => current.parent || (isRTL() && isDropdown(target)),
+                    callback: (navigator) => {
+                        if (isRTL() && isDropdown(navigator.activeItem?.target)) {
+                            navigator.activeItem?.select();
+                        } else if (current.parent) {
+                            current.close();
+                        }
+                    },
                 },
-                arrowright: (navigator) => {
-                    if (localization.direction === "rtl" && current.parent) {
-                        current.close();
-                    } else if (navigator.activeItem?.target.classList.contains("o-dropdown")) {
-                        navigator.activeItem?.select();
-                    }
+                arrowright: {
+                    isAvailable: ({ target }) => isDropdown(target) || (isRTL() && current.parent),
+                    callback: (navigator) => {
+                        if (isRTL() && current.parent) {
+                            current.close();
+                        } else if (isDropdown(navigator.activeItem?.target)) {
+                            navigator.activeItem?.select();
+                        }
+                    },
                 },
             },
         },

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -121,6 +121,21 @@ export class SelectMenu extends Component {
             () => [this.props.choices, this.props.groups]
         );
         useAutofocus({ refName: "inputRef" });
+
+        this.navigationOptions = {
+            virtualFocus: this.props.searchable,
+            hotkeys: {
+                enter: {
+                    isAvailable: ({ navigator }) => navigator.items.length > 0,
+                    callback: (navigator) => {
+                        const item = navigator.activeItem || navigator.items[0];
+                        if (item) {
+                            item.select();
+                        }
+                    },
+                },
+            },
+        };
     }
 
     get displayValue() {
@@ -132,17 +147,15 @@ export class SelectMenu extends Component {
     }
 
     get multiSelectChoices() {
-        return this.selectedChoice.map((c) => {
-            return {
-                id: c.value,
-                text: c.label,
-                onDelete: () => {
-                    const values = [...this.props.value];
-                    values.splice(values.indexOf(c.value), 1);
-                    this.props.onSelect(values);
-                },
-            };
-        });
+        return this.selectedChoice.map((c) => ({
+            id: c.value,
+            text: c.label,
+            onDelete: () => {
+                const values = [...this.props.value];
+                values.splice(values.indexOf(c.value), 1);
+                this.props.onSelect(values);
+            },
+        }));
     }
 
     get menuClass() {
@@ -222,9 +235,9 @@ export class SelectMenu extends Component {
         // Combine previously selected choices + newly selected choice from
         // the searched choices and then filter the choices based on
         // props.value i.e. valueSet.
-        return [...(this.selectedChoice || []), ...choices].filter((c, index, self) =>
-            valueSet.has(c.value)
-            && self.findIndex((t) => t.value === c.value) === index
+        return [...(this.selectedChoice || []), ...choices].filter(
+            (c, index, self) =>
+                valueSet.has(c.value) && self.findIndex((t) => t.value === c.value) === index
         );
     }
 

--- a/addons/web/static/src/core/select_menu/select_menu.xml
+++ b/addons/web/static/src/core/select_menu/select_menu.xml
@@ -9,7 +9,7 @@
                 position="'bottom-fit'"
                 beforeOpen.bind="onBeforeOpen"
                 onStateChanged.bind="onStateChanged"
-                navigationOptions="{ virtualFocus: this.props.searchable }"
+                navigationOptions="navigationOptions"
             >
                 <button type="button" t-att-class="`o_select_menu_toggler btn btn-light w-100 bg-light ${props.togglerClass || ''} ${canDeselect ? 'o_can_deselect' : ''}`" t-att-disabled="props.disabled">
                     <t t-if="props.multiSelect">

--- a/addons/web/static/src/core/time_picker/time_picker.js
+++ b/addons/web/static/src/core/time_picker/time_picker.js
@@ -74,16 +74,7 @@ export class TimePicker extends Component {
 
         return {
             virtualFocus: true,
-            focusInitialElementOnDisabled: () => false,
-            onEnabled: (navigator) => {
-                this.navigator = navigator;
-                if (this.state.value) {
-                    const index = this.suggestions.findIndex((s) => s.equals(this.state.value, this.props.showSeconds));
-                    if (index >= 0) {
-                        navigator.items[index]?.setActive();
-                    }
-                }
-            },
+            onUpdated: (navigator) => (this.navigator = navigator),
             hotkeys: {
                 enter: {
                     bypassEditableProtection: true,
@@ -251,5 +242,16 @@ export class TimePicker extends Component {
     getPlaceholder() {
         const seconds = this.props.showSeconds ? ":ss" : "";
         return `hh:mm${seconds}`;
+    }
+
+    onDropdownOpened() {
+        if (this.navigator) {
+            const index = this.state.value
+                ? this.suggestions.findIndex((s) =>
+                      s.equals(this.state.value, this.props.showSeconds)
+                  )
+                : 0;
+            this.navigator.items[index]?.setActive();
+        }
     }
 }

--- a/addons/web/static/src/core/time_picker/time_picker.xml
+++ b/addons/web/static/src/core/time_picker/time_picker.xml
@@ -9,9 +9,11 @@
                 state="dropdownState"
                 menuRef="menuRef"
                 manual="true"
+                focusToggleOnClosed="false"
                 position="'bottom-start'"
                 menuClass="'o_time_picker_dropdown pt-0 mt-0'"
                 navigationOptions="navigationOptions"
+                onOpened.bind="onDropdownOpened"
             >
                 <input
                     type="text"

--- a/addons/web/static/src/search/search_bar/search_bar.js
+++ b/addons/web/static/src/search/search_bar/search_bar.js
@@ -2,7 +2,7 @@ import { Domain } from "@web/core/domain";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { registry } from "@web/core/registry";
 import { KeepLast } from "@web/core/utils/concurrency";
-import { useAutofocus, useBus, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useBus, useChildRef, useService } from "@web/core/utils/hooks";
 import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
 import { fuzzyTest } from "@web/core/utils/search";
 import { _t } from "@web/core/l10n/translation";
@@ -13,7 +13,7 @@ import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 import { hasTouch } from "@web/core/browser/feature_detection";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { ACTIVE_ELEMENT_CLASS } from "@web/core/navigation/navigation";
+import { ACTIVE_ELEMENT_CLASS, useNavigation } from "@web/core/navigation/navigation";
 
 const parsers = registry.category("parsers");
 
@@ -108,8 +108,11 @@ export class SearchBar extends Component {
         this.items = useState([]);
         this.subItems = {};
 
+        this.facetContainerRef = useRef("facetContainerRef");
+        this.menuRef = useChildRef();
+        this.setupFacetNavigation();
         this.inputDropdownState = useDropdownState();
-        this.inputDropdownNavOptions = this.getInputDropdownNavOptions();
+        this.inputDropdownNavOptions = this.getDropdownNavigation();
 
         this.searchBarDropdownState = useDropdownState();
 
@@ -501,6 +504,141 @@ export class SearchBar extends Component {
         this.computeState({ expanded });
     }
 
+    setupFacetNavigation() {
+        const isFacet = (target) => target && target.classList.contains("o_searchview_facet");
+
+        useNavigation(this.facetContainerRef, {
+            shouldFocusChildInput: false,
+            getItems: () => {
+                if (this.root.el && this.inputRef.el) {
+                    return [
+                        ...this.root.el.querySelectorAll(":scope .o_searchview_facet"),
+                        this.inputRef.el,
+                    ];
+                }
+                return [];
+            },
+            isNavigationAvailable: ({ navigator, target }) => navigator.contains(target),
+            hotkeys: {
+                enter: {
+                    isAvailable: () => !this.inputDropdownState.isOpen,
+                    callback: () => this.env.searchModel.search() /** @todo keep this thing ?*/,
+                },
+                arrowdown: {
+                    callback: () => this.env.searchModel.trigger("focus-view"),
+                },
+                backspace: {
+                    bypassEditableProtection: true,
+                    allowRepeat: false,
+                    isAvailable: ({ target }) =>
+                        isFacet(target) ||
+                        (target.selectionStart === 0 && target.selectionEnd === 0),
+                    callback: (navigator) => {
+                        const facets = this.env.searchModel.facets;
+                        if (isFacet(navigator.activeItem.el)) {
+                            this.removeFacet(facets[navigator.activeItemIndex]);
+                        } else if (facets.length > 0) {
+                            this.removeFacet(facets[facets.length - 1]);
+                        }
+                    },
+                },
+                arrowright: {
+                    bypassEditableProtection: true,
+                    allowRepeat: false,
+                    isAvailable: ({ target }) =>
+                        isFacet(target) || target.selectionStart === this.state.query.length,
+                    callback: (navigator) => {
+                        navigator.next();
+                        if (navigator.activeItem.el === this.inputRef.el) {
+                            this.inputRef.el.setSelectionRange(0, 0);
+                        }
+                    },
+                },
+                arrowleft: {
+                    bypassEditableProtection: true,
+                    isAvailable: ({ target }) => isFacet(target) || target.selectionStart === 0,
+                    callback: (navigator) => {
+                        navigator.previous();
+                        if (navigator.activeItem.el === this.inputRef.el) {
+                            const inputLength = this.inputRef.el.value.length;
+                            this.inputRef.el.setSelectionRange(inputLength, inputLength);
+                        }
+                    },
+                },
+            },
+        });
+    }
+
+    /**
+     * @returns {import("@web/core/navigation/navigation").NavigationOptions}
+     */
+    getDropdownNavigation() {
+        const isExpansible = (index) => {
+            const item = this.items[index];
+            return item && item.isParent;
+        };
+
+        const isCollapsible = (index) => {
+            const item = this.items[index];
+            return (
+                item && ((item.isParent && item.isExpanded) || item.isChild || item.isFieldProperty)
+            );
+        };
+
+        return {
+            virtualFocus: true,
+            getItems: () => this.menuRef.el?.querySelectorAll(":scope .o-dropdown-item") ?? [],
+            isNavigationAvailable: ({ navigator, target }) =>
+                this.inputDropdownState.isOpen &&
+                (this.facetContainerRef.el?.contains(target) || navigator.contains(target)),
+            onUpdated: (navigator) => (this.navigator = navigator),
+            hotkeys: {
+                escape: {
+                    callback: () => {
+                        this.inputDropdownState.close();
+                        this.resetState();
+                    },
+                },
+                arrowright: {
+                    bypassEditableProtection: true,
+                    allowRepeat: false,
+                    isAvailable: ({ navigator }) => isExpansible(navigator.activeItemIndex),
+                    callback: (navigator) => {
+                        const item = this.items[navigator.activeItemIndex];
+                        if (item.isParent) {
+                            if (item.isExpanded) {
+                                navigator.next();
+                            } else {
+                                this.toggleItem(item, true);
+                            }
+                        }
+                    },
+                },
+                arrowleft: {
+                    bypassEditableProtection: true,
+                    isAvailable: ({ navigator }) => isCollapsible(navigator.activeItemIndex),
+                    callback: (navigator) => {
+                        const item = this.items[navigator.activeItemIndex];
+
+                        const findIndex = (id) =>
+                            this.items.findIndex(
+                                (item) => item.isParent && item.searchItemId === id
+                            );
+                        if (item && item.isParent && item.isExpanded) {
+                            this.toggleItem(item, false);
+                        } else if (item && item.isChild) {
+                            navigator.items[findIndex(item.searchItemId)]?.setActive();
+                        } else if (item && item.isFieldProperty) {
+                            navigator.items[findIndex(item.propertyItemId)]?.setActive();
+                        } else if (this.inputRef.el.selectionStart === 0) {
+                            navigator.items[this.env.searchModel.facets.length - 1]?.setActive();
+                        }
+                    },
+                },
+            },
+        };
+    }
+
     //---------------------------------------------------------------------
     // Handlers
     //---------------------------------------------------------------------
@@ -533,88 +671,9 @@ export class SearchBar extends Component {
 
     /**
      * @param {Object} facet
-     * @param {number} facetIndex
-     * @param {KeyboardEvent} ev
-     */
-    onFacetKeydown(facet, facetIndex, ev) {
-        switch (ev.key) {
-            case "ArrowLeft": {
-                ev.preventDefault();
-                ev.stopPropagation();
-                if (facetIndex === 0) {
-                    this.inputRef.el.focus();
-                    const inputLength = this.inputRef.el.value.length;
-                    this.inputRef.el.setSelectionRange(inputLength, inputLength);
-                } else {
-                    this.focusFacet(facetIndex - 1);
-                }
-                break;
-            }
-            case "ArrowRight": {
-                ev.preventDefault();
-                ev.stopPropagation();
-                const facets = this.root.el.getElementsByClassName("o_searchview_facet");
-                if (facetIndex === facets.length - 1) {
-                    this.inputRef.el.focus();
-                    this.inputRef.el.setSelectionRange(0, 0);
-                } else {
-                    this.focusFacet(facetIndex + 1);
-                }
-                break;
-            }
-            case "Backspace": {
-                this.removeFacet(facet);
-                break;
-            }
-        }
-    }
-
-    /**
-     * @param {Object} facet
      */
     onFacetRemove(facet) {
         this.removeFacet(facet);
-    }
-
-    /**
-     * @param {KeyboardEvent} ev
-     */
-    onSearchKeydown(ev) {
-        if (ev.isComposing || this.inputDropdownState.isOpen) {
-            // This case happens with an IME for example: we let it handle all key events.
-            return;
-        }
-        switch (ev.key) {
-            case "ArrowDown":
-                ev.preventDefault();
-                this.env.searchModel.trigger("focus-view");
-                break;
-            case "ArrowLeft":
-                if (ev.target.selectionStart === 0) {
-                    // focus rightmost facet if any.
-                    this.focusFacet();
-                }
-                break;
-            case "ArrowRight":
-                if (ev.target.selectionStart === this.state.query.length) {
-                    // focus leftmost facet if any.
-                    this.focusFacet(0);
-                }
-                break;
-            case "Backspace": {
-                const facets = this.env.searchModel.facets;
-                if (facets.length) {
-                    this.removeFacet(facets[facets.length - 1]);
-                }
-                break;
-            }
-            case "Enter":
-                this.env.searchModel.search(); /** @todo keep this thing ?*/
-                break;
-            case "Escape":
-                this.resetState();
-                break;
-        }
     }
 
     onSearchClick() {
@@ -664,73 +723,11 @@ export class SearchBar extends Component {
         this.state.showSearchBar = !this.state.showSearchBar;
     }
 
-    /**
-     * @returns {import("@web/core/navigation/navigation").NavigationOptions}
-     */
-    getInputDropdownNavOptions() {
-        return {
-            virtualFocus: true,
-            hotkeys: {
-                arrowright: {
-                    bypassEditableProtection: true,
-                    allowRepeat: false,
-                    isAvailable: (navigator) => {
-                        const focusedItem = this.items[navigator.activeItemIndex];
-                        return (
-                            focusedItem &&
-                            this.inputRef.el.selectionStart === this.state.query.length
-                        );
-                    },
-                    callback: (navigator) => {
-                        const focusedItem = this.items[navigator.activeItemIndex];
-                        if (focusedItem.isParent) {
-                            if (focusedItem.isExpanded) {
-                                navigator.next();
-                            } else {
-                                this.toggleItem(focusedItem, true);
-                            }
-                        } else {
-                            this.focusFacet(0);
-                        }
-                    },
-                },
-                arrowleft: {
-                    bypassEditableProtection: true,
-                    isAvailable: (navigator) => {
-                        const focusedItem = this.items[navigator.activeItemIndex];
-                        return (
-                            this.inputRef.el.selectionStart === 0 ||
-                            (focusedItem &&
-                                ((focusedItem.isParent && focusedItem.isExpanded) ||
-                                    focusedItem.isChild ||
-                                    focusedItem.isFieldProperty))
-                        );
-                    },
-                    callback: (navigator) => {
-                        const focusedItem = this.items[navigator.activeItemIndex];
-                        const findIndex = (id) =>
-                            this.items.findIndex(
-                                (item) => item.isParent && item.searchItemId === id
-                            );
-                        if (focusedItem && focusedItem.isParent && focusedItem.isExpanded) {
-                            this.toggleItem(focusedItem, false);
-                        } else if (focusedItem && focusedItem.isChild) {
-                            navigator.items[findIndex(focusedItem.searchItemId)]?.setActive();
-                        } else if (focusedItem && focusedItem.isFieldProperty) {
-                            navigator.items[findIndex(focusedItem.propertyItemId)]?.setActive();
-                        } else if (this.inputRef.el.selectionStart === 0) {
-                            this.focusFacet();
-                        }
-                    },
-                },
-            },
-            onEnabled: (navigator) => navigator.items[0]?.setActive(),
-        };
-    }
-
     onInputDropdownChanged(isOpen) {
         if (!isOpen) {
             this.resetState({ focus: false });
+        } else if (this.navigator) {
+            this.navigator.items[0]?.setActive();
         }
     }
 }

--- a/addons/web/static/src/search/search_bar/search_bar.xml
+++ b/addons/web/static/src/search/search_bar/search_bar.xml
@@ -8,7 +8,6 @@
                 role="listitem"
                 aria-label="search"
                 tabindex="0"
-                t-on-keydown="ev => this.onFacetKeydown(facet, facet_index, ev)"
                 >
 
                 <!-- :hover overlay -->
@@ -96,6 +95,7 @@
                 menuClass="'o_searchview_autocomplete'"
                 navigationOptions="inputDropdownNavOptions"
                 onStateChanged.bind="onInputDropdownChanged"
+                menuRef="menuRef"
             >
                 <div class="o_searchview form-control d-print-contents d-flex align-items-center py-1 border-end-0"
                     role="search" aria-autocomplete="list">
@@ -109,7 +109,7 @@
                             role="img"
                         />
                     </button>
-                    <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100">
+                    <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 mw-100" t-ref="facetContainerRef">
                         <t t-call="web.SearchBar.Facets"/>
                         <input type="text"
                             class="o_searchview_input o_input d-print-none flex-grow-1 w-auto border-0"
@@ -117,7 +117,6 @@
                             placeholder="Search..."
                             role="searchbox"
                             t-ref="autofocus"
-                            t-on-keydown="onSearchKeydown"
                             t-on-click="onSearchClick"
                             t-on-input="onSearchInput"
                         />

--- a/addons/web/static/tests/core/dropdown/dropdown.test.js
+++ b/addons/web/static/tests/core/dropdown/dropdown.test.js
@@ -1381,7 +1381,7 @@ test("multi-level dropdown: mouseentering a dropdown item should close any subdr
 });
 
 test.tags("desktop");
-test("multi-level dropdown: unsubscribe all keynav when root close", async () => {
+test("multi-level dropdown: unsubscribe all keynav when root destroyed", async () => {
     class Parent extends Component {
         static components = { Dropdown };
         static props = [];
@@ -1444,7 +1444,8 @@ test("multi-level dropdown: unsubscribe all keynav when root close", async () =>
 
     await mountWithCleanup(Parent);
     expect(DROPDOWN_MENU).toHaveCount(0);
-    expect(registeredHotkeys.size).toBe(0);
+    expect(registeredHotkeys.size).toBe(10);
+    checkKeys(registeredHotkeys);
 
     // Open dropdowns one by one
     await click(".first");
@@ -1460,13 +1461,12 @@ test("multi-level dropdown: unsubscribe all keynav when root close", async () =>
     await hover(".third");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(3);
-    checkKeys(registeredHotkeys);
 
     // Close third
     await press("escape");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(2);
-    checkKeys(removedHotkeys);
+    expect(removedHotkeys.size).toBe(0);
 
     // Reset hover
     await hover(getFixture());
@@ -1475,19 +1475,20 @@ test("multi-level dropdown: unsubscribe all keynav when root close", async () =>
     await hover(".third");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(3);
-    checkKeys(registeredHotkeys);
+    expect(registeredHotkeys.size).toBe(0);
 
     // Close third, second and first
     await press("escape");
     await animationFrame();
-    checkKeys(removedHotkeys);
 
     await press("escape");
     await animationFrame();
+    // Third dropdown is completely destroyed => check for removed keys
     checkKeys(removedHotkeys);
 
     await press("escape");
     await animationFrame();
     expect(DROPDOWN_MENU).toHaveCount(0);
+    // Second dropdown is completely destroyed => check for removed keys
     checkKeys(removedHotkeys);
 });

--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -723,7 +723,7 @@ test("checks that an arrowDown always selects an item", async () => {
     await hover(`.o_searchview_autocomplete .o-dropdown-item.o_indent:last-child`);
     await contains(".o_expand").click();
     await keyDown("ArrowDown");
-    expect(".focus").toHaveCount(1);
+    expect(".o_searchview_autocomplete .focus").toHaveCount(1);
 });
 
 test("checks that an arrowUp always selects an item", async () => {
@@ -742,7 +742,7 @@ test("checks that an arrowUp always selects an item", async () => {
     await hover(`.o_searchview_autocomplete .o-dropdown-item.o_indent:last-child`);
     await contains(".o_expand").click();
     await keyDown("ArrowUp");
-    expect(".focus").toHaveCount(1);
+    expect(".o_searchview_autocomplete .focus").toHaveCount(1);
 });
 
 test("many2one_reference fields are supported in search view", async () => {


### PR DESCRIPTION
This commit refactors the navigation hook to be more easily used in setups where the "container" is always in the dom but it's navigation is enabled under different conditions. This allows the hook to better work with inputs and menus.

This commit also remove the necessity for some special cases to be handled via custom `keydown` event handlers.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
