### PR TITLE
[FIX] spreadsheet: export cumulated_start

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_line_chart.js
@@ -23,6 +23,7 @@ export class OdooLineChart extends OdooChart {
         this.verticalAxisPosition = definition.verticalAxisPosition;
         this.stacked = definition.stacked;
         this.cumulative = definition.cumulative;
+        this.cumulatedStart = definition.cumulatedStart;
     }
 
     getDefinition() {
@@ -31,6 +32,7 @@ export class OdooLineChart extends OdooChart {
             verticalAxisPosition: this.verticalAxisPosition,
             stacked: this.stacked,
             cumulative: this.cumulative,
+            cumulatedStart: this.cumulatedStart,
         };
     }
 }

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -615,6 +615,9 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
                 model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
                 [15, 19, 24]
             );
+            const figure = model.exportData().sheets[0].figures[0];
+            assert.strictEqual(figure.data.cumulative, true);
+            assert.strictEqual(figure.data.cumulatedStart, true);
         });
 
         QUnit.test("cumulative line chart with past data before domain period specifying cumulated start as false", async (assert) => {
@@ -635,6 +638,9 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
                 model.getters.getChartRuntime(chartId).chartJsConfig.data.datasets[0].data,
                 [3, 7, 12]
             );
+            const figure = model.exportData().sheets[0].figures[0];
+            assert.strictEqual(figure.data.cumulative, true);
+            assert.strictEqual(figure.data.cumulatedStart, false);
         });
     });
 


### PR DESCRIPTION
Commit d69541efbe3 added `cumulatedStart` property on charts but the property was not exported.

Steps to reproduce:
- open CRM
- switch to the graph view
- Check the "cumulative" checkbox
- Group by create date: month
- Filter on March and April (the last 2 months in the filter)
- insert in spreadsheet
- reload

=> the chart data changed. It now includes historical data

Task-4792009

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
