### PR TITLE
[FIX] sale_project: use form view of product instead of product template

### DIFF
--- a/addons/sale_project/views/product_views.xml
+++ b/addons/sale_project/views/product_views.xml
@@ -29,6 +29,7 @@
         </field>
     </record>
 
+    <!-- TODO: remove me in master -->
     <record id="product_template_form_view_inherit_sale_project" model="ir.ui.view">
         <field name="name">product.template.sale.project.form</field>
         <field name="model">product.template</field>
@@ -42,4 +43,16 @@
         </field>
     </record>
 
+    <record id="product_product_form_view_inherit_sale_project" model="ir.ui.view">
+        <field name="name">product.product.sale.project.form</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <field name="mode">primary</field>
+        <field name="priority">999</field>
+        <field name="arch" type="xml">
+            <field name="type" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/addons/sale_project/views/sale_order_line_views.xml
+++ b/addons/sale_project/views/sale_order_line_views.xml
@@ -28,7 +28,7 @@
                 <attribute name="context">{
                     'default_type': 'service',
                     'default_service_policy': 'ordered_prepaid',
-                    'form_view_ref': 'sale_project.product_template_form_view_inherit_sale_project',
+                    'form_view_ref': 'sale_project.product_product_form_view_inherit_sale_project',
                 }</attribute>
             </field>
         </field>


### PR DESCRIPTION
Before this commit, when the user creates a SOL from scratch inside the form view of a task and would like to also create and edit the product linked to that new SOL, a traceback is occurred because a certain field cannot be computed correctly. The reason is because the form view loaded is the one of the `product.template` module instead of `product.product`.

This commit adds a new product form view to hide the product type if the user creates a product inside the SOL form view displayed when he creates a SOL in sale_line_id field of `project.task` model. This commit also changes the form view to load for `product.product` model to use the one added inside that commit.

task-4781817
