### PR TITLE
[FIX] base,account: use \t and \n instead of <tab> and <br>

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -890,7 +890,7 @@ class AccountAccount(models.Model):
                 account.display_name = (
                     f"""{account.code} {account.name}"""
                     f"""{f' `{_("Suggested")}`' if account.id in preferred_account_ids else ''}"""
-                    f"""{f'<br>--{account.description}--' if account.description else ''}"""
+                    + (f'\n--{account.description}--' if account.description else '')
                 )
             else:
                 account.display_name = f"{account.code} {account.name}" if account.code else account.name

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -123,8 +123,8 @@ export function capitalize(s) {
  *      \*\*text\*\* => Put the text in bold.
  *      --text-- => Put the text in muted.
  *      \`text\` => Put the text in a rounded badge (bg-primary).
- *      \<br> => Insert a breakline.
- *      \<tab> => Insert 4 spaces.
+ *      \n => Insert a breakline.
+ *      \t => Insert 4 spaces.
  *
  * @param {string} text **will be escaped**
  * @returns {ReturnType<markup>} the formatted text

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -258,6 +258,6 @@ class ResCountryState(models.Model):
     def _compute_display_name(self):
         for record in self:
             if self.env.context.get('formatted_display_name'):
-                record.display_name = f"{record.name} <tab> --{record.country_id.code}--"
+                record.display_name = f"{record.name} \t --{record.country_id.code}--"
             else:
                 record.display_name = f"{record.name} ({record.country_id.code})"


### PR DESCRIPTION
[1] introduces the new "odoomark" syntax where \<tab\> is supposed
to be displayed as a tab in m2o fields, notably.

[2] changes \<tab\> to \t and \<br\> to \n but does not update some uses.

This lead to \<tab\> and \<br\> appearing in plain text in the m2o selection.

task-4783344

[1]: f18bbfa6748c4be7f2f22ade479d00b1c1443468
[2]: 5effbe451d580c268c7e524fbf71640552111e18
