### PR TITLE
[FIX] stock: quand negative lot

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1037,7 +1037,7 @@ class StockQuant(models.Model):
             raise ValidationError(_('Quantity or Reserved Quantity should be set.'))
         self = self.sudo()
         quants = self._gather(product_id, location_id, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
-        if lot_id and quantity > 0:
+        if lot_id and (quantity > 0 or (quantity < 0 and sum(quants.mapped('quantity')) < quantity)):
             quants = quants.filtered(lambda q: q.lot_id)
 
         if location_id.should_bypass_reservation():


### PR DESCRIPTION
Usecase:
- Create a product with lot and create a quant 0 0 without lot
- Create 2 lots without quant, lot A and lot B
- Do a delivery and set the lots on the stock.move
- Validate

Expected behavior:
Two negative quants in stock with -1 lot A and -1 lot B

Current behavior:
The existing quant without lot is set to -2

It's an issue since we don't have any tool to reconcile the quant without lot to an incoming lot. And the user have to do it manually. It will be the opposite if the user receive product without lot and have to reconcile them with existing negative quant with lot but it's the edge case.