### PR TITLE
[IMP] web, *: streamline daterange display and usage in views

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -217,9 +217,7 @@
                         <field name="user_id" widget="many2one_avatar_user"/>
                         <div class="flex-grow-1">
                             <field name="name" string="Event Name" class="o_text_block o_text_bold"/>
-                            <field name="date_begin"/>
-                            <i class="fa fa-long-arrow-right mx-2" aria-label="Arrow icon" title="Arrow" />
-                            <field name="date_end"/>
+                            <field name="date_begin" widget="daterange" options="{'end_date_field': 'date_end'}"/>
                         </div>
                     </div>
                 </templates>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -443,10 +443,9 @@
                                     <span name="partner_name" class="text-muted d-flex align-items-baseline" t-if="record.partner_id.value">
                                         <span class="fa fa-user me-2" aria-label="Partner" title="Partner"></span><field class="text-truncate" name="partner_id"/>
                                     </span>
-                                    <div t-if="record.date.raw_value or record.date_start.raw_value" class="text-muted">
-                                        <span class="fa fa-clock-o me-2" title="Dates"></span><field name="date_start"/>
-                                        <i t-if="record.date.raw_value and record.date_start.raw_value" class="fa fa-long-arrow-right mx-2 oe_read_only" aria-label="Arrow icon" title="Arrow"/>
-                                        <field name="date"/>
+                                    <div t-if="record.date.raw_value or record.date_start.raw_value" class="text-muted d-flex align-items-baseline">
+                                        <span class="fa fa-clock-o me-2" title="Dates"/>
+                                        <field name="date_start" widget="daterange" options="{'end_date_field': 'date'}"/>
                                     </div>
                                     <div t-if="record.alias_email.value" class="text-muted text-truncate" t-att-title="record.alias_email.value">
                                         <span class="fa fa-envelope-o me-2" aria-label="Domain Alias" title="Domain Alias"></span><field name="alias_email"/>

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -8,6 +8,7 @@ import { ensureArray } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { formatDate, formatDateTime } from "../formatters";
 import { standardFieldProps } from "../standard_field_props";
+import { localization } from "@web/core/l10n/localization";
 
 function getFormattedPlaceholder(value, type, options) {
     if (value instanceof luxon.DateTime) {
@@ -193,12 +194,19 @@ export class DateTimeField extends Component {
      */
     getFormattedValue(valueIndex) {
         const value = this.values[valueIndex];
+        if (!value) {
+            return "";
+        }
         const { condensed, showSeconds, showTime } = this.props;
-        return value
-            ? this.field.type === "date"
-                ? formatDate(value, { condensed })
-                : formatDateTime(value, { condensed, showSeconds, showTime })
-            : "";
+        if (this.field.type === "date") {
+            return formatDate(value, { condensed });
+        }
+        if (showTime && valueIndex === 1 && this.values[0].hasSame(value, "day")) {
+            return formatDateTime(value, {
+                format: showSeconds ? localization.timeFormat : localization.shortTimeFormat,
+            });
+        }
+        return formatDateTime(value, { condensed, showSeconds, showTime });
     }
 
     /**

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1211,3 +1211,19 @@ test("updating time keeps selected dates", async () => {
     expect(".o_time_picker:first .o_time_picker_input").toHaveValue("15:35");
     expect(".o_time_picker:last .o_time_picker_input").toHaveValue("5:05");
 });
+
+test("daterange in readonly with same dates but different hours", async () => {
+    Partner._records[0].datetime_end = "2017-02-08 17:00:00";
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+            <form edit="0">
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}"/>
+            </form>`,
+    });
+    expect(".o_field_daterange").toHaveText("02/08/2017 15:30\n22:30", {
+        message: "end date only shows time since it has the same day as start date",
+    });
+});


### PR DESCRIPTION
This commit tweaks the datetime field in daterange mode so that the date of the end date is hidden if it falls on the same day as the start date, reducing visual redundancy. This is only applied in readonly mode.

It also replaces manually constructed daterange fields (using two datetime fields and an arrow) in some XML views with actual daterange fields to simplify view definitions and take advantage of the improved display behavior.

task-4788200
