### PR TITLE
[FIX] im_livechat: fix duration/response time demo data

### DIFF
--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -34,6 +34,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_message_2_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -43,6 +44,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_message_3_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -53,6 +55,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_message_4_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -62,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="create_date"/>
         </record>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -34,6 +34,7 @@
             <field name="body">Welcome to CompanyName! 👋</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_message_2_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -44,6 +45,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_message_3_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -53,6 +55,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_message_4_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -62,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="create_date"/>
         </record>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -34,6 +34,7 @@
             <field name="body">Welcome to CompanyName! 👋</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_2_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -43,6 +44,7 @@
             <field name="body">What are you looking for?</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_3_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -53,6 +55,7 @@
             <field name="body">I have a pricing question</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_4_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -62,6 +65,7 @@
             <field name="body">Hmmm, let me check if I can find someone that could help you with that...</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_5_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -71,6 +75,7 @@
             <field name="body">Hu-ho, it looks like none of our operators are available 🙁</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_6_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -80,6 +85,7 @@
             <field name="body">Would you mind leaving your email address so that we can reach you back?</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=6)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=6)" name="create_date"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_message_7_demo" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -90,6 +96,7 @@
             <field name="body">visitor@example.com</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=7)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=7)" name="create_date"/>
         </record>
     </data>
 </odoo>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -34,6 +34,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=1)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -45,6 +46,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=2)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -54,6 +56,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -65,6 +68,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=4)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_message_5" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -74,6 +78,7 @@
             <field name="body">You're welcome, have a nice day!</field>
             <field name="message_type">comment</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -83,6 +88,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5, seconds=25)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5, seconds=25)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_1</field>
@@ -103,6 +109,7 @@
             <field name="body">&lt;div data-oe-type=&#34;call&#34; class=&#34;o_mail_notification&#34;&gt;&lt;/div&gt;</field>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=3)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_1_call_1" model="discuss.call.history">
             <field name="channel_id" ref="im_livechat.livechat_channel_session_1" />

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -74,6 +74,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>
+            <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_10_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_10</field>
@@ -94,6 +95,7 @@
             <field name="body">&lt;div data-oe-type=&#34;call&#34; class=&#34;o_mail_notification&#34;&gt;&lt;/div&gt;</field>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(days=-1, seconds=20)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(days=-1, seconds=20)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_10_call_1" model="discuss.call.history">
             <field name="channel_id" ref="im_livechat.livechat_channel_session_10" />

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -49,6 +49,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>
+            <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_13_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_13</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -33,6 +33,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=6)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=6)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -44,6 +45,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=7)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=7)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -53,6 +55,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=8)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=8)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -64,6 +67,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=9)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=9)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_message_5" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -73,6 +77,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=10)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=10)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -82,6 +87,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=11)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=11)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_2</field>
@@ -102,6 +108,7 @@
             <field name="body">&lt;div data-oe-type=&#34;call&#34; class=&#34;o_mail_notification&#34;&gt;&lt;/div&gt;</field>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=6)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=6)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_2_call_1" model="discuss.call.history">
             <field name="channel_id" ref="im_livechat.livechat_channel_session_2"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -30,6 +30,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=11)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=11)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_3_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -39,6 +40,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=12)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=12)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_3_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -48,6 +50,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=13)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=13)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_3_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -57,6 +60,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=14)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=14)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_3_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -65,6 +69,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=15)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=15)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_3_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_3</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -31,6 +31,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=15)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=15)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_4_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -40,6 +41,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=16)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=16)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_4_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -49,6 +51,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=17)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=17)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_4_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -57,6 +60,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=20)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-3, minutes=20)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_4_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_4</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -34,6 +34,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=18)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=18)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_5_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -45,6 +46,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=19)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=19)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_5_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -54,6 +56,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=20)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=20)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_5_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -65,6 +68,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=21)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=21)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_5_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -74,6 +78,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=33)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-2, days=-4, minutes=33)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_5_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_5</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -34,6 +34,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=22)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=22)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_6_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -45,6 +46,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=23)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=23)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_6_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -54,6 +56,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=24)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=24)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_6_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -65,6 +68,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=25)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=25)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_6_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -74,6 +78,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=35)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-5, minutes=35)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_6_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_6</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -31,6 +31,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=26)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=26)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_7_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -40,6 +41,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=27)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=27)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_7_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -49,6 +51,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=28)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=28)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_7_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -58,6 +61,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=29)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=29)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_7_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -66,6 +70,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=50)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-6, minutes=50)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_7_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_7</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -34,6 +34,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=30)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=30)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_8_message_2" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -44,6 +45,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=31)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=31)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_8_message_3" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -53,6 +55,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=32)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=32)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_8_message_4" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -63,6 +66,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=33)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=33)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_8_rating_message" model="mail.message">
             <field name="model">discuss.channel</field>
@@ -72,6 +76,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=52)" name="date"/>
+            <field eval="DateTime.today() + relativedelta(months=-3, days=-7, minutes=52)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_8_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_8</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -108,6 +108,7 @@
             <field name="subtype_id" ref="mail.mt_note"/>
             <field name="message_type">notification</field>
             <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="date"/>
+            <field eval="datetime.now() - timedelta(days=1, seconds=-60)" name="create_date"/>
         </record>
         <record id="livechat_channel_session_9_rating" model="rating.rating">
             <field name="access_token">LIVECHAT_9</field>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(months=-1, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, minutes=1)"/>
         </record>
         <record id="support_bot_session_1_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_1_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(months=-1, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, minutes=2)"/>
         </record>
         <record id="support_bot_session_1_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_1_message_2"/>
@@ -63,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(months=-1, minutes=3)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, minutes=3)"/>
         </record>
         <record id="support_bot_session_1_chatbot_message_3" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_1_message_3"/>
@@ -78,6 +81,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(months=-1, minutes=4)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, minutes=4)"/>
         </record>
         <record id="support_bot_session_1_chatbot_message_4" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_1_message_4"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=1)"/>
         </record>
         <record id="support_bot_session_2_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_2_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=2)"/>
         </record>
         <record id="support_bot_session_2_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_2_message_2"/>
@@ -63,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=3)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=3)"/>
         </record>
         <record id="support_bot_session_2_chatbot_message_3" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_2_message_3"/>
@@ -78,6 +81,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=4)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2, minutes=4)"/>
         </record>
         <record id="support_bot_session_2_chatbot_message_4" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_2_message_4"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-10, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10, minutes=1)"/>
         </record>
         <record id="support_bot_session_3_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_3_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-10, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10, minutes=2)"/>
         </record>
         <record id="support_bot_session_3_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_3_message_2"/>
@@ -63,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-10, minutes=3)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10, minutes=3)"/>
         </record>
         <record id="support_bot_session_3_chatbot_message_3" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_3_message_3"/>
@@ -78,6 +81,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-10, minutes=4)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-10, minutes=4)"/>
         </record>
         <record id="support_bot_session_3_chatbot_message_4" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_3_message_4"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-7, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-7, minutes=1)"/>
         </record>
         <record id="support_bot_session_4_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_4_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-7, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-7, minutes=2)"/>
         </record>
         <record id="support_bot_session_4_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_4_message_2"/>
@@ -63,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-7, minutes=3)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-7, minutes=3)"/>
         </record>
         <record id="support_bot_session_4_chatbot_message_3" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_4_message_3"/>
@@ -78,6 +81,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-7, minutes=4)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-7, minutes=4)"/>
         </record>
         <record id="support_bot_session_4_chatbot_message_4" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_4_message_4"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-5, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5, minutes=1)"/>
         </record>
         <record id="support_bot_session_5_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_5_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-5, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5, minutes=2)"/>
         </record>
         <record id="support_bot_session_5_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_5_message_2"/>
@@ -63,6 +65,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-5, minutes=3)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5, minutes=3)"/>
         </record>
         <record id="support_bot_session_5_chatbot_message_3" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_5_message_3"/>
@@ -78,6 +81,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-5, minutes=4)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-5, minutes=4)"/>
         </record>
         <record id="support_bot_session_5_chatbot_message_4" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_5_message_4"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-6, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6, minutes=1)"/>
         </record>
         <record id="support_bot_session_6_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_6_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-6, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6, minutes=2)"/>
         </record>
         <record id="support_bot_session_6_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_6_message_2"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
@@ -32,6 +32,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-6, minutes=1)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6, minutes=1)"/>
         </record>
         <record id="support_bot_session_7_chatbot_message_1" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_7_message_1"/>
@@ -47,6 +48,7 @@
             <field name="message_type">comment</field>
             <field name="subtype_id" ref="mail.mt_comment"/>
             <field name="date" eval="DateTime.today() + relativedelta(days=-6, minutes=2)"/>
+            <field name="create_date" eval="DateTime.today() + relativedelta(days=-6, minutes=2)"/>
         </record>
         <record id="support_bot_session_7_chatbot_message_2" model="chatbot.message">
             <field name="mail_message_id" ref="support_bot_session_7_message_2"/>


### PR DESCRIPTION
Live chat demo data creation previously used the "date" field on messages to simulate chats at different times. However, the reporting query relies on the "create_date" field. This discrepancy led to unrealistic durations. This commit fixes the issue.

task-4753018

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
