### PR TITLE
[FIX] mail: blank "To" field

### DIFF
--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -74,6 +74,9 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
         );
         tags.forEach((tag) => {
             tag.email = emailByResId[tag.resId];
+            if( !tag.text ){
+                tag.text = tag.email;
+            }
             tag.name = tag.text;
             tag.title = tag.text;
         });


### PR DESCRIPTION
To reproduce:
=============

1. In v18.2, create a contact/invoicing address under a company without specifying a name.
2. Send an invoice to this contact.
3. Observe the "To" field in the email composer — it appears blank.

Problem:
========

In v18.2, the "To" field only displays the contact name. If the name is missing, the field appears empty, which can confuse users and make it unclear whether the email will be sent correctly.

In v18.1, the field displayed both the name (if available) and the associated email, providing better clarity.

Solution:
=========

Update the template logic to fall back to displaying the email address when the contact name is missing, ensuring the "To" field is always informative.

opw-4748001
