### PR TITLE
[FIX] account: skip origin tax on repartition tax line

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1962,7 +1962,7 @@ class AccountTax(models.Model):
                 if include_caba_tags or tax.tax_exigibility == 'on_invoice':
                     tax_rep_data['tax_tags'] = tax_rep.tag_ids
                 if tax.include_base_amount:
-                    tax_rep_data['taxes'] |= subsequent_taxes
+                    tax_rep_data['taxes'] |= subsequent_taxes - tax
                     for other_tax, tags in subsequent_tags_per_tax.items():
                         if tax != other_tax:
                             tax_rep_data['tax_tags'] |= tags


### PR DESCRIPTION
Steps to reproduce:
- Have a [TAX] configured with:
  - Affect Base of Subsequent Taxes: True
  - Base Affected by Previous Taxes: True
  - Tax Exigibility: Based on payment
  - Distribution for invoices:
    - Base, Tax grids: +A, +B
    - 100% of tax, Tax grids: +C
    - -100% of tax, Tax grids: -D, -E
  - Distribution for refunds:
    - Base, Tax grids: -A, -B
    - 100% of tax, Tax grids: -C
    - -100% of tax, Tax grids: +D, +E
- Create a BILL with [TAX]
- Create a matching Bank statement and reconcile with BILL
- Check the created Cash Basis Entry

Issue:

VAT line will feature base tags +A, +B in addition to the tax tags +C
This occurs because in the source bill 2 tax lines are created, the first one got the origin tax assigned
When the cash basis move is created the tax tags will be taken also from that tax

opw-4729298