### PR TITLE
[FIX] web: Fix external layout header address

### DIFF
--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -434,7 +434,7 @@
                             </div>
                         </span></li>
                         <li t-else="">
-                            <span t-field="company.company_details" class="text-nowrap">
+                            <span t-field="company.company_details" t-attf-class="'text-nowrap' if len(company.company_details) &lt; 46 else ''">
                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 w-100 opacity-75 text-muted text-center">
                                     <strong>Company details block</strong>
                                     <div>Contains the company details.</div>


### PR DESCRIPTION
Issue

When selecting the Bold (external_layout_bold) layout if the customer sets a long address, the address does not appear fully.

To resolve the issue, we need to apply a condition on the company_details length only apply the text-nowrap class if the length is less than the container’s capacity.

Steps to reproduce the issue:

1 - choose the bold (external_layout_bold) template for report 
2 - add a bigger address in one line in the document layout example :- 123 Sector 11 C Block Number 22 Ahmedabad Gandhinagar Gujarat India 
3 - print the report or see in the preview of document layout

Description of the issue/feature this PR addresses:

Current behavior before PR:

- The address in the report is not shown proper manner 

![before_fix](https://github.com/user-attachments/assets/f9385e29-5ba4-4ff9-91ac-485f7d41bd25)

Desired behavior after PR is merged:

- In the report's the address is shown in correct manner.
![after_fix](https://github.com/user-attachments/assets/57d719cd-c733-4d5f-ba0b-bfe72f71bdbf)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
