### PR TITLE
[FIX] point_of_sale: tuple of ids

### DIFF
--- a/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
+++ b/addons/point_of_sale/upgrades/1.0.2/post-deduplicate-uuids.py
@@ -32,7 +32,7 @@ def migrate(cr, version):
             ids = [r[0] for r in cr.fetchmany(10000)]
             cr.execute(
                 f"UPDATE {table} SET uuid = (%s::json)->>(id::text) WHERE id IN %s",
-                [Json({id_: str(uuid.uuid4()) for id_ in ids}), ids]
+                [Json({id_: str(uuid.uuid4()) for id_ in ids}), tuple(ids)]
             )
 
     deduplicate_uuids("pos_order")


### PR DESCRIPTION
To send a list to PostgreSQL, it should
be a tuple, or postgreSQL will cast a
Python list in a PostgreSQL ARRAY.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
