### PR TITLE
[REF] point_of_sale: extract orderline quantity change logic

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -129,6 +129,14 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
     get items() {
         return this.currentOrder.orderlines?.reduce((items, line) => items + line.quantity, 0) ?? 0;
     }
+    handleOrderLineQuantityChange(selectedLine, buffer, currentQuantity, lastId) {
+        const parsedInput = (buffer && parseFloat(buffer)) || 0;
+        if (lastId != selectedLine.cid || parsedInput < currentQuantity) {
+            this._showDecreaseQuantityPopup();
+        } else if (currentQuantity < parsedInput) {
+            this._setValue(buffer);
+        }
+    }
     async updateSelectedOrderline({ buffer, key }) {
         const order = this.pos.get_order();
         const selectedLine = order.get_selected_orderline();
@@ -166,14 +174,7 @@ export class ProductScreen extends ControlButtonsMixin(Component) {
                 });
                 return;
             }
-            const parsedInput = (buffer && parseFloat(buffer)) || 0;
-            if (lastId != selectedLine.cid) {
-                this._showDecreaseQuantityPopup();
-            } else if (currentQuantity < parsedInput) {
-                this._setValue(buffer);
-            } else if (parsedInput < currentQuantity) {
-                this._showDecreaseQuantityPopup();
-            }
+            this.handleOrderLineQuantityChange(selectedLine, buffer, currentQuantity, lastId);
             return;
         } else if (
             selectedLine &&


### PR DESCRIPTION
Moved quantity update logic into `handleOrderLineQuantityChange`for better readability, reuse and overrides.

task-id: 4771749

enterprise PR: https://github.com/odoo/enterprise/pull/85137



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
