### PR TITLE
[FIX] survey: fix button in conditional flow

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -765,8 +765,9 @@ class Survey(models.Model):
             elif self.questions_layout == 'page_per_section':
                 is_triggering_section = False
                 for question in page_or_question.question_ids:
-                    if any(triggering_answer in triggered_questions_by_answer.keys() for triggering_answer in
-                           question.suggested_answer_ids):
+                    if any(triggering_answer in triggered_questions_by_answer
+                           and page_or_question.sequence < max(triggered_questions_by_answer[triggering_answer].page_id.mapped('sequence'))
+                           for triggering_answer in question.suggested_answer_ids):
                         is_triggering_section = True
                         break
                 next_active_question = False

--- a/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
+++ b/addons/survey/static/tests/tours/survey_conditional_questions_on_different_page.js
@@ -47,6 +47,17 @@ registry.category("web_tour.tours").add('test_survey_conditional_question_on_dif
             content: 'Check that Q3 is now visible again',
             trigger: 'div.js_question-wrapper:contains("Q3")',
             isCheck: true,
+        }, {
+            content: 'Check that button is going to next page (Q4 is triggered)',
+            trigger: 'button[value="next"]',
+            isCheck: true,
+        }, {
+            content: 'Answer Q2 with Answer 2',
+            trigger: 'div.js_question-wrapper:contains("Q2") label:contains("Answer 2")',
+        }, {
+            content: 'Check that button is ending the survey (Q4 is not active)',
+            trigger: 'button[value="finish"]',
+            isCheck: true,
         }
     ],
 });

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -270,7 +270,17 @@ class TestUiFeedback(HttpCaseWithUserDemo):
                     'constr_mandatory': False,
                 }), Command.create({
                     'title': 'Q3',
-                    'sequence': 3,
+                    'sequence': 5,
+                    'question_type': 'numerical_box',
+                    'constr_mandatory': False,
+                }), Command.create({
+                    'title': 'Section 3',
+                    'is_page': True,
+                    'sequence': 6,
+                    'question_type': False,
+                }), Command.create({
+                    'title': 'Q4',
+                    'sequence': 7,
                     'question_type': 'numerical_box',
                     'constr_mandatory': False,
                 }),
@@ -284,8 +294,10 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         q2_a1 = q2.suggested_answer_ids.filtered(lambda a: a.value == 'Answer 1')
 
         q3 = survey_with_trigger_on_different_page.question_ids.filtered(lambda q: q.title == 'Q3')
-
         q3.triggering_answer_ids = q1_a1 | q2_a1
+
+        q4 = survey_with_trigger_on_different_page.question_ids.filtered(lambda q: q.title == 'Q4')
+        q4.triggering_answer_ids = q2_a1
 
         access_token = survey_with_trigger_on_different_page.access_token
         self.start_tour("/survey/start/%s" % access_token, 'test_survey_conditional_question_on_different_page')


### PR DESCRIPTION
Purpose
=======
Fix the survey submit button which is marked "Continue" even though submitting the answers is ending the survey.

Specification
=============
If a question can trigger a conditional question but not necessarily, for example selecting A will trigger another question but selecting B won't, the survey button will be labelled "Continue" no matter what. This can lead to strange behavior when the question is the last of the survey as selecting B and clicking "Continue" will end the survey.

=> Fixing that by updating the survey button label and behavior depending on the selected answers, the potential conditional questions and the survey layout.

In "one_page" layout, the button will always be "Submit" no matter what. The fix isn't applied to this layout.

In "page_per_section", the survey button will be updated to "Submit" if the page selected answers don't lead to any conditional question on the following pages and if the current page is, in that case, considered the last.

In "page_per_question", the survey button will be updated to "Submit" if the question selected answers don't lead to any following questions and if the current question is, in that case, considered the last.

Task-4792193

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
