### PR TITLE
[FIX] account: account selector markdown

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -878,6 +878,7 @@ class AccountAccount(models.Model):
     @api.depends('code')
     def _compute_display_name(self):
         formatted_display_name = self.env.context.get('formatted_display_name')
+        new_line = '\n'
         preferred_account_ids = self.env.context.get('preferred_account_ids', [])
         if (
             (move_type := self.env.context.get('move_type'))
@@ -890,7 +891,7 @@ class AccountAccount(models.Model):
                 account.display_name = (
                     f"""{account.code} {account.name}"""
                     f"""{f' `{_("Suggested")}`' if account.id in preferred_account_ids else ''}"""
-                    f"""{f'<br>--{account.description}--' if account.description else ''}"""
+                    f"""{f'{new_line}--{account.description}--' if account.description else ''}"""
                 )
             else:
                 account.display_name = f"{account.code} {account.name}" if account.code else account.name


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/29f7475437586363e473955315d74aef7d80028c changed the markdown syntax from `<br>` to `\n` Adapt the compute display name to the new format
