### PR TITLE
[FIX] hr_holidays: fix actual_lastcall being false in some cases.

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -659,6 +659,7 @@ class HolidaysAllocation(models.Model):
             if not allocation.lastcall:
                 if not current_level:
                     allocation.lastcall = today
+                    allocation.actual_lastcall = allocation.lastcall
                     continue
                 allocation.lastcall = max(
                     current_level._get_previous_date(today),


### PR DESCRIPTION
actual_lastcall was being false because it wasn't set in one case inside `add_lastcalls` method. This commit fixes this issue.