### PR TITLE
[FIX] sale_stock, l10n_hu_edi: fix move line rate values when generated from sale

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -258,6 +258,7 @@ class SaleOrder(models.Model):
     def _prepare_invoice(self):
         invoice_vals = super(SaleOrder, self)._prepare_invoice()
         invoice_vals['invoice_incoterm_id'] = self.incoterm.id
+        invoice_vals['delivery_date'] = self.effective_date
         return invoice_vals
 
     def _log_decrease_ordered_quantity(self, documents, cancel=False):


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_hu_edi and witch to Hungarian company
- Have two different rates for EUR<->HUF
- Create a pricelist in EUR
- Create a quotation with the pricelist and confirm
- Validate the delivery on another date (which has a different rate from today)
- In the sale order click "Create Invoice"
- The generated invoice has lines using the rate for today

### Cause:
The field `delivery_date` was `precompute=True` but on creation of the invoice, at the time of the precompute, `line_ids` is still `False`.
So the invoice is first computed without the delivery date so the currency rate used is the one of the invoice date. When the delivery date is written on the invoice, the line balance is not recomputed because it is "protected".

### Solution:
As the field `delivery_date` was implemented in `account_move` for localizations including l10n_hu, there are no reason to contain the fix only to l10n_hu.
So we add the value of `delivery_date` in the dictionnary used to create a new invoice from sale with the method `_create_invoices`. This way the delivery date is there on creation of the invoice and is used for the currency rate.

opw-4756568