### PR TITLE
[FIX] hr_holidays: smaller alert "back on x" in discuss

### DIFF
--- a/addons/hr_holidays/static/src/thread_patch.xml
+++ b/addons/hr_holidays/static/src/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.persona.outOfOfficeText" class="alert alert-primary rounded-0" t-esc="props.thread.correspondent.persona.outOfOfficeText" role="alert"/>
+            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.persona.outOfOfficeText" class="alert alert-primary py-0 rounded-0 mb-0 smaller fw-bold" t-esc="props.thread.correspondent.persona.outOfOfficeText" role="alert"/>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
When a user is on leave, the DM chat shows header on top with "Back on X".

Before this commit, the alert was far too big and has lots of bottom margin. This commit makes the alert much smaller similarly to the "1 unread mark as read" top banner.