### PR TITLE
[FIX] partner_autocomplete: Prevent unnecessary input field display for Mobile

### DIFF
--- a/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
+++ b/addons/partner_autocomplete/static/src/xml/partner_autocomplete.xml
@@ -40,7 +40,7 @@
 
     <t t-name="partner_autocomplete.PartnerAutoCompleteMany2XField" t-inherit="web.Many2XAutocomplete" t-inherit-mode="primary">
         <xpath expr="//AutoComplete" position="replace">
-            <PartnerAutoComplete
+            <PartnerAutoComplete t-else=""
                 value="this.props.value || ''"
                 autoSelect="true"
                 sources="sources"


### PR DESCRIPTION
**Steps to Reproduce:**
1. Install Sales module
2. Create a new quotation in mobile view

**Issue:**
- The input field of contact is displayed twice due to a missing `t-else` condition, causing both fields to appear simultaneously.

**Solution:**
- Added the missing `t-else` condition to ensure that only one input field is displayed as intended.

opw-4767186


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
