### PR TITLE
[DRAFT][FIX] hr_holidays: if no hourly type then on timeoff wiz fill first time off

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -77,15 +77,20 @@ class HrLeave(models.Model):
     def default_get(self, fields_list):
         defaults = super().default_get(fields_list)
         defaults = self._default_get_request_dates(defaults)
-
-        lt = self.env['hr.leave.type']
         if self.env.context.get('holiday_status_display_name', True) and 'holiday_status_id' in fields_list and not defaults.get('holiday_status_id'):
             domain = ['|', ('requires_allocation', '=', False), ('has_valid_allocation', '=', True)]
-            if defaults.get('request_unit_hours'):
-                domain.append(('request_unit', '=', 'hour'))
-            lt = self.env['hr.leave.type'].search(domain, limit=1, order='sequence')
-            if lt:
-                defaults['holiday_status_id'] = lt.id
+            defaults['holiday_status_id'] = False
+            leave_types = self.env['hr.leave.type'].search(domain, order='sequence')
+            selected_leave_type = next(
+                (
+                    leave_type for leave_type in leave_types
+                    if (defaults.get('request_unit_hours') and leave_type['request_unit'] == 'hour') or (not defaults.get('request_unit_hours'))
+                ),
+                leave_types[0] if leave_types else None,
+            )
+            if selected_leave_type:
+                defaults['holiday_status_id'] = selected_leave_type.id
+                defaults['request_unit_hours'] = (selected_leave_type.request_unit == 'hour')
 
         if 'request_date_from' in fields_list and 'request_date_from' not in defaults:
             defaults['request_date_from'] = fields.Date.today()


### PR DESCRIPTION
Steps To Reproduce:
- Archive all Hourly timeoffs
- Now raise a new timeoff from calendar from days/week

Fix:
- When there are no "Hourly Time Off" types configured in the company,
  pre-select an available time off type

task-4702467

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
