### PR TITLE
[FIX] hr_timesheet,web: choose the form view to display with view button

### DIFF
--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -38,7 +38,7 @@
                         <field name="analytic_account_active" invisible="1"/>
                     </t>
                     <page string="Timesheets" name="page_timesheets" id="timesheets_tab" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user">
-                    <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': ''}">
+                    <field name="timesheet_ids" mode="list,kanban" readonly="not analytic_account_active" context="{'default_project_id': project_id, 'default_name': '', 'form_view_ref': 'hr_timesheet.timesheet_view_form_user'}">
                         <list editable="bottom" string="Timesheet Activities" default_order="date" decoration-muted="readonly_timesheet == True">
                             <field name="readonly_timesheet" column_invisible="True"/>
                             <field name="date" readonly="readonly_timesheet"/>

--- a/addons/web/static/src/views/fields/x2many/x2many_field.js
+++ b/addons/web/static/src/views/fields/x2many/x2many_field.js
@@ -231,6 +231,7 @@ export class X2ManyField extends Component {
                 views: [[false, "form"]],
                 res_id: record.resId,
                 res_model: this.list.resModel,
+                context: this.props.context,
             },
             {
                 props: { resIds: this.list.resIds },

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11463,6 +11463,77 @@ test("open a one2many record containing a one2many", async () => {
     ]);
 });
 
+test("open a one2many record with optional open record displayed", async () => {
+    Partner._views = {
+        [["form", false]]: `<form>
+            <field name="p" context="{ 'form_view_ref': 1234 }">
+                <list editable="bottom"><field name="name" /></list>
+            </field>
+        </form>`,
+        [["form", 1234]]: `
+            <form>
+                <field name="name"/>
+            </form>`,
+        [["search", false]]: `<search/>`,
+    };
+    let firstLoad = true;
+
+    patchWithCleanup(localStorage, {
+        getItem(key) {
+            const value = super.getItem(...arguments);
+            if (key.startsWith("debug_open_view")) {
+                expect.step(["getItem", key, value]);
+            }
+            return value;
+        },
+        setItem(key, value) {
+            if (key.startsWith("debug_open_view")) {
+                expect.step(["setItem", key, value]);
+            }
+            super.setItem(...arguments);
+        },
+    });
+    onRpc("get_views", ({ model, method, kwargs }) => {
+        if (firstLoad) {
+            firstLoad = false;
+        } else {
+            expect(kwargs.context.form_view_ref).toBe(1234);
+            expect.step(`${model}.${method}`);
+        }
+    });
+    serverState.debug = true;
+    const rec = Partner._records.find(({ id }) => id === 2);
+    rec.p = [1];
+
+    await mountWithCleanup(WebClient);
+    await getService("action").doAction({
+        res_model: "partner",
+        type: "ir.actions.act_window",
+        views: [[false, "form"]],
+        res_id: 2,
+    });
+
+    const localStorageKey = "debug_open_view,partner,form,false,p,list,name";
+    expect.verifySteps([["getItem", localStorageKey, null]]);
+
+    expect(`td.o_list_record_open_form_view`).toHaveCount(0);
+    expect(".o_optional_columns_dropdown").toHaveCount(1);
+    await contains(".o_optional_columns_dropdown button").click();
+    expect(".o-dropdown-item:contains('View Button')").toHaveCount(1);
+    await contains(".o-dropdown-item:contains('View Button')").click();
+    expect.verifySteps([
+        ["setItem", localStorageKey, true],
+        ["getItem", localStorageKey, "true"],
+    ]);
+
+    expect(`td.o_list_record_open_form_view`).toHaveCount(1, {
+        message: "button to open form view should be present on each rows",
+    });
+
+    await contains(`td.o_list_record_open_form_view`).click();
+    expect.verifySteps(["partner.get_views"]);
+});
+
 test("if there are less than 4 lines in a one2many, empty lines must be displayed to cover the difference.", async () => {
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -9554,6 +9554,12 @@ test(`Can switch to form view on inline tree`, async () => {
         doAction(action, options) {
             expect.step("doAction");
             expect(action).toEqual({
+                context: {
+                    allowed_company_ids: [1],
+                    lang: "en",
+                    tz: "taht",
+                    uid: 7,
+                },
                 res_id: id,
                 res_model: "partner",
                 type: "ir.actions.act_window",


### PR DESCRIPTION
Before this commit, when the user is in debug mode and go to the form view of a task with some timesheets, he can optionally display the view button in the sub list view of timesheets. The problem is the view button will return the first form view found in timesheet model. Since timesheet model is in fact `account.analytic.line`, the first form view opened is the one used for Analytic Items and not for the timesheets.

This commit alters the form view by using `form_view_ref` context key on timesheet_ids field to be able to load the expected form view.

task-4781729
