### PR TITLE
[FIX] stock_dropshipping,stock_account: Fix invalid COGS on dropship

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -772,10 +772,12 @@ class ProductProduct(models.Model):
         if not qty_to_invoice:
             return 0
 
-        candidates = stock_moves\
-            .sudo()\
-            .filtered(lambda m: is_returned == bool(m.origin_returned_move_id and sum(m.stock_valuation_layer_ids.mapped('quantity')) >= 0))\
-            .mapped('stock_valuation_layer_ids')
+        candidates = self.env['stock.valuation.layer'].sudo()
+        for move in stock_moves.sudo():
+            move_candidates = move._get_layer_candidates()
+            if is_returned != bool(move.origin_returned_move_id and sum(move_candidates.mapped('quantity')) >= 0):
+                continue
+            candidates |= move_candidates
 
         if self.env.context.get('candidates_prefetch_ids'):
             candidates = candidates.with_prefetch(self.env.context.get('candidates_prefetch_ids'))

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -647,3 +647,7 @@ class StockMove(models.Model):
 
     def _get_all_related_sm(self, product):
         return self.filtered(lambda m: m.product_id == product)
+
+    def _get_layer_candidates(self):
+        self.ensure_one()
+        return self.stock_valuation_layer_ids

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -77,3 +77,15 @@ class StockLot(models.Model):
             ('location_dest_id.usage', '=', 'customer'),
             ('location_id.usage', '=', 'supplier'),
         ]])
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_layer_candidates(self):
+        layer_candidates = super()._get_layer_candidates()
+        if self._is_dropshipped():
+            layer_candidates = layer_candidates.filtered(lambda svl: svl.quantity < 0)
+        elif self._is_dropshipped_returned():
+            layer_candidates = layer_candidates.filtered(lambda svl: svl.quantity > 0)
+        return layer_candidates

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -337,3 +337,87 @@ class TestStockValuation(ValuationReconciliationTestCommon):
 
         self.assertTrue(8 in return_pick_2.move_ids.stock_valuation_layer_ids.mapped('value'))
         self.assertTrue(-8 in return_pick_2.move_ids.stock_valuation_layer_ids.mapped('value'))
+
+    def test_dropship_cogs_multiple_invoices(self):
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self.product1.product_tmpl_id.invoice_policy = 'order'
+        account_output = self.product1.product_tmpl_id.categ_id.property_stock_account_output_categ_id
+
+        # --- Create Dropship 1 --- #
+        self._dropship_product1()
+
+        # Check Dropship 1 COGS
+        dropship1_layers = self.purchase_order1.order_line.move_ids.stock_valuation_layer_ids
+        self.assertEqual(len(dropship1_layers), 2)
+        self.assertEqual(dropship1_layers[0].value, 8)
+        dropship1_cogs_line = self.customer_invoice1.line_ids.filtered(lambda aml: aml.account_id.id == account_output.id)
+        self.assertEqual(dropship1_cogs_line.balance, -8)
+
+        # --- Create Dropship 2 --- #
+        self.sale_order1.order_line.product_uom_qty = 2  # Should create a new PO
+        self.purchase_order2 = self.env['purchase.order'].search(
+            [('group_id', '=', self.sale_order1.procurement_group_id.id), ('state', '=', 'draft')]
+        )
+        self.purchase_order2.order_line.price_unit = 16
+        self.purchase_order2.button_confirm()
+
+        # Validate dropship transfer
+        dropship2 = self.sale_order1.picking_ids.filtered(lambda pck: pck.state != "done")
+        dropship2.move_ids.quantity_done = 1
+        dropship2._action_done()
+        self.assertEqual(dropship2.state, "done")
+
+        # create the customer invoice
+        customer_invoice2 = self.sale_order1._create_invoices()
+        customer_invoice2.action_post()
+
+        # Check Dropship 2 COGS
+        dropship2_layers = dropship2.move_ids.stock_valuation_layer_ids
+        self.assertEqual(len(dropship2_layers), 2)
+        self.assertEqual(dropship2_layers[0].value, 16)
+        dropship2_cogs_line = customer_invoice2.line_ids.filtered(lambda aml: aml.account_id.id == account_output.id)
+        self.assertEqual(dropship2_cogs_line.balance, -16)
+
+        # --- Create Dropship 3 --- #
+        self.sale_order1.order_line.product_uom_qty = 3  # Should create a new PO
+        self.purchase_order3 = self.env['purchase.order'].search(
+            [('group_id', '=', self.sale_order1.procurement_group_id.id), ('state', '=', 'draft')]
+        )
+        self.purchase_order3.order_line.price_unit = 24
+        self.purchase_order3.button_confirm()
+
+        # Validate dropship transfer
+        dropship3 = self.sale_order1.picking_ids.filtered(lambda pck: pck.state != "done")
+        dropship3.move_ids.quantity_done = 1
+        dropship3._action_done()
+        self.assertEqual(dropship3.state, "done")
+
+        # Return dropship
+        ret_model = self.env['stock.return.picking'].with_context(active_id=dropship3.id, active_model='stock.picking')
+        pck_return_wiz = Form(ret_model).save()
+        pck_return_action = pck_return_wiz.create_returns()
+        dropship3_return = self.env['stock.picking'].browse(pck_return_action['res_id'])
+        dropship3_return.move_ids.quantity_done = 1
+        dropship3_return._action_done()
+
+        # Return the dropship return
+        ret_model = ret_model.with_context(active_id=dropship3_return.id)
+        pck_return_wiz = Form(ret_model).save()
+        pck_return_action = pck_return_wiz.create_returns()
+        dropship3_return_return = self.env['stock.picking'].browse(pck_return_action['res_id'])
+        dropship3_return_return.move_ids.quantity_done = 1
+        dropship3_return_return._action_done()
+
+        # create the customer invoice
+        customer_invoice3 = self.sale_order1._create_invoices()
+        customer_invoice3.action_post()
+
+        # Check Dropship 3 COGS
+        dropship3_pcks = dropship3 | dropship3_return | dropship3_return_return
+        dropship3_layers = dropship3_pcks.move_ids.stock_valuation_layer_ids
+        self.assertEqual(len(dropship3_layers), 6)
+        self.assertEqual(dropship3_layers[0].value, 24)
+        dropship3_cogs_line = customer_invoice3.line_ids.filtered(lambda aml: aml.account_id.id == account_output.id)
+        self.assertEqual(dropship3_cogs_line.balance, -24)


### PR DESCRIPTION
If you have 2 invoices and 2 dropship picking linked to 1 Dropship Sale Order, and the two dropship have different SVL cost: The 2nd invoice will have incorrect COGS

https://github.com/user-attachments/assets/79f15933-0449-4081-aff0-daa5709889bf

## To reproduce
- Create Product P-DROP:
    * category: AVCO automated
    * Routes: Buy & Dropship
    * Purchase Vendors: Azure Interior @ $10
- Create Sale Order for 1 unit of P-Drop ⇾ Confirm
- Go to Purchase Order ⇾ ensure unit price is $10 ⇾ Confirm
- Receive products ⇾ ensure **valuation is $10**
- Create Vendor Bill (optional) ⇾ Confirm
- Create Invoice ⇾ Confirm
    * **COGS value is $10**  (ok)
- In Sale Order, set ordered quantity to 2 units
    * New draft PO should have been created
- Go to New Purchase Order ⇾ set price to $20 ⇾ Confirm
- Receive products ⇾ ensure **valuation is $20**
- Create Vendor Bill (optional) ⇾ Confirm
- Create Invoice ⇾ Confirm
    * COGS should be $20, but they are actually **$16.67** (KO)

---

## Test result without fix
```
2025-05-08 11:25:32,230 29041 ERROR oes_test_16 odoo.addons.stock_dropshipping.tests.test_stockvaluation: FAIL: TestStockValuation.test_dropship_cogs_multiple_invoices
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/16.0/odoo/addons/stock_dropshipping/tests/test_stockvaluation.py", line 380, in test_dropship_cogs_multiple_invoices
    self.assertEqual(dropship2_cogs_line.balance, -16)
AssertionError: -13.33 != -16
 ```

OPW-4665635

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
