### PR TITLE
[FIX] web, mail and board: 'debug' is not a Boolean value.

### DIFF
--- a/addons/board/static/tests/add_to_dashboard.test.js
+++ b/addons/board/static/tests/add_to_dashboard.test.js
@@ -353,7 +353,7 @@ test("Add a view to dashboard doesn't save default filters", async () => {
     };
 
     // makes mouseEnter work
-    serverState.debug = true;
+    serverState.debug = "1";
 
     onRpc("/board/add_to_dashboard", async (request) => {
         const { params: args } = await request.json();
@@ -368,9 +368,7 @@ test("Add a view to dashboard doesn't save default filters", async () => {
         });
         return true;
     });
-    onRpc("/web/domain/validate", () => {
-        return true;
-    });
+    onRpc("/web/domain/validate", () => true);
 
     await mountWithCleanup(WebClient);
 

--- a/addons/mail/static/tests/web/debug_menu.test.js
+++ b/addons/mail/static/tests/web/debug_menu.test.js
@@ -14,7 +14,7 @@ defineMailModels();
 describe.current.tags("desktop");
 
 test("Manage messages", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     const pyEnv = await startServer();
     MailMessage._views = {
         "list,false": "<list/>",

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -364,7 +364,7 @@ test("field context is propagated when opening selection", async function () {
 });
 
 test("domain field: manually edit domain with textarea", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -409,7 +409,7 @@ test("domain field: manually edit domain with textarea", async function () {
 });
 
 test("domain field: manually set an invalid domain with textarea", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -476,7 +476,7 @@ test("domain field: manually set an invalid domain with textarea", async functio
 });
 
 test("domain field: reload count by clicking on the refresh button", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -555,7 +555,7 @@ test("domain field: does not wait for the count to render", async function () {
 });
 
 test("domain field: have a default count limit of 10000", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -591,7 +591,7 @@ test("domain field: have a default count limit of 10000", async function () {
 });
 
 test("domain field: foldable and count limit reached", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -627,7 +627,7 @@ test("domain field: foldable and count limit reached", async function () {
 });
 
 test("domain field: configurable count limit", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     Partner._records = [
@@ -665,7 +665,7 @@ test("domain field: configurable count limit", async function () {
 test("domain field: edit domain with dynamic content", async function () {
     expect.assertions(3);
 
-    serverState.debug = true;
+    serverState.debug = "1";
 
     Partner._fields.bar = fields.Char();
     let rawDomain = `[("date", ">=", datetime.datetime.combine(context_today() + relativedelta(days = -365), datetime.time(0, 0, 0)).to_utc().strftime("%Y-%m-%d %H:%M:%S"))]`;
@@ -708,7 +708,7 @@ test("domain field: edit domain with dynamic content", async function () {
 });
 
 test("domain field: edit through selector (dynamic content)", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
     mockDate("2020-09-05 00:00:00");
 
     Partner._fields.bar = fields.Char();
@@ -854,7 +854,7 @@ test("domain field with 'inDialog' options", async function () {
 
 test("invalid value in domain field with 'inDialog' options", async function () {
     Partner._fields.name.default = "[]";
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountView({
         type: "form",
         resModel: "partner",
@@ -878,7 +878,7 @@ test("invalid value in domain field with 'inDialog' options", async function () 
 
 test("edit domain button is available even while loading records count", async function () {
     Partner._fields.name.default = "[]";
-    serverState.debug = true;
+    serverState.debug = "1";
     const searchCountDeffered = new Deferred();
     onRpc("/web/domain/validate", () => true);
     onRpc("search_count", () => searchCountDeffered);
@@ -902,7 +902,7 @@ test("edit domain button is available even while loading records count", async f
 
 test("debug input editing sets the field as dirty even without a focus out", async function () {
     Partner._fields.name.default = "[]";
-    serverState.debug = true;
+    serverState.debug = "1";
     onRpc("/web/domain/validate", () => {
         expect.step("validate domain");
         return true;
@@ -924,7 +924,7 @@ test("debug input editing sets the field as dirty even without a focus out", asy
 
 test("debug input corrections don't need a focus out to be saved", async function () {
     Partner._fields.name.default = "[]";
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountView({
         type: "form",
         resModel: "partner",
@@ -944,7 +944,7 @@ test("debug input corrections don't need a focus out to be saved", async functio
 });
 
 test("quick check on save if domain has been edited via the debug input", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
     Partner._fields.name = fields.Char({ default: "[['id', '=', False]]" });
     onRpc("/web/domain/validate", async (request) => {
         const { params } = await request.json();
@@ -1033,7 +1033,7 @@ test("domain field can be foldable", async function () {
 });
 
 test("add condition in empty foldable domain", async function () {
-    serverState.debug = true;
+    serverState.debug = "1";
     Partner._records[0].foo = '[("id", "=", 1)]';
 
     await mountView({

--- a/addons/web/static/tests/core/errors/error_service.test.js
+++ b/addons/web/static/tests/core/errors/error_service.test.js
@@ -366,7 +366,7 @@ test("show dialog for errors in third-party scripts in debug mode", async () => 
     class TestError extends Error {}
     const error = new TestError();
     error.name = "Script error.";
-    serverState.debug = true;
+    serverState.debug = "1";
 
     mockService("dialog", {
         add(_dialogClass, props) {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9143,7 +9143,7 @@ test(`display tooltips for buttons (debug = false)`, async () => {
 
 test.tags("desktop");
 test(`display tooltips for buttons (debug = true)`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     await mountView({
         resModel: "partner",
@@ -9514,7 +9514,7 @@ test(`basic support for widgets: onchange update`, async () => {
 
 test.tags("desktop");
 test(`proper stringification in debug mode tooltip`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     await mountView({
         resModel: "partner",
@@ -9544,7 +9544,7 @@ test(`proper stringification in debug mode tooltip`, async () => {
 
 test.tags("desktop");
 test(`field tooltip in debug mode, on field with domain attr`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     await mountView({
         resModel: "partner",
@@ -9566,7 +9566,7 @@ test(`field tooltip in debug mode, on field with domain attr`, async () => {
 
 test.tags("desktop");
 test(`do not display unset attributes in debug field tooltip`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     await mountView({
         resModel: "partner",
@@ -10811,7 +10811,7 @@ test(`save a form view with an invisible required field in a x2many`, async () =
 
 test(`help on field as precedence over field's declaration -- form`, async () => {
     Partner._fields.foo = fields.Char({ help: "pythonhelp" });
-    serverState.debug = true;
+    serverState.debug = "1";
 
     await mountView({
         resModel: "partner",

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -573,7 +573,7 @@ test(`editable list with open_form_view`, async () => {
 
 test.tags("desktop");
 test(`editable list with open_form_view in debug`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountView({
         resModel: "foo",
         type: "list",
@@ -602,7 +602,7 @@ test(`editable list without open_form_view in debug`, async () => {
             super.setItem(...arguments);
         },
     });
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountView({
         resModel: "foo",
         type: "list",
@@ -642,7 +642,7 @@ test(`editable list without open_form_view in debug`, async () => {
 });
 
 test(`non-editable list in debug`, async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountView({
         resModel: "foo",
         type: "list",
@@ -6656,7 +6656,7 @@ test(`can display a list with a many2many field`, async () => {
 
 test.tags("desktop");
 test(`display a tooltip on a field`, async () => {
-    serverState.debug = false;
+    serverState.debug = "";
 
     await mountView({
         resModel: "foo",
@@ -6675,7 +6675,7 @@ test(`display a tooltip on a field`, async () => {
     expect(`.o-tooltip`).toHaveCount(1);
     expect(`.o-tooltip`).toHaveText("Foo");
 
-    serverState.debug = true;
+    serverState.debug = "1";
 
     // it is necessary to rerender the list so tooltips can be properly created
     await validateSearch(); // reload view
@@ -6692,7 +6692,7 @@ test(`display a tooltip on a field`, async () => {
 
 test.tags("desktop");
 test("field (with help) tooltip in non debug mode", async function () {
-    serverState.debug = false;
+    serverState.debug = "";
     Foo._fields.foo.help = "This is a foo field";
     await mountView({
         type: "list",

--- a/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/export_data_dialog.test.js
@@ -322,7 +322,7 @@ test("Export dialog: interacting with export templates", async () => {
 });
 
 test("Export dialog: interacting with export templates in debug", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", () => [...fetchedFields.root]);
@@ -976,7 +976,7 @@ test("Export dialog: expand subfields after search", async () => {
 });
 
 test("Export dialog: search in debug", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
 
     onRpc("/web/export/formats", () => [{ tag: "csv", label: "CSV" }]);
     onRpc("/web/export/get_fields", async (request) => {

--- a/addons/web/static/tests/webclient/loading_indicator.test.js
+++ b/addons/web/static/tests/webclient/loading_indicator.test.js
@@ -40,7 +40,7 @@ test("displays the loading indicator in non debug mode", async () => {
 });
 
 test("displays the loading indicator for one rpc in debug mode", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountWithCleanup(LoadingIndicator, { noMainContainer: true });
     expect(".o_loading_indicator").toHaveCount(0, {
         message: "the loading indicator should not be displayed",
@@ -63,7 +63,7 @@ test("displays the loading indicator for one rpc in debug mode", async () => {
 });
 
 test("displays the loading indicator for multi rpc in debug mode", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountWithCleanup(LoadingIndicator, { noMainContainer: true });
     expect(".o_loading_indicator").toHaveCount(0, {
         message: "the loading indicator should not be displayed",

--- a/addons/web/static/tests/webclient/user_menu.test.js
+++ b/addons/web/static/tests/webclient/user_menu.test.js
@@ -120,7 +120,7 @@ test("can be rendered", async () => {
 });
 
 test("display the correct name in debug mode", async () => {
-    serverState.debug = true;
+    serverState.debug = "1";
     await mountWithCleanup(UserMenu);
     expect("img.o_user_avatar").toHaveCount(1);
     expect("small.oe_topbar_name").toHaveCount(1);


### PR DESCRIPTION
The debug key in the environment, is a string based on the query string of the URL that can have the following values : "1", "assets", "asset,test" or "".

This commit fixes some tests that incorrectly set the debug as a Boolean value.