### PR TITLE
[FIX] base_vat: fix typo preventing computation of fiscal position for POS

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -729,7 +729,7 @@ class ResPartner(models.Model):
         vat_required_valid = super()._get_vat_required_valid(company=company)
         if (
             company and self.with_company(company).perform_vies_validation
-            and ('EU' in company.country_id.country_codes or self.country_id and self.country_id.has_foreign_fiscal_position)
+            and ('EU' in company.country_id.country_group_codes or self.country_id and self.country_id.has_foreign_fiscal_position)
         ):
             vat_required_valid = vat_required_valid and self.vies_valid
         return vat_required_valid


### PR DESCRIPTION
To reproduce:
- Install `point_of_sale` and `base_vat`
- Install belgium localization
- Switch to 'My Belgian Company' and enable `Verify VAT Numbers' option
- Open a POS session

Before this commit, when opening a pos session it was crashing with:

`'res.country' object has no attribute 'country_codes'`

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
