### PR TITLE
[FIX] base,web: use \t instead of <tab> in formatted display_name

### DIFF
--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -123,8 +123,8 @@ export function capitalize(s) {
  *      \*\*text\*\* => Put the text in bold.
  *      --text-- => Put the text in muted.
  *      \`text\` => Put the text in a rounded badge (bg-primary).
- *      \<br> => Insert a breakline.
- *      \<tab> => Insert 4 spaces.
+ *      \n => Insert a breakline.
+ *      \t => Insert 4 spaces.
  *
  * @param {string} text **will be escaped**
  * @returns {ReturnType<markup>} the formatted text
@@ -146,7 +146,7 @@ export function odoomark(text) {
             )
             .replaceAll(brEx, `<br/>`)
             .replaceAll(tabEx, `&nbsp;&nbsp;&nbsp;&nbsp;`)
-        );
+    );
 }
 
 /* eslint-disable */

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -3826,7 +3826,9 @@ test("many2one field with false as name", async () => {
 });
 
 test("many2one search with false as name", async () => {
-    onRpc("web_name_search", () => [{ id: 1, display_name: false, __formatted_display_name: false }]);
+    onRpc("web_name_search", () => [
+        { id: 1, display_name: false, __formatted_display_name: false },
+    ]);
     await mountView({
         type: "form",
         resModel: "partner",

--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -258,6 +258,6 @@ class ResCountryState(models.Model):
     def _compute_display_name(self):
         for record in self:
             if self.env.context.get('formatted_display_name'):
-                record.display_name = f"{record.name} <tab> --{record.country_id.code}--"
+                record.display_name = f"{record.name} \t --{record.country_id.code}--"
             else:
                 record.display_name = f"{record.name} ({record.country_id.code})"


### PR DESCRIPTION
The formatted display_name feature introduced in [1] used `<tab>` and `<br>` as "indent 4 spaces" and newline identifiers. Commit [2] then changed those two identifiers into `\t` and `\n`. This commit adapts an override of `_compute_display_name` that had been forgotten, but also the docstring of the function to apply the formatting.

[1] https://github.com/odoo/odoo/pull/206217
[2] https://github.com/odoo/odoo/pull/207672

Followup of 4749554

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
