### PR TITLE
[FIX] l10n_jo_edi: e-invoice rendering fails on high currency precision

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -291,11 +291,8 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         if amount is None:
             return None
 
-        def get_decimal_places(number):
-            return len(f'{float(number)}'.split('.')[1])
-
         rounded_amount = float_repr(self._round_max_dp(amount), JO_MAX_DP).rstrip('0').rstrip('.')
-        decimal_places = get_decimal_places(rounded_amount)
+        decimal_places = len(rounded_amount.split('.')[1]) if '.' in rounded_amount else 0
         if decimal_places < precision_digits:
             rounded_amount = float_repr(float(rounded_amount), precision_digits)
         return rounded_amount


### PR DESCRIPTION
With Jordan Company setup:
- Set dummy values on the Jordan electronic invoicing settings
- Enable USD, set a rate and currency precision to 5
- Set the Product Price decimal accuracy to 5
- Make an invoice in USD adding a line as follows:
  - Price 0.13793
  - Qty 9
  - Discount 100%
  - Tax: 16%
- Confirm
- Send & Print, activate e-invoice (JoFotara (Jordan EDI))

Issue will raise:
```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
Template: account_edi_ubl_cii.ubl_20_MonetaryTotalType
Path: /t/t/cbc:TaxInclusiveAmount
Node: <ns0:TaxInclusiveAmount xmlns:ns0="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" t-att-currencyID="vals[\'currency\'].name" t-out="format_float(vals.get(\'tax_inclusive_amount\'), vals.get(\'currency_dp\'))"/>
```

This occurs because on high currency precision we may work with numbers that are represented in scientific notation (-2e-09) that when converted to string may keep the literal form unless using a specific format

opw-4739342
