### PR TITLE
[FIX] hr_timesheet:  avatar not displayed for users without employee access

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -271,7 +271,12 @@
                             <div class="oe_kanban_global_click o_kanban_record_has_image_fill px-0 pb-0">
                                 <div class="oe_kanban_details d-flex flex-column">
                                     <div class="o_kanban_record_top px-2 h-50">
-                                        <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)" t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value" class="o_image_40_cover float-start"/>
+                                        <img t-att-src="kanban_image('hr.employee', 'avatar_128', record.employee_id.raw_value)"
+                                            t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"
+                                            class="o_image_40_cover float-start" groups="hr.group_hr_user"/>
+                                        <img t-att-src="kanban_image('hr.employee.public', 'avatar_128', record.employee_id.raw_value)"
+                                            t-att-title="record.employee_id.value" t-att-alt="record.employee_id.value"
+                                            class="o_image_40_cover float-start" groups="!hr.group_hr_user"/>
                                         <div class="o_kanban_record_headings ps-4 pe-2">
                                             <div class="text-truncate">
                                                 <strong class="o_kanban_record_title">


### PR DESCRIPTION
Steps to Reproduce:
------------
- Log in with a user who has access to all timesheets but does not have access to the employee records.
- Open the Timesheet module.
- Navigate to Timesheet → All Timesheets.
- Open Kanban View

Issue:
---------
Avatars are not displayed in each line of the timesheet.

Reason:
-----------
- Currently, we are passing the hr.employee model to the kanban_image QWeb helper to generate the image source URL for all users.
- If the user doesn’t have access to employee, avatar can’t be loaded.

Fix:
-------
We pass the appropriate model ('hr.employee' or 'hr.employee.public') to the kanban_image helper to generate the image URL. This is controlled by the groups attribute in the view — if the user is in hr.group_hr_user, we use 'hr.employee' otherwise, we use 'hr.employee.public'.

task: 4461272
