### PR TITLE
[IMP] mrp: show workcenter blocked status in Gantt view

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -79,6 +79,13 @@ class MrpWorkcenter(models.Model):
     kanban_dashboard_graph = fields.Text(compute='_compute_kanban_dashboard_graph')
     resource_calendar_id = fields.Many2one(check_company=True)
 
+    def _compute_display_name(self):
+        super()._compute_display_name()
+        for workcenter in self:
+            # Show the red icon(workcenter is blocked) only when the Gantt view is accessed from MRP > Planning > Planning by Workcenter.
+            if self._context.get('group_by') and self._context.get('show_workcenter_status') and workcenter.working_state == 'blocked':
+                workcenter.display_name = f"{workcenter.display_name}\u00A0\u00A0🔴"
+
     @api.constrains('alternative_workcenter_ids')
     def _check_alternative_workcenter(self):
         for workcenter in self:

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -390,7 +390,7 @@
         <field name="path">workcenter-planning</field>
         <field name="view_mode">list,form,calendar,pivot,graph</field>
         <field name="search_view_id" ref="view_mrp_production_workorder_form_view_filter"/>
-        <field name="context">{'search_default_work_center': True, 'search_default_ready': True, 'search_default_blocked': True, 'search_default_progress': True}</field>
+        <field name="context">{'search_default_work_center': True, 'search_default_ready': True, 'search_default_blocked': True, 'search_default_progress': True, 'show_workcenter_status': True}</field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             No work orders to do!


### PR DESCRIPTION
With this commit, a red 🔴 icon is displayed next to the workcenter name (like: Drill_1 🔴) when its working state is blocked.

This visual indicator appears only in the `Planning > Planning by Workcenter` Gantt view, helping planners quickly identify blocked workcenters.

This enhancement provides clearer visibility into workcenter status during scheduling, supporting better planning decisions.

task - [3506680](https://www.odoo.com/odoo/project/966/tasks/3506680)
