### PR TITLE
[FIX] website_sale: fix visibility of quantity buttons in products

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -250,6 +250,7 @@
             <t t-set="product_variant_id" t-value="product._get_first_possible_variant_id()"/>
             <input name="product_id" t-att-value="product_variant_id" type="hidden"/>
             <input name="product_template_id" t-att-value="product.id" type="hidden"/>
+            <div t-if="is_view_active('website_sale.product_quantity')" class="js_add_cart_json d-none"/>
             <t t-if="product_variant_id and template_price_vals['price_reduce'] or not website.prevent_zero_price_sale">
                 <a t-if="product._website_show_quick_add()"
                    href="#" role="button" class="btn btn-primary a-submit" aria-label="Shopping cart" title="Shopping cart">


### PR DESCRIPTION
Steps to reproduce:
-
1. Install `website_sale` module
2. Go to the shop on the website
3. From the editor>customize, select  Button(add to cart)
4. Add the products through add cart button on products You will notice that the Select Quantity option is not visible, (even if the Select Quantity option is enabled).

Issue:
-
- In this [PR](https://github.com/odoo/odoo/pull/196947/files), we fix visibility of quantity buttons based on the [showQuantity](https://github.com/odoo/odoo/blob/aa7fdc055ec399e003cd29f11a48682305a82e26/addons/sale/static/src/js/product/product.xml#L32). But, when we activate the add cart option in all products page we didn't get showQuantity value [here](https://github.com/odoo/odoo/blob/aa7fdc055ec399e003cd29f11a48682305a82e26/addons/website_sale/static/src/js/website_sale_product_configurator.js#L46), due to this buttons are invisible.

Solution:
-
- Add the `js_add_cart_json` class when the Add to Cart option is enabled on the All Products page. We get the `showQuantity` value. The buttons are visible.

Before fix:
-
![before_fix](https://github.com/user-attachments/assets/6e1233c6-3292-4cdb-a140-23f21136ec89)

After fix:
-
![after_fix](https://github.com/user-attachments/assets/3d64005a-eacf-462f-9a77-a5b50783db9e)


**OPW** - [4686969](https://www.odoo.com/odoo/project/70/tasks/4781159)


Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
