### PR TITLE
[FIX] html_editor: avoid crash on rapid DOM changes

### DIFF
--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -92,7 +92,7 @@ export class MoveNodePlugin extends Plugin {
     intersectionObserverCallback(entries) {
         for (const entry of entries) {
             const element = entry.target;
-            if (entry.isIntersecting) {
+            if (entry.isIntersecting && element.isConnected) {
                 this.visibleMovableElements.add(element);
                 this.resetHooksNextMousemove = true;
             } else {


### PR DESCRIPTION
### Browser: Firefox

### Steps to reproduce:

- Create a To-do.
- Press Enter repeatedly and quickly.
- A traceback occurs.

### Description of the issue/feature this PR addresses:

- Pressing Enter quickly remove elements before their hooks are updated, causing hookElement to be
undefined and triggering a crash.

### Desired behavior after PR is merged:

- Traceback no longer occurs.

task-4766147

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
