### PR TITLE
[FIX] point_of_sale: unnecessary orders on releasing table

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -517,7 +517,7 @@ export class PosStore extends WithLazyGetterTrap {
                 if (
                     !ignoreChange &&
                     typeof order.id === "number" &&
-                    Object.keys(order.last_order_preparation_change).length > 0
+                    Object.keys(order.last_order_preparation_change?.lines || {}).length > 0
                 ) {
                     const orderPresetDate = DateTime.fromISO(order.preset_time);
                     const isSame = DateTime.now().hasSame(orderPresetDate, "day");

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -22,8 +22,7 @@ patch(OrderSummary.prototype, {
     },
     async unbookTable() {
         const order = this.pos.getOrder();
-        await this.pos._onBeforeDeleteOrder(order);
-        order.state = "cancel";
+        await this.pos.onDeleteOrder(order);
         this.pos.showScreen("FloorScreen");
     },
     showUnbookButton() {

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -271,6 +271,26 @@ registry.category("web_tour.tours").add("OrderTrackingTour", {
             PaymentScreen.clickValidate(),
             ReceiptScreen.discardOrderWarningDialog(),
             ReceiptScreen.isShown(),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola", true, "1"),
+            ProductScreen.clickOrderButton(),
+            Dialog.is({ title: "Printing failed" }),
+            Dialog.cancel(),
+            FloorScreen.clickTable("2"),
+            inLeftSide([
+                ...ProductScreen.clickLine("Coca-Cola", "1"),
+                ...["⌫", "⌫"].map(Numpad.click), // remove orderlines and release table
+            ]),
+            ProductScreen.orderIsEmpty(),
+            ProductScreen.clickReleaseButton(), // synced order should be cancelled instead of deletion
+            Dialog.is({ title: "Printing failed" }),
+            Dialog.cancel(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickReleaseButton(),
+            Chrome.clickOrders(),
+            TicketScreen.search("Reference", "00002"),
+            { trigger: ".ticket-screen .rightpane .orders h3:contains('No orders found')" },
         ].flat(),
 });
 registry.category("web_tour.tours").add("CategLabelCheck", {

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -12,6 +12,15 @@ export function clickOrderButton() {
         },
     ];
 }
+export function clickReleaseButton() {
+    return [
+        {
+            content: "click release button",
+            trigger: ".product-screen .leftpane .unbook-table",
+            run: "click",
+        },
+    ];
+}
 export function orderlinesHaveNoChange() {
     return Order.doesNotHaveLine({ withClass: ".has-change" });
 }

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -295,8 +295,11 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.write({'order_edit_tracking': True})
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('OrderTrackingTour')
-        order1 = self.env['pos.order'].search([('pos_reference', 'ilike', '%-00001')], limit=1, order='id desc')
-        self.assertTrue(order1.is_edited)
+        orders = self.env['pos.order'].search([], order='id ASC', limit=2)
+        self.assertEqual(orders.mapped('state'), ['paid', 'cancel'])
+        self.assertTrue(orders[0].is_edited)
+        released_order = self.env['pos.order'].search([('pos_reference', 'ilike', '%-00003')], limit=1)
+        self.assertFalse(released_order)
 
     def test_13_category_check(self):
         self.pos_config.with_user(self.pos_user).open_ui()
@@ -691,7 +694,8 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_delete_line_release_table')
         order = self.pos_config.current_session_id.order_ids[0]
-        self.assertEqual(len(order.lines), 0)
+        self.assertEqual(len(order.lines), 1)
+        self.assertEqual(order.state, 'cancel')
 
     def test_combo_synchronisation(self):
         """This test checks that when a combo line is set as dirty, the parent combo line is also set as dirty.


### PR DESCRIPTION
Steps to reproduce:
-------------------------
- Install POS restaurant.
- Open any table to order.
- Release the table.

Issue:
-------
- A draft order is created without purpose or use.

Cause:
---------
- On releasing the table we were not deleting the order, we were just cancelling the order even if it's not useful.

Fix:
-----
- We have called a proper function to manage the conditions like
  - If the order is sent to kitchen it will cancel the kitchen ticket to avoid inaccuracy kitchen side and already recorded on server so it will be cancelled and if the order was not sent to kitchen than there is no need of the order so will be removed totally.
- We have corrected condition to send order in kitchen
  as `last_order_preparation_change` will always have some keys
  with blank values but we need to send data based on the lines
  changed in lopc.

task: 4774814
