### PR TITLE
[FIX] hr_holidays : Correctly calculate future accrual allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -413,6 +413,7 @@ class HolidaysAllocation(models.Model):
         already_accrued = {allocation.id: allocation.already_accrued or (allocation.number_of_days != 0 and allocation.accrual_plan_id.accrued_gain_time == 'start') for allocation in self}
         first_allocation = _("""This allocation have already ran once, any modification won't be effective to the days allocated to the employee. If you need to change the configuration of the allocation, delete and create a new one.""")
         for allocation in self:
+            expiration_date = False
             level_ids = allocation.accrual_plan_id.level_ids.sorted('sequence')
             if not level_ids:
                 continue
@@ -507,6 +508,8 @@ class HolidaysAllocation(models.Model):
                 if allocation.nextcall == carryover_date:
                     allocation.last_executed_carryover_date = carryover_date
                     if current_level.action_with_unused_accruals in ['lost', 'maximum']:
+                        if current_level != first_level or (nextcall == expiration_date and allocation.number_of_days - leaves_taken == 0):
+                            allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, period_end)
                         allocated_days_left = allocation.number_of_days - leaves_taken
                         allocation_max_days = 0 # default if unused_accrual are lost
                         if current_level.action_with_unused_accruals == 'maximum':
@@ -587,7 +590,9 @@ class HolidaysAllocation(models.Model):
                         current_level_maximum_leave = current_level.maximum_leave
                     else:
                         current_level_maximum_leave = current_level.maximum_leave / allocation.employee_id._get_hours_per_day(allocation.date_from)
-                if allocation.actual_lastcall in {period_start, allocation.date_from} | set(level_start.keys()):
+                if allocation.actual_lastcall in {period_start, allocation.date_from} | set(level_start.keys())\
+                        or (allocation.actual_lastcall - get_timedelta(current_level.accrual_validity_count, current_level.accrual_validity_type)
+                            in {period_start, allocation.date_from} | set(level_start.keys())):
                     allocation._add_days_to_allocation(current_level, current_level_maximum_leave, leaves_taken, period_start, allocation.nextcall)
                     allocation.already_accrued = True
 

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -3918,3 +3918,98 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             leave.action_validate()
             allocation_data = leave_type_day.get_allocation_data(self.employee_emp)
             self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 1)
+
+    def test_accrual_allocation_date_in_the_future(self):
+        vals = {
+            'accrual_validity': True,
+            'accrual_validity_count': 6,
+            'accrual_validity_type': 'month',
+            'accrued_gain_time': 'start',
+            'action_with_unused_accruals': 'maximum',
+            'cap_accrued_time_yearly': False,
+            'frequency': 'yearly',
+            'postpone_max_days': 5,
+            'week_day': 'mon',
+        }
+        accrual_plan = self.env['hr.leave.accrual.plan'].create({
+            'name': 'Test accrual plan',
+            'is_based_on_worked_time': False,
+            'accrued_gain_time': 'start',
+            'level_ids': [(0, 0, {
+                **vals,
+                'added_value': 20,
+                'start_count': 0,
+                'start_type': 'day',
+                'maximum_leave': 25,
+            }),
+            (0, 0, {
+                **vals,
+                'added_value': 21,
+                'start_count': 2,
+                'start_type': 'year',
+                'maximum_leave': 26,
+            }),
+            (0, 0, {
+                **vals,
+                'added_value': 22,
+                'start_count': 4,
+                'start_type': 'year',
+                'maximum_leave': 27,
+            }),
+            (0, 0, {
+               **vals,
+                'added_value': 23,
+                'start_count': 6,
+                'start_type': 'year',
+                'maximum_leave': 28,
+            })]
+        })
+
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Test Leave Type',
+            'time_type': 'leave',
+            'requires_allocation': 'yes',
+            'allocation_validation_type': 'no_validation',
+            'request_unit': 'day',
+        })
+
+        allocation = self.env['hr.leave.allocation'].create({
+            'name': 'Accrual allocation for employee',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': leave_type.id,
+            'number_of_days': 20,
+            'allocation_type': 'accrual',
+            'accrual_plan_id': accrual_plan.id,
+            'date_from': '2025-01-01',
+        })
+        allocation.action_validate()
+        # Test after one year "Didn't get to any level yet"
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2026-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 25, "The carryover did not expire yet so the remaining leaves should be 25")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2026-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 20, "The carryover expired after 6 month so the remaining leaves should be 20")
+        # Test after two years
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2027-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2027-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
+        # Test after three years
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2028-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 26, "The carryover did not expire yet so the remaining leaves should be 26")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2028-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 21, "The carryover expired after 6 month so the remaining leaves should be 21")
+        # Test after four years
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2029-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2029-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
+        # Test after five years
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2030-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 27, "The carryover did not expire yet so the remaining leaves should be 27")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2030-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 22, "The carryover expired after 6 month so the remaining leaves should be 22")
+        # Test after six years
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2031-03-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 28, "The carryover did not expire yet so the remaining leaves should be 28")
+        allocation_data = leave_type.get_allocation_data(self.employee_emp, '2031-09-01')
+        self.assertEqual(allocation_data[self.employee_emp][0][1]['virtual_remaining_leaves'], 23, "The carryover expired after 6 month so the remaining leaves should be 23")


### PR DESCRIPTION
### Steps to reproduce:
	- Create an accrual plan with the following rule: 
	— The employee has 20 days off in the first year. Total 20. 
	— The employee has 21 days off in the second year and an additional 5 days off if available from the previous year, which can be taken until 6 months. Total 21 + 5 = 26 
	— The employee has 22 days off in the third year and an additional 5 days off if available from the previous year, which can be taken until 6 months. Total 22 + 5 = 27 
	— The employee has 23 days off in the fourth year and an additional 5 days off if available from the previous year, which can be taken until 6 months. Total 23 + 5 = 28
	- Create an accrual allocation with the created plan
	- Check future allocation data using 'Balance at the'
	- Notice the following behaviour: — until 31/12/2025 it CORRECTLY shows 20 days available.

		— from 01/01/2026 to 30/06/2026 it CORRECTLY shows 26 days (21 days for renewal and 5 days not used in 2025)
		— from 01/07/2026 it INCORRECTLY shows no days available.

		— from 01/01/2027 to 30/06/2027 it CORRECTLY shows 27 days (22 days for renewal and 5 days not used in 2026)
		— from 01/07/2027 it INCORRECTLY shows 5 days.

		— from 01/01/2028 to 30/06/2028 it CORRECTLY shows 28 days (23 days for renewal and 5 days not used in 2027)
		— from 01/07/2028 it INCORRECTLY shows no days available.

		— from 01/01/2029 it CORRECTLY shows 28 days again.
		— In the following years, after 6 months, one year shows 5 days and the next shows nothing.

### Cause:
The first cause here is that when we have validity for the carryover then we will have two calls in each year one at the start of the year and another at the expiration date of the carryover. So, when we add the days to the allocation we don't consider the second call in the condition and we only check if the allocation.actual_lastcall is equal to one of the start dates for each year

https://github.com/odoo/odoo/blob/3fb37cbc59adc2caace8efcdae418d2466a9b750/addons/hr_holidays/models/hr_leave_allocation.py#L588

The second cause where each two years one of them shows the number of carryover days from the previous year, this is happening because when we remove the expiring days for the first year we set the number of days to 0

https://github.com/odoo/odoo/blob/3fb37cbc59adc2caace8efcdae418d2466a9b750/addons/hr_holidays/models/hr_leave_allocation.py#L516-L517

And it will be 0 until we loop again and add the days to allocation

https://github.com/odoo/odoo/blob/3fb37cbc59adc2caace8efcdae418d2466a9b750/addons/hr_holidays/models/hr_leave_allocation.py#L521-L522

and since this is happening after we already set the expiring days which in this year will be 0 we won't remove those expiring days from the year's allocation data

### Fix:
We add a condition to check if the actual_lastcall is either a date in the start of the allocation or one of the expiration dates for the carryover.

Also, before we set the value of the expiring_carryover_days we call _add_days_to_allocation to calculate on the correct number of days for the plan level we are checking.

opw-4606886