### PR TITLE
[FIX] website_sale: misleading label for optional sign-in/up at checkout

### DIFF
--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -28,7 +28,7 @@
                         </div>
                     </setting>
                     <setting id="website_checkout_registration" title=" To send invitations in B2B mode, open a contact or select several ones in list view and click on 'Portal Access Management' option in the dropdown menu *Action*."
-                         string="Sign in/up at checkout" help="&quot;Optional&quot; allows guests to register from the order confirmation email to track their order.">
+                         string="Sign in/up at checkout" help="&quot;Optional&quot; allows guests to place an order without signing in and later register via the order confirmation page when free sign-up is enabled.">
                         <field name="account_on_checkout" class="w-75" widget="radio"/>
                     </setting>
                     <setting help="Instant checkout, instead of adding to cart">


### PR DESCRIPTION
Steps:
- Go to Website > Configuration > Settings.
- Under 'Checkout Process', set 'Sign in/up at checkout' to 'Optional'.

Issue:
- Label suggests that users can register from the confirmation email.
- In reality, users must go to 'View Order' → 'Sign in' → 'Don't have an account?'.
- Only works when 'Customer Account' is set to 'Free sign up', and not in B2B.

Cause:
- Label text was unclear and did not reflect the actual flow or technical constraints.

Fix:
- Updated label to clarify that registration is only possible via the order page and is not available in B2B mode.

opw: 4713476

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
