### PR TITLE
[IMP] payment_razorpay: Restrict multiple pending tokenized transactions for same document

### DIFF
--- a/addons/payment_razorpay/tests/common.py
+++ b/addons/payment_razorpay/tests/common.py
@@ -47,6 +47,11 @@ class RazorpayCommon(PaymentCommon):
             'customer_id': cls.customer_id,
             'token_id': cls.token_id,
         }
+        cls.payment_pending_data = {
+            'id': cls.payment_id,
+            'description': cls.reference,
+            'status': 'pending',
+        }
         cls.refund_data = {
             'id': cls.refund_id,
             'payment_id': cls.payment_id,


### PR DESCRIPTION
As per RBI Notification RBI/2019-20/47, ensure a pre-debit notification is sent at least 24 hours before the actual debit for recurring payments. Prevent creation of duplicate pending transactions with token for the same document because every transactions confirm after 24 hours.

task - 4678509

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
