### PR TITLE
[FIX] website: fix animations in mega menu

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -209,8 +209,15 @@ export class Colibri {
     getNodes(sel) {
         const selectors = this.interaction.dynamicSelectors;
         if (sel in selectors) {
-            const elem = selectors[sel]();
-            return elem ? [elem] : [];
+            const elems = selectors[sel]();
+            if (elems) {
+                if (elems.nodeName && ["FORM", "SELECT"].includes(elems.nodeName)) {
+                    return [elems];
+                }
+                return elems[Symbol.iterator] ? elems : [elems];
+            } else {
+                return [];
+            }
         }
         return this.interaction.el.querySelectorAll(sel);
     }

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -343,7 +343,12 @@ export class Interaction {
      * @returns {Function} removes the listeners
      */
     addListener(target, event, fn, options) {
-        const nodes = target[Symbol.iterator] ? target : [target];
+        let nodes;
+        if (target.nodeName && ["FORM", "SELECT"].includes(target.nodeName)) {
+            nodes = [target];
+        } else {
+            nodes = target[Symbol.iterator] ? target : [target];
+        }
         const [ev, handler, opts] = this.__colibri__.addListener(nodes, event, fn, options);
         return () => nodes.forEach((node) => node.removeEventListener(ev, handler, opts));
     }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -376,6 +376,50 @@ describe("using selectors", () => {
         );
         expect("span").toHaveAttribute("animal", "colibri");
     });
+
+    test("dynamic selector can return multiple nodes", async () => {
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicSelectors = {
+                _myselector: () => this.el.querySelectorAll(".my-selector"),
+            };
+            dynamicContent = {
+                _myselector: { "t-att-animal": () => "colibri" },
+            };
+        }
+        await startInteraction(
+            Test,
+            `
+            <div class="test">
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+                <span class="my-selector">coucou</span>
+            </div>`
+        );
+        expect(queryAll("span")).toHaveAttribute("animal", "colibri");
+    });
+
+    test("dynamicSelector on form element is applied on form, not on controls", async () => {
+        // <form> and <select> elements are iterable. Make sure that listeners
+        // and dynamic attributes are applied on the element, not its children.
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: { "t-att-animal": () => "colibri" },
+            };
+        }
+        await startInteraction(
+            Test,
+            `
+            <form class="test">
+                <input type="text">coucou</input>
+                <button type="button"/>Submit</button>
+            </form>`
+        );
+        expect(".test").toHaveAttribute("animal", "colibri");
+        expect(".test input").not.toHaveAttribute("animal");
+        expect(".test button").not.toHaveAttribute("animal");
+    });
 });
 
 describe("removing listeners", () => {

--- a/addons/website/static/src/interactions/animation.edit.js
+++ b/addons/website/static/src/interactions/animation.edit.js
@@ -1,0 +1,19 @@
+import { Animation } from "./animation";
+import { registry } from "@web/core/registry";
+
+const AnimationEdit = I => class extends I {
+    destroy() {
+        // We remove the "o_animate_preview" class here because it is added when
+        // an animation is selected in the options, and the "Animation"
+        // interaction considers it as part of the initial state. We remove it
+        // here because otherwise it is added back when exiting edit mode.
+        this.el.classList.remove("o_animate_preview");
+    }
+};
+
+registry
+    .category("public.interactions.edit")
+    .add("website.animation", {
+        Interaction: Animation,
+        mixin: AnimationEdit,
+    });

--- a/addons/website/static/src/interactions/animation.js
+++ b/addons/website/static/src/interactions/animation.js
@@ -30,7 +30,6 @@ export class Animation extends Interaction {
                 "o_animating": this.isAnimating,
                 "o_animated": this.isAnimated,
                 "o_animate_in_dropdown": !!el.closest(".dropdown"),
-                // TODO Remove with edit mode
                 "o_animate_preview": undefined,
             }),
             "t-att-style": (el) => {
@@ -208,9 +207,3 @@ export class Animation extends Interaction {
 registry
     .category("public.interactions")
     .add("website.animation", Animation);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.animation", {
-        Interaction: Animation,
-    });


### PR DESCRIPTION
**[FIX] website: fix animations in mega menu**

Steps to reproduce the issue:

1. Have a mega menu.
2. Go to edit.
3. Select one section of the mega menu.
4. Add an animation.
5. Error appears.

The issue arrises since this commit [1], where the new interactions
system was introduced. The elements in a mega menu should not animate
based on page scroll. But we were still trying to add a scroll listener
on an empty array, which caused the error.

This commit backports commit [2], which improves Colibri and was merged
in a later version. This allows the issue to be fixed.

[1]: https://github.com/odoo/odoo/commit/dd13994674d4ef4683f5a4d46a1f604650cfb92b
[2]: https://github.com/odoo/odoo/commit/56debb4f907a890511dca123c80e0c420b67cb36

opw-4778576

-------------------------------

**[FIX] website: fix animations not hidden in initial state**

- In Website edit mode.
- Drag and drop a "Columns" block into the page.
- Add a "fade in" animation to the first column of the block.
- Save the page.
- Bug: instead of being initially hidden before fading in, the column is
first visible, then becomes hidden, and only then starts fading in.

The issue arises from commit [1], where the new interactions system was
introduced. The "o_animate_preview" class, which forces the animated
element to be visible during animation preview in edit mode, was no
longer being removed when exiting edit mode.

[1]: https://github.com/odoo/odoo/commit/dd13994674d4ef4683f5a4d46a1f604650cfb92b

opw-4778576