### PR TITLE
[FIX] l10n_be: Change name of reco model

### DIFF
--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -66,17 +66,17 @@ class AccountChartTemplate(models.AbstractModel):
                 'name@de': 'Skonto',
             },
             'frais_bancaires_htva_template': {
-                'name': 'Bank Fees (No VAT)',
+                'name': 'Bank Fees',
                 'line_ids': [
                     Command.create({
                         'account_id': 'a6560',
                         'amount_type': 'percentage',
                         'amount_string': '100',
-                        'label': 'Bank Fees (No VAT)',
+                        'label': 'Bank Fees',
                     }),
                 ],
-                'name@fr': 'Frais bancaires (Hors TVA)',
-                'name@nl': 'Bankkosten (Geen BTW)',
-                'name@de': 'Bankgebühren (Ohne MwSt.)',
+                'name@fr': 'Frais bancaires',
+                'name@nl': 'Bankkosten',
+                'name@de': 'Bankgebühren',
             },
         }


### PR DESCRIPTION
This commit will change the name of the Bank fees reco model to remove the parenthesis

no task id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
