### PR TITLE
[FIX] mail: dark theme discuss sidebar unread indicator more visible

### DIFF
--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -2,6 +2,10 @@
     --mail-DiscussSidebarChannel-commandsHover: #{rgba($gray-400, .5)};
 }
 
+.o-mail-DiscussSidebar-unreadIndicator {
+    opacity: 75%;
+}
+
 .o-mail-DiscussSidebarChannel-container {
     --mail-DiscussSidebarChannel-borderOpacity: .125;
     ---mail-DiscussSidebarChannel-borderedBgColor: #{mix($gray-100, $gray-200, 75%)};

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -69,6 +69,7 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.4rem;
     left: -3px;
+    opacity: 50%;
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
         left: map-get($spacers, 2) + map-get($spacers, 1) / 2;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -144,7 +144,7 @@
     </t>
 
     <t t-name="mail.DiscussSidebar.unreadIndicator">
-        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute opacity-50" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.main">


### PR DESCRIPTION
When a conversation is unread (and no important messages), the conversation in discuss sidebar has a small dot next to the item.

In white theme its visibility is good, with `.opacity-50`. In dark theme however this indicator is hard to see.

This commit fixes the issue by keeping 50% opacity in white theme but bumping to 75% in dark theme specifically.