### PR TITLE
[IMP] http: add possibility to trigger a retry of the current request

### DIFF
--- a/odoo/exceptions.py
+++ b/odoo/exceptions.py
@@ -127,3 +127,15 @@ class ValidationError(UserError):
 
         When you try to create a new user with a login which already exist in the db.
     """
+
+
+class ConcurrencyError(Exception):
+    """
+    Signal that two concurrent transactions tried to commit something
+    that violates some constraint. Signal that the transaction that
+    failed should be retried after a short delay, see
+    :func:`~odoo.service.model.retrying`.
+
+    This exception is low-level and has very few use cases, it should
+    only be used if all alternatives are deemed worse.
+    """


### PR DESCRIPTION
The `retrying` function automatically retries to call its function if it catches errors related to concurrent databases operations (e.g. serialization failures).
However, there are other cases where an error is due to concurrency but can't be automatically caught by the retry mechanism.

For example, in a context where we search for a record before creating it, it can occur that two concurrent requests create the same record. If there is a uniqueness constraint, it will raise a `UniqueViolation` error that won't be caught by the retry mechanism. In this case, it can be useful to be able to manually trigger a retry.

Example of usage for this situation:
```py
class MyModel(models.Model):
    _name = 'my.model'

    name = fields.Char()
    value = fields.Integer()

    _uniq_name = models.Constraint('UNIQUE(name)', 'Name is unique')

    def update_value(name, value):
        record = self.search([('name', '=', name)])
        if not record:
            try:
                record = self.create({'name': name})
            except UniqueViolation as e:
                raise ConcurrencyError(
                    "Concurrent 'my.model' creation"
                ) from e
        record.value = value
```

Note: as of now, there are no usage for this (yet) in Odoo main repositories, but there are some in IAP servers (which are running on regular Odoo instances) as concurrency issues are much more frequent there.

task-none

Co-authored-by: @Julien00859 