### PR TITLE
[FIX] mrp: fixed getting bad query due to empty reference sequence

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -28,7 +28,7 @@ class PickingType(models.Model):
     sequence = fields.Integer('Sequence', help="Used to order the 'All Operations' kanban view")
     sequence_id = fields.Many2one(
         'ir.sequence', 'Reference Sequence',
-        check_company=True, copy=False)
+        check_company=True, copy=False, required=True)
     sequence_code = fields.Char('Sequence Prefix', required=True)
     default_location_src_id = fields.Many2one(
         'stock.location', 'Source Location', compute='_compute_default_location_src_id',


### PR DESCRIPTION
The error was caused by missing `sequence_id` during Manufacturing Order creation. This led to an invalid SQL query 
where `id = False`.

Steps to Replicate:
- Install `MRP` without any demo data (--without-demo=1).
- Go to `Inventory > Configuration > Operation Types`, click on `Manufacturing`.
- Remove the value from the field `Reference Sequence` and Save.
- Go to Shop Floor and then click on  `Load Samples` and the error should occur.

Error:
`UndefinedFunction: operator does not exist: integer = boolean LINE 1: SELECT number_next FROM ir_sequence WHERE id=false FOR UPDAT...`

Solution:
- Made the `Reference Sequence` field required to prevent errors caused by leaving it empty during record creation.

sentry-6589772561
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
