### PR TITLE
 [FIX] test_mail: activity: disable popover animations in tests

### DIFF
--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -17,7 +17,7 @@ import { ActivityModel } from "@mail/views/web/activity/activity_model";
 import { ActivityRenderer } from "@mail/views/web/activity/activity_renderer";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { keyDown, waitFor } from "@odoo/hoot-dom";
-import { animationFrame, mockDate } from "@odoo/hoot-mock";
+import { animationFrame, disableAnimations, mockDate } from "@odoo/hoot-mock";
 import { onMounted, onWillUnmount } from "@odoo/owl";
 import { MailTestActivity } from "@test_mail/../tests/mock_server/models/mail_test_activity";
 import { defineTestMailModels } from "@test_mail/../tests/test_mail_test_helpers";
@@ -82,6 +82,10 @@ function patchActivityDomain(load, params) {
     }
     return load(params);
 }
+
+// Because tests implicitly use Popover
+// and that it uses HTMLElement.animate()
+disableAnimations();
 
 describe.current.tags("desktop");
 defineTestMailModels();


### PR DESCRIPTION
HOOT disables CSS animations (https://github.com/odoo/odoo/commit/008541343faa39b5749f1d1621a8832f1a9167ad)
But Popover uses `HTMLElement.animate()` directly leading to race conditions.

After this commit, the race conditions mentioned should be fixed.

runbot-error-188379
runbot-error-188378