### PR TITLE
 [IMP] project: add index on is_template and improve _search_has_template_ancestor

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -318,6 +318,8 @@ class ProjectTask(models.Model):
         'A private task cannot have a parent.',
     )
 
+    _is_template_idx = models.Index('(is_template) WHERE is_template IS TRUE')
+
     @api.constrains('company_id', 'partner_id')
     def _ensure_company_consistency_with_partner(self):
         """ Ensures that the company of the task is valid for the partner. """
@@ -802,7 +804,7 @@ class ProjectTask(models.Model):
     def _search_has_template_ancestor(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             return NotImplemented
-        template_tasks = self.env['project.task'].with_context(active_test=False).search([('is_template', '=', True)])
+        template_tasks = self.env['project.task'].with_context(active_test=False).sudo().search([('is_template', '=', True)])
         domain = [('id', 'child_of', template_tasks.ids)]
         if (operator == "=") != value:
             domain = ['!', ('id', 'child_of', template_tasks.ids)]


### PR DESCRIPTION
Before this commit, the `_search_has_ancestor_template` took a lot of
time because we first fetch the tasks template to build the domain for
that search. The issue is because the search to gather the tasks
template is not done in sudo and so the ir.rules of the current are
included in the search.

This commit adds a sudo to that search to not include the ir.rules since
all task templates have to be included in the search method. This commit
also add an index on is_template when is_template is true on task since
the search will mostly search the tasks flagged as template.

By doing that, the search_read of one column in kanban view of tasks in
project Help is made in 0.30 seconds instead of 3 seconds.
