### PR TITLE
[FIX] sale: create invoice when SO lines are empty

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2027,7 +2027,7 @@ class SaleOrder(models.Model):
         :return The newly created SO lines.
         """
         self.ensure_one()
-        sequence = max(self.order_line.mapped('sequence') or 10) + 1
+        sequence = max(self.order_line.mapped('sequence') or [10]) + 1
         return self.env['sale.order.line'] \
             .with_context(sale_no_log_for_new_lines=True) \
             .create([
@@ -2049,7 +2049,7 @@ class SaleOrder(models.Model):
         if any(line.display_type and line.is_downpayment for line in self.order_line):
             return
 
-        sequence = max(self.order_line.mapped('sequence') or 10) + 1
+        sequence = max(self.order_line.mapped('sequence') or [10]) + 1
         return self.env['sale.order.line'] \
             .with_context(sale_no_log_for_new_lines=True) \
             .create({


### PR DESCRIPTION
This error occurs when creating an invoice for a sale order with no SO line.

Steps to reproduce:
---
- Install `sale_management` module
- Create a New SO and `Add a Section` > Confirm
- Remove SO line > Create Invoice > Down Payment > Create Draft

Traceback:
---
`TypeError: 'int' object is not iterable`

At [1], the error occurs because `self.order_line.mapped('sequence')` returns an empty list. The fallback value 10 is used, but since it's an integer (not a list), it causes a TypeError.

[1]- https://github.com/odoo/odoo/blob/f101a9b6d65e34cf3d3175a341b87e3f14c44a02/addons/sale/models/sale_order.py#L2052

sentry-6601545000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
