### PR TITLE
[FIX] sale: translated product name missing on SOL

### DIFF
--- a/addons/sale/__manifest__.py
+++ b/addons/sale/__manifest__.py
@@ -100,11 +100,15 @@ This module contains all the common features of Sales Management and eCommerce.
         ],
         'web.assets_unit_tests': [
             'sale/static/tests/mock_server/**/*',
+            'sale/static/tests/sale_test_helpers.js',
+            'sale/static/tests/**/*.test.js',
         ],
         'web.qunit_suite_tests': [
             'sale/static/tests/**/*',
             ('remove', 'sale/static/tests/tours/**/*'),
             ('remove', 'sale/static/tests/mock_server/**/*'),
+            ('remove', 'sale/static/tests/sale_test_helpers.js'),
+            ('remove', 'sale/static/tests/**/*.test.js'),
         ],
         'web.report_assets_common': [
             'sale/static/src/scss/sale_report.scss',

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -121,6 +121,7 @@ class SaleOrderLine(models.Model):
         string="Description",
         compute='_compute_name',
         store=True, readonly=False, required=True, precompute=True)
+    translated_product_name = fields.Text(compute='_compute_translated_product_name')
 
     product_uom_qty = fields.Float(
         string="Quantity",
@@ -474,6 +475,13 @@ class SaleOrderLine(models.Model):
                 )
 
         return name
+
+    @api.depends('product_id')
+    def _compute_translated_product_name(self):
+        for line in self:
+            line.translated_product_name = line.product_id.with_context(
+                lang=line.order_id._get_lang(),
+            ).display_name
 
     @api.depends('display_type', 'product_id', 'product_packaging_qty')
     def _compute_product_uom_qty(self):

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -147,6 +147,33 @@ export class SaleOrderLineProductField extends ProductLabelSectionAndNoteField {
         return className;
     }
 
+    get label() {
+        let label = super.label;
+        if (this.translatedProductName && label.startsWith(this.translatedProductName)) {
+            // Remove the translated name as it is already shown to the salesman on the SOL.
+            label = label.slice(label.indexOf("\n") + 1);
+        }
+        return label;
+    }
+
+    get translatedProductName() {
+        return this.props.record.data.translated_product_name;
+    }
+
+    updateLabel(value) {
+        if (this.translatedProductName === undefined) {
+            // View was not updated to include `translatedProductName`
+            return super.updateLabel(value);
+        }
+        this.props.record.update({
+            name: (
+                this.translatedProductName && value && this.translatedProductName.concat("\n", value)
+                || !value && this.translatedProductName
+                || value
+            ),
+        });
+    }
+
     onClick(ev) {
         // Override to get internal link to products in SOL that cannot be edited
         if (this.props.readonly) {

--- a/addons/sale/static/tests/mock_server/mock_models/product_product.js
+++ b/addons/sale/static/tests/mock_server/mock_models/product_product.js
@@ -1,0 +1,11 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+
+export class ProductProduct extends models.ServerModel {
+    _name = "product.product";
+
+    _records = [
+        {id: 1, name: "Test Product", type: "consu", list_price: 20.0},
+        {id: 2, name: "Test Service Product", type: "service", list_price: 50.0},
+    ];
+}

--- a/addons/sale/static/tests/mock_server/mock_models/product_template.js
+++ b/addons/sale/static/tests/mock_server/mock_models/product_template.js
@@ -1,0 +1,6 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+
+export class ProductTemplate extends models.ServerModel {
+    _name = "product.template";
+}

--- a/addons/sale/static/tests/mock_server/mock_models/sale_order.js
+++ b/addons/sale/static/tests/mock_server/mock_models/sale_order.js
@@ -1,0 +1,6 @@
+import { models } from "@web/../tests/web_test_helpers";
+
+
+export class SaleOrder extends models.ServerModel {
+    _name = "sale.order";
+}

--- a/addons/sale/static/tests/mock_server/mock_models/sale_order_line.js
+++ b/addons/sale/static/tests/mock_server/mock_models/sale_order_line.js
@@ -1,5 +1,9 @@
-import { models } from "@web/../tests/web_test_helpers";
+import { fields, models } from "@web/../tests/web_test_helpers";
+
 
 export class SaleOrderLine extends models.ServerModel {
     _name = "sale.order.line";
+
+    // Store the field for testing to be able to set the translation at the record creation.
+    translated_product_name = fields.Char({store: true});
 }

--- a/addons/sale/static/tests/sale_product_field.test.js
+++ b/addons/sale/static/tests/sale_product_field.test.js
@@ -1,0 +1,189 @@
+import { ProductProduct } from "./mock_server/mock_models/product_product";
+import { defineSaleModels } from "./sale_test_helpers";
+import { startServer } from "@mail/../tests/mail_test_helpers";
+import { expect, getFixture, test } from "@odoo/hoot";
+import { animationFrame, click, edit } from "@odoo/hoot-dom";
+import {
+    clickSave,
+    Command,
+    contains,
+    mountView,
+    serverState
+} from "@web/../tests/web_test_helpers";
+
+
+const WithTranslatedNameForm = `
+    <form>
+        <field name="order_line" widget="sol_o2m" mode="list">
+            <list editable="bottom">
+                <field name="product_id" widget="sol_product_many2one"/>
+                <field name="product_template_id" widget="sol_product_many2one"/>
+                <field name="name" widget="sol_text"/>
+                <field name="translated_product_name" column_invisible="1"/>
+            </list>
+        </field>
+    </form>
+`;
+const WithoutTranslatedNameForm = `
+    <form>
+        <field name="order_line" widget="sol_o2m" mode="list">
+            <list editable="bottom">
+                <field name="product_id" widget="sol_product_many2one"/>
+                <field name="product_template_id" widget="sol_product_many2one"/>
+                <field name="name" widget="sol_text"/>
+            </list>
+        </field>
+    </form>
+`;
+
+defineSaleModels();
+
+test("On updated form, product name should stay hidden", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name.concat("\nA description"),
+            translated_product_name: "Produit de test",
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+});
+
+test("On updated form, translated product name should be hidden if present", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: translatedProductName.concat("\nA description"),
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+});
+
+test("On outdated form, should continue to hide product name", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name.concat("\nA description"),
+            translated_product_name: "Produit de test",
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithoutTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+});
+
+test("On outdated form and translated product name already in the SOL name, should not hide the translated product name", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name.concat("\n", translatedProductName, "\nA description"),
+            translated_product_name: translatedProductName,
+        })],
+    });
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithoutTranslatedNameForm,
+    });
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue(
+        translatedProductName.concat("\nA description"),
+    );
+});
+
+test("On outdated form, editing the description should work as before", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name.concat("\nsomething wrong"),
+            translated_product_name: translatedProductName,
+        })],
+    });
+    const [so] = pyEnv["sale.order"].browse(soId);
+    const [sol] = pyEnv["sale.order.line"].browse(so.order_line);
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithoutTranslatedNameForm,
+    });
+
+    await contains(".o_field_product_label_section_and_note_cell textarea").focus();
+    await edit("A description");
+    await click(getFixture());
+    await animationFrame()
+    await clickSave();
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+    expect(sol.name).toBe(product.name.concat("\nA description"));
+});
+
+test("On updated form, editing the description shouldn't show the translated product name", async () => {
+    const product = ProductProduct._records[0];
+    const pyEnv = await startServer();
+    const translatedProductName = "Produit de test";
+    const soId = pyEnv["sale.order"].create({
+        partner_id: serverState.partnerId,
+        order_line: [Command.create({
+            product_id: product.id,
+            name: product.name.concat("\nsomething wrong"),
+            translated_product_name: translatedProductName,
+        })],
+    });
+    const [so] = pyEnv["sale.order"].browse(soId);
+    const [sol] = pyEnv["sale.order.line"].browse(so.order_line);
+    await mountView({
+        type: "form",
+        resModel: "sale.order",
+        resId: soId,
+        arch: WithTranslatedNameForm,
+    });
+
+    await contains(".o_field_product_label_section_and_note_cell textarea").focus();
+    await edit("A description");
+    await click(getFixture());
+    await animationFrame()
+    await clickSave();
+
+    expect(".o_field_product_label_section_and_note_cell textarea").toHaveValue("A description");
+    expect(sol.name).toBe(translatedProductName.concat("\nA description"));
+});

--- a/addons/sale/static/tests/sale_test_helpers.js
+++ b/addons/sale/static/tests/sale_test_helpers.js
@@ -1,0 +1,19 @@
+import { mailModels } from "@mail/../tests/mail_test_helpers";
+import { defineModels } from "@web/../tests/web_test_helpers";
+import { ProductProduct } from "./mock_server/mock_models/product_product";
+import { ProductTemplate } from "./mock_server/mock_models/product_template";
+import { SaleOrder } from "./mock_server/mock_models/sale_order";
+import { SaleOrderLine } from "./mock_server/mock_models/sale_order_line";
+
+
+export const saleModels = {
+    ...mailModels,
+    ProductProduct,
+    ProductTemplate,
+    SaleOrder,
+    SaleOrderLine,
+};
+
+export function defineSaleModels() {
+    defineModels(saleModels);
+}

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -523,6 +523,7 @@
                                 <field name="product_type" column_invisible="True"/>
                                 <field name="product_updatable" column_invisible="True"/>
                                 <field name="is_downpayment" column_invisible="True"/>
+                                <field name="translated_product_name" column_invisible="True"/>
                                 <field
                                     name="product_id"
                                     string="Product Variant"


### PR DESCRIPTION
Previously, when selling a product to a foreign customer, the translated product name was stored in the order line description. However, the salesman could update this description, and if he did, the product name would be automatically included in the quotation's line description but kept hidden to ensure it appears in the final quotation PDF. Unfortunately, the product name was not translated into the partner language.

This commit keeps the previous behavior with the exception that the product name included in quotations' line descriptions is now translated into the partner language.

opw-4760300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
