### PR TITLE
[FIX] account: add default string regex transaction_details

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -90,7 +90,7 @@ class AccountReconcileModelLine(models.Model):
         self.amount_string = ''
         if self.amount_type in ('percentage', 'percentage_st_line'):
             self.amount_string = '100'
-        elif self.amount_type == 'regex':
+        elif self.amount_type in ('regex', 'from_transaction_details'):
             self.amount_string = r'([\d,]+)'
 
     @api.depends('amount_string')


### PR DESCRIPTION
A new amount type match was added for reconcile lines in the form of `from_transaction_details`.
There is a value that is proposed by default for `regex`, but not for the new one, while the matching follows the same rule. We do expect atleast a group in the regex currently, but the user has no example on which to base itself. (they currently have a traceback but it will be fixed in https://github.com/odoo/enterprise/pull/84769)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
