### PR TITLE
[FIX] web: fix favorite_management_tour again

### DIFF
--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -25,8 +25,14 @@ registry.category("web_tour.tours").add("test_favorite_management", {
             run: "click",
         },
         {
+            trigger: ".o_searchview_facet .o_facet_value:contains(Apps1)",
+        },
+        {
             trigger: ".o_group_by_menu > .o-dropdown-item:contains(Category)",
             run: "click",
+        },
+        {
+            trigger: ".o_kanban_header:contains(Account Charts)",
         },
         {
             trigger: ".o_favorite_menu .o_accordion_values .o_input",


### PR DESCRIPTION
This commit adds steps to the favorite_management_tour to ensure the all steps are performed sequencially between first favorite save and applying a new groupBy.

Runbot-112238
