### PR TITLE
[FIX] bus: outdated page false positive

### DIFF
--- a/addons/bus/static/tests/outdated_page_watcher.test.js
+++ b/addons/bus/static/tests/outdated_page_watcher.test.js
@@ -18,13 +18,17 @@ describe.current.tags("desktop");
 
 test("disconnect during vacuum should ask for reload", async () => {
     browser.location.addEventListener("reload", () => asyncStep("reload"));
-    addBusServiceListeners(["connect", () => asyncStep("connect")]);
+    addBusServiceListeners(
+        ["connect", () => asyncStep("connect")],
+        ["disconnect", () => asyncStep("disconnect")]
+    );
     onRpc("/bus/has_missed_notifications", () => true);
     await mountWithCleanup(WebClient);
     startBusService();
     await runAllTimers();
     await waitForSteps(["connect"]);
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    await waitForSteps(["disconnect"]);
     await runAllTimers();
     await waitFor(".o_notification");
     expect(".o_notification_content:first").toHaveText(

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -958,7 +958,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "saas-18.2-1"
+    _VERSION = "saas-18.2-2"
 
     @classmethod
     def websocket_allowed(cls, request):

--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -795,7 +795,7 @@ export class MockWebSocket extends MockEventTarget {
             return;
         }
         this._readyState = WebSocket.CLOSING;
-        dispatchClose(this, { code, reason });
+        tick().then(() => dispatchClose(this, { code, reason }));
     }
 
     /** @type {WebSocket["send"]} */


### PR DESCRIPTION
The outdated page watcher checks whether bus notifications were missed when the bus reconnects after an unexpected disconnection. To do so, it checks if the last known notification id is still in the bus table.

When the bus disconnects, the last notification id is saved. However, disconnect event is not correctly sent when switching from online to offline. This commit fixes this issue.

follow up of https://github.com/odoo/odoo/pull/208625

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
