### PR TITLE
[FIX] project: set project of task when creating parent on the fly

### DIFF
--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -140,8 +140,8 @@ class TestProjectSubtasks(TestProjectCommon):
                     child_task_form.name = 'Test Subtask 1'
                     child_task_form.project_id = self.project_goats
             with Form(self.task_1.child_ids.with_context({'tracking_disable': True})) as subtask_form:
-                subtask_form.project_id = self.env['project.project']
                 subtask_form.parent_id = self.env['project.task']
+                subtask_form.project_id = self.env['project.project']
             orphan_subtask = subtask_form.save()
 
             self.assertFalse(orphan_subtask.project_id, "The project should be removed as expected.")

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -452,7 +452,7 @@
                         <page name="extra_info" string="Extra Info" groups="base.group_no_one">
                             <group>
                                 <group>
-                                    <field name="parent_id" groups="base.group_no_one" context="{'search_view_ref' : 'project.view_task_search_form','search_default_project_id': project_id}"/>
+                                    <field name="parent_id" invisible="not project_id" groups="base.group_no_one" context="{'search_view_ref' : 'project.view_task_search_form', 'search_default_project_id': project_id, 'default_project_id': project_id}"/>
                                     <field name="analytic_account_id" groups="analytic.group_analytic_accounting" context="{'default_partner_id': partner_id, 'default_company_id': company_id}"/>
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field name="sequence" groups="base.group_no_one"/>
@@ -530,7 +530,7 @@
                     <group>
                         <field name="project_id" invisible="1" />
                         <field name="company_id" invisible="1" />
-                        <field name="parent_id" domain="[('id', '!=', id), '!', ('id', 'child_of', id)]" context="{'search_default_project_id': project_id, 'search_default_open_tasks': 1}" />
+                        <field name="parent_id" domain="[('id', '!=', id), '!', ('id', 'child_of', id)]" context="{'search_default_project_id': project_id, 'search_default_open_tasks': 1, 'default_project_id': project_id}" />
                     </group>
                     <footer>
                         <button string="Convert Task" class="btn-primary" special="save" data-hotkey="q"/>
@@ -716,7 +716,7 @@
                     <field name="recurrence_id" column_invisible="True" />
                 </tree>
                 <xpath expr="//field[@name='partner_id']" position="after">
-                    <field name="parent_id" optional="hide" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id}" groups="base.group_no_one"/>
+                    <field name="parent_id" optional="hide" invisible="not project_id" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id, 'default_project_id': project_id}" groups="base.group_no_one"/>
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position="after">
                     <field name="personal_stage_type_id" string="Personal Stage" optional="hide"/>


### PR DESCRIPTION
Before this commit, when the user creates a parent task on the fly in the list view of tasks or even in the form view of task, the parent task creates does not have the project of the task by default.

This commit adds the project of the task as default value for the new parent task when the user creates a parent task in the parent_id field.

Steps to reproduce the issue
----------------------------
0. Install project.
1. Go to Projects > All tasks.
2. Show the parent task field.
3. Edit the parent_id field in the list view of an existing to create a new parent task.
4. Go to form view of the parent task

Expected Behavior
-----------------
The parent task should have the same project than the task in which we create the parent task.

Current Behavior
----------------
The parent task created has no project set by default.

task-4781342