### PR TITLE
[FIX] base: Add dependency on partner_id.name

### DIFF
--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -101,7 +101,7 @@ class ResPartnerBank(models.Model):
         for bank in self:
             bank.acc_type = self.retrieve_acc_type(bank.acc_number)
 
-    @api.depends('partner_id')
+    @api.depends('partner_id.name')
     def _compute_account_holder_name(self):
         for bank in self:
             bank.acc_holder_name = bank.partner_id.name


### PR DESCRIPTION
In the case where the name of the related partner is changed, the bank account holder name will not reflect the changes, we add here a dependency on partner_id.name