### PR TITLE
[FIX] bus: outdated page false positive

### DIFF
--- a/addons/bus/static/src/workers/websocket_worker.js
+++ b/addons/bus/static/src/workers/websocket_worker.js
@@ -396,6 +396,9 @@ export class WebsocketWorker {
         this.connectTimeout = null;
         this.isReconnecting = false;
         this.firstSubscribeDeferred.then(() => {
+            if (!this.websocket) {
+                return;
+            }
             this.messageWaitQueue.forEach((msg) => this.websocket.send(msg));
             this.messageWaitQueue = [];
         });
@@ -480,8 +483,14 @@ export class WebsocketWorker {
         this.connectRetryDelay = this.INITIAL_RECONNECT_DELAY;
         this.isReconnecting = false;
         this.lastChannelSubscription = null;
+        const shouldBroadcastClose =
+            this.websocket && this.websocket.readyState !== WebSocket.CLOSED;
         this.websocket?.close();
         this._removeWebsocketListeners();
+        this.websocket = null;
+        if (shouldBroadcastClose) {
+            this.broadcast("disconnect", { code: WEBSOCKET_CLOSE_CODES.CLEAN });
+        }
     }
 
     /**

--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -890,7 +890,7 @@ class WebsocketConnectionHandler:
     # Latest version of the websocket worker. This version should be incremented
     # every time `websocket_worker.js` is modified to force the browser to fetch
     # the new worker bundle.
-    _VERSION = "18.0-4"
+    _VERSION = "18.0-5"
 
     @classmethod
     def websocket_allowed(cls, request):

--- a/addons/web/static/lib/hoot/mock/network.js
+++ b/addons/web/static/lib/hoot/mock/network.js
@@ -795,7 +795,7 @@ export class MockWebSocket extends MockEventTarget {
             return;
         }
         this._readyState = WebSocket.CLOSING;
-        dispatchClose(this, { code, reason });
+        tick().then(() => dispatchClose(this, { code, reason }));
     }
 
     /** @type {WebSocket["send"]} */


### PR DESCRIPTION
The outdated page watcher checks whether bus notifications were missed when the bus reconnects after an unexpected disconnection. To do so, it checks if the last known notification id is still in the bus table.

When the bus disconnects, the last notification id is saved. However, disconnect event is not correctly sent when switching from online to offline. This commit fixes this issue.

follow up of https://github.com/odoo/odoo/pull/208625 backport of https://github.com/odoo/odoo/pull/209472

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
