### PR TITLE
[FIX] l10n_din5008: fix the color on addresses

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -53,24 +53,26 @@
                         <tr>
                             <td>
                                 <div class="address" id="din5008_report_main_address">
-                                    <t t-if="company.name">
-                                        <span t-field="company.name"/>
-                                    </t>
-                                    <t t-if="company.street">
-                                        <span>|</span> <span t-field="company.street"/>
-                                    </t>
-                                    <t t-if="company.street2">
-                                        <span>|</span> <span t-field="company.street2"/>
-                                    </t>
-                                    <t t-if="company.zip">
-                                        <span>|</span> <span t-field="company.zip"/>
-                                    </t>
-                                    <t t-if="company.city">
-                                        <span t-if="not company.zip">|</span> <span t-field="company.city"/>
-                                    </t>
-                                    <t t-if="company.country_id">
-                                        <span>|</span> <span t-field="company.country_id.name"/>
-                                    </t>
+                                    <div class="colored_address">
+                                        <t t-if="company.name">
+                                            <span t-field="company.name"/>
+                                        </t>
+                                        <t t-if="company.street">
+                                            <span>|</span> <span t-field="company.street"/>
+                                        </t>
+                                        <t t-if="company.street2">
+                                            <span>|</span> <span t-field="company.street2"/>
+                                        </t>
+                                        <t t-if="company.zip">
+                                            <span>|</span> <span t-field="company.zip"/>
+                                        </t>
+                                        <t t-if="company.city">
+                                            <span t-if="not company.zip">|</span> <span t-field="company.city"/>
+                                        </t>
+                                        <t t-if="company.country_id">
+                                            <span>|</span> <span t-field="company.country_id.name"/>
+                                        </t>
+                                    </div>
                                     <hr class="company_invoice_line" />
                                     <span t-if="address">
                                         <t t-out="address"/>
@@ -160,7 +162,7 @@
                         &amp;.invoice_note {
                             td {
                                 .address {
-                                    > span {
+                                    .colored_address {
                                         color: <t t-out='secondary'/>;
                                     }
                                 }

--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -44,8 +44,10 @@
                 .company_invoice_line {
                     margin-top: 1mm;
                 }
-                > span {
+                .colored_address {
                     color: $o-default-report-secondary-color;
+                }
+                > span {
                     font-size: 0.8em;
                 }
             }


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_din5008"
- In Settings > Layout, select DIN5008 as the report and change the two possible colors
- Create a quotation, print it
- The address is colored

### Cause
This [commit](https://github.com/odoo/odoo/commit/92e4c3cb3bec0b3d5537a50fd441a22fa6509ed1) reduced the size of the address by replacing `div` with `span` which is applied `font-size: 0.8em;`. 
But also `color: $o-default-report-secondary-color;` ([see](https://github.com/odoo/odoo/blob/d3e43681fd2b989ae7272731662cc3ac6a6d913b/addons/l10n_din5008/static/src/scss/report_din5008.scss#L47-L50)). 

### Solution
Don't use `span` in the CSS to select the text.
Instead we create a new class `colored_address` to apply the color and apply the same font size on the entire address block.
This way the addresses will always have the same font size and the color should only be applied where we want it to.


Before:
![image](https://github.com/user-attachments/assets/bff1bba2-14e0-49c7-9b99-052c9431d0a0)
After:
![image](https://github.com/user-attachments/assets/12dacd2e-08df-4fcf-bae1-02c9699742ef)

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4725169)
opw-4725169