### PR TITLE
[FIX] base: avoid nonetype keyerror

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1615,7 +1615,7 @@ class GroupsView(models.Model):
                     xml4.append(E.group(*right_group))
 
             xml4.append({'class': "o_label_nowrap"})
-            user_type_invisible = f'{user_type_field_name} != {group_employee.id}' if user_type_field_name else None
+            user_type_invisible = f'{user_type_field_name} != {group_employee.id}' if user_type_field_name else ''
 
             for xml_cat in sorted(xml_by_category.keys(), key=lambda it: it[0]):
                 master_category_name = xml_cat[1]


### PR DESCRIPTION
Avoids a KeyError: <class 'NoneType'> in _update_user_groups_view by replacing None with an empty string ('') when user_type_field_name is falsy.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
