### PR TITLE
[FIX] l10n_es_edi_tbai: correct freelance invoice cancellation

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -44,7 +44,8 @@
             <Ingresos t-if="freelancer">
                 <Ingreso t-foreach="tbai_b64_list" t-as="tbai_b64">
                     <TicketBai t-if="is_emission" t-out="tbai_b64"/>
-                    <Renta><DetalleRenta><Epigrafe t-out="epigrafe"/></DetalleRenta></Renta>
+                    <Renta t-if="is_emission"><DetalleRenta><Epigrafe t-out="epigrafe"/></DetalleRenta></Renta>
+                    <AnulacionTicketBai t-else="" t-out="tbai_b64"/>
                 </Ingreso>
             </Ingresos>
         </template>


### PR DESCRIPTION
The XML format used to cancel invoices for freelancers in Bizkaia was invalid.

Steps to reproduce:
- Configure a freelance company with Bizkaia as tax agency
- Create and send an invoice to TicketBAI
- Cancel it using "TicketBAI Cancel"
- You get an error: "Invalid content was found starting with element 'Renta'. One of '(AnulacionTicketBai)' is expected."

This fix follows the official Bizkaia documentation: https://www.batuz.eus/fitxategiak/batuz/lroe/Batuz_LROE_Especificaciones_Env%C3%ADo_Masivo_V1_0_7.pdf (see page 30) and the example provided here:
https://www.batuz.eus/fitxategiak/batuz/LROE/ejemplos/Ejemplo_Anulacion_1_LROE_PF_140_IngresosConFacturaConSG_79732487C.xml

opw-4634677