### PR TITLE
[IMP] *: show price per product unit in product catalog

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2895,39 +2895,10 @@ class AccountMove(models.Model):
         new_default_data = self.env['account.move.line']._get_product_catalog_lines_data()
         return {**default_data, **new_default_data}
 
-    def _get_product_catalog_order_data(self, products, **kwargs):
-        product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
-        for product in products:
-            product_catalog[product.id] |= self._get_product_price_and_data(product)
-        return product_catalog
-
-    def _get_product_price_and_data(self, product):
-        """
-            This function will return a dict containing the price of the product. If the product is a sale document then
-            we return the list price (which is the "Sales Price" in a product) otherwise we return the standard_price
-            (which is the "Cost" in a product).
-            In case of a purchase document, it's possible that we have special price for certain partner.
-            We will check the sellers set on the product and update the price and min_qty for it if needed.
-        """
-        self.ensure_one()
-        product_infos = {'price': product.list_price if self.is_sale_document() else product.standard_price}
-
-        # Check if there is a price and a minimum quantity for the order's vendor.
-        if self.is_purchase_document() and self.partner_id:
-            seller = product._select_seller(
-                partner_id=self.partner_id,
-                quantity=None,
-                date=self.invoice_date,
-                uom_id=product.uom_id,
-                ordered_by='min_qty',
-                params={'order_id': self}
-            )
-            if seller:
-                product_infos.update(
-                    price=seller.price,
-                    min_qty=seller.min_qty,
-                )
-        return product_infos
+    def _get_product_catalog_product_data(self, product, **kwargs):
+        product_data = super()._get_product_catalog_product_data(product)
+        product_data['price'] = product.standard_price if self.is_purchase_document() else product.lst_price
+        return product_data
 
     def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):
         grouped_lines = defaultdict(lambda: self.env['account.move.line'])
@@ -2967,7 +2938,7 @@ class AccountMove(models.Model):
             if quantity != 0:
                 move_line.quantity = quantity
             elif self.state in {'draft', 'sent'}:
-                price_unit = self._get_product_price_and_data(move_line.product_id)['price']
+                price_unit = move_line.price_unit
                 # The catalog is designed to allow the user to select products quickly.
                 # Therefore, sometimes they may select the wrong product or decide to remove
                 # some of them from the quotation. The unlink is there for that reason.

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2947,19 +2947,20 @@ class AccountMove(models.Model):
         return grouped_lines
 
     def _update_order_line_info(
-        self, product_id, quantity, *, section_id=False, child_field='line_ids', **kwargs
+        self, product, quantity, uom, *, section_id=False, child_field='line_ids', **kwargs
     ):
         """ Update account_move_line information for a given product or create a
         new one if none exists yet.
-        :param int product_id: The product, as a `product.product` id.
-        :param int quantity: The quantity selected in the catalog
+        :param object product: Recordset of `product.product`.
+        :param int quantity: The quantity selected in the catalog.
+        :param object uom: Recordset of `uom.uom`.
         :param int section_id: The id of section selected in the catalog.
         :return: The unit price of the product, based on the pricelist of the
                  sale order and the quantity selected.
         :rtype: float
         """
         move_line = self.line_ids.filtered(
-            lambda line: line.product_id.id == product_id
+            lambda line: line.product_id.id == product.id
             and line.get_parent_section_line().id == section_id,
         )
         if move_line:
@@ -2978,8 +2979,9 @@ class AccountMove(models.Model):
             move_line = self.env['account.move.line'].create({
                 'move_id': self.id,
                 'quantity': quantity,
-                'product_id': product_id,
+                'product_id': product.id,
                 'sequence': self._get_new_line_sequence(child_field, section_id),
+                'product_uom_id': uom.id,
             })
         return move_line.price_unit
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1073,7 +1073,7 @@ class AccountMoveLine(models.Model):
         for line in self.filtered(lambda l: l.parent_state == 'draft'):
             # vendor bills should have the product purchase UOM
             if line.move_id.is_purchase_document():
-                seller_ids = line.product_id.seller_ids._get_filtered_supplier(line.company_id, line.product_id, False)
+                seller_ids = line.product_id.seller_ids._get_filtered_supplier(line.company_id, line.product_id, {'partner_id': line.partner_id})
                 line.product_uom_id = seller_ids[:1].uom_id or line.product_id.uom_id
             else:
                 line.product_uom_id = line.product_id.uom_id
@@ -3858,29 +3858,31 @@ class AccountMoveLine(models.Model):
 
         :param products: Recordset of `product.product`.
         :param dict kwargs: additional values given for inherited models.
+        :raise odoo.exceptions.ValueError: ``len(self.product_id) != 1``
         :rtype: dict
         :return: A dict with the following structure:
             {
                 'quantity': float,
                 'price': float,
                 'readOnly': bool,
-                'min_qty': int, (optional)
+                'min_qty': int (optional),
+                'uomDisplayName': string,
+                'uomId': int,
+                'productUomFactor': float (optional),
+                'productUomDisplayName': string (optional),
             }
         """
         if self:
             self.product_id.ensure_one()
             return {
                 **self[0].move_id._get_product_price_and_data(self[0].product_id),
-                'quantity': sum(
-                    self.mapped(
-                        lambda line: line.product_uom_id._compute_quantity(
-                            qty=line.quantity,
-                            to_unit=line.product_id.uom_id,
-                        )
-                    )
-                ),
+                'quantity': self.quantity,
                 'readOnly': self.move_id._is_readonly() or len(self) > 1,
                 'uomDisplayName': len(self) == 1 and self.product_uom_id.display_name or self.product_id.uom_id.display_name,
+                'uomId': self[0].product_uom_id.id,
+                'productUomFactor': self[0].product_id.uom_id.factor / self[0].product_uom_id.factor,
+                'price': self[0].price_unit,
+                'productUomDisplayName': self.product_id.uom_id.display_name,
             }
         return {
             'quantity': 0,

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3875,14 +3875,12 @@ class AccountMoveLine(models.Model):
         if self:
             self.product_id.ensure_one()
             return {
-                **self[0].move_id._get_product_price_and_data(self[0].product_id),
                 'quantity': self.quantity,
                 'readOnly': self.move_id._is_readonly() or len(self) > 1,
-                'uomDisplayName': len(self) == 1 and self.product_uom_id.display_name or self.product_id.uom_id.display_name,
-                'uomId': self[0].product_uom_id.id,
-                'productUomFactor': self[0].product_id.uom_id.factor / self[0].product_uom_id.factor,
                 'price': self[0].price_unit,
-                'productUomDisplayName': self.product_id.uom_id.display_name,
+                **self.move_id._get_product_catalog_uom_data(
+                    self.product_id, self[0].product_uom_id
+                ),
             }
         return {
             'quantity': 0,

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -290,15 +290,15 @@ class SaleOrder(models.Model):
             weight += order_line.product_qty * order_line.product_id.weight
         return weight
 
-    def _update_order_line_info(self, product_id, quantity, **kwargs):
-        """Override of `sale` to recompute the delivery prices.
+    def _update_order_line_info(self, *args, **kwargs):
+        """ Override of `sale` to recompute the delivery prices.
 
-        :param int product_id: The product, as a `product.product` id.
-        :return: The unit price price of the product, based on the pricelist of the sale order and
+        :param object product_id: Recordset of `product.product`.
+        :return: The unit price of the product, based on the pricelist of the sale order and
                  the quantity selected.
         :rtype: float
         """
-        price_unit = super()._update_order_line_info(product_id, quantity, **kwargs)
+        price_unit = super()._update_order_line_info(*args, **kwargs)
         if self:
             self.onchange_order_line()
         return price_unit

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -532,10 +532,12 @@ class MrpBom(models.Model):
         lines = self[child_field].filtered(lambda line: line.product_id.id in product_ids)
         return lines.grouped('product_id')
 
-    def _update_order_line_info(self, product_id, quantity, *, child_field=False, **kwargs):
+    def _update_order_line_info(self, product, quantity, uom, *, child_field=False, **kwargs):
         if not child_field:
             return 0
-        entity = self[child_field].filtered(lambda line: line.product_id.id == product_id)
+        entity = self[child_field].filtered(lambda line: line.product_id.id == product.id)
+        bom_line_uom_id = entity.uom_id if entity else uom or product.uom_id
+        price_unit = product.uom_id._compute_price(product.standard_price, bom_line_uom_id)
         if entity:
             if quantity != 0:
                 entity.product_qty = quantity
@@ -544,12 +546,13 @@ class MrpBom(models.Model):
         elif quantity > 0:
             command = Command.create({
                 'product_qty': quantity,
-                'product_id': product_id,
+                'product_id': product.id,
                 'sequence': (self[child_field][-1:].sequence or 1) + 1,
+                'uom_id': bom_line_uom_id.id,
             })
             self.write({child_field: [command]})
 
-        return self.env['product.product'].browse(product_id).standard_price
+        return price_unit
 
     # -------------------------------------------------------------------------
     # DOCUMENT
@@ -833,16 +836,12 @@ class MrpBomLine(models.Model):
             self.product_id.ensure_one()
             return {
                 **self[0].bom_id._get_product_price_and_data(self[0].product_id),
-                'quantity': sum(
-                    self.mapped(
-                        lambda line: line.uom_id._compute_quantity(
-                            qty=line.product_qty,
-                            to_unit=line.uom_id,
-                        )
-                    )
-                ),
+                'quantity': self[0].product_qty,
                 'readOnly': len(self) > 1,
                 'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,
+                'uomId': self[0].uom_id.id,
+                'productUomDisplayName': self[0].product_id.uom_id.display_name,
+                'productUomFactor': self[0].product_id.uom_id.factor / self[0].uom_id.factor,
             }
         return {
             'quantity': 0,
@@ -914,16 +913,12 @@ class MrpBomByproduct(models.Model):
             self.product_id.ensure_one()
             return {
                 **self[0].bom_id._get_product_price_and_data(self[0].product_id),
-                'quantity': sum(
-                    self.mapped(
-                        lambda line: line.uom_id._compute_quantity(
-                            qty=line.product_qty,
-                            to_unit=line.uom_id,
-                        )
-                    )
-                ),
+                'quantity': self[0].product_qty,
                 'readOnly': len(self) > 1,
                 'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,
+                'uomId': self[0].uom_id.id,
+                'productUomDisplayName': self[0].product_id.uom_id.display_name,
+                'productUomFactor': self[0].product_id.uom_id.factor / self[0].uom_id.factor,
             }
         return {
             'quantity': 0,

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -516,16 +516,6 @@ class MrpBom(models.Model):
 
         return {**default_data, **new_default_data}
 
-    def _get_product_catalog_order_data(self, products, **kwargs):
-        product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
-        for product in products:
-            product_catalog[product.id] |= self._get_product_price_and_data(product)
-        return product_catalog
-
-    def _get_product_price_and_data(self, product):
-        self.ensure_one()
-        return {'price': product.standard_price}
-
     def _get_product_catalog_record_lines(self, product_ids, *, child_field=False, **kwargs):
         if not child_field:
             return {}
@@ -834,8 +824,9 @@ class MrpBomLine(models.Model):
     def _get_product_catalog_lines_data(self, default=False, **kwargs):
         if self and not default:
             self.product_id.ensure_one()
+            price = self[0].product_id.uom_id._compute_price(self.product_id.standard_price, self[0].uom_id)
             return {
-                **self[0].bom_id._get_product_price_and_data(self[0].product_id),
+                'price': price,
                 'quantity': self[0].product_qty,
                 'readOnly': len(self) > 1,
                 'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,
@@ -911,8 +902,9 @@ class MrpBomByproduct(models.Model):
     def _get_product_catalog_lines_data(self, default=False, **kwargs):
         if self and not default:
             self.product_id.ensure_one()
+            price = self[0].product_id.uom_id._compute_price(self.product_id.standard_price, self[0].uom_id)
             return {
-                **self[0].bom_id._get_product_price_and_data(self[0].product_id),
+                'price': price,
                 'quantity': self[0].product_qty,
                 'readOnly': len(self) > 1,
                 'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3177,33 +3177,34 @@ class MrpProduction(models.Model):
     def _get_product_catalog_domain(self):
         return super()._get_product_catalog_domain() & Domain('type', '=', 'consu')
 
-    def _update_order_line_info(self, product_id, quantity, *, child_field=False, **kwargs):
+    def _update_order_line_info(self, product, quantity, uom, *, child_field=False, **kwargs):
         if not child_field:
             return 0
-        entity = self[child_field].filtered(lambda line: line.product_id.id == product_id)
+        entity = self[child_field].filtered(lambda line: line.product_id.id == product.id)
         if entity:
             if quantity != 0:
                 self._update_catalog_line_quantity(entity, quantity, **kwargs)
             else:
                 entity.unlink()
         elif quantity > 0:
-            new_line_vals = self._get_new_catalog_line_values(product_id, quantity, child_field=child_field, **kwargs)
+            new_line_vals = self._get_new_catalog_line_values(product.id, quantity, uom, child_field=child_field, **kwargs)
             command = Command.create(new_line_vals)
             self.write({child_field: [command]})
-            new_line = self[child_field].filtered(lambda mv: mv.product_id.id == product_id)[-1:]
+            new_line = self[child_field].filtered(lambda mv: mv.product_id.id == product.id)[-1:]
             self._update_catalog_line_quantity(new_line, quantity, **kwargs)
 
-        return self.env['product.product'].browse(product_id).standard_price
+        return product.standard_price
 
     def _update_catalog_line_quantity(self, line, quantity, **kwargs):
         line.product_uom_qty = quantity
 
-    def _get_new_catalog_line_values(self, product_id, quantity, **kwargs):
+    def _get_new_catalog_line_values(self, product_id, quantity, uom, **kwargs):
         child_field = kwargs.get('child_field')
         return {
             'product_id': product_id,
             'product_uom_qty': quantity,
             'sequence': (self[child_field][-1:].sequence or 1) + 1,
+            'uom_id': uom.id,
         }
 
     def _is_display_stock_in_catalog(self):

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -3159,15 +3159,6 @@ class MrpProduction(models.Model):
 
         return {**default_data, **new_default_data}
 
-    def _get_product_catalog_order_data(self, products, **kwargs):
-        product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
-        for product in products:
-            product_catalog[product.id] |= self._get_product_price_and_data(product)
-        return product_catalog
-
-    def _get_product_price_and_data(self, product):
-        return {'price': product.standard_price}
-
     def _get_product_catalog_record_lines(self, product_ids, *, child_field=False, **kwargs):
         if not child_field:
             return {}

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5529,6 +5529,7 @@ class TestTourMrpOrder(HttpCase):
                     'product_id': component.id,
                     'quantity': 2,
                     'child_field': 'move_raw_ids',
+                    'uom_id': component.uom_id.id,
                 },
             },
         )

--- a/addons/mrp/views/product_views.xml
+++ b/addons/mrp/views/product_views.xml
@@ -63,7 +63,8 @@
             <field name="inherit_id" ref="product.product_view_search_catalog"/>
             <field name="model">product.product</field>
             <field name="arch" type="xml">
-                <filter name="goods" position="after">
+                <filter name="favorites" position="after">
+                    <separator/>
                     <filter string="In the BoM"
                             invisible="context.get('active_model') != 'mrp.bom.line'"
                             name="products_in_bom"

--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -21,6 +21,7 @@ class ProductCatalogController(Controller):
                     'quantity': float (optional)
                     'price': float
                     'uomDisplayName': string
+                    'productUomFactor': float (optional),
                     'code': string (optional)
                     'readOnly': bool (optional)
                 }
@@ -32,7 +33,7 @@ class ProductCatalogController(Controller):
         )
 
     @route('/product/catalog/update_order_line_info', auth='user', type='jsonrpc')
-    def product_catalog_update_order_line_info(self, res_model, order_id, product_id, quantity=0, **kwargs):
+    def product_catalog_update_order_line_info(self, res_model, order_id, product_id, quantity=0, uom_id=False, **kwargs):
         """ Update order line information on a given order for a given product.
 
         :param string res_model: The order model.
@@ -43,6 +44,8 @@ class ProductCatalogController(Controller):
         :rtype: float
         """
         order = request.env[res_model].browse(order_id)
+        product = request.env['product.product'].browse(product_id)
+        uom = request.env['uom.uom'].browse(uom_id) or product.uom_id
         return order.with_company(order.company_id)._update_order_line_info(
-            product_id, quantity, **kwargs,
+            product, quantity, uom, **kwargs,
         )

--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -17,13 +17,16 @@ class ProductCatalogController(Controller):
         :return: A dict with the following structure:
             {
                 product.id: {
-                    'productId': int
-                    'quantity': float (optional)
-                    'price': float
-                    'uomDisplayName': string
+                    'price': float,
+                    'uomDisplayName': string,
+                    'uomId': int,
                     'productUomFactor': float (optional),
-                    'code': string (optional)
-                    'readOnly': bool (optional)
+                    'sellerUomFactor': float (optional),
+                    'quantity': float (optional)
+                    'productType': string,
+                    'productUomDisplayName': string (optional),
+                    'code': string (optional),
+                    'readOnly': bool (optional),
                 }
             }
         """

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -138,14 +138,15 @@ class ProductCatalogMixin(models.AbstractModel):
         """
         return False
 
-    def _update_order_line_info(self, product_id, quantity, **kwargs):
+    def _update_order_line_info(self, product, quantity, uom, **kwargs):
         """ Update the line information for a given product or create a new one if none exists yet.
         Must be overrided by each model using this mixin.
-        :param int product_id: The product, as a `product.product` id.
+        :param object product: Recordset of `product.product`.
         :param int quantity: The product's quantity.
+        :param int uom: Recordset of `uom.uom`.
         :param dict kwargs: additional values given for inherited models.
         :return: The unit price of the product, based on the pricelist of the
-                 purchase order and the quantity selected.
+                 order and the quantity selected.
         :rtype: float
         """
-        return 0
+        return 0.0

--- a/addons/product/models/product_catalog_mixin.py
+++ b/addons/product/models/product_catalog_mixin.py
@@ -55,33 +55,16 @@ class ProductCatalogMixin(models.AbstractModel):
         return {}
 
     def _get_product_catalog_order_data(self, products, **kwargs):
-        """ Returns a dict containing the products' data. Those data are for products who aren't in
+        """ Returns a dict containing the products' data. This is for products that aren't in
         the record yet. For products already in the record, see `_get_product_catalog_lines_data`.
 
-        For each product, its id is the key and the value is another dict with all needed data.
-        By default, the price is the only needed data but each model is free to add more data.
-        Must be overrided by each model using this mixin.
+        For each product, we call `_get_product_catalog_product_data` that sets every individual product's data
 
         :param products: Recordset of `product.product`.
-        :param dict kwargs: additional values given for inherited models.
         :rtype: dict
-        :return: A dict with the following structure:
-            {
-                'productId': int
-                'quantity': float (optional)
-                'productType': string
-                'price': float
-                'uomDisplayName': string
-                'code': string (optional)
-                'readOnly': bool (optional)
-            }
         """
         return {
-            product.id: {
-                'productType': product.type,
-                'uomDisplayName': product.uom_id.display_name,
-                'code': product.code if product.code else '',
-            }
+            product.id: self._get_product_catalog_product_data(product, **kwargs)
             for product in products
         }
 
@@ -91,16 +74,6 @@ class ProductCatalogMixin(models.AbstractModel):
                                  of `product.product` ids.
         :param dict kwargs: additional values given for inherited models.
         :rtype: dict
-        :return: A dict with the following structure:
-            {
-                'productId': int
-                'quantity': float (optional)
-                'productType': string
-                'price': float
-                'uomDisplayName': string
-                'code': string (optional)
-                'readOnly': bool (optional)
-            }
         """
         order_line_info = {}
 
@@ -110,23 +83,21 @@ class ProductCatalogMixin(models.AbstractModel):
                'productType': product.type,
                'code': product.code if product.code else '',
             }
-            if not order_line_info[product.id]['uomDisplayName']:
+            if self.env['res.groups']._is_feature_enabled('uom.group_uom') and not order_line_info[product.id]['uomDisplayName']:
                 order_line_info[product.id]['uomDisplayName'] = product.uom_id.display_name
 
         default_data = self._default_order_line_values(child_field)
         products = self.env['product.product'].browse(product_ids)
-        product_data = self._get_product_catalog_order_data(products, **kwargs)
+        products_data = self._get_product_catalog_order_data(products, **kwargs)
 
-        for product_id, data in product_data.items():
+        for product_id, data in products_data.items():
             if product_id in order_line_info:
                 continue
             order_line_info[product_id] = {**default_data, **data}
-
         return order_line_info
 
     def _get_action_add_from_catalog_extra_context(self):
         return {
-            'display_uom': self.env.user.has_group('uom.group_uom'),
             'product_catalog_order_id': self.id,
             'product_catalog_order_model': self._name,
         }
@@ -150,3 +121,29 @@ class ProductCatalogMixin(models.AbstractModel):
         :rtype: float
         """
         return 0.0
+
+    def _get_product_catalog_product_data(self, product, **kwargs):
+        """ This function is called within `_get_product_catalog_order_data` to return a dict
+        with all the product's info needed for the catalog.
+        :rtype: dict
+        """
+        return {
+            'productType': product.type,
+            'price': product.standard_price,
+            'code': product.code if product.code else '',
+            **self._get_product_catalog_uom_data(product, product.uom_id)
+        }
+
+    def _get_product_catalog_uom_data(self, product, uom):
+        res = {
+            'uomId': uom.id,
+        }
+        if not self.env['res.groups']._is_feature_enabled('uom.group_uom'):
+            return res
+
+        res.update({
+            'uomDisplayName': uom.display_name,
+            'productUomFactor': product.uom_id.factor / uom.factor,
+            'productUomDisplayName': product.uom_id.display_name,
+        })
+        return res

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -116,4 +116,5 @@ class ProductSupplierinfo(models.Model):
         return super().write(vals)
 
     def _get_filtered_supplier(self, company_id, product_id, params=False):
-        return self.filtered(lambda s: (not s.company_id or s.company_id.id == company_id.id) and (s.partner_id.active and (not s.product_id or s.product_id == product_id)))
+        return self.filtered(lambda s: (not s.company_id or s.company_id.id == company_id.id) and (s.partner_id.active and (not s.product_id or s.product_id == product_id))
+                             and (not params or not params.get('partner_id') or s.partner_id == params.get('partner_id')))

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -23,7 +23,6 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             orderId: this.props.record.context.product_catalog_order_id,
             orderResModel: this.props.record.context.product_catalog_order_model,
             digits: this.props.record.context.product_catalog_digits,
-            displayUoM: this.props.record.context.display_uom,
             precision: this.props.record.context.precision,
             productId: this.props.record.resId,
             addProduct: this.addProduct.bind(this),

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -13,7 +13,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
 
     setup() {
         super.setup();
-        this.debouncedUpdateQuantity = useDebounced(this._updateQuantity, 500, {
+        this.debouncedUpdateQuantity = useDebounced(this._onQuantityChange, 500, {
             execBeforeUnmount: true,
         });
         this._pendingUpdate = Promise.resolve();
@@ -59,7 +59,7 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     // Data Exchanges
     //--------------------------------------------------------------------------
 
-    async _updateQuantity() {
+    async _onQuantityChange() {
         const price = await this._updateQuantityAndGetPrice();
         this.productCatalogData.price = parseFloat(price);
     }
@@ -81,7 +81,8 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
             quantity: this.productCatalogData.quantity,
             res_model: this.env.orderResModel,
             child_field: this.env.childField,
-        }
+            uom_id: this.productCatalogData.uomId,
+        };
     }
 
     //--------------------------------------------------------------------------

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -10,7 +10,7 @@ export class ProductCatalogOrderLine extends Component {
         price: Number,
         productType: String,
         uomId: Number,
-        uomDisplayName: String,
+        uomDisplayName: { type: String, optional: true },
         productUomFactor: { type: Number, optional: true },
         productUomDisplayName: { type: String, optional: true },
         sellerUomFactor: { type: Number, optional: true },

--- a/addons/product/static/src/product_catalog/order_line/order_line.js
+++ b/addons/product/static/src/product_catalog/order_line/order_line.js
@@ -9,8 +9,11 @@ export class ProductCatalogOrderLine extends Component {
         quantity: Number,
         price: Number,
         productType: String,
+        uomId: Number,
         uomDisplayName: String,
-        uomFactor: { type: Number, optional: true },
+        productUomFactor: { type: Number, optional: true },
+        productUomDisplayName: { type: String, optional: true },
+        sellerUomFactor: { type: Number, optional: true },
         code: { type: String, optional: true },
         readOnly: { type: Boolean, optional: true },
         warning: { type: String, optional: true },
@@ -45,6 +48,12 @@ export class ProductCatalogOrderLine extends Component {
         return formatMonetary(this.props.price, { currencyId, digits });
     }
 
+    get productUnitPrice() {
+        const { currencyId, digits } = this.env;
+        const productUnitPrice = this.props.price * (this.props.productUomFactor || 1);
+        return formatMonetary(productUnitPrice, { currencyId, digits });
+    }
+
     get quantity() {
         const digits = [false, this.env.precision];
         const options = { digits, decimalPoint: ".", thousandsSep: "" };
@@ -53,5 +62,14 @@ export class ProductCatalogOrderLine extends Component {
 
     get showPrice() {
         return true;
+    }
+
+    get displayPriceByProductUoM() {
+        const { uomDisplayName, productUomDisplayName } = this.props;
+        return (
+            uomDisplayName != productUomDisplayName &&
+            this.productUnitPrice &&
+            productUomDisplayName
+        );
     }
 }

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -43,7 +43,7 @@
                     t-on-focus="this._onFocus"
                 />
                 <span
-                    t-if="this.env.displayUoM"
+                    t-if="this.props.uomDisplayName"
                     class="input-group-text d-block rounded-0 text-truncate cursor-default"
                     t-out="this.props.uomDisplayName" t-att-title="this.props.uomDisplayName"
                 />

--- a/addons/product/static/src/product_catalog/order_line/order_line.xml
+++ b/addons/product/static/src/product_catalog/order_line/order_line.xml
@@ -8,6 +8,7 @@
                 <span t-if="this.showPrice" t-out="this.price" class="o_product_catalog_price fw-bold me-4"/>
                 <span t-if="this.props.code" t-out="this.props.code" class="text-muted"/>
             </div>
+            <span t-if="displayPriceByProductUoM" class="d-flex text-muted small" t-out="`${productUnitPrice}/${props.productUomDisplayName}`"/>
         </t>
         <div 
             t-if="this.props.readOnly and this.props.warning"

--- a/addons/project_purchase/controllers/catalog.py
+++ b/addons/project_purchase/controllers/catalog.py
@@ -7,7 +7,7 @@ from odoo.addons.product.controllers.catalog import ProductCatalogController
 class ProjectPurchaseCatalogController(ProductCatalogController):
 
     @route()
-    def product_catalog_update_order_line_info(self, res_model, order_id, product_id, quantity=0, **kwargs):
+    def product_catalog_update_order_line_info(self, *args, **kwargs):
         """ Override to update context with project_id.
 
         :param string res_model: The order model.
@@ -19,4 +19,4 @@ class ProjectPurchaseCatalogController(ProductCatalogController):
         """
         if (project_id := kwargs.get('project_id')):
             request.update_context(project_id=project_id)
-        return super().product_catalog_update_order_line_info(res_model, order_id, product_id, quantity, **kwargs)
+        return super().product_catalog_update_order_line_info(*args, **kwargs)

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1274,7 +1274,7 @@ class PurchaseOrder(models.Model):
                 # The discounted price is expressed in the product's UoM, not in the vendor
                 # price's UoM, so we need to convert it into to match the displayed UoM.
                 price = product_uom._compute_price(price, seller.uom_id)
-                product_infos.update(uomFactor=seller.uom_id.factor / product_uom.factor)
+                product_infos.update(sellerUomFactor=seller.uom_id.factor / product_uom.factor)
             product_infos.update(
                 price=price,
                 min_qty=seller.min_qty,
@@ -1346,7 +1346,7 @@ class PurchaseOrder(models.Model):
             line._update_date_planned(date)
 
     def _update_order_line_info(
-        self, product_id, quantity, *, section_id=False, child_field='order_line', **kwargs
+        self, product, quantity, uom, *, section_id=False, child_field='order_line', **kwargs
     ):
         """ Update purchase order line information for a given product or create
         a new one if none exists yet.
@@ -1359,7 +1359,7 @@ class PurchaseOrder(models.Model):
         """
         self.ensure_one()
         pol = self.order_line.filtered(
-            lambda l: l.product_id.id == product_id
+            lambda l: l.product_id.id == product.id
             and l.get_parent_section_line().id == section_id
         )
         if pol:
@@ -1374,18 +1374,11 @@ class PurchaseOrder(models.Model):
         elif quantity > 0:
             pol = self.env['purchase.order.line'].create({
                 'order_id': self.id,
-                'product_id': product_id,
+                'product_id': product.id,
                 'product_qty': quantity,
                 'sequence': self._get_new_line_sequence(child_field, section_id),
             })
-            if pol.selected_seller_id:
-                # Fix the PO line's price on the seller's one.
-                seller = pol.selected_seller_id
-                price = seller.price
-                if seller.currency_id != self.currency_id:
-                    price = seller.currency_id._convert(price, self.currency_id)
-                pol.price_unit = pol.technical_price_unit = price
-                pol.discount = seller.discount
+            pol.uom_id = uom  # Trigger seller computation
         return pol.price_unit_discounted
 
     def _get_default_create_section_values(self):

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -1219,11 +1219,11 @@ class PurchaseOrder(models.Model):
     def _get_product_catalog_domain(self):
         return super()._get_product_catalog_domain() & Domain('purchase_ok', '=', True)
 
-    def _get_product_catalog_order_data(self, products, **kwargs):
-        res = super()._get_product_catalog_order_data(products, **kwargs)
-        for product in products:
-            res[product.id] |= self._get_product_price_and_data(product)
-        return res
+    def _get_product_catalog_product_data(self, product, **kwargs):
+        product_data = super()._get_product_catalog_product_data(product)
+        seller_data = self._get_product_catalog_seller_data(product)
+        product_data.update(seller_data)
+        return product_data
 
     def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):
         grouped_lines = defaultdict(lambda: self.env['purchase.order.line'])
@@ -1243,44 +1243,52 @@ class PurchaseOrder(models.Model):
             grouped_lines[line.product_id] |= line
         return grouped_lines
 
-    def _get_product_price_and_data(self, product):
-        """ Fetch the product's data used by the purchase's catalog.
+    def _get_product_catalog_seller_data(self, product, **kwargs):
+        """ This function will return a dict containing the price of the product,
+        UoM display name , and the seller's data if found.
 
-        :return: the product's price and, if applicable, the minimum quantity to
-                 buy and the product's packaging data.
+        :param object product: Recordset of `product.product`.
         :rtype: dict
+        :return: A dict with the following structure:
+            {
+                'price': float,
+                'uomDisplayName': string,
+                'uomId' : int,
+                'sellerUomFactor': float (optional),
+                'productUomDisplayName': string (optional),
+                'min_qty': float (optional)
+            }
         """
         self.ensure_one()
+        product.ensure_one()
+        uom_id = kwargs.get('uom_id', False)
         product_infos = {
-            'price': product.standard_price,
-            'uomDisplayName': product.uom_id.display_name
+            'price':  product.standard_price,
+            **self._get_product_catalog_uom_data(product, uom_id or product.uom_id),
         }
-        params = {'order_id': self}
         # Check if there is a price and a minimum quantity for the order's vendor.
-        seller = product._select_seller(
-            partner_id=self.partner_id,
-            quantity=None,
-            date=self.date_order and self.date_order.date(),
-            uom_id=product.uom_id,
-            ordered_by='min_qty',
-            params=params
-        )
-        if seller:
-            product_uom = (seller.product_id or seller.product_tmpl_id).uom_id
-            price = seller.price_discounted
-            if seller.currency_id != self.currency_id:
-                price = seller.currency_id._convert(price, self.currency_id)
-            if seller.uom_id != product_uom:
-                # The discounted price is expressed in the product's UoM, not in the vendor
-                # price's UoM, so we need to convert it into to match the displayed UoM.
-                price = product_uom._compute_price(price, seller.uom_id)
-                product_infos.update(sellerUomFactor=seller.uom_id.factor / product_uom.factor)
-            product_infos.update(
-                price=price,
-                min_qty=seller.min_qty,
-                uomDisplayName=seller.uom_id.display_name,
+        if self.partner_id:
+            seller = product._select_seller(
+                partner_id=self.partner_id,
+                quantity=None,
+                date=self.date_order and self.date_order.date(),
+                uom_id=uom_id,
+                ordered_by='min_qty',
+                params={'order_id': self, 'force_uom': kwargs.get('force_uom', False)}
             )
-
+            if seller:
+                seller_price = seller.currency_id._convert(
+                    from_amount=seller.price_discounted,
+                    to_currency=product.currency_id,
+                    company=product.company_id,
+                    round=False
+                )
+                product_infos.update(
+                    self._get_product_catalog_uom_data(product, seller.uom_id),
+                    price=product.uom_id._compute_price(seller_price, seller.uom_id),
+                    min_qty=seller.min_qty,
+                    sellerUomFactor=seller.uom_id.factor / product.uom_id.factor,
+                )
         return product_infos
 
     def get_acknowledge_url(self):
@@ -1366,7 +1374,7 @@ class PurchaseOrder(models.Model):
             if quantity != 0:
                 pol.product_qty = quantity
             elif self.state in ['draft', 'sent']:
-                price_unit = self._get_product_price_and_data(pol.product_id)['price']
+                price_unit = pol.price_unit_discounted
                 pol.unlink()
                 return price_unit
             else:

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -483,7 +483,6 @@ class PurchaseOrderLine(models.Model):
             elif line.selected_seller_id:
                 price_unit = line.env['account.tax']._fix_tax_included_price_company(line.selected_seller_id.price, line.product_id.supplier_taxes_id, line.tax_ids, line.company_id) if line.selected_seller_id else 0.0
                 price_unit = line.selected_seller_id.currency_id._convert(price_unit, line.currency_id, line.company_id, line.date_order or fields.Date.context_today(line), False)
-                price_unit = float_round(price_unit, precision_digits=max(line.currency_id.decimal_places, self.env['decimal.precision'].precision_get('Product Price')))
                 line.price_unit = line.technical_price_unit = line.selected_seller_id.uom_id._compute_price(price_unit, line.uom_id)
                 line.discount = line.selected_seller_id.discount or 0.0
 
@@ -585,30 +584,25 @@ class PurchaseOrderLine(models.Model):
                 'price': float,
                 'readOnly': bool,
                 'uomDisplayName': String,
+                'uomId': int,
+                'productUomFactor': float (optional),
+                'productUomDisplayName': string (optional),
                 'packaging': dict,
                 'warning': String,
             }
         """
-        if len(self) == 1:
-            catalog_info = self.order_id._get_product_price_and_data(self.product_id)
-            catalog_info.update(
-                quantity=self.product_qty,
-                price=self.price_unit * (1 - self.discount / 100),
-                readOnly=self.order_id._is_readonly(),
-            )
-            if self.product_id.uom_id != self.uom_id:
-                catalog_info['uomDisplayName'] = self.uom_id.display_name
-            return catalog_info
-        elif self:
+        if self:
             self.product_id.ensure_one()
-            order_line = self[0]
-            catalog_info = order_line.order_id._get_product_price_and_data(order_line.product_id)
-            catalog_info['quantity'] = sum(self.mapped(
-                lambda line: line.uom_id._compute_quantity(
-                    qty=line.product_qty,
-                    to_unit=line.product_id.uom_id,
-            )))
-            catalog_info['readOnly'] = True
+            catalog_info = self[0].order_id._get_product_price_and_data(self.product_id)
+            catalog_info.update(
+                quantity=self[0].product_qty,
+                price=self[0].price_unit_discounted,
+                readOnly=self[0].order_id._is_readonly() or len(self) > 1,
+                uomId=self[0].uom_id.id,
+                uomDisplayName=self[0].uom_id.display_name,
+                productUomDisplayName=self[0].product_id.uom_id.display_name,
+                productUomFactor=self[0].product_id.uom_id.factor / self[0].uom_id.factor,
+            )
             return catalog_info
         return {'quantity': 0}
 
@@ -645,7 +639,7 @@ class PurchaseOrderLine(models.Model):
     def _prepare_add_missing_fields(self, values):
         """ Deduce missing required fields from the onchange """
         res = {}
-        onchange_fields = ['name', 'price_unit', 'product_qty', 'uom_id', 'tax_ids', 'date_planned']
+        onchange_fields = ['name', 'price_unit', 'product_qty', 'uom_id', 'tax_ids', 'date_planned', 'discount']
         if values.get('order_id') and values.get('product_id') and any(f not in values for f in onchange_fields):
             line = self.new(values)
             line.onchange_product_id()

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -593,15 +593,12 @@ class PurchaseOrderLine(models.Model):
         """
         if self:
             self.product_id.ensure_one()
-            catalog_info = self[0].order_id._get_product_price_and_data(self.product_id)
+            catalog_info = self[0].order_id._get_product_catalog_seller_data(self.product_id)
             catalog_info.update(
                 quantity=self[0].product_qty,
                 price=self[0].price_unit_discounted,
                 readOnly=self[0].order_id._is_readonly() or len(self) > 1,
-                uomId=self[0].uom_id.id,
-                uomDisplayName=self[0].uom_id.display_name,
-                productUomDisplayName=self[0].product_id.uom_id.display_name,
-                productUomFactor=self[0].product_id.uom_id.factor / self[0].uom_id.factor,
+                **self[0].order_id._get_product_catalog_uom_data(self.product_id, self[0].uom_id),
             )
             return catalog_info
         return {'quantity': 0}

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -78,7 +78,8 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
                     'order_id': purchase_order.id,
                     'product_id': other_product.id,
                     'quantity': 1,
-                    'res_model': 'purchase.order'
+                    'res_model': 'purchase.order',
+                    'uom_id': other_product.uom_id.id,
                 }
             }),
             headers={'Content-Type': 'application/json'},
@@ -94,13 +95,32 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
                     'order_id': purchase_order.id,
                     'product_id': company_product.id,
                     'quantity': 1,
-                    'res_model': 'purchase.order'
+                    'res_model': 'purchase.order',
+                    'uom_id': company_product.uom_id.id,
                 }
             }),
             headers={'Content-Type': 'application/json'},
         )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()['result'], company_product_price)
+
+        purchase_order.order_line[0].uom_id = self.env.ref('uom.product_uom_pack_6')
+        resp = self.make_jsonrpc_request(
+            route='/product/catalog/update_order_line_info',
+            params={
+                    'child_field': 'order_line',
+                    'order_id': purchase_order.id,
+                    'product_id': other_product.id,
+                    'quantity': 2,
+                    'res_model': 'purchase.order',
+                    'uom_id': other_product.uom_id.id,
+                },
+            headers={'Content-Type': 'application/json'},
+        )
+        self.assertTrue(resp)
+        product_uom_factor = purchase_order.order_line[0]._get_product_catalog_lines_data()['productUomFactor']
+        self.assertEqual(resp, other_product_price_converted * 6)
+        self.assertEqual(resp * product_uom_factor, other_product_price_converted)  # Price in product unit
 
     # === TOUR TESTS ===#
     def test_catalog_vendor_uom(self):

--- a/addons/purchase/tests/test_purchase_product_catalog.py
+++ b/addons/purchase/tests/test_purchase_product_catalog.py
@@ -203,5 +203,5 @@ class TestPurchaseProductCatalog(AccountTestInvoicingCommon, HttpCase):
         purchase_order = self.env['purchase.order'].create({
             'partner_id': self.partner_a.id,
         })
-        catalog_info = purchase_order._get_product_price_and_data(supplier_info.product_tmpl_id.product_variant_ids[0])
+        catalog_info = purchase_order._get_product_catalog_seller_data(supplier_info.product_tmpl_id.product_variant_ids[0])
         self.assertEqual(catalog_info['price'], 100.0)

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -214,7 +214,7 @@
                 <xpath expr="//field[@name='product_tmpl_id']" position="after">
                     <field name="seller_ids" string="Vendor"/>
                 </xpath>
-                <xpath expr="//filter[@name='goods']" position="after">
+                <xpath expr="//filter[@name='favorites']" position="after">
                     <separator/>
                     <filter string="In the Order"
                             name="products_in_purchase_order"

--- a/addons/purchase_alternative/models/purchase.py
+++ b/addons/purchase_alternative/models/purchase.py
@@ -126,9 +126,16 @@ class PurchaseOrder(models.Model):
                 product_to_best_price_unit[line.product_id] = line
             else:
                 price_subtotal = line.price_total_cc
-                price_unit = line.price_total_cc / line.product_qty
                 current_price_subtotal = product_to_best_price_line[line.product_id][0].price_total_cc
+
+                price_unit = line.uom_id._compute_price(line.price_total_cc / line.product_qty, line.product_id.uom_id)
+
                 current_price_unit = product_to_best_price_unit[line.product_id][0].price_total_cc / product_to_best_price_unit[line.product_id][0].product_qty
+                current_best_price_uom = product_to_best_price_unit[line.product_id][0].uom_id
+                current_price_unit = current_best_price_uom._compute_price(
+                                        current_price_unit,
+                                        line.product_id.uom_id
+                                    )
 
                 if current_price_subtotal > price_subtotal:
                     product_to_best_price_line[line.product_id] = line

--- a/addons/purchase_alternative/views/purchase_views.xml
+++ b/addons/purchase_alternative/views/purchase_views.xml
@@ -57,7 +57,7 @@
                 <field name="name" readonly="1"/>
                 <field name="date_planned" readonly="1"/>
                 <field name="product_qty"/>
-                <field name="uom_id" groups="uom.group_uom" widget="many2one_uom" options="{'no_open': True}" readonly="1"/>
+                <field name="uom_id" groups="uom.group_uom"/>
                 <field name="price_unit" widget="monetary" readonly="1"/>
                 <field name="price_subtotal" string="Total"/>
                 <field name="currency_id" column_invisible="True"/> <!-- Invisible fields -->

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -446,9 +446,9 @@ class PurchaseOrder(models.Model):
             )
         return super()._get_product_catalog_order_line_info(product_ids, child_field=child_field, **kwargs)
 
-    def _get_product_price_and_data(self, product):
+    def _get_product_catalog_seller_data(self, product, **kwargs):
         """ Fetch the product's data used by the purchase's catalog."""
-        res = super()._get_product_price_and_data(product)
+        res = super()._get_product_catalog_seller_data(product, **kwargs)
         res["suggested_qty"] = product.suggested_qty
         return res
 

--- a/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
+++ b/addons/purchase_stock/static/src/product_catalog/record/kanban_record.js
@@ -21,8 +21,8 @@ export class ProductCatalogPurchaseSuggestKanbanRecord extends ProductCatalogKan
     addProduct() {
         const { min_qty = 1, suggested_qty = 0 } = this.productCatalogData;
         let quantity_to_add = Math.max(min_qty, suggested_qty, 1);
-        if (this.productCatalogData.uomFactor) {
-            quantity_to_add = Math.ceil(quantity_to_add / this.productCatalogData.uomFactor);
+        if (this.productCatalogData.sellerUomFactor) {
+            quantity_to_add = Math.ceil(quantity_to_add / this.productCatalogData.sellerUomFactor);
         }
         super.addProduct(quantity_to_add);
     }

--- a/addons/purchase_stock/static/tests/product_catalog.test.js
+++ b/addons/purchase_stock/static/tests/product_catalog.test.js
@@ -59,6 +59,7 @@ const purchaseOrderLineInfo = {
         price: 35.0,
         productType: "consu",
         uomDisplayName: "Units",
+        uomId: 1,
     },
     2: {
         quantity: 0,
@@ -67,6 +68,7 @@ const purchaseOrderLineInfo = {
         price: 35.0,
         productType: "consu",
         uomDisplayName: "Units",
+        uomId: 1,
     },
     3: {
         quantity: 0,
@@ -75,6 +77,7 @@ const purchaseOrderLineInfo = {
         price: 35.0,
         productType: "consu",
         uomDisplayName: "Units",
+        uomId: 1,
     },
     4: {
         quantity: 0,
@@ -83,6 +86,7 @@ const purchaseOrderLineInfo = {
         price: 35.0,
         productType: "consu",
         uomDisplayName: "Units",
+        uomId: 1,
     },
 };
 

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -775,8 +775,8 @@ class RepairOrder(models.Model):
     def _is_display_stock_in_catalog(self):
         return True
 
-    def _update_order_line_info(self, product_id, quantity, **kwargs):
-        move = self.move_ids.filtered(lambda e: e.product_id.id == product_id)
+    def _update_order_line_info(self, product, quantity, uom, **kwargs):
+        move = self.move_ids.filtered(lambda e: e.product_id.id == product.id)
         if move:
             if quantity != 0:
                 move.product_uom_qty = quantity
@@ -786,13 +786,14 @@ class RepairOrder(models.Model):
             move = self.env['stock.move'].create({
                 'repair_id': self.id,
                 'product_uom_qty': quantity,
-                'product_id': product_id,
+                'product_id': product.id,
                 'location_id': self.location_id.id,
                 'location_dest_id': self.location_dest_id.id,
-                'repair_line_type': 'add'
+                'repair_line_type': 'add',
+                'uom_id': uom.id,
             })
 
-        return self.env['product.product'].browse(product_id).list_price
+        return product.list_price
 
     # ------------------------------------------------------------
     # MAIL.THREAD

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -753,15 +753,10 @@ class RepairOrder(models.Model):
     def _get_product_catalog_domain(self):
         return super()._get_product_catalog_domain() & Domain('type', '=', 'consu')
 
-    def _get_product_catalog_order_data(self, products, **kwargs):
-        product_catalog = super()._get_product_catalog_order_data(products, **kwargs)
-        for product in products:
-            product_catalog[product.id] |= self._get_product_price_and_data(product)
-        return product_catalog
-
-    def _get_product_price_and_data(self, product):
-        self.ensure_one()
-        return {'price': product.list_price}
+    def _get_product_catalog_product_data(self, product, **kwargs):
+        product_data = super()._get_product_catalog_product_data(product)
+        product_data['price'] = product.list_price
+        return product_data
 
     def _get_product_catalog_record_lines(self, product_ids, **kwargs):
         grouped_lines = defaultdict(lambda: self.env['stock.move'])

--- a/addons/repair/views/product_views.xml
+++ b/addons/repair/views/product_views.xml
@@ -17,7 +17,8 @@
         <field name="mode">primary</field>
         <field name="inherit_id" ref="product.product_view_search_catalog"/>
         <field name="arch" type="xml">
-            <xpath expr="//filter[@name='goods']" position="after">
+            <xpath expr="//filter[@name='favorites']" position="after">
+                <separator/>
                 <filter string="In the Repair Order"
                     invisible="context.get('active_model') != 'stock.move' or
                                 context.get('product_catalog_order_model') != 'repair.order'"

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2607,7 +2607,7 @@ class SaleOrder(models.Model):
         return "order_id"
 
     def _update_order_line_info(
-        self, product_id, quantity, *, section_id=False, child_field="order_line", **kwargs
+        self, product, quantity, uom, *, section_id=False, child_field="order_line", **kwargs
     ):
         """Update sale order line information for a given product or create a
         new one if none exists yet.
@@ -2622,7 +2622,7 @@ class SaleOrder(models.Model):
         request.update_context(catalog_skip_tracking=True)
         sol = self.order_line.filtered(
             lambda line: (
-                line.product_id.id == product_id and line.get_parent_section_line().id == section_id
+                line.product_id.id == product.id and line.get_parent_section_line().id == section_id
             )
         )
         if sol:
@@ -2633,6 +2633,7 @@ class SaleOrder(models.Model):
                     product=sol.product_id,
                     quantity=1.0,
                     currency=self.currency_id,
+                    uom=uom,
                     date=self.date_order,
                     **kwargs,
                 )
@@ -2643,15 +2644,17 @@ class SaleOrder(models.Model):
         elif quantity > 0:
             sol = self.env["sale.order.line"].create({
                 "order_id": self.id,
-                "product_id": product_id,
+                "product_id": product.id,
                 "product_uom_qty": quantity,
                 "sequence": self._get_new_line_sequence(child_field, section_id),
+                "product_uom_id": uom.id,
             })
         else:  # quantity of 0, no line to update, return defaut pricelist price
             return self.pricelist_id._get_product_price(
-                product=self.env["product.product"].browse(product_id),
+                product=product,
                 quantity=1.0,
                 currency=self.currency_id,
+                uom=uom,
                 date=self.date_order,
                 **kwargs,
             )

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2570,22 +2570,26 @@ class SaleOrder(models.Model):
     # === CATALOG === #
 
     def _get_product_catalog_order_data(self, products, **kwargs):
-        pricelist = self.pricelist_id._get_products_price(
+        res = super()._get_product_catalog_order_data(products, **kwargs)
+        prices = self.pricelist_id._get_products_price(
             quantity=1.0,
             products=products,
             currency=self.currency_id,
             date=self.date_order,
             **kwargs,
         )
-        res = super()._get_product_catalog_order_data(products, **kwargs)
-        has_warning_group = self.env.user.has_group("sale.group_warning_sale")
         for product in products:
-            res[product.id]["price"] = pricelist.get(product.id)
-            if product.sale_line_warn_msg and has_warning_group:
-                res[product.id]["warning"] = product.sale_line_warn_msg
+            res[product.id]["price"] = prices.get(product.id)
         return res
 
-    def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):  # noqa: ARG002
+    def _get_product_catalog_product_data(self, product, **kwargs):
+        product_data = super()._get_product_catalog_product_data(product)
+        has_warning_group = self.env["res.groups"]._is_feature_enabled("sale.group_warning_sale")
+        if product.sale_line_warn_msg and has_warning_group:
+            product_data.update(warning=product.sale_line_warn_msg)
+        return product_data
+
+    def _get_product_catalog_record_lines(self, product_ids, *, section_id=None, **kwargs):
         grouped_lines = defaultdict(lambda: self.env["sale.order.line"])
         if section_id is None:
             section_id = (

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1940,6 +1940,9 @@ class SaleOrderLine(models.Model):
                 'price': float,
                 'readOnly': bool,
                 'uomDisplayName': String,
+                'uomId': int,
+                'productUomFactor': float (optional),
+                'productUomDisplayName': string (optional),
             }
         """
         if len(self) == 1:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1950,7 +1950,7 @@ class SaleOrderLine(models.Model):
                 "quantity": self.product_uom_qty,
                 "price": self._get_discounted_price(),
                 "readOnly": (self.order_id._is_readonly() or bool(self.combo_item_id)),
-                "uomDisplayName": self.product_uom_id.display_name,
+                **self.order_id._get_product_catalog_uom_data(self.product_id, self.product_uom_id),
             }
         if self:
             self.product_id.ensure_one()

--- a/addons/sale/tests/test_product_catalog.py
+++ b/addons/sale/tests/test_product_catalog.py
@@ -48,6 +48,7 @@ class TestProductCatalog(HttpCase, SaleCommon):
                     "order_id": self.res_id,
                     "product_id": product.id,
                     "quantity": quantity,
+                    "uom_id": product.uom_id.id,
                     **kwargs,
                 }
             },

--- a/addons/sale/views/product_views.xml
+++ b/addons/sale/views/product_views.xml
@@ -163,18 +163,17 @@
         <field name="model">product.product</field>
         <field name="arch" type="xml">
             <filter name="favorites" position="after">
+                <separator/>
+                <filter string="In the Order"
+                        invisible="context.get('active_model', '') != 'sale.order.line'"
+                        name="products_in_sale_order"
+                        domain="[('product_catalog_product_is_in_sale_order', '=', True)]"/>
                 <filter
                     string="Previously bought"
                     name="products_previously_bought_by_customer"
                     domain="[('previously_bought_by_customer', '=', True)]"
                     invisible="context.get('active_model', '') != 'sale.order.line'"
                 />
-            </filter>
-            <filter name="goods" position="after">
-                <filter string="In the Order"
-                        invisible="context.get('active_model', '') != 'sale.order.line'"
-                        name="products_in_sale_order"
-                        domain="[('product_catalog_product_is_in_sale_order', '=', True)]"/>
             </filter>
         </field>
     </record>

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2654,12 +2654,10 @@ Please change the quantity done or the rounding precision in your settings.""",
             }
         self.product_id.ensure_one()
         return {
-            **parent_record._get_product_price_and_data(self.product_id),
+            'price': self.product_id.standard_price,
             'quantity': self[0].product_uom_qty,
             'readOnly': len(self) > 1,
-            'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,
-            'uomId': self[0].uom_id.id,
-            'productUomFactor': self[0].product_id.uom_id.factor / self[0].uom_id.factor,
+            **parent_record._get_product_catalog_uom_data(self.product_id, self[0].uom_id),
         }
 
     def _visible_quantity(self):

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2655,16 +2655,11 @@ Please change the quantity done or the rounding precision in your settings.""",
         self.product_id.ensure_one()
         return {
             **parent_record._get_product_price_and_data(self.product_id),
-            'quantity': sum(
-                self.mapped(
-                    lambda line: line.uom_id._compute_quantity(
-                        qty=line.product_qty,
-                        to_unit=line.uom_id,
-                    ),
-                ),
-            ),
+            'quantity': self[0].product_uom_qty,
             'readOnly': len(self) > 1,
             'uomDisplayName': len(self) == 1 and self.uom_id.display_name or self.product_id.uom_id.display_name,
+            'uomId': self[0].uom_id.id,
+            'productUomFactor': self[0].product_id.uom_id.factor / self[0].uom_id.factor,
         }
 
     def _visible_quantity(self):

--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -53,9 +53,9 @@ class AccountMove(models.Model):
             default_vendor_bill_id=self.id
         )._get_records_action(name=self.env._("Landed Costs"), views=views)
 
-    def _update_order_line_info(self, product_id, quantity, **kwargs):
-        price_unit = super()._update_order_line_info(product_id, quantity, **kwargs)
-        move_line = self.line_ids.filtered(lambda line: line.product_id.id == product_id)
+    def _update_order_line_info(self, product, quantity, uom, **kwargs):
+        price_unit = super()._update_order_line_info(product, quantity, uom, **kwargs)
+        move_line = self.line_ids.filtered(lambda line: line.product_id.id == product.id)
         if move_line:
             move_line.is_landed_costs_line = move_line.product_id.landed_cost_ok
         return price_unit

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -228,13 +228,15 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
             'partner_id': self.partner_a.id
         })
         account_move._update_order_line_info(
-            product_id=self.landed_cost.id,
-            quantity=1
+            product=self.landed_cost,
+            quantity=1,
+            uom=account_move.product_uom_id,
         )
         self.assertTrue(account_move.invoice_line_ids.is_landed_costs_line, "The landed cost should appear in the move line.")
         account_move._update_order_line_info(
-            product_id=self.product.id,
-            quantity=1
+            product=self.product,
+            quantity=1,
+            uom=account_move.product_uom_id,
         )
         move_line_no_landed = account_move.line_ids.filtered(lambda line: line.product_id == self.product)
         self.assertFalse(move_line_no_landed.is_landed_costs_line, "The landed cost should not be set to True.")

--- a/addons/uom/data/uom_data.xml
+++ b/addons/uom/data/uom_data.xml
@@ -98,7 +98,7 @@
         <field name="relative_uom_id" ref="uom.product_uom_gram"/>
     </record>
     <record id="product_uom_ton" model="uom.uom">
-        <field name="name">Ton</field>
+        <field name="name">t</field>
         <field name="relative_factor" eval="1000"/>
         <field name="relative_uom_id" ref="uom.product_uom_kgm"/>
     </record>


### PR DESCRIPTION
When a product is being sold/purchased/manufactured/invoiced
in a different unit than the product unit's, the price per
product unit will be shown to faciliate comparison.

This commit also improves the catalog;
- Keep consistent pricing when changing quantity.
- Match with the correct vendor in purchase and vendor bills.
- Create correct purchase order line and allign it with the catalog.
- Correctly propagate unit, price and quantity between catalog and lines.
-  Account for currency in price calculation.
- Send the correct unit to the frontend when deleting a product.
- Avoid quantity conversion when unit is changed in accounting.
- Create AMLs in vendor bills with correct vendor's data.
---
**Improve best price calculation in purchase alternatives comparison**:

- Best price calculation was based on price without accounting
for different units.

- New calculation highlights the best line based
on the best price per product unit.

- Additonally, units are no longer clickable.

---
- "In the Order" filter now has its own section with a seperator and
moved under favorites.
---
- Change Ton UoM name to its standard abbreviation 't'.

Task: 4736022

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
