### PR TITLE
[FIX] hr: fix hr test 'many2one in form view' 2 chat windows

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -287,8 +287,8 @@ test("many2one in form view", async () => {
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
-    expect(".o-mail-ChatWindow").toHaveCount(2);
     await waitFor(".o-mail-ChatWindow-header:contains('Luigi')");
+    expect(".o-mail-ChatWindow").toHaveCount(2);
 });
 
 test("many2one with hr group widget in form view", async () => {


### PR DESCRIPTION
The test `@hr/m2x_avatar_employee/many2one in form view` was failing non-deterministically with the following error:

```
9. [toHaveCount] found 1 element matching ".o-mail-ChatWindow"
> Expected: 2
> Received: 1
> Elements: [
  <div.o-mail-ChatWindow.fixed-bottom.overflow-hidden.d-flex.flex-column.shadow-sm.bg-100.rounded-4.border.border-dark.mb-2>,
]
```

This happens because it clicks on avatar card button to send a message, which opens a chat window. However the assertion is made synchronously after the `await contains().click()`, which is not necessarily enough time to ensure the chat window has been open.

The next assertion is asserting asynchronously presence of new chat window with specific header, therefore this commit fixes the issue by swapping the assertion orders. When the new chat window with header is shown, then asserting synchronously there are 2 chat windows is correct (it opens new chat window, in addition to keeping previous one open).

runbot-163001