### PR TITLE
[FIX] mail: prevent iframe removal in email templates by disabling video

### DIFF
--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -51,7 +51,7 @@
                             <page string="Content" name="content">
                                 <field name="can_write" invisible="1"/>
                                 <field name="body_html" widget="html_mail" class="oe-bordered-editor"
-                                    options="{'codeview': true, 'dynamic_placeholder': true}"
+                                    options="{'codeview': true, 'dynamic_placeholder': true, 'disableVideo': true}"
                                     readonly="not can_write and id"/>
                                 <div class="d-flex align-items-center gap-3">
                                     <field name="attachment_ids" widget="many2many_binary" class="m-0"/>


### PR DESCRIPTION
Problem:
When pasting a YouTube link and embedding it as an `iframe`, saving removes the `iframe` element. This happens because `iframe` is listed as a `kill_tag` in `SANITIZE_TAGS`, leading to its removal.

As a result, the wrapper `div` becomes empty and is converted to a self-closing element, which produces invalid HTML.

Solution:
Disable video embedding on `body_html` of email templates to avoid inserting `iframe` elements that will later be stripped.

Steps to reproduce:
1. Paste a YouTube link in an email template.
2. Choose "Embed YouTube Video" from the popup.
3. Save the template. → The content is broken due to missing `iframe`.

opw-4746178

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
