### PR TITLE
[FIX] base: fix alignment of address fields for l10n

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -62,6 +62,9 @@ class FormatAddressMixin(models.AbstractModel):
                         self.env['ir.ui.view'].postprocess_and_fields(sub_arch, model=self._name)
                     except ValueError:
                         return arch
+                new_address_node = sub_arch.find('.//div[@class="o_address_format"]')
+                if new_address_node is not None:
+                    sub_arch = new_address_node
                 address_node.getparent().replace(address_node, sub_arch)
         elif address_format and not self._context.get('no_address_format'):
             # For the zip, city and state fields we need to move them around in order to follow the country address format.

--- a/odoo/addons/base/tests/test_format_address_mixin.py
+++ b/odoo/addons/base/tests/test_format_address_mixin.py
@@ -30,8 +30,7 @@ class FormatAddressCase(ViewCase):
         arch = self.env[model].get_view(view.id)['arch']
         self.assertNotIn('"street"', arch)
         self.assertIn('"city"', arch)
-        # weird result: <form> inside a <form>
-        self.assertRegex(arch, r"<form>.*<form>.*</form>.*</form>")
+        self.assertRegex(arch, r'<form>.*<div class="o_address_format">.*</div>.*</form>')
         # no_address_format context
         arch = self.env[model].with_context(no_address_format=True).get_view(view.id)['arch']
         self.assertIn('"street"', arch)


### PR DESCRIPTION
Steps to reproduce
===================
1. Install l10n_pe or l10n_se
2. Switch to the newly installed company.
3. Open the contact form. The address fields are misaligned.

Technical
==========
With commit https://github.com/odoo/odoo/commit/4dd27bba346e50f40769d1412fbca0b5f65bb5a6, the contact form renders address fields dynamically based on
the selected country. The `_view_get_address` method in the `format.address.mixin`
replaces the default address `div` with the XML arch of the view linked in the
current company's `address_view_id` field. Since this arch is wrapped within the
`<form>` tags, the JS framework adds an extra div element and `o_form_nosheet` class,
causing layout misalignment.

After this commit
==============
This commit only includes address `div` element inside the `<form>` tag.

Task-4744412