### PR TITLE
[FIX] resource: Fix various flexible hours cases

### DIFF
--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -354,21 +354,14 @@ class HrAttendance(models.Model):
                 overtime_duration_real = 0
                 # Overtime is not counted if any shift is not closed or if there are no attendances for that day,
                 # this could happen when deleting attendances.
-                if not unfinished_shifts and attendances:
-                    # The employee is working flexible hours
-                    if emp.is_flexible:
-                        work_duration = 0
-                        for attendance in attendances:
-                            local_check_in = pytz.utc.localize(attendance.check_in)
-                            local_check_out = pytz.utc.localize(attendance.check_out)
-                            work_duration += (local_check_out - local_check_in).total_seconds() / 3600.0
-                        # In case of fully flexible employee, no overtime is computed
-                        if not emp.is_fully_flexible:
-                            overtime_duration = work_duration - emp.resource_id.calendar_id.hours_per_day
-                            overtime_duration_real = overtime_duration
 
+                # No overtime computed for fully flexible employees
+                if emp.is_fully_flexible:
+                    continue
+
+                if not unfinished_shifts and attendances:
                     # The employee usually doesn't work on that day
-                    elif not working_times[attendance_date]:
+                    if not working_times[attendance_date]:
                         # User does not have any resource_calendar_attendance for that day (week-end for example)
                         overtime_duration = sum(attendances.mapped('worked_hours'))
                         overtime_duration_real = overtime_duration
@@ -461,8 +454,9 @@ class HrAttendance(models.Model):
                 stop_dt = min(planned_end_dt, local_check_out)
                 work_duration += (stop_dt - start_dt).total_seconds() / 3600.0
                 # remove lunch time from work duration
-                lunch_intervals = employee._employee_attendance_intervals(start_dt, stop_dt, lunch=True)
-                work_duration -= sum((i[1] - i[0]).total_seconds() / 3600.0 for i in lunch_intervals)
+                if not employee.is_flexible:
+                    lunch_intervals = employee._employee_attendance_intervals(start_dt, stop_dt, lunch=True)
+                    work_duration -= sum((i[1] - i[0]).total_seconds() / 3600.0 for i in lunch_intervals)
 
             # There is an overtime at the end of the day
             if local_check_out > planned_end_dt:

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -423,28 +423,14 @@ class HolidaysRequest(models.Model):
             if not leave.date_from or not leave.date_to or not calendar:
                 result[leave.id] = (0, 0)
                 continue
-            if calendar.flexible_hours:
-                days = (leave.date_to - leave.date_from).days + (1 if not leave.request_unit_half else 0.5)
-                public_holidays = self.env['resource.calendar.leaves'].search([
-                    ('resource_id', '=', False),
-                    ('calendar_id', '=', calendar.id),
-                    ('date_from', '<=', leave.date_to),
-                    ('date_to', '>=', leave.date_from)
-                ])
-                excluded_days = sum(
-                    (min(holiday.date_to, leave.date_to) - max(holiday.date_from, leave.date_from)).days + 1
-                    for holiday in public_holidays
-                )
-                days = days - excluded_days
-                hours = leave.request_hour_to - leave.request_hour_from if leave.request_unit_hours \
-                    else (days * calendar.hours_per_day)
-                result[leave.id] = (days, hours)
-                continue
-            hours, days = (0, 0)
             if leave.employee_id:
-                if leave.employee_id.is_flexible and leave.leave_type_request_unit in ['day','half_day']:
-                    duration = leave.date_to - leave.date_from
-                    days = ceil(duration.total_seconds() / (24 * 3600))
+                # For flexible employees, if it's a single day leave, we force it to the real duration since the virtual intervals might not match reality on that day, especially for custom hours
+                if leave.employee_id.is_flexible and leave.date_to.date() == leave.date_from.date():
+                    hours = (leave.date_to - leave.date_from).total_seconds() / 3600
+                    if not leave.request_unit_hours:
+                        days = 1 if not leave.request_unit_half else 0.5
+                    else:
+                        days = (leave.date_to - leave.date_from).total_seconds() / 3600 / 24
                 elif leave.leave_type_request_unit == 'day' and check_leave_type:
                     # list of tuples (day, hours)
                     work_time_per_day_list = work_time_per_day_mapped[(leave.date_from, leave.date_to, calendar)][leave.employee_id.id]
@@ -1438,24 +1424,39 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         the earliest hour_from and latest hour_to that exist in the schedule.
         """
         self.ensure_one()
+
         domain = [
             ('calendar_id', '=', self.resource_calendar_id.id),
             ('display_type', '=', False),
             ('day_period', '!=', 'lunch'),
         ]
-        if day_period:
-            domain.append(('day_period', '=', day_period))
-        attendances = self.env['resource.calendar.attendance']._read_group(domain,
-            ['week_type', 'dayofweek'],
-            ['hour_from:min', 'hour_to:max'])
+        # In the case of flexible hours, we resort to centering the holiday hours around 12pm
+        if self.resource_calendar_id.flexible_hours:
+            hours_per_day = self.resource_calendar_id.hours_per_day
+            attendances = []
+            default_start = 12.0 - (hours_per_day / 2)
+            default_end = 12.0 + (hours_per_day / 2)
+            for week_type in [0, 1]:
+                for day in range(7):
+                    if day_period:
+                        attendances.append(DummyAttendance(default_start if day_period == 'morning' else 12, 12 if day_period == 'morning' else default_end, day, day_period, week_type))
+                    else:
+                        attendances.append(DummyAttendance(default_start, default_end, day, None, week_type))
+            attendances = sorted(attendances, key=lambda att: att.dayofweek)
+        else:
+            if day_period:
+                domain.append(('day_period', '=', day_period))
+            # Must be sorted by dayofweek ASC and day_period DESC
+            attendances = self.env['resource.calendar.attendance']._read_group(domain,
+                ['week_type', 'dayofweek'],
+                ['hour_from:min', 'hour_to:max'], order="dayofweek ASC")
 
-        # Must be sorted by dayofweek ASC and day_period DESC
-        attendances = sorted([DummyAttendance(hour_from, hour_to, dayofweek, None, week_type) for week_type, dayofweek, hour_from, hour_to in attendances], key=lambda att: att.dayofweek)
+            attendances = [DummyAttendance(hour_from, hour_to, dayofweek, None, week_type) for week_type, dayofweek, hour_from, hour_to in attendances]
 
-        # If we can't find any attendances on the exact days of the request,
-        # we default to the widest possible range that exists in the schedule.
-        default_start = min((attendance.hour_from for attendance in attendances), default=0)
-        default_end = max((attendance.hour_to for attendance in attendances), default=0)
+            # If we can't find any attendances on the exact days of the request,
+            # we default to the widest possible range that exists in the schedule.
+            default_start = min((attendance.hour_from for attendance in attendances), default=0)
+            default_end = max((attendance.hour_to for attendance in attendances), default=0)
 
         start_week_type = 0
         end_week_type = 0

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -436,7 +436,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
 
         calendar.write({
             'flexible_hours': True,
-            'hours_per_day': 8.0
+            'hours_per_day': 8.0,
+            'full_time_required_hours': 40
         })
 
         leave1 = self.env['hr.leave'].create({
@@ -1225,6 +1226,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'full_time_required_hours': 40,
             'flexible_hours': True,
         })
         employee.resource_calendar_id = calendar
@@ -1246,8 +1248,8 @@ class TestLeaveRequests(TestHrHolidaysCommon):
             'request_date_to': '2024-01-27',
         })
         holiday_status = self.holidays_type_4.with_user(self.user_employee_id)
-        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 15.0)
-        self.assertEqual(leave.duration_display, '5 days')
+        self._check_holidays_status(holiday_status, employee, 20.0, 0.0, 20.0, 16.0)
+        self.assertEqual(leave.duration_display, '4 days')
 
     def test_default_request_date_timezone(self):
         """
@@ -1391,6 +1393,7 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         calendar = self.env['resource.calendar'].create({
             'name': 'Test calendar',
             'hours_per_day': 8,
+            'full_time_required_hours': 56,
             'flexible_hours': True
         })
         self.employee_emp.resource_calendar_id = calendar

--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -167,6 +167,8 @@ class HrWorkEntry(models.Model):
 
         outside_entries = self.env['hr.work.entry']
         for calendar, entries in entries_by_calendar.items():
+            if calendar.flexible_hours:
+                continue
             datetime_start = min(entries.mapped('date_start'))
             datetime_stop = max(entries.mapped('date_stop'))
 

--- a/addons/hr_work_entry_holidays/tests/test_leave.py
+++ b/addons/hr_work_entry_holidays/tests/test_leave.py
@@ -264,6 +264,7 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
         flex_40h_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'full_time_required_hours': 40.0,
             'flexible_hours': True,
         })
 
@@ -281,6 +282,6 @@ class TestWorkEntryLeave(TestWorkEntryHolidaysBase):
 
         entries = self.jules_emp.contract_id.generate_work_entries(date(2024, 9, 9), date(2024, 9, 14))
         paid_leave_entry = entries.filtered_domain([('work_entry_type_id', '=', entry_type_paid.id)])
-
-        self.assertEqual(paid_leave_entry.duration, 32, "The duration of the work entry for flexible employee should "
-                                                        "be number of days * hours per day")
+        self.assertEqual(len(paid_leave_entry), 4, "Four work entries should be created for a flexible employee")
+        self.assertEqual(sum(paid_leave_entry.mapped('duration')), 32, "The combined duration of the work entries for flexible employee should "
+                                                                        "be number of days * hours per day")

--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -4,6 +4,8 @@
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
+import pytz
+
 
 class HolidaysType(models.Model):
     _inherit = "hr.leave.type"
@@ -80,9 +82,16 @@ class Holidays(models.Model):
             if not leave.employee_id:
                 continue
 
-            work_hours_data = leave.employee_id._list_work_time_per_day(
-                leave.date_from,
-                leave.date_to)[leave.employee_id.id]
+            if leave.employee_id.resource_calendar_id.flexible_hours and (leave.request_unit_hours or leave.request_unit_half):
+                calendar_timezone = pytz.timezone(leave.employee_id.resource_calendar_id.tz)
+                if leave.request_unit_hours:
+                    work_hours_data = [(leave.date_from.astimezone(calendar_timezone).date(), leave.request_hour_to - leave.request_hour_from)]
+                else:
+                    work_hours_data = [(leave.date_from.astimezone(calendar_timezone).date(), leave.employee_id.resource_calendar_id.hours_per_day / 2)]
+            else:
+                work_hours_data = leave.employee_id._list_work_time_per_day(
+                    leave.date_from,
+                    leave.date_to)[leave.employee_id.id]
 
             for index, (day_date, work_hours_count) in enumerate(work_hours_data):
                 vals_list.append(leave._timesheet_prepare_line_values(index, work_hours_data, day_date, work_hours_count, project, task))

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -60,6 +60,16 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             'timesheet_project_id': self.internal_project.id,
             'timesheet_task_id': self.internal_task_leaves.id,
         })
+
+        self.hr_leave_type_in_hours_with_ts = self.env['hr.leave.type'].create({
+            'name': 'Time Off Type with timesheet generation in hours',
+            'requires_allocation': 'no',
+            'request_unit': 'hour',
+            'timesheet_generate': True,
+            'timesheet_project_id': self.internal_project.id,
+            'timesheet_task_id': self.internal_task_leaves.id,
+        })
+
         self.hr_leave_type_no_ts = self.env['hr.leave.type'].create({
             'name': 'Time Off Type without timesheet generation',
             'requires_allocation': 'no',
@@ -269,6 +279,7 @@ class TestTimesheetHolidays(TestCommonTimesheet):
         flex_40h_calendar = self.env['resource.calendar'].create({
             'name': 'Flexible 40h/week',
             'hours_per_day': 8.0,
+            'full_time_required_hours': 40.0,
             'flexible_hours': True,
         })
 
@@ -288,5 +299,6 @@ class TestTimesheetHolidays(TestCommonTimesheet):
             ('date', '<=', self.leave_end_datetime),
             ('employee_id', '=', self.empl_employee.id),
         ])
-        self.assertEqual(timesheet.unit_amount, 24, "The duration of the timesheet for flexible employee leave "
+        self.assertEqual(len(timesheet), 3, "Three timesheets should be created for each leave day")
+        self.assertEqual(sum(timesheet.mapped('unit_amount')), 24, "The duration of the timesheet for flexible employee leave "
                                                         "should be number of days * hours per day")

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -366,19 +366,68 @@ class ResourceCalendar(models.Model):
         for tz, resources in resources_per_tz.items():
             res = result_per_tz[tz]
             res_intervals = WorkIntervals(res)
+            start_datetime = start_dt.astimezone(tz)
+            end_datetime = end_dt.astimezone(tz)
+
             for resource in resources:
-                if resource and resource._is_flexible():
-                    duration_days = (end - start).days + (0.5 if (end - start).total_seconds() / 3600 < resource.calendar_id.hours_per_day else 1)
-                    if resource.calendar_id and resource.calendar_id.flexible_hours:
-                        duration_hours = duration_days * resource.calendar_id.hours_per_day
-                    else:
-                        duration_hours = (end - start).total_seconds() / 3600
-                    # If the resource is flexible, return the whole period from start_dt to end_dt with a dummy attendance
+                if resource and resource._is_fully_flexible():
+                    # If the resource is fully flexible, return the whole period from start_dt to end_dt with a dummy attendance
                     dummy_attendance = self.env['resource.calendar.attendance'].new({
-                        'duration_hours': duration_hours,
-                        'duration_days': duration_days,
+                        'duration_hours': (end - start).total_seconds() / 3600,
+                        'duration_days': (end - start).days + 1,
                     })
                     result_per_resource_id[resource.id] = WorkIntervals([(start, end, dummy_attendance)])
+                elif resource and resource.calendar_id.flexible_hours:
+                    # For flexible Calendars, we create intervals to fill in the weekly intervals with the average daily hours
+                    # until the full time required hours are met. This gives us the most correct approximation when looking at a daily
+                    # and weekly range for time offs and overtime calculations and work entry generation
+                    start_date = start_datetime.date()
+                    end_datetime_adjusted = end_datetime - relativedelta(seconds=1)
+                    end_date = end_datetime_adjusted.date()
+
+                    full_time_required_hours = resource.calendar_id.full_time_required_hours
+                    max_hours_per_day = resource.calendar_id.hours_per_day
+
+                    intervals = []
+                    current_monday = start_date - timedelta(days=start_date.weekday())
+
+                    while current_monday <= end_date:
+                        current_sunday = current_monday + timedelta(days=6)
+
+                        week_start = max(current_monday, start_date)
+                        week_end = min(current_sunday, end_date)
+
+                        if current_monday < start_date:
+                            prior_days = (start_date - current_monday).days
+                            prior_hours = min(full_time_required_hours, max_hours_per_day * prior_days)
+                        else:
+                            prior_hours = 0
+
+                        remaining_hours = max(0, full_time_required_hours - prior_hours)
+
+                        current_day = week_start
+                        while current_day <= week_end:
+                            if remaining_hours > 0:
+                                allocate_hours = min(max_hours_per_day, remaining_hours)
+                                remaining_hours -= allocate_hours
+
+                                # Create interval centered at 12:00 PM
+                                midpoint = tz.localize(datetime.combine(current_day, time(12, 0)))
+                                start_time = midpoint - timedelta(hours=allocate_hours / 2)
+                                end_time = midpoint + timedelta(hours=allocate_hours / 2)
+
+                                dummy_attendance = self.env['resource.calendar.attendance'].new({
+                                    'duration_hours': allocate_hours,
+                                    'duration_days': 1,
+                                })
+
+                                intervals.append((start_time, end_time, dummy_attendance))
+
+                            current_day += timedelta(days=1)
+
+                        current_monday += timedelta(days=7)
+
+                    result_per_resource_id[resource.id] = WorkIntervals(intervals)
                 elif resource in per_resource_result:
                     resource_specific_result = [(max(bounds_per_tz[tz][0], tz.localize(val[0])), min(bounds_per_tz[tz][1], tz.localize(val[1])), val[2])
                         for val in per_resource_result[resource]]
@@ -450,7 +499,7 @@ class ResourceCalendar(models.Model):
                     tz_dates[(tz, end_dt)] = end
                 dt0 = string_to_datetime(leave_date_from).astimezone(tz)
                 dt1 = string_to_datetime(leave_date_to).astimezone(tz)
-                if leave_resource and leave_resource._is_flexible():
+                if leave_resource and leave_resource._is_fully_flexible():
                     dt0, dt1 = self._handle_flexible_leave_interval(dt0, dt1, leave)
                 result[resource.id].append((max(start, dt0), min(end, dt1), leave))
 

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -1332,6 +1332,8 @@ class TestTimezones(TestResourceCommon):
             'name': 'Flex Calendar',
             'tz': 'UTC',
             'flexible_hours': True,
+            'full_time_required_hours': 40,
+            'hours_per_day': 8
         })
         flex_resource = self.env['resource.resource'].create({
             'name': 'Test FlexResource',
@@ -1345,15 +1347,15 @@ class TestTimezones(TestResourceCommon):
             'date_to': '2025-03-07 17:00:00',
         })
 
-        start_dt = datetime(2025, 3, 7, 0, 0, 0, tzinfo=utc)
-        end_dt = datetime(2025, 3, 7, 23, 59, 59, 999999, tzinfo=utc)
+        start_dt = datetime(2025, 3, 7, 8, 0, 0, tzinfo=utc)
+        end_dt = datetime(2025, 3, 7, 16, 00, 00, 00, tzinfo=utc)
 
         intervals = flexible_calendar._leave_intervals_batch(start_dt, end_dt, [flex_resource])
         intervals_list = list(intervals[flex_resource.id])
         self.assertEqual(len(intervals_list), 1, "There should be one leave interval")
         interval = intervals_list[0]
-        self.assertEqual(interval[0], start_dt, "The start of the interval should be 00:00:00")
-        self.assertEqual(interval[1], end_dt, "The end of the interval should be 23:59:59.999999")
+        self.assertEqual(interval[0], start_dt, "The start of the interval should be 08:00:00")
+        self.assertEqual(interval[1], end_dt, "The end of the interval should be 16:00:00")
 
 class TestResource(TestResourceCommon):
 


### PR DESCRIPTION
This PR addresses multiple issues related to flexible working hours across several Odoo modules, including attendance, overtime calculation, time off (leave) management, and work entry generation. The primary change modifies the _attendance_intervals_batch method in the `resource` module to create daily attendance blocks for flexible calendars, using the average daily hours and the required weekly hours.

Attendance Intervals for Flexible Hours:

Old Behavior: For flexible employees, a single interval spanned the entire requested period, leading to inaccurate calculations.
New Behavior: For flexible calendars (not fully flexible), daily attendance blocks are created, centered around 12:00 PM, with each block’s duration equal to the average daily hours (hours_per_day). Fully flexible employees (no calendar) retain a single interval covering the full period.

A flexible employee’s attendance was one continuous block over the entire period.

+---------------------------+
|        Attendance         |
|   (e.g., Mon to Fri)     |
+---------------------------+

New Behavior (Daily Blocks):

For a flexible calendar with 8 hours/day, attendance is split into daily blocks centered at 12:00 PM (e.g., 8:00 AM - 4:00 PM).

+-----+ +-----+ +-----+
|  8h | |  8h | |  8h |
| Mon | | Tue | | Wed |
+-----+ +-----+ +-----+

Overtime Calculation:

Updated hr_attendance.py to skip overtime computation for fully flexible employees (is_fully_flexible). For flexible calendars, overtime is now based on the new daily attendance blocks.

Time Off:

In hr_leave.py, flexible calendars now center leave intervals around 12:00 PM for each day, matching the attendance blocks. For half-day leaves, the duration is halved.
Single-day leaves use specified hours, while multi-day leaves align with the virtual schedule.

Work Entry Generation:

In hr_contract.py, work entries for flexible calendars distinguish between one-day and multi-day leaves. Multi-day leaves align with the daily attendance blocks, while one-day leaves use exact hours.
Updated hr_work_entry.py to skip marking leaves outside the schedule for flexible hours, as their virtual schedule is dynamically generated.

Timesheet:

In hr_holidays.py, timesheet generation for flexible employees uses the new attendance intervals or exact hours for hourly/half-day leaves.


task-4771288

