### PR TITLE
[FIX] l10n_in_hr_holidays: access error in approved timeoff IN

### DIFF
--- a/addons/l10n_in_hr_holidays/models/hr_leave.py
+++ b/addons/l10n_in_hr_holidays/models/hr_leave.py
@@ -71,8 +71,8 @@ class HolidaysRequest(models.Model):
                 days, hours = result[leave.id]
                 updated_days = leave._l10n_in_apply_sandwich_rule(public_holidays, leaves_by_employee.get(leave.employee_id, []))
                 result[leave.id] = (updated_days, hours)
-                if updated_days:
+                if updated_days and leave.state not in ['validate', 'validate1']:
                     leave.l10n_in_contains_sandwich_leaves = updated_days != days
-            else:
+            elif leave.state not in ['validate', 'validate1']:
                 leave.l10n_in_contains_sandwich_leaves = False
         return result

--- a/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
+++ b/addons/l10n_in_hr_holidays/tests/test_sandwich_leave.py
@@ -9,15 +9,27 @@ class TestSandwichLeave(TransactionCase):
 
     def setUp(self):
         super().setUp()
+        self.indian_company = self.env['res.company'].create({
+            'name': 'Test Indian Company',
+            'country_id': self.env.ref('base.in').id
+        })
+
+        self.demo_user = self.env['res.users'].with_company(self.indian_company).create({
+            'name': 'Piyush User',
+            'login': 'piyush_user',
+            'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
+        })
+
+        self.demo_employee = self.env['hr.employee'].with_company(self.indian_company).create({
+            'name': 'Piyush',
+            'user_id': self.demo_user.id,
+        })
+
         self.leave_type = self.env['hr.leave.type'].create({
             'name': 'Test Leave Type',
             'request_unit': 'day',
             'l10n_in_is_sandwich_leave': True,
-        })
-
-        self.rahul_emp = self.env['hr.employee'].create({
-            'name': 'Rahul',
-            'country_id': self.env.ref('base.in').id,
+            'company_id': self.indian_company.id,
         })
 
     def test_sandwich_leave(self):
@@ -27,23 +39,23 @@ class TestSandwichLeave(TransactionCase):
                 'date_from': '2023-08-15',
                 'date_to': '2023-08-15',
                 'resource_id': False,
-                'company_id': self.env.company.id,
+                'company_id': self.indian_company.id,
             })
             before_holiday_leave = self.env['hr.leave'].create({
                 'name': 'Test Leave',
-                'employee_id': self.rahul_emp.id,
+                'employee_id': self.demo_employee.id,
                 'holiday_status_id': self.leave_type.id,
                 'request_date_from': "2023-08-14",
                 'request_date_to': "2023-08-14",
             })
             employee_leaves = self.env['hr.leave'].search([
-                ('employee_id', '=', self.rahul_emp.id),
+                ('employee_id', '=', self.demo_employee.id),
                 ('state', 'not in', ['cancel', 'refuse']),
                 ('leave_type_request_unit', '=', 'day'),
             ])
             after_holiday_leave = self.env['hr.leave'].create({
                 'name': 'Test Leave',
-                'employee_id': self.rahul_emp.id,
+                'employee_id': self.demo_employee.id,
                 'holiday_status_id': self.leave_type.id,
                 'request_date_from': "2023-08-16",
                 'request_date_to': "2023-08-16",
@@ -53,3 +65,15 @@ class TestSandwichLeave(TransactionCase):
             self.assertEqual(leave, 1, "The total leaves should be 1")
             sandwiched_leave = after_holiday_leave._l10n_in_apply_sandwich_rule(public_holiday, employee_leaves)
             self.assertEqual(sandwiched_leave, 2, "The total leaves should be 2 including sandwich leave")
+
+    def test_approved_leave_does_not_raise_access_error(self):
+        approved_leave = self.env['hr.leave'].create({
+            'name': 'Approved Sandwich Leave',
+            'employee_id': self.demo_employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'request_date_from': '2025-08-14',
+            'request_date_to': '2025-08-18',
+            'state': 'confirm',
+        })
+        approved_leave.action_approve()
+        self.assertIsNotNone(approved_leave.with_user(self.demo_user).leave_type_increases_duration)


### PR DESCRIPTION
**Steps to reproduce:**
1. Install l10n_in_hr_holidays and l10n_in
2. Switch to IN company
3. Create an employee related to Marc Demo in IN Company
4. Log in with Marc Demo and create a timeoff
5. Approve the timeoff by Mitchel admin
6. Open the form view of approved timeoff by Marc Demo

**Issue:**
- The _get_durations method in l10n_in_hr_holidays attempts to update the
  l10n_in_contains_sandwich_leaves field whenever it runs, including when opening
  the form view of an approved time off. This causes an access error,
  as updates are not allowed for Marc demo in the approved state.

**Solution:**
- Added a state check in the _get_durations method to
  prevent updating the field for approved records.

opw-4741162