### PR TITLE
[I18N] tx/config: add in missing modules

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -2485,6 +2485,15 @@ resource_name          = stock_landed_costs
 replace_edited_strings = false
 keep_translations      = false
 
+[o:odoo:p:odoo-s18-1:r:stock_maintenance]
+file_filter            = addons/stock_maintenance/i18n/<lang>.po
+source_file            = addons/stock_maintenance/i18n/stock_maintenance.pot
+type                   = PO
+minimum_perc           = 0
+resource_name          = stock_maintenance
+replace_edited_strings = false
+keep_translations      = false
+
 [o:odoo:p:odoo-s18-1:r:stock_picking_batch]
 file_filter            = addons/stock_picking_batch/i18n/<lang>.po
 source_file            = addons/stock_picking_batch/i18n/stock_picking_batch.pot


### PR DESCRIPTION
Add in missing modules to tx/config where their pots were auto-added by the pot export sync. Note that new pot files that were only for model names (i.e. not user facing) are usually bridge modules with nothing to translate => they weren't added to the config file

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
