### PR TITLE
[FIX] account: Prevent validation error on report line duplication

### DIFF
--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -15,6 +15,7 @@ from . import test_account_analytic
 from . import test_account_payment
 from . import test_account_payment_method_line
 from . import test_account_payment_duplicate
+from . import test_account_report
 from . import test_account_bank_statement
 from . import test_account_invoice_report
 from . import test_account_move_line_tax_details

--- a/addons/account/tests/test_account_report.py
+++ b/addons/account/tests/test_account_report.py
@@ -1,0 +1,67 @@
+from odoo import Command
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestAccountReport(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # Create a test report with lines and expressions to test copy functionality
+        cls.test_report = cls.env['account.report'].create({
+            'name': 'Test Report',
+            'sequence': 1,
+        })
+
+        # Create parent line with code and expression
+        cls.parent_line = cls.env['account.report.line'].create({
+            'name': 'Parent Line',
+            'code': 'PARENT',
+            'report_id': cls.test_report.id,
+            'expression_ids': [Command.create({
+                'label': 'balance',
+                'engine': 'aggregation',
+                'formula': 'CHILD1.balance + CHILD2.balance',
+            })],
+            'children_ids': [
+                Command.create({
+                    'name': 'Child Line 1',
+                    'code': 'CHILD1',
+                    'report_id': cls.test_report.id,
+                }),
+                Command.create({
+                    'name': 'Child Line 2',
+                    'code': 'CHILD2',
+                    'report_id': cls.test_report.id,
+                })
+            ]
+        })
+
+    def test_report_line_copy_and_uniqueness(self):
+        """Test the copy functionality of report lines including naming, code generation, formula updates and uniqueness"""
+        # Test first copy
+        first_copy = self.parent_line.copy()
+
+        # Test copied name and code generation
+        self.assertEqual(first_copy.name, "Parent Line (copy)")
+        self.assertEqual(first_copy.code, "PARENT_COPY")
+
+        # Test children were copied
+        self.assertEqual(len(first_copy.children_ids), 2)
+
+        # Test child lines have appropriate codes and names
+        copied_children_codes = first_copy.children_ids.mapped('code')
+        self.assertIn('CHILD1_COPY', copied_children_codes)
+        self.assertIn('CHILD2_COPY', copied_children_codes)
+
+        # Test expression was copied and formula was updated
+        copied_expression = first_copy.expression_ids.filtered(lambda e: e.engine == 'aggregation')
+        self.assertEqual(copied_expression.formula, 'CHILD1_COPY.balance + CHILD2_COPY.balance')
+
+        # Test second copy for name and code uniqueness
+        second_copy = self.parent_line.copy()
+        self.assertEqual(second_copy.name, "Parent Line (copy) (copy)")
+        self.assertEqual(second_copy.code, "PARENT_COPY_COPY")


### PR DESCRIPTION
**Steps to Reproduce:**  
- Copy an account report line with an existing `code`.

**Issue:**  
- Copying a report line raises a validation error due to the unique constraint 
  on the `code` field.

**Cause:**  
- The `code` field must be unique, but the copied line attempts to use the same 
  `code` as the original.

**Solution:**  
- Append `_COPY` to the `code` to maintain uniqueness.  
- Append `(copy)` to the `name` to indicate duplication.  

Task-4780936
