### PR TITLE
website: optimize update_footer_template performance

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -1052,7 +1052,9 @@ class Website(Home):
             classes = res[0].get('class').split()
             width = next((c for c in container_classes if c in classes), False)
             if width:
-                views_enable += [width_views.get(width)]
+                view = width_views.get(width)
+                if view is not None:
+                    views_enable += [view]
                 views_disable += [v for k, v in width_views.items() if k != width]
 
         # Activate/Deactivate the computed views

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -298,6 +298,11 @@ class IrUiView(models.Model):
         if not current_website_id:
             return self.filtered(lambda view: not view.website_id)
 
+        specific_views_keys = set()
+        for view_check in self:
+            if view_check.website_id and view_check.website_id.id == current_website_id:
+                specific_views_keys.add(view_check.key)
+
         for view in self:
             # specific view: add it if it's for the current website and ignore
             # it if it's for another website
@@ -305,7 +310,7 @@ class IrUiView(models.Model):
                 most_specific_views |= view
             # generic view: add it only if, for the current website, there is no
             # specific view for this view (based on the same `key` attribute)
-            elif not view.website_id and not any(view.key == view2.key and view2.website_id and view2.website_id.id == current_website_id for view2 in self):
+            elif not view.website_id and view.key not in specific_views_keys:
                 most_specific_views |= view
 
         return most_specific_views


### PR DESCRIPTION
Update_footer_template method was experiencing significant performance
degradation because of processing large numbers of records, when None
values were present in the keys list. The None values caused PostgreSQL
to get also elements with null key, and because of the quadratic time
complexity in the filter_duplicate method it resulted in taking up to 46
seconds instead of the expected sub-second performance. The problem
traces back to [1].

[1]: https://github.com/odoo/odoo/commit/e925651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
