### PR TITLE
[FIX] website_sale{_loyalty},payment_stripe: fix express checkout price

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -905,8 +905,10 @@ class WebsiteSale(payment_portal.PaymentPortal):
             return values
 
         values['cart_quantity'] = order.cart_quantity
+
+        # Values for express checkout
         values['minor_amount'] = payment_utils.to_minor_currency_units(
-            order.amount_total, order.currency_id
+            order._get_amount_total_excluding_delivery(), order.currency_id
         )
         values['amount'] = order.amount_total
 
@@ -1824,8 +1826,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         )
         payment_form_values.update({
             'payment_access_token': payment_form_values.pop('access_token'),  # Rename the key.
+            # Do not include delivery related lines
             'minor_amount': payment_utils.to_minor_currency_units(
-                order.amount_total, order.currency_id
+                order._get_amount_total_excluding_delivery(), order.currency_id
             ),
             'merchant_name': request.website.name,
             'transaction_route': f'/shop/payment/transaction/{order.id}',
@@ -1833,6 +1836,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'landing_route': '/shop/payment/validate',
             'payment_method_unknown_id': request.env.ref('payment.payment_method_unknown').id,
             'shipping_info_required': order._has_deliverable_products(),
+            # Todo: remove in master
             'delivery_amount': payment_utils.to_minor_currency_units(
                 order.order_line.filtered(lambda l: l.is_delivery).price_total, order.currency_id
             ),

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -216,6 +216,13 @@ class SaleOrder(models.Model):
             return self.env['website'].browse(website_id).get_base_url()
         return super()._get_note_url()
 
+    def _get_non_delivery_lines(self):
+        """Exclude delivery-related lines."""
+        return self.order_line.filtered(lambda line: not line.is_delivery)
+
+    def _get_amount_total_excluding_delivery(self):
+        return sum(self._get_non_delivery_lines().mapped('price_total'))
+
     def _cart_update_order_line(self, product_id, quantity, order_line, **kwargs):
         self.ensure_one()
 

--- a/addons/website_sale/tests/test_delivery_express_checkout_flows.py
+++ b/addons/website_sale/tests/test_delivery_express_checkout_flows.py
@@ -8,6 +8,9 @@ from odoo.http import root
 from odoo.tests import HttpCase, tagged
 
 from odoo.addons.base.tests.common import BaseUsersCommon
+from odoo.addons.payment import utils as payment_utils
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale.controllers.main import WebsiteSale
 from odoo.addons.website_sale.controllers.delivery import (
     Delivery as WebsiteSaleDeliveryController,
 )
@@ -118,6 +121,18 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(BaseUsersCommon, WebsiteSaleCo
                 partner.country_id,
                 "Partner's state should be within partner's country",
             )
+
+    def test_express_checkout_takes_order_amount_without_delivery(self):
+        """Test that the amount to pay does not include the delivery costs in express checkout."""
+        amount_without_delivery = payment_utils.to_minor_currency_units(
+            self.cart.amount_total, self.cart.currency_id
+        )
+        self.carrier.fixed_price = 20
+        self.cart.set_delivery_line(self.carrier, self.carrier.fixed_price)
+        with MockRequest(self.env, sale_order_id=self.cart.id, website=self.website):
+            payment_values = WebsiteSale()._get_express_shop_payment_values(self.sale_order)
+
+        self.assertEqual(payment_values['minor_amount'], amount_without_delivery)
 
     def test_express_checkout_public_user_shipping_address_change(self):
         """ Test that when using express checkout as a public user and selecting a shipping address,
@@ -292,7 +307,7 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(BaseUsersCommon, WebsiteSaleCo
             'odoo.addons.delivery.models.delivery_carrier.DeliveryCarrier.rate_shipment',
             return_value=self.rate_shipment_result
         ):
-            shipping_options = self.make_jsonrpc_request(
+            shipping_options_data = self.make_jsonrpc_request(
                 urls.url_join(
                     self.base_url(), WebsiteSaleDeliveryController._express_checkout_delivery_route
                 ), params={
@@ -304,7 +319,7 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(BaseUsersCommon, WebsiteSaleCo
             self.make_jsonrpc_request(urls.url_join(self.base_url(), WebsiteSaleDeliveryController._express_checkout_route), params={
                 'billing_address': dict(self.express_checkout_billing_values),
                 'shipping_address': dict(self.express_checkout_demo_shipping_values),
-                'shipping_option': shipping_options[0],
+                'shipping_option': shipping_options_data['delivery_methods'][0],
             })
             self.assertEqual(self.sale_order.partner_id.id, self.user_demo.partner_id.id)
 
@@ -340,7 +355,7 @@ class TestWebsiteSaleDeliveryExpressCheckoutFlows(BaseUsersCommon, WebsiteSaleCo
                 ), params={
                     'billing_address': dict(self.express_checkout_billing_values),
                     'shipping_address': dict(self.express_checkout_demo_shipping_values_2),
-                    'shipping_option': shipping_options[0],
+                    'shipping_option': shipping_options['delivery_methods'][0],
                 }
             )
             self.assertNotEqual(

--- a/addons/website_sale_loyalty/controllers/delivery.py
+++ b/addons/website_sale_loyalty/controllers/delivery.py
@@ -2,13 +2,24 @@
 
 from functools import partial
 
-from odoo.http import request
+from odoo.http import request, route
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.website_sale.controllers.delivery import Delivery
 
 
 class WebsiteSaleLoyaltyDelivery(Delivery):
+
+    @route()
+    def express_checkout_process_delivery_address(self, partial_delivery_address):
+        """Override of `website.sale` to include delivery discount if any."""
+        res = super().express_checkout_process_delivery_address(partial_delivery_address)
+        order_sudo = request.website.sale_get_order()
+        if free_shipping_lines := order_sudo._get_free_shipping_lines():
+            res['delivery_discount_minor_amount'] = payment_utils.to_minor_currency_units(
+                sum(free_shipping_lines.mapped('price_total')), order_sudo.currency_id
+            )
+        return res
 
     def _order_summary_values(self, order, **post):
         to_html = partial(
@@ -18,7 +29,7 @@ class WebsiteSaleLoyaltyDelivery(Delivery):
         res = super()._order_summary_values(order, **post)
         free_shipping_lines = order._get_free_shipping_lines()
         if free_shipping_lines:
-            shipping_discount = sum(free_shipping_lines.mapped('price_subtotal'))
+            shipping_discount = sum(free_shipping_lines.mapped('price_total'))
             res['amount_delivery_discounted'] = to_html(shipping_discount)
             res['delivery_discount_minor_amount'] = payment_utils.to_minor_currency_units(
                 shipping_discount, order.currency_id

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -181,6 +181,10 @@ class SaleOrder(models.Model):
         self._auto_apply_rewards()
         return res
 
+    def _get_non_delivery_lines(self):
+        """Override of `website_sale` to exclude delivery reward lines."""
+        return super()._get_non_delivery_lines() - self._get_free_shipping_lines()
+
     def _get_free_shipping_lines(self):
         self.ensure_one()
         return self.order_line.filtered(lambda l: l.reward_id.reward_type == 'shipping')


### PR DESCRIPTION
Steps to reproduce:
1) Create a free shipping reward
2) Enable standard delivery and set price to 100
3) Configure stripe provider with express checkout
4) Go to /shop
5) Add a product to the cart with the price less than 100
6) Go to the checkout and apply reward
7) Go back to the cart and observe a traceback

Reason: delivery_amount was calculated without a discount and in express checkout form `_getOrderDetails` this amount was subtracted from the order total which resulted in negative value

Solution:
Add discount if any

opw-4648641

