### PR TITLE
[FIX] pos_self_order: translation in kiosk tour

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -145,7 +145,7 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
         LandingPage.checkKioskCountryFlagShown("us"),
 
         LandingPage.selectKioskLocation("Test-Takeout"),
-        CategoryPage.clickKioskCategory("Uncategorised"),
+        CategoryPage.clickKioskCategory("Test Category"),
         ProductPage.clickKioskProduct("Test Product"),
         ProductPage.clickBack(),
         ...CategoryPage.clickCancel(),
@@ -156,7 +156,7 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
 
         Utils.clickBtn("Commander maintenant"),
         LandingPage.selectKioskLocation("Test-Takeout"),
-        CategoryPage.clickKioskCategory("Uncategorised"),
+        CategoryPage.clickKioskCategory("Catégorie Test"),
         ProductPage.clickKioskProduct("Produit Test"),
     ],
 });

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -102,12 +102,18 @@ class TestSelfOrderKiosk(SelfOrderCommonTest):
     def test_self_order_language_changes(self):
         self.env['res.lang']._activate_lang('fr_FR')
 
+        test_category = self.env['pos.category'].create({
+            'name': "Test Category",
+        })
+
         product = self.env['product.product'].create({
             'name': "Test Product",
             'list_price': 100,
             'taxes_id': False,
             'available_in_pos': True,
+            'pos_categ_ids': [(4, test_category.id)],
         })
+        test_category.with_context(lang='fr_FR').name = "Catégorie Test"
         product.with_context(lang='fr_FR').name = "Produit Test"
 
         self.pos_config.write({


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/c2191816fc781bfae350039c4259f1af8a4c3619, the terme "Uncategorised" has been translated in french. In the tour, it was not taken into account so the test was failing as it was not finding the correct button.

runbot-error: 198563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
