### PR TITLE
[FIX] website_sale: fix salesperson assignment

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -57,7 +57,11 @@ class SaleOrder(models.Model):
         super(SaleOrder, self - website_orders)._compute_user_id()
         for order in website_orders:
             if not order.user_id:
-                order.user_id = order.website_id.salesperson_id or order.partner_id.parent_id.user_id.id or order.partner_id.user_id.id
+                order.user_id = (
+                    order.website_id.salesperson_id
+                    or order.partner_id.user_id.id
+                    or order.partner_id.parent_id.user_id.id
+                )
 
     @api.model
     def _get_note_url(self):

--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -446,7 +446,7 @@ class Website(models.Model):
         affiliate_id = request.session.get('affiliate_id')
         salesperson_user_sudo = self.env['res.users'].sudo().browse(affiliate_id).exists()
         if not salesperson_user_sudo:
-            salesperson_user_sudo = self.salesperson_id or partner_sudo.parent_id.user_id or partner_sudo.user_id
+            salesperson_user_sudo = self.salesperson_id or partner_sudo.user_id or partner_sudo.parent_id.user_id
 
         values = {
             'company_id': self.company_id.id,


### PR DESCRIPTION
Steps:
- Create a partner and it's parent partner and set different salesperson on each.
- Login with child partner and add product to cart.
- Go to backend and open related quotation.

Issue:
- Salesperson set on quotation is customer's parent partner's salesperson even though salesperson set on customer. While in backend it first check customer's salesperson and if customer does not have salesperson then it set parent's salesperson.

Cause:
- In eCommerce we gave parent's salesperson first priority then customer's salesperson.

Fix:
- Swap priority to set first customer's salesperson

opw-4757042