### PR TITLE
[FIX] cloud_storage_azure: allow hyphens in container names

### DIFF
--- a/addons/cloud_storage_azure/models/ir_attachment.py
+++ b/addons/cloud_storage_azure/models/ir_attachment.py
@@ -60,12 +60,15 @@ def get_cloud_storage_azure_user_delegation_key(env):
 
 class IrAttachment(models.Model):
     _inherit = 'ir.attachment'
-    _cloud_storage_azure_url_pattern = re.compile(r'https://(?P<account_name>[\w]+).blob.core.windows.net/(?P<container_name>[\w]+)/(?P<blob_name>[^?]+)')
+    # https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage
+    _cloud_storage_azure_url_pattern = re.compile(
+        r'https://(?P<account_name>[a-z\d]{3,24})\.blob\.core\.windows\.net/(?P<container_name>[a-z\d][a-z\d-]{2,62})/(?P<blob_name>[^?]+)',
+    )
 
     def _get_cloud_storage_azure_info(self):
-        match = self._cloud_storage_azure_url_pattern.match(self.url)
+        match = self._cloud_storage_azure_url_pattern.match(self.url or '')
         if not match:
-            raise ValidationError('%s is not a valid Azure Blob Storage URL.', self.url)
+            raise ValidationError(f'"{self.url}" is not a valid Azure Blob Storage URL.')
         return {
             'account_name': match['account_name'],
             'container_name': match['container_name'],


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Create a Azure storage container with a hyphen in its name;
2. connect it to your database;
3. go to a contact;
4. click "Send message";
5. upload an attachment.

Issue
-----
Server Error pop-up.

In the logger, you get:
> `TypeError: UserError.__init__() takes 2 positional arguments but 3 were given`

Cause
-----
1. The `ValidationError` string is badly formatted.
2. The regex to verify Azure Blob Storage URLs doesn't allow hyphens in the container name.

Solution
--------
1. As the `ValidationError` is only shown in the logger, format it as an f-string.
2. Update the regex to the constraints imposed by Azure[^1].

[^1]: https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftstorage

opw-4770160