### PR TITLE
[FIX] purchase_stock: Use bill rate for amount_currency in receipt

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -41,9 +41,7 @@ class StockMove(models.Model):
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         line = self.purchase_line_id
         order = line.order_id
-        received_qty = line.qty_received
-        if self.state == 'done':
-            received_qty -= self.product_uom._compute_quantity(self.quantity_done, line.product_uom, rounding_method='HALF-UP')
+        received_qty = self._get_qty_received_without_self()
         if line.product_id.purchase_method == 'purchase' and float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
             move_layer = line.move_ids.sudo().stock_valuation_layer_ids
             invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
@@ -89,17 +87,36 @@ class StockMove(models.Model):
         else:
             price_unit = line._get_gross_price_unit()
         if order.currency_id != order.company_id.currency_id:
-            # The date must be today, and not the date of the move since the move move is still
-            # in assigned state. However, the move date is the scheduled date until move is
-            # done, then date of actual move processing. See:
-            # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
-            convert_date = fields.Date.context_today(self)
-            # use currency rate at bill date when invoice before receipt
-            if float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
-                convert_date = max(line.sudo().invoice_lines.move_id.filtered(lambda m: m.state == 'posted').mapped('invoice_date'), default=convert_date)
+            convert_date = self._get_currency_convert_date()
             price_unit = order.currency_id._convert(
                 price_unit, order.company_id.currency_id, order.company_id, convert_date, round=False)
         return price_unit
+
+    def _get_qty_received_without_self(self):
+        qty_received = self.purchase_line_id.qty_received
+        if self.state == 'done':
+            qty_received -= self.product_uom._compute_quantity(
+                self.quantity_done, self.purchase_line_id.product_uom, rounding_method='HALF-UP'
+            )
+        return qty_received
+
+    def _get_currency_convert_date(self):
+        self.ensure_one()
+        # The date must be today, and not the date of the move since the move move is still
+        # in assigned state. However, the move date is the scheduled date until move is
+        # done, then date of actual move processing. See:
+        # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
+        convert_date = fields.Date.context_today(self) if self.state != 'done' else self.date
+        line = self.purchase_line_id
+        if not line:
+            return convert_date
+
+        # Use currency rate at bill date when invoice before receipt
+        qty_received = self._get_qty_received_without_self()
+        if float_compare(line.qty_invoiced, qty_received, precision_rounding=line.product_uom.rounding) > 0:
+            posted_bills = line.sudo().invoice_lines.move_id.filtered(lambda m: m.state == 'posted')
+            convert_date = max(posted_bills.mapped('invoice_date'), default=convert_date)
+        return convert_date
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po
@@ -113,17 +130,18 @@ class StockMove(models.Model):
             return rslt
         svl = self.env['stock.valuation.layer'].browse(svl_id)
         if not svl.account_move_line_id:
+            convert_date = self._get_currency_convert_date()
             rslt['credit_line_vals']['amount_currency'] = company_currency._convert(
                 rslt['credit_line_vals']['balance'],
                 purchase_currency,
                 self.company_id,
-                self.date
+                convert_date
             )
             rslt['debit_line_vals']['amount_currency'] = company_currency._convert(
                 rslt['debit_line_vals']['balance'],
                 purchase_currency,
                 self.company_id,
-                self.date
+                convert_date
             )
             rslt['debit_line_vals']['currency_id'] = purchase_currency.id
             rslt['credit_line_vals']['currency_id'] = purchase_currency.id

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -3035,7 +3035,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
     def test_invoice_first_receipt_later_with_multicurrency_different_dates(self):
         """Ensure sure that use currency rate at bill date rather than the current date when invoice before receipt"""
         company = self.env.user.company_id
-        company.anglo_saxon_accounting = False
+        company.anglo_saxon_accounting = True
         company.currency_id = self.usd_currency
 
         self.product1.detailed_type = 'product'
@@ -3043,7 +3043,6 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
 
         self.product1.with_company(company).categ_id.property_cost_method = 'fifo'
         self.product1.with_company(company).categ_id.property_valuation = 'real_time'
-
 
         po_date = '2023-10-01'
         bill_date = '2023-10-15'
@@ -3102,25 +3101,20 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             receipt.move_ids.write({'quantity_done': 1.0})
             receipt.button_validate()
 
-        product_accounts = self.product1.product_tmpl_id.get_product_accounts()
         payable_id = self.company_data['default_account_payable'].id
-        stock_in_id = product_accounts['stock_input'].id
-        expense_id = product_accounts['expense'].id
-        stock_valuation = product_accounts['stock_valuation'].id
+        stock_in_id = self.stock_input_account.id
+        stock_valuation = self.stock_valuation_account.id
 
         # 1 Units invoiced at rate 2 and unit price 100 = 50
-        self.assertRecordValues(bill.line_ids, [
+        amls = self.env["account.move.line"].search([('parent_state', '=', 'posted')], order="id asc")
+        self.assertRecordValues(amls, [
             # pylint: disable=bad-whitespace
-            {'debit': 50.0,    'credit': 0,    'account_id': expense_id,   'reconciled': False,    'amount_currency':  100.0},
-            {'debit': 0,        'credit': 50.0,  'account_id': payable_id,   'reconciled': False,    'amount_currency': -100.0},
-        ])
-
-        layer_receipt = receipt.move_ids.stock_valuation_layer_ids
-
-        self.assertRecordValues(layer_receipt.account_move_id.line_ids, [
-            # pylint: disable=bad-whitespace
-            {'debit': 0,   'credit': 50.0,    'account_id': stock_in_id,  'reconciled': False, 'amount_currency': -110.0},
-            {'debit': 50.0,   'credit': 0,    'account_id': stock_valuation,  'reconciled': False, 'amount_currency': 110.0},
+            # Bill Lines
+            {'debit': 50.0, 'credit': 0,    'reconciled': True,  'amount_currency': 100.0, 'account_id': stock_in_id},
+            {'debit': 0,    'credit': 50.0, 'reconciled': False, 'amount_currency': -100.0, 'account_id': payable_id},
+            # Receipt Lines
+            {'debit': 0,    'credit': 50.0, 'reconciled': True,  'amount_currency': -100.0, 'account_id': stock_in_id},
+            {'debit': 50.0, 'credit': 0,    'reconciled': False, 'amount_currency': 100.0,  'account_id': stock_valuation},
         ])
 
     def test_analytic_distribution_propagation_with_exchange_difference(self):


### PR DESCRIPTION
When posting the vendor bill before validating the receipt, and the currency rate changed between the bill and receipt:
- An Exchange diff account move would be created, and the Stock Input Account would not be balanced

This is because the balance of the receipt would perfectly match the balance of the vendor bill, but not the Amount in currency. So, when we try to reconcile the 2 lines, because they are in the same currency, we are reconciling the Amount in Currency. Hence, the exchange rate journal entry is created, and a discrepancy in the Stock Input Account balance is introduced.

When the bill is posted before the receipt is validated, we want the receipt to have the value of the bill, and there is no reason to have only the balance or the amount in currency from the bill, so we can take both of them.


https://github.com/user-attachments/assets/c6dc5e72-8f5b-4c0f-99fa-c5e98a9574ff


## How to reproduce:
- Install stock_account,purchase
- Create product P:
    * Valued in AVCO automated.
    * Control Policy to 'On ordered quantities'
- Add currency rates for the EUR currency:
    * 2.0 on the 2025-01-01
    * 2.1 today
- Create and Confirm a new purchase for 1 unit of P and a price of 100 Euros
- Create the Bill:
    * Set the bill's accounting date & bill date to the 2025-01-01
    * Confirm the bill
          => Amount in Currency: 100 Euros - Balance: $50 USD - Rate used: 2.0
- Go back to the PO and receive the product.
          => Amount in Currency: 105 Euros - Balance: $50 USD - Rate used: 2.1
- Check the created Journal Entries:
          => Currency exchange rate difference: $2.38
          => (105 - 100) / 2.1

OPW-4631348

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
