### PR TITLE
[FIX] mail: ensure call starter name is displayed correctly

### DIFF
--- a/addons/im_livechat/static/tests/call.test.js
+++ b/addons/im_livechat/static/tests/call.test.js
@@ -1,0 +1,43 @@
+import {
+    click,
+    contains,
+    mockGetMedia,
+    setupChatHub,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+
+import { defineLivechatModels } from "@im_livechat/../tests/livechat_test_helpers";
+
+import { test } from "@odoo/hoot";
+import { mockDate } from "@odoo/hoot-mock";
+
+import { Command, serverState } from "@web/../tests/web_test_helpers";
+
+defineLivechatModels();
+
+test.tags("desktop");
+test("should display started a call message with operator livechat username", async () => {
+    mockDate("2025-01-01 12:00:00", +1);
+    mockGetMedia();
+    const pyEnv = await startServer();
+    pyEnv["res.partner"].write(serverState.partnerId, {
+        user_livechat_username: "mitchell boss",
+    });
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
+    const channelId = pyEnv["discuss.channel"].create({
+        anonymous_name: "Visitor",
+        channel_member_ids: [
+            Command.create({ partner_id: serverState.partnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        channel_type: "livechat",
+        livechat_active: true,
+        livechat_operator_id: serverState.partnerId,
+    });
+    setupChatHub({ opened: [channelId] });
+    await start();
+    await contains(".o-mail-ChatWindow", { text: "Visitor" });
+    await click("[title='Start a Call']");
+    await contains(".o-mail-NotificationMessage", { text: "mitchell boss started a call.1:00 PM" });
+});

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -357,7 +357,7 @@ export class Message extends Record {
         /** @this {import("models").Message} */
         compute() {
             if (this.notificationType === "call") {
-                return _t("%(caller)s started a call", { caller: this.author.name });
+                return _t("%(caller)s started a call", { caller: this.authorName });
             }
             if (this.isEmpty) {
                 return _t("This message has been removed");

--- a/addons/mail/static/src/core/common/notification_message.js
+++ b/addons/mail/static/src/core/common/notification_message.js
@@ -53,7 +53,7 @@ export class NotificationMessage extends Component {
     get callInformation() {
         const history = this.message.call_history_ids[0];
         if (history?.duration_hour === undefined || !history?.end_dt) {
-            return _t("%(author)s started a call.", { author: this.message.author.name });
+            return _t("%(author)s started a call.", { author: this.message.authorName });
         }
         let duration = luxon.Duration.fromObject({
             seconds: Math.max(1, Math.round(history.duration_hour * 3600)),

--- a/addons/mail/static/src/core/common/out_of_focus_service.js
+++ b/addons/mail/static/src/core/common/out_of_focus_service.js
@@ -44,11 +44,11 @@ export class OutOfFocusService {
             icon = author.avatarUrl;
             if (message.thread?.channel_type === "channel") {
                 notificationTitle = _t("%(author name)s from %(channel name)s", {
-                    "author name": author.name,
+                    "author name": message.authorName,
                     "channel name": message.thread.displayName,
                 });
             } else {
-                notificationTitle = author.name;
+                notificationTitle = message.authorName;
             }
         }
         const notificationContent = message.previewText

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_rtc_session.js
@@ -38,6 +38,19 @@ export class DiscussChannelRtcSession extends models.ServerModel {
                 }).get_result(),
             ]);
         }
+        for (const record of rtcSessions) {
+            const [channel] = DiscussChannel.browse(record.channel_id);
+            if (channel.rtc_session_ids.length === 1) {
+                DiscussChannel.message_post(
+                    channel.id,
+                    makeKwArgs({
+                        body: `<div data-oe-type="call" class="o_mail_notification"></div>`,
+                        message_type: "notification",
+                        subtype_xmlid: "mail.mt_comment",
+                    })
+                );
+            }
+        }
         BusBus._sendmany(notifications);
         return sessionIds;
     }


### PR DESCRIPTION
**purpose of this PR :**

The name was appearing as undefined because message.author.name was not set
for portal users. to handle this, we used `message.authorName` directly. also it was
changed to `message.authorName` to be consistent with the rest of the code.

task-[4782291](https://www.odoo.com/odoo/project/1519/tasks/4782291)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
