### PR TITLE
[FIX] website_sale: adapt to enterprise changes

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1586,6 +1586,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return: The route to redirect the customer to.
         :rtype: str
         """
+        # TODO: remove me in master with call site, not used in standard codebase anymore.
         return ''
 
     def _handle_extra_form_data(self, extra_form_data, address_values):


### PR DESCRIPTION
- Remove  _get_extra_billing_info_route method, as it is unnecessary. The
  user should always be redirected to the checkout step first, regardless of
  the existence of an invoicing info step.

Enterprise PR: https://github.com/odoo/enterprise/pull/85094

opw-4738797

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
