### PR TITLE
[IMP] web: change text-color to 900

### DIFF
--- a/addons/gamification/views/gamification_goal_views.xml
+++ b/addons/gamification/views/gamification_goal_views.xml
@@ -162,7 +162,7 @@
                         <div class="pt-3 fs-1 fw-bolder">
                             <t t-if="record.definition_display.raw_value == 'boolean'">
                                 <t t-if="record.state.raw_value=='reached'"><i role="img" class="text-success fa fa-check fa-3x" title="Goal Reached" aria-label="Goal Reached"/></t>
-                                <t t-if="record.state.raw_value=='inprogress'"><i role="img" class="text-700 fa fa-clock-o fa-3x" title="Goal in Progress" aria-label="Goal in Progress"/></t>
+                                <t t-if="record.state.raw_value=='inprogress'"><i role="img" class="text-body fa fa-clock-o fa-3x" title="Goal in Progress" aria-label="Goal in Progress"/></t>
                                 <t t-if="record.state.raw_value=='failed'"><i role="img" class="text-danger fa fa-times fa-3x" title="Goal Failed" aria-label="Goal Failed"/></t>
                             </t>
                             <t t-if="record.definition_display.raw_value == 'progress'">

--- a/addons/hr_homeworking/static/src/avatar_card_popover_patch.xml
+++ b/addons/hr_homeworking/static/src/avatar_card_popover_patch.xml
@@ -4,13 +4,13 @@
         <xpath expr="//span[@name='icon']" position="inside">
             <i t-elif="user.im_status === 'presence_home_online'" class="fa fa-fw fa-home text-success" title="At Home - Online" role="img" aria-label="At Home - Online"/>
             <i t-elif="user.im_status === 'presence_home_away'" class="fa fa-fw fa-home text-warning" title="At Home - Idle" role="img" aria-label="At Home - Idle"/>
-            <i t-elif="user.im_status === 'presence_home_offline'" class="fa fa-fw fa-home text-700" title="At Home - Offline" role="img" aria-label="At Home - Offline"/>
+            <i t-elif="user.im_status === 'presence_home_offline'" class="fa fa-fw fa-home text-body" title="At Home - Offline" role="img" aria-label="At Home - Offline"/>
             <i t-elif="user.im_status === 'presence_office_online'" class="fa fa-fw fa-building text-success" title="At Office - Online" role="img" aria-label="At Office - Online"/>
             <i t-elif="user.im_status === 'presence_office_away'" class="fa fa-fw fa-building text-warning" title="At Office - Idle" role="img" aria-label="At Office - Idle"/>
-            <i t-elif="user.im_status === 'presence_office_offline'" class="fa fa-fw fa-building text-700" title="At Office - Offline" role="img" aria-label="At Office - Offline"/>
+            <i t-elif="user.im_status === 'presence_office_offline'" class="fa fa-fw fa-building text-body" title="At Office - Offline" role="img" aria-label="At Office - Offline"/>
             <i t-elif="user.im_status === 'presence_other_online'" class="fa fa-fw fa-map-marker text-success" title="At Other - Online" role="img" aria-label="At Other - Online"/>
             <i t-elif="user.im_status === 'presence_other_away'" class="fa fa-fw fa-map-marker text-warning" title="At Other - Idle" role="img" aria-label="At Other - Idle"/>
-            <i t-elif="user.im_status === 'presence_other_offline'" class="fa fa-fw fa-map-marker text-700" title="At Other - Offline" role="img" aria-label="At Other - Offline"/>
+            <i t-elif="user.im_status === 'presence_other_offline'" class="fa fa-fw fa-map-marker text-body" title="At Other - Offline" role="img" aria-label="At Other - Offline"/>
         </xpath>
     </t>
 </templates>

--- a/addons/hr_homeworking/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
+++ b/addons/hr_homeworking/static/src/components/avatar_card_resource/avatar_card_resource_popover.xml
@@ -4,13 +4,13 @@
         <xpath expr="//span[@name='icon'][hasclass('o_user_im_status')]/i[hasclass('fa-question-circle')]" position="before">
             <i t-elif="record.im_status === 'presence_home_online'" class="fa fa-fw fa-home text-success" title="At Home - Online" role="img" aria-label="At Home - Online"/>
             <i t-elif="record.im_status === 'presence_home_away'" class="fa fa-fw fa-home text-warning" title="At Home - Idle" role="img" aria-label="At Home - Idle"/>
-            <i t-elif="record.im_status === 'presence_home_offline'" class="fa fa-fw fa-home text-700" title="At Home - Offline" role="img" aria-label="At Home - Offline"/>
+            <i t-elif="record.im_status === 'presence_home_offline'" class="fa fa-fw fa-home text-body" title="At Home - Offline" role="img" aria-label="At Home - Offline"/>
             <i t-elif="record.im_status === 'presence_office_online'" class="fa fa-fw fa-building text-success" title="At Office - Online" role="img" aria-label="At Office - Online"/>
             <i t-elif="record.im_status === 'presence_office_away'" class="fa fa-fw fa-building text-warning" title="At Office - Idle" role="img" aria-label="At Office - Idle"/>
-            <i t-elif="record.im_status === 'presence_office_offline'" class="fa fa-fw fa-building text-700" title="At Office - Offline" role="img" aria-label="At Office - Offline"/>
+            <i t-elif="record.im_status === 'presence_office_offline'" class="fa fa-fw fa-building text-body" title="At Office - Offline" role="img" aria-label="At Office - Offline"/>
             <i t-elif="record.im_status === 'presence_other_online'" class="fa fa-fw fa-map-marker text-success" title="At Other - Online" role="img" aria-label="At Other - Online"/>
             <i t-elif="record.im_status === 'presence_other_away'" class="fa fa-fw fa-map-marker text-warning" title="At Other - Idle" role="img" aria-label="At Other - Idle"/>
-            <i t-elif="record.im_status === 'presence_other_offline'" class="fa fa-fw fa-map-marker text-700" title="At Other - Offline" role="img" aria-label="At Other - Offline"/>
+            <i t-elif="record.im_status === 'presence_other_offline'" class="fa fa-fw fa-map-marker text-body" title="At Other - Offline" role="img" aria-label="At Other - Offline"/>
         </xpath>
         <xpath expr="//span[@name='icon'][hasclass('o_employee_presence_status')]" position="inside">
             <i t-if="record.hr_icon_display === 'presence_home'" class="fa fa-fw fa-home text-success me-1" title="At Home - Present" role="img" aria-label="At Home"/>

--- a/addons/hr_homeworking/static/src/im_status_patch.xml
+++ b/addons/hr_homeworking/static/src/im_status_patch.xml
@@ -8,7 +8,7 @@
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
                         <t t-set="status" t-value="persona.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
-                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-7000'}"/>
+                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-body'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>
                         <t t-set="text" t-value="status_map[status]"/>
                         <i class="fa" t-attf-class="{{icon}} {{text}}" t-attf-title="At {{location}} - {{status}}" role="img" t-attf-aria-label=" User work at {{location}} and is {{status}}"/>
@@ -29,7 +29,7 @@
                     <t t-if="location == 'home' || location == 'office' || location == 'other'">
                         <t t-set="status" t-value="correspondent.persona.im_status.split('_')[1]"/>
                         <t t-set="location_map" t-value="{'home': 'fa-home', 'office': 'fa-building', 'other': 'fa-map-marker'}"/>
-                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-7000'}"/>
+                        <t t-set="status_map" t-value="{'online': 'text-success', 'away': 'o-away', 'offline': 'text-body'}"/>
                         <t t-set="icon" t-value="location_map[location]"/>
                         <t t-set="text" t-value="status_map[status]"/>
                         <i class="fa" t-attf-class="{{icon}} {{text}}" t-attf-title="At {{location}} - {{status}}" role="img" t-attf-aria-label=" User work at {{location}} and is {{status}}"/>

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -182,10 +182,10 @@ $btn-border-radius-lg: $border-radius !default;
 $dropdown-border-color: $border-color !default;
 
 $dropdown-link-color: $o-main-text-color !default;
-$dropdown-link-hover-color: $gray-900 !default;
+$dropdown-link-hover-color: $black !default;
 $dropdown-link-hover-bg: rgba($black, 0.08) !default;
 
-$dropdown-link-active-color: $gray-900 !default;
+$dropdown-link-active-color: $black !default;
 $dropdown-link-active-bg: transparent !default;
 
 $dropdown-link-disabled-color: $o-main-color-muted !default;

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -117,9 +117,9 @@ $o-font-family-monospace: o-add-unicode-support-font((SFMono-Regular, Menlo, Mon
 $o-headings-font-family: o-add-unicode-support-font(("SF Pro Display", $o-system-fonts)) !default;
 
 // Font colors
-$o-main-text-color: $o-gray-700 !default;
-$o-main-color-muted: rgba($o-main-text-color, $o-opacity-muted) !default;
-$o-main-headings-color: $o-gray-900 !default;
+$o-main-text-color: $o-gray-900 !default;
+$o-main-color-muted: rgba($o-gray-700, $o-opacity-muted) !default;
+$o-main-headings-color: $o-black !default;
 $o-main-link-color: darken($o-brand-primary, 5%) !default;
 $o-main-favorite-color: #f3cc00 !default;
 $o-main-code-color: #d2317b !default;
@@ -129,7 +129,7 @@ $o-table-cell-padding-x-sm: .3rem !default;
 $o-table-cell-padding-y-sm: .5rem !default;
 
 // Components colors
-$o-component-active-color:  $o-gray-900 !default;
+$o-component-active-color:  $o-black !default;
 $o-component-active-bg: mix($o-action, $o-gray-100, 20%) !default;
 $o-component-active-border: $o-action !default;
 
@@ -210,7 +210,7 @@ $o-label-font-size-factor: 0.8 !default;
 
 // == List group
 
-$o-list-group-active-color: $o-gray-900 !default;
+$o-list-group-active-color: $o-black !default;
 $o-list-group-active-bg: lighten(saturate(adjust-hue($o-info, 15), 1.8), 50) !default;
 
 // Breadcrumbs
@@ -260,11 +260,11 @@ $o-btns-bs-override: map-merge((
     "secondary": (
         background: $o-gray-300,
         border: $o-gray-300,
-        color: $o-gray-800,
+        color: $o-gray-900,
 
         hover-background: $o-gray-400,
         hover-border: $o-gray-400,
-        hover-color: $o-gray-900,
+        hover-color: $o-black,
 
         active-background: $o-component-active-bg,
         active-border:  $o-component-active-border,
@@ -273,11 +273,11 @@ $o-btns-bs-override: map-merge((
     "light": (
         background: $o-white,
         border: $o-white,
-        color: $o-gray-700,
+        color: $o-gray-900,
 
         hover-background: $o-gray-200,
         hover-border: $o-gray-200,
-        hover-color: $o-gray-900,
+        hover-color: $o-black,
 
         active-background: $o-component-active-bg,
         active-border:  $o-component-active-border,
@@ -290,11 +290,11 @@ $o-btns-bs-outline-override: map-merge((
     "secondary": (
         background: transparent,
         border: $o-gray-300,
-        color: $o-gray-700,
+        color: $o-gray-900,
 
         hover-background: $o-gray-200,
         hover-border: $o-gray-300,
-        hover-color: $o-gray-800,
+        hover-color: $o-black,
 
         active-background: $o-component-active-bg,
         active-border:  $o-component-active-border,

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -186,7 +186,7 @@
             >
             <header
                 class="list-group-item list-group-item-action d-flex align-items-center px-0 py-lg-0 border-0"
-                t-att-class="{'active text-900 fw-bold': state.active[section.id] === valueId}"
+                t-att-class="{'active text-black fw-bold': state.active[section.id] === valueId}"
                 t-on-click="() => this.toggleCategory(section, value)"
                 >
                 <div

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.xml
@@ -86,7 +86,7 @@
             </label>
             <t t-if="filter.canRemove">
                 <button
-                    class="o_remove btn position-absolute top-0 end-0 py-0 p-1 bg-view text-700 transition-base"
+                    class="o_remove btn position-absolute top-0 end-0 py-0 p-1 bg-view text-body transition-base"
                     role="img"
                     title="Remove this favorite from the list"
                     aria-label="Remove this favorite from the list"

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -186,7 +186,7 @@
         >
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)"
                 tabindex="-1"
-                t-attf-class="o_group_name fs-6 fw-bold {{!group.isFolded ? 'text-900' : 'text-700'}}"
+                t-attf-class="o_group_name fs-6 fw-bold {{!group.isFolded ? 'text-black' : 'text-body'}}"
                 t-att-colspan="getGroupNameCellColSpan(group)">
                 <div class="d-flex align-items-center">
                     <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.variables.scss
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.variables.scss
@@ -4,4 +4,4 @@ $o-burger-base-bg: $o-white !default;
 $o-burger-base-color: $o-gray-800 !default;
 
 $o-burger-topbar-bg: $o-gray-100 !default;
-$o-burger-topbar-color: $o-gray-900 !default;
+$o-burger-topbar-color: $o-black !default;

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -46,7 +46,7 @@ body:not(.o_touch_device) .o_settings_container .o_field_selection {
 .o_base_settings_view .o_form_renderer {
    --settings__tab-bg: #{map-get($grays, '100')};
    --settings__tab-bg--active: #{$o-component-active-bg};
-   --settings__tab-color: #{map-get($grays, '700')};
+   --settings__tab-color: #{$body-color};
    --settings__title-bg: #{map-get($grays, '200')};
 
    height: 100%;
@@ -101,7 +101,7 @@ body:not(.o_touch_device) .o_settings_container .o_field_selection {
                }
 
                &:hover, &.selected {
-                   color: $o-gray-900;
+                   color: $black;
                }
            }
        }

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_item.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_item.xml
@@ -37,7 +37,7 @@
             t-on-click="() => this.logIntoCompany()"
         >
             <span
-                class="company_label text-700 text-truncate"
+                class="company_label text-body text-truncate"
                 t-attf-style="padding-left:{{props.level * 20}}px;">
                 <t t-out="props.company.name"/>
             </span>


### PR DESCRIPTION
The goal is to increase contrast between the global text-color and text-muted in the backend while keeping the current text-muted color.

This is done because the contrast was too small between these two colors and is an opportunity to increase the overall contrast.

The contrasting color for headings and active components is set to $black (#000 and #FFF darkmode).

To avoid the secondary buttons looking "disabled" the color is also adapted.

New values:

```
text: 900
headings: #000/#FFF(dm)
muted: 700 * .76
btn-secondary: 900
btn-light: 900
btn-secondary/light active/hover: #000/#FFF(dm)
list-group/dd: 900
list-group/dd active/hover: #000/#FFF(dm)
```

task-4756587

Enterprise PR: https://github.com/odoo/enterprise/pull/85027

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
