### PR TITLE
[FIX] website_event: set an opacity to demo's "An unpublished event"

### DIFF
--- a/addons/website_event/data/event_demo.xml
+++ b/addons/website_event/data/event_demo.xml
@@ -146,7 +146,7 @@
 
     <record id="event.event_6" model="event.event">
         <field name="website_published" eval="False"/>
-        <field name="cover_properties">{"background-image": "none", "background-color": "secondary", "opacity": ""}</field>
+        <field name="cover_properties">{"background-image": "none", "background-color": "secondary", "opacity": "0.6"}</field>
     </record>
 
     <record id="event.event_7" model="event.event">


### PR DESCRIPTION
Setting the opacity to the empty string leads to max opacity but is seen as "None" in the builder because no options corresponds to this value. And the "None" option is not that, which is confusing. Setting a known value for the opacity shows the correct choice for the option

> [CLAS] In event, banner Filter intensity "None" is actually at max by default : https://drive.google.com/file/d/1M8iqLt_nU-qWK47t26w_fFwtKmUrXUQz/view?usp=drive_link
