### PR TITLE
[FIX] point_of_sale: remove internal note from receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
+++ b/addons/point_of_sale/static/src/app/components/order_display/order_display.xml
@@ -21,7 +21,7 @@
                             </div>
                         </div>
                     </div>
-                    <div t-if="order.internal_note"
+                    <div t-if="order.internal_note and props.mode !== 'receipt'"
                         class="internal-note-container d-flex gap-2 flex-wrap m-1">
                         <t t-foreach="order.internal_note.split('\n') or []" t-as="note"
                             t-key="note_index">

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -8,7 +8,7 @@
                 <div class="pos-receipt-title" t-if="data.reprint">
                     DUPLICATA !
                 </div>
-                <div class="pos-receipt-title" t-if="data.preset_name">
+                <div class="pos-receipt-title preset-name" t-if="data.preset_name">
                     <t t-esc="data.preset_name"/>
                 </div>
                 <div class="o-employee-name" style="font-size: 78%;">

--- a/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/receipt_screen_tour.js
@@ -11,7 +11,7 @@ import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { registry } from "@web/core/registry";
 import { inLeftSide } from "@point_of_sale/../tests/pos/tours/utils/common";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
-import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+import { run, negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
 import { renderToElement } from "@web/core/utils/render";
 import { formatCurrency } from "@web/core/currency";
 
@@ -89,6 +89,23 @@ registry.category("web_tour.tours").add("ReceiptScreenTour", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             Order.hasLine({ customerNote: "Test customer note" }),
+            ReceiptScreen.clickNextOrder(),
+
+            // Test that Internal notes are not available on receipt
+            ProductScreen.addOrderline("Desk Pad", "1", "5"),
+            inLeftSide([
+                { ...ProductScreen.clickLine("Desk Pad")[0], isActive: ["mobile"] },
+                ...ProductScreen.addInternalNote("Test internal note"),
+                ...ProductScreen.clickSelectedLine("Desk Pad"),
+                ...ProductScreen.addInternalNote("Test internal note on order"),
+                ...Order.hasInternalNote("Test internal note on order"),
+            ]),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
+            negateStep(...Order.hasLine({ internalNote: "Test internal note" })),
+            negateStep(...Order.hasInternalNote("Test internal note on order")),
             ReceiptScreen.clickNextOrder(),
 
             // Test discount and original price

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -457,6 +457,9 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                     if (!rendered.innerHTML.includes("14:20")) {
                         throw new Error("14:20 not found in printed receipt");
                     }
+                    if (rendered.innerHTML.includes("DUPLICATA!")) {
+                        throw new Error("DUPLICATA! should not be present in printed receipt");
+                    }
                 },
             },
         ].flat(),


### PR DESCRIPTION
Before this commit:
---------------------
- Internal notes of  order were printed on the customer receipt.

After this commit:
-----------------------------
- Internal notes are no longer printed; only customer notes appear on the
  receipt.

Task:4789682

Related PR - https://github.com/odoo/enterprise/pull/85740
