### PR TITLE
[FIX] l10n_jo_edi: prevent crash on computed field test

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -60,7 +60,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return self._round_max_dp(self._get_unit_price_jod(line)) * self._round_max_dp(line.quantity) - self._round_max_dp(self._get_line_discount_jod(line))
 
     def _get_payment_method_code(self, invoice):
-        return PAYMENT_CODES_MAP[invoice.company_id.l10n_jo_edi_taxpayer_type]['receivable']
+        return PAYMENT_CODES_MAP.get(invoice.company_id.l10n_jo_edi_taxpayer_type, {}).get('receivable', '')
 
     def _aggregate_totals(self, vals):
         """
@@ -384,7 +384,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
             'order_reference': '',
             'sales_order_id': '',
             'profile_id': 'reporting:1.0',
-            'id': invoice.name.replace('/', '_'),
+            'id': (invoice.name or '').replace('/', '_'),
             'uuid': invoice.l10n_jo_edi_uuid,
             'document_currency_code': 'JOD',
             'tax_currency_code': 'JOD',


### PR DESCRIPTION
Ensure `_get_payment_method_code` and invoice name handling in `_export_invoice_vals` work safely with incomplete records during this test `test_computed_fields_without_dependencies`.

This test creates unsaved records where required fields like `company_id.l10n_jo_edi_taxpayer_type` and `invoice.name` are missing they are intialized in module testsuite . Attempting to access these directly led to a `KeyError` (due to missing taxpayer type) and an `AttributeError` when calling `.replace()` on a boolean.

These failures do not occur in the module test suite because records are fully populated, but for test robustness and future-proofing, we now handle missing or falsy values gracefully.

build_error-161152
