### PR TITLE
[FIX] hr: fix undeterminisms in avatar tests

### DIFF
--- a/addons/hr/static/tests/m2x_avatar_employee.test.js
+++ b/addons/hr/static/tests/m2x_avatar_employee.test.js
@@ -80,8 +80,8 @@ test("many2one in list view", async () => {
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
-    expect(".o-mail-ChatWindow").toHaveCount(2);
     await waitFor(".o-mail-ChatWindow-header:contains('Luigi')");
+    expect(".o-mail-ChatWindow").toHaveCount(2);
 
     // click on third employee (same as first)
     await contains(".o_data_cell .o_m2o_avatar > img:eq(2)").click();
@@ -91,6 +91,7 @@ test("many2one in list view", async () => {
     expect(".o_card_user_infos > a").toHaveText("Mario@partner.com");
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
+    await waitFor(".o-mail-ChatWindow-header:contains('Mario')");
     expect(".o-mail-ChatWindow").toHaveCount(2);
 });
 
@@ -517,8 +518,8 @@ test("many2many in kanban view", async () => {
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
-    expect(".o-mail-ChatWindow").toHaveCount(2);
     await waitFor(".o-mail-ChatWindow-header:contains('Luigi')");
+    expect(".o-mail-ChatWindow").toHaveCount(2);
 });
 
 test("many2many: click on an employee not associated with a user", async () => {
@@ -578,6 +579,6 @@ test("many2many: click on an employee not associated with a user", async () => {
     expect(".o_avatar_card").toHaveCount(1);
     expect(".o_avatar_card_buttons button:eq(0)").toHaveText("Send message");
     await contains(".o_avatar_card_buttons button:eq(0)").click();
-    expect(".o-mail-ChatWindow").toHaveCount(1);
     await waitFor(".o-mail-ChatWindow-header:contains('Luigi')");
+    expect(".o-mail-ChatWindow").toHaveCount(1);
 });


### PR DESCRIPTION
There were some errors in the tests because we asserted Chat windows were present without waiting for them (except for the one tick).

This produced indeterminism which are now fixed

runbot-error-162715
runbot-error-163000

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
