### PR TITLE
[FIX] project: set multiple priority levels via shortcut

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -48,7 +48,9 @@ class ProjectTask(models.Model):
         30h Allocate 30 hours to the task
         #tags Set tags on the task
         @user Assign the task to a user
-        ! Set the task a high priority\n
+        ! Set the task a medium priority
+        !! Set the task a high priority
+        !!! Set the task a urgent priority\n
         Make sure to use the right format and order e.g. Improve the configuration screen 5h #feature #v16 @Mitchell !""",
     )
     @property

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -302,7 +302,9 @@ class ProjectTask(models.Model):
         help="""Use these keywords in the title to set new tasks:\n
             #tags Set tags on the task
             @user Assign the task to a user
-            ! Set the task a high priority\n
+            ! Set the task a medium priority
+            !! Set the task a high priority
+            !!! Set the task a urgent priority\n
             Make sure to use the right format and order e.g. Improve the configuration screen #feature #v16 @Mitchell !""",
     )
     link_preview_name = fields.Char(compute='_compute_link_preview_name', export_string_translation=False)
@@ -724,7 +726,7 @@ class ProjectTask(models.Model):
     def _get_group_pattern(self):
         return {
             'tags_and_users': r'\s([#@]%s[^\s]+)',
-            'priority': r'\s(!)',
+            'priority': r'(?:^|\s)(!{1,3})(?=\s|$)',
         }
 
     def _prepare_pattern_groups(self):
@@ -767,9 +769,11 @@ class ProjectTask(models.Model):
         self.display_name, dummy = re.subn(pattern, '', self.display_name)
 
     def _extract_priority(self):
-        self.priority = "1"
         priority_group = self._get_group_pattern()['priority']
-        self.display_name, dummy = re.subn(priority_group, '', self.display_name)
+        match = re.search(priority_group, self.display_name)
+        if match:
+            self.priority = str(min(len(match.group(1)), 3))
+            self.display_name, _dummy = re.subn(priority_group, '', self.display_name)
 
     def _get_groups(self):
         return [

--- a/addons/project/tests/test_project_task_quick_create.py
+++ b/addons/project/tests/test_project_task_quick_create.py
@@ -35,6 +35,12 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
             'task A 30H 2.5h #Tag1 #tag2 #tag3 @Armande @Bast @raouf !': ('task A 30H 2.5h @raouf', 3, 2, "1", 0),
             'task A 30H 2.5h #Tag1 #tag2 #tag3 @Armande @Bastttt @raouf1 @raouf2 !': ('task A 30H 2.5h @Bastttt', 3, 3, "1", 0),
             'task A 30H 2.5h #TAG1 #tag1 #TAG2': ('task A 30H 2.5h', 2, 0, "0", 0),
+            'task A 30H 2.5h #Tag1 #tag2 @Armande @Bast @raouf1 @raouf2 !!': ('task A 30H 2.5h', 2, 4, "2", 0),
+            'task A !!': ('task A', 0, 0, "2", 0),
+            'task A 30H 2.5h #Tag1 #tag2 #tag3 @Armande @Bastttt @raouf1 @raouf2 !!': ('task A 30H 2.5h @Bastttt', 3, 3, "2", 0),
+            'task A 30H 2.5h #Tag1 #tag2 @Armande @Bast @raouf1 @raouf2 !!!': ('task A 30H 2.5h', 2, 4, "3", 0),
+            'task A !!!': ('task A', 0, 0, "3", 0),
+            'task A 30H 2.5h #Tag1 #tag2 #tag3 @Armande @Bastttt @raouf1 @raouf2 !!!': ('task A 30H 2.5h @Bastttt', 3, 3, "3", 0),
         }
 
         for expression, values in valid_expressions.items():
@@ -49,7 +55,13 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
             '#tag1 #tag2 #tag3 @Armande @Bast @raouf1 @raouf2',
             '@Armande @Bast @raouf1 @raouf2',
             '!',
-            'task A!'
+            'task A!',
+            'task A!!',
+            'task A!!!',
+            '!!',
+            '!!!',
+            '!! @Armande',
+            '!!! #tag1',
         )
 
         for expression in invalid_expressions:


### PR DESCRIPTION
Issue:
------------
  Currently, when creating a task using the shortcut, it is not possible to set multiple priority levels.

Fix:
---------
  With this commit, users will be able to set multiple priority  levels (up to 3) when creating a task using the shortcut syntax.

Supported priority levels:
-----------------
  - 1 star:  task1 @admin #high !
  - 2 stars: task1 @admin #high !!
  - 3 stars: task1 @admin #high !!!

Steps to Reproduce:
--------------
  - Install the Project module.
  - Go to the Project app.
  - In the Kanban view, create a task using the shortcut.
  - Paste the following into the task name field:
     `task1 @admin #high !!!`

task-3935867