### PR TITLE
[FIX] website_sale: allow portal order confirm without online payment

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -82,7 +82,13 @@ class SaleOrder(models.Model):
 
     def _compute_require_signature(self):
         website_orders = self.filtered('website_id')
-        website_orders.require_signature = False
+        for company, carts in website_orders.grouped('company_id').items():
+            # disable signature by default for website orders
+            # unless online payment is disabled, to still allow for order confirmation
+            carts.require_signature = (
+                not company.portal_confirmation_pay
+                and company.portal_confirmation_sign
+            )
         super(SaleOrder, self - website_orders)._compute_require_signature()
 
     def _compute_payment_term_id(self):


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Go to Sales settings;
2. ensure Online Signature is enabled;
3. disable Online Payment;
4. create an order via eCommerce;
5. go to portal preview.

Issue
-----
No sign and/or pay button that would allow the customer to confirm their order.

Cause
-----
Commit 880cd7a516147 disabled signatures for all eCommerce orders, as it could lead to customers getting an email to sign the quote, confirming the order, and triggering delivery without payment.

As a consequence, with online payment disabled, there's no longer a way for customers to confirm their order.

Solution
--------
Disable signatures for eCommerce orders if online payment is enabled.

opw-4739013