### PR TITLE
[FIX] bus: prevent error while receiving lastNotificationId as undefined

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -16,7 +16,7 @@ export class OutdatedPageWatcherService {
     setup(env, { bus_service, multi_tab, notification }) {
         this.notification = notification;
         this.multi_tab = multi_tab;
-        this.lastNotificationId = multi_tab.getSharedValue("last_notification_id");
+        this.lastNotificationId = multi_tab.getSharedValue("last_notification_id", 0);
         /** @deprecated */
         this.lastDisconnectDt = null;
         this.closeNotificationFn;
@@ -29,7 +29,7 @@ export class OutdatedPageWatcherService {
             { once: true }
         );
         bus_service.addEventListener("disconnect", () => {
-            this.lastNotificationId = multi_tab.getSharedValue("last_notification_id");
+            this.lastNotificationId = multi_tab.getSharedValue("last_notification_id", 0);
             this.lastDisconnectDt = DateTime.now();
         });
         bus_service.addEventListener("connect", async () => {

--- a/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
+++ b/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
@@ -12,15 +12,16 @@ import { createWebClient } from "@web/../tests/webclient/helpers";
 import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 
-QUnit.test("disconnect during bus gc should ask for reload", async () => {
+QUnit.test("disconnect during bus gc should ask for reload", async (assert) => {
     // When the bus table is cleared, reload might be required to recover
     // coherent state in apps like Discuss.
     addBusServicesToRegistry();
     registry.category("services").add("bus.outdated_page_watcher", outdatedPageWatcherService);
     const pyEnv = await startServer();
     const { env } = await createWebClient({
-        mockRPC(route) {
+        mockRPC(route, args) {
             if (route === "/bus/has_missed_notifications") {
+                assert.ok("last_notification_id" in args);
                 return true;
             }
         },
@@ -36,13 +37,14 @@ QUnit.test("disconnect during bus gc should ask for reload", async () => {
     await assertSteps(["reload"]);
 });
 
-QUnit.test("reconnect after going offline after bus gc should ask for reload", async () => {
+QUnit.test("reconnect after going offline after bus gc should ask for reload", async (assert) => {
     addBusServicesToRegistry();
     registry.category("services").add("bus.outdated_page_watcher", outdatedPageWatcherService);
     const { advanceTime } = mockTimeout();
     const { env } = await createWebClient({
-        mockRPC(route) {
+        mockRPC(route, args) {
             if (route === "/bus/has_missed_notifications") {
+                assert.ok("last_notification_id" in args);
                 return true;
             }
         },


### PR DESCRIPTION
Currently an error occurs when the user reconnects after a network interruption during login process.

Steps to replicate:
- Open an incognito tab browser and open the login page.
- Input credentials, and during the login process go to offline.
- Again, go online, and after a few times, an error will occur.

Note:- If an error does not occur, close the window and open a new one, try offline and online again.

Error:
`BusController.has_missed_notifications() missing 1 required positional argument: 'last_notification_id'`

This error occur because at code line [1]  the `lastNotificationId` is still undefined (due to the network  interruption). This results in the client calling `/bus/has_missed_notifications` with an invalid or missing parameter, causing the controller to raise a `TypeError` due to a missing required argument.

This commit will fix above issue by providing a default value for `last_notification_id` as 0, so that the field is always  present before making the RPC call to `/bus/has_missed_notifications`.

[1]-https://github.com/odoo/odoo/blob/18.0/addons/bus/static/src/outdated_page_watcher_service.js#L55

Video for error replication:
https://github.com/user-attachments/assets/3facbc96-b864-442b-8db8-73508eaf5e9e


sentry-5741581459
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
