### PR TITLE
[IMP] l10n_de: add check if audit_trail feature is activated

### DIFF
--- a/addons/l10n_de/models/ir_attachment.py
+++ b/addons/l10n_de/models/ir_attachment.py
@@ -17,6 +17,7 @@ class IrAttachment(models.Model):
             attachment.res_model == 'account.move'
             and attachment.res_id
             and attachment.raw
+            and attachment.company_id.check_account_audit_trail
             and guess_mimetype(attachment.raw) in (
                 'application/pdf',
                 'application/xml',
@@ -50,6 +51,7 @@ class IrAttachment(models.Model):
             attachment.res_model == 'account.move'
             and attachment.res_id
             and attachment.res_field in ('invoice_pdf_report_file', 'ubl_cii_xml_file')
+            and attachment.company_id.check_account_audit_trail
             and attachment.company_id.account_fiscal_country_id.code == 'DE'
         )
         if invoice_pdf_attachments:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The audit trail error is displayed eventhough the audit_trail is disabled for the company.

Current behavior before PR:
Attachments cannot be deleted with deactivated audit trail feature.

Desired behavior after PR is merged:
Only prevent deleting audit trail attachments, when audit trail setting is active.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
https://github.com/odoo/odoo/pull/207024