### PR TITLE
[FIX] sale_stock: give higher sequence to return sol for new products

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -142,15 +142,18 @@ class StockPicking(models.Model):
                 'qty_delivered': quantity,
                 'product_uom': move.product_uom.id,
             }
+            so_line = sale_order.order_line.filtered(lambda sol: sol.product_id == product)
             if product.invoice_policy == 'delivery':
                 # Check if there is already a SO line for this product to get
                 # back its unit price (in case it was manually updated).
-                so_line = sale_order.order_line.filtered(lambda sol: sol.product_id == product)
                 if so_line:
                     so_line_vals['price_unit'] = so_line[0].price_unit
             elif product.invoice_policy == 'order':
                 # No unit price if the product is invoiced on the ordered qty.
                 so_line_vals['price_unit'] = 0
+            # New lines should be added at the bottom of the SO (higher sequence number)
+            if not so_line:
+                so_line_vals['sequence'] = max(sale_order.order_line.mapped('sequence')) + len(sale_order_lines_vals) + 1
             sale_order_lines_vals.append(so_line_vals)
 
         if sale_order_lines_vals:

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -2254,3 +2254,28 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             so.order_line.free_qty_today, 1.0,
             "Free quantity today should be 1.0, indicating the quantity is usable for this SO."
         )
+
+    def test_extra_return_product_so_sequence(self):
+        """
+        Ensure returned products are added to the bottom of the SO
+        """
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                (0, 0, {'product_id': self.product_a.id, 'product_uom_qty': 2, 'sequence': 42}),
+                (0, 0, {'product_id': self.product_b.id, 'product_uom_qty': 3, 'sequence': 43}),
+            ],
+        })
+        sale_order.action_confirm()
+        picking = sale_order.picking_ids
+        picking.button_validate()
+        return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_id=picking.id, active_model='stock.picking'))
+        with return_picking_form.product_return_moves.new() as line:
+            line.product_id = self.new_product
+            line.quantity = 4
+        return_wiz = return_picking_form.save()
+        res = return_wiz.action_create_returns()
+        return_pick = self.env['stock.picking'].browse(res['res_id'])
+        return_pick.button_validate()
+        self.assertEqual(sale_order.order_line.mapped('sequence'), [42, 43, 44])


### PR DESCRIPTION
Issue
-----
When returning different products than the ones sold on the SO, the returned products have their sequence set to 10 so they all appear between the first and second sold products.

Steps to reproduce
-----
- Install both Sale & Stock apps
- Create & confirm a sale for 2 different products
- Confirm the delivery
- Create & validate a return for a third product
- Open the SO

-> The returned product sol is second in sequence

Cause
-----
The return SOL are created with no specified sequence value, so they all have the default (10).
See [review](https://github.com/odoo/odoo/pull/209091#pullrequestreview-2828126823) for details.

-----
Ticket:
opw-4564504
