### PR TITLE
[IMP] base, website_sale: return 404 instead of 403

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -22,7 +22,7 @@ from odoo.tools import consteq, email_normalize_all
 _logger = logging.getLogger(__name__)
 
 
-def handle_wslide_error(exception):
+def handle_wslide_error(exception, **kwargs):
     if isinstance(exception, AccessError):
         return request.redirect("/slides?invite_error=no_rights", 302)
 


### PR DESCRIPTION
Previously, protected records (e.g., empty categories, unpublished products) would raise an AccessError, resulting in a 403 response. This could inadvertently reveal the existence of restricted content.

This commit improves the behavior by:
- Returning a 404 Not Found instead of 403 for inaccessible records to prevent information leakage.
- Redirecting users to relevant fallback pages when possible:
  - If a product URL includes an outdated category, redirect to the product page.
  - If a product no longer belongs to a category, redirect to the category page.

opw-4747092