### PR TITLE
[FIX] l10n_hu_edi: Fix EDI currency rate computation during XML generation

### DIFF
--- a/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
+++ b/addons/l10n_hu_edi/tests/invoice_xmls/invoice_complex_eur.xml
@@ -51,7 +51,7 @@
                     <invoiceDeliveryDate>2024-02-01</invoiceDeliveryDate>
                     <smallBusinessIndicator>false</smallBusinessIndicator>
                     <currencyCode>EUR</currencyCode>
-                    <exchangeRate>380.769999</exchangeRate>
+                    <exchangeRate>380.770000</exchangeRate>
                     <paymentMethod>TRANSFER</paymentMethod>
                     <paymentDate>2024-02-01</paymentDate>
                     <cashAccountingIndicator>false</cashAccountingIndicator>


### PR DESCRIPTION
Problem
---------
Currently, when generating the XML to send to NAV, the XML currency rate is computed using an MMSE estimator. This leads to approximation error itself leading to a slight difference from the rate applied and given by the MNB of Hungary for that day. This is noticed by the NAV upon submiting the invoice who returns an error.

Objective
---------
Make it so that the rate returned by the HU bank is used during the XML generation.

Solution
---------
Instead of computing a MMSE estimator, we get the conversion rate stored in the database at the time of the invoice.

task-4707316

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
