### PR TITLE
[FIX] event_sale: use exact match instead of contains in tour

### DIFF
--- a/addons/event_sale/static/tests/tours/event_configurator_ui.js
+++ b/addons/event_sale/static/tests/tours/event_configurator_ui.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add("event_configurator_tour", {
             run: "click",
         },
         {
-            trigger: "ul.ui-autocomplete a:contains(Design)",
+            trigger: "ul.ui-autocomplete a:contains(/^Design Fair Los Angeles$/)",
             run: "click",
         },
         {


### PR DESCRIPTION
Fixes tour failure due to selection of a wrong autocomplete item with multiple options. This led to inconsistent behavior when multiple options with similar labels.

This change ensures the tour selects the correct item and selects it by exact match using css selector and regex.

The error appears in the runbot CI/CD , it doesnt have a build error in the runbot website for the moment
https://runbot.odoo.com/runbot/build/79912368

![image](https://github.com/user-attachments/assets/9baf8296-37e1-4ec7-816b-664e76bec448)



