### PR TITLE
[REV] web: remove styles on total display

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report_tables.scss
+++ b/addons/web/static/src/webclient/actions/reports/report_tables.scss
@@ -14,12 +14,6 @@ table.table {
 
 div#total {
     // Avoid crop in the total table if in middle of 2 pages
-    width: 100%;
-    display: table;
-    // override row style
-    --gutter-x: 0;
-    --gutter-y: 0;
-    margin: 0;
     page-break-inside: avoid;
 }
 

--- a/addons/web/views/report_templates.xml
+++ b/addons/web/views/report_templates.xml
@@ -185,7 +185,7 @@
                            </tbody>
                        </table>
                        <div id="right-elements" t-attf-class="#{'col-5' if report_type != 'html' else 'col-12 col-md-5'} ms-5 d-inline-block float-end">
-                           <div id="total" class="clearfix mt-n3">
+                           <div id="total" class="clearfix row mt-n3">
                                <div class="ms-auto">
                                    <table class="o_total_table table table-borderless">
                                        <tbody><tr class="o_subtotal">


### PR DESCRIPTION
## Version:
18.0+

## Issue:
Total section on Purchase Order document is misaligned.

## Steps to reproduce:
- Go to Purchase:
  - Open a purchase order record;
  - Click on Print > Purchase Order.

## Cause:
Fix in Sale app changing report styles without considering Purchase app: https://github.com/odoo/odoo/commit/344007299c91d990c851ad9ed6f7fb5f8aa7a273 

## Fix:
Full style reverting

opw-4771854