### PR TITLE
[FIX] mail: discuss app right panel lacks bg color

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -96,7 +96,7 @@
                                 <t name="thread"><Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/></t>
                                 <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
                             </div>
-                            <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer h-100 border-start border-secondary flex-shrink-0">
+                            <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="o-mail-Discuss-panelContainer o-mail-discussSidebarBgColor h-100 border-start border-secondary flex-shrink-0">
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
                             </div>
                         </t>


### PR DESCRIPTION
The bg color of the right panel in discuss app, e.g. channel member list, lack same bg color as header and left sidebar. As a result, the bg was the same as the message list, which made it hard to read due to being separated by only slight border in-between.

This commit puts the same bg color on this panel in discuss app as header and left sidebar.