### PR TITLE
[FIX] point_of_sale: preserve attribute order in orderline

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/product_configurator_popup/product_configurator_popup.js
@@ -95,8 +95,8 @@ export class ProductConfiguratorPopup extends Component {
     }
 
     get selectedValues() {
-        return Object.values(this.state.attributes)
-            .map((attribute) => attribute.selected)
+        return this.props.productTemplate.attribute_line_ids
+            .map((attrLine) => this.state.attributes[attrLine.attribute_id.id]?.selected || [])
             .flat();
     }
 

--- a/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_configurator_tour.js
@@ -94,3 +94,22 @@ registry.category("web_tour.tours").add("PosProductWithDynamicAttributes", {
             ProductScreen.selectedOrderlineHas("Dynamic Product", "1", "12.65", "Test 2"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_attribute_order", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Product Test"),
+            ProductConfigurator.pickRadio("Value 1"),
+            ProductConfigurator.pickRadio("Value 2"),
+            ProductConfigurator.pickRadio("Value 3"),
+            Dialog.confirm(),
+            ProductScreen.selectedOrderlineHas(
+                "Product Test",
+                "1",
+                "10",
+                "Value 1, Value 2, Value 3"
+            ),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1991,6 +1991,64 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_quantity_package_of_non_basic_unit', login="pos_user")
 
+    def test_attribute_order(self):
+        product = self.env['product.template'].create({
+            'name': 'Product Test',
+            'available_in_pos': True,
+            'list_price': 10,
+            'taxes_id': False,
+        })
+
+        attribute_3 = self.env['product.attribute'].create({
+            'name': 'Attribute 3',
+            'create_variant': 'no_variant',
+            'value_ids': [(0, 0, {
+                'name': 'Value 3',
+            }), (0, 0, {
+                'name': 'Value 4',
+            })],
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_3.id,
+            'value_ids': [(6, 0, attribute_3.value_ids.ids)],
+            'sequence': 3,
+        })
+
+        attribute_2 = self.env['product.attribute'].create({
+            'name': 'Attribute 2',
+            'create_variant': 'no_variant',
+            'value_ids': [(0, 0, {
+                'name': 'Value 2',
+            })],
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_2.id,
+            'value_ids': [(6, 0, attribute_2.value_ids.ids)],
+            'sequence': 2,
+        })
+
+        attribute_1 = self.env['product.attribute'].create({
+            'name': 'Attribute 1',
+            'create_variant': 'no_variant',
+            'value_ids': [(0, 0, {
+                'name': 'Value 1',
+            })],
+        })
+
+        self.env['product.template.attribute.line'].create({
+            'product_tmpl_id': product.id,
+            'attribute_id': attribute_1.id,
+            'value_ids': [(6, 0, attribute_1.value_ids.ids)],
+            'sequence': 1,
+        })
+
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_attribute_order', login="pos_user")
+
     def test_preset_timing(self):
         """
         Test to set order preset hour inside a tour


### PR DESCRIPTION
Before this commit, if the order of attributes added to a product differed from the order based on their IDs, adding a product with multiple attributes would result in the attributes appearing in the wrong order in the orderline.

opw-4736195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
