### PR TITLE
[IMP] account_peppol: Peppol mail footer amendment

### DIFF
--- a/addons/account_peppol/data/mail_templates_email_layouts.xml
+++ b/addons/account_peppol/data/mail_templates_email_layouts.xml
@@ -8,22 +8,18 @@
             <xpath expr="//t[hasclass('o_signature')]" position="after">
                 <div id="peppol_advertisement" t-if="peppol_info" style="font-size: 13px;">
                     <t t-if="peppol_info['is_peppol_sent']">
-                        <p style="min-width: 590px;">
-                            PS: This invoice has also been <b style="color: $o-enterprise-action-color">sent on Peppol</b>.
-                        </p>
+                        <i class="text-muted" style="min-width: 590px;">
+                            This invoice has also been <b style="color: $o-enterprise-action-color">sent via Peppol</b>.
+                        </i>
                     </t>
-                    <t t-if="not peppol_info['is_peppol_sent']">
-                        <p style="min-width: 590px;">
-                            PS: <b style="color: $o-enterprise-action-color;">We did not send your invoice on Peppol.</b>
+                    <t t-if="not peppol_info['is_peppol_sent'] and not peppol_info['partner_on_peppol']">
+                        <i class="text-muted" style="min-width: 590px;">
+                            <t t-out="company.name"/> uses <a target="_blank" href="https://www.odoo.com/app/invoicing?utm_source=db&amp;utm_medium=email&amp;utm_campaign=einvoicing" style="color: $o-enterprise-color;">Odoo</a> to send invoices, but this one <b style="color: $o-enterprise-action-color;">could not be sent via Peppol</b>.
                             <t t-if="peppol_info['peppol_country'] == 'BE'">
-                                In Belgium, electronic invoicing will be <u>mandatory as of January 2026</u>.
-                                <a target="_blank" href="https://finance.belgium.be/en/enterprises/vat/e-invoicing/mandatory-use-structured-electronic-invoices-2026" style="text-decoration: none;">
-                                    &#x1F517;
-                                </a>
+                                <br/>
+                                In Belgium, electronic invoicing will be <u>mandatory as of January 2026</u> - don't wait to register.
                             </t>
-                            <br/>
-                            If you need a Peppol compliant software, we recommend <a target="_blank" href="https://www.odoo.com/app/invoicing?utm_source=db&amp;utm_medium=email&amp;utm_campaign=einvoicing" style="color: $o-enterprise-color;">Odoo</a>.
-                        </p>
+                        </i>
                     </t>
                 </div>
             </xpath>

--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -19,7 +19,15 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
 msgid ""
 "<br/>\n"
-"                            If you need a Peppol compliant software, we recommend"
+"                                In Belgium, electronic invoicing will be <u>mandatory as of January 2026</u> - don't wait to register."
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"<i class=\"text-muted\" style=\"min-width: 590px;\">\n"
+"                            This invoice has also been <b style=\"color: $o-enterprise-action-color\">sent via Peppol</b>.\n"
+"                        </i>"
 msgstr ""
 
 #. module: account_peppol
@@ -286,13 +294,6 @@ msgid "Fetch from Peppol"
 msgstr ""
 
 #. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"In Belgium, electronic invoicing will be <u>mandatory as of January "
-"2026</u>."
-msgstr ""
-
-#. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid ""
 "In demo mode sending and receiving invoices is simulated. There will be no "
@@ -431,20 +432,6 @@ msgstr ""
 #. module: account_peppol
 #: model:ir.actions.server,name:account_peppol.ir_cron_peppol_get_participant_status_ir_actions_server
 msgid "PEPPOL: update participant status"
-msgstr ""
-
-#. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"PS: <b style=\"color: $o-enterprise-action-color;\">We did not send your "
-"invoice on Peppol.</b>"
-msgstr ""
-
-#. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"PS: This invoice has also been <b style=\"color: $o-enterprise-action-"
-"color\">sent on Peppol</b>."
 msgstr ""
 
 #. module: account_peppol
@@ -938,4 +925,16 @@ msgstr ""
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid "Your registration should be activated within a day."
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"to send invoices, but this one <b style=\"color: $o-enterprise-action-"
+"color;\">could not be sent via Peppol</b>."
+msgstr ""
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid "uses"
 msgstr ""

--- a/addons/account_peppol/i18n/fr.po
+++ b/addons/account_peppol/i18n/fr.po
@@ -1,12 +1,7 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
 # 	* account_peppol
-# 
-# Translators:
-# Jolien De Paepe, 2024
-# Wil Odoo, 2024
-# Manon Rondou, 2025
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
@@ -25,10 +20,21 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
 msgid ""
 "<br/>\n"
-"                            If you need a Peppol compliant software, we recommend"
+"                                In Belgium, electronic invoicing will be <u>mandatory as of January 2026</u> - don't wait to register."
 msgstr ""
 "<br/>\n"
-"                            Si vous avez besoin d'un logiciel conforme à Peppol, nous vous recommandons"
+"                                En Belgique, la facturation électronique sera <u>obligatoire dès janvier 2026</u> - n'attendez plus pour vous enregistrer."
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"<i class=\"text-muted\" style=\"min-width: 590px;\">\n"
+"                            This invoice has also been <b style=\"color: $o-enterprise-action-color\">sent via Peppol</b>.\n"
+"                        </i>"
+msgstr ""
+"<i class=\"text-muted\" style=\"min-width: 590px;\">\n"
+"                            Cette facture a également été <b style=\"color: $o-enterprise-action-color\">envoyée via Peppol</b>.\n"
+"                        </i>"
 
 #. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.account_peppol_view_move_form
@@ -318,15 +324,6 @@ msgid "Fetch from Peppol"
 msgstr "Récupérer de Peppol"
 
 #. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"In Belgium, electronic invoicing will be <u>mandatory as of January "
-"2026</u>."
-msgstr ""
-"En Belgique, la facturation électronique sera <u>obligatoire à partir de "
-"janvier 2026</u>."
-
-#. module: account_peppol
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid ""
 "In demo mode sending and receiving invoices is simulated. There will be no "
@@ -468,24 +465,6 @@ msgstr "PEPPOL : mettre à jour le statut du message"
 #: model:ir.actions.server,name:account_peppol.ir_cron_peppol_get_participant_status_ir_actions_server
 msgid "PEPPOL: update participant status"
 msgstr "PEPPOL : mettre à jour le statut du participant"
-
-#. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"PS: <b style=\"color: $o-enterprise-action-color;\">We did not send your "
-"invoice on Peppol.</b>"
-msgstr ""
-"PS : <b style=\"color: $o-enterprise-action-color;\">Nous n'avons pas envoyé"
-" votre facture sur Peppol.</b>"
-
-#. module: account_peppol
-#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
-msgid ""
-"PS: This invoice has also been <b style=\"color: $o-enterprise-action-"
-"color\">sent on Peppol</b>."
-msgstr ""
-"PS : Cette facture a également été <b style=\"color: $o-enterprise-action-"
-"color\">envoyée sur Peppol</b>."
 
 #. module: account_peppol
 #: model:ir.model.fields.selection,name:account_peppol.selection__res_company__account_peppol_proxy_state__pending
@@ -1013,3 +992,17 @@ msgstr "Votre clé de migration est :"
 #: model_terms:ir.ui.view,arch_db:account_peppol.res_config_settings_view_form
 msgid "Your registration should be activated within a day."
 msgstr "Votre inscription devrait être activée dans la journée."
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid ""
+"to send invoices, but this one <b style=\"color: $o-enterprise-action-"
+"color;\">could not be sent via Peppol</b>."
+msgstr ""
+"pour envoyer ses factures, mais celle-ci <b style=\"color: $o-enterprise-action-"
+"color;\">n'a pas pu être envoyée via Peppol</b>."
+
+#. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.mail_notification_layout_with_responsible_signature_and_peppol
+msgid "uses"
+msgstr "utilise"

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -77,9 +77,11 @@ class AccountMove(models.Model):
         invoice = render_context['record']
         invoice_country = invoice.commercial_partner_id.country_code
         company_country = invoice.company_id.country_code
-        if company_country in PEPPOL_MAILING_COUNTRIES and invoice_country in PEPPOL_MAILING_COUNTRIES:
+        company_on_peppol = invoice.company_id.account_peppol_proxy_state == 'active'
+        if company_on_peppol and company_country in PEPPOL_MAILING_COUNTRIES and invoice_country in PEPPOL_MAILING_COUNTRIES:
             render_context['peppol_info'] = {
                 'peppol_country': invoice_country,
                 'is_peppol_sent': invoice.peppol_move_state in ('processing', 'done'),
+                'partner_on_peppol': invoice.commercial_partner_id.account_peppol_is_endpoint_valid,
             }
         return render_context


### PR DESCRIPTION
When the invoice can't be sent via Peppol, we are adding a footer in the Invoice email. We sent this regardless of the partner Peppol status. This PR narrows the cases when we sent the footer.

Another issue is that "we recommend" Odoo, we are speaking in the name of our user. A better phrasing will make things fairer, such as this footer keeps its informative value, without being too pushy.

task-4782004
