### PR TITLE
[FIX] hr_work_entry:

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import itertools
 from collections import defaultdict
 from contextlib import contextmanager
+
 from dateutil.relativedelta import relativedelta
-import itertools
 from psycopg2 import OperationalError
 
-from odoo import api, fields, models, tools, _
+from odoo import _, api, fields, models, tools
 from odoo.osv import expression
 
 
@@ -167,6 +167,14 @@ class HrWorkEntry(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        company_by_employee_id = {}
+        for vals in vals_list:
+            if vals.get('company_id'):
+                continue
+            if vals['employee_id'] not in company_by_employee_id:
+                employee = self.env['hr.employee'].browse(vals['employee_id'])
+                company_by_employee_id[employee.id] = employee.company_id.id
+            vals['company_id'] = company_by_employee_id[vals['employee_id']]
         work_entries = super().create(vals_list)
         work_entries._check_if_error()
         return work_entries

--- a/addons/hr_work_entry/tests/__init__.py
+++ b/addons/hr_work_entry/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_hr_work_entry

--- a/addons/hr_work_entry/tests/test_hr_work_entry.py
+++ b/addons/hr_work_entry/tests/test_hr_work_entry.py
@@ -1,0 +1,44 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests.common import TransactionCase
+
+
+class TestHrWorkEntry(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create two companies
+        cls.company_a = cls.env['res.company'].create({'name': 'Company A'})
+        cls.company_b = cls.env['res.company'].create({'name': 'Company B'})
+        cls.env.user.company_ids = [(6, 0, [cls.company_a.id, cls.company_b.id])]
+        cls.env.user.company_id = cls.company_a.id
+        # Create an employee for each company
+        cls.employee_a = cls.env['hr.employee'].create({
+            'name': 'Employee A',
+            'company_id': cls.company_a.id,
+        })
+        cls.employee_b = cls.env['hr.employee'].create({
+            'name': 'Employee B',
+            'company_id': cls.company_b.id,
+        })
+        # Create a work entry type
+        cls.work_entry_type = cls.env['hr.work.entry.type'].create({
+            'name': 'Attendance',
+            'code': 'ATTEND',
+        })
+
+    def test_work_entry_company_from_employee(self):
+        """Test that work entry uses employee's company not the current user's company in vals."""
+        work_entry = self.env['hr.work.entry'].create({
+            'name': 'Test Work Entry',
+            'employee_id': self.employee_b.id,
+            'work_entry_type_id': self.work_entry_type.id,
+            'date_start': '2024-01-01 08:00:00',
+            'date_stop': '2024-01-01 16:00:00',
+            'duration': 8,
+        })
+        self.assertEqual(
+            work_entry.company_id, self.employee_b.company_id,
+            "Work entry should use the employee's company not the current user's company.",
+        )


### PR DESCRIPTION
BUG
- when you select 2 companies in the multi company widget (A & B, default : A) and I create a work entry for an employee of company B. The work entry will be related to company A.

Expected behavior:
- The default company should be the employee one if has a one

FIX
- check if the employee has a company add it to the create vals_list

Task: 4781100

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
