### PR TITLE
[FIX] mrp: fix traceback new operation

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -89,7 +89,7 @@ class MrpRoutingWorkcenter(models.Model):
             cycle_number = 0  # Never 0 unless infinite item['workcenter_id'].capacity
             for item in data:
                 total_duration += item['duration']
-                (capacity, _setup, _cleanup) = item['workcenter_id']._get_capacity(item.product_id, item.product_uom_id, operation.bom_id.product_qty)
+                (capacity, _setup, _cleanup) = item['workcenter_id']._get_capacity(item.product_id, item.product_uom_id, operation.bom_id.product_qty or 1)
                 cycle_number += float_round((item['qty_produced'] / capacity), precision_digits=0, rounding_method='UP')
             if cycle_number:
                 operation.time_cycle = total_duration / cycle_number
@@ -106,7 +106,7 @@ class MrpRoutingWorkcenter(models.Model):
                 continue
             quantity = self.env.context.get('quantity', operation.bom_id.product_qty or 1)
             unit = self.env.context.get('unit', operation.bom_id.product_uom_id)
-            (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty)
+            (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty or 1)
             operation.cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method="UP")
             operation.time_total = setup + cleanup + operation.cycle_number * operation.time_cycle * 100.0 / (workcenter.time_efficiency or 100.0)
             operation.show_time_total = operation.cycle_number > 1 or not float_is_zero(setup + cleanup, precision_digits=0)

--- a/odoo/addons/base/tests/test_display_name.py
+++ b/odoo/addons/base/tests/test_display_name.py
@@ -1,10 +1,12 @@
 import contextlib
+from lxml import etree
 
 from odoo.exceptions import UserError
+from odoo.tests import Form
 from odoo.tests.common import TransactionCase, tagged
 
 
-IGNORE_MODEL_NAMES = {
+IGNORE_MODEL_NAMES_DISPLAY_NAME = {
     'ir.attachment',
     'test_new_api.attachment',
     'payment.link.wizard',
@@ -12,9 +14,20 @@ IGNORE_MODEL_NAMES = {
     'account_followup.manual_reminder',
 }
 
+IGNORE_MODEL_NAMES_NEW_FORM = {
+    'account.report.line',  # only used as wizard, and display_name isn't compute in a wizard but Form add display_name automatically
+    'chatbot.script.step',  # only used as wizard
+    'stock.warehouse',  # avoid warning "Creating a new warehouse will automatically activate the Storage Locations setting"
+    'website.visitor',  # Visitors can only be created through the frontend.
+    'marketing.activity',  # only used as wizard and always used form marketing.campaign
+    # 'esg.emission.factor',  # FIXME: Form don't find end_date_field option 
+    # 'sale.commission.plan',
+}
+
 IGNORE_COMPUTED_FIELDS = {
     'account.payment.register.payment_token_id',  # must be computed within a specific environment
 }
+
 
 @tagged('-at_install', 'post_install')
 class TestEveryModel(TransactionCase):
@@ -22,7 +35,7 @@ class TestEveryModel(TransactionCase):
     def test_display_name_new_record(self):
         for model_name in self.registry:
             model = self.env[model_name]
-            if model._abstract or not model._auto or model_name in IGNORE_MODEL_NAMES:
+            if model._abstract or not model._auto or model_name in IGNORE_MODEL_NAMES_DISPLAY_NAME:
                 continue
 
             with self.subTest(
@@ -36,6 +49,36 @@ class TestEveryModel(TransactionCase):
                 fields_spec = dict.fromkeys(fields_used + ['display_name'], {})
                 with contextlib.suppress(UserError):
                     model.onchange({}, [], fields_spec)
+
+    def test_form_new_record(self):
+        for model_name in self.registry:
+            model = self.env[model_name]
+            if (
+                model._abstract
+                or model._transient
+                or not model._auto
+                or model_name in IGNORE_MODEL_NAMES_NEW_FORM
+                or model_name not in self.env['ir.model.access']._get_allowed_models('create')
+            ):
+                continue
+
+            default_form_id = self.env['ir.ui.view'].default_view(model_name, 'form')
+            if not default_form_id:
+                continue
+
+            default_form = self.env['ir.ui.view'].browse(default_form_id)
+            if not default_form.arch:
+                continue
+            view_elem = etree.fromstring(default_form.arch)
+            if view_elem.get('create') in ("0", "false"):
+                continue
+
+            with self.subTest(
+                msg="Create a new record from form view doesn't work (first onchange call).",
+                model=model_name,
+            ), contextlib.suppress(UserError):
+                # Test to open the Form view to check first onchange
+                Form(model)
 
     def test_computed_fields_without_dependencies(self):
         for model in self.env.values():


### PR DESCRIPTION
Go to the menu Manufacturin / Configuration / Operations (need to enable Work order option), click on new, got a traceback:

...
  File "/home/odoo/Documents/dev/odoo/addons/mail/models/mail_thread.py", line 464, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/Documents/dev/odoo/odoo/orm/models.py", line 4623, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/Documents/dev/odoo/odoo/orm/fields.py", line 73, in determine
    return needle(*args)
  File "/home/odoo/Documents/dev/odoo/addons/mrp/models/mrp_routing.py", line 110, in _compute_time_cycle
    operation.cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method="UP")
ZeroDivisionError: float division by zero

Fix it by adding a fallback with 1 as capacity.
Bug found by adding a test on all form view in https://github.com/odoo/odoo/pull/209587 PR. But need to backport this part.
