### PR TITLE
[FIX] event: Use the correct URL for kiosk PWA

### DIFF
--- a/addons/event/static/src/client_action/event_barcode.xml
+++ b/addons/event/static/src/client_action/event_barcode.xml
@@ -42,7 +42,7 @@
                 <div class="d-flex align-items-center justify-content-between my-3">
                     <a t-if="!isDisplayStandalone" href="#" class="o_event_previous_menu float-start"><i class="oi oi-chevron-left fa-lg" t-on-click.prevent="() => this.onClickBackToEvents()"></i></a>
                     <span class="fs-2 me-auto ms-2" t-out="data.name"/>
-                    <a t-if="!isDisplayStandalone" class="btn btn-secondary d-flex align-items-center justify-content-center fw-bolder" href="/scoped_app?app_id=event&amp;path=odoo/registration-desk" target="_blank">Install</a>
+                    <a t-if="!isDisplayStandalone" class="btn btn-secondary d-flex align-items-center justify-content-center fw-bolder" href="/scoped_app?app_id=event&amp;path=scoped_app/registration-desk" target="_blank">Install</a>
                 </div>
                 <div class="flex-grow-1 d-flex flex-column justify-content-center align-items-center vh-50">
                     <BarcodeScanner onBarcodeScanned="(ev) => this.onBarcodeScanned(ev)"/>


### PR DESCRIPTION
This commit fixes the URL being used in the path argument given to the 'scoped_app' route. Since '/odoo' is already used by the main PWA, we must not use 'odoo' in the actual path of the PWA.