### PR TITLE
[FIX] base: handled error when name comes as object instead of string

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -87,6 +87,8 @@ class ResCountry(models.Model):
 
     @api.model
     def name_search(self, name='', args=None, operator='ilike', limit=100):
+        if not isinstance(name, str):
+            name = ''
         result = []
         domain = args or []
         # first search by code


### PR DESCRIPTION
The system will crash if the `name` input is of type `datetime.time` or any other object, rather than a string, during the country search.

**Steps to Reproduce:**
1. Go to Contacts > Import Contacts.
2. Import the data and assign the `Odoo field` as `Country`, where the `file column` contains entries in `date format`.
3. Click the `Test` button.

**Error Message:**
`TypeError: object of type 'datetime.date' has no len()`

**Solution:**
- Ensure that the `name` is a string to prevent type errors. If the input is not a string, it defaults to an empty string ('').

**Sentry** - 6594489459

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
