### PR TITLE
[FIX] l10n_za: remove type in tax report

### DIFF
--- a/addons/l10n_za/data/account_tax_report_data.xml
+++ b/addons/l10n_za/data/account_tax_report_data.xml
@@ -130,7 +130,7 @@
                                 <field name="aggregation_formula">(VAT5.balance * 0.6) + VAT7.balance</field>
                             </record>
                             <record id="vat_on_accomodation_28_days" model="account.report.line">
-                                <field name="name">[9] x 15 / (100 ??) </field>
+                                <field name="name">[9] x 15 / 100 </field>
                                 <field name="aggregation_formula">SEC6.balance * 0.6 + SEC7.balance </field>
                                 <field name="children_ids">
                                     <record id="vat_on_accomodation_exceeding_28_days" model="account.report.line">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This commit removes the typo (question marks) in the tax report in South Africa localization.

task-4789823


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
