### PR TITLE
[FIX] web: Avoid splitting QR codes in documents

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -319,3 +319,9 @@ li.oe-nested {
 .h6-fs {
     font-size: 1rem;
 }
+
+// This class should be applied on div elements that contain a QR code to avoid breaking the QR image on multiple pages
+.o_qr_wrapper {
+    display: table;
+    page-break-inside: avoid;
+}


### PR DESCRIPTION
Before this commit, QR codes in PDF reports may split over 2 pages if not styled properly. Split QR codes are not usuable, and some of them have legal implications.

task-4756331




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
