### PR TITLE
[IMP] purchase_order_suggest: add option to suggest on actual demand

### DIFF
--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -59,4 +59,18 @@
             </div>
         </field>
     </record>
+
+    <record id="product_view_search_catalog" model="ir.ui.view">
+        <field name="name">purchase.view.search.catalog.inherit.purchase_stock</field>
+        <field name="model">product.product</field>
+        <field name="mode">extension</field>
+        <field name="inherit_id" ref="purchase.product_view_search_catalog"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='products_in_purchase_order']" position="after">
+                <separator/>
+                <filter string="To Order" name="products_with_negative_forecast" domain="[('virtual_available', '&lt;', 0)]"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>

--- a/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
+++ b/addons/purchase_stock/wizard/purchase_order_suggest_views.xml
@@ -10,8 +10,8 @@
                 <field name="product_ids" invisible="1"/> <!-- Needed for `_compute_product_count`. -->
                 <group>
                     <div class="text-muted">
-                        <p>Get recommendations of products to purchase at <field name="partner_id" class="oe_inline fw-bold" options="{'no_open': True}"/> based on stock on hand, and expected sales volumes.</p>
-                        <p>Set a reference period to estimate sales, and use the percentage to take into account seasonability and the increase/decrease of business.</p>
+                        <p>Get recommendations of products to purchase at <field name="partner_id" class="oe_inline fw-bold" options="{'no_open': True}"/> based on stock on hand, and expected sales volumes or actual demand.</p>
+                        <p>Estimate the sales volume based on a past period or order what you need based on actual demand. Use the percentage to take into account seasonality or business growth.</p>
                     </div>
                 </group>
                 <group>


### PR DESCRIPTION
### This PR includes 2 improvements:
#### 1- purchase_stock:
This PR adds a filter `To Order` in the products catalog search to filter products with negative forecast.

#### 2- purchase_order_suggest:
This PR adds an option in the suggest products to purchase wizard, based on `Actual Demand`. This option should suggest the products with negative forecast and have already been confirmed for out delivery. 


Task-4747147