### PR TITLE
[FIX] point_of_sale: test_preset_timing failure on sundays

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1989,7 +1989,7 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'hour_from': 0,
                 'hour_to': 24,
                 'day_period': 'morning',
-            }) for day in range(0, 6)],
+            }) for day in range(0, 7)],
         })
         self.preset_takeaway.write({
             'use_timing': True,


### PR DESCRIPTION
Issue:
- When the system date is set to a Sunday, the `test_preset_timing` tour fails.
- The failure occurs because no time slots are selectable, due to the absence of Sunday attendance records.

Fix:
- included Sunday as well when creating attendance in the `resource_calendar`.

