### PR TITLE
[IMP] mrp: Auto Populate MO's lot_producing_id

### DIFF
--- a/addons/stock/static/src/client_actions/multi_print.js
+++ b/addons/stock/static/src/client_actions/multi_print.js
@@ -25,7 +25,9 @@ async function doMultiPrint(env, action) {
         // handle special cases such as barcode
         action.params.onClose()
     } else {
-        return env.services.action.doAction("reload_context");
+        setTimeout(() => {
+            return env.services.action.doAction("reload_context");
+        }, 66);
     }
 }
 


### PR DESCRIPTION
Marking a manufacturing order as done without a provided/generated lot/serial number raises with the message
"You need to supply a Lot/Serial number for product ...".

We want this information to be populated automatically.

The automatic report printing actions had to be reworked to include these generated lots/serials, as well as the mrp.batch.produce which previously did not handle them.

task: 4595752
