### PR TITLE
[FIX] mrp: disable video rendering in worksheet view

### DIFF
--- a/addons/mrp/views/mrp_routing_views.xml
+++ b/addons/mrp/views/mrp_routing_views.xml
@@ -123,7 +123,7 @@
                                     <field name="worksheet_type" widget="radio"/>
                                     <field name="worksheet" help="Upload your PDF file." widget="pdf_viewer" invisible="worksheet_type != 'pdf'" required="worksheet_type == 'pdf'"/>
                                     <field name="worksheet_google_slide" placeholder="Google Slide Link" widget="embed_viewer" invisible="worksheet_type != 'google_slide'" required="worksheet_type == 'google_slide'"/>
-                                    <field name="note" invisible="worksheet_type != 'text'"/>
+                                    <field name="note" invisible="worksheet_type != 'text'" options="{'embedded_components': False}"/>
                                 </group>
                             </page>
                         </notebook>


### PR DESCRIPTION
Problem:
Videos added in the operation worksheet are not visible on the Shop
Floor interface.

Cause:
`embedded_components`, such as video iframes, are only supported
within the HTML editor context and cannot be rendered elsewhere.
This results in the video being silently dropped.

Solution:
Introduce a `disableVideo` flag for the `note` field in worksheet
views. This avoids embedding unsupported video content and ensures
the interface remains consistent.

Steps to reproduce:
1. Go to Manufacturing > Operations > Worksheet.
2. Add a video in the worksheet's description field.
3. Create a Manufacturing Order (MO) for a product using this
   operation.
4. Confirm the MO and open it in the Shop Floor interface.
5. Open the worksheet tab.
→ The video is missing (not rendered).

opw-4783722

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
