### PR TITLE
16.0 opw 4482622 suju

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -32,6 +32,7 @@ class WebsiteAccount(CustomerPortal):
         ]
 
     def _prepare_home_portal_values(self, counters):
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         values = super()._prepare_home_portal_values(counters)
         CrmLead = request.env['crm.lead']
         if 'lead_count' in counters:
@@ -50,6 +51,7 @@ class WebsiteAccount(CustomerPortal):
 
     @http.route(['/my/leads', '/my/leads/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_leads(self, page=1, date_begin=None, date_end=None, sortby=None, **kw):
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         values = self._prepare_portal_layout_values()
         CrmLead = request.env['crm.lead']
         domain = self.get_domain_my_lead(request.env.user)
@@ -93,6 +95,7 @@ class WebsiteAccount(CustomerPortal):
 
     @http.route(['/my/opportunities', '/my/opportunities/page/<int:page>'], type='http', auth="user", website=True)
     def portal_my_opportunities(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
+        request.update_context(allowed_company_ids=request.env.user.company_ids.ids)
         values = self._prepare_portal_layout_values()
         CrmLead = request.env['crm.lead']
         domain = self.get_domain_my_opp(request.env.user)

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -149,7 +149,7 @@ class TestPartnerAssign(TransactionCase):
             pass
 
 
-class TestPartnerLeadPortal(TestCrmCommon):
+class TestPartnerLeadPortal(TestCrmCommon, HttpCase):
 
     def setUp(self):
         super(TestPartnerLeadPortal, self).setUp()
@@ -222,6 +222,58 @@ class TestPartnerLeadPortal(TestCrmCommon):
         record_action = self.lead_portal._get_access_action(access_uid=self.user_portal.id)
         self.assertEqual(record_action['url'], '/my/opportunity/%s' % self.lead_portal.id)
         self.assertEqual(record_action['type'], 'ir.actions.act_url')
+    
+    def test_portal_routes_leads_and_opportunities_multiple_companies(self):
+        """This test checks if a portal user can see leads(opportunities) from multiple companies that are assigned to him"""
+
+        original_company = self.user_portal.company_id
+        partner_id = self.user_portal.partner_id.id
+
+        company_a = self.env['res.company'].create({'name': 'Company A'})
+
+        self.user_portal.write({'company_ids': [Command.set([original_company.id, company_a.id])]})
+
+        lead_name_orig = 'Test Portal Lead Orig'
+        lead_name_a = 'Test Portal Lead A'
+        opp_name_orig = 'Test Portal Opp Orig'
+        opp_name_a = 'Test Portal Opp A'
+
+        self.env['crm.lead'].create([
+            {
+                'name': lead_name_orig,
+                'type': 'lead',
+                'company_id': original_company.id,
+                'partner_assigned_id': partner_id,
+            },
+            {
+                'name': lead_name_a,
+                'type': 'lead',
+                'company_id': company_a.id,
+                'partner_assigned_id': partner_id,
+            },
+            {
+                'name': opp_name_orig,
+                'type': 'opportunity',
+                'company_id': original_company.id,
+                'partner_assigned_id': partner_id,
+            },
+            {
+                'name': opp_name_a,
+                'type': 'opportunity',
+                'company_id': company_a.id,
+                'partner_assigned_id': partner_id,
+            },
+        ])
+
+        self.authenticate(self.user_portal.login, self.user_portal.login)
+
+        response_leads = self.url_open('/my/leads')
+        self.assertIn(lead_name_orig, response_leads.text)
+        self.assertIn(lead_name_a, response_leads.text)
+
+        response_opps = self.url_open('/my/opportunities')
+        self.assertIn(opp_name_orig, response_opps.text)
+        self.assertIn(opp_name_a, response_opps.text)
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
Correct multi-company lead visibility in portal.

[task-4482622](https://www.odoo.com/web#view_type=form&model=project.task&id=4482622)

Description of the issue/feature this PR addresses:
In a multi-company environment, portal users (partners) were unable to
access Opportunities and Leads belonged to them, when these
records belonged to company(branch) that is not main company. Their visibility
was restricted to records from the main company, even if their access
rights were configured to allow access to multiple companies.

Steps to reproduce:
1. Create a new company
2. Create a partner and grant them portal access
3. Grant the partner access right to the new company.
4. Switch to the new company and create an opportunity and assign it to
this partner (Under assigned Partner tab).
5. Log in as the partner, go to "my/opportunities."
6. The opportunity is not there.

Desired behavior after PR is merged:
Partners can see lead/opportunities from multiple companies.

---
Current behavior exists for other portal endpoints such as my/subscriptions, my/sales, my/invoices but I believe that the current behavior is expected and normal for these endpoints.

---
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)