### PR TITLE
[FIX] mail: make discuss message bubble rounder

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -96,6 +96,30 @@ $o-discuss-talkingColor: lighten($success, 10%);
     text-decoration: underline;
 }
 
+.o-rounded-bubble {
+    border-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+}
+
+.o-rounded-top-bubble {
+    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+}
+
+.o-rounded-end-bubble {
+    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+}
+
+.o-rounded-bottom-bubble {
+    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+}
+
+.o-rounded-start-bubble {
+    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+}
+
 .o-text-white {
     color: #FFF !important;
 }

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -14,7 +14,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: rgba(lighten(mix($gray-100, $info, 87.5%), 2.5%), .5) !important;
+        border-color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
@@ -22,7 +22,7 @@
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: rgba(lighten(mix($gray-100, $success, 87.5%), 2.5%), .5) !important;
+        border-color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
@@ -30,10 +30,37 @@
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: rgba(lighten(mix($gray-100, $warning, 72.5%), 2.5%), .5) !important;
+        border-color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;
+        }
+    }
+}
+
+.o-mail-Message-bubbleTail {
+     &.o-blue {
+        .o-mail-Message-bubbleTailBg {
+            color:mix($gray-100, $info, 87.5%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black) !important;
+        }
+    }
+    &.o-green {
+        .o-mail-Message-bubbleTailBg {
+            color: mix($gray-100, $success, 87.5%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black) !important;
+        }
+    }
+    &.o-orange {
+        .o-mail-Message-bubbleTailBg {
+            color: mix($gray-100, $warning, 72.5%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -226,7 +226,8 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
-            "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-secondary rounded-3": this.props.asCard,
+            "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-secondary shadow-sm rounded-3":
+                this.props.asCard,
             "pt-1": !this.props.asCard && !this.props.squashed,
             "o-pt-0_5": !this.props.asCard && this.props.squashed,
             "o-selfAuthored": this.message.isSelfAuthored && !this.env.messageCard,

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -84,7 +84,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: rgba(darken(mix($o-view-background-color, $info, 87.5%), 10%), .5) !important;
+        border-color: mix(darken(mix($o-view-background-color, $info, 87.5%), 10%), white, 75%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
@@ -92,7 +92,7 @@
     }
     &.o-green {
         background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: rgba(darken(mix($o-view-background-color, $success, 87.5%), 10%), .5) !important;
+        border-color: mix(darken(mix($o-view-background-color, $success, 87.5%), 10%), white, 75%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
@@ -100,10 +100,42 @@
     }
     &.o-orange {
         background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: rgba(darken(mix($o-view-background-color, $warning, 75%), 10%), .5) !important;
+        border-color: mix(darken(mix($o-view-background-color, $warning, 75%), 10%), white, 75%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
+        }
+    }
+}
+
+.o-mail-Message-bubbleTail {
+    width: 6px;
+    height: 12px;
+    z-index: 1;
+    top: 0;
+
+    &.o-blue {
+        .o-mail-Message-bubbleTailBg {
+            color: mix($o-view-background-color, $info, 87.5%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(darken(mix($o-view-background-color, $info, 87.5%), 10%), white, 75%) !important;
+        }
+    }
+    &.o-green {
+        .o-mail-Message-bubbleTailBg {
+            color: mix($o-view-background-color, $success, 87.5%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(darken(mix($o-view-background-color, $success, 87.5%), 10%), white, 75%) !important;
+        }
+    }
+    &.o-orange {
+        .o-mail-Message-bubbleTailBg {
+            color: mix($o-view-background-color, $warning, 75%) !important;
+        }
+        .o-mail-Message-bubbleTailBorder {
+            color: mix(darken(mix($o-view-background-color, $warning, 75%), 10%), white, 75%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -69,10 +69,10 @@
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
-                                                    'rounded-3': props.squashed,
-                                                    'rounded-bottom-3': !props.squashed,
-                                                    'rounded-start-3': !props.squashed and isAlignedRight,
-                                                    'rounded-end-3': !props.squashed and !isAlignedRight,
+                                                    'o-rounded-bubble': props.squashed,
+                                                    'o-rounded-bottom-bubble': !props.squashed,
+                                                    'o-rounded-start-bubble': !props.squashed and isAlignedRight,
+                                                    'o-rounded-end-bubble': !props.squashed and !isAlignedRight,
                                                     'o-blue': message.bubbleColor === 'blue',
                                                     'o-green': message.bubbleColor === 'green',
                                                     'o-orange': message.bubbleColor === 'orange',
@@ -85,8 +85,8 @@
                                                             'py-2': !message.is_note and !state.isEditing,
                                                             'pt-2 pb-1': !message.is_note and state.isEditing,
                                                             'o-note': message.is_note,
-                                                            'rounded-3': props.squashed,
-                                                            'align-self-start rounded-end-3 rounded-bottom-3': !state.isEditing and !message.is_note and !props.squashed,
+                                                            'o-rounded-bubble': props.squashed,
+                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !state.isEditing and !message.is_note and !props.squashed,
                                                             'flex-grow-1': state.isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-esc="message.inlineBody"/>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -67,6 +67,16 @@
                                     <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or state.isEditing or message.edited))">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="false"/>
                                         <t t-else="">
+                                            <div t-if="message.bubbleColor and !props.squashed" class="o-mail-Message-bubbleTail position-absolute d-flex" t-att-style="isAlignedRight ? 'right: -4px; transform: rotateY(180deg);' : 'left: -4px;'" t-att-class="{
+                                                'o-blue': message.bubbleColor === 'blue',
+                                                'o-green': message.bubbleColor === 'green',
+                                                'o-orange': message.bubbleColor === 'orange',
+                                            }">
+                                                <svg viewBox="0 0 6 12" height="12" width="6" x="0px" y="0px">
+                                                    <path class="o-mail-Message-bubbleTailBorder" fill="currentColor" d="M 0, 0 L 5, 9 V 0 z"/>
+                                                    <path class="o-mail-Message-bubbleTailBg" fill="currentColor" d="M 2, 1 L 5, 7 V 1 z"/>
+                                                </svg>
+                                            </div>
                                             <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-rounded-bubble': props.squashed,


### PR DESCRIPTION
Before this commit, the roundness of message bubble was 6px. Messaging app competitors have rounded bubble at about 7.5px which looks better than Odoo discuss ones.

This commit increases the roundness of discuss bubble to 7.5px, thanks to newly introduced `.o-rounded-bubble` classnames.
