### PR TITLE
[FIX] hr_expense: better error msg if no account

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1739,6 +1739,12 @@ class HrExpense(models.Model):
         if journal.type == 'purchase':
             account = journal.default_account_id
 
+        if not account:
+            raise UserError(_(
+                "Odoo had a look at your expense, its product, your company and the journal but came back with empty hands.\n"
+                "Give Odoo a hand to find an account by setting up an expense account.\n"
+                "%(expense)s %(expense_name)s.\n"
+            ), {'expense': self, 'expense_name': self.name})
         return account
 
     def _get_expense_account_destination(self):


### PR DESCRIPTION
The aim of this commit is to give an user friendly message when there is a lack of configuration.

Context:
Odoo IN didn't set up their expense account and end user faced a very unfriendly (some even says mean!) traceback.

They then selected Odoo SA as main company and ended with another meanier traceback as an account from Odoo SA was selected for an expense of Odoo IN.

Before this commit:
End users could face an unfriendly traceback in case of lack of configuration.

After this commit:
End users will face a friendly userError in case of a lack of configuration.

opw-4699717