### PR TITLE
[FIX] website_sale(_*): show select quantity based on editor

### DIFF
--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -42,6 +42,7 @@
                                     t-att-data-product-template-id="product_template_id"
                                     t-att-data-product-selected="record.is_product_variant"
                                     t-att-data-product-type="record.type"
+                                    t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                 >
                                     <i class="fa fa-fw fa-shopping-cart"/>
                                 </button>
@@ -236,6 +237,7 @@
                                 t-att-data-product-template-id="product_template_id"
                                 t-att-data-product-selected="record.is_product_variant"
                                 t-att-data-product-type="record.type"
+                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                             >
                                 Add to Cart
                             </button>
@@ -280,6 +282,7 @@
                                         t-att-data-product-template-id="product_template_id"
                                         t-att-data-product-selected="record.is_product_variant"
                                         t-att-data-product-type="record.type"
+                                        t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                     >
                                         Add to Cart
                                     </button>
@@ -338,6 +341,7 @@
                                             t-att-data-product-template-id="product_template_id"
                                             t-att-data-product-selected="record.is_product_variant"
                                             t-att-data-product-type="record.type"
+                                            t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                         >
                                             <i class="fa fa-fw fa-shopping-cart"/>
                                         </button>
@@ -388,6 +392,7 @@
                                     t-att-data-product-template-id="product_template_id"
                                     t-att-data-product-selected="record.is_product_variant"
                                     t-att-data-product-type="record.type"
+                                    t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                 >
                                     Add to Cart
                                 </button>

--- a/addons/website_sale/static/src/js/cart.js
+++ b/addons/website_sale/static/src/js/cart.js
@@ -61,12 +61,15 @@ publicWidget.registry.websiteSaleCart = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onClickSuggestedProduct: function (ev) {
+        const dataset = ev.currentTarget.dataset;
+
         this.call('cart', 'add', {
-            productTemplateId: parseInt(ev.currentTarget.dataset.productTemplateId, 10),
-            productId: parseInt(ev.currentTarget.dataset.productId, 10),
-            isCombo: ev.currentTarget.dataset.productType === 'combo',
+            productTemplateId: parseInt(dataset.productTemplateId, 10),
+            productId: parseInt(dataset.productId, 10),
+            isCombo: dataset.productType === 'combo',
         }, {
             isBuyNow: true,
+            showQuantity: Boolean(dataset.showQuantity),
         });
     },
     /**

--- a/addons/website_sale/static/src/js/cart_service.js
+++ b/addons/website_sale/static/src/js/cart_service.js
@@ -103,7 +103,8 @@ export class CartService {
      *      redirect the customer to the cart. Defaults to true.
      * @param {Boolean} [options.isConfigured=false] - Whether the product is already configured.
      *      Defaults to false.
-     *
+     * @param {Boolean} [options.showQuantity=true] - Whether quantity selector should be shown
+     *      Defaults to true.
      * @returns {Number} - The product's quantity added to the cart.
      */
     async add({
@@ -120,6 +121,7 @@ export class CartService {
             isBuyNow=false,
             redirectToCart=true,
             isConfigured=false,
+            showQuantity=true,
         } = {},
     ) {
         if (!productId && ptavs.length) {
@@ -170,7 +172,7 @@ export class CartService {
                 remainingData,
                 {
                     isBuyNow: isBuyNow,
-                    showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
+                    showQuantity: showQuantity,
                 },
                 rest
             );
@@ -205,7 +207,7 @@ export class CartService {
                 {
                     isBuyNow: isBuyNow,
                     isMainProductConfigurable: !isConfigured,
-                    showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
+                    showQuantity: showQuantity,
                 },
                 rest
             );

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -313,9 +313,11 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             this._updateRootProduct((ev.currentTarget).closest('form'));
             const isBuyNow = ev.currentTarget.classList.contains('o_we_buy_now');
             const isConfigured = ev.currentTarget.parentElement.id === 'add_to_cart_wrap';
+            const showQuantity = Boolean(ev.currentTarget.dataset.showQuantity);
             return this.call('cart', 'add', this.rootProduct, {
                 isBuyNow: isBuyNow,
                 isConfigured: isConfigured,
+                showQuantity: showQuantity,
             });
         };
         if ($('.js_add_cart_variants').children().length) {

--- a/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
+++ b/addons/website_sale/static/src/snippets/s_add_to_cart/000.js
@@ -19,6 +19,7 @@ publicWidget.registry.AddToCartSnippet = publicWidget.Widget.extend({
         const productTemplateId = parseInt(dataset.productTemplateId);
         const productId = parseInt(dataset.productVariantId);
         const isCombo = dataset.productType === 'combo';
+        const showQuantity = Boolean(dataset.showQuantity);
         const action = dataset.action;
 
         if (productId) {
@@ -42,6 +43,7 @@ publicWidget.registry.AddToCartSnippet = publicWidget.Widget.extend({
             },
             {
                 isBuyNow: action === 'buy_now',
+                showQuantity: showQuantity,
             }
         );
     },

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/product_card.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/product_card.js
@@ -32,11 +32,14 @@ const DynamicSnippetProductsCard = publicWidget.Widget.extend({
         const productTemplateId = parseInt(dataset.productTemplateId);
         const productId = parseInt(dataset.productId);
         const isCombo = dataset.productType === 'combo';
+        const showQuantity = Boolean(dataset.showQuantity);
 
         await this.call('cart', 'add', {
             productTemplateId: productTemplateId,
             productId: productId,
             isCombo: isCombo,
+        }, {
+            showQuantity: showQuantity,
         });
         if (this.add2cartRerender) {
             this.trigger_up('widgets_start_request', {

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -312,6 +312,7 @@
                     class="btn btn-light a-submit"
                     aria-label="Shopping cart"
                     title="Shopping cart"
+                    t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                 >
                     <span class="fa fa-shopping-cart"/>
                 </a>
@@ -1808,7 +1809,14 @@
                                     </p>
                                     <div id="o_wsale_cta_wrapper" class="d-flex flex-wrap align-items-center">
                                         <div id="add_to_cart_wrap" t-attf-class="{{'d-none' if combination_info['prevent_zero_price_sale'] else 'd-inline-flex'}} align-items-center mb-2 me-auto">
-                                            <a data-animation-selector=".o_wsale_product_images" role="button" id="add_to_cart" t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1" href="#">
+                                            <a
+                                                id="add_to_cart"
+                                                role="button"
+                                                href="#"
+                                                t-attf-class="btn btn-primary js_check_product a-submit flex-grow-1"
+                                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
+                                                data-animation-selector=".o_wsale_product_images"
+                                            >
                                                 <i class="fa fa-shopping-cart me-2"/>
                                                 Add to cart
                                             </a>
@@ -2603,6 +2611,7 @@
                                 t-att-data-product-id="product.id"
                                 t-att-data-product-template-id="product.product_tmpl_id.id"
                                 t-att-data-product-type="product.type"
+                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                             >
                                 <i class="d-md-none fa fa-shopping-cart" role="presentation"/>
                                 <span class="d-none d-md-inline">Add to cart</span>

--- a/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/src/js/website_sale_comparison.js
@@ -307,9 +307,13 @@ publicWidget.registry.ProductComparison = publicWidget.Widget.extend({
         const productId = parseInt(
             form.querySelector('input[type="hidden"][name="product_id"]').value
         );
+        const showQuantity = Boolean(form.dataset.showQuantity);
+
         this.call('cart', 'add', {
             productTemplateId: productTemplateId,
             productId: productId,
+        }, {
+            showQuantity: showQuantity,
         });
     },
 });

--- a/addons/website_sale_comparison/views/website_sale_comparison_template.xml
+++ b/addons/website_sale_comparison/views/website_sale_comparison_template.xml
@@ -201,7 +201,10 @@
                                                     </t>
                                                 </small>
                                             </span>
-                                            <form class="text-center o_add_cart_form_compare">
+                                            <form
+                                                class="text-center o_add_cart_form_compare"
+                                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
+                                            >
                                                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                                                 <input
                                                     name="product_template_id"

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -176,11 +176,14 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
         const isCombo = td.querySelector(
             'input[type="hidden"][name="product_type"]'
         )?.value === 'combo';
+        const showQuantity = Boolean(ev.currentTarget.dataset.showQuantity);
 
         const addToCart = this.call('cart', 'add', {
             productTemplateId: productTemplateId,
             productId: parseInt(productId, 10),
             isCombo: isCombo,
+        }, {
+            showQuantity: showQuantity,
         });
 
         if (!document.getElementById('b2b_wish').checked) {

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -305,6 +305,7 @@
                                                 type="button"
                                                 role="button"
                                                 class="btn btn-secondary btn-block o_wish_add mb4"
+                                                t-att-data-show-quantity="is_view_active('website_sale.product_quantity')"
                                             >
                                                 <span class="fa fa-fw fa-shopping-cart"/>
                                                 <span class="d-none d-md-inline">Add</span>


### PR DESCRIPTION
Currently the show quantity setting visible on /product page does not apply on the product and combo configurator.

We want to uniformize the behavior and if the setting is enabled then view the quantity selector everywhere depending on whether its visible on /product

opw-4716312



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
