### PR TITLE
[FIX] sale_project: don't use form view of SO to edit SOL

### DIFF
--- a/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
+++ b/addons/sale_project/static/src/components/so_line_create_button/so_line_create_button.js
@@ -23,6 +23,7 @@ export class SoLineCreateButton extends Component {
             resModel: "sale.order",
             context: {
                 ...context,
+                form_view_ref: context.so_form_view_ref,
                 default_company_id: context.default_company_id || user.activeCompany.id,
                 default_user_id: user.userId,
             },

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -195,7 +195,7 @@
                         options="{'no_create': True}"
                         readonly="0"
                         context="{
-                            'form_view_ref': 'sale_project.view_order_simple_form',
+                            'so_form_view_ref': 'sale_project.view_order_simple_form',
                             'create_for_task_id': id,
                             'default_partner_id': partner_id,
                             'default_company_id': company_id,

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -28,7 +28,7 @@
                                 options="{'no_create': True, 'no_open': True}"
                                 context="{
                                     'search_default_order_id': sale_order_id,
-                                    'form_view_ref': 'sale_project.view_order_simple_form',
+                                    'so_form_view_ref': 'sale_project.view_order_simple_form',
                                     'create_for_employee_mapping': True,
                                     'default_partner_id': partner_id,
                                     'default_company_id': company_id,
@@ -81,6 +81,7 @@
                                         widget="so_line_create_button"
                                         context="{
                                             'search_default_order_id': sale_order_id,
+                                            'so_form_view_ref': 'sale_project.view_order_simple_form',
                                             'create_for_employee_mapping': True,
                                             'default_partner_id': partner_id,
                                             'default_company_id': company_id,


### PR DESCRIPTION
Before this commit, when the user would like to go to the form view of SOL linked to a task (when he is on task form view and click on the arrow right next to the sale_line_id field), a traceback is occurred because a field is undefined in `sale.order.line` model. The reason is because the form view loaded is the one of the SO.

This commit changes `form_view_ref` into `so_form_view_ref` because the `so_line_create_button` could need to use another form view of SO than the default one when the user clicks on `fa-plus` button to create a new SO.

Steps to reproduce the issue
----------------------------

0. Install `sale_project` module
1. Create a billable project
2. Create a new task inside that project
3. In the form view of that task, clicks on the `+` button displayed next to the SOL field to create a new SO
4. Create the SO with at least one service product in the SO and save
5. In the task form view, open the form view of the SOL set on the task.

Expected behavior
-----------------

The SOL form view should be opened without any issue.

Current Behavior
----------------

A traceback is occurred because a field does not exist in SOL model, the reason is because we open the form view of SO instead of the SOL one.

task-4781247
