### PR TITLE
[FIX] account: prevent traceback when audit_trail menu is deleted or missing

### DIFF
--- a/addons/account/models/ir_ui_menu.py
+++ b/addons/account/models/ir_ui_menu.py
@@ -6,6 +6,9 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if not any(company.check_account_audit_trail for company in self.env.user.company_ids):
-            res.append(self.env.ref('account.account_audit_trail_menu').id)
+        hide_audit_menu = not any(company.check_account_audit_trail for company in self.env.user.company_ids)
+        if hide_audit_menu:
+            audit_menu = self.env.ref('account.account_audit_trail_menu', raise_if_not_found=False)
+            if audit_menu:
+                res.append(audit_menu.id)
         return res


### PR DESCRIPTION
Currently, If a user deletes the `account.account_audit_trail_menu` record from Settings → Technical → User Interface → Menu Items, ValueError is encountered.

**Steps to Reproduce:**
1) Install the `Accounting (account + accountant)` modules.
2) Activate Developer Mode, Navigate to `Settings → Technical → User Interface → Menu Items`.
3) Search for `Audit Trail` and **delete** the corresponding menu item.
4) Refresh any page.

**Error:**
ValueError: External ID not found in the system: account.account_audit_trail_menu** **Traceback (most recent call last)

**Root Cause:**
- The override of `_load_menus_blacklist()` unconditionally calls `env.ref('account.account_audit_trail_menu')`, which, by default, raises if that XML-ID is absent.

**Solution:**
- Use the `raise_if_not_found=False` flag on `env.ref()` and only append the menu ID when the reference actually exists.

Sentry-6590284629

