### PR TITLE
[FIX] base: avoid error if  embedded action refers to uninstalled module

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -115,12 +115,14 @@ class IrActions(models.Model):
         return res
 
     def unlink(self):
-        """unlink ir.action.todo/ir.filters which are related to actions which will be deleted.
+        """unlink ir.action.todo, ir.filters, ir.embedded.actions which are related to actions which will be deleted.
            NOTE: ondelete cascade will not work on ir.actions.actions so we will need to do it manually."""
         todos = self.env['ir.actions.todo'].search([('action_id', 'in', self.ids)])
         todos.unlink()
         filters = self.env['ir.filters'].search([('action_id', 'in', self.ids)])
         filters.unlink()
+        embedded_actions = self.env['ir.embedded.actions'].search([('action_id', 'in', self.ids)])
+        embedded_actions.unlink()
         res = super(IrActions, self).unlink()
         # self.get_bindings() depends on action records
         self.env.registry.clear_cache()


### PR DESCRIPTION
The system failed to evaluate the embedded action, which refers to the Uninstalled module.

Steps to produce:
1. Install `Project` and `Timesheets`.
2. Go to Project and open any project.
3. Click on the embedded action icon and select `Timesheets`.
4. Save the view from the embedded action's icon.
5. Now, Uninstall `Timesheets`.
6. Now, go to that Project and try to open it.

Error:-
`KeyError: 'allow_timesheets'`
`ValueError: Invalid field in filter of project.project:
 [('allow_timesheets', '=', True)]`

Solution:-
- Here,
https://github.com/odoo/odoo/blob/e7efc2c3ad70aa9273412b089a71a9ade75ad525/odoo/addons/base/models/ir_embedded_actions.py#L19

- Also, use `ondelete="cascade"`. but `ondelete="cascade"` not works on `ir.actions.actions`.
https://github.com/odoo/odoo/blob/e7efc2c3ad70aa9273412b089a71a9ade75ad525/odoo/addons/base/models/ir_actions.py#L117-L127

We should remove `ondelete="cascade"` from the `action_id` field and add explicit unlink logic for `ir.embedded.actions`in the unlink method.

Sentry - 6495174314

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
