### PR TITLE
[FIX] base:  hide File Content label for attachment type URL

### DIFF
--- a/odoo/addons/base/views/ir_attachment_views.xml
+++ b/odoo/addons/base/views/ir_attachment_views.xml
@@ -13,7 +13,7 @@
                     <group>
                         <group class="w-100">
                             <field name="type"/>
-                            <label for="datas" class="mt-1"/>
+                            <label for="datas" class="mt-1" invisible="type == 'url'"/>
                             <field name="datas" nolabel="1" class="w-100" filename="name" invisible="type == 'url'"/>
                             <field name="url" widget="url" invisible="type == 'binary'"/>
                             <field name="mimetype" groups="base.group_no_one"/>


### PR DESCRIPTION
**Purpose:**
- The label `File Content (base64)` is still visible even if the attachment type is URL.

**Specifications:**
- Hide label `File Content (base64)` when attachment type is URL.

task-4778138

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
