### PR TITLE
[I18N] tx/config: add in missing modules

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1594,6 +1594,15 @@ resource_name          = pos_paytm
 replace_edited_strings = false
 keep_translations      = false
 
+[o:odoo:p:odoo-18:r:pos_pine_labs]
+file_filter            = addons/pos_pine_labs/i18n/<lang>.po
+source_file            = addons/pos_pine_labs/i18n/pos_pine_labs.pot
+type                   = PO
+minimum_perc           = 0
+resource_name          = pos_pine_labs
+replace_edited_strings = false
+keep_translations      = false
+
 [o:odoo:p:odoo-18:r:pos_razorpay]
 file_filter            = addons/pos_razorpay/i18n/<lang>.po
 source_file            = addons/pos_razorpay/i18n/pos_razorpay.pot


### PR DESCRIPTION
Add in missing modules to tx/config where their pots were auto-added by the pot export sync. Note that new pot files that were only for model names (i.e. not user facing) are usually bridge modules with nothing to translate => they weren't added to the config file

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
