### PR TITLE
[FIX] website_sale: fix visibility of add to cart pop-up on shop page

### DIFF
--- a/addons/website_sale/static/src/js/notification/notification_service.js
+++ b/addons/website_sale/static/src/js/notification/notification_service.js
@@ -13,7 +13,7 @@ export class CartNotificationContainer extends NotificationContainer {
         Notification: CartNotification,
     }
     static template = xml`
-    <div class="position-absolute w-100 h-100 top-0 pe-none">
+    <div class="position-fixed w-100 h-100 top-0 pe-none">
         <div class="d-flex flex-column container align-items-end">
             <t t-foreach="notifications" t-as="notification" t-key="notification">
                 <Transition leaveDuration="0" name="'o_notification_fade'" t-slot-scope="transition">

--- a/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
+++ b/addons/website_sale/static/tests/tours/website_sale_cart_notification.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add("website_sale_cart_notification", {
         },
         {
             content: "check that the notification is closed",
-            trigger: "div.position-absolute.w-100.h-100.top-0.pe-none",
+            trigger: "div.position-fixed.w-100.h-100.top-0.pe-none",
             run() {
                 if (this.anchor.querySelectorAll("div").length !== 1) {
                     console.error("The cart notification is not closed!");


### PR DESCRIPTION
The issue is only reproducible from version 18.0 onwards, even if the `position-absolute` class still exists in earlier versions because the regression was introduced by [[1]](https://github.com/odoo/odoo/commit/189a7c96e6e26825dc05c0c6466576fe63aa091e), where the scroll handling was moved out of `div#wrapwrap`, which inadvertently affected the positioning of notifications.

Steps to Reproduce:
- Install `website_sale` and enable the 'Add to Cart' button from the website editor on the `/shop` page
- Navigate to the shop page and scroll to the last product
- Add the last product to the cart
- The pop-up does not appear unless you scroll back up

Issue:
- The add to cart pop-up is not visible when the user is scrolled down on the page

Root cause:
- The CSS class `position-absolute` restricts the pop-up to a specific location in the scrollable content

Fix:
- Replace `position-absolute` with `position-fixed` to keep the pop-up visible regardless of scroll position

opw-4686886
Affected version - 18.0

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
