### PR TITLE
[FIX] account: fix available payment methods for credit card journal

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -325,7 +325,7 @@ class AccountJournal(models.Model):
         method_information_mapping = results['method_information_mapping']
         providers_per_code = results['providers_per_code']
 
-        journal_bank_cash = self.filtered(lambda j: j.type in ('bank', 'cash'))
+        journal_bank_cash = self.filtered(lambda j: j.type in ('bank', 'cash', 'credit'))
         journal_other = self - journal_bank_cash
         journal_other.available_payment_method_ids = False
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install account
- Go to "Invoicing / Configuration / Accounting / Journals"
- Create a "Credit Card" type journal
- In "Incoming Payments" tab (or "Outgoing Payments"), try to add a line

**Issue:**
There is no option for "Payment Method" select field. If the default "Manual Payment" line is removed, it's not possible to add it again.

**Cause:**
The list of available payment methods for credit card journal is empty.
The method that is computing the available payment methods is always returning False for credit card journals, but it should not.

**Solution:**
Compute the available payment methods normally as it is the case for bank and cash journals.

opw-4754110




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
