### PR TITLE
[FIX] point_of_sale: read parentCategories from product template

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -201,7 +201,7 @@ export class ProductTemplate extends Base {
                     (rulesIds.includes(rule.id) || (!rule.product_id && !rule.product_tmpl_id)) &&
                     (!rule.min_quantity || quantity >= rule.min_quantity) &&
                     (!rule.product_id || rule.product_id.id === product?.id) &&
-                    (!rule.categ_id || product.parentCategories.includes(rule.categ_id.id))
+                    (!rule.categ_id || productTmpl.parentCategories.includes(rule.categ_id.id))
             ) || [];
 
         const rule = rules.length && rules[0];


### PR DESCRIPTION
Before this commit, the parentCategories field was read from the product variant, which could be missing in certain calls. For example, in getProductInfo, the getPrice method is called without a variant, leading to errors.

opw-4772883

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
