### PR TITLE
[FIX] stock: forecast qty update display help + cleanup

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_buttons.js
@@ -1,6 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
-import { Component } from "@odoo/owl";
+import { Component, markup } from "@odoo/owl";
 
 export class ForecastedButtons extends Component {
     static template = "stock.ForecastedButtons";
@@ -49,9 +49,10 @@ export class ForecastedButtons extends Component {
 
     async _onClickUpdateQuantity() {
         const action = await this.orm.call(this.resModel, "action_open_quants", [[this.productId]]);
-        if (action.res_model === "stock.quant") { // Quant view in inventory mode.
-            action.views = [[false, "list"]];
+        action.views = [[false, "list"]];  // varies from where called from => only show list
+        if (action.help) {
+            action.help = markup(action.help);
         }
-        return this.actionService.doAction(action, { onClose: this._onClose.bind(this) });
+        return this.actionService.doAction(action);
     }
 }


### PR DESCRIPTION
Followup to https://github.com/odoo/odoo/commit/fdcb584b20af1f99cf760eaff94e489a77e6c36d

When the `_onClickUpdateQuantity` was updated to use a view instead of a
wizard that opens in a new window, it was not checked that the HTML help
when no records found is correctly rendered. This fixes that by ensuring
it's correctly parsed, i.e. copied same solution as here:
https://github.com/odoo/odoo/commit/f9f7d9d6a8470f3ca5ff464bb425b219ac4ed571

Steps to reproduce:
- open any product > click on forecast report button
- click on "Update Quantity"
- apply a filter so that no records are found (e.g. only "Transit
  Locations"

Expected result: normal no records found icon + help
Actual result: raw html

Additionally cleaned up some of the junk code that was left by the
original commit....

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
