### PR TITLE
[FIX] sale_timesheet: hide 'View Timesheets' button for users without access

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -108,6 +108,13 @@ class CustomerPortal(payment_portal.PaymentPortal):
         request.session['my_orders_history'] = values['orders'].ids[:100]
         return request.render("sale.portal_my_orders", values)
 
+    # ------------------------------------------------------------
+    # My Order
+    # ------------------------------------------------------------
+
+    def _sale_order_get_page_view_values(self, order_sudo, access_token, values, history_session_key, **kwargs):
+        return self._get_page_view_values(order_sudo, access_token, values, history_session_key, False, **kwargs)
+
     @http.route(['/my/orders/<int:order_id>'], type='http', auth="public", website=True)
     def portal_order_page(
         self,
@@ -184,8 +191,8 @@ class CustomerPortal(payment_portal.PaymentPortal):
         else:
             history_session_key = 'my_orders_history'
 
-        values = self._get_page_view_values(
-            order_sudo, access_token, values, history_session_key, False)
+        values = self._sale_order_get_page_view_values(
+            order_sudo, access_token, values, history_session_key, **kw)
 
         return request.render('sale.sale_order_portal_template', values)
 

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -12,6 +12,7 @@ from odoo.addons.account.controllers.portal import PortalAccount
 from odoo.addons.hr_timesheet.controllers.portal import TimesheetCustomerPortal
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.project.controllers.portal import ProjectCustomerPortal
+from odoo.addons.sale.controllers.portal import CustomerPortal
 
 
 class PortalProjectAccount(PortalAccount, ProjectCustomerPortal):
@@ -136,3 +137,17 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
     @http.route()
     def portal_my_timesheets(self, *args, groupby='sol', **kw):
         return super().portal_my_timesheets(*args, groupby=groupby, **kw)
+
+
+class SaleTimesheetSaleCustomerPortal(CustomerPortal):
+
+    def _sale_order_get_page_view_values(self, order_sudo, access_token, values, history_session_key, **kwargs):
+        values = super()._sale_order_get_page_view_values(order_sudo, access_token, values, history_session_key, **kwargs)
+
+        domain = request.env['account.analytic.line']._timesheet_get_portal_domain()
+        domain = expression.AND([
+            domain,
+            [('so_line', 'in', values.get('sale_order').order_line.ids)],
+        ])
+        values['is_timesheet'] = request.env['account.analytic.line'].sudo().search_count(domain, limit=1)
+        return values

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -4,8 +4,10 @@ from datetime import date, timedelta
 
 from odoo import Command
 from odoo.fields import Date
+from odoo.osv import expression
 from odoo.tools import float_is_zero
 from odoo.exceptions import UserError
+from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.hr_timesheet.tests.test_timesheet import TestCommonTimesheet
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
 from odoo.tests import tagged, new_test_user
@@ -1138,6 +1140,69 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         credit_note.action_post()
         self.assertFalse(timesheet1.timesheet_invoice_id, "Timesheet1 should be cleared after partial refund of its task")
         self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "Timesheet2 should still be linked to the original invoice")
+
+    def test_portal_sale_order_timesheet_visibility(self):
+        """
+        Ensure a portal user only sees timesheets of subscribed SO lines.
+        Steps:
+        1. Create a portal user.
+        2. Use one SO line from self.so.
+        3. Create a second SO with product.
+        4. Log timesheets on both SO lines' tasks.
+        5. Subscribe portal user only to the first SO line's task.
+        6. Verify:
+        - User can sees timesheet for subscribed SO line (line 1).
+        - User does not see timesheet for the other SO line (line 2).
+        """
+        portal_user = mail_new_test_user(
+            self.env,
+            name='Portal user',
+            login='portal_user',
+            email='portal_user@example.com',
+            groups='base.group_portal',
+        )
+        so_line_1 = self.so.order_line[1]
+        sale_order_2 = self.env['sale.order'].with_context(mail_notrack=True, mail_create_nolog=True).create({
+            'partner_id': self.partner_a.id,
+            'user_id': self.user_employee_company_B.id,
+        })
+        so_line_2 = self.env['sale.order.line'].create({
+            'order_id': sale_order_2.id,
+            'product_id': self.product_order_timesheet3.id,
+        })
+        sale_order_2.action_confirm()
+        AnalyticLine = self.env['account.analytic.line']
+        timesheets_entry = AnalyticLine.create([
+            {
+                'name': 'Timesheet for line 1',
+                'employee_id': self.employee_user.id,
+                'task_id': so_line_1.task_id.id,
+                'so_line': so_line_1.id,
+            },
+            {
+                'name': 'Timesheet for line 2',
+                'employee_id': self.employee_user.id,
+                'task_id': so_line_2.task_id.id,
+                'so_line': so_line_2.id,
+            },
+        ])
+        timesheet_1, timesheet_2 = timesheets_entry[0], timesheets_entry[1]
+        (so_line_1.task_id | so_line_2.task_id).message_subscribe(partner_ids=portal_user.partner_id.ids)
+        domain = AnalyticLine.with_user(portal_user)._timesheet_get_portal_domain()
+        domain = expression.AND([
+            domain,
+            [('so_line', 'in', so_line_1.ids)]
+        ])
+
+        timesheets = AnalyticLine.search(domain)
+        self.assertIn(
+            timesheet_1.id, timesheets.ids,
+            "Portal user should see the timesheet of the subscribed SO line (line 1)."
+        )
+        self.assertNotIn(
+            timesheet_2.id, timesheets.ids,
+            "Portal user should not see the timesheet of another SO line (line 2)."
+        )
 
 
 class TestSaleTimesheetView(TestCommonTimesheet):

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -4,7 +4,7 @@
     <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_template">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
             <div t-if="sale_order.timesheet_count > 0 and sale_order.state == 'sale'" class="flex-grow-1">
-                <a class="btn btn-secondary d-block w-100" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name">View Timesheets</a>
+                <a class="btn btn-secondary d-block w-100" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name" t-if="is_timesheet">View Timesheets</a>
             </div>
         </xpath>
     </template>
@@ -89,12 +89,12 @@
 
     <template id="portal_invoice_page_inherit" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
-            <div t-if="invoice.timesheet_count > 0" class="flex-grow-1 border-0">
+            <div t-if="invoice.timesheet_count > 0">
                 <div class="btn-toolbar flex-sm-nowrap justify-content-center">
                     <div class="btn-group mb-1">
                         <t t-set="search_value" t-value="invoice.name"/>
                         <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
-                        <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"
+                        <a class="btn btn-secondary d-block w-100" t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and timesheets"
                            target="_blank" t-att-href="'/my/timesheets?search_in=invoice&amp;search=%s' % search_value">View Timesheets</a>
                     </div>
                 </div>


### PR DESCRIPTION
sale: add sale order specific hook to extend page values
------

Allows adding custom data (e.g., timesheets) without overriding generic _get_page_view_values

sale_timesheet: hide 'View Timesheets' button for users without access
-------

Steps to Reproduce:
-----------------
   - Create a product with the invoice policy set to Based on Timesheets
   - Enable Project and Tasks on the order.
   - Create and confirm a sale order using a portal user.
   - Log timesheets on the related task.
   - Create an invoice from the sale order.
   - Log in as the portal user and open the invoice.
   - Click the 'View Timesheets' button.
    
 Issue:
-------------
   The 'View Timesheets' button is shown to the portal user even though they don’t have access to view timesheets.

Root Cause:
------------
 The timesheets are linked to the sale order, so the button appears based on the timesheet_count, but the portal user does not actually have permission to access those timesheets.
    
 Fix:
-----------
   We replaced the timesheet_count check with a check that verifies  whether the user actually has access to any of the related timesheets.
    
task-4745519
