### PR TITLE
[FIX] base_automation: extend eval context for time based domains

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -621,6 +621,8 @@ class BaseAutomation(models.Model):
             'uid': self.env.uid,
             'user': self.env.user,
             'model': model,
+            'context_today': safe_eval.datetime.datetime.today,
+            'relativedelta': safe_eval.dateutil.relativedelta.relativedelta,
         }
         if payload is not None:
             eval_context['payload'] = payload
@@ -977,7 +979,10 @@ class BaseAutomation(models.Model):
             domain = []
             context = dict(self._context)
             if automation.filter_domain:
-                domain = safe_eval.safe_eval(automation.filter_domain, eval_context)
+                # to_utc is a purely JS concept where datetime is localized by default
+                # as that is the default in python, and to_utc is undefined, we can disregard it
+                domain = automation.filter_domain.replace('.to_utc()', '')
+                domain = safe_eval.safe_eval(domain, eval_context)
             records = self.env[automation.model_name].with_context(context).search(domain)
 
             def get_record_dt(record):


### PR DESCRIPTION
# Bug:

Currently, base automations that use filters constructed by the front-end using `context_today` and `relativedelta` will fail.

These are for example constructed when using the "is within" operator for filter domains, producing search domains like: "Created on is within -1 months"
```
["&", ("create_date", ">=", datetime.datetime.combine(context_today() +
relativedelta(months = -1), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S")),
 ("create_date", "<=", datetime.datetime.combine(context_today(),
 datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))]
```

When running the CRON for the automation rules, it will silently fail throwing a `NameError: name 'context_today' is not defined` error.

# Proposed solution:

Extend the `eval_context` dictionnary in `_get_eval_context` to whitelist the needed methods to resolve such filter domains. Additionally replace `.to_utc()` calls that only make sense when evaluating the filter domain in thre front-end JS

opw-4763409


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
