### PR TITLE
[IMP] *: ActionHelper component with reset filter and sample data banner

### DIFF
--- a/addons/account/static/src/views/account_move_list/account_move_list_renderer.xml
+++ b/addons/account/static/src/views/account_move_list/account_move_list_renderer.xml
@@ -1,7 +1,7 @@
 <templates>
 
     <t t-name="account.AccountMoveListRenderer" t-inherit="account.FileUploadListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <t t-if="this.env.searchModel._context?.default_move_type == 'in_invoice'">
                     <div class="o_view_nocontent">
@@ -10,11 +10,9 @@
                         </div>
                     </div>
                 </t>
-                <t t-else="" t-call="web.ActionHelper">
-                    <t t-set="noContentHelp" t-value="props.noContentHelp"/>
-                </t>
+				<t t-else="">$0</t>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 
 </templates>

--- a/addons/hr/static/src/views/hr_graph_controller.xml
+++ b/addons/hr/static/src/views/hr_graph_controller.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr.GraphView" t-inherit="web.GraphView">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
                 <HrActionHelper
                     noContentTitle.translate="Create an employee."
                     noContentParagraph.translate="Find all the information on employees."
                 />
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </odoo>

--- a/addons/hr/static/src/views/hr_pivot_controller.xml
+++ b/addons/hr/static/src/views/hr_pivot_controller.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr.PivotView" t-inherit="web.PivotView">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
                 <HrActionHelper
                     noContentTitle.translate="Create an employee."
                     noContentParagraph.translate="Find all the information on employees."
                 />
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </odoo>

--- a/addons/hr_attendance/static/src/views/attendance_list_view.xml
+++ b/addons/hr_attendance/static/src/views/attendance_list_view.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr_attendance.AttendanceListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
-        </t>
+        <ActionHelper position="replace"/>
         <table position="after">
             <t t-if="showNoContentHelper">
                 <AttendanceActionHelper noContentHelp="props.noContentHelp"/>

--- a/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.xml
+++ b/addons/hr_org_chart/static/src/views/hr_employee_hierarchy/hr_employee_hierarchy_controller.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr_org_chart.HierarchyView" t-inherit="web_hierarchy.HierarchyView" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="props.info.noContentHelp">
                 <HrActionHelper
                     noContentTitle.translate="Create an employee."
                     noContentParagraph.translate="Find all the information on employees."
                 />
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </odoo>

--- a/addons/hr_recruitment/static/src/scss/hr_job.scss
+++ b/addons/hr_recruitment/static/src/scss/hr_job.scss
@@ -29,10 +29,6 @@
 }
 
 .o_kanban_view {
-    .o_view_sample_data .ribbon {
-        display: none;
-    }
-
     .o_kanban_renderer {
         .o_hr_recruitment_kanban_card_mobile_screen {
             min-height: 130px;

--- a/addons/hr_recruitment/static/src/views/recruitment_kanban_view.xml
+++ b/addons/hr_recruitment/static/src/views/recruitment_kanban_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr_recruitment.RecruitmentKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <RecruitmentActionHelper noContentHelp="props.noContentHelp"/>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </odoo>

--- a/addons/hr_recruitment/static/src/views/recruitment_list_view.xml
+++ b/addons/hr_recruitment/static/src/views/recruitment_list_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="hr_recruitment.RecruitmentListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <RecruitmentActionHelper noContentHelp="props.noContentHelp"/>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </odoo>

--- a/addons/loyalty/static/src/xml/loyalty_templates.xml
+++ b/addons/loyalty/static/src/xml/loyalty_templates.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <t t-name="loyalty.LoyaltyListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <LoyaltyActionHelper noContentHelp="props.noContentHelp"/>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 
     <t t-name="loyalty.LoyaltyActionHelper">

--- a/addons/lunch/static/src/views/list.xml
+++ b/addons/lunch/static/src/views/list.xml
@@ -11,8 +11,8 @@
     </t>
 
     <t t-name="lunch.WebListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary" owl="1">
-        <t t-call="web.ActionHelper" position="after">
+        <ActionHelper position="after">
             <t t-call="lunch.NoContentHelper"/>
-        </t>
+        </ActionHelper>
     </t>
 </templates>

--- a/addons/sale/static/src/views/sale_onboarding_list/sale_onboarding_list_renderer.xml
+++ b/addons/sale/static/src/views/sale_onboarding_list/sale_onboarding_list_renderer.xml
@@ -2,10 +2,10 @@
 
 <templates xml:space="preserve">
     <t t-name="sale.SaleListRenderer" t-inherit="account.FileUploadListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <SaleActionHelper noContentHelp="props.noContentHelp"/>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 </templates>

--- a/addons/stock/static/src/views/stock_empty_list_help.xml
+++ b/addons/stock/static/src/views/stock_empty_list_help.xml
@@ -2,11 +2,11 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="stock.StockListRenderer" t-inherit="web.ListRenderer" t-inherit-mode="primary">
-        <t t-call="web.ActionHelper" position="replace">
+        <ActionHelper position="replace">
             <t t-if="showNoContentHelper">
                 <StockActionHelper noContentHelp="props.noContentHelp"/>
             </t>
-        </t>
+        </ActionHelper>
     </t>
 
     <t t-name="stock.StockActionHelper">

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -514,6 +514,20 @@ export class SearchModel extends EventBus {
     }
 
     /**
+     * Removes filter, field and favorite facets but keeps groupBy ones
+     */
+    clearFilters() {
+        this.blockNotification = true;
+        this.facets.forEach((facet) => {
+            if (facet.type !== "groupBy") {
+                this.deactivateGroup(facet.groupId);
+            }
+        });
+        this.blockNotification = false;
+        this._notify();
+    }
+
+    /**
      * Create a new filter of type 'favorite' and activate it.
      * A new group containing only that filter is created.
      * The query is emptied before activating the new favorite.

--- a/addons/web/static/src/views/action_helper.js
+++ b/addons/web/static/src/views/action_helper.js
@@ -1,0 +1,28 @@
+import { Component } from "@odoo/owl";
+import { Widget } from "@web/views/widgets/widget";
+import { RibbonWidget } from "@web/views/widgets/ribbon/ribbon";
+
+export class ActionHelper extends Component {
+    static template = "web.ActionHelper";
+    static components = { Widget, RibbonWidget };
+    static props = {
+        showRibbon: { type: Boolean, optional: true, default: false },
+        noContentHelp: { type: String, optional: true },
+    };
+
+    get hasFacets() {
+        return this.env.searchModel.facets.length > 0;
+    }
+
+    get showDefaultHelper() {
+        return !this.props.noContentHelp;
+    }
+
+    showWidgetSampleData() {
+        return this.props.showRibbon;
+    }
+
+    clearFilters() {
+        this.env.searchModel.clearFilters();
+    }
+}

--- a/addons/web/static/src/views/action_helper.xml
+++ b/addons/web/static/src/views/action_helper.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.ActionHelper">
+        <div class="o_view_nocontent">
+            <div class="o_nocontent_help">
+                <t t-if="showWidgetSampleData()">
+                    <RibbonWidget  t-props="{
+                        text: 'SAMPLE DATA',
+                        bgClass: 'text-bg-danger',
+                    }"/>
+                </t>
+                <t t-if="showDefaultHelper">
+                    <p class="o_view_nocontent_empty_folder">
+                        <t t-if="title" t-esc="title"/>
+                        <t t-else="">No data to display</t>
+                    </p>
+                    <p>
+                    <t t-if="description" t-esc="description"/>
+                    <t t-else="">Try to add some records, or make sure that there is no
+                        active filter in the search bar.</t>
+                    </p>
+                </t>
+                <t t-else="">
+                    <t t-out="props.noContentHelp"/>
+                </t>
+                <t t-if="hasFacets">
+                    <button 
+                        class="btn text-nowrap me-1 btn-primary my-2 o_reset_filter_button"
+                        t-on-click="this.clearFilters">Reset Filters</button>
+                </t>
+            </div>    
+        </div>
+    </t>
+
+</templates>

--- a/addons/web/static/src/views/graph/graph_controller.js
+++ b/addons/web/static/src/views/graph/graph_controller.js
@@ -5,12 +5,14 @@ import { useSetupAction } from "@web/search/action_hook";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { CogMenu } from "@web/search/cog_menu/cog_menu";
+import { Widget } from "@web/views/widgets/widget";
+import { ActionHelper } from "@web/views/action_helper";
 
 import { Component, useRef } from "@odoo/owl";
 
 export class GraphController extends Component {
     static template = "web.GraphView";
-    static components = { Layout, SearchBar, CogMenu };
+    static components = { Layout, SearchBar, CogMenu, Widget, ActionHelper };
     static props = {
         ...standardViewProps,
         Model: Function,

--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -64,8 +64,8 @@
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
                 <t t-if="model.isReady and model.data">
-                    <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
-                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
+					<t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp">
+						<ActionHelper noContentHelp="props.noContentHelp" showRibbon="model.useSampleModel"/>
                     </t>
                     <t t-if="model.data.exceeds">
                         <div class="alert alert-info text-center o_graph_alert" role="status">

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -21,6 +21,7 @@ import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { cookie } from "@web/core/browser/cookie";
 import { createElementWithContent } from "@web/core/utils/html";
 import { ReportViewMeasures } from "@web/views/view_components/report_view_measures";
+import { Widget } from "@web/views/widgets/widget";
 
 const NO_DATA = _t("No data");
 const formatters = registry.category("formatters");
@@ -115,7 +116,7 @@ function shortenLabel(label) {
 
 export class GraphRenderer extends Component {
     static template = "web.GraphRenderer";
-    static components = { Dropdown, DropdownItem, ReportViewMeasures };
+    static components = { Dropdown, DropdownItem, ReportViewMeasures, Widget };
     static props = ["class?", "model", "buttonTemplate"];
 
     setup() {

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -17,6 +17,8 @@ import { KanbanColumnQuickCreate } from "./kanban_column_quick_create";
 import { KanbanHeader } from "./kanban_header";
 import { KanbanRecord } from "./kanban_record";
 import { KanbanRecordQuickCreate } from "./kanban_record_quick_create";
+import { Widget } from "@web/views/widgets/widget";
+import { ActionHelper } from "@web/views/action_helper";
 
 const DRAGGABLE_GROUP_TYPES = ["many2one"];
 
@@ -44,6 +46,8 @@ export class KanbanRenderer extends Component {
         KanbanHeader,
         KanbanRecord,
         KanbanRecordQuickCreate,
+        Widget,
+        ActionHelper,
     };
     static props = [
         "archInfo",

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -114,12 +114,9 @@
                 <!-- kanban ghost cards are used to properly space last elements. -->
                 <div t-foreach="[,,,,,,]" t-as="i" t-key="i_index" class="o_kanban_record o_kanban_ghost flex-grow-1 flex-md-shrink-1 flex-shrink-0 my-0" />
             </t>
-            <t t-if="showNoContentHelper">
-                <t t-if="props.noContentHelp" t-call="web.ActionHelper">
-                    <t t-set="noContentHelp" t-value="props.noContentHelp"/>
-                </t>
-                <t t-else="" t-call="web.NoContentHelper"/>
-            </t>
+	    <t t-if="showNoContentHelper">
+			<ActionHelper noContentHelp="props.noContentHelp" showRibbon="props.list.model.useSampleModel"/>
+	    </t>
         </div>
     </t>
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -36,7 +36,7 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { MOVABLE_RECORD_TYPES } from "@web/model/relational_model/dynamic_group_list";
-
+import { ActionHelper } from "@web/views/action_helper";
 /**
  * @typedef {import('@web/model/relational_model/dynamic_list').DynamicList} DynamicList
  * @typedef {import('@web/model/relational_model/group').Group} Group
@@ -96,8 +96,18 @@ export class ListRenderer extends Component {
     static groupRowTemplate = "web.ListRenderer.GroupRow";
     static useMagicColumnWidths = true;
     static LONG_TOUCH_THRESHOLD = 400;
-    static components = { DropdownItem, Field, ViewButton, CheckBox, Dropdown, Pager, Widget };
+    static components = {
+        DropdownItem,
+        Field,
+        ViewButton,
+        CheckBox,
+        Dropdown,
+        Pager,
+        Widget,
+        ActionHelper,
+    };
     static defaultProps = { allowSelectors: false, cycleOnTab: true };
+
     static props = [
         "activeActions?",
         "list",

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -8,8 +8,8 @@
             tabindex="-1"
             t-ref="root"
         >
-            <t t-if="showNoContentHelper" t-call="web.ActionHelper">
-                <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+            <t t-if="showNoContentHelper">
+    			<ActionHelper noContentHelp="props.noContentHelp" showRibbon="props.list.model.useSampleModel"/>
             </t>
             <table t-attf-class="o_list_table table table-sm table-hover position-relative mb-0 {{props.list.isGrouped ? 'o_list_table_grouped' : 'o_list_table_ungrouped table-striped'}}" t-ref="table">
                 <thead>

--- a/addons/web/static/src/views/no_content_helpers.xml
+++ b/addons/web/static/src/views/no_content_helpers.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
 
-    <t t-name="web.ActionHelper">
-        <div class="o_view_nocontent">
-            <div class="o_nocontent_help">
-                <t t-out="noContentHelp"/>
-            </div>
-        </div>
-    </t>
-
     <t t-name="web.NoContentHelper">
         <div class="o_view_nocontent" role="alert">
             <div class="o_nocontent_help">

--- a/addons/web/static/src/views/pivot/pivot_controller.js
+++ b/addons/web/static/src/views/pivot/pivot_controller.js
@@ -5,12 +5,14 @@ import { useSetupAction } from "@web/search/action_hook";
 import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { CogMenu } from "@web/search/cog_menu/cog_menu";
+import { Widget } from "@web/views/widgets/widget";
+import { ActionHelper } from "@web/views/action_helper";
 
 import { Component, useRef } from "@odoo/owl";
 
 export class PivotController extends Component {
     static template = "web.PivotView";
-    static components = { Layout, SearchBar, CogMenu };
+    static components = { Layout, SearchBar, CogMenu, Widget, ActionHelper };
     static props = {
         ...standardViewProps,
         Model: Function,

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -31,11 +31,8 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-if="model.isReady and displayNoContent">
-                    <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
-                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
-                    </t>
-                    <t t-else="" t-call="web.NoContentHelper"/>
+				<t t-if="model.isReady and displayNoContent">
+    				<ActionHelper noContentHelp="props.info.noContentHelp" showRibbon="model.useSampleModel"/>
                 </t>
                 <t t-if="model.isReady" t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate"/>
             </Layout>

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.js
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.js
@@ -17,10 +17,11 @@ import { Component } from "@odoo/owl";
  *        If you don't specify the bg_color prop the bg-success class will be used
  *        by default.
  */
-class RibbonWidget extends Component {
+export class RibbonWidget extends Component {
     static template = "web.Ribbon";
     static props = {
         ...standardWidgetProps,
+        record: { type: Object, optional: true },
         text: { type: String },
         title: { type: String, optional: true },
         bgClass: { type: String, optional: true },
@@ -43,13 +44,11 @@ class RibbonWidget extends Component {
 
 export const ribbonWidget = {
     component: RibbonWidget,
-    extractProps: ({ attrs }) => {
-        return {
-            text: attrs.title || attrs.text,
-            title: attrs.tooltip,
-            bgClass: attrs.bg_color,
-        };
-    },
+    extractProps: ({ attrs }) => ({
+        text: attrs.title || attrs.text,
+        title: attrs.tooltip,
+        bgClass: attrs.bg_color,
+    }),
     supportedAttributes: [
         {
             label: _t("Title"),

--- a/addons/web/static/src/views/widgets/widget.js
+++ b/addons/web/static/src/views/widgets/widget.js
@@ -130,7 +130,6 @@ export class Widget extends Component {
                 ? this.widget.extractProps(widgetInfo, dynamicInfo)
                 : {};
         }
-
         return {
             record,
             readonly: !record.isInEdition || readonlyFromModifiers || false,

--- a/addons/web/static/src/webclient/navbar/navbar.js
+++ b/addons/web/static/src/webclient/navbar/navbar.js
@@ -26,7 +26,14 @@ export class MenuDropdown extends Dropdown {}
 
 export class NavBar extends Component {
     static template = "web.NavBar";
-    static components = { Dropdown, DropdownItem, DropdownGroup, MenuDropdown, ErrorHandler, Transition };
+    static components = {
+        Dropdown,
+        DropdownItem,
+        DropdownGroup,
+        MenuDropdown,
+        ErrorHandler,
+        Transition,
+    };
     static props = {};
 
     setup() {

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -6167,6 +6167,41 @@ test("quick create column with x_name as _rec_name", async () => {
 });
 
 test.tags("desktop");
+test("reset filter button should appear when no data corresponding to facets", async () => {
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <field name="foo"/>
+                    </t>
+                </templates>
+            </kanban>`,
+        searchViewArch: `
+            <search>
+                <filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
+            </search>`,
+        noContentHelp: "click to add a partnerReset Filters",
+    });
+
+    await contains(".o_kanban_view").click();
+    await toggleSearchBarMenu();
+    await toggleMenuItem("Match nothing");
+
+    expect(".o_view_nocontent").toHaveCount(1);
+    expect(getFacetTexts()).not.toEqual([]);
+    expect(".o_reset_filter_button").toHaveCount(1);
+    expect(".o_reset_filter_button").toHaveText("Reset Filters");
+    expect(".o_facet_value").toHaveText("Match nothing");
+
+    await contains(".o_reset_filter_button").click();
+    expect(getFacetTexts()).toEqual([]);
+    expect(".o_reset_filter_button").not.toHaveCount(1);
+});
+
+test.tags("desktop");
 test("count of folded groups in empty kanban with sample data", async () => {
     onRpc("web_read_group", () => ({
         groups: [
@@ -6996,6 +7031,8 @@ test("empty kanban with sample data", async () => {
         message: "there should be 10 sample records",
     });
     expect(".o_view_nocontent").toHaveCount(1);
+    expect(".ribbon").toHaveCount(1);
+    expect(".ribbon").toHaveText("SAMPLE DATA");
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Match nothing");
@@ -7003,6 +7040,7 @@ test("empty kanban with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
     expect(".o_view_nocontent").toHaveCount(1);
+    expect(".ribbon").toHaveCount(0);
 });
 
 test("empty grouped kanban with sample data and many2many_tags", async () => {
@@ -7122,12 +7160,14 @@ test("non empty kanban with sample data", async () => {
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(4);
     expect(".o_view_nocontent").toHaveCount(0);
+    expect(".ribbon").toHaveCount(0);
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Match nothing");
 
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_kanban_record:not(.o_kanban_ghost)").toHaveCount(0);
+    expect(".ribbon").toHaveCount(0);
 });
 
 test("empty grouped kanban with sample data: add a column", async () => {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -7041,6 +7041,34 @@ test(`no nocontent helper when no data and no help`, async () => {
     expect(`.o_list_view table`).toHaveCount(1, { message: "should have a table in the dom" });
 });
 
+test.tags("desktop");
+test("reset filter button should appear when no data corresponding to facets", async () => {
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `<list><field name="foo"/></list>`,
+        searchViewArch: `
+            <search>
+                <filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
+            </search>`,
+        noContentHelp: "click to add a partnerReset Filters",
+    });
+
+    await contains(".o_list_view").click();
+    await toggleSearchBarMenu();
+    await toggleMenuItem("Match nothing");
+
+    expect(".o_view_nocontent").toHaveCount(1);
+    expect(getFacetTexts()).not.toEqual([]);
+    expect(".o_reset_filter_button").toHaveCount(1);
+    expect(".o_reset_filter_button").toHaveText("Reset Filters");
+    expect(".o_facet_value").toHaveText("Match nothing");
+
+    await contains(".o_reset_filter_button").click();
+    expect(getFacetTexts()).toEqual([]);
+    expect(".o_reset_filter_button").not.toHaveCount(1);
+});
+
 test(`empty list with sample data`, async () => {
     await mountView({
         resModel: "foo",
@@ -7070,6 +7098,8 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(10);
     expect(`.o_nocontent_help`).toHaveCount(1);
+    expect(".ribbon").toHaveCount(1);
+    expect(".ribbon").toHaveText("SAMPLE DATA");
 
     // Check list sample data
     expect(`.o_data_row .o_data_cell:eq(0)`).toHaveText("", {
@@ -7098,6 +7128,7 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_nocontent_help`).toHaveCount(1);
+    expect(".ribbon").toHaveCount(0);
 
     await toggleMenuItem("False Domain");
     await toggleMenuItem("True Domain");
@@ -7105,6 +7136,7 @@ test(`empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(4);
     expect(`.o_nocontent_help`).toHaveCount(0);
+    expect(".ribbon").toHaveCount(0);
 });
 
 test(`refresh empty list with sample data`, async () => {
@@ -7255,6 +7287,7 @@ test(`non empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(4);
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
+    expect(".ribbon").toHaveCount(0);
 
     await toggleSearchBarMenu();
     await toggleMenuItem("true_domain");
@@ -7262,6 +7295,7 @@ test(`non empty list with sample data`, async () => {
     expect(`.o_list_table`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(0);
     expect(`.o_list_view .o_content`).not.toHaveClass("o_view_sample_data");
+    expect(".ribbon").toHaveCount(0);
 });
 
 test(`click on header in empty list with sample data`, async () => {

--- a/addons/web/static/tests/views/pivot_view.test.js
+++ b/addons/web/static/tests/views/pivot_view.test.js
@@ -2729,6 +2729,41 @@ test("empty pivot view with action helper", async () => {
 });
 
 test.tags("desktop");
+test("reset filter button should appear when no data corresponding to facets", async () => {
+    Partner._views["pivot,false"] = `<pivot>
+		<field name="product_id" type="measure"/>
+		<field name="date" interval="month" type="col"/>
+	</pivot>`;
+    Partner._views["search,false"] = `<search>
+		<filter name="no_match" string="Match nothing" domain="[['id', '=', 0]]"/>
+	</search>`;
+
+    await mountView({
+        type: "pivot",
+        resModel: "partner",
+        context: { search_default_small_than_0: true },
+        noContentHelp: markup(`<p class="abc">click to add a foo</p>`),
+        config: {
+            views: [[false, "search"]],
+        },
+    });
+
+    await contains(".o_pivot_view").click();
+    await toggleSearchBarMenu();
+    await toggleMenuItem("Match nothing");
+
+    expect(".o_view_nocontent").toHaveCount(1);
+    expect(getFacetTexts()).not.toEqual([]);
+    expect(".o_reset_filter_button").toHaveCount(1);
+    expect(".o_reset_filter_button").toHaveText("Reset Filters");
+    expect(".o_facet_value").toHaveText("Match nothing");
+
+    await contains(".o_reset_filter_button").click();
+    expect(getFacetTexts()).toEqual([]);
+    expect(".o_reset_filter_button").not.toHaveCount(1);
+});
+
+test.tags("desktop");
 test("empty pivot view with sample data", async () => {
     Partner._views["pivot"] = `<pivot sample="1">
 		<field name="product_id" type="measure"/>
@@ -2750,9 +2785,12 @@ test("empty pivot view with sample data", async () => {
 
     expect(".o_pivot_view .o_content").toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(1);
+    expect(".ribbon").toHaveCount(1);
+    expect(".ribbon").toHaveText("SAMPLE DATA");
     await removeFacet();
     expect(".o_pivot_view .o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(0);
+    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(1);
 });
 
@@ -2776,11 +2814,13 @@ test("non empty pivot view with sample data", async () => {
 
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(0);
+    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(1);
     await toggleSearchBarMenu();
     await toggleMenuItem("Small Than 0");
     expect(".o_content").not.toHaveClass("o_view_sample_data");
     expect(".o_view_nocontent .abc").toHaveCount(1);
+    expect(".ribbon").toHaveCount(0);
     expect("table").toHaveCount(0);
 });
 

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -840,7 +840,10 @@ test("SelectCreateDialog empty list, default no content helper", async () => {
     expect(".o_dialog .o_list_view .o_data_row").toHaveCount(0);
     expect(".o_dialog .o_list_view .o_view_nocontent").toHaveCount(1);
     expect(queryOne(".o_dialog .o_list_view .o_view_nocontent")).toHaveInnerHTML(
-        `<div class="o_nocontent_help"><p>No record found</p><p>Adjust your filters or create a new record.</p></div>`
+        `<div class="o_nocontent_help">
+            <p>No record found</p>
+            <p>Adjust your filters or create a new record.</p>
+        </div>`
     );
 });
 test.tags("mobile");
@@ -857,7 +860,10 @@ test("SelectCreateDialog empty kanban, default no content helper", async () => {
     expect(".o_dialog .o_kanban_view .o_kanban_record[data-id]").toHaveCount(0);
     expect(".o_dialog .o_kanban_view .o_view_nocontent").toHaveCount(1);
     expect(queryOne(".o_dialog .o_kanban_view .o_view_nocontent")).toHaveInnerHTML(
-        `<div class="o_nocontent_help"><p>No record found</p><p>Adjust your filters or create a new record.</p></div>`
+        `<div class="o_nocontent_help">
+            <p>No record found</p>
+            <p>Adjust your filters or create a new record.</p>
+        </div>`
     );
 });
 
@@ -886,7 +892,10 @@ test("SelectCreateDialog empty list, noContentHelp props", async () => {
     expect(".o_dialog .o_list_view .o_data_row").toHaveCount(0);
     expect(".o_dialog .o_list_view .o_view_nocontent").toHaveCount(1);
     expect(queryOne(".o_dialog .o_list_view .o_view_nocontent")).toHaveInnerHTML(
-        `<div class="o_nocontent_help"><p class="custom_classname">Hello</p><p>I'm an helper</p></div>`
+        `<div class="o_nocontent_help">
+            <p class="custom_classname">Hello</p>
+            <p>I'm an helper</p>  
+        </div>`
     );
 });
 

--- a/addons/web_hierarchy/static/src/hierarchy_controller.js
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.js
@@ -10,12 +10,14 @@ import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSearchBarToggler } from "@web/search/search_bar/search_bar_toggler";
 import { standardViewProps } from "@web/views/standard_view_props";
 import { useViewButtons } from "@web/views/view_button/view_button_hook";
+import { ActionHelper } from "@web/views/action_helper";
 
 export class HierarchyController extends Component {
     static components = {
         Layout,
         CogMenu,
         SearchBar,
+        ActionHelper,
     };
     static props = {
         ...standardViewProps,

--- a/addons/web_hierarchy/static/src/hierarchy_controller.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.xml
@@ -28,10 +28,7 @@
                 </t>
                 <t t-set-slot="default" t-slot-scope="layout">
                 <t t-if="displayNoContent">
-                    <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
-                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
-                    </t>
-                    <t t-else="" t-call="web.NoContentHelper"/>
+					<ActionHelper noContentHelp="props.info.noContentHelp"/>
                 </t>
                     <t t-component="props.Renderer"
                         model="model"


### PR DESCRIPTION
\* = appointment, documents, esg, hr_appraisal, sign, web_cohort, web_gantt, web_grid

Before this commit, the web.ActionHelper was only an XML template. In order to add new features to it, it is now a Component.
This commit adds:
- A button to reset filters and on the helper when there is at least one facet in the searchModel and there is no data corresponding.
- A ribbon widget displayed when sample data is used in the helper.
- An ActionHelper component centralizing the two previous features.

task-4648766