### PR TITLE
[FIX] hr_holidays: update accruals via cron if archived employees

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -257,15 +257,16 @@ class HolidaysAllocation(models.Model):
     @api.depends('employee_ids', 'allocation_type', 'accrual_plan_id')
     def _compute_from_employee_ids(self):
         for allocation in self:
+            employees = allocation.with_context(active_test=False).employee_ids
             accrual_plan = allocation.accrual_plan_id
-            if len(allocation.employee_ids) == 1 or (
-                allocation.employee_ids and not accrual_plan.is_based_on_worked_time
+            if len(employees) == 1 or (
+                employees and not accrual_plan.is_based_on_worked_time
                 and accrual_plan.level_ids and not accrual_plan.level_ids[0].frequency == 'hourly'
             ):
-                allocation.employee_id = allocation.employee_ids[0]._origin
+                allocation.employee_id = employees[0]._origin
             else:
                 allocation.employee_id = False
-            allocation.multi_employee = len(allocation.employee_ids) > 1
+            allocation.multi_employee = len(employees) > 1
 
     @api.depends('holiday_type')
     def _compute_from_holiday_type(self):

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -2751,3 +2751,42 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             leave.action_validate()
             allocation_data = leave_type_day.get_allocation_data(self.employee_emp)
             self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
+
+    def test_archived_employee_update_accrual(self):
+        """
+        Check updating accruals works even for archived employees, since it is possible to archive an employee
+        without archiving its allocations.
+        """
+        with freeze_time("2020-01-01"):
+            accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+                'name': 'Test accrual plan',
+                'level_ids': [Command.create({
+                    'start_count': 1,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'added_value_type': 'day',
+                    'frequency': 'hourly',
+                    'cap_accrued_time': True,
+                    'maximum_leave': 10000
+                })],
+            })
+            allocation = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee',
+                'accrual_plan_id': accrual_plan.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation.action_validate()
+
+            # Archive employee but not the allocation
+            self.env["hr.departure.wizard"].create({
+                'employee_id': self.employee_emp.id,
+                'archive_allocation': False,
+            }).with_context(toggle_active=True).action_register_departure()
+            self.assertFalse(self.employee_emp.active, "Check employee has been archived")
+
+            with freeze_time(datetime.date.today() + relativedelta(days=2)):
+                allocation._update_accrual()
+                self.assertEqual(allocation.number_of_days, 8)


### PR DESCRIPTION
**Issue**
Accrual allocations are not updated when some employees have been archived but not their accrual allocations. The cron fails silently and fails to update the allocations, even for non-archived employees.

**Cause**
Commit 324a766993dcc0eb3342d34b725d1a459a94a82a added `accrual_plan_id` as a dependency of `_compute_from_employee_ids`.
https://github.com/odoo/odoo/blob/324a766993dcc0eb3342d34b725d1a459a94a82a/addons/hr_holidays/models/hr_leave_allocation.py#L257-L258

When the `_update_acrcual` cron is called, it also considers allocations of archived employees. When days are added in `_add_days_to_allocation`, since it is a dependency of `_compute_from_holiday_status_id`, the `accrual_plan_is` is marked to be recomputed.

The computation fails because of the following constraint https://github.com/odoo/odoo/blob/324a766993dcc0eb3342d34b725d1a459a94a82a/addons/hr_holidays/models/hr_leave_allocation.py#L137 because `allocation.employee_ids` returns an empty recordset if the employees are archived.

**Steps to reproduce**
- Create an accrual allocation for an employee with a start date in the past, validate it.
- Archive the employee and uncheck "Allocations" in the wizard to preserve its allocations.
- Run the `_update_accrual` cron in the future (using freezegun or setting your machine time in the future).
- `Validation Error The operation cannot be completed: The employee, department, company or employee category of this request is missing. Please make sure that your user login is linked to an employee.`

opw-4705667
