### PR TITLE
[FIX] base_setup: prevent traceback on invite user

### DIFF
--- a/addons/base_setup/i18n/base_setup.pot
+++ b/addons/base_setup/i18n/base_setup.pot
@@ -533,6 +533,12 @@ msgid ""
 msgstr ""
 
 #. module: base_setup
+#. odoo-python
+#: code:addons/base_setup/models/res_users.py:0
+msgid "You have to install the Discuss application to use this feature."
+msgstr ""
+
+#. module: base_setup
 #: model:ir.model.fields,field_description:base_setup.field_res_config_settings__module_google_recaptcha
 msgid "reCAPTCHA"
 msgstr ""

--- a/addons/base_setup/models/res_users.py
+++ b/addons/base_setup/models/res_users.py
@@ -3,6 +3,7 @@
 
 from odoo import models, api, tools
 from odoo.tools.misc import str2bool
+from odoo.exceptions import UserError
 
 
 class ResUsers(models.Model):
@@ -11,6 +12,9 @@ class ResUsers(models.Model):
     @api.model
     def web_create_users(self, emails):
         emails_normalized = [tools.mail.parse_contact_from_email(email)[1] for email in emails]
+
+        if 'email_normalized' not in self._fields:
+            raise UserError(self.env._("You have to install the Discuss application to use this feature."))
 
         # Reactivate already existing users if needed
         deactivated_users = self.with_context(active_test=False).search([


### PR DESCRIPTION
Steps to reproduce the issue:
- Start a new database without installing any module
- Log in
- Go to Settings
- Invite a new user

=> A traceback occurs due to the `email_normalized` field being accessed on `res.users`. This field is defined in the `mail` module, but `base_setup` does not depend on it.

This commit adds a check to ensure that the `email_normalized` field exists before attempting to access it, preventing the traceback.

opw-4784587
