### PR TITLE
[FIX] stock_account: fix "missing record" error when adding product attributes

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -91,12 +91,14 @@ will update the cost of every lot/serial number in stock."),
         res = super(ProductTemplate, self).write(vals)
 
         for product_template, (products, description, products_orig_quantity_svl) in impacted_templates.items():
-            # Replenish the stock with the new cost method.
-            in_svl_vals_list = products._svl_replenish_stock(description, products_orig_quantity_svl)
-            in_stock_valuation_layers = SVL.create(in_svl_vals_list)
-            if product_template.valuation == 'real_time':
-                move_vals_list += Product._svl_replenish_stock_am(in_stock_valuation_layers)
-            products._update_lots_standard_price()
+            products = products.exists()
+            if products:
+                # Replenish the stock with the new cost method.
+                in_svl_vals_list = products._svl_replenish_stock(description, products_orig_quantity_svl)
+                in_stock_valuation_layers = SVL.create(in_svl_vals_list)
+                if product_template.valuation == 'real_time':
+                    move_vals_list += Product._svl_replenish_stock_am(in_stock_valuation_layers)
+                products._update_lots_standard_price()
 
         # Check access right
         if move_vals_list and not self.env['stock.valuation.layer'].has_access('read'):

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -1,6 +1,7 @@
 from . import test_account_move
 from . import test_anglo_saxon_valuation_reconciliation_common
 from . import test_lot_valuation
+from . import test_product
 from . import test_stockvaluation
 from . import test_stockvaluationlayer
 from . import test_stock_valuation_layer_revaluation

--- a/addons/stock_account/tests/test_product.py
+++ b/addons/stock_account/tests/test_product.py
@@ -1,0 +1,53 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_stockvaluationlayer import TestStockValuationCommon
+from odoo.fields import Command
+
+
+class TestStockAccountProduct(TestStockValuationCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.fifo_category = cls.env['product.category'].create({
+            'name': 'All/Saleable FIFO',
+            'parent_id': cls.env.ref('product.product_category_all').id,
+            'property_cost_method': 'fifo',
+        })
+        cls.attribute_legs = cls.env['product.attribute'].create({
+            'name': 'Legs',
+            'value_ids': [
+                Command.create({'name': 'Steel'}),
+                Command.create({'name': 'Aluminium'}),
+                Command.create({'name': 'Custom'}),
+            ],
+        })
+
+    def test_update_categ_and_add_attributes(self):
+        """ Check that one can adapt the `property_cost_method` of a product with variants."""
+        template = self.env['product.template'].create({
+            'name': 'Table',
+            'type': 'consu',
+            'is_storable': True,
+            'categ_id': self.env.ref('product.product_category_all').id,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.attribute_legs.id,
+                    'value_ids': [
+                        Command.link(self.attribute_legs.value_ids[0].id),  # Add Steel
+                        Command.link(self.attribute_legs.value_ids[1].id),  # Add Aluminium
+                ]}),
+            ],
+        })
+        initial_variants = template.product_variant_ids
+        self.assertEqual(len(initial_variants), 2, "Expected 2 initial variants.")
+        template.write({
+            'categ_id': self.fifo_category.id,
+            'attribute_line_ids': [Command.update(template.attribute_line_ids[0].id, {
+                'value_ids': [
+                    Command.unlink(self.attribute_legs.value_ids[0].id),  # Remove Steel
+                    Command.link(self.attribute_legs.value_ids[2].id),  # Add Custom
+                ]
+            })]
+        })
+        final_variants = template.product_variant_ids
+        self.assertEqual(len(final_variants), 2, "Expected 2 product variants after attribute change.")


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to Sales > Configuration > Product Categories 
2. Select All / Saleable, and set Costing Method to FIFO 
3. Go to Products > New
4. Fill in Name , set Track Inventory True and add Cost, then save the product
5. Change the Category to All / Saleable
6. Navigate to Attributes & Variants, add attribute Leg, and add values Steel and Aluminium

<b>Issue :</b>
- When modifying a product template with FIFO costing by adding multiple attributes, the system may delete and recreate product variants. This causes "missing record" error during stock valuation replenishment, as the code tries to access  deleted product variants.

<b>Solution :</b>
- After calling super().write(vals), the original products recordset may contain deleted records due to variant regeneration.
  A check was added to verify if the variants still exist, If not, then continues.

<b>opw-4741530</b>