### PR TITLE
[FIX] html_editor: cursor navigation within file box on ArrowUp/Down

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -230,9 +230,10 @@ export class DomPlugin extends Plugin {
             }
         }
 
+        let textNode;
         if (startNode.nodeType === Node.ELEMENT_NODE) {
             if (selection.anchorOffset === 0) {
-                const textNode = this.document.createTextNode("");
+                textNode = this.document.createTextNode("");
                 if (isSelfClosingElement(startNode)) {
                     startNode.parentNode.insertBefore(textNode, startNode);
                 } else {
@@ -454,6 +455,9 @@ export class DomPlugin extends Plugin {
             { anchorNode: lastPosition[0], anchorOffset: lastPosition[1] },
             { normalize: false }
         );
+        if (textNode) {
+            textNode.remove();
+        }
         return firstInsertedNodes.concat(insertedNodes).concat(lastInsertedNodes);
     }
 

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -4,11 +4,15 @@ import {
 } from "@html_editor/main/media/media_dialog/document_selector";
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { _t } from "@web/core/l10n/translation";
+import { closestBlock } from "../../utils/blocks";
+import { closestElement } from "../../utils/dom_traversal";
+import { isTextNode } from "@html_editor/utils/dom_info";
 
 export class FilePlugin extends Plugin {
     static id = "file";
-    static dependencies = ["dom", "history"];
+    static dependencies = ["dom", "history", "selection"];
     resources = {
         user_commands: {
             id: "uploadFile",
@@ -35,6 +39,98 @@ export class FilePlugin extends Plugin {
         }),
         selectors_for_feff_providers: () => ".o_file_box",
     };
+
+    setup() {
+        this.addDomListener(this.editable, "keydown", (ev) => {
+            if (["arrowup", "arrowdown"].includes(getActiveHotkey(ev))) {
+                this.navigateFileBox(ev);
+            }
+        });
+    }
+
+    navigateFileBox(ev) {
+        const isArrowUp = ev.key === "ArrowUp";
+        const { anchorNode, anchorOffset } =
+            this.dependencies.selection.getSelectionData().deepEditableSelection;
+
+        const fileBox = closestElement(anchorNode, ".o_file_box");
+        const baseNode = fileBox?.previousSibling || anchorNode;
+        const block = closestBlock(baseNode);
+        const currentNode = anchorNode === block ? block.childNodes[anchorOffset] : anchorNode;
+
+        const findLineBreakNeighbor = (startNode = currentNode) => {
+            let node = startNode;
+            while (node && node.nodeName !== "BR") {
+                node = isArrowUp ? node.previousSibling : node.nextSibling;
+            }
+            return isArrowUp ? node : node?.nextSibling;
+        };
+
+        const getNodeRect = (node, atCursor = true) => {
+            if (!node) {
+                return null;
+            }
+
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (atCursor) {
+                    return this.document.getSelection().getRangeAt(0).getBoundingClientRect();
+                }
+                const range = this.document.createRange();
+                range.selectNode(node);
+                return range.getBoundingClientRect();
+            }
+            return node.getBoundingClientRect();
+        };
+
+        const currentRect = getNodeRect(currentNode);
+        const nextLineNode = fileBox ? findLineBreakNeighbor(fileBox) : findLineBreakNeighbor();
+        let targetRect;
+        if (nextLineNode) {
+            targetRect = getNodeRect(nextLineNode, false);
+        } else {
+            const siblingBlock = isArrowUp
+                ? block.previousElementSibling
+                : block.nextElementSibling;
+            let nodeToTarget = isArrowUp ? siblingBlock?.lastChild : siblingBlock?.firstChild;
+            if (nodeToTarget && isTextNode(nodeToTarget) && nodeToTarget.textContent === "\n") {
+                nodeToTarget = isArrowUp ? nodeToTarget.previousSibling : nodeToTarget.nextSibling;
+            }
+            targetRect = getNodeRect(nodeToTarget, false);
+        }
+
+        if (targetRect) {
+            const linkPopover = document.querySelector(".o-we-linkpopover");
+            linkPopover?.classList.add("d-none");
+
+            const x = currentRect.left;
+            const y = targetRect.top;
+
+            let targetNode, targetOffset;
+
+            if (this.document.caretPositionFromPoint) {
+                const pos = this.document.caretPositionFromPoint(x, y);
+                targetNode = pos?.offsetNode;
+                targetOffset = pos?.offset;
+            } else if (this.document.caretRangeFromPoint) {
+                const range = this.document.caretRangeFromPoint(x, y);
+                targetNode = range?.startContainer;
+                targetOffset = range?.startOffset;
+            }
+
+            linkPopover?.classList.remove("d-none");
+
+            if (targetNode && targetOffset !== undefined) {
+                const withinFileBoxScope = fileBox || closestElement(targetNode, ".o_file_box");
+                if (withinFileBoxScope) {
+                    ev.preventDefault();
+                    this.dependencies.selection.setSelection({
+                        anchorNode: targetNode,
+                        anchorOffset: targetOffset,
+                    });
+                }
+            }
+        }
+    }
 
     get recordInfo() {
         return this.config.getRecordInfo?.() || {};

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -3021,9 +3021,9 @@ describe("images", () => {
             // select xxx in "<p>ab[xxx]cd</p>""
             const p = editor.editable.querySelector("p");
             const selection = {
-                anchorNode: p.childNodes[1],
+                anchorNode: p.firstChild,
                 anchorOffset: 2,
-                focusNode: p.childNodes[1],
+                focusNode: p.firstChild,
                 focusOffset: 5,
             };
             setSelection(selection);
@@ -3217,9 +3217,9 @@ describe("youtube video", () => {
             // select xxx in "<p>ab[xxx]cd</p>"
             const p = editor.editable.querySelector("p");
             const selection = {
-                anchorNode: p.childNodes[1],
+                anchorNode: p.firstChild,
                 anchorOffset: 2,
-                focusNode: p.childNodes[1],
+                focusNode: p.firstChild,
                 focusOffset: 5,
             };
             setSelection(selection);


### PR DESCRIPTION
### Approach:

- Addressed an issue where cursor navigation using ArrowUp/ArrowDown resulted in unexpected behavior when the cursor was inside an .o_file_box or was expected to move into it.
- The fix uses horizontal position of the current caret and vertical position of neighboring line to resolve a target position using caretPositionFromPoint or caretRangeFromPoint, ensuring accurate and consistent cursor movement.

### Description of the issue/feature this PR addresses:

- Pressing ArrowUp/ArrowDown caused erratic cursor behavior when navigating within or around a `file_box`.

### Desired behavior after PR is merged:

- Cursor navigation behaves as expected when moving inside a `file_box`.
- An empty text node was previously inserted into the DOM to preserve the caret position during content manipulation. This placeholder has been removed after the content is inserted.

task-4671755

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
