### PR TITLE
[FIX] website_sale: checkout step skipped for guest user when extra step enabled

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1019,10 +1019,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         )
 
         is_new_address = not partner_sudo
-        is_extra_step_active = request.website.viewref('website_sale.extra_info').active
-        if is_extra_step_active:
-            callback = callback or '/shop/extra_info'
-        elif is_new_address or order_sudo.only_services:
+        if is_new_address or order_sudo.only_services:
             callback = callback or '/shop/checkout?try_skip_step=true'
         else:
             callback = callback or '/shop/checkout'


### PR DESCRIPTION
Steps to reproduce:
1. Enable extra step setting.
2. Go to the shop as a guest user.
3. Add a product to the cart and proceed to checkout.
4. Fill out the address form and submit.

Issue:
- Checkout page is skipped for guest users when the extra step is enabled.

Cause:
- The address submission logic is prioritizing redirect to the extra step if it was active.

Fix:
- Removed the explicit check for the extra step, as it is unnecessary.

opw-4722276

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
