### PR TITLE
[REF] account: convert simple warnings to actionable_errors

### DIFF
--- a/addons/account/static/src/components/actionable_errors/actionable_errors.js
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.js
@@ -12,6 +12,7 @@ export class ActionableErrors extends Component {
     setup() {
         super.setup();
         this.actionService = useService("action");
+        this.orm = useService("orm");
     }
 
     get errorData() {
@@ -24,7 +25,13 @@ export class ActionableErrors extends Component {
             errorData.action['views'] = errorData.action.view_mode.split(',').map(mode => [false, mode]);
             delete errorData.action['view_mode'];
         }
-        this.env.model.action.doAction(errorData.action);
+        if (errorData.action_call) {
+            const [model, method, args] = errorData.action_call;
+            await this.orm.call(model, method, [args]);
+            this.env.model.action.doAction("soft_reload");
+        } else {
+            this.env.model.action.doAction(errorData.action);
+        }
     }
 
     get sortedActionableErrors() {

--- a/addons/account/static/src/components/actionable_errors/actionable_errors.xml
+++ b/addons/account/static/src/components/actionable_errors/actionable_errors.xml
@@ -9,7 +9,7 @@
                         <div t-att-name="error" style="white-space: pre-wrap;">
                             <t t-out="error_value.message"/>
                             <a class="fw-bold"
-                               t-if="error_value.action"
+                               t-if="error_value.action or error_value.action_call"
                                href="#"
                                t-on-click.prevent="() => this.handleOnClick(error_value)"
                             >

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -787,19 +787,17 @@
                         <field name="state" widget="account_move_statusbar_secured" statusbar_visible="draft,posted"
                                groups="account.group_account_secured"/>
                     </header>
+
+                    <!-- General warnings computed from `_get_alerts` -->
+                    <div class="m-0" id="alerts" invisible="not alerts">
+                        <field name="alerts" class="o_field_html" widget="actionable_errors"/>
+                    </div>
+                    <!--Duplicate check-->
                     <div class="alert alert-warning w-100 d-flex align-items-center gap-1" invisible="not duplicated_ref_ids"  role="alert">
-                        <span>Warning: this document might be a duplicate of</span>
+                        <span>This document might be a duplicate of</span>
                         <field name="duplicated_ref_ids" widget="x2many_buttons" string="Duplicated Documents" context="{'name_as_amount_total': True}"/>
                     </div>
-                    <div class="alert alert-info" role="alert" invisible="not is_being_sent">
-                        This invoice is being sent in the background.
-                    </div>
                     <!-- Invoice outstanding credits -->
-                    <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-warning" role="alert"
-                         invisible="state != 'draft' or not tax_lock_date_message">
-                        <field name="tax_lock_date_message" nolabel="1"/>
-                    </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
                          invisible="move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
@@ -820,19 +818,6 @@
                          invisible="move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this vendor.
                     </div>
-                    <div class="alert alert-info" role="alert"
-                         invisible="state != 'draft' or auto_post != 'at_date'">
-                        This move is configured to be posted automatically at the accounting date: <field name="date" readonly="1"/>.
-                    </div>
-                    <div class="alert alert-info" role="alert"
-                         invisible="state != 'draft' or auto_post == 'no' or auto_post == 'at_date'">
-                         <field name="auto_post" readonly="1"/> auto-posting enabled. Next accounting date: <field name="date" readonly="1"/>.<span invisible="not auto_post_until"> The recurrence will end on <field name="auto_post_until" readonly="1"/> (included).</span>
-                    </div>
-                    <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-warning" role="alert"
-                         invisible="partner_credit_warning == ''">
-                        <field name="partner_credit_warning"/>
-                    </div>
                     <!-- Currency consistency -->
                     <div class="alert alert-warning" role="alert"
                          invisible="not display_inactive_currency_warning or move_type not in ('in_invoice', 'in_refund', 'in_receipt')">
@@ -842,14 +827,7 @@
                          invisible="not display_inactive_currency_warning or move_type not in ('out_invoice', 'out_refund', 'out_receipt')">
                         In order to validate this invoice, you must <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the invoice</button>. The journal entries need to be computed by Odoo before being posted in your company's currency.
                     </div>
-                    <div class="alert alert-warning" role="alert"
-                         invisible="not abnormal_amount_warning">
-                        <field name="abnormal_amount_warning"/>
-                    </div>
-                    <div class="alert alert-warning" role="alert"
-                         invisible="not abnormal_date_warning">
-                        <field name="abnormal_date_warning"/>
-                    </div>
+
                     <sheet>
                         <div name="button_box" class="oe_button_box">
                             <button name="action_open_business_doc"


### PR DESCRIPTION
- Convert all simple invoice warnings (displayed above the header) to one `actionable_errors` widget; similar to how the send wizard handles warning generation (a.k.a. the modern way). This makes it much more simple to add/modify warnings for `account.move`, and cleans the code revolving this feature.

- Add one new warning on `account.move`: if any empty lines are detected, add an alert to notify the user and an action to remove all empty lines on the move at once.

- Add `action_call` key to ActionableErrors widget, to allow calling the `orm.call` method (from `useService('orm')`), thus making it possible for ActionableErrors to call something in python. This key will serve as an alternative to the `action` key that gives the whole action object to the ActionableErrors widget.

task-4684083
