### PR TITLE
[FIX] website_crm_partner_assign: leads from multiple companies

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -31,6 +31,7 @@ class WebsiteAccount(CustomerPortal):
 
     def _prepare_home_portal_values(self, counters):
         values = super()._prepare_home_portal_values(counters)
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         CrmLead = request.env['crm.lead']
         if 'lead_count' in counters:
             values['lead_count'] = (
@@ -49,6 +50,7 @@ class WebsiteAccount(CustomerPortal):
     @http.route(['/my/leads', '/my/leads/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_leads(self, page=1, date_begin=None, date_end=None, sortby=None, **kw):
         values = self._prepare_portal_layout_values()
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         CrmLead = request.env['crm.lead']
         domain = self.get_domain_my_lead(request.env.user)
 
@@ -92,6 +94,7 @@ class WebsiteAccount(CustomerPortal):
     @http.route(['/my/opportunities', '/my/opportunities/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_opportunities(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
         values = self._prepare_portal_layout_values()
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         CrmLead = request.env['crm.lead']
         domain = self.get_domain_my_opp(request.env.user)
 


### PR DESCRIPTION
Correct multi-company lead visibility in portal.

[task-4482622](https://www.odoo.com/web#view_type=form&model=project.task&id=4482622)

Description of the issue/feature this PR addresses:
In a multi-company environment, portal users (partners) were unable to access Opportunities and Leads belonged to them, when these records belonged to company(branch) that is not main company. Their visibility was restricted to records from the main company, even if their access rights were configured to allow access to multiple companies.

Steps to reproduce:
1. Create a new company
2. Create a partner and grant them portal access
3. Grant the partner access right to the new company.
4. Switch to the new company and create an opportunity and assign it to
this partner (Under assigned Partner tab).
5. Log in as the partner, go to "my/opportunities."
6. The opportunity is not there.

Desired behavior after PR is merged:
Partners can see lead/opportunities from multiple companies.

---
Current behavior exists for other portal endpoints such as my/subscriptions, my/sales, my/invoices but I believe that the current behavior is expected and normal for these endpoints.

---
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)