### PR TITLE
[FIX] hr_holidays,mail: Out of office banner not shown in multi-companies

### DIFF
--- a/addons/hr_holidays/models/res_partner.py
+++ b/addons/hr_holidays/models/res_partner.py
@@ -27,16 +27,28 @@ class ResPartner(models.Model):
     def mail_partner_format(self, fields=None):
         """Override to add the current leave status."""
         partners_format = super().mail_partner_format(fields=fields)
-        if not fields:
-            fields = {'out_of_office_date_end': True}
-        for partner in self:
-            if 'out_of_office_date_end' in fields:
-                # in the rare case of multi-user partner, return the earliest possible return date
-                dates = partner.mapped('user_ids.leave_date_to')
-                states = partner.mapped('user_ids.current_leave_state')
-                date = sorted(dates)[0] if dates and all(dates) else False
-                state = sorted(states)[0] if states and all(states) else False
+        if not fields or 'out_of_office_date_end' in fields:
+            out_of_office_date_end = self._get_out_of_office_date_end()
+            for partner, date, state in out_of_office_date_end:
                 partners_format.get(partner).update({
                     'out_of_office_date_end': date.strftime(DEFAULT_SERVER_DATE_FORMAT) if state == 'validate' and date else False,
                 })
         return partners_format
+
+    def _get_out_of_office_date_end(self):
+        out_of_office_data = []
+        # sudo: any user can access the leave state of any employee for the out of office
+        all_employees_sudo = self.env["hr.employee"].sudo().search_fetch(
+            domain=[("user_partner_id", "in", self.ids)],
+            field_names=["leave_date_to", "current_leave_state", "user_partner_id", "company_id"],
+        )
+        for partner in self:
+            employees_partner = all_employees_sudo.filtered(lambda emp: emp.user_partner_id == partner)
+            if same_company_emp_sudo := employees_partner.sudo().filtered(lambda emp: emp.company_id in self.env.company):
+                employees_partner = same_company_emp_sudo
+            dates = employees_partner.mapped('leave_date_to')
+            states = employees_partner.mapped('current_leave_state')
+            date = sorted(dates)[0] if dates and all(dates) else False
+            state = sorted(states)[0] if states and all(states) else False
+            out_of_office_data.append((partner, date, state))
+        return out_of_office_data

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -12,7 +12,7 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase):
-    _query_count = 63
+    _query_count = 110
 
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Before this commit:
The user was not able to see the out of office banner when in a chat with a user of a different company.

This commit solves this problem and takes any employee that matches the correspondent of the chat regardless of the current company. However if an employee is found in the current company, this one will always be taken by default.

task-4784252


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
