### PR TITLE
[FIX] point_of_sale: avoid popup for scanned dynamic attribute variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -118,7 +118,7 @@ export class ProductTemplate extends Base {
         return (
             this.isConfigurable() &&
             this.attribute_line_ids.length > 0 &&
-            !this.attribute_line_ids.every((l) => l.attribute_id.create_variant === "always")
+            this.attribute_line_ids.some((l) => l.attribute_id.create_variant === "no_variant")
         );
     }
 


### PR DESCRIPTION
Before this commit, scanning a product with a dynamic attribute, an existing variant, and an assigned barcode in the PoS would still trigger the configuration popup unnecessarily.

opw-4779504

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
