### PR TITLE
[FIX] ai: crash on enter in chat/channel with / commands

### DIFF
--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -234,19 +234,6 @@ test("Click on avatar opens its partner chat window", async () => {
     await contains(".o_card_user_infos > a", { text: "+45687468" });
 });
 
-test("Can use channel command /who", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({
-        channel_type: "channel",
-        name: "my-channel",
-    });
-    await start();
-    await openDiscuss(channelId);
-    await insertText(".o-mail-Composer-input", "/who");
-    await press("Enter");
-    await contains(".o_mail_notification", { text: "You are alone in this channel." });
-});
-
 test("sidebar: chat im_status rendering", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2, partnerId_3] = pyEnv["res.partner"].create([

--- a/addons/web/static/tests/_framework/mock_server/mock_models/ir_http.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_models/ir_http.js
@@ -1,0 +1,9 @@
+import { ServerModel } from "../mock_model";
+
+export class IrHttp extends ServerModel {
+    _name = "ir.http";
+
+    lazy_session_info() {
+        return {};
+    }
+}

--- a/addons/web/static/tests/web_test_helpers.js
+++ b/addons/web/static/tests/web_test_helpers.js
@@ -4,6 +4,7 @@ import { loadBundle } from "@web/core/assets";
 import * as _fields from "./_framework/mock_server/mock_fields";
 import * as _models from "./_framework/mock_server/mock_model";
 import { IrAttachment } from "./_framework/mock_server/mock_models/ir_attachment";
+import { IrHttp } from "./_framework/mock_server/mock_models/ir_http";
 import { IrModel } from "./_framework/mock_server/mock_models/ir_model";
 import { IrModelAccess } from "./_framework/mock_server/mock_models/ir_model_access";
 import { IrModelFields } from "./_framework/mock_server/mock_models/ir_model_fields";
@@ -169,6 +170,7 @@ export const fields = _fields;
 export const models = _models;
 
 export const webModels = {
+    IrHttp,
     IrAttachment,
     IrModel,
     IrModelAccess,


### PR DESCRIPTION
**Purpose of this PR:**

The ir.http model should be loaded at the start. If more test cases are expected, it's best to define them now for future-proofing.

Entering commands such as /who or similar in a chat or channel previously caused a crash. the issue has been resolved by updating the message posting flow to ensure that commands are processed correctly.

Enterprise: https://github.com/odoo/enterprise/pull/84418
task-4759888

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
