### PR TITLE
[FIX] point_of_sale: don't merge orderlines with different prices

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -328,7 +328,10 @@ export class PosOrderline extends Base {
             this.is_pos_groupable() &&
             // don't merge discounted orderlines
             this.get_discount() === 0 &&
-            floatIsZero(price - order_line_price - orderline.get_price_extra(), this.currency) &&
+            floatIsZero(
+                price - order_line_price - orderline.get_price_extra(),
+                this.currency.decimal_places
+            ) &&
             !this.isLotTracked() &&
             this.full_product_name === orderline.full_product_name &&
             isSameCustomerNote &&


### PR DESCRIPTION
Before this commit, the can_be_merged_with method did not work correctly because an incorrect argument was passed to floatIsZero. As a result, orderlines with different prices could be merged together, leading to inaccurate order information.

opw-4778629

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
