### PR TITLE
[FIX] hr_attendance: Correct overtime duration with tolerance

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -39,11 +39,11 @@ class HrEmployee(models.Model):
         compute='_compute_total_overtime', compute_sudo=True,
         groups="hr_attendance.group_hr_attendance_kiosk,hr_attendance.group_hr_attendance,hr.group_hr_user")
 
-    @api.depends('overtime_ids.duration', 'attendance_ids')
+    @api.depends('overtime_ids.duration_real', 'attendance_ids')
     def _compute_total_overtime(self):
         for employee in self:
             if employee.company_id.hr_attendance_overtime:
-                employee.total_overtime = float_round(sum(employee.overtime_ids.mapped('duration')), 2)
+                employee.total_overtime = float_round(sum(employee.overtime_ids.mapped('duration_real')), 2)
             else:
                 employee.total_overtime = 0
 
@@ -173,7 +173,7 @@ class HrEmployee(models.Model):
         action_message['total_overtime'] = employee.total_overtime
         # Overtime have an unique constraint on the day, no need for limit=1
         action_message['overtime_today'] = self.env['hr.attendance.overtime'].sudo().search([
-            ('employee_id', '=', employee.id), ('date', '=', fields.Date.context_today(self)), ('adjustment', '=', False)]).duration or 0
+            ('employee_id', '=', employee.id), ('date', '=', fields.Date.context_today(self)), ('adjustment', '=', False)]).duration_real or 0
         return {'action': action_message}
 
     def _attendance_action_change(self):

--- a/addons/hr_attendance/views/hr_attendance_overtime_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_overtime_view.xml
@@ -7,7 +7,7 @@
             <tree edit="0" create="0">
                 <field name="date"/>
                 <field name="employee_id"/>
-                <field name="duration" widget="float_time"/>
+                <field name="duration_real" widget="float_time"/>
             </tree>
         </field>
     </record>
@@ -18,7 +18,7 @@
         <field name="arch" type="xml">
             <search>
                 <field name="employee_id"/>
-                <field name="duration" filter_domain="[('duration', '>=', self)]"/>
+                <field name="duration_real" filter_domain="[('duration_real', '>=', self)]"/>
             </search>
         </field>
     </record>

--- a/addons/hr_holidays_attendance/models/hr_leave.py
+++ b/addons/hr_holidays_attendance/models/hr_leave.py
@@ -41,10 +41,11 @@ class HRLeave(models.Model):
                 continue
             employee = leave.employee_id
             duration = leave.number_of_hours_display
-            overtime_duration = leave.overtime_id.sudo().duration
+            overtime_duration = leave.overtime_id.sudo().duration_real
             if overtime_duration != -1 * duration:
                 if duration > employee.total_overtime - overtime_duration:
                     raise ValidationError(_('The employee does not have enough extra hours to extend this leave.'))
+                leave.overtime_id.sudo().duration_real = -1 * duration
                 leave.overtime_id.sudo().duration = -1 * duration
         return res
 
@@ -65,6 +66,7 @@ class HRLeave(models.Model):
                     'date': leave.date_from,
                     'adjustment': True,
                     'duration': -1 * duration,
+                    'duration_real': -1 * duration,
                 })
 
     def action_draft(self):

--- a/addons/hr_holidays_attendance/models/hr_leave_allocation.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_allocation.py
@@ -45,6 +45,7 @@ class HolidaysAllocation(models.Model):
                         'date': allocation.date_from,
                         'adjustment': True,
                         'duration': -1 * duration,
+                        'duration_real': -1 * duration,
                     })
         return res
 
@@ -57,10 +58,11 @@ class HolidaysAllocation(models.Model):
         for allocation in self.sudo().filtered('overtime_id'):
             employee = allocation.employee_id
             duration = allocation.number_of_hours_display
-            overtime_duration = allocation.overtime_id.sudo().duration
+            overtime_duration = allocation.overtime_id.sudo().duration_real
             if overtime_duration != -1 * duration:
                 if duration > employee.total_overtime - overtime_duration:
                     raise ValidationError(_('The employee does not have enough extra hours to extend this allocation.'))
+                allocation.overtime_id.sudo().duration_real = -1 * duration
                 allocation.overtime_id.sudo().duration = -1 * duration
         return res
 
@@ -76,7 +78,8 @@ class HolidaysAllocation(models.Model):
                 'employee_id': allocation.employee_id.id,
                 'date': allocation.date_from,
                 'adjustment': True,
-                'duration': -1 * allocation.number_of_hours_display
+                'duration': -1 * allocation.number_of_hours_display,
+                'duration_real': -1 * allocation.number_of_hours_display,
             })
             allocation.sudo().overtime_id = overtime.id
         return res


### PR DESCRIPTION
BUG
if we have x min tolerance on the company for attendance it was not taking into account when we create the attendance

Reproduce
- put 60 min in attendance config for tolerance
- create an attendance 8:18 for an employee with 8:17 calendar
- 1 extra hour is given to him

Current behavior
the overtime of employee takes the overtime duration not the real duration with tolerance into account

FIX
Use the `duration_real` instead of `duration` in the employee overtime calculation

Task: 4774528


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
