### PR TITLE
[FIX] iot_box_image: increace /tmp size

### DIFF
--- a/addons/iot_box_image/configuration/setup_ramdisks.sh
+++ b/addons/iot_box_image/configuration/setup_ramdisks.sh
@@ -16,9 +16,11 @@ create_ramdisk () {
 }
 
 echo "Creating ramdisks..."
+# Note: As of 2025 we are using 2 Gb ram rpi4 as basic IoT Boxes.
+# The 2 Gb limit applies here
 create_ramdisk "/var" "192M"
-create_ramdisk "/etc" "16M"
-create_ramdisk "/tmp" "64M"
+create_ramdisk "/etc" "64M"
+create_ramdisk "/tmp" "1G" # big size necessary for chromium kiosk usage
 
 # bind mount / so that we can get to the real /var and /etc
 mount --bind / /root_bypass_ramdisks


### PR DESCRIPTION
Currently Chromium generates a lot of temporary files like .org.chromium.Chromium.0ouinx in /tmp directory

This leads to the kiosk using IoT Boxes being non responsive and eventually having issues/crashing

This PR increases the size of /tmp directory following the recommendation of it being half the size of the ram (which is 2GB for our rpi 4)

We also increase /etc directory size to allow more cups storage where it it used

Recommendation link: https://docs.aws.amazon.com/linux/al2023/ug/filesystem-slash-tmp.html
