### PR TITLE
[FIX] web: prevent error when rendering a non-existent view

### DIFF
--- a/addons/board/static/tests/board_test.js
+++ b/addons/board/static/tests/board_test.js
@@ -737,8 +737,7 @@ QUnit.module("Board", (hooks) => {
                     doAction(action) {
                         assert.step("do action");
                         assert.deepEqual(action.views, [
-                            [false, "list"],
-                            [false, "form"],
+                            [false, "list"]
                         ]);
                     },
                 };

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -743,14 +743,17 @@ export class GraphRenderer extends Component {
             }
         });
 
-        const views = {};
-        for (const [viewId, viewType] of this.env.config.views || []) {
-            views[viewType] = viewId;
-        }
-        function getView(viewType) {
-            return [views[viewType] || false, viewType];
-        }
-        const actionViews = [getView("list"), getView("form")];
+        // Retrieve form and list view ids from the action
+        // Always include 'list'; include 'form' only if it exists in the views
+        const { views = [] } = this.env.config;
+
+        const actionViews = ["list"]
+            .concat(views.some(view => view[1] === "form") ? ["form"] : [])
+            .map((viewType) => {
+                const view = views.find((view) => view[1] === viewType);
+                return [view ? view[0] : false, viewType];
+            });
+
         this.openView(domain, actionViews, context);
     }
 

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -225,11 +225,15 @@ export class PivotRenderer extends Component {
         });
 
         // retrieve form and list view ids from the action
+        // Always include 'list'; include 'form' only if it exists in the views
         const { views = [] } = this.env.config;
-        this.views = ["list", "form"].map((viewType) => {
-            const view = views.find((view) => view[1] === viewType);
-            return [view ? view[0] : false, viewType];
-        });
+
+        this.views = ["list"]
+            .concat(views.some(view => view[1] === "form") ? ["form"] : [])
+            .map((viewType) => {
+                const view = views.find((view) => view[1] === viewType);
+                return [view ? view[0] : false, viewType];
+            });
 
         const group = {
             rowValues: cell.groupId[0],

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -615,6 +615,91 @@ QUnit.module("Views", (hooks) => {
         await click(target.querySelectorAll(".o_pivot_cell_value")[1]); // should trigger a do_action
     });
 
+    QUnit.test("clicking on a cell triggers do_action with form view present", async function (assert) {
+        assert.expect(1);
+
+        serverData.views = {
+            "partner,2,form": "<form/>",
+        }
+
+        serviceRegistry.add(
+            "action",
+            {
+                start() {
+                    return {
+                        doAction(action) {
+                            assert.deepEqual(
+                                action.views,
+                                [
+                                    [false, "list"],
+                                    [false, "form"],
+                                ],
+                            );
+                            return Promise.resolve(true);
+                        },
+                    };
+                },
+            },
+            { force: true }
+        );
+
+        await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <pivot string="Partners">
+                    <field name="product_id" type="row"/>
+                    <field name="foo" type="measure"/>
+                </pivot>`,
+            config: {
+                views: [
+                    [false, "form"],
+                ],
+            },
+        });
+
+        await click(target.querySelectorAll(".o_pivot_cell_value")[0]);
+    });
+
+
+    QUnit.test("clicking on a cell triggers do_action without form view", async function (assert) {
+        assert.expect(1);
+
+        serviceRegistry.add(
+            "action",
+            {
+                start() {
+                    return {
+                        doAction(action) {
+                            assert.deepEqual(
+                                action.views,
+                                [
+                                    [false, "list"],
+                                ],
+                            );
+                            return Promise.resolve(true);
+                        },
+                    };
+                },
+            },
+            { force: true }
+        );
+
+        await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <pivot string="Partners">
+                    <field name="product_id" type="row"/>
+                    <field name="foo" type="measure"/>
+                </pivot>`,
+        });
+
+        await click(target.querySelectorAll(".o_pivot_cell_value")[0]);
+    });
+
     QUnit.test("row and column are highlighted when hovering a cell", async function (assert) {
         assert.expect(11);
 


### PR DESCRIPTION
This error occurs in 18.2 when a user creates a course record for any attendee.

Steps to Reproduce:
 - Install the website_slide module.
 - Go to Reporting > Attendees.
 - Go to either the Graph or Pivot View and click on any count value.
 - Open any attendee record and click on New.

SyntaxError: syntax error at or near ")"
LINE 18:             WHERE SCP.id IN ()
                                      ^

This error occurs because when the user clicks on New to create the attendee's course record, the system triggers the compute method before saving the record. Since the record has not been saved yet, the self.id is empty, which causes the error.

In the list and kanban views, clicking on any attendee record does not open any form view. However, in the graph and pivot views, clicking on an attendee record opens a form view that does not exist, resulting in an error.

This commit ensures that if the form view is present, it will be included in the graph and pivot views. The list view is always included to display the records. The form view may contain computed methods, which can lead to errors if the view is not properly defined.

Sentry-6465821899

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
