### PR TITLE
[FIX] website_sale: preserve combo product structure during reorder from portal

### DIFF
--- a/addons/website_sale/controllers/reorder.py
+++ b/addons/website_sale/controllers/reorder.py
@@ -11,6 +11,30 @@ class CustomerPortal(sale_portal.CustomerPortal):
     def _sale_reorder_get_line_context(self):
         return {}
 
+    def _get_common_order_line_data(self, line, add_to_cart_allowed=True):
+        combination = (
+            line.product_id.product_template_attribute_value_ids
+            | line.product_no_variant_attribute_value_ids
+        )
+        return {
+            'product_template_id': line.product_id.product_tmpl_id.id,
+            'product_id': line.product_id.id,
+            'combination': combination.ids,
+            'no_variant_attribute_value_ids': line.product_no_variant_attribute_value_ids.ids,
+            'product_custom_attribute_values': [
+                {
+                    'custom_product_template_attribute_value_id': pcav.custom_product_template_attribute_value_id.id,
+                    'custom_value': pcav.custom_value,
+                }
+                for pcav in line.product_custom_attribute_value_ids
+            ],
+            'qty': line.product_uom_qty,
+            'combinationInfo': line.product_id.product_tmpl_id.with_context(
+                **self._sale_reorder_get_line_context()
+            )._get_combination_info(combination, line.product_id.id, line.product_uom_qty)
+            if add_to_cart_allowed else {},
+        }
+
     @route('/my/orders/reorder_modal_content', type='json', auth='public', website=True)
     def my_orders_reorder_modal_content(self, order_id, access_token):
         try:
@@ -24,34 +48,27 @@ class CustomerPortal(sale_portal.CustomerPortal):
             'products': [],
         }
         for line in sale_order.order_line:
-            if line.display_type:
+            if not line._show_in_cart():
                 continue
-            if line._is_delivery():
-                continue
-            combination = line.product_id.product_template_attribute_value_ids | line.product_no_variant_attribute_value_ids
+
+            selected_combo_items = []
+            if line.product_id.type == 'combo':
+                for linked_line in line.linked_line_ids.filtered('combo_item_id'):
+                    selected_combo_items.append({
+                        **self._get_common_order_line_data(linked_line),
+                        'combo_item_id': linked_line.combo_item_id.id,
+                    })
+
+            add_to_cart_allowed = line.with_user(request.env.user).sudo()._is_reorder_allowed()
             res = {
-                'product_template_id': line.product_id.product_tmpl_id.id,
-                'product_id': line.product_id.id,
-                'combination': combination.ids,
-                'no_variant_attribute_value_ids': line.product_no_variant_attribute_value_ids.ids,
-                'product_custom_attribute_values': [
-                    { # Same input format as provided by product configurator
-                        'custom_product_template_attribute_value_id': pcav.custom_product_template_attribute_value_id.id,
-                        'custom_value': pcav.custom_value,
-                    } for pcav in line.product_custom_attribute_value_ids
-                ],
+                **self._get_common_order_line_data(line, add_to_cart_allowed),
                 'type': line.product_id.type,
                 'name': line.name_short,
                 'description_sale': line.product_id.description_sale or '' + line._get_sale_order_line_multiline_description_variants(),
-                'qty': line.product_uom_qty,
-                'add_to_cart_allowed': line.with_user(request.env.user).sudo()._is_reorder_allowed(),
+                'add_to_cart_allowed': add_to_cart_allowed,
                 'has_image': bool(line.product_id.image_128),
+                'selected_combo_items': selected_combo_items,
             }
-            if res['add_to_cart_allowed']:
-                res['combinationInfo'] = line.product_id.product_tmpl_id.with_context(
-                    **self._sale_reorder_get_line_context()
-                )._get_combination_info(combination, res['product_id'], res['qty'])
-            else:
-                res['combinationInfo'] = {}
+
             result['products'].append(res)
         return result

--- a/addons/website_sale/static/src/xml/website_sale_reorder_modal.xml
+++ b/addons/website_sale/static/src/xml/website_sale_reorder_modal.xml
@@ -24,6 +24,20 @@
                             <td t-att-colspan="product.has_image ? '1' : '2'">
                                 <h5><t t-esc="product.name"/></h5>
                                 <span class="text-muted d-none d-md-inline-block" t-if="product.description_sale" t-out="product.description_sale"/>
+                                <ul
+                                    t-if="product.selected_combo_items.length"
+                                    class="list-unstyled mb-0 small text-muted mt-1"
+                                >
+                                    <t
+                                        t-foreach="product.selected_combo_items"
+                                        t-as="comboItem"
+                                        t-key="comboItem.combo_item_id"
+                                    >
+                                        <li>
+                                            <t t-esc="product.qty"/> x <t t-esc="comboItem.combinationInfo.display_name"/>
+                                        </li>
+                                    </t>
+                                </ul>
                             </td>
                             <t t-if="product.add_to_cart_allowed">
                                 <td class="text-center td-qty">

--- a/addons/website_sale_stock/controllers/reorder.py
+++ b/addons/website_sale_stock/controllers/reorder.py
@@ -17,4 +17,6 @@ class CustomerPortal(reorder.CustomerPortal):
         result = super().my_orders_reorder_modal_content(order_id, access_token)
         for product in result['products']:
             product['is_storable'] = request.env['product.product'].browse(product['product_id']).is_storable
+            for combo_item in product['selected_combo_items']:
+                combo_item['is_storable'] = request.env['product.product'].browse(combo_item['product_id']).is_storable
         return result


### PR DESCRIPTION
Steps to Reproduce:
- Install `website_sale_stock` and enable the Reorder from portal feature.
- Place an order from `/shop` that includes one or more combo products.
- Navigate to `/my/orders` and attempt to reorder the same.
- Combo products are broken into separate lines rather than shown as a single combo.
- Stock information for the combo is not available, as the items are treated independently.

Issue:
- Combo products are displayed as separate lines in reorder modal
- Also stock management of combo products is not there

Cause:
- The `/my/orders/reorder_modal_content` controller route lacks logic to handle combo products. The reorder modal builds the cart lines assuming all items are standalone, disregarding combo grouping and related stock aggregation.

Solution:
- Extend the `/my/orders/reorder_modal_content` route logic to correctly identify and process combo products as single bundled entities.
- Update the reorder modal in `website_sale_stock` to incorporate combo-specific stock handling, ensuring accurate availability feedback for the entire combo.
- This ensures that the reorder experience mirrors the original order composition and improves stock visibility for bundled products.

opw-4731014
Affected Version-18.0