### PR TITLE
[FIX] website_sale: category back button not editable


### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -347,7 +347,7 @@
                                     <t t-set="_classes" t-valuef="d-none me-auto d-lg-inline-block"/>
                                 </t>
 
-                                <div t-if="category" class="d-flex align-items-center d-lg-none me-auto">
+                                <div t-if="category" class="d-flex align-items-center d-lg-none me-auto o_not_editable">
                                     <t t-if="not category.parent_id" t-set="backUrl" t-valuef="/shop"/>
                                     <t t-else="" t-set="backUrl" t-value="keep('/shop/category/' + slug(category.parent_id), category=0)"/>
 


### PR DESCRIPTION

Scenario: in mobile, edit the link of the category back button

Result: the link is changed, but it is overriden by t-att-href so will
not be taken into account.

Fix: add o_not_editable on parent to prevent editing this part, this
prevent to change style but there is no simple way to prevent editing
only the link and there is no information that there is a "t-att-href".

opw-4725198
