### PR TITLE
[FIX] html_editor: selection not extending when scrolling

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -133,8 +133,8 @@ function scrollToSelection(selection) {
     const offsetTop = rect.top - containerRect.top + container.scrollTop;
     const offsetBottom = rect.bottom - containerRect.top + container.scrollTop;
 
-    if (rect.height >= containerRect.height) {
-        // Selection is larger than scrollable so we do nothing.
+    if (rect.bottom > containerRect.top && rect.top < containerRect.bottom) {
+        // If selection is partially visible, no need to scroll.
         return;
     }
     // Simulate the "nearest" behavior by scrolling to the closest top/bottom edge

--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -1,13 +1,19 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { press, queryFirst, queryOne } from "@odoo/hoot-dom";
+import { isInViewPort, press, queryFirst, queryOne } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
-import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import {
+    defineModels,
+    fields,
+    models,
+    mountView,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
 import { useAutofocus } from "@web/core/utils/hooks";
 import { Plugin } from "../src/plugin";
 import { MAIN_PLUGINS } from "../src/plugin_sets";
 import { setupEditor } from "./_helpers/editor";
-import { getContent } from "./_helpers/selection";
+import { getContent, setSelection } from "./_helpers/selection";
 import { insertText, tripleClick } from "./_helpers/user_actions";
 
 test("getEditableSelection should work, even if getSelection returns null", async () => {
@@ -251,4 +257,63 @@ test("preserveSelection's restore should always set the selection, even if it's 
     const cursors = editor.shared.selection.preserveSelection();
     cursors.restore();
     expect.verifySteps(["setBaseAndExtent"]);
+});
+
+test.tags("desktop");
+test("should not autoscroll if selection is partially visible in viewport", async () => {
+    class Test extends models.Model {
+        name = fields.Char();
+        txt = fields.Html();
+        _records = [{ id: 1, name: "Test", txt: "<p>This is some text</p>".repeat(50) }];
+    }
+
+    defineModels([Test]);
+    await mountView({
+        type: "form",
+        resId: 1,
+        resModel: "test",
+        arch: `
+            <form>
+                <field name="name"/>
+                <field name="txt" widget="html"/>
+            </form>`,
+    });
+
+    const scrollableElement = queryOne(".o_content");
+    const editable = queryOne(".odoo-editor-editable");
+    const lastParagraph = editable.lastElementChild;
+    const fifthLastParagraph = editable.children[45];
+
+    // Select the last five paragraphs in backward.
+    setSelection({
+        anchorNode: lastParagraph,
+        anchorOffset: 1,
+        focusNode: fifthLastParagraph,
+        focusOffset: 0,
+    });
+    await animationFrame();
+
+    // Both ends of the selection are initially visible in the viewport.
+    expect(isInViewPort(fifthLastParagraph)).toBe(true);
+    expect(isInViewPort(lastParagraph)).toBe(true);
+
+    // Scroll above so that last paragraph becomes invisible in viewport.
+    scrollableElement.scrollTop -= 70;
+    await animationFrame();
+    expect(isInViewPort(lastParagraph)).toBe(false);
+    expect(isInViewPort(fifthLastParagraph)).toBe(true);
+
+    const scrollTop = scrollableElement.scrollTop;
+    // Extend the selection to include one more paragraph above.
+    setSelection({
+        anchorNode: lastParagraph,
+        anchorOffset: 1,
+        focusNode: fifthLastParagraph.previousElementSibling,
+        focusOffset: 0,
+    });
+    await animationFrame();
+
+    // Ensure that extending selection did not trigger any auto-scrolling.
+    expect(scrollableElement.scrollTop).toBe(scrollTop);
+    expect(isInViewPort(lastParagraph)).toBe(false);
 });


### PR DESCRIPTION
**Current behaviour before PR:**

Steps to reproduce:

- Have a long content so that editable content becomes scrollable.
- Scroll to the bottom of content.
- Select the last line of text.
- Try extending selection by scrolling through mouse.
- Selection is not extending and it flickers.

The issue happens because `scrollToSelection` function is invoked on selectionchange and forcefully scrolls to the selected content. As result, selection is not extending when scrolling.

**Desired behaviour after PR is merged:**

Now, `scrollToSelection` doesn't scroll to the selection if selection range is is within visible viewport area. As result, selection
can be extended by scrolling.

task-4756869



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
