### PR TITLE
[FIX] hr_holidays: give correct label to delete button based on the leave state

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.js
@@ -28,6 +28,10 @@ export class TimeOffCalendarCommonPopover extends CalendarCommonPopover {
         return this.state !== undefined;
     }
 
+    get canCancel() {
+        return this.record.can_cancel;
+    }
+
     async onClickButton(ev) {
         const args = (ev.target.name === "action_approve") ? [this.record.id, false] : [this.record.id];
         await this.orm.call("hr.leave", ev.target.name, args);

--- a/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.xml
+++ b/addons/hr_holidays/static/src/views/calendar/common/calendar_common_popover.xml
@@ -12,5 +12,11 @@
                 t-if="isManager and state !== 'refuse'"
                 name="action_refuse" t-on-click="onClickButton" data-hotkey="z">Refuse</button>
         </xpath>
+        <xpath expr="//a[contains(@class, 'o_cw_popover_delete')]" position="replace">
+            <a href="#" class="btn btn-secondary o_cw_popover_delete" t-on-click="onDeleteEvent">
+                <t t-if="canCancel">Cancel</t>
+                <t t-else="">Delete</t>
+            </a>
+        </xpath>
     </t>
 </templates>


### PR DESCRIPTION
**Steps to reproduce this issue:**

1) Install Time Off
2) Create an approved leave record
3) Click on the approved leave record in month mode(calendar view) 
4) The Delete button appears instead of the Cancel button

**Issue:-**

In the Time off dashboard, in the year view, if I click on a leave and open the popup, 
I can click on “Cancel” to cancel my leave

But this “Cancel” button appears as “Delete” in the month, week and day views. 
However, it does cancel the leave, not delete it.

**Solution:-**

This button should be renamed “Cancel” to be consistent with the system.

opw-4782277

