### PR TITLE
[IMP] base_sparse_field: allow defaults on sparse fields

### DIFF
--- a/addons/base_sparse_field/models/fields.py
+++ b/addons/base_sparse_field/models/fields.py
@@ -50,7 +50,13 @@ def _get_attrs(self, model_class, name):
 def _compute_sparse(self, records):
     for record in records:
         values = record[self.sparse]
-        record[self.name] = values.get(self.name)
+        if self.name in values:
+            record[self.name] = values.get(self.name)
+        elif self.default:
+            record[self.name] = self.default(record)
+        else:
+            record[self.name] = None
+
     if self.relational:
         for record in records:
             record[self.name] = record[self.name].exists()

--- a/addons/base_sparse_field/models/models.py
+++ b/addons/base_sparse_field/models/models.py
@@ -100,3 +100,5 @@ class Sparse_FieldsTest(models.TransientModel):
     char = fields.Char(sparse='data')
     selection = fields.Selection([('one', 'One'), ('two', 'Two')], sparse='data')
     partner = fields.Many2one('res.partner', sparse='data')
+
+    char_default = fields.Char(sparse='data', default='one')

--- a/addons/base_sparse_field/tests/test_sparse_fields.py
+++ b/addons/base_sparse_field/tests/test_sparse_fields.py
@@ -38,3 +38,11 @@ class TestSparseFields(common.TransactionCase):
         self.assertEqual(len(fields), len(names))
         for field in fields:
             self.assertEqual(field.serialization_field_id.name, 'data')
+
+    def test_sparse_default(self):
+        """ test sparse fields with default values. """
+        record = self.env['sparse_fields.test'].create({})
+        self.assertEqual(record.char_default, 'one')
+        
+        record2 = self.env['sparse_fields.test'].create({'char_default': 'override'})
+        self.assertEqual(record2.char_default, 'override')

--- a/doc/cla/individual/psevertson.md
+++ b/doc/cla/individual/psevertson.md
@@ -1,0 +1,11 @@
+United States, 2024-05-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Porter Severtson portersevertson@gmail.com https://github.com/psevertson


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Adds the ability to use default values on sparse fields

Current behavior before PR:
- Sparse fields ignored the `default` parameter

Desired behavior after PR is merged:
- Sparse fields can be assigned a `default ` value to use if not defined in the Serialized field


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
