### PR TITLE
[FIX] hr_employee: let attendance officers open the Attendance app

### DIFF
--- a/addons/hr_attendance/models/hr_employee.py
+++ b/addons/hr_attendance/models/hr_employee.py
@@ -14,7 +14,7 @@ class HrEmployee(models.Model):
     attendance_manager_id = fields.Many2one(
         'res.users', store=True, readonly=False,
         domain="[('share', '=', False), ('company_ids', 'in', company_id)]",
-        groups="hr_attendance.group_hr_attendance_manager",
+        groups="hr_attendance.group_hr_attendance_officer",
         help="The user set in Attendance will access the attendance of the employee through the dedicated app and will be able to edit them.")
     attendance_ids = fields.One2many(
         'hr.attendance', 'employee_id', groups="hr_attendance.group_hr_attendance_officer,hr.group_hr_user")


### PR DESCRIPTION
**Problem**
Users in the `hr_attendance.group_hr_attendance_officer` group are blocked from opening the Attendance app when they lack the manager role.

**Steps to reproduce**
 - Remove `hr_attendance.group_hr_attendance_manager` from your user.

 - Add `hr_attendance.group_hr_attendance_officer`.

 - Open the Attendance app: access is denied.

**Cause**
The method [read_group_employee_id](https://github.com/odoo/odoo/blob/cd428bd75b63f96c67942be5457d0afdb00d29b0/addons/hr_attendance/models/hr_attendance.py#L672) applies a domain on attendance_manager_id, which incorrectly prevents officers from passing the check.

**Solution**
Switch the group on the attendance_manager_id field in hr_employee.py so that officers aren’t inadvertently blocked. Officers will still be restricted from reading records they don’t manage.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
