### PR TITLE
[FIX] html_editor: restore base container in column after backspace

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -917,21 +917,33 @@ export class DeletePlugin extends Plugin {
      * @returns {Range}
      */
     expandRangeToIncludeNonEditables(range) {
-        const { startContainer, endContainer, commonAncestorContainer: commonAncestor } = range;
+        const {
+            startContainer,
+            startOffset,
+            endContainer,
+            endOffset,
+            commonAncestorContainer: commonAncestor,
+        } = range;
         const isNonEditable = (node) => !isContentEditable(node);
-        const startUneditable = findFurthest(startContainer, commonAncestor, isNonEditable);
+        const startUneditable =
+            startOffset === 0 &&
+            !previousLeaf(startContainer, closestBlock(startContainer)) &&
+            findFurthest(startContainer, commonAncestor, isNonEditable);
         if (startUneditable) {
             // @todo @phoenix: Review this spec. I suggest this instead (no block merge after removing):
             // startContainer = startUneditable.parentElement;
             // startOffset = childNodeIndex(startUneditable);
-            const leaf = previousLeaf(startUneditable);
+            const leaf = previousLeaf(startUneditable, this.editable);
             if (leaf) {
                 range.setStart(leaf, nodeSize(leaf));
             } else {
                 range.setStart(commonAncestor, 0);
             }
         }
-        const endUneditable = findFurthest(endContainer, commonAncestor, isNonEditable);
+        const endUneditable =
+            endOffset === nodeSize(endContainer) &&
+            !nextLeaf(endContainer, closestBlock(endContainer)) &&
+            findFurthest(endContainer, commonAncestor, isNonEditable);
         if (endUneditable) {
             range.setEndAfter(endUneditable);
         }

--- a/addons/html_editor/static/src/main/movenode_plugin.js
+++ b/addons/html_editor/static/src/main/movenode_plugin.js
@@ -430,7 +430,7 @@ export class MoveNodePlugin extends Plugin {
 function isNodeMovable(node) {
     return (
         node.parentElement?.getAttribute("contentEditable") === "true" &&
-        !node.parentElement.closest(".o_editor_banner")
+        !node.parentElement.closest(".o_text_columns, .o_editor_banner")
     );
 }
 

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -411,10 +411,11 @@ export class TablePlugin extends Plugin {
         }
 
         for (const td of selectedTds) {
-            // @todo @phoenix this replaces paragraphs by inline content. Is this intended?
-            td.replaceChildren(this.document.createElement("br"));
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.appendChild(this.document.createElement("br"));
+            td.replaceChildren(baseContainer);
         }
-        this.dependencies.selection.setCursorStart(selectedTds[0]);
+        this.dependencies.selection.setCursorStart(selectedTds[0].firstChild);
     }
 
     /**

--- a/addons/html_editor/static/tests/columnize.test.js
+++ b/addons/html_editor/static/tests/columnize.test.js
@@ -2,16 +2,25 @@ import { describe, expect, test } from "@odoo/hoot";
 import { press, queryAllTexts } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "./_helpers/editor";
-import { getContent } from "./_helpers/selection";
+import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, redo, undo } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
+import { nodeSize } from "@html_editor/utils/position";
 
 function columnsContainer(contents) {
-    return `<div class="container o_text_columns"><div class="row">${contents}</div></div>`;
+    return `<div class="container o_text_columns o-contenteditable-false"><div class="row">${contents}</div></div>`;
 }
 
 function column(size, contents) {
-    return `<div class="col-${size}">${contents}</div>`;
+    return `<div class="col-${size} o-contenteditable-true">${contents}</div>`;
+}
+
+function columsDuringEditContainer(contents) {
+    return `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row">${contents}</div></div>`;
+}
+
+function columnDuringEdit(size, contents) {
+    return `<div class="col-${size} o-contenteditable-true" contenteditable="true">${contents}</div>`;
 }
 
 function columnize(numberOfColumns) {
@@ -30,9 +39,9 @@ describe("2 columns", () => {
                     column(6, "<p><br></p>")
                 ),
             contentAfterEdit:
-                columnsContainer(
-                    column(6, `<p placeholder="Empty column" class="o-we-hint">[]<br></p>`) +
-                    column(6, `<p><br></p>`)
+                columsDuringEditContainer(
+                    columnDuringEdit(6, `<p placeholder="Empty column" class="o-we-hint">[]<br></p>`) +
+                    columnDuringEdit(6, `<p><br></p>`)
                 ),
             /* eslint-enable */
         });
@@ -47,9 +56,9 @@ describe("2 columns", () => {
                     column(6, "<p><br></p>")
                 ),
             contentAfterEdit:
-                columnsContainer(
-                    column(6, `<table><tbody><tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
-                    column(6, `<p><br></p>`)
+                columsDuringEditContainer(
+                    columnDuringEdit(6, `<table><tbody><tr><td><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p></td><td><p><br></p></td></tr></tbody></table>`) +
+                    columnDuringEdit(6, `<p><br></p>`)
                 ),
             /* eslint-enable */
         });
@@ -73,9 +82,9 @@ describe("2 columns", () => {
             stepFunction: columnize(2),
             contentAfterEdit:
             /* eslint-disable */
-                columnsContainer(
-                    column(6, "<p>[]abcd</p>") +
-                    column(6, `<p><br></p>`)
+                columsDuringEditContainer(
+                    columnDuringEdit(6, "<p>[]abcd</p>") +
+                    columnDuringEdit(6, `<p><br></p>`)
                 ) +
                 "<p><br></p>",
             contentAfter:
@@ -125,7 +134,7 @@ describe("2 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -145,10 +154,10 @@ describe("3 columns", () => {
             ),
             /* eslint-disable */
             contentBeforeEdit:
-                columnsContainer(
-                    column(4, "<p>abcd</p>") +
-                    column(4, `<p><br></p>`) +
-                    column(4, `<p placeholder="Empty column" class="o-we-hint">[]<br></p>`)
+                columsDuringEditContainer(
+                    columnDuringEdit(4, "<p>abcd</p>") +
+                    columnDuringEdit(4, `<p><br></p>`) +
+                    columnDuringEdit(4, `<p placeholder="Empty column" class="o-we-hint">[]<br></p>`)
                 ),
             /* eslint-enable */
             stepFunction: columnize(3),
@@ -164,10 +173,10 @@ describe("3 columns", () => {
             stepFunction: columnize(3),
             /* eslint-disable */
             contentAfterEdit:
-                columnsContainer(
-                    column(4, "<p>ab[]cd</p>") +
-                    column(4, `<p><br></p>`) +
-                    column(4, `<p><br></p>`)
+                columsDuringEditContainer(
+                    columnDuringEdit(4, "<p>ab[]cd</p>") +
+                    columnDuringEdit(4, `<p><br></p>`) +
+                    columnDuringEdit(4, `<p><br></p>`)
                 ) + "<p><br></p>",
             contentAfter:
                 columnsContainer(
@@ -218,7 +227,7 @@ describe("3 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-4"><p>ab[]cd</p></div><div class="col-4"><p><br></p></div><div class="col-4"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-4 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p><br></p></div><div class="col-4 o-contenteditable-true" contenteditable="true"><p><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -304,7 +313,7 @@ describe("4 columns", () => {
 
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-3"><p>ab[]cd</p></div><div class="col-3"><p><br></p></div><div class="col-3"><p><br></p></div><div class="col-3"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-3 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p><br></p></div><div class="col-3 o-contenteditable-true" contenteditable="true"><p><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/columns");
@@ -374,7 +383,7 @@ describe("remove columns", () => {
         // add 2 columns
         await press("enter");
         expect(getContent(el)).toBe(
-            `<div class="container o_text_columns"><div class="row"><div class="col-6"><p>ab[]cd</p></div><div class="col-6"><p><br></p></div></div></div><p><br></p>`
+            `<div class="container o_text_columns o-contenteditable-false" contenteditable="false"><div class="row"><div class="col-6 o-contenteditable-true" contenteditable="true"><p>ab[]cd</p></div><div class="col-6 o-contenteditable-true" contenteditable="true"><p><br></p></div></div></div><p><br></p>`
         );
 
         await insertText(editor, "/removecolumns");
@@ -406,17 +415,17 @@ describe("complex", () => {
     test("should not add a container when one already exists", async () => {
         await testEditor({
             contentBefore:
-                '<div class="container"><div class="row"><div class="col">' +
+                '<div class="container o-contenteditable-false"><div class="row"><div class="col o-contenteditable-true">' +
                 "<p>ab[]cd</p>" +
                 "</div></div></div>",
             stepFunction: columnize(2),
             contentAfter:
-                '<div class="container"><div class="row"><div class="col">' +
-                '<div class="o_text_columns"><div class="row">' + // no "container" class
-                '<div class="col-6">' +
+                '<div class="container o-contenteditable-false"><div class="row"><div class="col o-contenteditable-true">' +
+                '<div class="o_text_columns o-contenteditable-false"><div class="row">' + // no "container" class
+                '<div class="col-6 o-contenteditable-true">' +
                 "<p>ab[]cd</p>" +
                 "</div>" +
-                '<div class="col-6"><p><br></p></div>' +
+                '<div class="col-6 o-contenteditable-true"><p><br></p></div>' +
                 "</div></div>" +
                 "<p><br></p>" +
                 "</div></div></div>",
@@ -449,6 +458,46 @@ describe("undo", () => {
             contentAfter:
                 columnsContainer(column(6, "<p>x[]</p>") + column(6, "<p><br></p>")) +
                 "<p><br></p>",
+        });
+    });
+});
+
+describe("selection", () => {
+    test("should be able to select across columns using Shift + ArrowUp", async () => {
+        await testEditor({
+            contentBefore: "<p>a</p><p>b[]</p>",
+            stepFunction: async (editor) => {
+                columnize(2)(editor);
+                const editable = editor.editable;
+                const children = editable.querySelectorAll("p");
+                const lastP = children[children.length - 1];
+                lastP.innerHTML = "ab";
+                setSelection({ anchorNode: lastP.firstChild, anchorOffset: 0 });
+                await press(["shift", "arrowUp"]);
+            },
+            contentAfter:
+                "<p>a]</p>" +
+                columnsContainer(column(6, "<p>b</p>") + column(6, "<p><br></p>")) +
+                "<p>[ab</p>",
+        });
+    });
+    test("should be able to select across columns using Shift + ArrowDown", async () => {
+        await testEditor({
+            contentBefore: "<p>a</p><p>b[]</p>",
+            stepFunction: async (editor) => {
+                columnize(2)(editor);
+                const editable = editor.editable;
+                const children = editable.querySelectorAll("p");
+                const lastP = children[children.length - 1];
+                lastP.innerHTML = "ab";
+                const firstP = children[0];
+                setSelection({ anchorNode: firstP.lastChild, anchorOffset: nodeSize(firstP) });
+                await press(["shift", "arrowDown"]);
+            },
+            contentAfter:
+                "<p>a[</p>" +
+                columnsContainer(column(6, "<p>b</p>") + column(6, "<p><br></p>")) +
+                "<p>]ab</p>",
         });
     });
 });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -1711,8 +1711,8 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteBackward,
             contentAfter: unformat(
                 `<table><tbody>
-                        <tr><td>cd</td><td>[]<br></td><td>gh</td></tr>
-                        <tr><td>ij</td><td><br></td><td>mn</td></tr>
+                        <tr><td>cd</td><td><p>[]<br></p></td><td>gh</td></tr>
+                        <tr><td>ij</td><td><p><br></p></td><td>mn</td></tr>
                         <tr><td>op</td><td>qr</td><td>st</td></tr>
                     </tbody></table>`
             ),

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -398,29 +398,29 @@ describe("deleteSelection", () => {
             test("should not remove bootstrap columns, but clear its content", async () => {
                 await testEditor({
                     contentBefore: unformat(
-                        `<div class="container o_text_columns">
+                        `<div class="container o_text_columns o-contenteditable-false">
                             <div class="row">
-                                <div class="col-6">a[bc</div>
-                                <div class="col-6">def</div>
+                                <div class="col-6 o-contenteditable-true">a[bc</div>
+                                <div class="col-6 o-contenteditable-true">def</div>
                             </div>
                         </div>
                         <p>gh]i</p>`
                     ),
                     stepFunction: deleteSelection,
                     contentAfterEdit: unformat(
-                        `<div class="container o_text_columns">
+                        `<div class="container o_text_columns o-contenteditable-false" contenteditable="false">
                             <div class="row">
-                                <div class="col-6">a[]</div>
-                                <div class="col-6"><br></div>
+                                <div class="col-6 o-contenteditable-true" contenteditable="true">a[]</div>
+                                <div class="col-6 o-contenteditable-true" contenteditable="true"><p><br></p></div>
                             </div>
                         </div>
                         <p>i</p>`
                     ),
                     contentAfter: unformat(
-                        `<div class="container o_text_columns">
+                        `<div class="container o_text_columns o-contenteditable-false">
                             <div class="row">
-                                <div class="col-6">a[]</div>
-                                <div class="col-6"><br></div>
+                                <div class="col-6 o-contenteditable-true">a[]</div>
+                                <div class="col-6 o-contenteditable-true"><p><br></p></div>
                             </div>
                         </div>
                         <p>i</p>`
@@ -431,10 +431,10 @@ describe("deleteSelection", () => {
                 await testEditor({
                     contentBefore: unformat(
                         `<p>x[yz</p>
-                        <div class="container o_text_columns">
+                        <div class="container o_text_columns o-contenteditable-false">
                             <div class="row">
-                                <div class="col-6">abc</div>
-                                <div class="col-6">def</div>
+                                <div class="col-6 o-contenteditable-true">abc</div>
+                                <div class="col-6 o-contenteditable-true">def</div>
                             </div>
                         </div>
                         <p>gh]i</p>`

--- a/addons/html_editor/static/tests/delete/delete_range.test.js
+++ b/addons/html_editor/static/tests/delete/delete_range.test.js
@@ -463,7 +463,7 @@ describe("deleteSelection", () => {
                     contentAfter: unformat(
                         `<table><tbody>
                             <tr>
-                                <td>[]<br></td> <td><br></td> <td>c</td> 
+                                <td><p>[]<br></p></td> <td><p><br></p></td> <td>c</td>
                             </tr>
                             <tr>
                                 <td>d</td> <td>e</td> <td>f</td> 

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1410,8 +1410,8 @@ describe("Selection not collapsed", () => {
             stepFunction: deleteForward,
             contentAfter: unformat(
                 `<table><tbody>
-                        <tr><td>cd</td><td>[]<br></td><td>gh</td></tr>
-                        <tr><td>ij</td><td><br></td><td>mn</td></tr>
+                        <tr><td>cd</td><td><p>[]<br></p></td><td>gh</td></tr>
+                        <tr><td>ij</td><td><p><br></p></td><td>mn</td></tr>
                         <tr><td>op</td><td>qr</td><td>st</td></tr>
                     </tbody></table>`
             ),

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -429,8 +429,8 @@ describe("not collapsed selection", () => {
             },
             contentAfter: unformat(
                 `<table><tbody>
-                        <tr><td>cd</td><td><span class="a">TEST</span>[]</td><td>gh</td></tr>
-                        <tr><td>ij</td><td><br></td><td>mn</td></tr>
+                        <tr><td>cd</td><td><p><span class="a">TEST</span>[]</p></td><td>gh</td></tr>
+                        <tr><td>ij</td><td><p><br></p></td><td>mn</td></tr>
                         <tr><td>op</td><td>qr</td><td>st</td></tr>
                     </tbody></table>`
             ),


### PR DESCRIPTION
**Current behavior before PR:**

- Pressing backspace while a column is selected could cause the column hint to be incorrectly positioned. This happened because the base container inside the column was removed during the backspace action.
- When a table row or column was not fully selected, pressing Backspace would replace the contents of the selected `td` elements with a `br` tag.

**Desired behavior after PR is merged:**

- If the base container is removed during backspace, it is now reinserted to ensure the column hint remains correctly positioned.
- Pressing Backspace in a partially selected row or column now replaces the content of the selected `td` elements with a base container instead of a `br` tag.

task:4783325
