### PR TITLE
[FIX] mail: fix crash on orphan activities

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -365,7 +365,7 @@ class MailActivity(models.Model):
 
         allowed_ids = defaultdict(set)
         for res_model, res_ids in model_ids.items():
-            records = self.env[res_model].browse(res_ids)
+            records = self.env[res_model].browse(res_ids).exists()
             # fall back on related document access right checks. Use the same as defined for mail.thread
             # if available; otherwise fall back on read
             operation = getattr(records, '_mail_post_access', 'read')

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -12,6 +12,7 @@ import pytz
 import random
 
 from odoo import fields, exceptions, tests
+from odoo.addons.mail.models.mail_activity import MailActivity
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestActivity
 from odoo.tests import Form, HttpCase, users
@@ -780,6 +781,23 @@ class TestActivityMixin(TestActivityCommon):
         act2 = test_record.activity_schedule(summary='Archived', active=False)
         test_record.unlink()
         self.assertFalse((act1 + act2).exists(), 'Removing records should remove activities, even archived')
+
+    @users('employee')
+    def test_record_unlinked_orphan_activities(self):
+        """Test the fix preventing error on corrupted database where activities without related record are present."""
+        self.env.ref("test_mail.mail_act_test_todo").sudo().keep_done = True
+        test_record = self.env['mail.test.activity'].with_context(
+            self._test_context).create({'name': 'Test'}).with_user(self.user_employee)
+        act = test_record.activity_schedule("test_mail.mail_act_test_todo", summary='Orphan activity')
+        act.action_done()
+        # Delete the record while preventing the cascade deletion of the activity to simulate a corrupted database
+        with patch.object(MailActivity, 'unlink', lambda self: None):
+            test_record.unlink()
+        self.assertTrue(act.exists())
+        self.assertFalse(act.active)
+        self.assertFalse(test_record.exists())
+        self.assertFalse(self.env['mail.activity'].with_user(self.user_admin).with_context(active_test=False).search(
+            [('active', '=', False)]))
 
 
 @tests.tagged("mail_activity")


### PR DESCRIPTION
How to reproduce:
–	Revert fix: odoo/odoo#206361 which fix archived activities not being deleted when their related record are
–	Install project and log as admin
–	In Settings -> Activity Type -> To-Do -> check “Keep Done” –	In Project -> Office Design -> Energy Certificate -> Schedule an activity To-Do for “Marc Demo” (it must be another user)
–	Mark it as done
–	Delete the task (cog menu)
–	Click on the clock on the top right
–	And then on “View all activities”
–	Remove all filters
–	Add filter “Done”
You get a “Missing Record” error: “Record does not exist or has been deleted.”

The error happens on
allowed_ids[res_model] = set(records._filtered_access(operation)._ids) because records contains the deleted task.
Note that this line is bypassed for activities of the current user, that’s why it is important to assign the test activity to another user.

We solve the problem by restraining the records to the existing one (using .exists on the recordset). Note that in v17, there is no problem because _filter_access_rules (with check_access_right) was used instead of _filtered_access.

We've considered to clean the records as they were detected in the mail_activity _search method but that was not straightforward as it is usually executed with a readonly transaction (web_search_read) and there is any way already an upgrade script which suppress all orphan activities: https://github.com/odoo/upgrade/pull/6952.

Technical note: the test doesn't reproduce exactly the problem (no exception) but we check that the records are filtered as explained above.

Task-4730338