### PR TITLE
[FIX] *: domain field: option allow_expressions

### DIFF
--- a/addons/mail/tests/test_mail_tools.py
+++ b/addons/mail/tests/test_mail_tools.py
@@ -3,8 +3,6 @@
 
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import tagged, users
-from odoo.addons.mail.tools.parser import domain_eval
-from freezegun import freeze_time
 
 
 @tagged('mail_tools', 'res_partner')
@@ -180,22 +178,6 @@ class TestMailTools(MailCommon):
         for record, (expected_partner, msg) in zip(records, expected_partners):
             found = Partner._mail_find_partner_from_emails([self._test_email], records=record)
             self.assertEqual(found, [expected_partner], msg)
-
-    @freeze_time('2030-05-24')
-    def test_domain_eval(self):
-        success_pairs = [
-            ("list()", []),
-            ("list(range(1, 4))", [1, 2, 3]),
-            ("['|', (1, '=', 1), (1, '>', 0)]", ['|', (1, '=', 1), (1, '>', 0)]),
-            ("[(2, '=', 1 + 1)]", [(2, '=', 2)]),
-            (
-                "[('create_date', '<', datetime.datetime.combine(context_today() - relativedelta(days=100), datetime.time(1, 2, 3)).to_utc().strftime('%Y-%m-%d %H:%M:%S'))]",
-                [('create_date', '<', "2030-02-13 01:02:03")],
-            ),  # use the date utils used by front-end domains
-        ]
-        for domain_expression, domain_value in success_pairs:
-            with self.subTest(domain_expression=domain_expression, domain_value=domain_value):
-                self.assertEqual(domain_eval(domain_expression), domain_value)
 
 
 @tagged('mail_tools', 'mail_init')

--- a/addons/mail/tools/parser.py
+++ b/addons/mail/tools/parser.py
@@ -5,7 +5,6 @@ import ast
 
 from odoo import _, tools
 from odoo.exceptions import ValidationError
-from odoo.tools import safe_eval
 
 
 def parse_res_ids(res_ids):
@@ -34,15 +33,3 @@ def parse_res_ids(res_ids):
         raise ValidationError(error_msg)
 
     return res_ids
-
-
-def domain_eval(domain):
-    domain = domain.replace('.to_utc()', '')
-    evaluated_domain = safe_eval.safe_eval(domain, {
-        'context_today': safe_eval.datetime.datetime.today,
-        'datetime': safe_eval.datetime,
-        'dateutil': safe_eval.dateutil,
-        'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
-        'time': safe_eval.time,
-    })
-    return evaluated_domain

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -3598,6 +3598,13 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/views/fields/domain/domain_field.js:0
+#, python-format
+msgid "If true, non-literals are accepted"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
 #: code:addons/web/static/src/core/file_viewer/file_viewer.xml:0
 #: code:addons/web/static/src/views/fields/attachment_image/attachment_image_field.xml:0
 #: code:addons/web/static/src/views/fields/image/image_field.js:0
@@ -7084,6 +7091,20 @@ msgstr ""
 msgid ""
 "The content of this cell is too long for an XLSX file (more than %s "
 "characters). Please use the CSV format for this export."
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/views/fields/domain/domain_field.js:0
+#, python-format
+msgid "The domain involves non-literals. Their evaluation might fail."
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/views/fields/domain/domain_field.js:0
+#, python-format
+msgid "The domain should not involve non-literals"
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -138,6 +138,34 @@ export function complexCondition(value) {
     return { type: "complex_condition", value };
 }
 
+function treeContainsExpressions(tree) {
+    if (tree.type === "condition") {
+        const { path, operator, value } = tree;
+        return [path, operator, value].some(
+            (v) =>
+                v instanceof Expression ||
+                (Array.isArray(v) && v.some((w) => w instanceof Expression))
+        );
+    }
+    for (const child of tree.children) {
+        if (treeContainsExpressions(child)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function domainContainsExpresssions(domain) {
+    let tree;
+    try {
+        tree = treeFromDomain(domain);
+    } catch {
+        return null;
+    }
+    // detect expressions in the domain tree, which we know is well-formed
+    return treeContainsExpressions(tree);
+}
+
 /**
  * @param {Value} value
  * @returns {Value}

--- a/addons/website/controllers/model_page.py
+++ b/addons/website/controllers/model_page.py
@@ -5,7 +5,6 @@ import werkzeug
 from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.http import Controller, request, route
 from odoo.osv.expression import AND, OR
-from odoo.addons.mail.tools.parser import domain_eval
 
 
 class ModelPageController(Controller):
@@ -46,7 +45,7 @@ class ModelPageController(Controller):
         if not Model.check_access_rights("read", raise_exception=False):
             raise werkzeug.exceptions.Forbidden()
 
-        rec_domain = domain_eval(page.record_domain or "[]")
+        rec_domain = ast.literal_eval(page.record_domain or "[]")
         domains = [rec_domain]
 
         if record_slug:


### PR DESCRIPTION
Some views use a domain widget to edit/save a domain and use it afterwards in several places where domains must have literals only. Typically, a literal_eval is used to evaluate the (string) domain. Thus expressions like "uid" or "context_today()"" should not be used in those contexts.
Here we introduce an option "allow_expressions" (default False) for the domain field and use it to mark as invalid domains that contain expressions when the option is set to False. A notification is displayed when a domain contains an unwanted expressions.

Since we cannot expect modules like base to be updated, we have to find another system to allow the usage of expressions in the form views for the models ir.filters and base.automation: we simply hardcode those models as allowing expressions. Since for these models, the evaluation of domains is done via safe_eval but with a restricted evaluation context, we also display a notification that alerts the user that the evaluation of expressions (although accepted by the domain field) can fail.

We revert the recent commit https://github.com/odoo/odoo/commit/a6787552150434d4366e30cbeb6f6d309c2c6cb9 that introduced potentially problematic calls to safe_eval in order to allow evaluation of expressions.

