### PR TITLE
[FIX] sale_project: does not take task template into account in task …

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -190,7 +190,7 @@ class SaleOrder(models.Model):
         return action
 
     def _tasks_ids_domain(self):
-        return ['&', ('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids)]
+        return ['&', ('project_id', '!=', False), '|', ('sale_line_id', 'in', self.order_line.ids), ('sale_order_id', 'in', self.ids), ('has_template_ancestor', '=', False)]
 
     def action_create_project(self):
         self.ensure_one()

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -421,7 +421,7 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertFalse(sale_order_2.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertFalse(sale_order_2.show_task_button, "There is no project on the sale order, the button should be hidden")
         # create a new task, whose sale order item is a sol of the SO
-        self.env['project.task'].create({
+        task = self.env['project.task'].create({
             'name': 'Test Task',
             'project_id': self.project_global.id,
             'sale_line_id': line_prepaid.id,
@@ -431,6 +431,12 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertTrue(sale_order_2.show_create_project_button, "There is a product service with the service_policy set on 'ordered_prepaid' on the sale order, the button should be displayed")
         self.assertFalse(sale_order_2.show_project_button, "There is no project on the sale order, the button should be hidden")
         self.assertTrue(sale_order_2.show_task_button, "There is no project on the sale order and there is a task whose sale item is one of the sale_line of the SO, the button should be displayed")
+        self.assertEqual(sale_order_2.tasks_ids, task)
+        task.action_convert_to_template()
+        sale_order_2._compute_tasks_ids()
+        sale_order_2._compute_show_project_and_task_button()
+        self.assertFalse(sale_order_2.show_task_button, 'The button should no longer be visible since no tasks are linked to the SO.')
+        self.assertFalse(sale_order_2.tasks_ids, 'No tasks should be linked to the SO since the task has been converted into a template.')
 
         # add a manual service product
         self.env['sale.order.line'].create({


### PR DESCRIPTION
…count

Before this commit, the tasks stat button displayed in the SO form view takes into account the task templates if the templates are linked to the SO.

This commit adds a condition to exclude the task templates in the count displayed in that stat button.

Steps to reproduce the issue
----------------------------

0. Install sale_timesheet module
1. Go to Sales app
2. Create a quotation with a service product in which a task will be created once the quotation will be confirmed.
3. Confirm the SO
4. Click on tasks stat button
5. Click on the task containing in the list view
6. Convert that task into a template
7. Go back to the form view of the SO created.

Expected Behavior
-----------------

The Tasks stat button count should not take the template into account.

Current Behavior
----------------

The Tasks stat button count take the template into account.

task-4781135
