### PR TITLE
[FIX] web_editor: restore proper styling for <pre> code blocks

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -572,7 +572,12 @@ blockquote {
     font-style: italic;
 }
 
-pre {
+pre {    
+    padding: map-get($spacers, 2) map-get($spacers, 3);
+    border: $border-width solid $border-color;
+    border-radius: $border-radius;
+    background-color: $gray-100;
+    color: $gray-900;
     white-space: pre-wrap;
 
     p {


### PR DESCRIPTION
Problem:
The `<pre>` tag does not have proper styling in the editor, making code blocks visually inconsistent and harder to read.

Cause:
Styling regression or missing styles after recent updates.

Solution:
Apply the appropriate styling for `<pre>` blocks, aligning with the expected design used in saas-17.4.

Steps to reproduce:
1. Type `/code` in the HTML editor to insert a code block.
2. Observe the code block is missing styling or poorly formatted.

opw-4790406

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
