### PR TITLE
[FIX] account: Propagate product tags on tax lines

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1498,8 +1498,10 @@ class AccountTax(models.Model):
                 for tag_id in tax_data[base_tags_field]:
                     base_tags_ids.add(tag_id)
         base_tags = self.env['account.account.tag'].browse(list(base_tags_ids))
+        product_tags = self.env['account.account.tag']
         if product:
-            base_tags |= product.sudo().account_tag_ids
+            product_tags = product.sudo().account_tag_ids
+            base_tags |= product_tags
 
         # Convert id to records.
         taxes_data = taxes_computation['taxes_data']
@@ -1512,7 +1514,7 @@ class AccountTax(models.Model):
                 'tax': tax,
                 'group': group,
                 'taxes': subsequent_taxes,
-                'tags': subsequent_tags,
+                'tags': subsequent_tags | product_tags,
             })
 
         # Repartition lines.

--- a/addons/account/tests/test_invoice_taxes.py
+++ b/addons/account/tests/test_invoice_taxes.py
@@ -894,3 +894,51 @@ class TestInvoiceTaxes(AccountTestInvoicingCommon):
         self.assertRecordValues(receivable_line, [
             {'amount_currency': 1410.02, 'balance': 705.02},
         ])
+
+    def test_product_account_tags(self):
+        product_tag = self.env['account.account.tag'].create({
+            'name': "Pikachu",
+            'applicability': 'products',
+        })
+        self.product_a.account_tag_ids = [Command.set(product_tag.ids)]
+
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2025-01-01',
+            'partner_id': self.partner_a.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'test with product tag',
+                    'product_id': self.product_a.id,
+                    'price_unit': 1000,
+                    'tax_ids': self.percent_tax_1.ids,
+                }),
+                Command.create({
+                    'name': 'test with product tag',
+                    'product_id': self.product_b.id,
+                    'price_unit': 100,
+                    'tax_ids': self.percent_tax_1.ids,
+                }),
+                Command.create({
+                    'name': 'test without product tag',
+                    'product_id': self.product_b.id,
+                    'price_unit': 200,
+                    'tax_ids': self.percent_tax_2.ids,
+                }),
+            ]
+        })
+
+        invoice.action_post()
+
+        self.assertRecordValues(
+            invoice.line_ids,
+            [
+                {'tax_ids': self.percent_tax_1.ids, 'tax_line_id': False,                 'tax_tag_ids': product_tag.ids,  'credit': 1000, 'debit': 0},
+                {'tax_ids': self.percent_tax_1.ids, 'tax_line_id': False,                 'tax_tag_ids': [],               'credit': 100,  'debit': 0},
+                {'tax_ids': self.percent_tax_2.ids, 'tax_line_id': False,                 'tax_tag_ids': [],               'credit': 200,  'debit': 0},
+                {'tax_ids': [],                     'tax_line_id': self.percent_tax_1.id, 'tax_tag_ids': product_tag.ids,  'credit': 210,  'debit': 0},
+                {'tax_ids': [],                     'tax_line_id': self.percent_tax_1.id, 'tax_tag_ids': [],               'credit': 21,   'debit': 0},
+                {'tax_ids': [],                     'tax_line_id': self.percent_tax_2.id, 'tax_tag_ids': [],               'credit': 24,   'debit': 0},
+                {'tax_ids': [],                     'tax_line_id': False,                 'tax_tag_ids': [],               'credit': 0,    'debit': 1555},
+            ],
+        )


### PR DESCRIPTION
If a tag is set on a product, it has to be propagated on the base and the tax lines. It was only set on the base line before this fix.

task_id: 4789153

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
