### PR TITLE
[IMP] hr_holidays: Hide Attach File button after First Approval

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -363,7 +363,7 @@
                             <field name="name" readonly="state != 'confirm'" widget="text" nolabel="1" colspan="2" placeholder="No description provided" />
                         </group>
                         <group>
-                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="state not in ('confirm', 'validate1')" />
+                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" invisible="state != 'confirm'" />
                         </group>
                     </div>
                     <div class="o_hr_leave_column col_right col-md-6 col-12">


### PR DESCRIPTION
- After this PR Attach file button will be hidden from the UI if the leave state is 'confirm'

task: 4780992

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
