### PR TITLE
[IMP] account_edi_ubl_cii: support AttachedDocument imports for UBL

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -1,3 +1,9 @@
+import binascii
+
+from base64 import b64decode
+from contextlib import suppress
+from lxml import etree
+
 from odoo import _, api, fields, models, Command
 
 
@@ -87,9 +93,43 @@ class AccountMove(models.Model):
             if 'urn:cen.eu:en16931:2017' in customization_id.text:
                 return self.env['account.edi.xml.ubl_bis3']
 
+    @api.model
+    def _ubl_parse_attached_document(self, tree):
+        """
+        In UBL, an AttachedDocument file is a wrapper around multiple different UBL files.
+        According to the specifications the original document is stored within the top most
+        Attachment node either as an Attachment/EmbeddedDocumentBinaryObject or (in special cases)
+        a CDATA string stored in Attachment/ExternalReference/Description.
+
+        We must parse this before passing the original file to the decoder to figure out how best
+        to handle it.
+        """
+        attachment_node = tree.find('{*}Attachment')
+        if attachment_node is None:
+            return tree
+
+        attachment_binary_data = attachment_node.find('./{*}EmbeddedDocumentBinaryObject')
+        if attachment_binary_data is not None \
+                and attachment_binary_data.attrib.get('mimeCode') in ('application/xml', 'text/xml'):
+            with suppress(etree.XMLSyntaxError, binascii.Error):
+                text = b64decode(attachment_binary_data.text)
+                return etree.fromstring(text)
+
+        external_reference = attachment_node.find('./{*}ExternalReference')
+        if external_reference is not None:
+            description = external_reference.findtext('./{*}Description')
+            mime_code = external_reference.findtext('./{*}MimeCode')
+
+            if description and mime_code in ('application/xml', 'text/xml'):
+                with suppress(etree.XMLSyntaxError):
+                    return etree.fromstring(description.encode('utf-8'))
+        return tree
+
     def _get_edi_decoder(self, file_data, new=False):
         # EXTENDS 'account'
         if file_data['type'] == 'xml':
+            if etree.QName(file_data['xml_tree']).localname == 'AttachedDocument':
+                file_data['xml_tree'] = self._ubl_parse_attached_document(file_data['xml_tree'])
             ubl_cii_xml_builder = self._get_ubl_cii_builder_from_xml_tree(file_data['xml_tree'])
             if ubl_cii_xml_builder is not None:
                 return ubl_cii_xml_builder._import_invoice_ubl_cii

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_xml_cii_fr
 from . import test_xml_cii_us
 from . import test_xml_ubl_nl
 from . import test_xml_ubl_au
+from . import test_xml_ubl_attacheddocument

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice_attacheddocument_b64.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice_attacheddocument_b64.xml
@@ -1,0 +1,179 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<AttachedDocument xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:ccts="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2" xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="urn:oasis:names:specification:ubl:schema:xsd:AttachedDocument-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:xades141="http://uri.etsi.org/01903/v1.4.1#">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>AttachedDocument</cbc:ID>
+    <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+    <cbc:IssueTime>12:00:00</cbc:IssueTime>
+    <cbc:DocumentType>string</cbc:DocumentType>
+    <cbc:ParentDocumentID>INV/2017/00001</cbc:ParentDocumentID>
+    <cac:SenderParty>
+      <cbc:EndpointID schemeID="0151">83914571673</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Spring St.</cbc:StreetName>
+        <cbc:CityName>Melbourne</cbc:CityName>
+        <cbc:PostalZone>3002</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>83914571673</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">83914571673</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+31 180 6 225789</cbc:Telephone>
+        <cbc:ElectronicMail>info@outlook.au</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:SenderParty>
+    <cac:ReceiverParty>
+      <cbc:EndpointID schemeID="0151">53930548027</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Parliament Dr</cbc:StreetName>
+        <cbc:CityName>Canberra</cbc:CityName>
+        <cbc:PostalZone>2600</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>53930548027</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">53930548027</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:Contact>
+    </cac:ReceiverParty>
+    <cac:Attachment>
+        <cbc:EmbeddedDocumentBinaryObject mimeCode="text/xml">
+PD94bWwgdmVyc2lvbj0nMS4wJyBlbmNvZGluZz0nVVRGLTgnPz4KPEludm9pY2UgeG1sbnM9InVy
+bjpvYXNpczpuYW1lczpzcGVjaWZpY2F0aW9uOnVibDpzY2hlbWE6eHNkOkludm9pY2UtMiIgeG1s
+bnM6Y2FjPSJ1cm46b2FzaXM6bmFtZXM6c3BlY2lmaWNhdGlvbjp1Ymw6c2NoZW1hOnhzZDpDb21t
+b25BZ2dyZWdhdGVDb21wb25lbnRzLTIiIHhtbG5zOmNiYz0idXJuOm9hc2lzOm5hbWVzOnNwZWNp
+ZmljYXRpb246dWJsOnNjaGVtYTp4c2Q6Q29tbW9uQmFzaWNDb21wb25lbnRzLTIiPgogIDxjYmM6
+Q3VzdG9taXphdGlvbklEPnVybjpjZW4uZXU6ZW4xNjkzMToyMDE3I2NvbmZvcm1hbnQjdXJuOmZk
+YzpwZXBwb2wuZXU6MjAxNzpwb2FjYzpiaWxsaW5nOmludGVybmF0aW9uYWw6YXVuejozLjA8L2Ni
+YzpDdXN0b21pemF0aW9uSUQ+CiAgPGNiYzpQcm9maWxlSUQ+dXJuOmZkYzpwZXBwb2wuZXU6MjAx
+Nzpwb2FjYzpiaWxsaW5nOjAxOjEuMDwvY2JjOlByb2ZpbGVJRD4KICA8Y2JjOklEPklOVi8yMDE3
+LzAwMDAxPC9jYmM6SUQ+CiAgPGNiYzpJc3N1ZURhdGU+MjAxNy0wMS0wMTwvY2JjOklzc3VlRGF0
+ZT4KPGNiYzpEdWVEYXRlPjIwMTctMDItMjg8L2NiYzpEdWVEYXRlPgo8Y2JjOkludm9pY2VUeXBl
+Q29kZT4zODA8L2NiYzpJbnZvaWNlVHlwZUNvZGU+CjxjYmM6Tm90ZT50ZXN0IG5hcnJhdGlvbjwv
+Y2JjOk5vdGU+CjxjYmM6RG9jdW1lbnRDdXJyZW5jeUNvZGU+VVNEPC9jYmM6RG9jdW1lbnRDdXJy
+ZW5jeUNvZGU+CjxjYmM6QnV5ZXJSZWZlcmVuY2U+cmVmX3BhcnRuZXJfMjwvY2JjOkJ1eWVyUmVm
+ZXJlbmNlPgo8Y2FjOk9yZGVyUmVmZXJlbmNlPgo8Y2JjOklEPl9fX2lnbm9yZV9fXzwvY2JjOklE
+Pgo8L2NhYzpPcmRlclJlZmVyZW5jZT4KPGNhYzpBZGRpdGlvbmFsRG9jdW1lbnRSZWZlcmVuY2U+
+CjxjYmM6SUQ+X19faWdub3JlX19fPC9jYmM6SUQ+CjxjYmM6QXR0YWNobWVudD4KPGNiYzpFbWJl
+ZGRlZERvY3VtZW50QmluYXJ5T2JqZWN0Pl9fX2lnbm9yZV9fXzwvY2JjOkVtYmVkZGVkRG9jdW1l
+bnRCaW5hcnlPYmplY3Q+CjwvY2JjOkF0dGFjaG1lbnQ+CjwvY2FjOkFkZGl0aW9uYWxEb2N1bWVu
+dFJlZmVyZW5jZT4KPGNhYzpBY2NvdW50aW5nU3VwcGxpZXJQYXJ0eT4KPGNhYzpQYXJ0eT4KPGNi
+YzpFbmRwb2ludElEIHNjaGVtZUlEPSIwMTUxIj44MzkxNDU3MTY3MzwvY2JjOkVuZHBvaW50SUQ+
+CjxjYWM6UGFydHlOYW1lPgo8Y2JjOk5hbWU+cGFydG5lcl8xPC9jYmM6TmFtZT4KPC9jYWM6UGFy
+dHlOYW1lPgo8Y2FjOlBvc3RhbEFkZHJlc3M+CjxjYmM6U3RyZWV0TmFtZT5TcHJpbmcgU3QuPC9j
+YmM6U3RyZWV0TmFtZT4KPGNiYzpDaXR5TmFtZT5NZWxib3VybmU8L2NiYzpDaXR5TmFtZT4KPGNi
+YzpQb3N0YWxab25lPjMwMDI8L2NiYzpQb3N0YWxab25lPgo8Y2FjOkNvdW50cnk+CjxjYmM6SWRl
+bnRpZmljYXRpb25Db2RlPkFVPC9jYmM6SWRlbnRpZmljYXRpb25Db2RlPgo8L2NhYzpDb3VudHJ5
+Pgo8L2NhYzpQb3N0YWxBZGRyZXNzPgo8Y2FjOlBhcnR5VGF4U2NoZW1lPgo8Y2JjOkNvbXBhbnlJ
+RD44MzkxNDU3MTY3MzwvY2JjOkNvbXBhbnlJRD4KPGNhYzpUYXhTY2hlbWU+CjxjYmM6SUQ+R1NU
+PC9jYmM6SUQ+CjwvY2FjOlRheFNjaGVtZT4KPC9jYWM6UGFydHlUYXhTY2hlbWU+CjxjYWM6UGFy
+dHlMZWdhbEVudGl0eT4KPGNiYzpSZWdpc3RyYXRpb25OYW1lPnBhcnRuZXJfMTwvY2JjOlJlZ2lz
+dHJhdGlvbk5hbWU+CjxjYmM6Q29tcGFueUlEIHNjaGVtZUlEPSIwMTUxIj44MzkxNDU3MTY3Mzwv
+Y2JjOkNvbXBhbnlJRD4KPC9jYWM6UGFydHlMZWdhbEVudGl0eT4KPGNhYzpDb250YWN0Pgo8Y2Jj
+Ok5hbWU+cGFydG5lcl8xPC9jYmM6TmFtZT4KPGNiYzpUZWxlcGhvbmU+KzMxIDE4MCA2IDIyNTc4
+OTwvY2JjOlRlbGVwaG9uZT4KPGNiYzpFbGVjdHJvbmljTWFpbD5pbmZvQG91dGxvb2suYXU8L2Ni
+YzpFbGVjdHJvbmljTWFpbD4KPC9jYWM6Q29udGFjdD4KPC9jYWM6UGFydHk+CjwvY2FjOkFjY291
+bnRpbmdTdXBwbGllclBhcnR5Pgo8Y2FjOkFjY291bnRpbmdDdXN0b21lclBhcnR5Pgo8Y2FjOlBh
+cnR5Pgo8Y2JjOkVuZHBvaW50SUQgc2NoZW1lSUQ9IjAxNTEiPjUzOTMwNTQ4MDI3PC9jYmM6RW5k
+cG9pbnRJRD4KPGNhYzpQYXJ0eU5hbWU+CjxjYmM6TmFtZT5wYXJ0bmVyXzI8L2NiYzpOYW1lPgo8
+L2NhYzpQYXJ0eU5hbWU+CjxjYWM6UG9zdGFsQWRkcmVzcz4KPGNiYzpTdHJlZXROYW1lPlBhcmxp
+YW1lbnQgRHI8L2NiYzpTdHJlZXROYW1lPgo8Y2JjOkNpdHlOYW1lPkNhbmJlcnJhPC9jYmM6Q2l0
+eU5hbWU+CjxjYmM6UG9zdGFsWm9uZT4yNjAwPC9jYmM6UG9zdGFsWm9uZT4KPGNhYzpDb3VudHJ5
+Pgo8Y2JjOklkZW50aWZpY2F0aW9uQ29kZT5BVTwvY2JjOklkZW50aWZpY2F0aW9uQ29kZT4KPC9j
+YWM6Q291bnRyeT4KPC9jYWM6UG9zdGFsQWRkcmVzcz4KPGNhYzpQYXJ0eVRheFNjaGVtZT4KPGNi
+YzpDb21wYW55SUQ+NTM5MzA1NDgwMjc8L2NiYzpDb21wYW55SUQ+CjxjYWM6VGF4U2NoZW1lPgo8
+Y2JjOklEPkdTVDwvY2JjOklEPgo8L2NhYzpUYXhTY2hlbWU+CjwvY2FjOlBhcnR5VGF4U2NoZW1l
+Pgo8Y2FjOlBhcnR5TGVnYWxFbnRpdHk+CjxjYmM6UmVnaXN0cmF0aW9uTmFtZT5wYXJ0bmVyXzI8
+L2NiYzpSZWdpc3RyYXRpb25OYW1lPgo8Y2JjOkNvbXBhbnlJRCBzY2hlbWVJRD0iMDE1MSI+NTM5
+MzA1NDgwMjc8L2NiYzpDb21wYW55SUQ+CjwvY2FjOlBhcnR5TGVnYWxFbnRpdHk+CjxjYWM6Q29u
+dGFjdD4KPGNiYzpOYW1lPnBhcnRuZXJfMjwvY2JjOk5hbWU+CjwvY2FjOkNvbnRhY3Q+CjwvY2Fj
+OlBhcnR5Pgo8L2NhYzpBY2NvdW50aW5nQ3VzdG9tZXJQYXJ0eT4KPGNhYzpEZWxpdmVyeT4KPGNh
+YzpEZWxpdmVyeUxvY2F0aW9uPgo8Y2FjOkFkZHJlc3M+CjxjYmM6U3RyZWV0TmFtZT5QYXJsaWFt
+ZW50IERyPC9jYmM6U3RyZWV0TmFtZT4KPGNiYzpDaXR5TmFtZT5DYW5iZXJyYTwvY2JjOkNpdHlO
+YW1lPgo8Y2JjOlBvc3RhbFpvbmU+MjYwMDwvY2JjOlBvc3RhbFpvbmU+CjxjYWM6Q291bnRyeT4K
+PGNiYzpJZGVudGlmaWNhdGlvbkNvZGU+QVU8L2NiYzpJZGVudGlmaWNhdGlvbkNvZGU+CjwvY2Fj
+OkNvdW50cnk+CjwvY2FjOkFkZHJlc3M+CjwvY2FjOkRlbGl2ZXJ5TG9jYXRpb24+CjwvY2FjOkRl
+bGl2ZXJ5Pgo8Y2FjOlBheW1lbnRNZWFucz4KPGNiYzpQYXltZW50TWVhbnNDb2RlIG5hbWU9ImNy
+ZWRpdCB0cmFuc2ZlciI+MzA8L2NiYzpQYXltZW50TWVhbnNDb2RlPgo8Y2JjOlBheW1lbnRJRD5J
+TlYvMjAxNy8wMDAwMTwvY2JjOlBheW1lbnRJRD4KPGNhYzpQYXllZUZpbmFuY2lhbEFjY291bnQ+
+CjxjYmM6SUQ+MDAwMDk5OTk4QjU3PC9jYmM6SUQ+CjwvY2FjOlBheWVlRmluYW5jaWFsQWNjb3Vu
+dD4KPC9jYWM6UGF5bWVudE1lYW5zPgo8Y2FjOlBheW1lbnRUZXJtcz4KPGNiYzpOb3RlPlBheW1l
+bnQgdGVybXM6IDMwJSBBZHZhbmNlIEVuZCBvZiBGb2xsb3dpbmcgTW9udGg8L2NiYzpOb3RlPgo8
+L2NhYzpQYXltZW50VGVybXM+CjxjYWM6VGF4VG90YWw+CjxjYmM6VGF4QW1vdW50IGN1cnJlbmN5
+SUQ9IlVTRCI+MjY4LjIwPC9jYmM6VGF4QW1vdW50Pgo8Y2FjOlRheFN1YnRvdGFsPgo8Y2JjOlRh
+eGFibGVBbW91bnQgY3VycmVuY3lJRD0iVVNEIj4yNjgyLjAwPC9jYmM6VGF4YWJsZUFtb3VudD4K
+PGNiYzpUYXhBbW91bnQgY3VycmVuY3lJRD0iVVNEIj4yNjguMjA8L2NiYzpUYXhBbW91bnQ+Cjxj
+YWM6VGF4Q2F0ZWdvcnk+CjxjYmM6SUQ+UzwvY2JjOklEPgo8Y2JjOlBlcmNlbnQ+MTAuMDwvY2Jj
+OlBlcmNlbnQ+CjxjYWM6VGF4U2NoZW1lPgo8Y2JjOklEPkdTVDwvY2JjOklEPgo8L2NhYzpUYXhT
+Y2hlbWU+CjwvY2FjOlRheENhdGVnb3J5Pgo8L2NhYzpUYXhTdWJ0b3RhbD4KPC9jYWM6VGF4VG90
+YWw+CjxjYWM6TGVnYWxNb25ldGFyeVRvdGFsPgo8Y2JjOkxpbmVFeHRlbnNpb25BbW91bnQgY3Vy
+cmVuY3lJRD0iVVNEIj4yNjgyLjAwPC9jYmM6TGluZUV4dGVuc2lvbkFtb3VudD4KPGNiYzpUYXhF
+eGNsdXNpdmVBbW91bnQgY3VycmVuY3lJRD0iVVNEIj4yNjgyLjAwPC9jYmM6VGF4RXhjbHVzaXZl
+QW1vdW50Pgo8Y2JjOlRheEluY2x1c2l2ZUFtb3VudCBjdXJyZW5jeUlEPSJVU0QiPjI5NTAuMjA8
+L2NiYzpUYXhJbmNsdXNpdmVBbW91bnQ+CjxjYmM6UHJlcGFpZEFtb3VudCBjdXJyZW5jeUlEPSJV
+U0QiPjAuMDA8L2NiYzpQcmVwYWlkQW1vdW50Pgo8Y2JjOlBheWFibGVBbW91bnQgY3VycmVuY3lJ
+RD0iVVNEIj4yOTUwLjIwPC9jYmM6UGF5YWJsZUFtb3VudD4KPC9jYWM6TGVnYWxNb25ldGFyeVRv
+dGFsPgo8Y2FjOkludm9pY2VMaW5lPgo8Y2JjOklEPjU1NzwvY2JjOklEPgo8Y2JjOkludm9pY2Vk
+UXVhbnRpdHkgdW5pdENvZGU9IkRaTiI+Mi4wPC9jYmM6SW52b2ljZWRRdWFudGl0eT4KPGNiYzpM
+aW5lRXh0ZW5zaW9uQW1vdW50IGN1cnJlbmN5SUQ9IlVTRCI+MTc4Mi4wMDwvY2JjOkxpbmVFeHRl
+bnNpb25BbW91bnQ+CjxjYWM6QWxsb3dhbmNlQ2hhcmdlPgo8Y2JjOkNoYXJnZUluZGljYXRvcj5m
+YWxzZTwvY2JjOkNoYXJnZUluZGljYXRvcj4KPGNiYzpBbGxvd2FuY2VDaGFyZ2VSZWFzb25Db2Rl
+Pjk1PC9jYmM6QWxsb3dhbmNlQ2hhcmdlUmVhc29uQ29kZT4KPGNiYzpBbW91bnQgY3VycmVuY3lJ
+RD0iVVNEIj4xOTguMDA8L2NiYzpBbW91bnQ+CjwvY2FjOkFsbG93YW5jZUNoYXJnZT4KPGNhYzpJ
+dGVtPgo8Y2JjOkRlc2NyaXB0aW9uPnByb2R1Y3RfYTwvY2JjOkRlc2NyaXB0aW9uPgo8Y2JjOk5h
+bWU+cHJvZHVjdF9hPC9jYmM6TmFtZT4KPGNhYzpDbGFzc2lmaWVkVGF4Q2F0ZWdvcnk+CjxjYmM6
+SUQ+UzwvY2JjOklEPgo8Y2JjOlBlcmNlbnQ+MTAuMDwvY2JjOlBlcmNlbnQ+CjxjYWM6VGF4U2No
+ZW1lPgo8Y2JjOklEPkdTVDwvY2JjOklEPgo8L2NhYzpUYXhTY2hlbWU+CjwvY2FjOkNsYXNzaWZp
+ZWRUYXhDYXRlZ29yeT4KPC9jYWM6SXRlbT4KPGNhYzpQcmljZT4KPGNiYzpQcmljZUFtb3VudCBj
+dXJyZW5jeUlEPSJVU0QiPjk5MC4wPC9jYmM6UHJpY2VBbW91bnQ+CjwvY2FjOlByaWNlPgo8L2Nh
+YzpJbnZvaWNlTGluZT4KPGNhYzpJbnZvaWNlTGluZT4KPGNiYzpJRD41NTg8L2NiYzpJRD4KPGNi
+YzpJbnZvaWNlZFF1YW50aXR5IHVuaXRDb2RlPSJDNjIiPjEwLjA8L2NiYzpJbnZvaWNlZFF1YW50
+aXR5Pgo8Y2JjOkxpbmVFeHRlbnNpb25BbW91bnQgY3VycmVuY3lJRD0iVVNEIj4xMDAwLjAwPC9j
+YmM6TGluZUV4dGVuc2lvbkFtb3VudD4KPGNhYzpJdGVtPgo8Y2JjOkRlc2NyaXB0aW9uPnByb2R1
+Y3RfYjwvY2JjOkRlc2NyaXB0aW9uPgo8Y2JjOk5hbWU+cHJvZHVjdF9iPC9jYmM6TmFtZT4KPGNh
+YzpDbGFzc2lmaWVkVGF4Q2F0ZWdvcnk+CjxjYmM6SUQ+UzwvY2JjOklEPgo8Y2JjOlBlcmNlbnQ+
+MTAuMDwvY2JjOlBlcmNlbnQ+CjxjYWM6VGF4U2NoZW1lPgo8Y2JjOklEPkdTVDwvY2JjOklEPgo8
+L2NhYzpUYXhTY2hlbWU+CjwvY2FjOkNsYXNzaWZpZWRUYXhDYXRlZ29yeT4KPC9jYWM6SXRlbT4K
+PGNhYzpQcmljZT4KPGNiYzpQcmljZUFtb3VudCBjdXJyZW5jeUlEPSJVU0QiPjEwMC4wPC9jYmM6
+UHJpY2VBbW91bnQ+CjwvY2FjOlByaWNlPgo8L2NhYzpJbnZvaWNlTGluZT4KPGNhYzpJbnZvaWNl
+TGluZT4KPGNiYzpJRD41NTk8L2NiYzpJRD4KPGNiYzpJbnZvaWNlZFF1YW50aXR5IHVuaXRDb2Rl
+PSJDNjIiPi0xLjA8L2NiYzpJbnZvaWNlZFF1YW50aXR5Pgo8Y2JjOkxpbmVFeHRlbnNpb25BbW91
+bnQgY3VycmVuY3lJRD0iVVNEIj4tMTAwLjAwPC9jYmM6TGluZUV4dGVuc2lvbkFtb3VudD4KPGNh
+YzpJdGVtPgo8Y2JjOkRlc2NyaXB0aW9uPnByb2R1Y3RfYjwvY2JjOkRlc2NyaXB0aW9uPgo8Y2Jj
+Ok5hbWU+cHJvZHVjdF9iPC9jYmM6TmFtZT4KPGNhYzpDbGFzc2lmaWVkVGF4Q2F0ZWdvcnk+Cjxj
+YmM6SUQ+UzwvY2JjOklEPgo8Y2JjOlBlcmNlbnQ+MTAuMDwvY2JjOlBlcmNlbnQ+CjxjYWM6VGF4
+U2NoZW1lPgo8Y2JjOklEPkdTVDwvY2JjOklEPgo8L2NhYzpUYXhTY2hlbWU+CjwvY2FjOkNsYXNz
+aWZpZWRUYXhDYXRlZ29yeT4KPC9jYWM6SXRlbT4KPGNhYzpQcmljZT4KPGNiYzpQcmljZUFtb3Vu
+dCBjdXJyZW5jeUlEPSJVU0QiPjEwMC4wPC9jYmM6UHJpY2VBbW91bnQ+CjwvY2FjOlByaWNlPgo8
+L2NhYzpJbnZvaWNlTGluZT4KPC9JbnZvaWNlPg==
+        </cbc:EmbeddedDocumentBinaryObject>
+    </cac:Attachment>
+</AttachedDocument>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice_attacheddocument_description.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/a_nz_out_invoice_attacheddocument_description.xml
@@ -1,0 +1,260 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<AttachedDocument xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:ccts="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2" xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="urn:oasis:names:specification:ubl:schema:xsd:AttachedDocument-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:xades141="http://uri.etsi.org/01903/v1.4.1#">
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:CustomizationID>urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+    <cbc:ID>AttachedDocument</cbc:ID>
+    <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+    <cbc:IssueTime>12:00:00</cbc:IssueTime>
+    <cbc:DocumentType>string</cbc:DocumentType>
+    <cbc:ParentDocumentID>INV/2017/00001</cbc:ParentDocumentID>
+    <cac:SenderParty>
+      <cbc:EndpointID schemeID="0151">83914571673</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Spring St.</cbc:StreetName>
+        <cbc:CityName>Melbourne</cbc:CityName>
+        <cbc:PostalZone>3002</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>83914571673</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">83914571673</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+31 180 6 225789</cbc:Telephone>
+        <cbc:ElectronicMail>info@outlook.au</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:SenderParty>
+    <cac:ReceiverParty>
+      <cbc:EndpointID schemeID="0151">53930548027</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Parliament Dr</cbc:StreetName>
+        <cbc:CityName>Canberra</cbc:CityName>
+        <cbc:PostalZone>2600</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>53930548027</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">53930548027</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:Contact>
+    </cac:ReceiverParty>
+    <cac:Attachment>
+        <cac:ExternalReference>
+            <cbc:MimeCode>text/xml</cbc:MimeCode>
+            <cbc:EncodingCode>UTF-8</cbc:EncodingCode>
+            <cbc:Description><![CDATA[<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:cen.eu:en16931:2017#conformant#urn:fdc:peppol.eu:2017:poacc:billing:international:aunz:3.0</cbc:CustomizationID>
+  <cbc:ProfileID>urn:fdc:peppol.eu:2017:poacc:billing:01:1.0</cbc:ProfileID>
+  <cbc:ID>INV/2017/00001</cbc:ID>
+  <cbc:IssueDate>2017-01-01</cbc:IssueDate>
+  <cbc:DueDate>2017-02-28</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:Note>test narration</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>ref_partner_2</cbc:BuyerReference>
+  <cac:OrderReference>
+    <cbc:ID>___ignore___</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>___ignore___</cbc:ID>
+    <cbc:Attachment>
+      <cbc:EmbeddedDocumentBinaryObject>___ignore___</cbc:EmbeddedDocumentBinaryObject>
+    </cbc:Attachment>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0151">83914571673</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Spring St.</cbc:StreetName>
+        <cbc:CityName>Melbourne</cbc:CityName>
+        <cbc:PostalZone>3002</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>83914571673</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">83914571673</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+31 180 6 225789</cbc:Telephone>
+        <cbc:ElectronicMail>info@outlook.au</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0151">53930548027</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Parliament Dr</cbc:StreetName>
+        <cbc:CityName>Canberra</cbc:CityName>
+        <cbc:PostalZone>2600</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>53930548027</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_2</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">53930548027</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_2</cbc:Name>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Parliament Dr</cbc:StreetName>
+        <cbc:CityName>Canberra</cbc:CityName>
+        <cbc:PostalZone>2600</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2017/00001</cbc:PaymentID>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>000099998B57</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">268.20</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">2682.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">268.20</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">2682.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">2682.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">2950.20</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">2950.20</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>557</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="DZN">2.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1782.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:Amount currencyID="USD">198.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">990.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>558</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">10.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+  <cac:InvoiceLine>
+    <cbc:ID>559</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">-1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">-100.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_b</cbc:Description>
+      <cbc:Name>product_b</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">100.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>]]></cbc:Description>
+        </cac:ExternalReference>
+    </cac:Attachment>
+</AttachedDocument>
+

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_attacheddocument.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_attacheddocument.py
@@ -1,0 +1,75 @@
+from odoo.addons.l10n_account_edi_ubl_cii_tests.tests.common import TestUBLCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLAttachedDocument(TestUBLCommon):
+
+    @classmethod
+    @TestUBLCommon.setup_country('au')
+    def setUpClass(cls):
+        """ AttachedDocuments are a wrapper of multiple different types of documents, as such we
+        need a country/localization to import a file properly. This is not Australia specific
+        but instead just re-using the files and setup from other test classes. """
+        super().setUpClass()
+
+        cls.partner_1 = cls.env['res.partner'].create({
+            'name': "partner_1",
+            'street': "Spring St.",
+            'zip': "3002",
+            'city': "Melbourne",
+            'vat': '83 914 571 673',
+            'phone': '+31 180 6 225789',
+            'email': 'info@outlook.au',
+            'country_id': cls.env.ref('base.au').id,
+            'bank_ids': [(0, 0, {'acc_number': '000099998B57'})],
+            'ref': 'ref_partner_1',
+            'invoice_edi_format': 'ubl_a_nz',
+        })
+
+        cls.partner_2 = cls.env['res.partner'].create({
+            'name': "partner_2",
+            'street': "Parliament Dr",
+            'zip': "2600",
+            'city': "Canberra",
+            'vat': '53 930 548 027',
+            'country_id': cls.env.ref('base.au').id,
+            'bank_ids': [(0, 0, {'acc_number': '93999574162167'})],
+            'ref': 'ref_partner_2',
+            'invoice_edi_format': 'ubl_a_nz',
+        })
+
+        cls.tax_10 = cls.env['account.tax'].create({
+            'name': 'tax_10',
+            'amount_type': 'percent',
+            'amount': 10,
+            'type_tax_use': 'sale',
+            'country_id': cls.env.ref('base.au').id,
+        })
+
+    def test_import_attached_document_invoice_xml(self):
+        """ The original invoice can be stored in one of two places, either as a base64 encoded
+        string in EmbeddedDocumentBinaryObject or as a CDATA[] value inside of an
+        ExternalReference/Description tag. Importing such files should ignore the outside wrapper
+        and return the correct original invoice takes from a_nz_out_invoice. """
+        self._assert_imported_invoice_from_file(
+            subfolder='tests/test_files/from_odoo',
+            filename='a_nz_out_invoice_attacheddocument_b64.xml',
+            invoice_vals={
+                'currency_id': self.other_currency.id,
+                'amount_total': 2950.2,
+                'amount_tax': 268.2,
+                'invoice_lines': [{'price_subtotal': x} for x in (1782, 1000, -100)]
+            },
+        )
+
+        self._assert_imported_invoice_from_file(
+            subfolder='tests/test_files/from_odoo',
+            filename='a_nz_out_invoice_attacheddocument_description.xml',
+            invoice_vals={
+                'currency_id': self.other_currency.id,
+                'amount_total': 2950.2,
+                'amount_tax': 268.2,
+                'invoice_lines': [{'price_subtotal': x} for x in (1782, 1000, -100)]
+            },
+        )


### PR DESCRIPTION
AttachedDocuments are a wrapper filetype in the UBL 2.0/2.1 specification that allows for multiple documents to be bundled together. Colombia uses it as a way to return back values from the EDI but it is in the standard and can therefore be used by any UBL 2.0/2.1 compliant system.

To be able to parse the documents inside correctly, we must obtain the original record which is stored in the outermost Attachment node either under the EmbeddedDocumentBinaryObject element or the ExternalReference/Description node. Once we find it we send it to the normal decoder process.

Specification: https://docs.oasis-open.org/ubl/os-UBL-2.1/mod/summary/reports/UBL-AttachedDocument-2.1.html

task-4299222
