### PR TITLE
[PERF] im_livechat: improve report performances

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_1_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(months=-1)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_1_guest_demo" model="mail.guest">
             <field name="name">Visitor #301</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_2_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(weeks=-2)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_2_guest_demo" model="mail.guest">
             <field name="name">Visitor #302</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_3_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(days=-10)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_3_guest_demo" model="mail.guest">
             <field name="name">Visitor #303</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_4_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(days=-7)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_4_guest_demo" model="mail.guest">
             <field name="name">Visitor #304</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_5_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(days=-5)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_5_guest_demo" model="mail.guest">
             <field name="name">Visitor #305</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_6_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(days=-6)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_6_guest_demo" model="mail.guest">
             <field name="name">Visitor #306</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
@@ -14,6 +14,7 @@
             <field name="channel_id" ref="support_bot_session_7_demo"/>
             <field name="last_interest_dt" eval="DateTime.today() + relativedelta(days=-6)"/>
             <field name="livechat_member_type">bot</field>
+            <field name="chatbot_script_id" ref="chatbot_script_support_bot_demo"/>
         </record>
         <record id="support_bot_session_7_guest_demo" model="mail.guest">
             <field name="name">Visitor #307</field>

--- a/addons/im_livechat/models/chatbot_message.py
+++ b/addons/im_livechat/models/chatbot_message.py
@@ -15,10 +15,10 @@ class ChatbotMessage(models.Model):
     _order = 'create_date desc, id desc'
     _rec_name = 'discuss_channel_id'
 
-    mail_message_id = fields.Many2one('mail.message', string='Related Mail Message', required=True, ondelete="cascade")
+    mail_message_id = fields.Many2one('mail.message', string='Related Mail Message')
     discuss_channel_id = fields.Many2one('discuss.channel', string='Discussion Channel', required=True, index=True, ondelete="cascade")
     script_step_id = fields.Many2one(
-        'chatbot.script.step', string='Chatbot Step', required=True, ondelete='cascade')
+        "chatbot.script.step", string="Chatbot Step", index="btree_not_null")
     user_script_answer_id = fields.Many2one('chatbot.script.answer', string="User's answer", ondelete="set null")
     user_raw_script_answer_id = fields.Integer(help="Id of the script answer. Useful for statistics when answer is deleted.")
     user_raw_answer = fields.Html(string="User's raw answer")
@@ -26,4 +26,7 @@ class ChatbotMessage(models.Model):
     __unique_mail_message_id = models.Constraint(
         'unique (mail_message_id)',
         'A mail.message can only be linked to a single chatbot message',
+    )
+    _channel_id_user_raw_script_answer_id_idx = models.Index(
+        "(discuss_channel_id, user_raw_script_answer_id) WHERE user_raw_script_answer_id IS NOT NULL",
     )

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -89,6 +89,9 @@ class DiscussChannel(models.Model):
     _livechat_is_escalated_idx = models.Index(
         "(livechat_is_escalated) WHERE livechat_is_escalated IS TRUE"
     )
+    _livechat_channel_type_create_date_idx = models.Index(
+        "(channel_type, create_date) WHERE channel_type = 'livechat'"
+    )
 
     @api.depends('message_ids')
     def _compute_duration(self):


### PR DESCRIPTION
This commit optimizes the channel report query by replacing inefficient
CTEs with lateral joins. The previous CTE implementation lacked initial
filtering, processing all rows. This change introduces lateral joins,
enabling efficient filtering: first for live chat channels and, for
the default report, focusing on the significantly smaller dataset of
last month's live chats. This significantly improves efficiency.

Testing on a large dataset (1.6M+ channels, 600K+ live chats, ~20M messages)
shows a significant speedup, from approximately 30 seconds down to around
2 seconds after refactoring.

https://github.com/odoo/enterprise/pull/85164