### PR TITLE
[IMP] web: add option to hide sections

### DIFF
--- a/addons/hr/views/hr_department_views.xml
+++ b/addons/hr/views/hr_department_views.xml
@@ -33,7 +33,7 @@
                                 <field name="color" widget="color_picker" string="Color"/>
                             </group>
                             <group colspan="5" invisible="not id or id and not child_ids and not parent_id">
-                                <widget name="hr_department_chart"/>
+                                <widget name="hr_department_chart" class="mb-3"/>
                             </group>
                         </group>
                     </sheet>


### PR DESCRIPTION
Add context option to hide the filters on the calendar view.
The attendees filter on the view causes confusion when you have default attendees set through the action.

Community pr: https://github.com/odoo/odoo/pull/208900
Enterprise pr: https://github.com/odoo/enterprise/pull/83440
Upgrade pr: https://github.com/odoo/upgrade/pull/7728
task-4678232

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
