### PR TITLE
[PERF] pos_sale: Add pagination to quotations/order list

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useService, useBus } from "@web/core/utils/hooks";
 import { Component, useState } from "@odoo/owl";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 
@@ -26,6 +26,9 @@ export class SaleOrderManagementControlPanel extends Component {
         this.pos = usePos();
         this.ui = useState(useService("ui"));
         this.saleOrderFetcher = useService("sale_order_fetcher");
+        this.state = useState({
+            paginationString: "",
+        });
         useAutofocus();
 
         const currentPartner = this.pos.get_order().get_partner();
@@ -33,11 +36,15 @@ export class SaleOrderManagementControlPanel extends Component {
             this.pos.orderManagement.searchString = `"${currentPartner.name}"`;
         }
         this.saleOrderFetcher.setSearchDomain(this._computeDomain());
+        useBus(this.saleOrderFetcher, "update", this.updatePagination);
     }
     onInputKeydown(event) {
         if (event.key === "Enter") {
             this.props.onSearch(this._computeDomain());
         }
+    }
+    updatePagination() {
+        this.state.paginationString = `(${this.saleOrderFetcher.currentPage}/${this.saleOrderFetcher.lastPage})`
     }
     get showPageControls() {
         return this.saleOrderFetcher.lastPage > 1;

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.xml
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_control_panel/sale_order_management_control_panel.xml
@@ -22,20 +22,19 @@
                     </button>
                 </div> 
             </div>
-            <div t-if="showPageControls" class="item item d-flex align-items-center ms-3 gap-2">
+            <div class="item item d-flex align-items-center ms-3 gap-2">
                 <div class="page-controls input-group">
-                    <button class="previous btn btn-lg btn-secondary" t-on-click="() => this.props.onPrevPage">
+                    <button class="previous btn btn-lg btn-secondary" t-on-click="() => this.props.onPrevPage()">
                         <i class="oi oi-chevron-left" role="img" aria-label="Previous Order List" title="Previous Order List"></i>
                     </button>
-                    <button class="next btn btn-lg btn-secondary" t-on-click="() => this.props.onNextPage">
+                    <button class="next btn btn-lg btn-secondary" t-on-click="() => this.props.onNextPage()">
                         <i class="oi oi-chevron-right" role="img" aria-label="Next Order List" title="Next Order List"></i>
                     </button>
                 </div>
                 <div class="page">
-                    <span><t t-esc="pageNumber" /></span>
+                    <span><t t-esc="state.paginationString" /></span>
                 </div>
             </div>
-            <div t-else="" class="item"></div>
         </div>
     </t>
 

--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -48,17 +48,6 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
         onMounted(this.onMounted);
     }
     onMounted() {
-        // calculate how many can fit in the screen.
-        // It is based on the height of the header element.
-        // So the result is only accurate if each row is just single line.
-        const flexContainer = this.root.el.querySelector(".flex-container");
-        const cpEl = this.root.el.querySelector(".control-panel");
-        const headerEl = this.root.el.querySelector(".header-row");
-        const val = Math.trunc(
-            (flexContainer.offsetHeight - cpEl.offsetHeight - headerEl.offsetHeight) /
-                headerEl.offsetHeight
-        );
-        this.saleOrderFetcher.setNPerPage(val);
         this.saleOrderFetcher.fetch();
     }
     _getSaleOrderOrigin(order) {


### PR DESCRIPTION
Before this change, all quotations and orders were loaded into the same view in the POS frontend. This caused severe performance issues and even complete unresponsiveness when a large number of records were present.

This commit introduces proper pagination for this view, limiting the number of displayed records to 80 per page to avoid bloating frontend memory and speeding up the fetch.

** Benchmarks:**
| num records | before              | after     |
|-------------|---------------------|-----------|
| 17,000+     | frontend unresponsive | < 500ms  |


  opw-4728862
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
