### PR TITLE
[IMP] point_of_sale: improve IoT error messages

### DIFF
--- a/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.js
@@ -8,12 +8,14 @@ export class RetryPrintPopup extends Component {
     static props = {
         title: { type: String, optional: true },
         message: { type: String, optional: true },
+        canRetry: { type: Boolean, optional: true },
         download: Function,
         retry: Function,
         close: Function,
     };
     static defaultProps = {
         title: _t("Printing error"),
+        message: _t("An unknown error occurred. Do you want to download the receipt instead?"),
     };
 
     onClickDownload() {

--- a/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
+++ b/addons/point_of_sale/static/src/app/components/popups/retry_print_popup/retry_print_popup.xml
@@ -3,11 +3,10 @@
 
     <t t-name="point_of_sale.RetryPrintPopup">
         <Dialog size="'md'" title="props.title">
-            <p t-if="props.message" t-out="props.message"/>
-            <p>Do you want to retry printing, or download it instead?</p>
+            <p t-if="props.message" t-out="props.message" class="text-prewrap"/>
             <t t-set-slot="footer">
-                <button class="btn btn-primary btn-lg" t-on-click="onClickRetry">Retry</button>
-                <button class="btn btn-secondary btn-lg" t-on-click="onClickDownload">Download</button>
+                <button t-if="props.canRetry" class="btn btn-primary btn-lg" t-on-click="onClickRetry">Retry</button>
+                <button class="btn btn-lg" t-att-class="{ 'btn-secondary': props.canRetry, 'btn-primary': !props.canRetry }" t-on-click="onClickDownload">Download</button>
                 <button class="btn btn-secondary btn-lg" t-on-click="props.close">Discard</button>
             </t>
         </Dialog>

--- a/addons/point_of_sale/static/src/app/services/pos_printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/pos_printer_service.js
@@ -45,6 +45,7 @@ export class PosPrinterService extends PrinterService {
             this.dialog.add(RetryPrintPopup, {
                 title: error.title,
                 message: error.body,
+                canRetry: error.canRetry,
                 retry: () => {
                     this.printHtml(...arguments);
                 },

--- a/addons/point_of_sale/static/src/app/services/printer_service.js
+++ b/addons/point_of_sale/static/src/app/services/printer_service.js
@@ -36,6 +36,7 @@ export class PrinterService extends Reactive {
         throw {
             title: printResult.message.title || "Error",
             body: printResult.message.body,
+            canRetry: printResult.canRetry,
             errorCode: printResult.errorCode,
         };
     }


### PR DESCRIPTION
This commit improves the error messages in the following scenarios when receipt printing fails:
- If the user if offline, we get a message telling them to reconnect to the internet.
- If the IoT box responds but the printer cannot be found, we explain this to the user and ask them to check the printer.
- If we fail to connect to the IoT box at all, we assume there is a HTTPS problem and tell the user to set up their subscription.

task-4787508

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
