### PR TITLE
[FIX] Dashboard : dashboard display problem for rtf languages

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -7,7 +7,7 @@
         <div
             t-foreach="figures" t-as="figure"
             t-key="figure.id"
-            t-attf-style="min-height: #{figure.height}px;"
+            t-attf-style="min-height: #{figure.height}px; direction: ltr;"
         >
             <t t-component="getFigureComponent(figure)" figure="figure" onFigureDeleted="() => {}"/>
         </div>


### PR DESCRIPTION
[FIX] Dashboard : dashboard display problem for rtf languages

to reproduce:
=============
- step 1 :  change language to arab
- step 2 : go to dashboard app using mobile
...

Problem:
========
overlapped text in the Dashboard module
we forced direction to ltr on all languages in web and we  didn't add this change in the mobile part


Solution:
force ltr direction even on rtl languages in the mobile part
 
=========
how to fix that
we will force ltr direction to all languages 

how the fix looks like 

opw-4586743