### PR TITLE
[IMP] website, *: enhance sitemap.xml and remove non-200 URLs

### DIFF
--- a/addons/website_forum/controllers/website_forum.py
+++ b/addons/website_forum/controllers/website_forum.py
@@ -66,7 +66,16 @@ class WebsiteForum(WebsiteProfile):
     # Forum
     # --------------------------------------------------
 
-    @http.route(['/forum'], type='http', auth="public", website=True, sitemap=True, readonly=True, list_as_website_content=_lt("Forum"))
+    def sitemap_forum(env, rule, qs):
+        website = env['website'].get_current_website()
+        domain = website.website_domain()
+        forums_count = env['forum.forum'].search_count(domain, limit=2)
+
+        if forums_count > 1:
+            if not qs or qs.lower() in '/forum':
+                yield {'loc': '/forum'}
+
+    @http.route(['/forum'], type='http', auth="public", website=True, sitemap=sitemap_forum, readonly=True, list_as_website_content=_lt("Forum"))
     def forum(self, **kwargs):
         domain = request.website.website_domain()
         forums = request.env['forum.forum'].search(domain)
@@ -78,7 +87,7 @@ class WebsiteForum(WebsiteProfile):
             'forums': forums
         })
 
-    def sitemap_forum(env, rule, qs):
+    def sitemap_forum_all(env, rule, qs):
         Forum = env['forum.forum']
         dom = sitemap_qs2dom(qs, '/forum', Forum._rec_name)
         dom &= env['website'].get_current_website().website_domain()
@@ -110,7 +119,7 @@ class WebsiteForum(WebsiteProfile):
                  '/forum/<model("forum.forum"):forum>/page/<int:page>',
                  '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions''',
                  '''/forum/<model("forum.forum"):forum>/tag/<model("forum.tag"):tag>/questions/page/<int:page>''',
-                 ], type='http', auth="public", website=True, sitemap=sitemap_forum, readonly=True)
+                 ], type='http', auth="public", website=True, sitemap=sitemap_forum_all, readonly=True)
     def questions(self, forum=None, tag=None, page=1, filters='all', my=None, sorting=None, search='', create_uid=False, include_answers=False, **post):
         Post = request.env['forum.post']
 

--- a/addons/website_hr_recruitment/controllers/main.py
+++ b/addons/website_hr_recruitment/controllers/main.py
@@ -176,7 +176,13 @@ class WebsiteHrRecruitment(WebsiteForm):
         })
         return f"/jobs/{request.env['ir.http']._slug(job)}"
 
-    @http.route('''/jobs/detail/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=True)
+    def sitemap_jobs_detail(env, rule, qs):
+        slug = env['ir.http']._slug
+        for job in env['hr.job'].search([('is_published', '=', True)]):
+            if not qs or qs.lower() in f'/jobs/{slug(job)}':
+                yield {'loc': f'/jobs/{slug(job)}'}
+
+    @http.route('''/jobs/detail/<model("hr.job"):job>''', type='http', auth="public", website=True, sitemap=sitemap_jobs_detail)
     def jobs_detail(self, job, **kwargs):
         redirect_url = f"/jobs/{request.env['ir.http']._slug(job)}"
         return request.redirect(redirect_url, code=301)

--- a/addons/website_slides/controllers/legacy.py
+++ b/addons/website_slides/controllers/legacy.py
@@ -11,7 +11,7 @@ class WebsiteSlidesLegacy(http.Controller):
     """
 
     @http.route(['/slides/all', '/slides/all/tag/<string:slug_tags>'], type='http', auth="public", website=True,
-                sitemap=True, readonly=True)
+                sitemap=False, readonly=True)
     def slides_channel_all(self, slug_tags=None, **post):
         """ "All" in < 19 was different from "Home". Both have been merged, but we keep
         some backward compatibility for saved links, even if the display is going to


### PR DESCRIPTION
*= website_blog, website_event, website_forum, website_hr_recruitment,
website_slides

This commit improves sitemap generation by ensuring that only pages
returning a 200 OK status are included.

- Exclude URLs that have a corresponding `website.rewrite` record.
- Resolve 301/302 redirects and include only the final target URL.
- Remove redirecting routes which previously appeared in the sitemap
  while their actual destination URLs were missing.
- Align sitemap behavior with Google guidelines, which recommend
  including only canonical URLs returning 200 OK responses.

Example:
- `[https://www.odoo.com/event/.../register`](https://www.odoo.com/event/.../register%60) (200) will be included.
- `[https://www.odoo.com/event/...`](https://www.odoo.com/event/...%60) (301) will no longer appear in
  sitemap.xml.

Enterprise PR: https://github.com/odoo/enterprise/pull/95304
task-4655590