### PR TITLE
[FIX] im_livechat: chat bubble not showing on shopify

### DIFF
--- a/addons/im_livechat/static/src/embed/common/boot_helpers.js
+++ b/addons/im_livechat/static/src/embed/common/boot_helpers.js
@@ -43,6 +43,7 @@ export function makeRoot(target) {
     root.classList.add("o-livechat-root");
     root.style.zIndex = "calc(9e999)";
     root.style.position = "relative";
+    root.style.display = "block";
     target.appendChild(root);
     return root;
 }


### PR DESCRIPTION
The live chat uses a shadow DOM to preserve its styles. However, shopify hides empty block. Since the live chat root only contains the shadow DOM, it is considered empty which leads to the chat bubble not being displayed. This commit fixes the issue by explicitly setting the "display" style on the live chat root.

opw-4768389

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
