### PR TITLE
[FIX] analytic: runbot build error industry_fsm single app tests

### DIFF
--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -71,6 +71,14 @@ class TestAnalyticAccount(TransactionCase):
             'analytic_distribution': {cls.analytic_account_2.id: 100}
         })
 
+        """ Removes access rights linked to timesheet and project as these add
+        record rules blocking analytic flows; account overrides it"""
+        if 'account.account' not in cls.env:
+            core_group_ids = cls.env.ref("hr_timesheet.group_hr_timesheet_user", raise_if_not_found=False) or cls.env['ir.rule']
+            problematic_group_ids = cls.env.user.groups_id.filtered(lambda g: (g | g.trans_implied_ids) & core_group_ids)
+            if problematic_group_ids:
+                cls.env.user.groups_id -= problematic_group_ids
+
     def test_get_plans_without_options(self):
         """ Test that the plans with the good appliability are returned without if no options are given """
         kwargs = {}


### PR DESCRIPTION
### Steps to reproduce:

- install fsm_industry
- run any of these tests:
    - test_change_parent_plan
    - test_change_parent_plan_conflict
    - test_change_parent_plan_with_intermediate
    - test_change_plan
    - test_change_plan_conflict
    - test_change_plan_no_conflict
#### > create access right error for the `account.analytic.line` model

### Cause of the issue:

The following three record rules provide the creation of `account.analytic.line` for users related to project or timesheet access rights unless the analytic line it self is linked to a project: https://github.com/odoo/odoo/blob/e7bd20e64e023c279bf574630e2d8c8a45ba2fe2/addons/hr_timesheet/security/hr_timesheet_security.xml#L52-L64 https://github.com/odoo/odoo/blob/e7bd20e64e023c279bf574630e2d8c8a45ba2fe2/addons/hr_timesheet/security/hr_timesheet_security.xml#L66-L76 https://github.com/odoo/odoo/blob/e7bd20e64e023c279bf574630e2d8c8a45ba2fe2/addons/hr_timesheet/security/hr_timesheet_security.xml#L78-L83 Since the analytic module is unrelated to the project module, these tests will inevitably fail.

### Note:

These record rules do not stop the record creation once the account module is installed since the following record rules override the creation access rights for `account.group_account_invoice` users: https://github.com/odoo/odoo/blob/e7bd20e64e023c279bf574630e2d8c8a45ba2fe2/addons/account/security/account_security.xml#L102-L107

Similar issue treated in commit 9d164c1d2cd8e532109b9859ab776fcf2f71d115

### Note 2:

A priori, the same problem would occur if we were to write post install analytic tests for portal users:
https://github.com/odoo/odoo/blob/e7bd20e64e023c279bf574630e2d8c8a45ba2fe2/addons/hr_timesheet/security/hr_timesheet_security.xml#L33-L50

runbot-160013
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
