### PR TITLE
[FIX] base,tests: pad screencast frames to even dimensions

### DIFF
--- a/odoo/addons/base/tests/test_http_case.py
+++ b/odoo/addons/base/tests/test_http_case.py
@@ -75,6 +75,11 @@ class TestChromeBrowser(HttpCase):
         self.browser._save_screencast()
 
 
+@tagged('-at_install', 'post_install')
+class TestChromeBrowserOddDimensions(TestChromeBrowser):
+    browser_size = "1215x768"
+
+
 class TestRequestRemaining(HttpCase):
     # This test case tries to reproduce the case where a request is lost between two test and is execute during the secone one.
     #

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1507,7 +1507,7 @@ which leads to stray network requests and inconsistencies."""
                     concat_file.write("file '%s'\nduration %s\n" % (frame_file_path, duration))
                 concat_file.write("file '%s'" % frame_file_path)  # needed by the concat plugin
             try:
-                subprocess.run([ffmpeg_path, '-f', 'concat', '-safe', '0', '-i', concat_script_path, '-pix_fmt', 'yuv420p', '-g', '0', outfile], check=True)
+                subprocess.run([ffmpeg_path, '-f', 'concat', '-safe', '0', '-i', concat_script_path, '-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2', '-pix_fmt', 'yuv420p', '-g', '0', outfile], check=True)
             except subprocess.CalledProcessError:
                 self._logger.error('Failed to encode screencast.')
                 return


### PR DESCRIPTION
Currently, the default ffmpeg configuration used for screencast conversion fails when browser dimensions result in odd-numbered width or height, as H.264 requires even dimensions.

This commit adds a padding filter to ensure dimensions are even numbers.

runbot-160976