### PR TITLE
[IMP] l10n_eg_edi_eta: Change many2one ir.attachment to binary

### DIFF
--- a/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
+++ b/addons/l10n_eg_edi_eta/models/eta_thumb_drive.py
@@ -33,7 +33,7 @@ class L10n_Eg_EdiThumbDrive(models.Model):
 
         to_sign_dict = dict()
         for invoice_id in invoice_ids:
-            eta_invoice = json.loads(invoice_id.l10n_eg_eta_json_doc_id.raw)['request']
+            eta_invoice = json.loads(base64.b64decode(invoice_id.l10n_eg_eta_json_doc_file))['request']
             signed_attrs = self._generate_signed_attrs__(eta_invoice, invoice_id.l10n_eg_signing_time)
             to_sign_dict[invoice_id.id] = base64.b64encode(signed_attrs.dump()).decode()
 
@@ -75,13 +75,13 @@ class L10n_Eg_EdiThumbDrive(models.Model):
         invoices = json.loads(invoices)
         for key, value in invoices.items():
             invoice_id = self.env['account.move'].browse(int(key))
-            eta_invoice_json = json.loads(invoice_id.l10n_eg_eta_json_doc_id.raw)
+            eta_invoice_json = json.loads(base64.b64decode(invoice_id.l10n_eg_eta_json_doc_file))
 
             signature = self._generate_cades_bes_signature(eta_invoice_json['request'], invoice_id.l10n_eg_signing_time,
                                                            base64.b64decode(value))
 
             eta_invoice_json['request']['signatures'] = [{'signatureType': 'I', 'value': signature}]
-            invoice_id.l10n_eg_eta_json_doc_id.raw = json.dumps(eta_invoice_json)
+            invoice_id.l10n_eg_eta_json_doc_file = base64.b64encode(json.dumps(eta_invoice_json).encode())
             invoice_id.l10n_eg_is_signed = True
         return True
 

--- a/addons/l10n_eg_edi_eta/views/account_move_view.xml
+++ b/addons/l10n_eg_edi_eta/views/account_move_view.xml
@@ -32,7 +32,7 @@
                                 <field name="l10n_eg_submission_number" readonly="1"/>
                             </group>
                             <group>
-                                <field name="l10n_eg_eta_json_doc_id" readonly="1" invisible="1"/>
+                                <field name="l10n_eg_eta_json_doc_file" widget="binary" readonly="1" invisible="1"/>
                                 <field name="l10n_eg_is_signed" invisible="1"/>
                             </group>
                             <group>


### PR DESCRIPTION
This is part of a general change for all the many2one ir.attachment fields to binary to avoid security issues, as many2one would allow access to all ir.attachment records.

task-4771709


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
