### PR TITLE
[FIX] base, web: ir.ui.view: prevent crash in invalid_locators.

### DIFF
--- a/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.js
+++ b/addons/web/static/src/core/ir_ui_view_code_editor/code_editor.js
@@ -37,6 +37,9 @@ export class IrUiViewCodeEditor extends CodeEditor {
         if (resModel === "ir.ui.view" && resId) {
             const { doc } = this.aceEditor.session;
             for (const spec of invalid_locators) {
+                if (spec.broken_hierarchy) {
+                    continue
+                }
                 const { tag, attrib, sourceline } = spec;
                 const attribRegex = Object.entries(attrib)
                     .map(([key, value]) => {


### PR DESCRIPTION
HAve a broken hierarchy of views.
This can happen when an inheriting view's arch has been forcibly written, via SQL or during the upgrade process.

Access the form View of another inheriting view just below the broken one. Before this commit, the form view crashed.

After this commit, the form view doesn't crash and is fully usable.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
