### PR TITLE
[IMP] mail: add notification log on channel and thread rename

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1366,6 +1366,8 @@ class DiscussChannel(models.Model):
     def channel_rename(self, name):
         self.ensure_one()
         self.write({'name': name})
+        body = Markup('<div data-oe-type="channel_rename" class="o_mail_notification">%s</div>') % name
+        self.message_post(body=body, message_type="notification", subtype_xmlid="mail.mt_comment")
 
     def channel_change_description(self, description):
         self.ensure_one()

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -16,6 +16,8 @@ import { user } from "@web/core/user";
 import { createDocumentFragmentFromContent, createElementWithContent } from "@web/core/utils/html";
 import { url } from "@web/core/utils/urls";
 
+import { markup } from "@odoo/owl";
+
 const { DateTime } = luxon;
 export class Message extends Record {
     static _name = "mail.message";
@@ -376,6 +378,13 @@ export class Message extends Record {
         compute() {
             if (this.notificationType === "call") {
                 return _t("%(caller)s started a call", { caller: this.authorName });
+            }
+            if (this.notificationType === "channel_rename") {
+                const name = htmlToTextContentInline(this.body);
+                const params = { user: this.authorName, name: markup`<b>${name}</b>` };
+                return this.thread?.parent_channel_id
+                    ? _t("%(user)s changed the thread name to %(name)s", params)
+                    : _t("%(user)s changed the channel name to %(name)s", params);
             }
             if (this.isEmpty) {
                 return _t("This message has been removed");

--- a/addons/mail/static/src/core/common/notification_message.xml
+++ b/addons/mail/static/src/core/common/notification_message.xml
@@ -7,6 +7,9 @@
             <t t-if="message.notificationType === 'call'">
                 <span class="text-muted opacity-50" t-esc="callInformation"/>
             </t>
+            <t t-elif="message.notificationType === 'channel_rename'">
+                <span class="text-muted opacity-50" t-out="message.inlineBody"/>
+            </t>
             <t t-else="">
                 <span class="o-mail-NotificationMessage-author d-inline text-muted opacity-50" t-if="message.authorName and !message.richBody.includes(escape(message.authorName))" t-esc="message.authorName"/> <span class="text-muted opacity-50" t-out="message.richBody"/>
             </t>

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel.js
@@ -521,6 +521,14 @@ export class DiscussChannel extends models.ServerModel {
 
         const [channel] = this.browse(ids);
         this.write([channel.id], { name });
+        this.message_post(
+            channel.id,
+            makeKwArgs({
+                body: `<div data-oe-type="channel_rename" class="o_mail_notification">${name}</div>`,
+                message_type: "notification",
+                subtype_xmlid: "mail.mt_comment",
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
Purpose of this PR:
Users can track when a channel and thread is renamed and by whom.

- This commit posts a system notification in the channel log
when its name is changed. The message includes the user
who performed the rename and displays the new channel
or thread name.

- To ensure proper localization, the message body is not translated server-side.
Instead, a lightweight element with a specific oe-type is posted, and the final
message is rendered client-side in each user's language.



task-[4780916](https://www.odoo.com/odoo/project/1519/tasks/4780916)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
