### PR TITLE
[FIX] mail: chat window action panel takes whole chat window width

### DIFF
--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -20,10 +20,16 @@ export class ActionPanel extends Component {
     }
 
     get classNames() {
-        return `o-mail-ActionPanel overflow-auto d-flex flex-column flex-shrink-0 position-relative py-2 pt-0 h-100 bg-inherit ${
-            !this.env.inChatter ? " px-2" : " o-mail-ActionPanel-chatter"
-        } ${this.env.inDiscussApp ? " o-mail-discussSidebarBgColor" : ""} ${
-            this.props.resizable ? "" : "rounded"
-        }`;
+        const attClass = {
+            "o-mail-ActionPanel overflow-auto d-flex flex-column flex-shrink-0 position-relative py-2 pt-0 h-100 bg-inherit": true,
+            "o-mail-ActionPanel-chatter": this.env.inChatter,
+            "o-chatWindow": this.env.inChatWindow,
+            "px-2": !this.env.inChatter,
+            rounded: !this.props.resizable,
+        };
+        return Object.entries(attClass)
+            .filter(([classNames, value]) => value)
+            .map(([classNames]) => classNames)
+            .join(" ");
     }
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/action_panel.scss
@@ -2,7 +2,7 @@
     --form-check-bg: #{$white};
 }
 
-.o-mail-ActionPanel:not(.o-mail-ActionPanel-chatter) {
+.o-mail-ActionPanel:not(.o-mail-ActionPanel-chatter):not(.o-chatWindow) {
     @media (min-width: 750px) {
         max-width: 30vw;
     }


### PR DESCRIPTION
Before this commit, sometimes the action panel in chat window were taking part of the chat window available width.

Steps to reproduce:
- open a chat window of a discuss conversation
- open Notification settings
- reduce the width of browser window just before mobile threshold => the "Notification settings" panel takes part of the width of chat window

This happens because some responsive code for max width of action panel from Discuss app was mistakenly involved in chat window.

This commit fixes the issue by ensuring this responsive behaviour of max width doesn't apply in chat window.