### PR TITLE
[FIX] spreadsheet_dashboard: fix dashboard language display

### DIFF
--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/mobile_figure_container/mobile_figure_container.xml
@@ -7,7 +7,7 @@
         <div
             t-foreach="figures" t-as="figure"
             t-key="figure.id"
-            t-attf-style="min-height: #{figure.height}px;"
+            t-attf-style="min-height: #{figure.height}px; direction: ltr;"
         >
             <t t-component="getFigureComponent(figure)" figure="figure" onFigureDeleted="() => {}"/>
         </div>


### PR DESCRIPTION
to reproduce:
===========

    step 1 : change language to arab
    step 2 : go to dashboard app using mobile
 

Problem:
=======

overlapped text in the Dashboard module
we forced direction to ltr on all languages in web and we didn't add this change in the mobile part

Solution:
=======

force ltr direction even on rtl languages in the mobile part

opw-4586743





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
