### PR TITLE
[FIX] account,uom: Many2Many Autocomplete search results label

### DIFF
--- a/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
+++ b/addons/account/static/src/components/many2x_tax_tags/many2x_tax_tags.js
@@ -30,7 +30,7 @@ export class Many2XTaxTagsAutocomplete extends Many2XAutocomplete {
         return this.orm
             .call(this.props.resModel, "search_read", [], {
                 domain: [...this.props.getDomain(), ["name", "ilike", name]],
-                fields: ["id", "name", "tax_scope"],
+                fields: ["id", "display_name", "tax_scope"],
                 context: this.props.context,
             })
             .then((records) => {

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -55,7 +55,7 @@ export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
         let records = await this.orm.searchRead(
             this.props.resModel,
             [...this.props.getDomain(), ["name", "ilike", name]],
-            ["id", "name", "relative_factor", "factor", "relative_uom_id", "parent_path"],
+            ["id", "display_name", "relative_factor", "factor", "relative_uom_id", "parent_path"],
         );
         const hasCommonReference = (uom1, uom2) => {
             const uom1Path = uom1.parent_path.split("/");


### PR DESCRIPTION
This commit resolves an issue where the search results label in many2many fields for Taxes and UOMs displayed `Unnamed` instead of the correct labels.
This issue was caused by components inheriting `Many2XAutocomplete` and overriding the `search` method.

TaskID:4778867

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
