### PR TITLE
[FIX] hr_expense,point_of_sale,stock_account: get account from related company

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -995,7 +995,7 @@ class HrExpense(models.Model):
 
         # expense account of the product then the product category
         if self.product_id:
-            account = self.product_id.product_tmpl_id._get_product_accounts()['expense']
+            account = self.product_id.with_company(self.company_id).product_tmpl_id._get_product_accounts()['expense']
         else:
             field = self.env['product.category']._fields['property_account_expense_categ_id']
             account = field.get_company_dependent_fallback(self.env['product.category'])

--- a/addons/hr_expense/wizard/hr_expense_split.py
+++ b/addons/hr_expense/wizard/hr_expense_split.py
@@ -99,7 +99,7 @@ class HrExpenseSplit(models.TransientModel):
             'product_uom_id': self.product_id.uom_id.id,
         }
 
-        account = self.product_id.product_tmpl_id._get_product_accounts()['expense']
+        account = self.product_id.with_company(self.company_id).product_tmpl_id._get_product_accounts()['expense']
         if account:
             vals['account_id'] = account.id
         return vals

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -897,7 +897,7 @@ class PosOrder(models.Model):
                 ('product_id.categ_id.property_valuation', '=', 'real_time')
             ])
             for stock_move in stock_moves:
-                expense_account = stock_move.product_id._get_product_accounts()['expense']
+                expense_account = stock_move.with_company(stock_move.company_id).product_id._get_product_accounts()['expense']
                 stock_output_account = stock_move.product_id.categ_id.property_stock_account_output_categ_id
                 balance = -sum(stock_move.stock_valuation_layer_ids.mapped('value'))
                 aml_vals_list_per_nature['stock'].append({

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -972,6 +972,7 @@ class PosSession(models.Model):
                         .filtered(lambda m: not bool(m.origin_returned_move_id and sum(m.stock_valuation_layer_ids.mapped('quantity')) >= 0))\
                         .mapped('stock_valuation_layer_ids')
                     for move in stock_moves_batch.with_context(candidates_prefetch_ids=candidates._prefetch_ids):
+                        move = move.with_company(move.company_id)
                         exp_key = move.product_id._get_product_accounts()['expense']
                         out_key = move.product_id.categ_id.property_stock_account_output_categ_id
                         signed_product_qty = move.product_qty

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -133,6 +133,7 @@ class StockPicking(models.Model):
                 for line in rec.move_line_ids:
                     if not line.product_id.is_storable or line.product_id.valuation != 'real_time':
                         continue
+                    line = line.with_company(line.company_id)
                     out = line.product_id.categ_id.property_stock_account_output_categ_id
                     exp = line.product_id._get_product_accounts()['expense']
                     line_cost = next(iter(line.move_id._get_price_unit().values())) * line.quantity_product_uom

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -193,6 +193,7 @@ class AccountMove(models.Model):
             if not move.company_id.anglo_saxon_accounting:
                 continue
 
+            move = move.with_company(move.company_id)
             stock_moves = move._stock_account_get_last_step_stock_moves()
             # In case we return a return, we have to provide the related AMLs so all can be reconciled
             stock_moves |= stock_moves.origin_returned_move_id


### PR DESCRIPTION
The aim of this commit is to ensure the account select through product
is related to the correct company. (ie. the one related to the
processed model)

Before this commit:
If a user has company_a selected as the main company in the company
switcher and create an expense for company_b, the account selected from
the product will be an account from company_a.

(because product is shared between company but the account properties on
those are company dependent)

This could also happens in other places so we fixed it.

After this commit:
The account selected from the product will be from the company set on
the model.

task-4699717