### PR TITLE
[FIX] test_website: fix tour for website page properties

### DIFF
--- a/addons/test_website/tests/test_website_page_properties.py
+++ b/addons/test_website/tests/test_website_page_properties.py
@@ -13,4 +13,15 @@ class TestWebsitePageProperties(HttpCase):
         self.start_tour('/test_website/model_item/1', 'website_page_properties_can_publish', login='admin')
 
     def test_website_page_properties_website_page(self):
+        # Create a website page with a different URL to be tested for dependency
+        # tracking
+        self.env['website.page'].create({
+            'name': 'Base',
+            'type': 'qweb',
+            'arch': '<div><a href="/cool-page">Cool page</a></div>',
+            'key': 'test.cool_page',
+            'url': '/dependency_page',
+            'website_id': self.env['website'].search([], limit=1).id,
+        })
+
         self.start_tour('/', 'website_page_properties_website_page', login='admin')


### PR DESCRIPTION
Since [1], we have to adapt the tour for the website page properties to fit the new behaviour of the page dependencies.

[1]: https://github.com/odoo/odoo/commit/cd4b0c91c1cf60ff72e91cf0544cb255ee5aff3f
