### PR TITLE
[IMP] base: improve customizable of res_partner form

### DIFF
--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1056,3 +1056,63 @@ class TestPartnerRecursion(TransactionCase):
         self.p1.parent_id = self.p2
         with self.assertRaises(ValidationError):
             (self.p3|self.p2).write({'parent_id': self.p1.id})
+
+
+@tagged('res_partner')
+class TestResPartnerUi(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.ResPartner = cls.env["res.partner"]
+
+        cls.Partner_company = cls.ResPartner.create(
+            {"name": "Company Partner", "is_company": True, "type": "contact"}
+        )
+        cls.Partner_contact = cls.ResPartner.create(
+            {"name": "Individual Partner", "is_company": False, "type": "contact"}
+        )
+        cls.Partner_child = cls.ResPartner.create(
+            {
+                "name": "Child Partner",
+                "is_company": False,
+                "type": "contact",
+                "parent_id": cls.Partner_company.id,
+            }
+        )
+        cls.Partner_other = cls.ResPartner.create(
+            {"name": "Other Partner", "is_company": False, "type": "other"}
+        )
+        cls.Partner_invoice = cls.ResPartner.create(
+            {"name": "Invoice Partner", "is_company": False, "type": "invoice"}
+        )
+        cls.Partner_delivery = cls.ResPartner.create(
+            {"name": "Shipping Partner", "is_company": False, "type": "delivery"}
+        )
+
+    def test_is_address_readonly(self):
+        self.assertFalse(self.Partner_company.is_address_readonly)
+        self.assertFalse(self.Partner_contact.is_address_readonly)
+        self.assertTrue(self.Partner_child.is_address_readonly)
+        self.assertFalse(self.Partner_invoice.is_address_readonly)
+        self.assertFalse(self.Partner_delivery.is_address_readonly)
+
+    def test_is_individual_types(self):
+        self.assertFalse(self.Partner_company.is_individual)
+        self.assertTrue(self.Partner_contact.is_individual)
+        self.assertTrue(self.Partner_other.is_individual)
+        self.assertFalse(self.Partner_invoice.is_individual)
+        self.assertFalse(self.Partner_delivery.is_individual)
+
+    def test_can_be_parent(self):
+        self.assertTrue(self.Partner_company.can_be_parent)
+        self.assertFalse(self.Partner_contact.can_be_parent)
+        self.assertFalse(self.Partner_other.can_be_parent)
+        self.assertFalse(self.Partner_invoice.can_be_parent)
+        self.assertFalse(self.Partner_delivery.can_be_parent)
+
+    def test_can_be_child(self):
+        self.assertFalse(self.Partner_company.can_be_child)
+        self.assertTrue(self.Partner_contact.can_be_child)
+        self.assertTrue(self.Partner_other.can_be_child)
+        self.assertTrue(self.Partner_invoice.can_be_child)
+        self.assertTrue(self.Partner_delivery.can_be_child)

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -82,14 +82,14 @@
                     <div class="oe_title">
                         <field name="company_type" options="{'horizontal': true}" widget="radio" groups="base.group_no_one"/>
                         <h1>
-                            <field id="company" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact' and is_company"/>
-                            <field id="individual" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact' and not is_company"/>
+                            <field id="company" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="is_company"/>
+                            <field id="individual" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="is_individual"/>
                         </h1>
                         <field name="parent_id"
                             widget="res_partner_many2one"
                             placeholder="Company Name..."
-                            domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
-                            invisible="is_company"/>
+                            domain="[('can_be_parent', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
+                            invisible="not can_be_child"/>
                     </div>
                     <group>
                         <field name="function" placeholder="e.g. Sales Director" invisible="is_company"/>
@@ -158,14 +158,14 @@
                         <field name="company_type" widget="radio" options="{'horizontal': true}"/>
                         <h1>
                             <field id="company" options="{'line_breaks': False}" widget="text" class="text-break" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact'"/>
-                            <field id="individual" options="{'line_breaks': False}" widget="text" class="text-break" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact'"/>
+                            <field id="individual" options="{'line_breaks': False}" widget="text" class="text-break" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="is_individual"/>
                         </h1>
                         <div class="o_row">
                             <field name="parent_id"
                                 widget="res_partner_many2one"
                                 placeholder="Company Name..."
-                                domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
-                                invisible="((is_company and not parent_id) or company_name) and company_name != ''"/>
+                                domain="[('can_be_parent', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
+                                invisible="not can_be_child"/>
                                 <field name="company_name" invisible="not company_name or company_name == '' or is_company"/>
                                 <button name="create_company" icon="fa-plus-square" string="Create company"
                                     type="object" class="oe_edit_only btn-link"
@@ -205,7 +205,7 @@
                             <field name="email" widget="email" context="{'gravatar_image': True}" required="user_ids"/>
                             <field name="website" string="Website" widget="url" placeholder="e.g. https://www.odoo.com"/>
                             <field name="title" options='{"no_open": True}' placeholder="e.g. Mister"
-                                invisible="is_company"/>
+                                invisible="not is_individual"/>
                             <field name="lang" invisible="active_lang_count &lt;= 1"/>
                             <field name="category_id" widget="many2many_tags" options="{'color_field': 'color'}"
                                    placeholder='e.g. "B2B", "VIP", "Consulting", ...'/>
@@ -262,14 +262,14 @@
                                         <hr/>
                                         <group>
                                             <group>
-                                                <field name="name" string="Contact Name" required="type == 'contact'"
+                                                <field name="name" string="Contact Name" required="is_individual or is_company"
                                                      placeholder="e.g. New Address"/>
                                                 <field name="title" options="{'no_open': True}" placeholder="e.g. Mr."
-                                                    invisible="type != 'contact'"/>
+                                                    invisible="not is_individual"/>
                                                 <field name="function" placeholder="e.g. Sales Director"
-                                                    invisible="type != 'contact'"/>
-                                                <label for="street" string="Address" invisible="type == 'contact'"/>
-                                                <div invisible="type == 'contact'">
+                                                    invisible="not is_individual"/>
+                                                <label for="street" string="Address" invisible="is_address_readonly"/>
+                                                <div invisible="is_address_readonly">
                                                     <div class="o_address_format" name="div_address">
                                                         <field name="street" placeholder="Street..." class="o_address_street"/>
                                                         <field name="street2" placeholder="Street 2..." class="o_address_street"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The current contact UI is partly inconsistent regarding the child/parent behavior and also it is not flexible extensible regarding new contact types like "Home office Contact", which is a "Contact" but has a different Address, and also an "Delivery Address" is in my opinion not an individual, but neigther a company. 

Therefore I suggest to de-couple the different topics and add new variables. These variables can be customized by overwriting the 
"_compute_contact_type" method according to the users needs.

e.g. you could add a new individual type "home office contact" which is an individual, but also has an editable address.
By changing can_be_child to True on Company contacts, you could create multi-level company structures.

In this patch, the current behavior is not changed, but gives better possibilities for customizations.

Current behavior before PR:
The forms are hardly customizable regarding new contact types.

Desired behavior after PR is merged:

The UI can be more customizable and using is_address_readonly, is_individual, can_be_parent and can_be_child instead of linking the type directly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
