### PR TITLE
[FIX] base: prevent traceback when model_id  is missing in server actions

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -812,7 +812,12 @@ class IrActionsServer(models.Model):
 
     def _get_relation_chain(self, searched_field_name):
         self.ensure_one()
-        if not searched_field_name or not searched_field_name in self._fields or not self[searched_field_name]:
+        if (
+            not searched_field_name
+            or not searched_field_name in self._fields
+            or not self[searched_field_name]
+            or not self.model_id
+        ):
             return [], ""
         path = self[searched_field_name].split('.')
         if not path:


### PR DESCRIPTION
Currently, an error produced on creating a new server action if the user
selects a field in the **Action Details** without specifying a model.

**Steps to Reproduce:**
1) Navigate to `Settings>Technical>Actions>Server Action`.
2) Click on `New Server Action`.
3) Select the field in Action Details without selecting the Model.
4) Observe the Error.

**Error:**
KeyError: False

**Root Cause:**
- The error occurs because the system attempts to access `self.model_id.model` at [1] without verifying it exists or not, which leads to a `KeyError`.

[1]-https://github.com/odoo/odoo/blob/4fa26954bbb5f6a9c9679b7d44ec2261057da29e/odoo/addons/base/models/ir_actions.py#L820

**Solution:**
- This commit prevents errors by adding checks to ensure model_id and model_id.model are present before accessing them.

Sentry-6591474450