### PR TITLE
[FIX] mail: delete message from deleted thread less records

### DIFF
--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -10,7 +10,7 @@ class MailboxController(http.Controller):
     def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages")
+        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
         return {
             **res,
             "data": Store(messages, for_current_user=True, add_followers=True).get_result(),
@@ -21,7 +21,7 @@ class MailboxController(http.Controller):
     def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", False)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages")
+        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
         return {
             **res,
             "data": Store(messages, for_current_user=True).get_result(),
@@ -32,7 +32,7 @@ class MailboxController(http.Controller):
     def discuss_starred_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("starred_partner_ids", "in", [request.env.user.partner_id.id])]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages")
+        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
         return {
             **res,
             "data": Store(messages, for_current_user=True).get_result(),

--- a/addons/mail/controllers/mailbox.py
+++ b/addons/mail/controllers/mailbox.py
@@ -3,6 +3,7 @@
 from odoo import http
 from odoo.http import request
 from odoo.addons.mail.tools.discuss import Store
+from odoo.addons.mail.tools.message import filter_messages_exist
 
 
 class MailboxController(http.Controller):
@@ -10,7 +11,7 @@ class MailboxController(http.Controller):
     def discuss_inbox_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", True)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
+        messages = filter_messages_exist(request.env, res.pop("messages"))
         return {
             **res,
             "data": Store(messages, for_current_user=True, add_followers=True).get_result(),
@@ -21,7 +22,7 @@ class MailboxController(http.Controller):
     def discuss_history_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("needaction", "=", False)]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
+        messages = filter_messages_exist(request.env, res.pop("messages"))
         return {
             **res,
             "data": Store(messages, for_current_user=True).get_result(),
@@ -32,7 +33,7 @@ class MailboxController(http.Controller):
     def discuss_starred_messages(self, search_term=None, before=None, after=None, limit=30, around=None):
         domain = [("starred_partner_ids", "in", [request.env.user.partner_id.id])]
         res = request.env["mail.message"]._message_fetch(domain, search_term=search_term, before=before, after=after, around=around, limit=limit)
-        messages = res.pop("messages").filtered(lambda m: request.env[m.model].browse(m.res_id).exists())
+        messages = filter_messages_exist(request.env, res.pop("messages"))
         return {
             **res,
             "data": Store(messages, for_current_user=True).get_result(),

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import contextlib
 import logging
 import re
 import textwrap
@@ -7,7 +8,7 @@ from binascii import Error as binascii_error
 from collections import defaultdict
 
 from odoo import _, api, fields, models, modules, tools
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, MissingError
 from odoo.osv import expression
 from odoo.tools import clean_context, format_list, groupby, SQL
 from odoo.tools.misc import OrderedSet
@@ -988,8 +989,11 @@ class Message(models.Model):
         for record in records:
             thread_data = {}
             if record._name != "discuss.channel":
-                # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
-                thread_data["name"] = record.sudo().display_name
+                try:
+                    # sudo: mail.thread - if mentionned in a non accessible thread, name is allowed
+                    thread_data["name"] = record.sudo().display_name
+                except MissingError:
+                    continue  # related non mail.thread document deleted, still show message in history
             if self.env[record._name]._original_module:
                 thread_data["module_icon"] = modules.module.get_module_icon(
                     self.env[record._name]._original_module
@@ -1004,16 +1008,17 @@ class Message(models.Model):
             # model, res_id, record_name need to be kept for mobile app as iOS app cannot be updated
             data = message._read_format(fields, load=False)[0]
             record = record_by_message.get(message)
+            record_name = False
+            default_subject = False
             if record:
-                # sudo: if mentionned in a non accessible thread, user should be able to see the name
-                record_name = record.sudo().display_name
-                default_subject = record_name
-                if hasattr(record, "_message_compute_subject"):
-                    # sudo: if mentionned in a non accessible thread, user should be able to see the subject
-                    default_subject = record.sudo()._message_compute_subject()
-            else:
-                record_name = False
-                default_subject = False
+                with contextlib.suppress(MissingError):
+                    # sudo: if mentionned in a non accessible thread, user should be able to see the name
+                    record_name = record.sudo().display_name
+                if record_name:
+                    default_subject = record_name
+                    if hasattr(record, "_message_compute_subject"):
+                        # sudo: if mentionned in a non accessible thread, user should be able to see the subject
+                        default_subject = record.sudo()._message_compute_subject()
             data["default_subject"] = default_subject
             vals = {
                 # sudo: mail.message - reading attachments on accessible message is allowed

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -893,7 +893,7 @@ class Message(models.Model):
             model_name: self.env[model_name]
             .browse(ids)
             .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
-            for model_name, ids in ids_by_model.items() if self.env[model_name].browse(ids).exists()
+            for model_name, ids in ids_by_model.items()
         }
 
     def _record_by_message(self):
@@ -902,12 +902,7 @@ class Message(models.Model):
             message: self.env[message.model]
             .browse(message.res_id)
             .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
-            for message in self.filtered(
-                lambda m:
-                    m.model and m.res_id and
-                    m.model in records_by_model_name and
-                    m.res_id in records_by_model_name[m.model].ids
-                )
+            for message in self.filtered(lambda m: m.model and m.res_id)
         }
 
     def _to_store(

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -346,13 +346,12 @@ class MailThread(models.AbstractModel):
         return result
 
     def unlink(self):
-        """ Override unlink to delete (scheduled) messages and followers. This cannot be
+        """ Override unlink to delete scheduled messages and followers. This cannot be
         cascaded, because link is done through (res_model, res_id). """
         if not self:
             return True
         # discard pending tracking
         self._track_discard()
-        self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         res = super(MailThread, self).unlink()
         self.env['mail.followers'].sudo().search(
             [('res_model', '=', self._name), ('res_id', 'in', self.ids)]

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -16,6 +16,13 @@ _logger = logging.getLogger(__name__)
 class BaseModel(models.AbstractModel):
     _inherit = 'base'
 
+    def unlink(self):
+        # Override unlink to delete messages. This cannot be
+        # cascaded, because link is done through (model, res_id). """
+        if self:
+            self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
+        return super().unlink()
+
     def _valid_field_parameter(self, field, name):
         # allow tracking on abstract models; see also 'mail.thread'
         return (

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -19,6 +19,8 @@ class BaseModel(models.AbstractModel):
     def unlink(self):
         # Override unlink to delete messages. This cannot be
         # cascaded, because link is done through (model, res_id). """
+        if self._abstract or self._transient:
+            return super().unlink()
         if self:
             self.env['mail.message'].sudo().search([('model', '=', self._name), ('res_id', 'in', self.ids)]).unlink()
         return super().unlink()

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -41,7 +41,7 @@
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
-                                    on <a t-if="message.thread.displayName" t-att-href="message.resUrl" t-esc="message.thread.displayName"/><em class="pe-1 text-decoration-line-through" t-else="">Deleted document</em>
+                                    on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
                                 </t>
                                 <t t-else="">
                                     (from <a t-att-href="message.resUrl"><t t-esc="message.thread.prefix"/><t t-esc="message.thread.displayName or message.default_subject"/></a>)

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -41,7 +41,7 @@
                             </small>
                             <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.thread.model !== 'discuss.channel'">
-                                    on <a t-att-href="message.resUrl"><t t-esc="message.thread.displayName"/></a>
+                                    on <a t-if="message.thread.displayName" t-att-href="message.resUrl" t-esc="message.thread.displayName"/><em class="pe-1 text-decoration-line-through" t-else="">Deleted document</em>
                                 </t>
                                 <t t-else="">
                                     (from <a t-att-href="message.resUrl"><t t-esc="message.thread.prefix"/><t t-esc="message.thread.displayName or message.default_subject"/></a>)

--- a/addons/mail/tools/__init__.py
+++ b/addons/mail/tools/__init__.py
@@ -5,5 +5,6 @@ from . import alias_error
 from . import discuss
 from . import link_preview
 from . import mail_validation
+from . import message
 from . import parser
 from . import web_push

--- a/addons/mail/tools/message.py
+++ b/addons/mail/tools/message.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from collections import defaultdict
+from odoo.tools.misc import OrderedSet
+
+
+def filter_messages_exist(env, messages):
+    ids_by_model = defaultdict(OrderedSet)
+    prefetch_ids_by_model = defaultdict(OrderedSet)
+    prefetch_messages = messages | messages.browse(messages._prefetch_ids)
+    for message in prefetch_messages.filtered(lambda m: m.model and m.res_id):
+        target = ids_by_model if message in messages else prefetch_ids_by_model
+        target[message.model].add(message.res_id)
+    records_by_model_name = {
+        model_name: env[model_name]
+        .browse(ids)
+        .with_prefetch(tuple(ids_by_model[model_name] | prefetch_ids_by_model[model_name]))
+        for model_name, ids in ids_by_model.items() if env[model_name].browse(ids).exists()
+    }
+    record_by_message = {
+        message: env[message.model]
+        .browse(message.res_id)
+        .with_prefetch(records_by_model_name[message.model]._prefetch_ids)
+        for message in messages.filtered(
+            lambda m:
+                m.model and m.res_id and
+                m.model in records_by_model_name and
+                m.res_id in records_by_model_name[m.model].ids
+            )
+    }
+    return messages.browse([msg.id for msg in record_by_message])


### PR DESCRIPTION
opw-4546920

~~https://github.com/odoo/enterprise/pull/87182~~


old commit:
## [FIX] mail: message related to deleted record doesn't break discuss

Before this commit, when a message notification from inbox or history has its related record deleted, the user couldn't load inbox or history.

Steps to reproduce:
- Have mitchell admin receive notification in Odoo
- Install `mail_group`
- Wait a few seconds to receive following user_notification from mail group:
```
on My Company News
Hello,
You have messages to moderate, please go for the proceedings.
```
- Go to related record then delete it
- Go back to inbox or history

=> One of them show `An error occurred while fetching messages.`

This happens because the related record is not a `mail.thread`, but still creates some `mail.message` to send user notifications.

`mail.thread` cascade delete the messages in message list, but threadless records do not. Because the related record is deleted, these messages are attempted to be displayed in mailbox, but due to related record having no `display_name` by non-existing, the fetch data of inbox/history crashes with:
```
MissingError: Record does not exist or has been deleted
```

This commit fixes the issue by doing its best to show message even when the related record has been deleted.

opw-4546920

Before
![Screenshot 2025-05-13 at 14 35 04](https://github.com/user-attachments/assets/eb0fdf04-5a47-4fd3-8e47-be26abec54a3)

After
![Screenshot 2025-05-13 at 14 35 25](https://github.com/user-attachments/assets/c706f8d2-780e-45e5-9bda-0be16354f60f)
