### PR TITLE
[FIX] im_livechat: rating reason useless break line

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -160,7 +160,9 @@ class LivechatController(http.Controller):
         )
 
     def _post_feedback_message(self, channel, rating, reason):
-        reason = Markup("<br>" + re.sub(r'\r\n|\r|\n', "<br>", reason) if reason else "")
+        reason = Markup(
+            "<br>" + re.sub(r"\r\n|\r|\n", "<br>", tools.html_escape(reason)) if reason else ""
+        )
         body = Markup('''
             <div class="o_mail_notification o_hide_author">
                 %(rating)s: <img class="o_livechat_emoji_rating" src="%(rating_url)s" alt="rating"/>%(reason)s


### PR DESCRIPTION
This commit removes a useless break line added to the end of chat ratign. Break line is used to put the reason on a different line than the rating smiley but is useless when no reason is passed.

task-4791376

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
