### PR TITLE
[IMP] point_of_sale: play error sound when barcode scan fails to match a product

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -230,6 +230,7 @@ export class ProductScreen extends Component {
         const product = await this._getProductByBarcode(code);
 
         if (!product) {
+            this.sound.play("error");
             this.barcodeReader.showNotFoundNotification(code);
             return;
         }


### PR DESCRIPTION

Before this commit:
====================
Only a notification message was displayed when a scanned barcode did not match any product. This message could easily be overlooked by cashiers, especially when scanning quickly and not looking at the screen.

After this commit
=====================
An error sound is played when the barcode scanner fails to find a matching product, providing an immediate and audible alert to the user, reducing the chances of unnoticed scan failures.

Task-4787523

