### PR TITLE
[FIX] account: prevent audit error by safely loading demo CoA

### DIFF
--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import UserError
 from odoo.osv.expression import OR
 
@@ -147,7 +148,7 @@ class Message(models.Model):
 
     @api.ondelete(at_uninstall=True)
     def _except_audit_log(self):
-        if self.env.context.get('bypass_audit') is bypass_token:
+        if self.env.context.get('bypass_audit') is bypass_token or self.env.context.get(MODULE_UNINSTALL_FLAG):
             return
         to_check = self
         partner_message = self.filtered(lambda m: m.account_audit_log_partner_id)


### PR DESCRIPTION
When installing the Accounting app on a new database created with Germany as
country and with demo data loaded, the demo loader invokes in
`account/demo/account_demo.xml` the `<function name="try_loading">` call which
does a wholesale `records.with_context({MODULE_UNINSTALL_FLAG: True}).unlink()`. This
cascades into deleting mail.message records, but the audit‑trail hook in
only bypasses its check when the `bypass_audit` token is present not when `MODULE_UNINSTALL_FLAG is set
causing a “You cannot remove parts of the audit trail” UserError.

Steps to reproduce:
- Created new database, with Germany as country
- Download demo data
- Attempt to install Accounting application
! Receive error message
OPW- 4712364