### PR TITLE
[IMP] mail: add message subtype model 

### DIFF
--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -95,8 +95,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                     "id": chatbot_message.id,
                     "incoming_email_cc": False,
                     "incoming_email_to": False,
-                    "is_discussion": True,
-                    "is_note": False,
                     "message_link_preview_ids": [],
                     "message_type": "comment",
                     "model": "discuss.channel",
@@ -116,7 +114,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                         "model": "discuss.channel",
                     },
                     "subject": False,
-                    "subtype_description": False,
+                    "subtype_id": self.env.ref("mail.mt_comment").id,
                     "trackingValues": [],
                     "write_date": fields.Datetime.to_string(chatbot_message.write_date),
                 }
@@ -169,8 +167,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                         "default_subject": "test1 Ernest Employee",
                         "incoming_email_cc": False,
                         "incoming_email_to": False,
-                        "is_discussion": False,
-                        "is_note": True,
                         "message_link_preview_ids": [],
                         "message_type": "notification",
                         "reactions": [],
@@ -187,10 +183,13 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                         "scheduledDatetime": False,
                         "starred": False,
                         "subject": False,
-                        "subtype_description": False,
+                        "subtype_id": self.env.ref("mail.mt_note").id,
                         "trackingValues": [],
                     },
                 ),
+                "mail.message.subtype": [
+                    {"description": False, "id": self.env.ref("mail.mt_note").id}
+                ],
                 "mail.thread": self._filter_threads_fields(
                     {
                         "display_name": "test1 Ernest Employee",
@@ -283,8 +282,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                         "id": message.id,
                                         "incoming_email_cc": False,
                                         "incoming_email_to": False,
-                                        "is_discussion": True,
-                                        "is_note": False,
                                         "message_link_preview_ids": [],
                                         "message_type": "notification",
                                         "model": "discuss.channel",
@@ -297,11 +294,14 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                         "res_id": channel.id,
                                         "scheduledDatetime": False,
                                         "subject": False,
-                                        "subtype_description": False,
+                                        "subtype_id": self.env.ref("mail.mt_comment").id,
                                         "thread": {"id": channel.id, "model": "discuss.channel"},
                                         "write_date": fields.Datetime.to_string(message.write_date),
                                     },
                                 ),
+                                "mail.message.subtype": [
+                                    {"description": False, "id": self.env.ref("mail.mt_comment").id}
+                                ],
                                 "mail.thread": self._filter_threads_fields(
                                     {
                                         "display_name": "Chell Gladys Ernest Employee",

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -320,7 +320,8 @@ class ResUsers(models.Model):
             action_discuss_id=xmlid_to_res_id("mail.action_discuss"),
             hasLinkPreviewFeature=self.env["mail.link.preview"]._is_link_preview_enabled(),
             internalUserGroupId=self.env.ref("base.group_user").id,
-            mt_comment_id=xmlid_to_res_id("mail.mt_comment"),
+            mt_comment=xmlid_to_res_id("mail.mt_comment"),
+            mt_note=xmlid_to_res_id("mail.mt_note"),
             # sudo: res.partner - exposing OdooBot data is considered acceptable
             odoobot=Store.One(self.env.ref("base.partner_root").sudo()),
         )

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -12,6 +12,7 @@ declare module "models" {
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
     import { MailActivityType as MailActivityTypeClass } from "@mail/core/common/mail_activity_type_model";
+    import { MailMessageSubtype as MailMessageSubtypeClass } from "@mail/core/common/mail_message_subtype_model";
     import { MailTemplate as MailTemplateClass } from "@mail/core/common/mail_template_model";
     import { Message as MessageClass } from "@mail/core/common/message_model";
     import { MessageLinkPreview as MessageLinkPreviewClass } from "@mail/core/common/message_link_preview_model";
@@ -39,6 +40,7 @@ declare module "models" {
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
     export interface MailActivityType extends MailActivityTypeClass {}
+    export interface MailMessageSubtype extends MailMessageSubtypeClass {}
     export interface MailTemplate extends MailTemplateClass {}
     export interface Message extends MessageClass {}
     export interface MessageLinkPreview extends MessageLinkPreviewClass {}
@@ -68,6 +70,7 @@ declare module "models" {
         "mail.link.preview": StaticMailRecord<LinkPreview, typeof LinkPreviewClass>;
         "mail.message": StaticMailRecord<Message, typeof MessageClass>;
         "mail.message.link.preview": StaticMailRecord<MessageLinkPreview, typeof MessageLinkPreviewClass>;
+        "mail.message.subtype": StaticMailRecord<MailMessageSubtype, typeof MailMessageSubtypeClass>;
         "mail.notification": StaticMailRecord<Notification, typeof NotificationClass>;
         "mail.template": StaticMailRecord<MailTemplate, typeof MailTemplateClass>;
         MessageReactions: StaticMailRecord<MessageReactions, typeof MessageReactionsClass>;
@@ -97,6 +100,7 @@ declare module "models" {
         "mail.link.preview": LinkPreview;
         "mail.message": Message;
         "mail.message.link.preview": MessageLinkPreview;
+        "mail.message.subtype": MailMessageSubtype;
         "mail.notification": Notification;
         "mail.template": MailTemplate;
         MessageReactions: MessageReactions;

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -11,6 +11,7 @@ export class Follower extends Record {
     /** @type {boolean} */
     is_active;
     partner_id = fields.One("Persona");
+    subtype_ids = fields.Many("mail.message.subtype");
 
     /** @returns {boolean} */
     get isEditable() {

--- a/addons/mail/static/src/core/common/mail_message_subtype_model.js
+++ b/addons/mail/static/src/core/common/mail_message_subtype_model.js
@@ -1,0 +1,14 @@
+import { Record } from "@mail/model/record";
+
+export class MailMessageSubtype extends Record {
+    static id = "id";
+    static _name = "mail.message.subtype";
+
+    /** @type {string} */
+    description;
+    /** @type {number} */
+    id;
+    /** @type {string} */
+    name;
+}
+MailMessageSubtype.register();

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -277,8 +277,8 @@ export class Message extends Component {
 
     get showSubtypeDescription() {
         return (
-            this.message.subtype_description &&
-            this.message.subtype_description.toLowerCase() !==
+            this.message.subtype_id?.description &&
+            this.message.subtype_id.description.toLowerCase() !==
                 htmlToTextContentInline(this.message.body || "").toLowerCase()
         );
     }
@@ -291,7 +291,7 @@ export class Message extends Component {
             return _t("Automated message");
         }
         if (
-            !this.props.message.is_discussion &&
+            !this.props.message.isDiscussion &&
             this.props.message.message_type !== "user_notification"
         ) {
             return _t("Note");

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -27,7 +27,7 @@
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': isEditing }" t-ref="messageContent">
-                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note, 'pe-2': props.asCard and isMobileOS }" name="header">
+                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.isNote, 'pe-2': props.asCard and isMobileOS }" name="header">
                             <span t-if="message.authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1" t-esc="message.authorName"/>
                             </span>
@@ -58,10 +58,10 @@
                                    'flex-row-reverse': isAlignedRight,
                                    }"
                         >
-                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.is_note }">
+                            <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': isEditing, 'opacity-50': message.isPending, 'pt-1': message.isNote }">
                                 <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': isEditing }">
                                     <t t-if="message.message_type === 'notification' and message.richBody" t-call="mail.Message.bodyAsNotification" name="bodyAsNotification"/>
-                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_description or isEditing or message.edited))">
+                                    <t t-if="message.isEmpty or (message.message_type !== 'notification' and !message.is_transient and (message.hasTextContent or message.subtype_id?.description or isEditing or message.edited))">
                                         <MessageLinkPreviewList t-if="!isEditing and message.linkPreviewSquash" messageLinkPreviews="message.message_link_preview_ids"/>
                                         <t t-else="">
                                             <div t-if="message.bubbleColor and !props.squashed" class="o-mail-Message-bubbleTail position-absolute d-flex" t-att-style="isAlignedRight ? 'right: -4px; transform: rotateY(180deg);' : 'left: -4px;'" t-att-class="{
@@ -86,14 +86,14 @@
                                                 }"/>
                                                 <MessageInReply t-if="message.parent_id" message="message" onClick="props.onParentMessageClick"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
-                                                            'p-1': message.is_note,
+                                                            'p-1': message.isNote,
                                                             'fs-1': !isEditing and !env.inChatter and message.onlyEmojis,
-                                                            'mb-0': !message.is_note,
-                                                            'py-2': !message.is_note and !isEditing,
-                                                            'pt-2 pb-1': !message.is_note and isEditing,
-                                                            'o-note': message.is_note,
+                                                            'mb-0': !message.isNote,
+                                                            'py-2': !message.isNote and !isEditing,
+                                                            'pt-2 pb-1': !message.isNote and isEditing,
+                                                            'o-note': message.isNote,
                                                             'o-rounded-bubble': props.squashed,
-                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !isEditing and !message.is_note and !props.squashed,
+                                                            'align-self-start o-rounded-end-bubble o-rounded-bottom-bubble': !isEditing and !message.isNote and !props.squashed,
                                                             'flex-grow-1': isEditing,
                                                             }" t-ref="body">
                                                     <i t-if="message.isEmpty" class="text-muted opacity-75" t-out="message.inlineBody"/>
@@ -110,7 +110,7 @@
                                                             <i class="text-danger fa fa-warning" role="img" aria-label="Translation Failure"/>
                                                             <t t-if="message.translationErrors" t-esc="translationFailureText"/>
                                                         </p>
-                                                        <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
+                                                        <t t-if="showSubtypeDescription" t-out="props.messageSearch?.highlight(message.subtype_id?.description) ?? message.subtype_id?.description"/>
                                                     </t>
                                                 </div>
                                             </div>

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -4,7 +4,7 @@
     <div class="o-mail-MessageReactions position-relative d-flex flex-wrap mt-n1"
         t-att-class="{
             'flex-row-reverse me-3': env.inChatWindow and env.alignedRight,
-            'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
+            'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.isDiscussion),
             'o-emojiPickerOpen': emojiPicker.isOpen,
         }">
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -81,8 +81,8 @@ export class Store extends BaseStore {
     users = {};
     /** @type {number} */
     internalUserGroupId;
-    /** @type {number} */
-    mt_comment_id;
+    mt_comment = fields.One("mail.message.subtype");
+    mt_note = fields.One("mail.message.subtype");
     /** @type {boolean} */
     hasMessageTranslationFeature;
     imStatusTrackedPersonas = fields.Many("Persona", {

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -548,7 +548,7 @@ export class Thread extends Component {
         if (!msg.thread?.eq(prevMsg.thread)) {
             return false;
         }
-        if (msg.is_note) {
+        if (msg.isNote) {
             return false;
         }
         return msg.datetime.ts - prevMsg.datetime.ts < 5 * 60 * 1000;

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -94,7 +94,7 @@
                         <t t-if="thread">
                             <div class="o-mail-Discuss-threadContainer d-flex flex-column flex-grow-1 bg-inherit">
                                 <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent"/></t>
-                                <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.is_note ? 'note' : 'message') : undefined"/>
+                                <Composer t-if="thread.model !== 'mail.box' or thread.composer.replyToMessage" t-key="thread.localId" composer="thread.composer" autofocus="true" onDiscardCallback="() => (thread.composer.replyToMessage = undefined)" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="thread.composer.replyToMessage ? (thread.composer.replyToMessage.isNote ? 'note' : 'message') : undefined"/>
                             </div>
                             <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0">
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>

--- a/addons/mail/static/src/core/web/follower_subtype_dialog.xml
+++ b/addons/mail/static/src/core/web/follower_subtype_dialog.xml
@@ -11,7 +11,7 @@
                     t-att-data-follower-subtype-id="subtype.id"
                 >
                     <label class="flex-grow-1 align-items-center d-flex mb-0 p-2 cursor-pointer">
-                        <input class="form-check-input me-2" type="checkbox" t-att-checked="subtype.followed ? 'checked': ''" t-on-change="(ev) => this.onChangeCheckbox(ev, subtype)"/>
+                        <input class="form-check-input me-2" type="checkbox" t-att-checked="subtype.in(this.props.follower.subtype_ids) ? 'checked': ''" t-on-change="(ev) => this.onChangeCheckbox(ev, subtype)"/>
                         <t t-esc="subtype.name"/>
                     </label>
                 </div>

--- a/addons/mail/static/src/core/web/message_model_patch.js
+++ b/addons/mail/static/src/core/web/message_model_patch.js
@@ -6,7 +6,7 @@ import { patch } from "@web/core/utils/patch";
 const messagePatch = {
     /** @param {import("models").Thread} thread the thread where the message is shown */
     canReplyAll(thread) {
-        return this.canForward(thread) && !this.is_note;
+        return this.canForward(thread) && !this.isNote;
     },
     /** @param {import("models").Thread} thread */
     canForward(thread) {

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -4,9 +4,9 @@
         <xpath expr="//t[@name='bodyAsNotification']" position="replace">
             <t t-if="message.message_type === 'notification' or message.is_transient or message.trackingValues.length > 0" name="hasTrackingValue">
                 <div>
-                    <t t-if="message.subtype_description">
+                    <t t-if="message.subtype_id?.description">
                         <p class="mb-0">
-                            <t t-out="props.messageSearch?.highlight(message.subtype_description) ?? message.subtype_description"/>
+                            <t t-out="props.messageSearch?.highlight(message.subtype_id.description) ?? message.subtype_id.description"/>
                         </p>
                     </t>
                     <t t-if="message.trackingValues.length">

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -47,7 +47,7 @@ export class DiscussCoreCommon {
                 author: this.store.odoobot,
                 body: markup(body),
                 id: lastMessageId + 0.01,
-                is_note: true,
+                subtype_id: this.store.mt_note,
                 is_transient: true,
                 thread: { id: channel_id, model: "discuss.channel" },
             });

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1091,7 +1091,9 @@ test("Do not squash logged notes", async () => {
             author_id: serverState.partnerId,
             needaction: true,
             res_id: partnerId,
-            is_note: true,
+            subtype_id: pyEnv["mail.message.subtype"].search([
+                ["subtype_xmlid", "=", "mail.mt_note"],
+            ])[0],
         },
         {
             model: "res.partner",
@@ -1099,7 +1101,9 @@ test("Do not squash logged notes", async () => {
             author_id: serverState.partnerId,
             needaction: true,
             res_id: partnerId,
-            is_note: true,
+            subtype_id: pyEnv["mail.message.subtype"].search([
+                ["subtype_xmlid", "=", "mail.mt_note"],
+            ])[0],
         },
     ]);
     pyEnv["mail.notification"].create({

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -95,7 +95,9 @@ test('"reply to" composer should log note if message replied to is a note', asyn
     const partnerId = pyEnv["res.partner"].create({ name: "Demo" });
     const messageId = pyEnv["mail.message"].create({
         body: "not empty",
-        is_note: true,
+        subtype_id: pyEnv["mail.message.subtype"].search([
+            ["subtype_xmlid", "=", "mail.mt_note"],
+        ])[0],
         model: "res.partner",
         needaction: true,
         res_id: partnerId,
@@ -127,7 +129,9 @@ test('"reply to" composer should send message if message replied to is not a not
     const partnerId = pyEnv["res.partner"].create({});
     const messageId = pyEnv["mail.message"].create({
         body: "not empty",
-        is_discussion: true,
+        subtype_id: pyEnv["mail.message.subtype"].search([
+            ["subtype_xmlid", "=", "mail.mt_comment"],
+        ])[0],
         model: "res.partner",
         needaction: true,
         res_id: partnerId,

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -15,8 +15,6 @@ export class MailMessage extends models.ServerModel {
     _name = "mail.message";
 
     author_id = fields.Generic({ default: () => serverState.partnerId });
-    is_discussion = fields.Boolean({ string: "Discussion" });
-    is_note = fields.Boolean({ string: "Note" });
     pinned_at = fields.Generic({ default: false });
 
     /** @param {DomainListRepr} [domain] */
@@ -103,14 +101,11 @@ export class MailMessage extends models.ServerModel {
                 "body",
                 "create_date",
                 "date",
-                "is_discussion",
-                "is_note",
                 "message_type",
                 "model",
                 "pinned_at",
                 "res_id",
                 "subject",
-                "subtype_description",
                 "write_date",
             ];
         }
@@ -185,8 +180,10 @@ export class MailMessage extends models.ServerModel {
                 ),
             });
             if (message.subtype_id) {
-                const [subtype] = MailMessageSubtype.browse(message.subtype_id);
-                data.subtype_description = subtype.description;
+                data.subtype_id = mailDataHelpers.Store.one(
+                    MailMessageSubtype.browse(message.subtype_id),
+                    makeKwArgs({ fields: ["description"] })
+                );
             }
             if (for_current_user) {
                 data["needaction"] = Boolean(

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message_subtype.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message_subtype.js
@@ -1,4 +1,4 @@
-import { fields, models } from "@web/../tests/web_test_helpers";
+import { fields, getKwArgs, models } from "@web/../tests/web_test_helpers";
 
 export class MailMessageSubtype extends models.ServerModel {
     _name = "mail.message.subtype";
@@ -29,4 +29,15 @@ export class MailMessageSubtype extends models.ServerModel {
             track_recipients: true,
         },
     ];
+
+    _to_store(ids, store, fields) {
+        const kwargs = getKwArgs(arguments, "ids", "store", "fields");
+        ids = kwargs.ids;
+        store = kwargs.store;
+        fields = kwargs.fields ?? [];
+
+        for (const subtypeId of ids) {
+            store.add(this.browse(subtypeId), this._read_format(subtypeId, fields, false)[0]);
+        }
+    }
 }

--- a/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_thread.js
@@ -105,6 +105,8 @@ export class MailThread extends models.ServerModel {
         const MailThread = this.env["mail.thread"];
         /** @type {import("mock_models").ResUsers} */
         const ResUsers = this.env["res.users"];
+        /** @type {import("mock_models").MailMessageSubtype} */
+        const MailMessageSubtype = this.env["mail.message.subtype"];
 
         const id = ids[0]; // ensure_one
         if (kwargs.context?.mail_post_autofollow && kwargs.partner_ids?.length) {
@@ -123,7 +125,6 @@ export class MailThread extends models.ServerModel {
             });
             kwargs.attachment_ids = attachmentIds.map((attachmentId) => Command.link(attachmentId));
         }
-        const subtype_xmlid = kwargs.subtype_xmlid || "mail.mt_note";
         let author_id;
         let email_from;
         const author_guest_id =
@@ -141,8 +142,9 @@ export class MailThread extends models.ServerModel {
             author_id,
             author_guest_id,
             email_from,
-            is_discussion: subtype_xmlid === "mail.mt_comment",
-            is_note: subtype_xmlid === "mail.mt_note",
+            subtype_id: MailMessageSubtype._filter([
+                ["subtype_xmlid", "=", kwargs.subtype_xmlid || "mail.mt_note"],
+            ])[0]?.id,
             model: this._name,
             res_id: id,
         });

--- a/addons/mail/static/tests/mock_server/mock_models/res_users.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_users.js
@@ -24,13 +24,17 @@ export class ResUsers extends webModels.ResUsers {
         const ResPartner = this.env["res.partner"];
         /** @type {import("mock_models").ResUsersSettings} */
         const ResUsersSettings = this.env["res.users.settings"];
-
+        /** @type {import("mock_models").MailMessageSubtype} */
+        const MailMessageSubtype = this.env["mail.message.subtype"];
         store.add({
             action_discuss_id: DISCUSS_ACTION_ID,
             channel_types_with_seen_infos: DiscussChannel._types_allowing_seen_infos(),
             hasGifPickerFeature: true,
             hasLinkPreviewFeature: true,
             hasMessageTranslationFeature: true,
+            mt_comment: MailMessageSubtype._filter([["subtype_xmlid", "=", "mail.mt_comment"]])[0]
+                .id,
+            mt_note: MailMessageSubtype._filter([["subtype_xmlid", "=", "mail.mt_note"]])[0].id,
             odoobot: mailDataHelpers.Store.one(ResPartner.browse(serverState.odoobotId)),
         });
         if (!this._is_public(this.env.uid)) {

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -94,7 +94,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         },
                                         "body": [
                                             "markup",
-                                            f'<div class="o_mail_notification" data-oe-type=\"channel-joined\">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
+                                            f'<div class="o_mail_notification" data-oe-type="channel-joined">invited <a href="#" data-oe-model="res.partner" data-oe-id="{self.test_partner.id}">@Test Partner</a> to the channel</div>',
                                         ],
                                         "create_date": fields.Datetime.to_string(
                                             message.create_date
@@ -105,8 +105,6 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         "id": message.id,
                                         "incoming_email_cc": False,
                                         "incoming_email_to": False,
-                                        "is_discussion": True,
-                                        "is_note": False,
                                         "message_link_preview_ids": [],
                                         "message_type": "notification",
                                         "model": "discuss.channel",
@@ -120,11 +118,14 @@ class TestChannelInternals(MailCommon, HttpCase):
                                         "res_id": channel.id,
                                         "scheduledDatetime": False,
                                         "subject": False,
-                                        "subtype_description": False,
+                                        "subtype_id": self.env.ref("mail.mt_comment").id,
                                         "thread": {"id": channel.id, "model": "discuss.channel"},
                                         "write_date": fields.Datetime.to_string(message.write_date),
                                     },
                                 ),
+                                "mail.message.subtype": [
+                                    {"description": False, "id": self.env.ref("mail.mt_comment").id}
+                                ],
                                 "mail.thread": self._filter_threads_fields(
                                     {
                                         "display_name": "Channel",

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -130,8 +130,9 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search mail_link_preview
     #       - search mail_message_reaction
     #       - search mail_message_res_partner_rel
-    #       - search mail_message_subtype
+    #       - search mail_message_subtype (_filter_unimportant_notifications)
     #       - search mail_notification
+    #       - search mail_message_subtype (mail.message@_to_store)
     #       - search rating_rating
     #       - fetch mail_notification
     #       - search discuss_call_history
@@ -142,7 +143,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
     #       - search user (_author_to_store)
     #       - fetch user (_author_to_store)
     #       - _compute_rating_stats
-    _query_count_discuss_channels = 59
+    _query_count_discuss_channels = 60
 
     def setUp(self):
         super().setUp()
@@ -418,7 +419,8 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "hasMessageTranslationFeature": False,
                 "has_access_create_lead": False,
                 "internalUserGroupId": self.env.ref("base.group_user").id,
-                "mt_comment_id": xmlid_to_res_id("mail.mt_comment"),
+                "mt_comment": self.env.ref("mail.mt_comment").id,
+                "mt_note": self.env.ref("mail.mt_note").id,
                 "odoobot": {"id": self.user_root.partner_id.id, "type": "partner"},
                 "self": {"id": self.users[0].partner_id.id, "type": "partner"},
                 "settings": {
@@ -549,6 +551,10 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             ),
             "mail.notification": [
                 self._expected_result_for_notification(self.channel_channel_public_1),
+            ],
+            "mail.message.subtype": [
+                {"description": False, "id": self.env.ref("mail.mt_note").id},
+                {"description": False, "id": self.env.ref("mail.mt_comment").id},
             ],
             "mail.thread": self._filter_threads_fields(
                 self._expected_result_for_thread(self.channel_general),
@@ -1281,8 +1287,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": False,
-                "is_note": True,
                 "message_link_preview_ids": [],
                 "message_type": "comment",
                 "model": "discuss.channel",
@@ -1302,7 +1306,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
                 "thread": {"id": channel.id, "model": "discuss.channel"},
                 "trackingValues": [],
                 "write_date": write_date,
@@ -1319,8 +1323,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": False,
-                "is_note": True,
                 "message_link_preview_ids": [],
                 "message_type": "comment",
                 "model": "discuss.channel",
@@ -1341,7 +1343,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": True,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }
@@ -1360,8 +1362,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": True,
-                "is_note": False,
                 "message_link_preview_ids": [],
                 "message_type": "notification",
                 "model": "discuss.channel",
@@ -1378,7 +1378,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_comment").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }
@@ -1398,8 +1398,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": False,
-                "is_note": True,
                 "message_link_preview_ids": [],
                 "message_type": "notification",
                 "model": "discuss.channel",
@@ -1416,7 +1414,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }
@@ -1435,8 +1433,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": True,
-                "is_note": False,
                 "message_link_preview_ids": [],
                 "message_type": "notification",
                 "model": "discuss.channel",
@@ -1453,7 +1449,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_comment").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }
@@ -1468,8 +1464,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": False,
-                "is_note": True,
                 "message_link_preview_ids": [],
                 "message_type": "notification",
                 "model": "discuss.channel",
@@ -1486,7 +1480,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }
@@ -1502,8 +1496,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "id": last_message.id,
                 "incoming_email_cc": False,
                 "incoming_email_to": False,
-                "is_discussion": False,
-                "is_note": True,
                 "message_link_preview_ids": [],
                 "message_type": "comment",
                 "model": "discuss.channel",
@@ -1520,7 +1512,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "scheduledDatetime": False,
                 "starred": False,
                 "subject": False,
-                "subtype_description": False,
+                "subtype_id": self.env.ref("mail.mt_note").id,
                 "trackingValues": [],
                 "write_date": write_date,
             }

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1497,8 +1497,6 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "id": message.id,
                                     "incoming_email_cc": False,
                                     "incoming_email_to": False,
-                                    "is_discussion": True,
-                                    "is_note": False,
                                     "message_link_preview_ids": [],
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
@@ -1513,12 +1511,15 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "scheduledDatetime": None,
                                     "starred": False,
                                     "subject": False,
-                                    "subtype_description": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
                                     "thread": {"id": record.id, "model": "mail.test.simple"},
                                     "trackingValues": [],
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ),
+                            "mail.message.subtype": [
+                                {"description": False, "id": self.env.ref("mail.mt_comment").id},
+                            ],
                             "mail.notification": [
                                 {
                                     "failure_type": False,
@@ -1610,8 +1611,6 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "id": message.id,
                                     "incoming_email_cc": False,
                                     "incoming_email_to": False,
-                                    "is_discussion": True,
-                                    "is_note": False,
                                     "message_link_preview_ids": [],
                                     "message_type": "comment",
                                     "model": "mail.test.simple",
@@ -1626,12 +1625,15 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "scheduledDatetime": None,
                                     "starred": False,
                                     "subject": False,
-                                    "subtype_description": False,
+                                    "subtype_id": self.env.ref("mail.mt_comment").id,
                                     "thread": {"id": record.id, "model": "mail.test.simple"},
                                     "trackingValues": [],
                                     "write_date": fields.Datetime.to_string(message.write_date),
                                 },
                             ),
+                            "mail.message.subtype": [
+                                {"description": False, "id": self.env.ref("mail.mt_comment").id},
+                            ],
                             "mail.notification": [
                                 {
                                     "failure_type": False,


### PR DESCRIPTION
The mail message "_to_store" methods adds custom fields related
to its "subtype_id" field. We should avoid custom fields and rely
on correct modeling instead. This commit adds the subtype model
on the client side. "is_note", "is_discussion" and "subtype_description"
fields are now directly deduced from "subtype_id".

task-4676083

enterprise: https://github.com/odoo/enterprise/pull/85350