### PR TITLE
[FIX] l10n_sa_edi: exclude retention tax when computing taxes

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -396,7 +396,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             # TaxableAmount and the TaxAmount nodes correctly. To avoid this, we re-caclculate the taxes_vals just before
             # we set the values for the down payment line, and we do not pass any filters to the _prepare_edi_tax_details
             # method
-            line_taxes = line.move_id._prepare_edi_tax_details(grouping_key_generator=grouping_key_generator)
+            line_taxes = line.move_id._prepare_edi_tax_details(filter_to_apply=lambda l, t: not self.env['account.tax'].browse(t['id']).l10n_sa_is_retention, grouping_key_generator=grouping_key_generator)
             taxes_vals = line_taxes['tax_details_per_record'][line]
 
         line_vals = super()._get_invoice_line_vals(line, taxes_vals)

--- a/addons/l10n_sa_edi/tests/test_edi_zatca.py
+++ b/addons/l10n_sa_edi/tests/test_edi_zatca.py
@@ -56,6 +56,13 @@ class TestEdiZatca(TestSaEdiCommon):
 
             self.assertXmlTreeEqual(current_tree, expected_tree)
 
+        retention_tax = self.env['account.tax'].create({
+            'l10n_sa_is_retention': True,
+            'name': 'Retention Tax',
+            'amount_type': 'percent',
+            'amount': -5.0,
+        })
+
         with freeze_time(datetime(year=2022, month=9, day=5, hour=8, minute=20, second=2, tzinfo=timezone('Etc/GMT-3'))):
             self.partner_us.vat = 'US12345677'
 
@@ -68,7 +75,7 @@ class TestEdiZatca(TestSaEdiCommon):
                         'product_id': self.product_a.id,
                         'price_unit': 1000,
                         'product_uom_qty': 1,
-                        'tax_id': [Command.set(self.tax_15.ids)],
+                        'tax_id': [Command.set((self.tax_15 + retention_tax).ids)],
                     })
                 ]
             })


### PR DESCRIPTION
Fix crash when a retention tax is applied on an invoice that includes a down payment line.

Steps to reproduce:
1. Create a retention tax (negative, with retention checked)
2. Create a sale order with product A
3. Create and validate a down payment invoice
4. Create the full invoice and add the retention tax to the line of product A
5. Try to submit to ZATCA

This raises:
`IndexError: list index out of range
→ tax_category_vals = self._get_tax_category_list(...)[0]`

The issue occurs because the retention tax is not filtered due to a missing `filter_to_apply` parameter.

opw-4771567