### PR TITLE
[FIX] web_editor: keep button editable when cleared

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2724,6 +2724,9 @@ export class OdooEditor extends EventTarget {
                     node.classList.add('o_editable_media');
                 } else {
                     node.setAttribute('contenteditable', true);
+                    if (!isBlock(node) && node.textContent === "\u200b") {
+                        node.setAttribute('data-oe-zws-empty-inline', '');
+                    }
                 }
             }
         }
@@ -4761,9 +4764,9 @@ export class OdooEditor extends EventTarget {
         const allWhitespaceRegex = /^[\s\u200b]*$/;
         for (const emptyElement of [...element.querySelectorAll('[data-oe-zws-empty-inline]')].reverse()) {
             emptyElement.removeAttribute('data-oe-zws-empty-inline');
+            const isEmptyArch = emptyElement.getAttribute("data-oe-field") === "arch" && emptyElement.textContent === "\u200b";
             if (
-                !allWhitespaceRegex.test(emptyElement.textContent) ||
-                emptyElement.hasAttribute("data-oe-field")
+                (!allWhitespaceRegex.test(emptyElement.textContent) || emptyElement.hasAttribute("data-oe-field")) && !isEmptyArch
             ) {
                 // Remove ZWS if the element is field or has meaningful text.
                 cleanZWS(emptyElement);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/odooFields.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/odooFields.test.js
@@ -29,4 +29,23 @@ describe('Odoo fields', () => {
             contentAfter: `<p><span data-oe-model="product.template" data-oe-id="27" data-oe-field="name" data-oe-type="char" data-oe-expression="product.name" data-oe-xpath="/t[1]/div[1]/h3[2]/span[1]" class="o_editable">[]</span><br></p>`,
         });
     });
+    it('should keep zero-width breaking space for empty inline editable', async () => {
+        testEditor(BasicEditor, {
+            contentBefore: '<div><span class="o_editable" data-oe-field="arch">\u200b</span></div>',
+            stepFunction: async editor => {
+                await editor.cleanForSave();
+                const cleanContent = editor.editable.innerHTML;
+                window.chai.assert.strictEqual(
+                    cleanContent,
+                    '<div><span class="o_editable" data-oe-field="arch" contenteditable="true">\u200b</span></div>'
+                );
+            },
+            contentAfter: '<div><span class="o_editable" data-oe-field="arch" contenteditable="true">\u200b</span></div>',
+        }, {
+            isRootEditable: false,
+            getContentEditableAreas: function (editor) {
+                return [...editor.editable.querySelectorAll('span')];
+            }
+        });
+    });
 });


### PR DESCRIPTION
Problem:
When the "Apply Now!" button text is deleted (e.g., on
`/jobs/experienced-developer-4`), it becomes uneditable after saving.

Cause:
When all text is deleted, a zero-width space (ZWS) is inserted with
the `data-oe-zws-empty-inline` attribute. This is removed
during the save process. Since the button has `data-oe-field="arch"`
and becomes empty, it is excluded from editable areas in
`_getContentEditableAreas`, making it uneditable after reload.

This worked in 17.0 due to inherited `display: block` from a floated
parent, which added a `<br>` in empty blocks.

Solution:
Preserve the ZWS for inline empty elements with
`data-oe-field="arch"`, ensuring the element remains editable after save.

Steps to reproduce:
1. Navigate to `/jobs/experienced-developer-4`.
2. Open the web editor.
3. Delete the text inside the "Apply Now!" button.
4. Save the page.
5. Reopen the web editor.
→ The button is no longer editable.

opw-4737255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
