### PR TITLE
[FIX] pos_restaurant: ensure write_date is loaded for all dynamicModels

### DIFF
--- a/addons/pos_restaurant/models/restaurant_order_course.py
+++ b/addons/pos_restaurant/models/restaurant_order_course.py
@@ -27,4 +27,4 @@ class RestaurantOrderCourse(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['uuid', 'fired', 'order_id', 'line_ids', 'index']
+        return ['uuid', 'fired', 'order_id', 'line_ids', 'index', 'write_date']


### PR DESCRIPTION
Before this commit, the write_date field was not loaded for restaurant.order.course, which caused issues during the loading.

opw-4779831

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
