### PR TITLE
[IMP] mass_mailing: garbage collect cancelled mail.mail

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -4,6 +4,8 @@
 import re
 import werkzeug.urls
 
+from datetime import datetime, timedelta
+
 from odoo import api, fields, models, tools
 
 
@@ -104,3 +106,16 @@ class MailMail(models.Model):
         else:
             self.filtered('mailing_id').mailing_trace_ids.set_sent()
         return super()._postprocess_sent_message(success_pids, failure_reason=failure_reason, failure_type=failure_type)
+
+    @api.autovacuum
+    def _gc_canceled_mail_mail(self):
+        """Garbage collects old canceled mail.mail records as we consider
+        nobody is going to look at them anymore, becoming noise."""
+        # The 10000 limit is arbitrary, chosen a big limit so that the cleaning can be shorter and not too big so that we don't block the server
+        months_limit = self.env['ir.config_parameter'].sudo().get_param("mass_mailing.cancelled_mails_months_limit", 6)
+        if months_limit <= 0:
+            return
+        history_deadline = datetime.utcnow() - timedelta(months=months_limit)  # 6 months history will be kept
+        canceled_mails = self.with_context(active_test=False).search([('state', '=', 'cancel'), ('write_date', '<=', history_deadline)], order="id asc", limit=10000)
+
+        canceled_mails.with_context(prefetch_fields=False).mail_message_id.unlink()


### PR DESCRIPTION
This commit adds a garbage collector to the mass_mailing override of mail.mail. This garbage collector is here to pickup any cancelled email that were left behind before the merge of ad01ad5eb9f68cfdb8ee7e163660d7796c144243.

The linked commit introduced the filtering of cancelled emails before trying to send them, while keeping the traces. This lessened the load on the storage of the DB.

task-4464074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
