### PR TITLE
[FIX] payment: skip some tests if "account" is not installed

### DIFF
--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -11,6 +11,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_capture_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can capture it. """
+        if 'account' not in self.env["ir.module.module"]._installed():
+            self.skipTest("account module is not installed")
         self.provider.support_manual_capture = True
         tx = self._create_transaction('redirect', state='authorized')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
@@ -18,6 +20,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_void_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can void it. """
+        if 'account' not in self.env["ir.module.module"]._installed():
+            self.skipTest("account module is not installed")
         self.provider.support_manual_capture = True
         tx = self._create_transaction('redirect', state='authorized')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')
@@ -25,6 +29,8 @@ class TestPaymentTransaction(PaymentCommon):
 
     def test_refund_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can refund it. """
+        if 'account' not in self.env["ir.module.module"]._installed():
+            self.skipTest("account module is not installed")
         self.provider.support_refund = 'full_only'
         tx = self._create_transaction('redirect', state='done')
         user = self._prepare_user(self.internal_user, 'account.group_account_invoice')


### PR DESCRIPTION
**Issue:**
Some tests are failing when "account" module is not installed because they use "account.group_account_invoice".

**Solution:**
Skip these tests if "account" module is not installed.

runbot-163123
runbot-163124
runbot-163125




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
