### PR TITLE
[FIX] l10n_it_edi: branches share the Proxy User settings with their root company

### DIFF
--- a/addons/account_edi_proxy_client/security/account_edi_proxy_client_security.xml
+++ b/addons/account_edi_proxy_client/security/account_edi_proxy_client_security.xml
@@ -4,7 +4,7 @@
     <record id="account_edi_proxy_client_user_comp_rule" model="ir.rule">
         <field name="name">Account EDI Proxy Client User</field>
         <field name="model_id" ref="model_account_edi_proxy_client_user"/>
-        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
     </record>
 </data>
 </odoo>

--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -28,3 +28,8 @@ class AccountEdiProxyClientUser(models.Model):
                 raise UserError(_('Please fill your codice fiscale to be able to receive invoices from FatturaPA'))
             return company.partner_id._l10n_it_edi_normalized_codice_fiscale()
         return super()._get_proxy_identification(company, proxy_type)
+
+    def _register_proxy_user(self, company, proxy_type, edi_mode):
+        if proxy_type == 'l10n_it_edi':
+            company = company.root_id
+        return super()._register_proxy_user(company, proxy_type, edi_mode)

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -538,7 +538,7 @@ class AccountMove(models.Model):
             importo_totale_documento += values['base_amount_currency']
             importo_totale_documento += values['tax_amount_currency']
 
-        company = self.company_id
+        company = self.company_id.root_id
         partner = self.commercial_partner_id
         sender = company
         buyer = partner if not is_self_invoice else company

--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -114,7 +114,7 @@ class ResCompany(models.Model):
     @api.depends("account_edi_proxy_client_ids")
     def _compute_l10n_it_edi_proxy_user_id(self):
         for company in self:
-            company.l10n_it_edi_proxy_user_id = company.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
+            company.l10n_it_edi_proxy_user_id = company.root_id.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
 
     def _l10n_it_edi_export_check(self):
         checks = {

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -7,6 +7,7 @@ class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
     is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
+    company_parent_id = fields.Many2one(related='company_id.parent_id', readonly=True)
     l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
     l10n_it_edi_register = fields.Boolean(compute='_compute_l10n_it_edi_register', inverse='_set_l10n_it_edi_register_demo_mode')
     l10n_it_edi_demo_mode = fields.Selection(
@@ -26,10 +27,7 @@ class ResConfigSettings(models.TransientModel):
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_l10n_it_edi_demo_mode(self):
         for config in self:
-            edi_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
+            edi_user = config.company_id.l10n_it_edi_proxy_user_id
             config.l10n_it_edi_demo_mode = edi_user.edi_mode or 'demo'
 
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
@@ -40,11 +38,7 @@ class ResConfigSettings(models.TransientModel):
     @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
     def _compute_l10n_it_edi_proxy_current_state(self):
         for config in self:
-            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
+            proxy_user = config.company_id.l10n_it_edi_proxy_user_id
             config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
 
     @api.depends('company_id')
@@ -54,39 +48,19 @@ class ResConfigSettings(models.TransientModel):
 
     def _set_l10n_it_edi_register_demo_mode(self):
         for config in self:
+            proxy_user = config.company_id.l10n_it_edi_proxy_user_id
 
-            proxy_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
-            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-                ('id_client', 'not like', 'demo'),
-            ])
-
-            # Update the config as per the selected radio button
-            previous_demo_state = proxy_user.edi_mode
+            old_edi_mode = config.company_id.l10n_it_edi_proxy_user_id.edi_mode
             edi_mode = config.l10n_it_edi_demo_mode
-
             # If the user is trying to change from a state in which they have a registered official or testing proxy client
             # to another state, we should stop them
-            if real_proxy_users and previous_demo_state != edi_mode:
+            if old_edi_mode not in ('demo', False, edi_mode):
                 raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
 
             if config.l10n_it_edi_register:
-                # There should only be one user at a time, if there are no users, register one
-                if not proxy_user:
-                    self._create_proxy_user(config.company_id, edi_mode)
-                    return
-
-                # If there is a demo user, and we are transitioning from demo to test or production, we should
-                # delete all demo users and then create the new user.
-                elif proxy_user.id_client[:4] == 'demo' and edi_mode != 'demo':
-                    self.env['account_edi_proxy_client.user'].search([
-                        ('company_id', '=', config.company_id.id),
-                        ('proxy_type', '=', 'l10n_it_edi'),
-                        ('id_client', '=like', 'demo%'),
-                    ]).sudo().unlink()
-                    self._create_proxy_user(config.company_id, edi_mode)
+                # If we are transitioning from a demo user
+                # to test or production one, then we should
+                # delete the old one before creating the new one.
+                if old_edi_mode == 'demo' and edi_mode != 'demo':
+                    proxy_user.sudo().unlink()
+                self._create_proxy_user(config.company_id, edi_mode)

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
-                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT'" id='account_edi'>
+                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT' or company_parent_id" id='account_edi'>
                     <setting id="italian_edi">
                         <div class="group-content">
                             <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
@@ -42,6 +42,11 @@
                             A Demo service is in use.
                         </div>
                     </setting>
+                </block>
+                <block title="Italian Electronic Invoicing" invisible="(country_code != 'IT') or not company_parent_id" id='account_edi_branch'>
+                    <span class="o_form_label">
+                        Branches use the EDI settings of their main company
+                    </span>
                 </block>
             </xpath>
         </field>


### PR DESCRIPTION
- Prevent duplicate user conflict during official mode activation in multi-branch setups
- Handle scenario where branches of the same company use the same Partita IVA (VAT number) or codice fiscale
- Avoid "An user already exist in the database" error by validating user association logic
- The branch should affect the same record in the db the will have the same proxy user

Task [link](https://www.odoo.com/odoo/project/967/tasks/4737181)
task-4737181