### PR TITLE
[IMP] account_qrcode_emv,l10n_vn: QR fixes

### DIFF
--- a/addons/account_qr_code_emv/models/res_bank.py
+++ b/addons/account_qr_code_emv/models/res_bank.py
@@ -57,7 +57,7 @@ class ResPartnerBank(models.Model):
         merchant_name = self.partner_id.name and self._remove_accents(self.partner_id.name)[:25] or 'NA'
         merchant_city = self.partner_id.city and self._remove_accents(self.partner_id.city)[:15] or ''
         comment = structured_communication or free_communication or ''
-        comment = re.sub(r'/[^ A-Za-z0-9_@.\/#&+-]+/g', '', self._remove_accents(comment))
+        comment = re.sub(r'[^ A-Za-z0-9_@.\\/#&+-]+', '', self._remove_accents(comment))
         additional_data_field = self._get_additional_data_field(comment) if self.include_reference else None
         return [
             (0, '01'),                                                              # Payload Format Indicator

--- a/addons/l10n_vn/models/res_bank.py
+++ b/addons/l10n_vn/models/res_bank.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 
@@ -47,7 +49,8 @@ class ResPartnerBank(models.Model):
 
     def _get_additional_data_field(self, comment):
         if self.country_code == 'VN':
-            return self._serialize(8, comment)
+            # The first check is too permissive for VietQR.
+            return self._serialize(8, re.sub(r"[^a-zA-Z0-9 _\\\-.]+", "", comment))
         return super()._get_additional_data_field(comment)
 
     def _get_error_messages_for_qr(self, qr_method, debtor_partner, currency):

--- a/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
+++ b/addons/l10n_vn/tests/test_l10n_vn_emv_qr.py
@@ -81,7 +81,7 @@ class TestL10nVNEmvQrCode(AccountTestInvoicingCommon):
         )
 
         # Check the whole qr code string
-        self.assertEqual(emv_qr_vals, '00020101021238590010A0000007270129000697042201156607040600001290208QRIBFTTA52040000530370454031005802VN5914company_1_data6007Vietnam62170813INV/TEST/00016304600B')
+        self.assertEqual(emv_qr_vals, '00020101021238590010A0000007270129000697042201156607040600001290208QRIBFTTA52040000530370454031005802VN5914company_1_data6007Vietnam62150811INVTEST000163042656')
 
     def test_remove_vietnamese_accents(self):
         accent_string = "áàảãạăắằẳẵặâấầẩẫậÁÀẢÃẠĂẮẰẲẴẶÂẤẦẨẪẬéèẻẽẹêếềểễệÉÈẺẼẸÊẾỀỂỄỆóòỏõọôốồổỗộơớờởỡợÓÒỎÕỌÔỐỒỔỖỘƠỚỜỞỠỢíìỉĩịÍÌỈĨỊúùủũụưứừửữựÚÙỦŨỤƯỨỪỬỮỰýỳỷỹỵÝỲỶỸỴđĐ"
@@ -102,4 +102,4 @@ class TestL10nVNEmvQrCode(AccountTestInvoicingCommon):
         )
 
         # Check the whole qr code string
-        self.assertEqual(emv_qr_vals, '00020101021238590010A0000007270129000697042201156607040600001290208QRIBFTTA52040000530370454031005802VN5914aAeEoOiIuUyYdD6007Vietnam62170813INV/TEST/000263041AA5')
+        self.assertEqual(emv_qr_vals, '00020101021238590010A0000007270129000697042201156607040600001290208QRIBFTTA52040000530370454031005802VN5914aAeEoOiIuUyYdD6007Vietnam62150811INVTEST00026304E1C2')


### PR DESCRIPTION
Fixes two issue with EMV QR generation:
- The regex applied on comments is wrong and actually does nothing.
- VietQR allows less character than that general regex, so we filter it more.

opw-4671523

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
