### PR TITLE
[IMP] pos_preparation_display: not display future order immediately

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -17,13 +17,10 @@ import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { user } from "@web/core/user";
 import { OrderTabs } from "@point_of_sale/app/components/order_tabs/order_tabs";
-import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_slots_popup/preset_slots_popup";
-import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { openProxyCustomerDisplay } from "@point_of_sale/customer_display/utils";
 import { uuidv4 } from "@point_of_sale/utils";
 import { QrCodeCustomerDisplay } from "@point_of_sale/app/customer_display/customer_display_qr_code_popup";
-const { DateTime } = luxon;
 
 export class Navbar extends Component {
     static template = "point_of_sale.Navbar";
@@ -174,20 +171,7 @@ export class Navbar extends Component {
     }
 
     async openPresetTiming() {
-        const order = this.pos.getOrder();
-        const data = await makeAwaitable(this.dialog, PresetSlotsPopup);
-
-        if (data) {
-            if (order.preset_id.id != data.presetId) {
-                await this.pos.selectPreset(this.pos.models["pos.preset"].get(data.presetId));
-            }
-
-            order.preset_time = data.slot.datetime;
-            if (data.slot.datetime > DateTime.now()) {
-                this.pos.addPendingOrder([order.id]);
-                await this.pos.syncAllOrders();
-            }
-        }
+        await this.pos.openPresetTiming();
     }
 
     get mainButton() {

--- a/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.xml
+++ b/addons/pos_restaurant/static/src/app/popup/edit_order_name_popup/edit_order_name_popup.xml
@@ -25,6 +25,5 @@
         <xpath expr="//button[hasclass('o-default-button', 'btn-primary')]" position="attributes">
             <attribute name="t-attf-class">{{state.inputValue ? '' : 'disabled'}}</attribute>
         </xpath>
-        <xpath expr="//button[hasclass('o-default-button', 'btn-secondary')]" position="replace"/>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -2,7 +2,6 @@ import { patch } from "@web/core/utils/patch";
 import { PosStore } from "@point_of_sale/app/services/pos_store";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
-import { EditOrderNamePopup } from "@pos_restaurant/app/popup/edit_order_name_popup/edit_order_name_popup";
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { NumberPopup } from "@point_of_sale/app/components/popups/number_popup/number_popup";
 import { SelectionPopup } from "@point_of_sale/app/components/popups/selection_popup/selection_popup";
@@ -547,22 +546,6 @@ patch(PosStore.prototype, {
                 this.addNewOrder({ table_id: table });
             }
         }
-    },
-    editFloatingOrderName(order) {
-        this.dialog.add(EditOrderNamePopup, {
-            title: _t("Edit Order Name"),
-            placeholder: _t("18:45 John 4P"),
-            startingValue: order.floating_order_name || "",
-            getPayload: async (newName) => {
-                if (typeof order.id == "number") {
-                    this.data.write("pos.order", [order.id], {
-                        floating_order_name: newName,
-                    });
-                } else {
-                    order.floating_order_name = newName;
-                }
-            },
-        });
     },
     setFloatingOrder(floatingOrder) {
         if (this.getOrder()?.isFilledDirectSale) {


### PR DESCRIPTION
After this commit, selecting a preset configured with use_time will display the PresetSlotsPopup to choose the time.

Related: https://github.com/odoo/enterprise/pull/84957
task-4725279

