### PR TITLE
[IMP] web: allow changing a record's company_id to a non-connected company

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1172,7 +1172,10 @@ export class Record extends DataPoint {
             );
         } catch (e) {
             if (onError) {
-                return onError(e, { discard: () => this._discard() });
+                return onError(e, {
+                    discard: () => this._discard(),
+                    retry: () => this._save(...arguments),
+                });
             }
             if (!this.isInEdition) {
                 await this._load({});

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -7,11 +7,11 @@ import { Component, useChildSubEnv, useRef, useState } from "@odoo/owl";
 import { useCommand } from "@web/core/commands/command_hook";
 import { _t } from "@web/core/l10n/translation";
 import { symmetricalDifference } from "@web/core/utils/arrays";
-import { useChildRef, useService } from "@web/core/utils/hooks";
+import { useBus, useChildRef, useService } from "@web/core/utils/hooks";
 import { SwitchCompanyItem } from "@web/webclient/switch_company_menu/switch_company_item";
 import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
 import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
-import { user } from "@web/core/user";
+import { user, userBus } from "@web/core/user";
 import { router } from "@web/core/browser/router";
 
 function getCompany(cid) {
@@ -190,6 +190,9 @@ export class SwitchCompanyMenu extends Component {
         });
 
         useCommand(_t("Switch Company"), () => this.dropdown.open(), { hotkey: "alt+shift+u" });
+        useBus(userBus, "ACTIVE_COMPANIES_CHANGED", () => {
+            this.companySelector.reset();
+        });
 
         this.containerRef = useChildRef();
         this.navigationOptions = {

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
@@ -147,8 +147,8 @@ test("single company selected: toggling it off will keep it", async () => {
     expect(cookie.get("cids")).toEqual("1");
     expect(user.activeCompanies.map((c) => c.id)).toEqual([1]);
     expect(user.activeCompany.id).toBe(1);
-    expect("[data-company-id] .fa-check-squarqe").toHaveCount(0);
-    expect("[data-company-id] .fa-square-o").toHaveCount(3);
+    expect("[data-company-id] .fa-check-square").toHaveCount(1);
+    expect("[data-company-id] .fa-square-o").toHaveCount(2);
 });
 
 test("single company mode: companies can be logged in", async () => {

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -188,8 +188,8 @@ test("single company selected: toggling it off will keep it", async () => {
     expect(user.activeCompany.id).toBe(3);
 
     await openCompanyMenu();
-    expect("[data-company-id] .fa-check-square").toHaveCount(0);
-    expect("[data-company-id] .fa-square-o").toHaveCount(5);
+    expect("[data-company-id] .fa-check-square").toHaveCount(1);
+    expect("[data-company-id] .fa-square-o").toHaveCount(4);
 });
 
 test("single company mode: companies can be logged in", async () => {


### PR DESCRIPTION
Before this commit, if a user had write rights for a company but was not
connected to it, an error would occur when changing the company_id field of a
record to that company (or create a new record with the company_id field set to
that company). The user would then have to select the company in the company
switcher, wait for the webclient to reload, re-enter the changes, and save the
record again.

This commit allows users to write a record (create a new record, or changing
the company of an existing record) belonging to a company for which they have
write permissions, even if they are not connected to it. In this case, the
company will be automatically added to the connected companies. Note that, this
is the same behaviour when opening a record from a non-connected company(see [1)].

[1] : https://github.com/odoo/odoo/commit/6213c40932236101b529b82f0ea9fce1829c8c24

task-id 4655385