### PR TITLE
[FIX] hw_drivers: clear all configuration on dc

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -600,6 +600,9 @@ def disconnect_from_server():
         'remote_server': '',
         'token': '',
         'db_uuid': '',
+        'screen_orientation': '',
+        'browser_url': '',
+        'iot_handlers_etag': '',
     })
 
 


### PR DESCRIPTION
This PR adds the reset of:
1) screen orientation
2) browser_url
3) iot_handlers_etag
when disconnecting a database

This allows to switch between the different versions of the database more easily and avoid getting stuck with a non existent runbot db instance pos customer display for example