### PR TITLE
[FIX] website_sale_loyalty: prevent traceback on multireward coupons

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -12,7 +12,7 @@ from odoo.addons.website_sale.controllers import main
 class WebsiteSale(main.WebsiteSale):
 
     @http.route()
-    def pricelist(self, promo, **post):
+    def pricelist(self, promo, reward_id=None, **post):
         order = request.website.sale_get_order()
         if not order:
             return request.redirect('/shop')
@@ -25,6 +25,8 @@ class WebsiteSale(main.WebsiteSale):
             reward_successfully_applied = True
             if len(coupon_status) == 1:
                 coupon, rewards = next(iter(coupon_status.items()))
+                if reward_id in rewards.ids:
+                    rewards = rewards.browse(reward_id)
                 if request.env.context.get('product_id') or (len(rewards) == 1 and not rewards.multi_product):
                     reward_successfully_applied = self._apply_reward(order, rewards, coupon)
 
@@ -104,7 +106,7 @@ class WebsiteSale(main.WebsiteSale):
                     (program_sudo.trigger == 'with_code' and program_sudo.program_type != 'promo_code')
                     or (program_sudo.trigger == 'auto' and program_sudo.applies_on == 'future')
                 ):
-                    return self.pricelist(code, **post)
+                    return self.pricelist(code, reward_id=reward_id, **post)
         if coupon:
             self._apply_reward(order_sudo, reward_sudo, coupon)
         return request.redirect(redirect)

--- a/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
+++ b/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
@@ -1,23 +1,28 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details
 
-from odoo.fields import Command
-from odoo.tests import TransactionCase, tagged
+from odoo import Command, http
+from odoo.tests import tagged
 
+from odoo.addons.base.tests.common import TransactionCaseWithUserPortal
 from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
 
 
 @tagged('post_install', '-at_install')
-class TestClaimReward(TransactionCase):
+class TestClaimReward(TransactionCaseWithUserPortal):
 
-    def test_claim_reward_with_multi_product(self):
-        WebsiteSaleController = WebsiteSale()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
 
-        tag = self.env['product.tag'].create({
+        cls.WebsiteSaleController = WebsiteSale()
+        cls.website = cls.env.ref('website.default_website')
+
+        tag = cls.env['product.tag'].create({
             'name': 'multi reward',
         })
 
-        product1, product2 = self.env['product.product'].create([
+        cls.product1, cls.product2 = cls.env['product.product'].create([
             {
             'name': 'Test Product',
             'list_price': 10.0,
@@ -28,12 +33,7 @@ class TestClaimReward(TransactionCase):
             'product_tag_ids': tag,
         }])
 
-        partner = self.env['res.partner'].create({
-            'name': 'Test Customer',
-            'email': 'test@example.com',
-        })
-
-        promo_program = self.env['loyalty.program'].create({
+        cls.promo_program, cls.coupon_program = cls.env['loyalty.program'].create([{
             'name': 'Free Products',
             'program_type': 'promotion',
             'applies_on': 'current',
@@ -48,22 +48,77 @@ class TestClaimReward(TransactionCase):
                 'reward_product_tag_id': tag.id,
                 'reward_product_qty': 1,
                 'required_points': 1,
-            })]
-        })
+            })],
+        }, {
+            'name': "Multi-reward coupons",
+            'program_type': 'coupons',
+            'applies_on': 'current',
+            'trigger': 'with_code',
+            'reward_ids': [
+                Command.create({
+                    'reward_type': 'product',
+                    'reward_product_tag_id': tag.id,
+                    'reward_product_qty': 1,
+                    'required_points': 1,
+                    'discount': None,
+                }),
+                Command.create({
+                    'reward_type': 'discount',
+                    'discount': 10.0,
+                    'discount_mode': 'percent',
+                    'required_points': 1,
+                }),
+            ],
+            'coupon_ids': [Command.create({'points': 1})],
+        }])
+        cls.coupon = cls.coupon_program.coupon_ids
 
-        website = self.env['website'].browse(1)
-        order = self.env['sale.order'].create({
-            'website_id': website.id,
-            'partner_id': partner.id,
+        cls.cart = cls.env['sale.order'].create({
+            'website_id': cls.website.id,
+            'partner_id': cls.partner_portal.id,
             'order_line': [Command.create({
-                'product_id': product1.id,
+                'product_id': cls.product1.id,
                 'product_uom_qty': 1,
             })],
         })
-        order._update_programs_and_rewards()
-        with MockRequest(self.env, website=website, sale_order_id=order.id):
+        cls.cart._update_programs_and_rewards()
 
-            WebsiteSaleController.claim_reward(promo_program.reward_ids[:1].id, product_id=str(product2.id))
+        installed_modules = set(cls.env['ir.module.module'].search([
+            ('state', '=', 'installed'),
+        ]).mapped('name'))
+        for _ in http._generate_routing_rules(installed_modules, nodb_only=False):
+            pass
+
+    def test_claim_reward_with_multi_products(self):
+        order = self.cart
+        product2 = self.product2
+
+        with MockRequest(self.env, website=self.website, sale_order_id=order.id):
+            self.WebsiteSaleController.claim_reward(
+                self.promo_program.reward_ids.id,
+                product_id=str(product2.id),
+            )
 
             self.assertEqual(len(order.order_line), 2, 'reward line should be added to order')
             self.assertEqual(order.order_line[1].product_id, product2, 'added reward line should should contain product 2')
+
+    def test_apply_coupon_with_multiple_rewards(self):
+        discount_reward = self.coupon_program.reward_ids.filtered('discount')
+
+        with MockRequest(self.env, website=self.website, sale_order_id=self.cart.id):
+            self.WebsiteSaleController.pricelist(promo=self.coupon.code)
+            self.assertFalse(self.cart.order_line.reward_id)
+
+            self.WebsiteSaleController.claim_reward(discount_reward.id, code=self.coupon.code)
+            self.assertTrue(self.cart.order_line.reward_id)
+            self.assertIn(
+                discount_reward.discount_line_product_id,
+                self.cart.order_line.product_id,
+                "Discount product should be added to order",
+            )
+            self.assertAlmostEqual(
+                self.product1.list_price * 0.9,
+                self.cart.amount_untaxed,
+                delta=self.cart.currency_id.rounding,
+                msg="10% discount should be applied",
+            )


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a coupon that grants a discount;
2. add a second reward giving free products;
3. use a product tag to turn it into a multiproduct reward;
4. save program, generate coupons, and copy a code;
5. add the free product tag to two or more products;
6. go to eCommerce;
7. add any product to cart and go to checkout;
8. apply coupon code;
9. claim a reward.

Issue
-----
- Claiming a free product results in a traceback.
- Claiming the discount does not apply the discount.

Cause
-----
Commit db3ffae3ef5a5 modified the reward claiming logic to allow for multiproduct rewards, but overlooked the possibility of the program having multiple rewards, multiproduct being one of them.

It therefore passes all of the coupon's rewards to `_apply_reward`, which only expects a single reward.

This is also a consequence of commit 6525d5fba40c, which moved part of the `claim_reward` logic to `pricelist`, without passing which reward was claimed to `pricelist`.

Solution
--------
Add an optional `reward_id` parameter to `pricelist`, letting it know which reward we intend to claim.

opw-4778945