### PR TITLE
[FIX] point_of_sale: handled UndefinedTable Error

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -416,8 +416,10 @@ class PosSession(models.Model):
 
     def unlink(self):
         self.statement_line_ids.unlink()
-        (self.order_seq_id | self.login_number_seq_id).unlink()
-        return super(PosSession, self).unlink()
+        sequences_to_unlink = (self.order_seq_id | self.login_number_seq_id)
+        result = super().unlink()
+        sequences_to_unlink.unlink()
+        return result
 
     def login(self):
         self.ensure_one()


### PR DESCRIPTION
Currently, an error occurs on reopening a POS session if its `Login Number Sequence` record has been deleted.

## **Steps to Reproduce:**
1) Install **Point of Sale**
2) Open POS and **duplicate** the tab (Assume Tab A and Tab B) 3) In **Tab A**, open any POS session (e.g., Bakery Shop). Ensure the session is in the **Opening Control** state either right after
   clicking **Open Register** (when the Opening Control popup appears), or after clicking **Close Register** (when Open Register and Backend buttons are shown).
4) In **Tab B**, open **same** pos session(e.g Bakery Shop).

## **Note:** 
- The error may not occur on the first attempt — multiple tries may be necessary to reproduce the issue.

## **Error:**
**UndefinedTable: relation `ir_sequence_235` does not exist** **LINE 1: SELECT nextval('ir_sequence_235')**

## **Root Cause:**
- The custom `unlink()` override was deleting the session’s `order_seq_id` and `login_number_seq_id` **before** the POS session itself was fully removed at [1]. As a result, any immediate client‐side call to `pos_session.login()` still referenced a sequence that had just been dropped, causing the `UndefinedTable` error when `nextval()` was invoked.

[1]- https://github.com/odoo/odoo/blob/d87ca9b15ae0742ff03ddbfdf4233e22857926a3/addons/point_of_sale/models/pos_session.py#L419

## **Solution:**
1) we remember which two sequences `(order_seq_id and login_number_seq_id)` belong to this session.

2) **Then**, we call **super().unlink()**, which actually removes the session record and all its related data (but doesn’t yet touch our remembered sequences).

3) **Finally**, once the session is fully deleted and no code will try to nextval() on its sequences, we delete those two sequences safely.

- with this commit we ensure that,  when the POS UI immediately tries to log in (and calls `nextval()`), the sequences are still there. Only afterward do we clean them up.

Sentry-6233486197
