### PR TITLE
[FIX] website_sale: remove redirection to extra step from address route

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1019,10 +1019,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
         )
 
         is_new_address = not partner_sudo
-        is_extra_step_active = request.website.viewref('website_sale.extra_info').active
-        if is_extra_step_active:
-            callback = callback or '/shop/extra_info'
-        elif is_new_address or order_sudo.only_services:
+
+        if is_new_address or order_sudo.only_services:
             callback = callback or '/shop/checkout?try_skip_step=true'
         else:
             callback = callback or '/shop/checkout'


### PR DESCRIPTION
Steps to reproduce:
1) Publish one dm
2) Enable extra step
3) As a public user add a deliverable product and checkout
4) Fill in an address and submit it
5) It will skip delivery and proceed to payment
6) Try to pay

Reason: address_submit redirects to extra_info instead of checkout skipping setting a dm

Solution:
Remove redirect to extra_step

opw-4711750
