### PR TITLE
[IMP] stock_picking_batch: detailed operations button to batch view

### DIFF
--- a/addons/stock_picking_batch/models/stock_move.py
+++ b/addons/stock_picking_batch/models/stock_move.py
@@ -40,3 +40,9 @@ class StockMove(models.Model):
     def _action_assign(self, force_qty=False):
         super()._action_assign(force_qty=force_qty)
         self.move_line_ids._auto_wave()
+
+    def action_show_details(self):
+        action = super().action_show_details()
+        if self.picking_id.batch_id:
+            action['context']['default_picking_id'] = self.picking_id.id
+        return action

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -35,6 +35,10 @@
             <xpath expr="//field[@name='quantity']" position="attributes">
                 <attribute name="readonly">1</attribute>
             </xpath>
+            <xpath expr="//field[@name='product_uom']" position="after">
+                <button name="action_show_details" type="object" title="Details"
+                        icon="fa-list" invisible="not show_details_visible"/>
+            </xpath>
         </field>
     </record>
 
@@ -50,7 +54,8 @@
                 <field name="picking_id" required="1" readonly="id"
                     options="{'no_create_edit': True}" domain="[('id', 'in', parent.picking_ids)]"/>
                 <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="parent.show_lots_text" />
-                <field name="lot_name" groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="not parent.show_lots_text"/>
+                <field name="lot_name" string="Lot/Serial Number" groups="stock.group_production_lot"
+                       readonly="tracking not in ['lot', 'serial']" column_invisible="not parent.show_lots_text"/>
                 <field name="location_id"/>
                 <field name="location_dest_id"/>
                 <field name="package_id" groups="stock.group_tracking_lot"/>


### PR DESCRIPTION
We want to be able to make use of the detailed operations view to generate stock move lines by serial/lot numbers in batch/wave operations view, so we add the 'Details' button to the stock moves list.

(Plus `lot_name` has the same label as `lot_id` now.)

Task ID: [4711804](https://www.odoo.com/odoo/project/966/tasks/4711804)