### PR TITLE
[FIX] mail: message bubble border too dark in dark theme

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -14,7 +14,7 @@
 .o-mail-Message-bubble {
     &.o-blue {
         background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black) !important;
+        border-color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
@@ -22,7 +22,7 @@
     }
     &.o-green {
         background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black) !important;
+        border-color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
@@ -30,7 +30,7 @@
     }
     &.o-orange {
         background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black) !important;
+        border-color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
             background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;
@@ -44,7 +44,7 @@
             color:mix($gray-100, $info, 87.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black) !important;
+            color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black, 75%) !important;
         }
     }
     &.o-green {
@@ -52,7 +52,7 @@
             color: mix($gray-100, $success, 87.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black) !important;
+            color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black, 75%) !important;
         }
     }
     &.o-orange {
@@ -60,7 +60,7 @@
             color: mix($gray-100, $warning, 72.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black) !important;
+            color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black, 75%) !important;
         }
     }
 }


### PR DESCRIPTION
Before this commit, message bubble border was too dark. This gave the impression that squashed messages had too much spacing.