### PR TITLE
[FIX] account_*, l10n_*, hr_expense, web, base: barcode quiet mode

### DIFF
--- a/addons/account_payment/models/account_move.py
+++ b/addons/account_payment/models/account_move.py
@@ -170,7 +170,7 @@ class AccountMove(models.Model):
     def _generate_portal_payment_qr(self):
         self.ensure_one()
         portal_url = self._get_portal_payment_link()
-        barcode = self.env['ir.actions.report'].barcode(barcode_type="QR", value=portal_url, width=128, height=128)
+        barcode = self.env['ir.actions.report'].barcode(barcode_type="QR", value=portal_url, width=128, height=128, quiet=False)
         return image_data_uri(base64.b64encode(barcode))
 
     def _get_portal_payment_link(self):

--- a/addons/account_qr_code_emv/models/res_bank.py
+++ b/addons/account_qr_code_emv/models/res_bank.py
@@ -88,6 +88,7 @@ class ResPartnerBank(models.Model):
         if qr_method == 'emv_qr':
             return {
                 'barcode_type': 'QR',
+                'quiet': False,
                 'width': 128,
                 'height': 128,
                 'humanreadable': 1,

--- a/addons/account_qr_code_sepa/models/res_bank.py
+++ b/addons/account_qr_code_sepa/models/res_bank.py
@@ -31,6 +31,7 @@ class ResPartnerBank(models.Model):
         if qr_method == 'sct_qr':
             return {
                 'barcode_type': 'QR',
+                'quiet': False,
                 'width': 128,
                 'height': 128,
                 'humanreadable': 1,

--- a/addons/hr_expense/static/src/components/qrcode_action.js
+++ b/addons/hr_expense/static/src/components/qrcode_action.js
@@ -15,7 +15,7 @@ class QRModalComponent extends Component {
 
     setup() {
         this.url = sprintf(
-            "/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1",
+            "/report/barcode/?barcode_type=QR&value=%s&width=256&height=256&humanreadable=1&quiet=0",
             this.props.action.params.url);
     }
 }

--- a/addons/l10n_ch/models/res_bank.py
+++ b/addons/l10n_ch/models/res_bank.py
@@ -158,7 +158,7 @@ class ResPartnerBank(models.Model):
                 'barcode_type': 'QR',
                 'width': 256,
                 'height': 256,
-                'quiet': 1,
+                'quiet': 0,
                 'mask': 'ch_cross',
                 'value': '\n'.join(self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication)),
                 # Swiss QR code requires Error Correction Level = 'M' by specification

--- a/addons/l10n_ch/tests/test_swissqr.py
+++ b/addons/l10n_ch/tests/test_swissqr.py
@@ -151,7 +151,7 @@ class TestSwissQR(AccountTestInvoicingCommon):
             'barLevel': 'M',
             'width': 256,
             'height': 256,
-            'quiet': 1,
+            'quiet': 0,
             'mask': 'ch_cross',
             'value': payload,
         }

--- a/addons/l10n_eg_edi_eta/views/report_invoice.xml
+++ b/addons/l10n_eg_edi_eta/views/report_invoice.xml
@@ -6,7 +6,7 @@
                     <p>
                         <strong class="text-center">ETA QR Code</strong>
                         <img style="display:block;"
-                             t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', o.l10n_eg_qr_code, 130, 130)"/>
+                             t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s'%('QR', o.l10n_eg_qr_code, 130, 130, 0)"/>
                     </p>
                 </div>
             </xpath>

--- a/addons/l10n_es_edi_tbai/views/report_invoice.xml
+++ b/addons/l10n_es_edi_tbai/views/report_invoice.xml
@@ -5,7 +5,7 @@
             <div name="l10n_es_tbai_qrcode" t-if="o.l10n_es_tbai_state == 'sent'" style="page-break-inside: avoid">
                 <div t-out="o.l10n_es_tbai_post_document_id._get_tbai_id()"/>
                 <img
-                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;barLevel=%s'%('QR', quote_plus(o.l10n_es_tbai_post_document_id._get_tbai_qr()), 125, 125, 'M')"/>
+                    t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;barLevel=%s&amp;quiet=%s'%('QR', quote_plus(o.l10n_es_tbai_post_document_id._get_tbai_qr()), 125, 125, 'M', 0)"/>
 
                 <!-- NOTE: Sizes assume a 90 dpi resolution to meet requirements (between 30 and 40 mm) -->
             </div>

--- a/addons/l10n_gr_edi/models/account_move.py
+++ b/addons/l10n_gr_edi/models/account_move.py
@@ -307,6 +307,7 @@ class AccountMove(models.Model):
         if document.state in ('invoice_sent', 'bill_sent'):
             barcode_params = urlencode({
                 'barcode_type': 'QR',
+                'quiet': False,
                 'value': document.mydata_url,
                 'width': 180,
                 'height': 180,

--- a/addons/l10n_id/models/res_bank.py
+++ b/addons/l10n_id/models/res_bank.py
@@ -124,6 +124,7 @@ class ResPartnerBank(models.Model):
                 return {}
             return {
                 'barcode_type': 'QR',
+                'quiet': False,
                 'width': 120,
                 'height': 120,
                 'value': self._get_qr_vals(qr_method, amount, currency, debtor_partner, free_communication, structured_communication),

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -596,7 +596,7 @@ class AccountMove(models.Model):
                 self.amount_residual,
                 self.payment_reference or self.name,
                 ("Payment for %s" % self.name))
-            barcode = self.env['ir.actions.report'].barcode(barcode_type="QR", value=payment_url, width=120, height=120)
+            barcode = self.env['ir.actions.report'].barcode(barcode_type="QR", value=payment_url, width=120, height=120, quiet=False)
             return image_data_uri(base64.b64encode(barcode))
         return super()._generate_qr_code(silent_errors)
 

--- a/addons/l10n_in_edi/views/edi_pdf_report.xml
+++ b/addons/l10n_in_edi/views/edi_pdf_report.xml
@@ -17,7 +17,7 @@
                     <span t-esc="l10n_in_einvoice_json['Irn']"/>
                 </div>
                 <div class="col-3 mt-1">
-                    <img t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' %('QR', l10n_in_einvoice_json['SignedQRCode'], 500, 500)" style="max-height: 155px"/>
+                    <img t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' %('QR', l10n_in_einvoice_json['SignedQRCode'], 500, 500, 0)" style="max-height: 155px"/>
                 </div>
             </div>
         </xpath>

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -93,6 +93,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         encoded_params = url_encode({
             'barcode_type': 'QR',
+            'quiet': False,
             'value': self.l10n_jo_edi_qr,
             'width': 200,
             'height': 200,

--- a/addons/l10n_ke_edi_tremol/views/report_invoice.xml
+++ b/addons/l10n_ke_edi_tremol/views/report_invoice.xml
@@ -22,7 +22,7 @@
                     <div class="col">
                         <p t-if="o.l10n_ke_cu_qrcode">
                             <strong class="text-center">TIMS URL</strong><br/><br/>
-                            <img style="display:block;"  t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('QR', quote_plus(o.l10n_ke_cu_qrcode), 130, 130)" alt="QR Code"/>
+                            <img style="display:block;"  t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s' % ('QR', quote_plus(o.l10n_ke_cu_qrcode), 130, 130, 0)" alt="QR Code"/>
                         </p>
                     </div>
                 </div>

--- a/addons/l10n_my_edi/models/account_move.py
+++ b/addons/l10n_my_edi/models/account_move.py
@@ -846,6 +846,7 @@ class AccountMove(models.Model):
         try:
             qr_code = self.env['ir.actions.report'].barcode(
                 barcode_type='QR',
+                quiet=False,
                 width=128,
                 height=128,
                 humanreadable=1,

--- a/addons/l10n_sa/views/report_invoice.xml
+++ b/addons/l10n_sa/views/report_invoice.xml
@@ -24,7 +24,7 @@
                     <p class="col-6 me-3">
                         <img t-if="o.l10n_sa_qr_code_str"
                             style="display:block;"
-                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
+                            t-att-src="'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s&amp;quiet=%s'%('QR', quote_plus(o.l10n_sa_qr_code_str), 200, 200, 0)"/>
                     </p>
                     <div class="col-6" t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)" groups="account.group_delivery_invoice_address" name="shipping_address_block">
                         <strong>Shipping Address:</strong>

--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -71,7 +71,7 @@ class ReportController(http.Controller):
         :param height: Pixel height of the barcode
         :param humanreadable: Accepted values: 0 (default) or 1. 1 will insert the readable value
         at the bottom of the output image
-        :param quiet: Accepted values: 0 (default) or 1. 1 will display white
+        :param quiet: Accepted values: 0 or 1 (default). 1 will display white
         margins on left and right.
         :param mask: The mask code to be used when rendering this QR-code.
                      Masks allow adding elements on top of the generated image,

--- a/addons/web/controllers/report.py
+++ b/addons/web/controllers/report.py
@@ -72,7 +72,7 @@ class ReportController(http.Controller):
         :param humanreadable: Accepted values: 0 (default) or 1. 1 will insert the readable value
         at the bottom of the output image
         :param quiet: Accepted values: 0 or 1 (default). 1 will display white
-        margins on left and right.
+        margins on left and right for barcodes and on all sides for QR codes.
         :param mask: The mask code to be used when rendering this QR-code.
                      Masks allow adding elements on top of the generated image,
                      such as the Swiss cross in the center of QR-bill codes.

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -711,7 +711,8 @@ class IrActionsReport(models.Model):
         elif barcode_type == 'QR':
             # for `QR` type, `quiet` is not supported. And is simply ignored.
             # But we can use `barBorder` to get a similar behaviour.
-            if 'quiet' in kwargs and not kwargs['quiet']:
+            # quiet=True & barBorder=4 by default cf above, remove border only if quiet=False
+            if not kwargs['quiet']:
                 kwargs['barBorder'] = 0
 
         if barcode_type in ('EAN8', 'EAN13') and not check_barcode_encoding(value, barcode_type):

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -711,7 +711,7 @@ class IrActionsReport(models.Model):
         elif barcode_type == 'QR':
             # for `QR` type, `quiet` is not supported. And is simply ignored.
             # But we can use `barBorder` to get a similar behaviour.
-            if kwargs['quiet']:
+            if 'quiet' in kwargs and not kwargs['quiet']:
                 kwargs['barBorder'] = 0
 
         if barcode_type in ('EAN8', 'EAN13') and not check_barcode_encoding(value, barcode_type):


### PR DESCRIPTION
Before the fix:
- method documentation outdated
- quiet mode for QR Code was inverted and only add white border when disabled.

After the fix:
- method documentation aligned with the code
- quiet mode works for QR code like other type

Notice that this change, can have an impact for all usage of QR type as the default format has now the white border.
Need to be checked with PO and team using barcode (stock, accounting)

Existing usage has been updated to use format like before. So without borders most of the time

Enteprise: https://github.com/odoo/enterprise/pull/85228

opw-4785714