### PR TITLE
[FIX] product: recompute base in discount when change compute price

### DIFF
--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -333,6 +333,7 @@ class PricelistItem(models.Model):
 
     @api.onchange('compute_price')
     def _onchange_compute_price(self):
+        self.base_pricelist_id = False
         if self.compute_price != 'fixed':
             self.fixed_price = 0.0
         if self.compute_price != 'percentage':

--- a/addons/product/tests/test_pricelist.py
+++ b/addons/product/tests/test_pricelist.py
@@ -198,3 +198,22 @@ class TestPricelist(ProductCommon):
 
         with Form(partner) as partner_form:
             self.assertEqual(partner_form.property_product_pricelist, self.sale_pricelist_id)
+
+    def test_pricelist_change_to_formula_and_back(self):
+        pricelist_2 = self.env['product.pricelist'].create({
+            'name': 'Sale pricelist 2',
+            'item_ids': [
+                Command.create({
+                    'compute_price': 'percentage',
+                    'percent_price': 20,
+                    'base': 'pricelist',
+                    'base_pricelist_id': self.sale_pricelist_id.id,
+                    'applied_on': '3_global',
+                }),
+            ],
+        })
+        with Form(pricelist_2.item_ids) as item_form:
+            item_form.compute_price = 'formula'
+            item_form.compute_price = 'percentage'
+            item_form.percent_price = 20
+        self.assertFalse(pricelist_2.item_ids.base_pricelist_id.id)


### PR DESCRIPTION
**Problem:**
When changing the price type of a Discount pricelist rule to 
"formula" and going back to the original price type "discount"
the rule does not take into account the base pricelist anymore
and uses the list price of the product to compute the discount

**Steps to reproduce:**
- Navigate to Sales/Products/Pricelists
- Create a new pricelist, click on Add a line
- In "Price Type" select Fixed Price and set a Fixed Price of 10
- Save and Close > create a second new price list
- Click on "Add a line" and select a Price Type Discount
- Set a 50% discount percent and select your first pricelist
as the base price (next to "on")
- Save and Close > save the form
- Open the rule again and change the Price Type to formula 
- Change the Price Type back to Discount and set a discount percentage
of 50% again
- Save and Close
- Create a new quotation with a product and select the second pricelist
you created > click on Update Prices

**Current behavior:**
 Amount is 50% of the price of the product 

**Expected behavior:**
It should be 50% of 10 because our second pricelist is based on the 
first one which has a fixed price of 10

**Cause of the issue:**
when _onchange_compute_price is triggeredwhen going back 
to discount value, base will be set to list_price
https://github.com/odoo/odoo/blob/d3e43681fd2b989ae7272731662cc3ac6a6d913b/addons/product/models/product_pricelist_item.py#L334-L342
because of this, the base price will not be computed based on the 
base pricelist 
https://github.com/odoo/odoo/blob/d3e43681fd2b989ae7272731662cc3ac6a6d913b/addons/product/models/product_pricelist_item.py#L580-L583

**fix:**
By resetting the base_pricelist_id, it's now visible to the user
on the form that the computation is no more based on a pricelist.
If the user enters a pricelist, the correct value will be computerd
for base and base_pricelist_id at that time.

opw-4757951
