### PR TITLE
[FIX] point_of_sale: prevent error on installing module

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -35,11 +35,11 @@
             <field name="is_pos_groupable">True</field>
         </record>
 
-        <record id="uom.product_uom_pack_6" model="uom.uom">
+        <record id="uom.product_uom_pack_6" model="uom.uom" forcecreate="0">
             <field name="is_pos_groupable">True</field>
         </record>
 
-        <record id="uom.product_uom_dozen" model="uom.uom">
+        <record id="uom.product_uom_dozen" model="uom.uom" forcecreate="0">
             <field name="is_pos_groupable">True</field>
         </record>
 


### PR DESCRIPTION
Steps to reproduce:
---
- Install `stock` module
- Enable `Units of Measure & Packagings`
- Delete `Pack of 6` in Units & Packagings
- Install `point_of_sale` module

Traceback:
---
```
Exception: Cannot update missing record 'uom.product_uom_pack_6'

ParseError: while parsing /home/odoo/src/odoo/saas-18.2/addons/point_of_sale/data/point_of_sale_data.xml:38, somewhere inside <record id="uom.product_uom_pack_6" model="uom.uom">
            <field name="is_pos_groupable">True</field>
        </record>
```

The error occurred because the user deleted `Pack of 6` from `Units & Packagings` before attempting to install the other module.

sentry-6550555809

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
