### PR TITLE
[FIX] mail: show mute/deafen shortcut on pression ALT

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call_action_button.xml
+++ b/addons/mail/static/src/discuss/call/common/call_action_button.xml
@@ -4,6 +4,7 @@
     <t t-name="discuss.CallActionList.button">
         <button class="btn smaller d-flex m-1 border-0 rounded-circle shadow-none opacity-75-hover align-items-center p-0"
             t-att-class="{ 'bg-600 opacity-75': !props.action.available, 'opacity-100': props.action.available }"
+            t-att-data-hotkey="props.action.hotkey"
             t-att-aria-label="props.action.name"
             t-att-title="title"
             t-on-click="props.action.select">


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/204663

PR above add the new feature to quickly mute and deafen through hotkey `shift+m` and `shift+d`. While this works, the discovery of feature is poor, due to ALT not promoting them.

This commit fixes the issue by adding the `data-hotkey` on call actions that have these hotkeys, so that they are shown when pressing ALT to display all available hotkey.