### PR TITLE
[FIX] l10n_in: Remove the journal name from move PDF

### DIFF
--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -36,21 +36,6 @@
             </td>
         </xpath>
 
-        <xpath expr="//h2" position="replace" >
-            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
-                <h2>
-                        <span t-if="o.move_type == 'out_invoice' and o.state == 'posted'" t-field="o.journal_id.name"/>
-                        <span t-if="o.move_type == 'out_invoice' and o.state == 'draft'">Draft <span t-field="o.journal_id.name"/></span>
-                        <span t-if="o.move_type == 'out_invoice' and o.state == 'cancel'">Cancelled <span t-field="o.journal_id.name"/></span>
-                        <span t-if="o.move_type == 'out_refund'">Credit Note</span>
-                        <span t-if="o.move_type == 'in_refund'">Vendor Credit Note</span>
-                        <span t-if="o.move_type == 'in_invoice'">Vendor Bill</span>
-                        <span t-field="o.name"/>
-                </h2>
-            </t>
-            <t t-else="">$0</t>
-        </xpath>
-
     </template>
 
     <!-- Workarounds for Studio reports, see odoo/odoo#60660 -->


### PR DESCRIPTION
This commit fixes the historical unwanted change that was introduced with commit https://github.com/odoo/odoo/commit/2b3c8e6ca9777f6264ecb3d1510dd292ed30ab9f#diff-172160b358fb41b84d667d936b3c05b4db242c48bf1ae109614e2b8e0c4c2dac Which modifies the report name for india and replace them with the Journal name.

After discussing and clarifying it with the PO. This not an expected thing to be happen.

Hence this commit removes the xpath introduced to replace the report name

opw-4781816


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
