### PR TITLE
[FIX] website: fix the "Pricelist" snippet "Layout" option behavior

### DIFF
--- a/addons/website/views/snippets/s_product_catalog.xml
+++ b/addons/website/views/snippets/s_product_catalog.xml
@@ -5,12 +5,9 @@
     <section class="s_product_catalog oe_img_bg o_bg_img_center oe_custom_bg pt64 pb64" style="background-image: url('/web/image/website.s_product_catalog_default_image');" data-vcss="002">
         <div class="o_we_bg_filter bg-white-85"/>
         <div class="container">
-            <div class="row">
-                <div class="col pb48 text-center">
-                    <h2 class="h3-fs">Our Menu</h2>
-                    <p class="lead">Handcrafted Delights: Everything Homemade, Just for You.</p>
-                </div>
-            </div>
+            <h2 class="h3-fs" style="text-align: center;">Our Menu</h2>
+            <p class="lead" style="text-align: center;">Handcrafted Delights: Everything Homemade, Just for You.</p>
+            <p><br/></p>
             <div class="row">
                 <div class="col-lg-6 pt16 pb16">
                     <h3 class="h4-fs">Pastries</h3>


### PR DESCRIPTION
Since its redesign in [1], the "Pricelist" snippet now has two rows, one for the title and one for the menu. This breaks the "Layout" option behavior, especially when toggling the grid mode on drag, when dragging one of the price columns.

This commit fixes these issues by removing the first row and extracting its text, while keeping the same look.

Steps to reproduce:
- Drop a "Pricelist" snippet and click on it. => The "Column Count" option displays "1" where we would expect "2".
- Click on a price column and drag it. => The row with the title is the one who toggled the grid mode.
- Drag the column over the grid and then drop it in a normal dropzone. => Traceback

[1]: 1b361326f8f6c7e27c197ee2ca9496f556f9915c

Related to task-3665307
