### PR TITLE
[FIX] purchase_stock: ensure the correct warehouse location is shown in the error message

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -267,7 +267,7 @@ class PurchaseOrderLine(models.Model):
         dest_loc = self.move_dest_ids.location_id or self.orderpoint_id.location_id
         if warehouse_loc and dest_loc and dest_loc.warehouse_id and not warehouse_loc.parent_path in dest_loc[0].parent_path:
             raise UserError(_('For the product %s, the warehouse of the operation type (%s) is inconsistent with the location (%s) of the reordering rule (%s). Change the operation type or cancel the request for quotation.',
-                              self.product_id.display_name, self.order_id.picking_type_id.display_name, self.orderpoint_id.location_id.display_name, self.orderpoint_id.display_name))
+                              self.product_id.display_name, self.order_id.picking_type_id.display_name, dest_loc.display_name, self.orderpoint_id.display_name))
 
     def _prepare_stock_move_vals(self, picking, price_unit, product_uom_qty, product_uom):
         self.ensure_one()


### PR DESCRIPTION
The change added in https://github.com/odoo/odoo/commit/9b43d7ec5aff92bf9b4286ec3b44e2c628dcddea updates the logic to get dest_loc without updating the error message, so that the message displays "location False"

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
