### PR TITLE
[FIX] web: fix inconsistent width in list date range fields

### DIFF
--- a/addons/web/static/src/core/utils/autoresize.js
+++ b/addons/web/static/src/core/utils/autoresize.js
@@ -53,7 +53,11 @@ export function useAutoresize(ref, options = {}) {
     });
 }
 
-function resizeInput(input) {
+/**
+ * @param {HTMLInputElement} input
+ * @param {{ offset?: number }} [options]
+ */
+function resizeInput(input, options) {
     // This mesures the maximum width of the input which can get from the flex layout.
     input.style.width = "100%";
     const maxWidth = input.clientWidth;
@@ -69,9 +73,13 @@ function resizeInput(input) {
         input.style.width = "100%";
         return;
     }
-    input.style.width = input.scrollWidth + 5 + (isSafari16 ? 8 : 0) + "px";
+    input.style.width = input.scrollWidth + 5 + (isSafari16 ? 8 : 0) + (options.offset || 0) + "px";
 }
 
+/**
+ * @param {HTMLTextAreaElement} input
+ * @param {{ minimumHeight?: number }} [options]
+ */
 export function resizeTextArea(textarea, options = {}) {
     const minimumHeight = options.minimumHeight || 0;
     let heightOffset = 0;

--- a/addons/web/static/src/views/fields/datetime/list_datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/list_datetime_field.js
@@ -1,7 +1,14 @@
+import { useRef } from "@odoo/owl";
 import { registry } from "@web/core/registry";
+import { useAutoresize } from "@web/core/utils/autoresize";
 import { DateTimeField, dateField, dateRangeField, dateTimeField } from "./datetime_field";
 
 export class ListDateTimeField extends DateTimeField {
+    setup() {
+        super.setup();
+        const startDateRef = useRef("start-date");
+        useAutoresize(startDateRef, { offset: -5 });
+    }
     /**
      * @override
      */

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -10,6 +10,7 @@ import {
     queryValue,
     resize,
     edit,
+    queryOne,
 } from "@odoo/hoot-dom";
 import { animationFrame, Deferred, mockDate, mockTimeZone } from "@odoo/hoot-mock";
 import {
@@ -928,6 +929,26 @@ test("list daterange: column widths (no record)", async () => {
     expect(".o_data_row").toHaveCount(0);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
     expect(columnWidths).toEqual([40, 189, 304, 267]);
+});
+
+test.tags("desktop");
+test("list daterange: start date input width matches its span counterpart", async () => {
+    Partner._records[0].datetime_end = "2017-02-09 17:00:00";
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <list multi_edit="1">
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}" />
+            </list>`,
+    });
+
+    expect(".o_data_row").toHaveCount(1);
+    await contains(".o_list_record_selector input").click();
+    const initialWidth = queryOne(".o_field_daterange span:first").offsetWidth;
+    await contains(".o_field_daterange span:first").click();
+    expect(".o_field_daterange input:first").toHaveProperty("offsetWidth", initialWidth);
 });
 
 test("always range: related end date, both start date and end date empty", async () => {


### PR DESCRIPTION
This commit fixes a layout issue where the start date in a list date range field had a noticeably different width between read and edit modes. The problem stems from list field inputs using width: 100%, which works for single inputs but causes imbalance when a field consists of two inputs (each taking 50% of the space).

To resolve this, the autoresize hook is now applied to the start date input so it only takes up as much space as needed—matching the behavior of the span element in read mode. Additionally, an offset option was added to the autoresize hook to allow fine-tuning of the input width for more precise alignment.

task-4751837
