### PR TITLE
[FIX] mrp: fix manufacture order prepick move demands

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2546,6 +2546,8 @@ class MrpProduction(models.Model):
             byproduct_values.append(move_byproduct_vals)
         self.move_finished_ids += self.env['stock.move'].create(byproduct_values)
 
+        if self.warehouse_id.manufacture_steps in ('pbm', 'pbm_sam'):
+            moves_to_unlink.product_uom_qty = 0
         moves_to_unlink._action_cancel()
         moves_to_unlink.unlink()
         workorders_to_unlink.unlink()

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1839,7 +1839,7 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(mo_1.is_outdated_bom, True)
         mo_1.action_update_bom()
         self.assertRecordValues(picking.move_ids, [
-            {'product_id': self.product_2.id, 'product_uom_qty': 2},  # Ideally, this move should have been deleted but this isn't handled for now.
+            {'product_id': self.product_2.id, 'product_uom_qty': 0},  # Ideally, this move should have been deleted but this isn't handled for now (updated to 0 demand instead of removing).
             {'product_id': self.product_1.id, 'product_uom_qty': 4},
             {'product_id': self.product_3.id, 'product_uom_qty': 2},
         ])


### PR DESCRIPTION
Steps to reproduce:
1. Set company warehouse to two-step manufacturing.
2. Create products: X, A, B, C.
3. Add on-hand quantities: A = 10, C = 5.
4. Create a BOM for X with A and B as components.
5. Create and confirm a MO for X in the two-step warehouse.
6. Check product B's forecast report → shows -1.
7. Add a reordering rule for B → forecast shows -1.
8. Edit X’s BOM: remove B and add C instead.
9. Update the MO using the `update_bom` button.
10. Check MO components.
11. Check WH/Preprod transfer → B is still there.
12. Re-check steps 6 and 7.

**Issue**:
In two-step manufacturing, two stock moves are created:
- move1: WH/Stock → WH/Preprod
- move2: WH/Preprod → Virtual/Production

The forecast report uses the company warehouse (WH) as the
location domain and includes move2. It calculates:
  forecast = qty_available - demand = 0 - 1 = -1

The reordering rule uses WH/Stock (its default location) and
includes move1, resulting in the same forecast: -1.

After updating the BOM to remove B:
- move2 is deleted correctly.
- move1 remains on the pre-production transfer.

This causes an inconsistency:
- Forecast report (based on move2) → shows 0
- Reordering rule (based on move1) → still shows -1

We set the product_uom_qty to 0 of the prepoduction moves
so procurement runs with negative qty move and it is merged
with the existing ones in the preproduction picking.
This will make the moves in the preprod picking be 0 and not
deleted to avoid deleting manually added moves from the client
in the preproduction picking.

**Limitation**
The current setup will update the pre_prod_pick moves with
0 demand, but for the post_prod_pick moves there is no pull rule
that will trigger a procurement with -ve old demand to update
the post_prod_pick move leaving it not updated to the bom changes.

This will not be an issue in 18.0+ because of changing to push rules
as the post_prod_pick will not be there unless the MO is done, so
BoM updates will not be needed to be reflected.

opw-4746230