### PR TITLE
[FIX] l10n_in: Remove the journal name from move PDF

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.2a1+e\n"
+"Project-Id-Version: Odoo Server saas~18.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-13 10:29+0000\n"
-"PO-Revision-Date: 2025-02-13 10:29+0000\n"
+"POT-Creation-Date: 2025-05-19 06:21+0000\n"
+"PO-Revision-Date: 2025-05-19 06:21+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -278,13 +278,25 @@ msgstr ""
 #. module: l10n_in
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled %(journal_name)s"
+msgid "Cancelled Credit Note"
 msgstr ""
 
 #. module: l10n_in
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled Proforma %(journal_name)s"
+msgid "Cancelled Invoice"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Cancelled Proforma Credit Note"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Cancelled Proforma Invoice"
 msgstr ""
 
 #. module: l10n_in
@@ -395,6 +407,12 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Credit Note"
+msgstr ""
+
+#. module: l10n_in
 #: model:iap.service,unit_name:l10n_in.iap_service_l10n_in_edi
 msgid "Credits"
 msgstr ""
@@ -461,13 +479,25 @@ msgstr ""
 #. module: l10n_in
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft %(journal_name)s"
+msgid "Draft Credit Note"
 msgstr ""
 
 #. module: l10n_in
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft Proforma %(journal_name)s"
+msgid "Draft Invoice"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Draft Proforma Credit Note"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Draft Proforma Invoice"
 msgstr ""
 
 #. module: l10n_in
@@ -884,6 +914,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
 msgid "Invalid sequence as per GST rule 46(b)"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Invoice"
 msgstr ""
 
 #. module: l10n_in
@@ -1352,7 +1388,31 @@ msgstr ""
 #. module: l10n_in
 #. odoo-python
 #: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Proforma %(journal_name)s"
+msgid "Proforma Credit Note"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Proforma Invoice"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Proforma Tax Invoice"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Proforma Vendor Bill"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Proforma Vendor Credit Note"
 msgstr ""
 
 #. module: l10n_in
@@ -1921,6 +1981,12 @@ msgid "Tax"
 msgstr ""
 
 #. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Tax Invoice"
+msgstr ""
+
+#. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_l10n_in_section_alert__tax_source_type
 msgid "Tax Source Type"
 msgstr ""
@@ -2078,6 +2144,18 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 msgid "Use this if setup with Reseller(E-Commerce)."
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Vendor Bill"
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/account_invoice.py:0
+msgid "Vendor Credit Note"
 msgstr ""
 
 #. module: l10n_in

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -716,17 +716,22 @@ class AccountMove(models.Model):
         :rtype: str
         """
         self.ensure_one()
-        if not proforma:
-            if self.state == 'posted':
-                return self.journal_id.name
-            elif self.state == 'draft':
-                return _("Draft %(journal_name)s", journal_name=self.journal_id.name)
-            elif self.state == 'cancel':
-                return _("Cancelled %(journal_name)s", journal_name=self.journal_id.name)
-        else:
-            if self.state == 'posted':
-                return _("Proforma %(journal_name)s", journal_name=self.journal_id.name)
-            elif self.state == 'draft':
-                return _("Draft Proforma %(journal_name)s", journal_name=self.journal_id.name)
-            elif self.state == 'cancel':
-                return _("Cancelled Proforma %(journal_name)s", journal_name=self.journal_id.name)
+        if self.move_type == 'out_invoice' and self.state == 'posted':
+            if self.invoice_line_ids.tax_ids:
+                return _("Tax Invoice") if not proforma else _("Proforma Tax Invoice")
+            else:
+                return _("Invoice") if not proforma else _("Proforma Invoice")
+        elif self.move_type == 'out_invoice' and self.state == 'draft':
+            return _("Draft Invoice") if not proforma else _("Draft Proforma Invoice")
+        elif self.move_type == 'out_invoice' and self.state == 'cancel':
+            return _("Cancelled Invoice") if not proforma else _("Cancelled Proforma Invoice")
+        elif self.move_type == 'out_refund' and self.state == 'posted':
+            return _("Credit Note") if not proforma else _("Proforma Credit Note")
+        elif self.move_type == 'out_refund' and self.state == 'draft':
+            return _("Draft Credit Note") if not proforma else _("Draft Proforma Credit Note")
+        elif self.move_type == 'out_refund' and self.state == 'cancel':
+            return _("Cancelled Credit Note") if not proforma else _("Cancelled Proforma Credit Note")
+        elif self.move_type == 'in_refund':
+            return _("Vendor Credit Note") if not proforma else _("Proforma Vendor Credit Note")
+        elif self.move_type == 'in_invoice':
+            return _("Vendor Bill") if not proforma else _("Proforma Vendor Bill")


### PR DESCRIPTION
This commit fixes the historical unwanted change that was introduced with commit https://github.com/odoo/odoo/commit/2b3c8e6ca9777f6264ecb3d1510dd292ed30ab9f Which modifies the report name for india and replace them with the Journal name. Till saas-18.2 It was okay for indian localisation but following the changes made in PR https://github.com/odoo/odoo/pull/195279 and https://github.com/odoo/odoo/pull/189664

Which changes the journal name and takes standard xml inheritance to py method. After the above mentioned PRs. It displays unwanted Report i.e. In case of Invoice it displays the `Sales INV/2025-26/01` which is unwanted. In this commit we adapt the standard `account` report name for `l10n_in` which should be removed in the `master` only one case should be adapted for India which is whenever an invoice having tax we should print it
as **Tax Invoice**

opw-4781816



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
