### PR TITLE
[FIX] html_editor: applied custom color lost after switching tab

### DIFF
--- a/addons/html_editor/static/src/main/font/color_selector.xml
+++ b/addons/html_editor/static/src/main/font/color_selector.xml
@@ -75,7 +75,7 @@
                                     <button data-color="white" class="o_color_button btn bg-white"></button>
                                 </div>
                                 <Colorpicker
-                                    defaultColor="this.defaultColor"
+                                    defaultColor="this.currentCustomColor.color"
                                     onColorSelect.bind="(color) => this.applyColor(color.cssColor)"
                                     onColorPreview.bind="onColorPreview" />
                             </div>

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -172,6 +172,30 @@ test("custom background colors used in the editor are shown in the colorpicker",
     expect(queryOne("button[data-color='#00ff00']").style.backgroundColor).toBe("rgb(0, 255, 0)");
 });
 
+test("applied custom color should be shown in colorpicker after switching tab", async () => {
+    const { el } = await setupEditor(
+        '<p><font style="background-color: rgb(255, 0, 0);">[test]</font></p>'
+    );
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+    await click(".o-we-toolbar .o-select-color-background");
+    await animationFrame();
+    await click(".btn:contains('Custom')");
+    await animationFrame();
+    expect(".o_hex_input").toHaveValue("#FF0000");
+    const newColor = "#00FF00";
+    await contains(".o_hex_input").edit(newColor);
+    expect(".o_hex_input").toHaveValue(newColor);
+    expect(getContent(el)).toBe(
+        '<p><font style="background-color: rgb(0, 255, 0);">[test]</font></p>'
+    );
+    await click(".btn:contains('Solid')");
+    await animationFrame();
+    await click(".btn:contains('Custom')");
+    await animationFrame();
+    expect(".o_hex_input").toHaveValue(newColor);
+});
+
 test("select hex color and apply it", async () => {
     const { el } = await setupEditor(`<p>[test]</p>`);
     await waitFor(".o-we-toolbar");


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Select a text, open color selector.
- Switch to custom tab.
- Apply any custom color.
- Switch to any other tab without closing color selector.
- Switch back to the custom color tab.
- Selected default color in colorpicker is old one rather than applied one.

**Desired behaviour after PR is merged:**

Applied custom color should be selected by default when switching back to custom tab.

task-4737027


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
