### PR TITLE
[FIX] website_sale_loyalty: filter claimed rewards out of claimables

### DIFF
--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -213,7 +213,7 @@ class SaleOrder(models.Model):
         global_discount_reward = self._get_applied_global_discount()
         for coupon in loyality_cards:
             points = self._get_real_points_for_coupon(coupon)
-            for reward in coupon.program_id.reward_ids:
+            for reward in coupon.program_id.reward_ids - self.order_line.reward_id:
                 if reward.is_global_discount and global_discount_reward and global_discount_reward.discount >= reward.discount:
                     continue
                 if reward.reward_type == 'discount' and total_is_zero:

--- a/addons/website_sale_loyalty/tests/test_free_product_reward.py
+++ b/addons/website_sale_loyalty/tests/test_free_product_reward.py
@@ -1,36 +1,40 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http
-from odoo.tests.common import HttpCase
+from odoo import Command, http
 from odoo.tests import tagged
+
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
+
 @tagged('post_install', '-at_install')
-class TestFreeProductReward(HttpCase):
+class TestFreeProductReward(HttpCaseWithUserDemo):
 
-    def setUp(self):
-        super().setUp()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        self.WebsiteSaleController = WebsiteSale()
-        self.website = self.env['website'].browse(1)
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.website = cls.env.ref('website.default_website').with_user(cls.user_demo)
 
-        self.sofa = self.env['product.product'].create({
-            'name': 'Test Sofa',
-            'list_price': 2950.0,
-            'website_published': True,
-        })
-
-        self.carpet = self.env['product.product'].create({
-            'name': 'Test Carpet',
-            'list_price': 500.0,
-            'website_published': True,
-        })
+        cls.sofa, cls.carpet = cls.env['product.product'].create([
+            {
+                'name': "Test Sofa",
+                'list_price': 2950.0,
+                'website_published': True,
+            },
+            {
+                'name': "Test Carpet",
+                'list_price': 500.0,
+                'website_published': True,
+            },
+        ])
 
         # Disable any other program
-        self.program = self.env['loyalty.program'].search([]).write({'active': False})
+        cls.program = cls.env['loyalty.program'].search([]).write({'active': False})
 
-        self.program = self.env['loyalty.program'].create({
+        cls.program = cls.env['loyalty.program'].create({
             'name': 'Get a product for free',
             'program_type': 'promotion',
             'applies_on': 'current',
@@ -40,26 +44,21 @@ class TestFreeProductReward(HttpCase):
                 'minimum_amount': 0.00,
                 'reward_point_amount': 1,
                 'reward_point_mode': 'order',
-                'product_ids': self.sofa,
+                'product_ids': cls.sofa,
             })],
             'reward_ids': [(0, 0, {
                 'reward_type': 'product',
-                'reward_product_id': self.carpet.id,
+                'reward_product_id': cls.carpet.id,
                 'reward_product_qty': 1,
                 'required_points': 1,
             })],
         })
 
-        self.steve = self.env['res.partner'].create({
-            'name': 'Steve Bucknor',
-            'email': 'steve.bucknor@example.com',
+        cls.empty_order = cls.env['sale.order'].create({
+            'partner_id': cls.partner_demo.id,
         })
 
-        self.empty_order = self.env['sale.order'].create({
-            'partner_id': self.steve.id
-        })
-
-        installed_modules = set(self.env['ir.module.module'].search([
+        installed_modules = set(cls.env['ir.module.module'].search([
             ('state', '=', 'installed'),
         ]).mapped('name'))
         for _ in http._generate_routing_rules(installed_modules, nodb_only=False):
@@ -79,3 +78,27 @@ class TestFreeProductReward(HttpCase):
             self.assertEqual(sofa_line.product_uom_qty, 1, "Should have only 1 qty of Sofa")
             self.assertEqual(carpet_reward_line.product_uom_qty, 1, "Should have only 1 qty for the carpet as reward")
             self.assertEqual(carpet_line.product_uom_qty, 1, "Should have only 1 qty for carpet as non reward")
+
+    def test_get_claimable_free_shipping(self):
+        order = self.empty_order
+        self.program.write({
+            'program_type': 'next_order_coupons',
+            'applies_on': 'future',
+            'coupon_ids': [Command.create({'partner_id': order.partner_id.id, 'points': 100})],
+            'reward_ids': [Command.update(self.program.reward_ids.id, {
+                'reward_type': 'shipping',
+                'reward_product_id': None,
+            })],
+        })
+        coupon = self.program.coupon_ids
+
+        with MockRequest(self.website.env, website=self.website, sale_order_id=order.id):
+            self.assertDictEqual(order._get_claimable_and_showable_rewards(), {
+                coupon: self.program.reward_ids,
+            })
+            self.WebsiteSaleController.cart_update_json(self.sofa.id, set_qty=1)
+            self.WebsiteSaleController.claim_reward(self.program.reward_ids.id, code=coupon.code)
+            self.assertFalse(
+                order._get_claimable_and_showable_rewards(),
+                "Rewards should no longer be claimable if already claimed",
+            )


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Set up a Next Order Coupon program;
2. add Free Shipping as a reward;
3. create a coupon for current user with enough points to claim reward;
4. add a product to your cart;
5. go to check out;
6. claim Free Shipping.

Issue
-----
Free Shipping is still displayed as claimable

Cause
-----
The `_get_claimable_and_showable_rewards` method does not factor in whether the rewards have already been claimed on the current order.

For discounts & free products, this isn't an issue, as claiming them will use as many points as possible, meaning there's no points left to claim more, but free shipping can only be claimed once per order.

Solution
--------
Filter out rewards that have already been claimed.

opw-4784359