### PR TITLE
[FIX] mrp: cast record ID to NewID for dict lookup during onchange

### DIFF
--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -237,3 +237,36 @@ class TestMrpReplenish(TestMrpCommon):
 
         self.assertEqual(len(mo_final), 1, "Expected one MO for the final product.")
         self.assertEqual(len(mo_component), 1, "Expected one MO for the manufactured BOM component.")
+
+    def test_orderpoint_onchange_reordering_rule(self):
+        """ Ensure onchange logic works properly when editing a reordering rule
+            linked to a confirmed MO, which is started but not finished by the
+            end of the stock forecast.
+        """
+        route_manufacture = self.warehouse_1.manufacture_pull_id.route_id
+
+        self.product_4.route_ids = [Command.set([route_manufacture.id])]
+        self.product_4.bom_ids.produce_delay = 2
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'product_id': self.product_4.id,
+            'product_min_qty': 2,
+            'product_max_qty': 2,
+        })
+
+        orderpoint.action_replenish()
+
+        prod = self.env['mrp.production'].search([('origin', '=', orderpoint.name)])
+        # Error is triggered for date_start <= lead_days_date < date_finished
+        prod.date_start = fields.Date.today() + timedelta(days=1)
+
+        with Form(orderpoint, view='stock.view_warehouse_orderpoint_tree_editable') as form:
+            form.product_min_qty = 3
+        self.assertEqual(orderpoint.qty_to_order, 1)
+
+        orderpoint.trigger = 'manual'
+        with Form(orderpoint, view='stock.view_warehouse_orderpoint_tree_editable') as form:
+            form.product_min_qty = 10
+            self.assertEqual(form.qty_to_order, 0)
+        self.assertEqual(form.qty_to_order, 8)
+        self.assertEqual(orderpoint.qty_to_order, 8)

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -326,6 +326,8 @@ class StockWarehouseOrderpoint(models.Model):
         for orderpoint in self:
             if orderpoint.trigger == 'auto':
                 orderpoint.qty_to_order_manual = 0
+            elif not orderpoint.qty_to_order_manual and not orderpoint.qty_to_order:
+                orderpoint.qty_to_order = orderpoint.qty_to_order_computed
             elif orderpoint.qty_to_order != orderpoint.qty_to_order_computed:
                 orderpoint.qty_to_order_manual = orderpoint.qty_to_order
 
@@ -344,8 +346,7 @@ class StockWarehouseOrderpoint(models.Model):
             # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
             # there is a already something to ressuply base on lead times.
             return (
-                orderpoint.product_id
-                and orderpoint.location_id
+                orderpoint.id
                 and float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=rounding) < 0
             )
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install MRP module
- Create a new product tracked by quantity and set its route to manufacture
- Create a new BoM and set the Manuf. Lead Time to 2 days
- Create a new reordering rule, set the minimum quantity to 2 and click on order
- Navigate to the newly created manufacturing order and set the scheduled date to the next day
- Try increasing the minimum quantity on the reordering rule
- `KeyError` is triggered

**Issue:**
When computing `unwanted_replenish` field, the `_quantity_in_progress` function builds a dictionary (`res`) created using the IDs of current 'stock.warehouse.orderpoint' records as keys.

During `onchange()` process the keys can be set as temporary IDs (`NewID` class). But, when evaluating domains, `orderpoint.id` is returned as the real ID (`orderpoint._origin.id`), which make the index lookup fails when checking value of existing model:

```
self.id             => NewId origin=6
res                 => {<NewId origin=6> : 0.0}
orderpoint.id       => 6
res[orderpoint.id]  => KeyError
```

This mismatch occurs due to the implicit conversion when using `NewId` inside domain filters with `.ids`. In which case they return the elements which matched the `_origin` id (for previous existing records). Domains will return the matching records with real IDs, but the dictionary still expects `NewId` as key.

**Fix:**
Ensure safe lookup by explicitly checking whether the dictionary has either the real ID or the `NewId` wrapper.

opw-4729116

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
