### PR TITLE
[FIX] sale_project: do not raise an error when create SO from billable project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -300,3 +300,9 @@ class SaleOrder(models.Model):
     def _compute_completed_task_percentage(self):
         for so in self:
             so.completed_task_percentage = so.tasks_count and so.closed_task_count / so.tasks_count
+
+    def action_confirm(self):
+        if len(self) == 1 and self.env.context.get('create_for_project_id') and self.state == 'sale':
+            # do nothing since the SO has been automatically confirmed during its creation
+            return True
+        return super().action_confirm()


### PR DESCRIPTION
Before this commit, when the user clicks on `Make Billable` stat button displayed in the project form view when there is not yet any SO set on that project and directly confirm the SO, a user error is raised because the SO is already confirmed after executing confirm action of that button clicked. The reason is because in that case, the SO is automatically confirmed during the creation of that SO which means the action_confirm could be called 2 times in that use case, one during the save (creation) and another one because the user clicks on `Confirm` button.

This commit makes sure the action_confirm does nothing if the SO is already confirmed and we are in the context in which the user creates the SO via the stat button in project.

Steps to reproduce
------------------
0. install sale_project or sale_timesheet modules
1. Go to Projects > Confirmation > Projects
2. Click on `New` button to create a new project
3. Enable `Billable` feature if it is not already the case by default
4. Add a customer to the project
5. Click on `Make Billable` stat button
6. Add a service product on the SO to create
7. Click on `Confirm` button.

Expected behavior
-----------------

The SO should be created and confirmed without any issues

Current Behavior
----------------

A user error is raised because the SO is already confirmed before executing the action for the button clicked.

task-4781751
