### PR TITLE
[FIX] point_of_sale: skip printing steps if no printing device

### DIFF
--- a/addons/point_of_sale/static/src/app/services/printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/printer_service.js
@@ -40,6 +40,10 @@ export class PrinterService extends Reactive {
         };
     }
     async print(component, props, options) {
+        if (!this.device && !options?.webPrintFallback) {
+            console.log("No printer device available and webPrintFallback is not enabled");
+            return;
+        }
         this.state.isPrinting = true;
         const el = await this.renderer.toHtml(component, props);
         try {


### PR DESCRIPTION
the code that tried to print would do some preparation (render a full
component node, load related images) witout checking if there even was a
device to print the ticket.

The preparation steps (specifically loading images), could be a source
of indeteriminism when running test tours since we don't await properly
the printing step (see
https://github.com/odoo/odoo/pull/201578/files#diff-10ebe5a60b7906fdb3a686b58676079783540b2c91b3423faadc27a0267ba393R33)

the revision cuts short the printing when there is no printing device
and therefore avoids the tests issues.

runbot errors:
https://runbot.odoo.com/odoo/error/181566
https://runbot.odoo.com/odoo/error/160941
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
