### PR TITLE
[FIX] im_livechat: rating reason useless break line

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup
+from markupsafe import Markup, escape
 import re
 from werkzeug.exceptions import NotFound
 from urllib.parse import urlsplit
@@ -10,6 +10,7 @@ from odoo.exceptions import UserError
 from odoo.http import request
 from odoo.tools import replace_exceptions
 from odoo.addons.base.models.assetsbundle import AssetsBundle
+from odoo.addons.base.models.ir_qweb_fields import nl2br
 from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
 
 
@@ -200,7 +201,6 @@ class LivechatController(http.Controller):
         return channel_info
 
     def _post_feedback_message(self, channel, rating, reason):
-        reason = Markup("<br>" + re.sub(r'\r\n|\r|\n', "<br>", reason) if reason else "")
         body = Markup('''
             <div class="o_mail_notification o_hide_author">
                 %(rating)s: <img class="o_livechat_emoji_rating" src="%(rating_url)s" alt="rating"/>%(reason)s
@@ -208,7 +208,7 @@ class LivechatController(http.Controller):
         ''') % {
             'rating': _('Rating'),
             'rating_url': rating.rating_image_url,
-            'reason': reason,
+            'reason': Markup(nl2br(escape("\n" + reason))) if reason else "",
         }
         channel.message_post(body=body, message_type='notification', subtype_xmlid='mail.mt_comment')
 


### PR DESCRIPTION
This commit removes a useless break line added to the end of chat ratign. Break line is used to put the reason on a different line than the rating smiley but is useless when no reason is passed.

task-4791376

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
