### PR TITLE
[FIX] pos_self_order: Fix displayed product price (with variant)

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -45,7 +45,7 @@ class ProductProduct(models.Model):
     @api.model
     def _load_pos_self_data_fields(self, config_id):
         params = super()._load_pos_self_data_fields(config_id)
-        params += ['public_description']
+        params += ['public_description', 'list_price']
         return params
     
     @api.model


### PR DESCRIPTION
- Fix issue in `pos_self_order` module where the displayed product price was wrong when a product had variants (with creation "Instantly") and with an extra price.
- The price displayed in the product card was the price of the first variant instead of the price of the product template (since we have not yet chosen a variant).

opw: 4755565



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
