### PR TITLE
[FIX] hr_timesheet: make 'name' not required in mobile view

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -57,7 +57,7 @@
                             <field name="readonly_timesheet"/>
                             <field name="date"/>
                             <field name="user_id"/>
-                            <field name="name"/>
+                            <field name="name" required="0" readonly="readonly_timesheet"/>
                             <field name="unit_amount" decoration-danger="unit_amount &gt; 24"/>
                             <field name="project_id"/>
                             <field name="task_id"/>


### PR DESCRIPTION
**Issue:**
when defining the form for kanban view, required attribute is not added making it true by default


**steps to reproduce:**
1. install timesheets app
2. from projects app, open a task with timesheet in mobile view
3. click on `Add` button present in timesheet page
4. try to save the timesheet without 'Description'

observation: Form not saved with notification
"invalid field: Description"

**solution:**
Add relevant `required` and `readonly` property to the field this makes the behavior same across each view
[see list view](https://github.com/odoo/odoo/blob/17.0/addons/hr_timesheet/views/project_task_views.xml#L41-L54)

note: 
1. techincal name of Description field is 'name'
2. `readonly` attribute is added to make the behavior same across each view

opw-4725348



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
; 