### PR TITLE
[FIX] mail: show counter in discuss mobile navbar

### DIFF
--- a/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
+++ b/addons/im_livechat/static/src/core/public_web/messaging_menu_patch.js
@@ -14,6 +14,11 @@ patch(MessagingMenu.prototype, {
         );
         if (hasLivechats) {
             items.push({
+                counter: this.store.discuss.livechats.reduce(
+                    (acc, channel) =>
+                        channel.selfMember?.message_unread_counter > 0 ? acc + 1 : acc,
+                    0
+                ),
                 id: "livechat",
                 icon: "fa fa-commenting-o",
                 label: _t("Livechat"),

--- a/addons/mail/static/src/core/public_web/messaging_menu.js
+++ b/addons/mail/static/src/core/public_web/messaging_menu.js
@@ -125,11 +125,16 @@ export class MessagingMenu extends Component {
     get tabs() {
         return [
             {
+                counter: this.store.getDiscussSidebarCategoryCounter(this.store.discuss.chats.id),
                 icon: "fa fa-user",
                 id: "chat",
                 label: _t("Chat"),
             },
             {
+                channelHasUnread: Boolean(this.store.discuss.unreadChannels.length),
+                counter: this.store.getDiscussSidebarCategoryCounter(
+                    this.store.discuss.channels.id
+                ),
                 icon: "fa fa-users",
                 id: "channel",
                 label: _t("Channel"),

--- a/addons/mail/static/src/core/public_web/messaging_menu.scss
+++ b/addons/mail/static/src/core/public_web/messaging_menu.scss
@@ -18,6 +18,16 @@
     }
 }
 
+.o-mail-MessagingMenu-tabCounter, .o-mail-MessagingMenu-tabUnread {
+    transform: translate(80%, 50%) !important;
+}
+
+.o-discuss-badge.o-mail-MessagingMenu-tabUnread {
+    --o-discuss-badge-bg: #{transparent};
+    opacity: 50%;
+    color: unset !important;
+}
+
 .o_popover:has(.o-mail-MessagingMenu) {
     --popover-border-color: #{$secondary};
 }

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -52,13 +52,15 @@
         </div>
     </div>
     <div t-if="ui.isSmall" class="o-mail-MessagingMenu-navbar d-flex bg-view shadow-lg w-100 btn-group">
-        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent" t-att-class="{
+        <button t-foreach="tabs" t-key="tab.id" t-as="tab" class="o-mail-MessagingMenu-tab btn d-flex flex-column align-items-center flex-grow-1 flex-basis-0 p-2 mx-0 rounded-0 bg-transparent position-relative" t-att-class="{
             'text-primary fw-bold o-active': store.discuss.activeTab === tab.id,
             'pb-4': isIosPwa,
             'pb-2': !isIosPwa,
         }" t-on-click="() => this.onClickNavTab(tab.id)">
             <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
             <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
+            <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-esc="tab.counter"/>
+            <span t-elif="tab.channelHasUnread" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabUnread overflow-visible d-inline-block ms-2"><i class="fa fa-circle"/></span>
         </button>
     </div>
 </t>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -99,6 +99,7 @@ patch(MessagingMenu.prototype, {
     get tabs() {
         return [
             {
+                counter: this.env.inDiscussApp ? this.store.inbox.counter : undefined,
                 icon: this.env.inDiscussApp ? "fa fa-inbox" : "fa fa-envelope",
                 id: "main",
                 label: this.env.inDiscussApp ? _t("Mailboxes") : _t("All"),

--- a/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_app_model_patch.js
@@ -35,6 +35,7 @@ const discussAppPatch = {
             },
             eager: true,
         });
+        this.unreadChannels = Record.many("Thread", { inverse: "appAsUnreadChannels" });
     },
     computeChats() {
         return {

--- a/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/public_web/thread_model_patch.js
@@ -8,6 +8,11 @@ import { patch } from "@web/core/utils/patch";
 const threadPatch = {
     setup() {
         super.setup(...arguments);
+        this.appAsUnreadChannels = Record.one("DiscussApp", {
+            compute() {
+                return this.channel_type === "channel" && this.isUnread ? this.store.discuss : null;
+            },
+        });
         this.discussAppCategory = Record.one("DiscussAppCategory", {
             compute() {
                 return this._computeDiscussAppCategory();

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -291,7 +291,7 @@ test("mobile: mark as read when opening chat", async () => {
     await start();
     await openDiscuss();
     await contains("button.active", { text: "Inbox" });
-    await click("button", { text: "Chat" });
+    await click("button:has(.badge:contains('1'))", { text: "Chat" });
     await contains(".o-mail-NotificationItem:has(.badge:contains(1))", { text: "bob" });
     await click(".o-mail-NotificationItem", { text: "bob" });
     await click(".o-mail-ChatWindow-command[title*='Close Chat Window']");


### PR DESCRIPTION
This commit adds counters in the mobile discuss app navbar, so that it's much easier to find the right category containing unread and important conversations.

- "Mailboxes" category shows the unread counter in inbox
- All other categories show the counter of category, similary to the counter when folding a category in desktop discuss sidebar. Livechat tab reconciles for all livechats, as if there's only 1 livechat category
- Unread channels do not show a counter, however the navbar item displays a dot (unread indicator), similarly to chat bubble and next to discuss sidebar item.

Task-4781564

Before
![Screenshot 2025-05-09 at 16 19 00](https://github.com/user-attachments/assets/140a567f-069f-4e69-985d-8c2483b0cb96)
After
![Screenshot 2025-05-09 at 16 18 24](https://github.com/user-attachments/assets/e9eb30ae-e59d-47bc-8ef4-e471186adea1)

