### PR TITLE
[IMP] website: add `s_attributes_vertical` snippet

### DIFF
--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -153,6 +153,7 @@
         'views/snippets/s_badge.xml',
         'views/snippets/s_color_blocks_2.xml',
         'views/snippets/s_attributes_horizontal.xml',
+        'views/snippets/s_attributes_vertical.xml',
         'views/snippets/s_product_list.xml',
         'views/snippets/s_mega_menu_multi_menus.xml',
         'views/snippets/s_mega_menu_menu_image_menu.xml',

--- a/addons/website/static/src/snippets/s_attributes_vertical/000.scss
+++ b/addons/website/static/src/snippets/s_attributes_vertical/000.scss
@@ -1,0 +1,10 @@
+.s_attributes_vertical {
+    .s_attributes_vertical_img {
+        &.float-start {
+            margin-inline-end: var(--s_attributes_vertical_margin, #{map-get($spacers, 3)}) !important;
+        }
+        &.float-end {
+            margin-inline-start: var(--s_attributes_vertical_margin, #{map-get($spacers, 3)}) !important;
+        }
+    }
+}

--- a/addons/website/views/snippets/s_attributes_vertical.xml
+++ b/addons/website/views/snippets/s_attributes_vertical.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+<template id="s_attributes_vertical" name="Vertical Attributes">
+    <section class="s_attributes_vertical">
+        <div class="container-fluid">
+            <div class="row">
+                <div class="col-lg-4 border pt48 pb48" data-name="Column">
+                    <img src="/web_editor/shape/website/s_attributes_1.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
+                        class="s_attributes_vertical_img img img-fluid mx-auto"
+                        alt=""
+                        style="width: 25% !important; padding: 20px;"/>
+                    <div class="d-flex flex-column">
+                        <h6 style="text-align: center;">
+                            Easy returns with quick<br/>
+                            and simple process
+                        </h6>
+                        <small class="text-muted" style="text-align: center;">
+                            Free 30-day returns with quick refunds<br/>
+                            or easy exchanges and no stress.
+                        </small>
+                    </div>
+                </div>
+                <div class="col-lg-4 border pt48 pb48" data-name="Column">
+                    <img src="/web_editor/shape/website/s_attributes_3.svg?c1=rgba(0,0,0,.25)&amp;c4=o-color-4&amp;c5=o-color-5"
+                        class="s_attributes_vertical_img img img-fluid mx-auto"
+                        alt=""
+                        style="width: 25% !important; padding: 20px;"/>
+                    <div class="d-flex flex-column">
+                        <h6 style="text-align: center;">
+                            Secure payment<br/>
+                            with trusted methods
+                        </h6>
+                        <small class="text-muted" style="text-align: center;">
+                            Your information is protected with encrypted<br/>
+                            checkout and trusted payment methods.
+                        </small>
+                    </div>
+                </div>
+                <div class="col-lg-4 border pt48 pb48" data-name="Column">
+                    <img src="/web_editor/shape/website/s_attributes_4.svg?c1=rgba(0,0,0,.25)&amp;c2=rgba(0,0,0,.5)&amp;c4=o-color-4&amp;c5=o-color-5"
+                        class="s_attributes_vertical_img img img-fluid mx-auto"
+                        alt=""
+                        style="width: 25% !important; padding: 20px;"/>
+                    <div class="d-flex flex-column">
+                        <h6 style="text-align: center;">
+                            Quality assured<br/>
+                            with every purchase
+                        </h6>
+                        <small class="text-muted" style="text-align: center;">
+                            Every product is carefully tested to meet<br/>
+                            high standards of durability and performance.
+                        </small>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</template>
+
+<record id="website.s_attributes_vertical_000_scss" model="ir.asset">
+    <field name="name">Vertical Attributes 000 SCSS</field>
+    <field name="bundle">web.assets_frontend</field>
+    <field name="path">website/static/src/snippets/s_attributes_vertical/000.scss</field>
+</record>
+
+</odoo>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -423,6 +423,9 @@
                 <t t-snippet="website.s_banner_categories" string="Banner Categories" group="catalog">
                     <keywords>hero, categories, ecommerce, shop, illustration, buy, photos, shop, product, grid, pictures</keywords>
                 </t>
+                <t t-snippet="website.s_attributes_vertical" string="Vertical Attributes" group="catalog">
+                    <keywords>services, icons, features, characteristic, specs, advantages, functionalities, exhibit, details, capabilities, attributes, promotion, overview, specifications</keywords>
+                </t>
                 <t id="sale_products_hook"/>
 
                 <!-- Blogs group -->


### PR DESCRIPTION
This commit introduces a variant of the `s_attributes_horizontal` snippet using larger columns and a vertical layout.

Requires:
- https://github.com/odoo/design-themes/pull/1063

task-4778437
Part of task-4252024

![Capture d’écran 2025-05-12 à 15 56 18](https://github.com/user-attachments/assets/e1f9e386-2d4b-47d6-b56b-6a4ad1cd6517)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
