### PR TITLE
[FIX] survey: fix traceback on checking question options

### DIFF
--- a/addons/survey/models/survey_question.py
+++ b/addons/survey/models/survey_question.py
@@ -70,6 +70,9 @@ class SurveyQuestion(models.Model):
     scoring_type = fields.Selection(related='survey_id.scoring_type', string='Scoring Type', readonly=True)
     sequence = fields.Integer('Sequence', default=10)
     session_available = fields.Boolean(related='survey_id.session_available', string='Live Session available', readonly=True)
+    survey_session_speed_rating = fields.Boolean(related="survey_id.session_speed_rating")
+    survey_session_speed_rating_time_limit = fields.Integer(related="survey_id.session_speed_rating_time_limit", string="General Time limit (seconds)")
+
     # page specific
     is_page = fields.Boolean('Is a page?')
     question_ids = fields.One2many('survey.question', string='Questions', compute="_compute_question_ids")

--- a/addons/survey/views/survey_question_views.xml
+++ b/addons/survey/views/survey_question_views.xml
@@ -272,11 +272,11 @@
                                         <field name="is_time_limited" nolabel="1" class="oe_inline"
                                             widget="boolean_update_flag"
                                             options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating}"/>
+                                            context="{'referenceValue': survey_session_speed_rating}"/>
                                         <field name="time_limit" nolabel="1" class="oe_inline"
                                             widget="integer_update_flag"
                                             options="{'flagFieldName': 'is_time_customized'}"
-                                            context="{'referenceValue': parent.session_speed_rating_time_limit}"
+                                            context="{'referenceValue': survey_session_speed_rating_time_limit}"
                                             invisible="not is_time_limited" />
                                     </div>
                                 </group>


### PR DESCRIPTION
The issue concerns surveys with a live session available ('live_session' and 'custom' types).

When you want to consult the options of a question:
- if you do it from the survey's form view, no problem
- if you do it from the navbar's 'Questions and Answers' menu, you'll get an EvalError indicating that the name 'parent' is not defined.

'parent' here refers to a survey container record and works only inside sub-views of relational fields.

To fix it, we replace calls to 'parent.field' by related fields, added on the suvey_question model.

task-4592388