### PR TITLE
[FIX] stock: bypass procurement on backorder of mto moves

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -211,6 +211,9 @@ class StockMove(models.Model):
     def _prepare_move_split_vals(self, uom_qty):
         vals = super(StockMove, self)._prepare_move_split_vals(uom_qty)
         vals['purchase_line_id'] = self.purchase_line_id.id
+        # when backordering an mto move link the bakcorder to the purchase order
+        if self.procure_method == 'make_to_order' and self.created_purchase_line_ids:
+            vals['created_purchase_line_ids'] = [Command.set(self.created_purchase_line_ids.ids)]
         return vals
 
     def _clean_merged(self):

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1335,3 +1335,43 @@ class TestReorderingRule(TransactionCase):
             [("product_id", "=", self.product_01.id)])
         self.assertTrue(po_line)
         self.assertEqual(po_line.order_id.currency_id, foreign_currency)
+
+    def test_backorder_mto_buy(self):
+        """
+        Check that purchase order created to fullfill an mto buy demand are
+        well behaved with respect to backorder deliveries.
+        """
+        buy_product = self.product_01
+        mto_route = self.env.ref('stock.route_warehouse0_mto')
+        mto_route.active = True
+        buy_product.route_ids |= mto_route
+        pg = self.env["procurement.group"].create({'name': 'Test mto buy procurement'})
+        self.env["procurement.group"].run(
+            [pg.Procurement(
+                buy_product, 100, buy_product.uom_id,
+                self.env.ref('stock.stock_location_customers'), "Test mto buy", "/",
+                self.env.company,
+                {
+                    "warehouse_id": self.env.ref('stock.warehouse0'),
+                    "group_id": pg,
+                },
+            )])
+        po_line = self.env["purchase.order.line"].search([("product_id", "=", buy_product.id)], limit=1)
+        self.assertEqual(po_line.product_uom_qty, 100)
+        delivery = po_line.move_dest_ids.picking_id
+        # Deliver only 30 units and backorder the rest
+        delivery.move_ids.quantity = 30
+        backorder_wizard_dict = delivery.button_validate()
+        backorder_wizard_form = Form(self.env[backorder_wizard_dict['res_model']].with_context(backorder_wizard_dict['context'])).save()
+        backorder_wizard_form.process()
+        # Check the bakorder values
+        purchase_order_line = self.env["purchase.order.line"].search([("product_id", "=", buy_product.id)])
+        self.assertRecordValues(delivery.backorder_ids.move_ids, [{
+            'product_uom_qty': 70, 'procure_method': 'make_to_order', 'state': 'waiting', 'created_purchase_line_ids': purchase_order_line.ids,
+        }])
+        # Check that the backorder belongs to the same procurement group
+        self.assertEqual(delivery.backorder_ids.group_id, delivery.group_id)
+        # Check that the qty of the PO was not updated but that both pickings are referenced by the current
+        self.assertRecordValues(purchase_order_line, [
+            {'product_uom_qty': 100, 'move_dest_ids': [delivery.move_ids.id, delivery.backorder_ids.move_ids.id]}
+        ])

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1378,7 +1378,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
         # create procurements for make to order moves
         procurement_requests = []
-        for move in move_create_proc:
+        for move in move_create_proc if not self.env.context.get('bypass_procurement_creation') else self.env['stock.move']:
             values = move._prepare_procurement_values()
             origin = move._prepare_procurement_origin()
             procurement_requests.append(self.env['procurement.group'].Procurement(
@@ -1916,7 +1916,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             backorder_moves = self.env['stock.move'].create(backorder_moves_vals)
             # The backorder moves are not yet in their own picking. We do not want to check entire packs for those
             # ones as it could messed up the result_package_id of the moves being currently validated
-            backorder_moves.with_context(bypass_entire_pack=True)._action_confirm(merge=False)
+            backorder_moves.with_context(bypass_entire_pack=True, bypass_procurement_creation=True)._action_confirm(merge=False)
         moves_todo.mapped('move_line_ids').sorted()._action_done()
         # Check the consistency of the result packages; there should be an unique location across
         # the contained quants.


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Step routes
- Unarchive the MTO route
- Create a storable product using the MTO and buy route
- Create and confirm a sale order for 100 units of that product
- Validate the delivery for only 30 units and backorder the rest
#### > The purchase order demand was updated to 170 units

### Cause of the issue:

Processing the backorder wizard will create and confirm moves for the backorder picking:
https://github.com/odoo/odoo/blob/a71c0c7d1c3391beb1bf2939ae076a804a627dbd/addons/stock/models/stock_move.py#L1916-L1919 However, as these moves are `make_to_order` they are planned to create and run procurements in their respective `_action_confirm`'s: https://github.com/odoo/odoo/blob/a71c0c7d1c3391beb1bf2939ae076a804a627dbd/addons/stock/models/stock_move.py#L1379-L1388

opw-4633920
opw-4713650
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
