### PR TITLE
[FIX] web: make reference field test more robust

### DIFF
--- a/addons/web/static/tests/views/fields/reference_field.test.js
+++ b/addons/web/static/tests/views/fields/reference_field.test.js
@@ -958,6 +958,7 @@ test("reference field should await fetch model before render", async () => {
         `,
     });
 
+    await animationFrame();
     expect(".o_form_view").toHaveCount(0);
     def.resolve();
 


### PR DESCRIPTION
This commit adds an `await animationFrame()` in a reference field test. This makes the first assertion relevant, as it wasn't before (the view could never be there instantly). It also makes the test more robust as it could sometimes fail for the second assertions (race condition), see https://runbot.odoo.com/runbot/build/80157085

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
