### PR TITLE
[FIX] account: allow branch-only active users to access chart of accounts

### DIFF
--- a/addons/account/security/account_security.xml
+++ b/addons/account/security/account_security.xml
@@ -171,7 +171,7 @@
     <record id="account_comp_rule" model="ir.rule">
         <field name="name">Account multi-company</field>
         <field name="model_id" ref="model_account_account"/>
-        <field name="domain_force">[('company_ids', 'parent_of', company_ids)]</field>
+        <field name="domain_force">[('company_ids', 'in', [user.company_id.id])]</field>
     </record>
 
     <record id="account_group_comp_rule" model="ir.rule">

--- a/addons/account/static/tests/tours/tour_tests_coa.js
+++ b/addons/account/static/tests/tours/tour_tests_coa.js
@@ -1,0 +1,26 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('chart_of_accounts_branch_access_tour', {
+    steps: () => [
+        {
+            trigger: '.o_app:contains("Accounting")',
+            content: "Open Accounting App",
+            run: 'click',
+        },
+        {
+            content: "Go to Configuration",
+            trigger: 'span:contains("Configuration")',
+            run: "click",
+        },
+        {
+            content: "Go to Chart of Accounts",
+            trigger: 'a:contains("Chart of Accounts")',
+            run: "click",
+        },
+        {
+            trigger: '.o_breadcrumb .text-truncate:contains("Chart of Accounts")',
+        },
+    ]
+});

--- a/addons/account/tests/test_tour.py
+++ b/addons/account/tests/test_tour.py
@@ -87,3 +87,22 @@ class TestUi(AccountTestInvoicingHttpCommon):
         product.supplier_taxes_id = new_tax
 
         self.start_tour("/odoo", 'account_tax_group', login="admin")
+
+    def test_branch_chart_of_accounts_access_tour(self):
+        branch_company = self.env['res.company'].create({
+            'name': 'Branch Co',
+            'parent_id': self.company_data['company'].id,
+        })
+        test_user = self.env['res.users'].with_context(no_reset_password=True).create({
+            'name': 'Branch User',
+            'login': 'branch.user@test.com',
+            'email': 'branch.user@test.com',
+            'company_id': branch_company.id,
+            'company_ids': [Command.set([self.company_data['company'].id, branch_company.id])],
+            'groups_id': [
+                Command.link(self.env.ref('base.group_user').id),
+                Command.link(self.env.ref('account.group_account_manager').id),
+            ],
+        })
+
+        self.start_tour("/web", 'chart_of_accounts_branch_access_tour', login=test_user.login)


### PR DESCRIPTION
When a user has access to both a parent company and its branch but activates only the branch, accessing the chart of accounts fails with an access error. And this is because after this commit 0238971a
Users can access records from a parent company when working inside a branch, if both are in their allowed companies. but we are setting active companies `activeCompanyIds` in allowed companies instead of allowed companies This commit fix this and set all the companies the user has access to them in the allowed companies.

Steps to reproduce:
1. Create a branch company.
2. Create a user with access to both the parent and branch companies.
3. Log in as the user and activate only the branch company.
4. Go to Accounting > Configuration > Chart of Accounts. An access error will occur.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
