### PR TITLE
[FIX] mrp: fix traceback new operation

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -89,7 +89,7 @@ class MrpRoutingWorkcenter(models.Model):
             cycle_number = 0  # Never 0 unless infinite item['workcenter_id'].capacity
             for item in data:
                 total_duration += item['duration']
-                (capacity, _setup, _cleanup) = item['workcenter_id']._get_capacity(item.product_id, item.product_uom_id, operation.bom_id.product_qty)
+                (capacity, _setup, _cleanup) = item['workcenter_id']._get_capacity(item.product_id, item.product_uom_id, operation.bom_id.product_qty or 1)
                 cycle_number += float_round((item['qty_produced'] / capacity), precision_digits=0, rounding_method='UP')
             if cycle_number:
                 operation.time_cycle = total_duration / cycle_number
@@ -106,7 +106,7 @@ class MrpRoutingWorkcenter(models.Model):
                 continue
             quantity = self.env.context.get('quantity', operation.bom_id.product_qty or 1)
             unit = self.env.context.get('unit', operation.bom_id.product_uom_id)
-            (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty)
+            (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty or 1)
             operation.cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method="UP")
             operation.time_total = setup + cleanup + operation.cycle_number * operation.time_cycle * 100.0 / (workcenter.time_efficiency or 100.0)
             operation.show_time_total = operation.cycle_number > 1 or not float_is_zero(setup + cleanup, precision_digits=0)


### PR DESCRIPTION
Go to the menu Manufacturin / Configuration / Operations (need to enable Work order option), click on new, got a traceback:

...
  File "/home/odoo/Documents/dev/odoo/addons/mail/models/mail_thread.py", line 464, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/Documents/dev/odoo/odoo/orm/models.py", line 4623, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/Documents/dev/odoo/odoo/orm/fields.py", line 73, in determine
    return needle(*args)
  File "/home/odoo/Documents/dev/odoo/addons/mrp/models/mrp_routing.py", line 110, in _compute_time_cycle
    operation.cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method="UP")
ZeroDivisionError: float division by zero

Fix it by adding a fallback with 1 as capacity.
Bug found by adding a test on all form view in https://github.com/odoo/odoo/pull/209587 PR. But need to backport this part.
