### PR TITLE
[FIX] web: percent-encode fileame in download URLs

### DIFF
--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -49,7 +49,21 @@ export const FileModelMixin = (T) =>
         }
 
         get downloadUrl() {
-            return url(this.urlRoute, { ...this.urlQueryParams, download: true });
+            const params = {
+                ...this.urlQueryParams,
+                download: true,
+            };
+            // Hacky way to minimally encode url with WHATWG URL API, without modifying widely used url function, toString must be called to run encoding
+            const searchParams = new URLSearchParams(params || {});
+            const encodedString = searchParams.toString();
+            const encodedObject = Object.fromEntries(
+                encodedString.split("&").map((pair) => {
+                    const [key, value] = pair.split("=");
+                    return [key, value];
+                })
+            );
+
+            return url(this.urlRoute, encodedObject);
         }
 
         get isImage() {

--- a/addons/web/static/tests/core/file_model.test.js
+++ b/addons/web/static/tests/core/file_model.test.js
@@ -18,3 +18,17 @@ test("url query params of FileModel returns proper params", () => {
     const fileModel = Object.assign(new FileModel(), attachmentData);
     expect(fileModel.urlQueryParams).toEqual(expectedQueryParams);
 });
+
+test("downloadUrl percent-encodes apostrophes in the filename param", () => {
+    const attachmentData = {
+        name: "test'.xml",
+        id: 123456789,
+        checksum: "f6a9d2bcbb34ce90a73785d8c8d1b82e5cdf0b5b",
+        access_token: "4b52e31e-a155-4598-8d15-538f64f0fb7b",
+        extension: "xlsx",
+        mimetype: "'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'",
+    };
+    const encodedFilename = "filename=test%2527";
+    const fileModel = Object.assign(new FileModel(), attachmentData);
+    expect(fileModel.downloadUrl).toInclude(encodedFilename);
+});


### PR DESCRIPTION
Before this change, filenames containing special characters (e.g. apostrophes) were injected raw into the download URL.
Because download mechanism validates urls using WHATWG URL serialization the downloaded link was't considered an URL.
That misrouted the flow into the “blob-of-text” fallback,
causing the client to save a tiny file containing the URL
rather than fetching the real XLSX bytes with the file.

This commit switches the download-URL builder to use WHATWG-compliant encoding
for every query parameter via `URLSearchParams`.

Reproduce
---
- install knowledge
- open any article
- insert /file with ' in name, must be not `isViewable` (example: `file'.xlsx`)
- click on it to download
- BUG: downloaded file containg broken link instead of the file

opw-[4746027](https://www.odoo.com/web#id=4746027&view_type=form&model=project.task)