### PR TITLE
[FIX] point_of_sale: prevent shrinking of order section

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.ProductScreen">
         <div class="product-screen d-flex h-100">
             <div t-att-class="{'flex-grow-1 w-100 mw-100': ui.isSmall, 'd-none': ui.isSmall and pos.mobile_pane !== 'left'}"
-                class="leftpane d-flex flex-column pb-2 border-end bg-view">
+                class="leftpane d-flex flex-column pb-2 border-end bg-view flex-shrink-0">
                 <OrderSummary />
                 <div class="pads px-2">
                     <div class="control-buttons d-flex justify-content-between gap-2 w-100 py-2">


### PR DESCRIPTION
**Description:**
when there are more number of pos category with large names, the order section shrinks. reducing overall UX

**Issue**:
leftpane was shrinking because it had the default flex-shrink: 1, allowing it
to shrink when space was tight. At the same time,  rightpane had flex-grow-1,
causing it to expand — especially when its children (also using flex-grow-1)
had large content — pushing leftpane to shrink.

**Steps to reproduce:**
1. add 10+ pos categories with big names
2. open pos 
observation: the order section shrinks

**Solution:**
add "flex-shrinking-0" class to avoid shrinking

Before

![before](https://github.com/user-attachments/assets/70515af8-ac5d-4a23-b565-8317d42e6bff)


After
![after](https://github.com/user-attachments/assets/0cbb3474-a2a4-42fd-9ac6-3e8fc1e543c3)



opw-4768473



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
