### PR TITLE
[FIX] point_of_sale: include general note in accounting invoice

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -255,6 +255,12 @@ class PosOrder(models.Model):
                     'display_type': 'line_note',
                 }))
 
+        if self.general_note:
+            invoice_lines.append((0, None, {
+                'name': self['general_note'],
+                'display_type': 'line_note',
+            }))
+
         return invoice_lines
 
     def _get_pos_anglo_saxon_price_unit(self, product, partner_id, quantity):


### PR DESCRIPTION
**Issue**
When a POS order is completed with a general note, the note appears on the POS receipt but is missing from the generated accounting invoice.

**Steps to Reproduce:**
1. Install Accounting and Point of Sale apps.
2. Start a POS session.
3. Add a product and a general note via Actions → General Note.
4. Add a customer and enable invoicing.
5. Complete the order.

**Expected Behavior:**
The general note appears in both the POS receipt and the accounting invoice.

**Actual Behavior:**
The note only appears in the POS receipt.

**Root Cause**

The _prepare_invoice_lines method only handles customer notes. General notes are not processed and thus excluded from the invoice report.https://github.com/odoo/odoo/blob/ba779f01975c4665eb84086d86b167a2c0f9625e/addons/point_of_sale/models/pos_order.py#L251-L255

opw-4747903
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
