### PR TITLE
[FIX] repair: avoid traceback when updating uom in repair order

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -91,7 +91,7 @@ class RepairOrder(models.Model):
     allowed_uom_ids = fields.Many2many('uom.uom', compute='_compute_allowed_uom_ids')
     product_uom = fields.Many2one(
         'uom.uom', 'Unit', domain="[('id', 'in', allowed_uom_ids)]",
-        compute='compute_product_uom', store=True, precompute=True)
+        compute='compute_product_uom', store=True, precompute=True, readonly=False)
     lot_id = fields.Many2one(
         'stock.lot', 'Lot/Serial',
         compute="compute_lot_id", store=True,


### PR DESCRIPTION
Steps to reproduce:
- Enable "Units of Measure" in Inventory settings
- Create a repair order
    - Select a product
    - Change its UoM

Problem:
A traceback is triggered:
```
Uncaught Promise > Can not evaluate python expression:
([('id', 'in', allowed_uom_ids)]) Error: Name 'allowed_uom_ids' is not defined
Occured on localhost:8076 on 2025-05-07 20:02:29 GMT
EvalError: Can not evaluate python expression: ([('id', 'in', allowed_uom_ids)])
    Error: Name 'allowed_uom_ids' is not defined

```

The problem is that the field is "readonly=False" in the view, but by
default it's "readonly=True" in Python side.
As a result, the ORM considers the field as read-only and does not
trigger the computation of "allowed_uom_id". When the domain is later
applied in Python, it causes a traceback due to the missing computed
value.

Solution:
Explicitly set readonly=False in the Python field definition.

opw-4773270
