### PR TITLE
[PERF] hr_expense: add missing index `account.move.line.expense_id`

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -9,7 +9,7 @@ from odoo.tools.misc import frozendict
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    expense_id = fields.Many2one('hr.expense', string='Expense', copy=True) # copy=True, else we don't know price is tax incl.
+    expense_id = fields.Many2one('hr.expense', string='Expense', copy=True, index='btree_not_null')  # copy=True, else we don't know price is tax incl.
 
     @api.constrains('account_id', 'display_type')
     def _check_payable_receivable(self):


### PR DESCRIPTION
Description
-----------
Deleting an expense is slow when the `account_move_line` table is large, as the `Many2one`/`fkey` `expense_id` needs to be set to `NULL` where necessary. If there is no index on the `fkey`, it's `Seq. Scan` on the table `account_move_line`.

Benchmark:
----------
On odoo.com, unlinking an expense took:

| Before | After |
|--------|-------|
| 10s    | 58ms  |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
