### PR TITLE
[IMP] account,l10n_gcc_invoice: Improved invoice PDFs in draft

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -64,7 +64,9 @@
                             <span t-if="o.name and o.name != '/'" t-field="o.name">INV/2023/0001</span>
                         </t>
                         <div class="oe_structure"></div>
-                        <div id="informations" class="row mb-4">
+                        <div
+                            id="informations" class="row mb-4"
+                            t-if="o.invoice_date or (o.invoice_date_due and o.move_type == 'out_invoice' and o.state == 'posted') or o.delivery_date or o.invoice_origin or o.partner_id.ref or o.ref or o.invoice_incoterm_id">
                             <div class="col" t-if="o.invoice_date" name="invoice_date">
                                 <t t-if="o.move_type == 'out_invoice'"><strong>Invoice Date</strong></t>
                                 <t t-elif="o.move_type == 'out_refund'"><strong>Credit Note Date</strong></t>

--- a/addons/l10n_gcc_invoice/views/report_invoice.xml
+++ b/addons/l10n_gcc_invoice/views/report_invoice.xml
@@ -75,7 +75,9 @@
                     </div>
                 </h3>
 
-                <div id="informations" class="pb-3">
+                <div
+                    id="informations" class="pb-3"
+                    t-if="o.invoice_date or (o.invoice_date_due and o.move_type == 'out_invoice' and o.state == 'posted') or o.invoice_origin or o.partner_id.ref or o.ref">
                     <div class="row" t-if="o.invoice_date" name="invoice_date">
                         <div class="col-2 offset-6">
                             <strong style="white-space:nowrap">Invoice Date:


### PR DESCRIPTION
Before this commit, for the layouts "Wavy" and "Bubble",
when they're applied when printing Draft Invoices,
the grey box (with id=informations) has no data and appears as a weird gray line.

This commit hides this grey box by adding to it an outer `t-if` condition.

task-4670747



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
