### PR TITLE
[FIX] mail: limit number of recipients in headers

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -123,6 +123,9 @@ class MailThread(models.AbstractModel):
     _mail_thread_customer = False  # subscribe customer when being in post recipients
     _mail_post_access = 'write'  # access required on the document to post on it
     _primary_email = 'email'  # Must be set for the models that can be created by alias
+
+    _CUSTOMER_HEADERS_LIMIT_COUNT = 50
+
     _Attachment = namedtuple('Attachment', ('fname', 'content', 'info'))
 
     message_is_follower = fields.Boolean(
@@ -3735,12 +3738,12 @@ class MailThread(models.AbstractModel):
         # prepare headers (as sudo as accessing mail.alias.domain, restricted)
         headers = {}
         # prepare external emails to modify Msg[To] and enable Reply-All including external people
-        external = ','.join(
+        external_emails = [
             formataddr((r['name'], r['email_normalized']))
             for r in recipients_data if r['id'] and r['active'] and r['email_normalized'] and r['share']
-        )
-        if external:
-            headers['X-Msg-To-Add'] = external
+        ]
+        if external_emails and len(external_emails) < self._CUSTOMER_HEADERS_LIMIT_COUNT:  # more than threshold = considered as public record (slide, forum, ...) -> do not leak
+            headers['X-Msg-To-Add'] = ','.join(external_emails)
         if message_sudo.record_alias_domain_id.bounce_email:
             headers['Return-Path'] = message_sudo.record_alias_domain_id.bounce_email
         headers = self._notify_by_email_get_headers(headers=headers)

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -23,6 +23,8 @@ class BlogBlog(models.Model):
     ]
     _order = 'name'
 
+    _CUSTOMER_HEADERS_LIMIT_COUNT = 0  # never use X-Msg-To headers
+
     def _default_sequence(self):
         return (self.search([], order="sequence desc", limit=1).sequence or 0) + 1
 

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -25,6 +25,8 @@ class ForumPost(models.Model):
     ]
     _order = "is_correct DESC, vote_count DESC, last_activity_date DESC"
 
+    _CUSTOMER_HEADERS_LIMIT_COUNT = 0  # never use X-Msg-To headers
+
     name = fields.Char('Title')
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True)
     content = fields.Html('Content', strip_style=True)
@@ -737,12 +739,6 @@ class ForumPost(models.Model):
                 if not post.can_edit:
                     raise AccessError(_('%d karma required to edit a post.', post.karma_edit))
         return super()._get_mail_message_access(res_ids, operation, model_name=model_name)
-
-    def _notify_by_email_get_headers(self, headers=None):
-        # Never use explicit recipients
-        headers = super()._notify_by_email_get_headers(headers=headers)
-        headers.pop('X-Msg-To-Add', False)
-        return headers
 
     def _notify_get_recipients_groups(self, message, model_description, msg_vals=False):
         groups = super()._notify_get_recipients_groups(

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -285,6 +285,8 @@ class SlideChannel(models.Model):
     _order = 'sequence, id'
     _partner_unfollow_enabled = True
 
+    _CUSTOMER_HEADERS_LIMIT_COUNT = 0  # never use X-Msg-To headers
+
     def _default_cover_properties(self):
         """ Cover properties defaults are overridden to keep a consistent look for the slides
         channels headers across Odoo versions (pre-customization, with purple gradient fitting the
@@ -863,12 +865,6 @@ class SlideChannel(models.Model):
 
     def _mail_get_partner_fields(self, introspect_fields=False):
         return []
-
-    def _notify_by_email_get_headers(self, headers=None):
-        # Never use explicit recipients
-        headers = super()._notify_by_email_get_headers(headers=headers)
-        headers.pop('X-Msg-To-Add', False)
-        return headers
 
     # ---------------------------------------------------------
     # Business / Actions


### PR DESCRIPTION
Allow to limit number of recipients before hiding them in email To headers. By default we consider that more than 50 recipients denotates a public record on which headers should not be modified. Instead standard Odoo behavior (reply to record) will be used.

Replaces odoo/odoo@c95ae3d4ee4dd4d6fc92d9f69b75194e9524ecb5 with a more generic approach. Notably it is customizable by class, which is quite handy.

Task-4787149
