### PR TITLE
[FIX] account: increase dashboard cards min height

### DIFF
--- a/addons/account/static/src/scss/account_journal_dashboard.scss
+++ b/addons/account/static/src/scss/account_journal_dashboard.scss
@@ -5,7 +5,7 @@
     .o_kanban_record {
 
         &:not(.o_kanban_ghost) {
-            min-height: 150px;
+            min-height: 250px;
         }
 
         @include media-breakpoint-up(sm) {


### PR DESCRIPTION
The min height for the kanban journal dashboard in Accounting makes it looks currently like this is an unwanted behavior. This PR slightly increase it to match the cards having graphs on it.

task-4792156

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
