### PR TITLE
[IMP] payment: replace exceptions bubbling with state-based error reporting

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -135,7 +135,7 @@ class AccountPayment(models.Model):
         res = super(AccountPayment, self - payments_need_tx).action_post()
 
         for tx in transactions:  # Process the transactions with a payment by token
-            tx._send_payment_request()
+            tx._charge_with_token()
 
         # Post payments for issued transactions
         transactions._post_process()

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -66,7 +66,7 @@ class PaymentTransaction(models.Model):
     #=== BUSINESS METHODS - PAYMENT FLOW ===#
 
     @api.model
-    def _compute_reference_prefix(self, provider_code, separator, **values):
+    def _compute_reference_prefix(self, separator, **values):
         """ Compute the reference prefix from the transaction values.
 
         If the `values` parameter has an entry with 'invoice_ids' as key and a list of (4, id, O) or
@@ -75,7 +75,6 @@ class PaymentTransaction(models.Model):
 
         Note: This method should be called in sudo mode to give access to documents (INV, SO, ...).
 
-        :param str provider_code: The code of the provider handling the transaction
         :param str separator: The custom separator used to separate data references
         :param dict values: The transaction values used to compute the reference prefix. It should
                             have the structure {'invoice_ids': [(X2M command), ...], ...}.
@@ -92,7 +91,7 @@ class PaymentTransaction(models.Model):
                 if name := values.get('name_next_installment'):
                     prefix = name
                 return prefix
-        return super()._compute_reference_prefix(provider_code, separator, **values)
+        return super()._compute_reference_prefix(separator, **values)
 
     #=== BUSINESS METHODS - POST-PROCESSING ===#
 
@@ -123,9 +122,8 @@ class PaymentTransaction(models.Model):
 
             if tx.payment_id:
                 message = _(
-                    "The payment related to the transaction with reference %(ref)s has been"
-                    " posted: %(link)s",
-                    ref=tx.reference,
+                    "The payment related to transaction %(ref)s has been posted: %(link)s",
+                    ref=tx._get_html_link(),
                     link=tx.payment_id._get_html_link(),
                 )
                 tx._log_message_on_linked_documents(message)

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -145,7 +145,7 @@ class TestAccountPayment(AccountPaymentCommon):
 
         with patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._send_payment_request'
+            '._charge_with_token'
         ) as patched:
             payment_without_token.action_post()
             patched.assert_not_called()

--- a/addons/account_payment/wizards/payment_refund_wizard.py
+++ b/addons/account_payment/wizards/payment_refund_wizard.py
@@ -80,5 +80,5 @@ class PaymentRefundWizard(models.TransientModel):
             wizard.has_pending_refund = pending_refunds_count > 0
 
     def action_refund(self):
-        for wizard in self:
-            wizard.transaction_id.action_refund(amount_to_refund=wizard.amount_to_refund)
+        self.ensure_one()
+        return self.transaction_id.action_refund(amount_to_refund=self.amount_to_refund)

--- a/addons/delivery/models/payment_provider.py
+++ b/addons/delivery/models/payment_provider.py
@@ -11,6 +11,17 @@ class PaymentProvider(models.Model):
 
     custom_mode = fields.Selection(selection_add=[('cash_on_delivery', 'Cash On Delivery')])
 
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.custom_mode != 'cash_on_delivery':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
+    # === BUSINESS METHODS === #
+
     @api.model
     def _get_compatible_providers(self, *args, sale_order_id=None, report=None, **kwargs):
         """ Override of payment to exclude COD providers if the delivery method doesn't match.
@@ -38,10 +49,3 @@ class PaymentProvider(models.Model):
             )
 
         return compatible_providers
-
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
-        if self.custom_mode != 'cash_on_delivery':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES

--- a/addons/payment/const.py
+++ b/addons/payment/const.py
@@ -5,6 +5,8 @@ from odoo.tools.translate import LazyTranslate
 
 _lt = LazyTranslate(__name__, default_lang='en_US')
 
+# The keys that are sensitive and should not be logged.
+SENSITIVE_KEYS = set()
 
 # According to https://en.wikipedia.org/wiki/ISO_4217#Minor_unit_fractions
 CURRENCY_MINOR_UNITS = {

--- a/addons/payment/logging.py
+++ b/addons/payment/logging.py
@@ -1,0 +1,90 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import re
+
+
+class SensitiveDataFilter(logging.Filter):
+
+    def __init__(self, sensitive_keys):
+        super().__init__()
+        if sensitive_keys is None:
+            self._sensitive_keys = set()
+        else:
+            self._sensitive_keys = sensitive_keys
+        self._compile_patterns()
+
+    def _compile_patterns(self):
+        """Precompile regex patterns for all sensitive keys, matching double/single-quoted JSON
+        entries.
+
+        :return: None
+        """
+        self._patterns = []
+        for key in self._sensitive_keys:
+            # 1st group: "<key>" or '<key>'
+            # 2nd group: The quote char for the value
+            pattern = re.compile(rf'([\'"]{key}[\'"])\s*:\s*([\'"])([^\'"]+)\2')
+            self._patterns.append(pattern)
+
+    def filter(self, record):
+        """Override of `logging` to mask any sensitive data in record.args before the record is
+        emitted. Always returns True to allow the record through.
+
+        :return: True
+        :rtype: bool
+        """
+        if len(self._patterns) != len(self._sensitive_keys):  # If keys changed.
+            self._compile_patterns()  # Recompile the patterns.
+
+        record.args = self._mask(record.args)
+        return True
+
+    def _mask(self, data):
+        """Recursively mask dicts, iterables, and strings.
+
+        :param data: The data to mask.
+        :return: The masked data.
+        """
+        if isinstance(data, dict):
+            masked_dict = {}
+            for k, v in data.items():
+                masked_dict[k] = "[REDACTED]" if k in self._sensitive_keys else self._mask(v)
+            return masked_dict
+        if isinstance(data, (list, tuple, set)):
+            cls = type(data)
+            return cls(self._mask(v) for v in data)
+        if isinstance(data, str):
+            return self._mask_string(data)
+        return data
+
+    def _mask_string(self, text):
+        """Apply each pattern, replacing the value with [REDACTED].
+
+        :param str text: The string to mask.
+        :return: The masked string.
+        :rtype: str
+        """
+        def replace(m):
+            # 1st group: "<key>" or '<key>'
+            # 2nd group: The quote char for the value
+            quote = m.group(2)
+            return f"{m.group(1)}: {quote}[REDACTED]{quote}"
+
+        for pattern in self._patterns:
+            text = re.sub(pattern, replace, text)
+        return text
+
+
+def get_payment_logger(name, sensitive_keys=None):
+    """Return a logger with a SensitiveDataFilter added if sensitive keys are provided.
+
+    :param str name: The name of the logger.
+    :param set sensitive_keys: The keys of the payment data that should not be logged.
+    :return: The logger.
+    :rtype: logging.Logger
+    """
+    logger = logging.getLogger(name)
+    if sensitive_keys is not None:
+        logger.addFilter(SensitiveDataFilter(sensitive_keys))
+    return logger

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -106,7 +106,7 @@ class PaymentMethod(models.Model):
         context={'active_test': False},
     )
 
-    #=== COMPUTE METHODS ===#
+    # === COMPUTE METHODS === #
 
     def _compute_is_primary(self):
         for payment_method in self:
@@ -117,7 +117,7 @@ class PaymentMethod(models.Model):
             return NotImplemented
         return [('primary_payment_method_id', operator, [False])]
 
-    #=== ONCHANGE METHODS ===#
+    # === ONCHANGE METHODS === #
 
     @api.onchange('active', 'provider_ids', 'support_tokenization')
     def _onchange_warn_before_disabling_tokens(self):
@@ -188,7 +188,7 @@ class PaymentMethod(models.Model):
                 " manual capture activated: %s", ", ".join(incompatible_pms.mapped('name'))
             ))
 
-    #=== CRUD METHODS ===#
+    # === CRUD METHODS === #
 
     def write(self, vals):
         # Handle payment methods being archived, detached from providers, or blocking tokenization.

--- a/addons/payment/models/payment_token.py
+++ b/addons/payment/models/payment_token.py
@@ -35,14 +35,14 @@ class PaymentToken(models.Model):
     )
     active = fields.Boolean(string="Active", default=True)
 
-    #=== COMPUTE METHODS ===#
+    # === COMPUTE METHODS === #
 
     @api.depends('payment_details', 'create_date')
     def _compute_display_name(self):
         for token in self:
             token.display_name = token._build_display_name()
 
-    #=== CRUD METHODS ===#
+    # === CRUD METHODS === #
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -113,7 +113,7 @@ class PaymentToken(models.Model):
         """
         return
 
-    #=== BUSINESS METHODS ===#
+    # === BUSINESS METHODS === #
 
     def _get_available_tokens(self, providers_ids, partner_id, is_validation=False, **kwargs):
         """ Return the available tokens linked to the given providers and partner.

--- a/addons/payment/static/src/js/payment_form.js
+++ b/addons/payment/static/src/js/payment_form.js
@@ -375,6 +375,13 @@ publicWidget.registry.PaymentForm = publicWidget.Widget.extend({
             this.paymentContext['transactionRoute'],
             this._prepareTransactionRouteParams(),
         ).then(processingValues => {
+            if (processingValues.state === 'error') {
+                this._displayErrorDialog(
+                    _t("Payment processing failed"), processingValues.state_message
+                );
+                this._enableButton(); // The button has been disabled before initiating the flow.
+                return;
+            }
             if (flow === 'redirect') {
                 this._processRedirectFlow(
                     providerCode, paymentOptionId, paymentMethodCode, processingValues

--- a/addons/payment/tests/test_flows.py
+++ b/addons/payment/tests/test_flows.py
@@ -347,7 +347,7 @@ class TestFlows(PaymentHttpCommon):
         self.user = self.portal_user
         with patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._send_payment_request'
+            '._charge_with_token'
         ) as patched:
             self._portal_transaction(
                 **self._prepare_transaction_values(self.payment_method_id, None, 'direct')
@@ -361,7 +361,7 @@ class TestFlows(PaymentHttpCommon):
         self.user = self.portal_user
         with patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._send_payment_request'
+            '._charge_with_token'
         ) as patched:
             self._portal_transaction(
                 **self._prepare_transaction_values(self.payment_method_id, None, 'redirect')
@@ -375,7 +375,7 @@ class TestFlows(PaymentHttpCommon):
         self.user = self.portal_user
         with patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._send_payment_request'
+            '._charge_with_token'
         ) as patched:
             self._portal_transaction(
                 **self._prepare_transaction_values(None, self._create_token().id, 'token')

--- a/addons/payment/wizards/payment_capture_wizard.py
+++ b/addons/payment/wizards/payment_capture_wizard.py
@@ -36,7 +36,7 @@ class PaymentCaptureWizard(models.TransientModel):
     has_draft_children = fields.Boolean(compute='_compute_has_draft_children')
     has_remaining_amount = fields.Boolean(compute='_compute_has_remaining_amount')
 
-    #=== COMPUTE METHODS ===#
+    # === COMPUTE METHODS === #
 
     @api.depends('transaction_ids')
     def _compute_authorized_amount(self):
@@ -106,7 +106,7 @@ class PaymentCaptureWizard(models.TransientModel):
             if not wizard.has_remaining_amount:
                 wizard.void_remaining_amount = False
 
-    #=== CONSTRAINT METHODS ===#
+    # === CONSTRAINT METHODS === #
 
     @api.constrains('amount_to_capture')
     def _check_amount_to_capture_within_boundaries(self):
@@ -126,29 +126,36 @@ class PaymentCaptureWizard(models.TransientModel):
                     "Handle the transactions individually to capture a partial amount."
                 ))
 
-    #=== ACTION METHODS ===#
+    # === ACTION METHODS === #
 
     def action_capture(self):
-        for wizard in self:
-            remaining_amount_to_capture = wizard.amount_to_capture
-            for source_tx in wizard.transaction_ids.filtered(lambda tx: tx.state == 'authorized'):
-                partial_capture_child_txs = wizard.transaction_ids.child_transaction_ids.filtered(
-                    lambda tx: tx.source_transaction_id == source_tx and tx.state == 'done'
-                )  # We can void all the remaining amount only at once => don't check cancel state.
-                source_tx_remaining_amount = source_tx.currency_id.round(
-                    source_tx.amount - sum(partial_capture_child_txs.mapped('amount'))
-                )
-                if remaining_amount_to_capture:
-                    amount_to_capture = min(source_tx_remaining_amount, remaining_amount_to_capture)
-                    # In sudo mode because we need to be able to read on provider fields.
-                    source_tx.sudo()._send_capture_request(amount_to_capture=amount_to_capture)
-                    remaining_amount_to_capture -= amount_to_capture
-                    source_tx_remaining_amount -= amount_to_capture
+        self.ensure_one()
 
-                if source_tx_remaining_amount and wizard.void_remaining_amount:
-                    # The source tx isn't fully captured and the user wants to void the remaining.
-                    # In sudo mode because we need to be able to read on provider fields.
-                    source_tx.sudo()._send_void_request(amount_to_void=source_tx_remaining_amount)
-                elif not remaining_amount_to_capture and not wizard.void_remaining_amount:
-                    # The amount to capture has been completely captured.
-                    break  # Skip the remaining transactions.
+        remaining_amount_to_capture = self.amount_to_capture
+        processed_txs_sudo = self.env['payment.transaction'].sudo()
+        for source_tx in self.transaction_ids.filtered(lambda tx: tx.state == 'authorized'):
+            partial_capture_child_txs = self.transaction_ids.child_transaction_ids.filtered(
+                lambda tx: tx.source_transaction_id == source_tx and tx.state == 'done'
+            )  # We can void all the remaining amount only at once => don't check cancel state.
+            source_tx_remaining_amount = source_tx.currency_id.round(
+                source_tx.amount - sum(partial_capture_child_txs.mapped('amount'))
+            )
+            if remaining_amount_to_capture:
+                amount_to_capture = min(source_tx_remaining_amount, remaining_amount_to_capture)
+                # In sudo mode because we need to be able to read on provider fields.
+                processed_txs_sudo |= source_tx.sudo()._capture(
+                    amount_to_capture=amount_to_capture
+                )
+                remaining_amount_to_capture -= amount_to_capture
+                source_tx_remaining_amount -= amount_to_capture
+
+            if source_tx_remaining_amount and self.void_remaining_amount:
+                # The source tx isn't fully captured and the user wants to void the remaining.
+                # In sudo mode because we need to be able to read on provider fields.
+                processed_txs_sudo |= source_tx.sudo()._void(
+                    amount_to_void=source_tx_remaining_amount
+                )
+            elif not remaining_amount_to_capture and not self.void_remaining_amount:
+                # The amount to capture has been completely captured.
+                break  # Skip the remaining transactions.
+        return processed_txs_sudo._build_action_feedback_notification()

--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -1,19 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import logging
 import re
 
-import requests
-
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_adyen import const
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentProvider(models.Model):
@@ -40,7 +37,7 @@ class PaymentProvider(models.Model):
         required_if_provider='adyen',
     )
 
-    #=== CRUD METHODS ===#
+    # === CRUD METHODS === #
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -51,6 +48,13 @@ class PaymentProvider(models.Model):
     def write(self, vals):
         self._adyen_extract_prefix_from_api_url(vals)
         return super().write(vals)
+
+    def _get_default_payment_method_codes(self):
+        """Override of `payment` to return the default payment method codes."""
+        self.ensure_one()
+        if self.code != 'adyen':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
 
     @api.model
     def _adyen_extract_prefix_from_api_url(self, values):
@@ -64,7 +68,7 @@ class PaymentProvider(models.Model):
                 r'(?:https://)?(\w+-\w+).*', r'\1', values['adyen_api_url_prefix']
             )
 
-    #=== COMPUTE METHODS ===#
+    # === COMPUTE METHODS === #
 
     def _compute_feature_support_fields(self):
         """ Override of `payment` to enable additional features. """
@@ -75,80 +79,7 @@ class PaymentProvider(models.Model):
             'support_tokenization': True,
         })
 
-    #=== BUSINESS METHODS - PAYMENT FLOW ===#
-
-    def _adyen_make_request(self, endpoint, endpoint_param=None, payload=None, method='POST', idempotency_key=None):
-        """ Make a request to Adyen API at the specified endpoint.
-
-        Note: self.ensure_one()
-
-        :param str endpoint: The endpoint to be reached by the request
-        :param str endpoint_param: A variable required by some endpoints which are interpolated with
-                                   it if provided. For example, the provider reference of the source
-                                   transaction for the '/payments/{}/refunds' endpoint.
-        :param dict payload: The payload of the request
-        :param str method: The HTTP method of the request
-        :param str idempotency_key: The idempotency key to pass in the request.
-        :return: The JSON-formatted content of the response
-        :rtype: dict
-        :raise: ValidationError if an HTTP error occurs
-        """
-
-        def _build_url(prefix_, version_, endpoint_):
-            """ Build an API URL by appending the version and endpoint to a base URL.
-
-            The final URL follows this pattern: `<_base>/V<_version>/<_endpoint>`.
-
-            :param str prefix_: The API URL prefix of the account.
-            :param int version_: The version of the endpoint.
-            :param str endpoint_: The endpoint of the URL.
-            :return: The final URL.
-            :rtype: str
-            """
-            prefix_ = prefix_.rstrip('/')  # Remove potential trailing slash
-            endpoint_ = endpoint_.lstrip('/')  # Remove potential leading slash
-            test_mode_ = self.state == 'test'
-            prefix_ = f'{prefix_}.adyen' if test_mode_ else f'{prefix_}-checkout-live.adyenpayments'
-            return f'https://{prefix_}.com/checkout/V{version_}/{endpoint_}'
-
-        self.ensure_one()
-
-        version = const.API_ENDPOINT_VERSIONS[endpoint]
-        endpoint = endpoint if not endpoint_param else endpoint.format(endpoint_param)
-        url = _build_url(self.adyen_api_url_prefix, version, endpoint)
-        headers = {'X-API-Key': self.adyen_api_key}
-        if method == 'POST' and idempotency_key:
-            headers['idempotency-key'] = idempotency_key
-        try:
-            response = requests.request(method, url, json=payload, headers=headers, timeout=60)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                _logger.exception(
-                    "invalid API request at %s with data %s: %s", url, payload, response.text
-                )
-                msg = response.json().get('message', '')
-                raise ValidationError(
-                    "Adyen: " + _("The communication with the API failed. Details: %s", msg)
-                )
-        except requests.exceptions.ConnectionError:
-            _logger.exception("unable to reach endpoint at %s", url)
-            raise ValidationError("Adyen: " + _("Could not establish the connection to the API."))
-        return response.json()
-
-    def _adyen_compute_shopper_reference(self, partner_id):
-        """ Compute a unique reference of the partner for Adyen.
-
-        This is used for the `shopperReference` field in communications with Adyen and stored in the
-        `adyen_shopper_reference` field on `payment.token` if the payment method is tokenized.
-
-        :param recordset partner_id: The partner making the transaction, as a `res.partner` id
-        :return: The unique reference for the partner
-        :rtype: str
-        """
-        return f'ODOO_PARTNER_{partner_id}'
-
-    #=== BUSINESS METHODS - GETTERS ===#
+    # === BUSINESS METHODS === #
 
     def _adyen_get_inline_form_values(self, pm_code, amount=None, currency=None):
         """ Return a serialized JSON of the required values to render the inline form.
@@ -189,9 +120,50 @@ class PaymentProvider(models.Model):
             'currency': currency_code,
         }
 
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+    def _adyen_compute_shopper_reference(self, partner_id):
+        """ Compute a unique reference of the partner for Adyen.
+
+        This is used for the `shopperReference` field in communications with Adyen and stored in the
+        `adyen_shopper_reference` field on `payment.token` if the payment method is tokenized.
+
+        :param recordset partner_id: The partner making the transaction, as a `res.partner` id
+        :return: The unique reference for the partner
+        :rtype: str
+        """
+        return f'ODOO_PARTNER_{partner_id}'
+
+    # === REQUEST HELPERS === #
+
+    def _build_request_url(self, endpoint, *, endpoint_param=None, **kwargs):
+        """Override of `payment` to build the request URL based on the API URL prefix.
+
+        The final URL follows the pattern `<_base>/V<_version>/<_endpoint>`.
+        """
         if self.code != 'adyen':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES
+            return self._build_request_url(endpoint, endpoint_param=endpoint_param, **kwargs)
+
+        version = const.API_ENDPOINT_VERSIONS[endpoint]
+        endpoint = endpoint if not endpoint_param else endpoint.format(endpoint_param)
+        prefix_ = self.adyen_api_url_prefix.rstrip('/')  # Remove potential trailing slash.
+        endpoint = endpoint.lstrip('/')  # Remove potential leading slash.
+        test_mode_ = self.state == 'test'
+        prefix_ = f'{prefix_}.adyen' if test_mode_ else f'{prefix_}-checkout-live.adyenpayments'
+        return f'https://{prefix_}.com/checkout/V{version}/{endpoint}'
+
+    def _build_request_headers(self, method, *args, idempotency_key=None, **kwargs):
+        """Override of `payment` to include the API key and idempotency key in the headers."""
+        if self.code != 'adyen':
+            return self._build_request_headers(
+                method, *args, idempotency_key=idempotency_key, **kwargs
+            )
+
+        headers = {'X-API-Key': self.adyen_api_key}
+        if method == 'POST' and idempotency_key:
+            headers['idempotency-key'] = idempotency_key
+        return headers
+
+    def _parse_response_error(self, response):
+        """Override of `payment` to extract the error message from the response."""
+        if self.code != 'adyen':
+            return super()._parse_response_error(response)
+        return response.json().get('message', '')

--- a/addons/payment_aps/controllers/main.py
+++ b/addons/payment_aps/controllers/main.py
@@ -1,17 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import hmac
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
+from odoo.addons.payment.logging import get_payment_logger
 
-_logger = logging.getLogger(__name__)
+
+_logger = get_payment_logger(__name__)
 
 
 class APSController(http.Controller):
@@ -22,7 +22,7 @@ class APSController(http.Controller):
         _return_url, type='http', auth='public', methods=['POST'], csrf=False, save_session=False
     )
     def aps_return_from_checkout(self, **data):
-        """ Process the notification data sent by APS after redirection.
+        """Process the payment data sent by APS after redirection.
 
         The route is flagged with `save_session=False` to prevent Odoo from assigning a new session
         to the user if they are redirected to this route with a POST request. Indeed, as the session
@@ -32,64 +32,51 @@ class APSController(http.Controller):
         will satisfy any specification of the `SameSite` attribute, the session of the user will be
         retrieved and with it the transaction which will be immediately post-processed.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         """
         _logger.info("Handling redirection from APS with data:\n%s", pprint.pformat(data))
 
-        # Check the integrity of the notification.
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-            'aps', data
-        )
-        self._verify_notification_signature(data, tx_sudo)
-
-        # Handle the notification data.
-        tx_sudo._handle_notification_data('aps', data)
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('aps', data)
+        if tx_sudo:
+            self._verify_signature(data, tx_sudo)
+            tx_sudo._process('aps', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def aps_webhook(self, **data):
-        """ Process the notification data sent by APS to the webhook.
+        """Process the payment data sent by APS to the webhook.
 
         See https://paymentservices-reference.payfort.com/docs/api/build/index.html#transaction-feedback.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         :return: The 'SUCCESS' string to acknowledge the notification
         :rtype: str
         """
         _logger.info("Notification received from APS with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'aps', data
-            )
-            self._verify_notification_signature(data, tx_sudo)
-
-            # Handle the notification data.
-            tx_sudo._handle_notification_data('aps', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
-
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('aps', data)
+        if tx_sudo:
+            self._verify_signature(data, tx_sudo)
+            tx_sudo._process('aps', data)
         return ''  # Acknowledge the notification.
 
     @staticmethod
-    def _verify_notification_signature(notification_data, tx_sudo):
-        """ Check that the received signature matches the expected one.
+    def _verify_signature(payment_data, tx_sudo):
+        """Check that the received signature matches the expected one.
 
-        :param dict notification_data: The notification data
-        :param recordset tx_sudo: The sudoed transaction referenced by the notification data, as a
-                                  `payment.transaction` record
+        :param dict payment_data: The payment data.
+        :param payment.transaction tx_sudo: The sudoed transaction referenced by the payment data.
         :return: None
-        :raise: :class:`werkzeug.exceptions.Forbidden` if the signatures don't match
+        :raise Forbidden: If the signatures don't match.
         """
-        received_signature = notification_data.get('signature')
+        received_signature = payment_data.get('signature')
         if not received_signature:
-            _logger.warning("received notification with missing signature")
+            _logger.warning("Received payment data with missing signature.")
             raise Forbidden()
 
         # Compare the received signature with the expected signature computed from the data.
         expected_signature = tx_sudo.provider_id._aps_calculate_signature(
-            notification_data, incoming=True
+            payment_data, incoming=True
         )
         if not hmac.compare_digest(received_signature, expected_signature):
-            _logger.warning("received notification with invalid signature")
+            _logger.warning("Received payment data with invalid signature.")
             raise Forbidden()

--- a/addons/payment_aps/models/payment_transaction.py
+++ b/addons/payment_aps/models/payment_transaction.py
@@ -1,19 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-
 from werkzeug import urls
 
 from odoo import _, api, models
-from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_aps import utils as aps_utils
 from odoo.addons.payment_aps.const import PAYMENT_STATUS_MAPPING
 from odoo.addons.payment_aps.controllers.main import APSController
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentTransaction(models.Model):
@@ -49,9 +47,8 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific processing values.
         :rtype: dict
         """
-        res = super()._get_specific_rendering_values(processing_values)
         if self.provider_code != 'aps':
-            return res
+            return super()._get_specific_rendering_values(processing_values)
 
         converted_amount = payment_utils.to_minor_currency_units(self.amount, self.currency_id)
         base_url = self.provider_id.get_base_url()
@@ -77,88 +74,55 @@ class PaymentTransaction(models.Model):
         })
         return rendering_values
 
-    def _get_tx_from_notification_data(self, provider_code, notification_data):
-        """ Override of `payment` to find the transaction based on APS data.
+    @api.model
+    def _extract_reference(self, provider_code, payment_data):
+        """Override of `payment` to extract the reference from the APS data."""
+        if provider_code != 'aps':
+            return super()._extract_reference(provider_code, payment_data)
+        return payment_data.get('merchant_reference')
 
-        :param str provider_code: The code of the provider that handled the transaction.
-        :param dict notification_data: The notification data sent by the provider.
-        :return: The transaction if found.
-        :rtype: recordset of `payment.transaction`
-        :raise ValidationError: If inconsistent data are received.
-        :raise ValidationError: If the data match no transaction.
-        """
-        tx = super()._get_tx_from_notification_data(provider_code, notification_data)
-        if provider_code != 'aps' or len(tx) == 1:
-            return tx
-
-        reference = notification_data.get('merchant_reference')
-        if not reference:
-            raise ValidationError(
-                "APS: " + _("Received data with missing reference %(ref)s.", ref=reference)
-            )
-
-        tx = self.search([('reference', '=', reference), ('provider_code', '=', 'aps')])
-        if not tx:
-            raise ValidationError(
-                "APS: " + _("No transaction found matching reference %s.", reference)
-            )
-
-        return tx
-
-    def _compare_notification_data(self, notification_data):
-        """ Override of `payment` to compare the transaction based on APS data.
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If the transaction's amount and currency don't match the
-            notification data.
-        """
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
         if self.provider_code != 'aps':
-            return super()._compare_notification_data(notification_data)
+            return super()._extract_amount_data(payment_data)
 
         amount = payment_utils.to_major_currency_units(
-            float(notification_data.get('amount', 0)), self.currency_id
+            float(payment_data.get('amount', 0)), self.currency_id
         )
-        currency_code = notification_data.get('currency')
-        self._validate_amount_and_currency(amount, currency_code)
+        return {
+            'amount': amount,
+            'currency_code': payment_data.get('currency'),
+        }
 
-    def _process_notification_data(self, notification_data):
-        """ Override of `payment' to process the transaction based on APS data.
-
-        Note: self.ensure_one()
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If inconsistent data are received.
-        """
-        super()._process_notification_data(notification_data)
+    def _apply_updates(self, payment_data):
+        """Override of `payment' to update the transaction based on the payment data."""
         if self.provider_code != 'aps':
-            return
+            return super()._apply_updates(payment_data)
 
         # Update the provider reference.
-        self.provider_reference = notification_data.get('fort_id')
+        self.provider_reference = payment_data.get('fort_id')
 
         # Update the payment method.
-        payment_option = notification_data.get('payment_option', '')
+        payment_option = payment_data.get('payment_option', '')
         payment_method = self.env['payment.method']._get_from_code(payment_option.lower())
         self.payment_method_id = payment_method or self.payment_method_id
 
         # Update the payment state.
-        status = notification_data.get('status')
+        status = payment_data.get('status')
         if not status:
-            raise ValidationError("APS: " + _("Received data with missing payment state."))
-        if status in PAYMENT_STATUS_MAPPING['pending']:
+            self._set_error(_("Received data with missing payment state."))
+        elif status in PAYMENT_STATUS_MAPPING['pending']:
             self._set_pending()
         elif status in PAYMENT_STATUS_MAPPING['done']:
             self._set_done()
         else:  # Classify unsupported payment state as `error` tx state.
-            status_description = notification_data.get('response_message')
+            status_description = payment_data.get('response_message')
             _logger.info(
                 "Received data with invalid payment status (%(status)s) and reason '%(reason)s' "
-                "for transaction with reference %(ref)s",
+                "for transaction %(ref)s.",
                 {'status': status, 'reason': status_description, 'ref': self.reference},
             )
-            self._set_error("APS: " + _(
+            self._set_error(_(
                 "Received invalid transaction status %(status)s and reason '%(reason)s'.",
                 status=status, reason=status_description
             ))

--- a/addons/payment_aps/tests/common.py
+++ b/addons/payment_aps/tests/common.py
@@ -18,7 +18,7 @@ class APSCommon(PaymentHttpCommon):
 
         cls.provider = cls.aps
 
-        cls.notification_data = {
+        cls.payment_data = {
             'access_code': cls.provider.aps_access_code,
             'amount': cls.amount,
             'authorization_code': '123456',

--- a/addons/payment_aps/tests/test_payment_transaction.py
+++ b/addons/payment_aps/tests/test_payment_transaction.py
@@ -64,9 +64,9 @@ class TestPaymentTransaction(APSCommon):
         self.assertEqual(form_info['method'], 'post')
         self.assertListEqual(list(form_info['inputs'].keys()), expected_input_keys)
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicate a
+    def test_processing_payment_data_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.notification_data)
+        tx._apply_updates(self.payment_data)
         self.assertEqual(tx.state, 'done')

--- a/addons/payment_aps/tests/test_processing_flows.py
+++ b/addons/payment_aps/tests/test_processing_flows.py
@@ -21,28 +21,26 @@ class TestProcessingFlows(APSCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(APSController._return_url)
         with patch(
-            'odoo.addons.payment_aps.controllers.main.APSController._verify_notification_signature'
+            'odoo.addons.payment_aps.controllers.main.APSController._verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_post_request(url, data=self.notification_data)
-            self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_post_request(url, data=self.payment_data)
+            self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_aps.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification triggers the processing of the
-        notification data. """
+        payment data. """
         self._create_transaction('redirect')
         url = self._build_url(APSController._webhook_url)
         with patch(
-            'odoo.addons.payment_aps.controllers.main.APSController._verify_notification_signature'
+            'odoo.addons.payment_aps.controllers.main.APSController._verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_post_request(url, data=self.notification_data)
-            self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_post_request(url, data=self.payment_data)
+            self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_aps.controllers.main')
     def test_redirect_notification_triggers_signature_check(self):
@@ -50,12 +48,11 @@ class TestProcessingFlows(APSCommon):
         self._create_transaction('redirect')
         url = self._build_url(APSController._return_url)
         with patch(
-            'odoo.addons.payment_aps.controllers.main.APSController._verify_notification_signature'
+            'odoo.addons.payment_aps.controllers.main.APSController._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_http_post_request(url, data=self.notification_data)
+            self._make_http_post_request(url, data=self.payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_aps.controllers.main')
@@ -64,31 +61,30 @@ class TestProcessingFlows(APSCommon):
         self._create_transaction('redirect')
         url = self._build_url(APSController._webhook_url)
         with patch(
-            'odoo.addons.payment_aps.controllers.main.APSController._verify_notification_signature'
+            'odoo.addons.payment_aps.controllers.main.APSController._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_http_post_request(url, data=self.notification_data)
+            self._make_http_post_request(url, data=self.payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     def test_accept_notification_with_valid_signature(self):
         """ Test the verification of a notification with a valid signature. """
         tx = self._create_transaction('redirect')
         self._assert_does_not_raise(
-            Forbidden, APSController._verify_notification_signature, self.notification_data, tx
+            Forbidden, APSController._verify_signature, self.payment_data, tx
         )
 
     @mute_logger('odoo.addons.payment_aps.controllers.main')
     def test_reject_notification_with_missing_signature(self):
         """ Test the verification of a notification with a missing signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.notification_data, signature=None)
-        self.assertRaises(Forbidden, APSController._verify_notification_signature, payload, tx)
+        payload = dict(self.payment_data, signature=None)
+        self.assertRaises(Forbidden, APSController._verify_signature, payload, tx)
 
     @mute_logger('odoo.addons.payment_aps.controllers.main')
     def test_reject_notification_with_invalid_signature(self):
         """ Test the verification of a notification with an invalid signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.notification_data, signature='dummy')
-        self.assertRaises(Forbidden, APSController._verify_notification_signature, payload, tx)
+        payload = dict(self.payment_data, signature='dummy')
+        self.assertRaises(Forbidden, APSController._verify_signature, payload, tx)

--- a/addons/payment_asiapay/controllers/main.py
+++ b/addons/payment_asiapay/controllers/main.py
@@ -1,17 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import hmac
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 
+from odoo.addons.payment.logging import get_payment_logger
 
-_logger = logging.getLogger(__name__)
+
+_logger = get_payment_logger(__name__)
 
 
 class AsiaPayController(http.Controller):
@@ -20,56 +20,47 @@ class AsiaPayController(http.Controller):
 
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def asiapay_return_from_checkout(self, **data):
-        """ Process the notification data sent by AsiaPay after redirection.
+        """Process the payment data sent by AsiaPay after redirection.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         """
-        # Don't process the notification data as they contain no valuable information except for the
+        # Don't process the payment data as they contain no valuable information except for the
         # reference and AsiaPay doesn't expose an endpoint to fetch the data from the API.
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def asiapay_webhook(self, **data):
-        """ Process the notification data sent by AsiaPay to the webhook.
+        """Process the payment data sent by AsiaPay to the webhook.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         :return: The 'OK' string to acknowledge the notification.
         :rtype: str
         """
         _logger.info("Notification received from AsiaPay with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification data.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'asiapay', data
-            )
-            self._verify_notification_signature(data, tx_sudo)
-
-            # Handle the notification data.
-            tx_sudo._handle_notification_data('asiapay', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
-
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('asiapay', data)
+        if tx_sudo:
+            self._verify_signature(data, tx_sudo)
+            tx_sudo._process('asiapay', data)
         return 'OK'  # Acknowledge the notification.
 
     @staticmethod
-    def _verify_notification_signature(notification_data, tx_sudo):
-        """ Check that the received signature matches the expected one.
+    def _verify_signature(payment_data, tx_sudo):
+        """Check that the received signature matches the expected one.
 
-        :param dict notification_data: The notification data
-        :param recordset tx_sudo: The sudoed transaction referenced by the notification data, as a
-                                  `payment.transaction` record
+        :param dict payment_data: The payment data.
+        :param payment.transaction tx_sudo: The sudoed transaction referenced by the payment data.
         :return: None
-        :raise: :class:`werkzeug.exceptions.Forbidden` if the signatures don't match
+        :raise Forbidden: If the signatures don't match.
         """
-        received_signature = notification_data.get('secureHash')
+        received_signature = payment_data.get('secureHash')
         if not received_signature:
-            _logger.warning("Received notification with missing signature.")
+            _logger.warning("Received payment data with missing signature.")
             raise Forbidden()
 
         # Compare the received signature with the expected signature computed from the data.
         expected_signature = tx_sudo.provider_id._asiapay_calculate_signature(
-            notification_data, incoming=True
+            payment_data, incoming=True
         )
         if not hmac.compare_digest(received_signature, expected_signature):
-            _logger.warning("Received notification with invalid signature.")
+            _logger.warning("Received payment data with invalid signature.")
             raise Forbidden()

--- a/addons/payment_asiapay/models/payment_provider.py
+++ b/addons/payment_asiapay/models/payment_provider.py
@@ -60,6 +60,15 @@ class PaymentProvider(models.Model):
                     currencies=", ".join(unsupported_currency_codes),
                 ))
 
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.code != 'asiapay':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
     # === BUSINESS METHODS ===#
 
     def _asiapay_get_api_url(self):
@@ -89,10 +98,3 @@ class PaymentProvider(models.Model):
         shasign = hashnew(self.asiapay_secure_hash_function)
         shasign.update(signing_string.encode())
         return shasign.hexdigest()
-
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
-        if self.code != 'asiapay':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES

--- a/addons/payment_asiapay/tests/common.py
+++ b/addons/payment_asiapay/tests/common.py
@@ -19,10 +19,10 @@ class AsiaPayCommon(PaymentCommon):
 
         cls.provider = cls.asiapay
 
-        cls.redirect_notification_data = {
+        cls.redirect_payment_data = {
             'Ref': cls.reference,
         }
-        cls.webhook_notification_data = {
+        cls.webhook_payment_data = {
             'src': 'dummy',
             'prc': 'dummy',
             'successcode': '0',

--- a/addons/payment_asiapay/tests/test_payment_provider.py
+++ b/addons/payment_asiapay/tests/test_payment_provider.py
@@ -34,6 +34,6 @@ class TestPaymentProvider(AsiaPayCommon):
     def test_signature_calculation_for_incoming_data(self):
         """ Test that the calculated signature matches the expected signature for incoming data. """
         calculated_signature = self.asiapay._asiapay_calculate_signature(
-            self.webhook_notification_data, incoming=True
+            self.webhook_payment_data, incoming=True
         )
         self.assertEqual(calculated_signature, '3e5bf55d9a23969130a6686db7aa4f0230956d0a')

--- a/addons/payment_asiapay/tests/test_payment_transaction.py
+++ b/addons/payment_asiapay/tests/test_payment_transaction.py
@@ -108,9 +108,9 @@ class TestPaymentTransaction(AsiaPayCommon, PaymentHttpCommon):
         self.assertEqual(form_info['method'], 'post')
         self.assertListEqual(list(form_info['inputs'].keys()), expected_input_keys)
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicate a
+    def test_apply_updates_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.webhook_notification_data)
+        tx._apply_updates(self.webhook_payment_data)
         self.assertEqual(tx.state, 'done')

--- a/addons/payment_asiapay/tests/test_processing_flows.py
+++ b/addons/payment_asiapay/tests/test_processing_flows.py
@@ -18,18 +18,16 @@ class TestProcessingFlows(AsiaPayCommon, PaymentHttpCommon):
     @mute_logger('odoo.addons.payment_asiapay.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification triggers the processing of the
-        notification data. """
+        payment data. """
         self._create_transaction('redirect')
         url = self._build_url(AsiaPayController._webhook_url)
         with patch(
-            'odoo.addons.payment_asiapay.controllers.main.AsiaPayController.'
-            '_verify_notification_signature'
+            'odoo.addons.payment_asiapay.controllers.main.AsiaPayController._verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_post_request(url, data=self.webhook_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_post_request(url, data=self.webhook_payment_data)
+        self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_asiapay.controllers.main')
     def test_webhook_notification_triggers_signature_check(self):
@@ -37,35 +35,30 @@ class TestProcessingFlows(AsiaPayCommon, PaymentHttpCommon):
         self._create_transaction('redirect')
         url = self._build_url(AsiaPayController._webhook_url)
         with patch(
-            'odoo.addons.payment_asiapay.controllers.main.AsiaPayController'
-            '._verify_notification_signature'
+            'odoo.addons.payment_asiapay.controllers.main.AsiaPayController._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_http_post_request(url, data=self.webhook_notification_data)
+            self._make_http_post_request(url, data=self.webhook_payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     def test_accept_webhook_notification_with_valid_signature(self):
         """ Test the verification of a webhook notification with a valid signature. """
         tx = self._create_transaction('redirect')
         self._assert_does_not_raise(
-            Forbidden,
-            AsiaPayController._verify_notification_signature,
-            self.webhook_notification_data,
-            tx,
+            Forbidden, AsiaPayController._verify_signature, self.webhook_payment_data, tx
         )
 
     @mute_logger('odoo.addons.payment_asiapay.controllers.main')
     def test_reject_notification_with_missing_signature(self):
         """ Test the verification of a notification with a missing signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.webhook_notification_data, secureHash='dummy')
-        self.assertRaises(Forbidden, AsiaPayController._verify_notification_signature, payload, tx)
+        payload = dict(self.webhook_payment_data, secureHash='dummy')
+        self.assertRaises(Forbidden, AsiaPayController._verify_signature, payload, tx)
 
     @mute_logger('odoo.addons.payment_asiapay.controllers.main')
     def test_reject_notification_with_invalid_signature(self):
         """ Test the verification of a notification with an invalid signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.webhook_notification_data, secureHash='dummy')
-        self.assertRaises(Forbidden, AsiaPayController._verify_notification_signature, payload, tx)
+        payload = dict(self.webhook_payment_data, secureHash='dummy')
+        self.assertRaises(Forbidden, AsiaPayController._verify_signature, payload, tx)

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -1,17 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 import pprint
 
 from odoo import _, models
-from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_authorize import const
 from odoo.addons.payment_authorize.models.authorize_request import AuthorizeAPI
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentTransaction(models.Model):
@@ -26,9 +25,8 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific processing values
         :rtype: dict
         """
-        res = super()._get_specific_processing_values(processing_values)
         if self.provider_code != 'authorize':
-            return res
+            return super()._get_specific_processing_values(processing_values)
 
         return {
             'access_token': payment_utils.generate_access_token(
@@ -53,58 +51,41 @@ class PaymentTransaction(models.Model):
             return authorize_API.auth_and_capture(self, opaque_data=opaque_data)
 
     def _send_payment_request(self):
-        """ Override of payment to send a payment request to Authorize.
-
-        Note: self.ensure_one()
-
-        :return: None
-        :raise: UserError if the transaction is not linked to a token
-        """
-        super()._send_payment_request()
+        """Override of `payment` to send a payment request to Authorize."""
         if self.provider_code != 'authorize':
-            return
-
-        if not self.token_id.authorize_profile:
-            raise UserError("Authorize.Net: " + _("The transaction is not linked to a token."))
+            return super()._send_payment_request()
 
         authorize_API = AuthorizeAPI(self.provider_id)
         if self.provider_id.capture_manually:
             res_content = authorize_API.authorize(self, token=self.token_id)
             _logger.info(
-                "authorize request response for transaction with reference %s:\n%s",
+                "authorize request response for transaction %s:\n%s",
                 self.reference, pprint.pformat(res_content)
             )
         else:
             res_content = authorize_API.auth_and_capture(self, token=self.token_id)
             _logger.info(
-                "auth_and_capture request response for transaction with reference %s:\n%s",
+                "auth_and_capture request response for transaction %s:\n%s",
                 self.reference, pprint.pformat(res_content)
             )
-        self._handle_notification_data('authorize', {'response': res_content})
+        self._process('authorize', {'response': res_content})
 
-    def _send_refund_request(self, amount_to_refund=None):
-        """ Override of payment to send a refund request to Authorize.
-
-        Note: self.ensure_one()
-
-        :param float amount_to_refund: The amount to refund
-        :return: The refund transaction created to process the refund request.
-        :rtype: recordset of `payment.transaction`
-        """
-        self.ensure_one()
-
+    def _send_refund_request(self):
+        """Override of `payment` to send a refund request to Authorize."""
         if self.provider_code != 'authorize':
-            return super()._send_refund_request(amount_to_refund=amount_to_refund)
+            return super()._send_refund_request()
 
         authorize_api = AuthorizeAPI(self.provider_id)
-        tx_details = authorize_api.get_transaction_details(self.provider_reference)
+        tx_details = authorize_api.get_transaction_details(
+            self.source_transaction_id.provider_reference
+        )
         if 'err_code' in tx_details:  # Could not retrieve the transaction details.
-            raise ValidationError("Authorize.Net: " + _(
+            self._set_error(_(
                 "Could not retrieve the transaction details. (error code: %(error_code)s; error_details: %(error_message)s)",
                 error_code=tx_details['err_code'], error_message=tx_details.get('err_msg'),
             ))
+            return
 
-        refund_tx = self.env['payment.transaction']
         tx_status = tx_details.get('transaction', {}).get('transactionStatus')
         if tx_status in const.TRANSACTION_STATUS_MAPPING['voided']:
             # The payment has been voided from Authorize.net side before we could refund it.
@@ -112,8 +93,7 @@ class PaymentTransaction(models.Model):
         elif tx_status in const.TRANSACTION_STATUS_MAPPING['refunded']:
             # The payment has been refunded from Authorize.net side before we could refund it. We
             # create a refund tx on Odoo to reflect the move of the funds.
-            refund_tx = super()._send_refund_request(amount_to_refund=amount_to_refund)
-            refund_tx._set_done()
+            self._set_done()
             # Immediately post-process the transaction as the post-processing will not be
             # triggered by a customer browsing the transaction from the portal.
             self.env.ref('payment.cron_post_process_payment_tx')._trigger()
@@ -121,114 +101,79 @@ class PaymentTransaction(models.Model):
             if tx_status in const.TRANSACTION_STATUS_MAPPING['authorized']:
                 # The payment has not been settled on Authorize.net yet. It must be voided rather
                 # than refunded. Since the funds have not moved yet, we don't create a refund tx.
-                res_content = authorize_api.void(self.provider_reference)
-                tx_to_process = self
+                res_content = authorize_api.void(self.source_transaction_id.provider_reference)
             else:
                 # The payment has been settled on Authorize.net side. We can refund it.
-                refund_tx = super()._send_refund_request(amount_to_refund=amount_to_refund)
-                rounded_amount = round(amount_to_refund, self.currency_id.decimal_places)
+                rounded_amount = round(self.amount, self.currency_id.decimal_places)
                 res_content = authorize_api.refund(
                     self.provider_reference, rounded_amount, tx_details
                 )
-                tx_to_process = refund_tx
             _logger.info(
-                "refund request response for transaction with reference %s:\n%s",
+                "refund request response for transaction %s:\n%s",
                 self.reference, pprint.pformat(res_content)
             )
-            data = {'reference': tx_to_process.reference, 'response': res_content}
-            tx_to_process._handle_notification_data('authorize', data)
+            data = {'reference': self.reference, 'response': res_content}
+            self._process('authorize', data)
         else:
-            raise ValidationError("Authorize.net: " + _(
-                "The transaction is not in a status to be refunded. (status: %(status)s, details: %(message)s)",
+            err_msg = _(
+                "The transaction is not in a status to be refunded."
+                " (status: %(status)s, details: %(message)s)",
                 status=tx_status, message=tx_details.get('messages', {}).get('message'),
-            ))
-        return refund_tx
+            )
+            _logger.warning(err_msg)
+            self._set_error(err_msg)
 
-    def _send_capture_request(self, amount_to_capture=None):
-        """ Override of `payment` to send a capture request to Authorize. """
-        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
+    def _send_capture_request(self):
+        """Override of `payment` to send a capture request to Authorize."""
         if self.provider_code != 'authorize':
-            return child_capture_tx
+            return super()._send_capture_request()
 
         authorize_API = AuthorizeAPI(self.provider_id)
         rounded_amount = round(self.amount, self.currency_id.decimal_places)
-        res_content = authorize_API.capture(self.provider_reference, rounded_amount)
+        res_content = authorize_API.capture(
+            self.source_transaction_id.provider_reference, rounded_amount
+        )
         _logger.info(
-            "capture request response for transaction with reference %s:\n%s",
+            "capture request response for transaction %s:\n%s",
             self.reference, pprint.pformat(res_content)
         )
-        self._handle_notification_data('authorize', {'response': res_content})
+        self._process('authorize', {'response': res_content})
 
-        return child_capture_tx
-
-    def _send_void_request(self, amount_to_void=None):
-        """ Override of payment to send a void request to Authorize. """
-        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
+    def _send_void_request(self):
+        """Override of `payment` to send a void request to Authorize."""
         if self.provider_code != 'authorize':
-            return child_void_tx
+            return super()._send_void_request()
 
         authorize_API = AuthorizeAPI(self.provider_id)
         res_content = authorize_API.void(self.provider_reference)
         _logger.info(
-            "void request response for transaction with reference %s:\n%s",
+            "void request response for transaction %s:\n%s",
             self.reference, pprint.pformat(res_content)
         )
-        self._handle_notification_data('authorize', {'response': res_content})
+        self._process('authorize', {'response': res_content})
 
-        return child_void_tx
-
-    def _get_tx_from_notification_data(self, provider_code, notification_data):
-        """ Find the transaction based on Authorize.net data.
-
-        :param str provider_code: The code of the provider that handled the transaction
-        :param dict notification_data: The notification data sent by the provider
-        :return: The transaction if found
-        :rtype: recordset of `payment.transaction`
-        """
-        tx = super()._get_tx_from_notification_data(provider_code, notification_data)
-        if provider_code != 'authorize' or len(tx) == 1:
-            return tx
-
-        reference = notification_data.get('reference')
-        tx = self.search([('reference', '=', reference), ('provider_code', '=', 'authorize')])
-        if not tx:
-            raise ValidationError(
-                "Authorize.Net: " + _("No transaction found matching reference %s.", reference)
-            )
-        return tx
-
-    def _compare_notification_data(self, notification_data):
-        """ Override of `payment` to compare the transaction based on Authorize data.
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If the transaction's amount and currency don't match the
-            notification data.
-        """
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
         if self.provider_code != 'authorize':
-            return super()._compare_notification_data(notification_data)
+            return super()._extract_amount_data(payment_data)
 
         tx_details = AuthorizeAPI(self.provider_id).get_transaction_details(
-            notification_data.get('response', {}).get('x_trans_id')
+            payment_data.get('response', {}).get('x_trans_id')
         )
         amount = tx_details.get('transaction', {}).get('authAmount')
         # Authorize supports only one currency per account.
         currency_code = self.provider_id.available_currency_ids[0].name
-        self._validate_amount_and_currency(amount, currency_code)
+        return {
+            'amount': float(amount),
+            'currency_code': currency_code,
+        }
 
-    def _process_notification_data(self, notification_data):
-        """ Override of payment to process the transaction based on Authorize data.
-
-        Note: self.ensure_one()
-
-        :param dict notification_data: The notification data sent by the provider
-        :return: None
-        """
-        super()._process_notification_data(notification_data)
+    def _apply_updates(self, payment_data):
+        """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != 'authorize':
-            return
+            return super()._apply_updates(payment_data)
 
-        response_content = notification_data.get('response')
+        response_content = payment_data.get('response')
 
         # Update the provider reference.
         self.provider_reference = response_content.get('x_trans_id')
@@ -246,14 +191,10 @@ class PaymentTransaction(models.Model):
             status_type = response_content.get('x_type').lower()
             if status_type in ('auth_capture', 'prior_auth_capture'):
                 self._set_done()
-                if self.tokenize and not self.token_id:
-                    self._authorize_tokenize()
             elif status_type == 'auth_only':
                 self._set_authorized()
-                if self.tokenize and not self.token_id:
-                    self._authorize_tokenize()
                 if self.operation == 'validation':
-                    self._send_void_request()  # In last step because it processes the response.
+                    self._void()  # In last step because it processes the response.
             elif status_type == 'void':
                 if self.operation == 'validation':  # Validation txs are authorized and then voided
                     self._set_done()  # If the refund went through, the validation tx is confirmed
@@ -271,57 +212,40 @@ class PaymentTransaction(models.Model):
         else:  # Error / Unknown code
             error_code = response_content.get('x_response_reason_text')
             _logger.info(
-                "received data with invalid status (%(status)s) and error code (%(err)s) for "
-                "transaction with reference %(ref)s",
+                "Received data with invalid status (%(status)s) and error code (%(err)s) for "
+                "transaction %(ref)s.",
                 {
                     'status': status_code,
                     'err': error_code,
                     'ref': self.reference,
                 },
             )
-            self._set_error(
-                "Authorize.Net: " + _(
-                    "Received data with status code \"%(status)s\" and error code \"%(error)s\"",
-                    status=status_code, error=error_code
-                )
-            )
+            self._set_error(_(
+                "Received data with status code \"%(status)s\" and error code \"%(error)s\".",
+                status=status_code, error=error_code
+            ))
 
-    def _authorize_tokenize(self):
-        """ Create a token for the current transaction.
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to extract the token values from the payment data."""
+        if self.provider_code != 'authorize':
+            return super()._extract_token_values(payment_data)
 
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        self.ensure_one()
+        if self.token_id:
+            return {}
 
         authorize_API = AuthorizeAPI(self.provider_id)
         cust_profile = authorize_API.create_customer_profile(
             self.partner_id, self.provider_reference
         )
         _logger.info(
-            "create_customer_profile request response for transaction with reference %s:\n%s",
+            "create_customer_profile request response for transaction %s:\n%s",
             self.reference, pprint.pformat(cust_profile)
         )
-        if cust_profile:
-            token = self.env['payment.token'].create({
-                'provider_id': self.provider_id.id,
-                'payment_method_id': self.payment_method_id.id,
-                'payment_details': cust_profile.get('payment_details'),
-                'partner_id': self.partner_id.id,
-                'provider_ref': cust_profile.get('payment_profile_id'),
-                'authorize_profile': cust_profile.get('profile_id'),
-            })
-            self.write({
-                'token_id': token.id,
-                'tokenize': False,
-            })
-            _logger.info(
-                "created token with id %(token_id)s for partner with id %(partner_id)s from "
-                "transaction with reference %(ref)s",
-                {
-                    'token_id': token.id,
-                    'partner_id': self.partner_id.id,
-                    'ref': self.reference,
-                },
-            )
+        if not cust_profile or 'payment_profile_id' not in cust_profile:  # Failed to fetch data.
+            return {}
+
+        return {
+            'payment_details': cust_profile.get('payment_details'),
+            'provider_ref': cust_profile['payment_profile_id'],
+            'authorize_profile': cust_profile.get('profile_id'),
+        }

--- a/addons/payment_buckaroo/models/payment_provider.py
+++ b/addons/payment_buckaroo/models/payment_provider.py
@@ -20,6 +20,8 @@ class PaymentProvider(models.Model):
     buckaroo_secret_key = fields.Char(
         string="Buckaroo Secret Key", required_if_provider='buckaroo', groups='base.group_system')
 
+    # === COMPUTE METHODS ===#
+
     def _get_supported_currencies(self):
         """ Override of `payment` to return the supported currencies. """
         supported_currencies = super()._get_supported_currencies()
@@ -28,6 +30,17 @@ class PaymentProvider(models.Model):
                 lambda c: c.name in const.SUPPORTED_CURRENCIES
             )
         return supported_currencies
+
+    # === CRUD METHODS ===#
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.code != 'buckaroo':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
+    # === BUSINESS METHODS === #
 
     def _buckaroo_get_api_url(self):
         """ Return the API URL according to the state.
@@ -74,12 +87,3 @@ class PaymentProvider(models.Model):
         sign_string += self.buckaroo_secret_key
         # Calculate the SHA-1 hash over the signing string
         return sha1(sign_string.encode('utf-8')).hexdigest()
-
-    # === BUSINESS METHODS ===#
-
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
-        if self.code != 'buckaroo':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES

--- a/addons/payment_buckaroo/tests/common.py
+++ b/addons/payment_buckaroo/tests/common.py
@@ -18,7 +18,7 @@ class BuckarooCommon(PaymentCommon):
         cls.provider = cls.buckaroo
         cls.currency = cls.currency_euro
 
-        cls.sync_notification_data = {
+        cls.sync_payment_data = {
             'brq_payment': 'ABCDEF0123456789ABCDEF0123456789',
             'brq_payment_method': 'paypal',
             'brq_statuscode': '190',  # confirmed
@@ -31,7 +31,7 @@ class BuckarooCommon(PaymentCommon):
             'brq_signature': '5d389aa4f563cd99666a2e6bef79da3d4a32eb50',
         }
 
-        cls.async_notification_data = {
+        cls.async_payment_data = {
             'brq_transactions': '0123456789ABCDEF0123456789ABCDEF',
             'brq_transaction_method': 'paypal',
             'brq_statuscode': '190',  # confirmed

--- a/addons/payment_custom/controllers/main.py
+++ b/addons/payment_custom/controllers/main.py
@@ -1,12 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 import pprint
 
 from odoo.http import Controller, request, route
 
+from odoo.addons.payment.logging import get_payment_logger
 
-_logger = logging.getLogger(__name__)
+
+_logger = get_payment_logger(__name__)
 
 
 class CustomController(Controller):
@@ -15,5 +16,5 @@ class CustomController(Controller):
     @route(_process_url, type='http', auth='public', methods=['POST'], csrf=False)
     def custom_process_transaction(self, **post):
         _logger.info("Handling custom processing with data:\n%s", pprint.pformat(post))
-        request.env['payment.transaction'].sudo()._handle_notification_data('custom', post)
+        request.env['payment.transaction'].sudo()._process('custom', post)
         return request.redirect('/payment/status')

--- a/addons/payment_demo/controllers/main.py
+++ b/addons/payment_demo/controllers/main.py
@@ -11,7 +11,7 @@ class PaymentDemoController(http.Controller):
     def demo_simulate_payment(self, **data):
         """ Simulate the response of a payment request.
 
-        :param dict data: The simulated notification data.
+        :param dict data: The simulated payment data.
         :return: None
         """
-        request.env['payment.transaction'].sudo()._handle_notification_data('demo', data)
+        request.env['payment.transaction'].sudo()._process('demo', data)

--- a/addons/payment_demo/models/payment_provider.py
+++ b/addons/payment_demo/models/payment_provider.py
@@ -11,7 +11,7 @@ class PaymentProvider(models.Model):
 
     code = fields.Selection(selection_add=[('demo', 'Demo')], ondelete={'demo': 'set default'})
 
-    #=== COMPUTE METHODS ===#
+    # === COMPUTE METHODS === #
 
     def _compute_feature_support_fields(self):
         """ Override of `payment` to enable additional features. """
@@ -30,9 +30,11 @@ class PaymentProvider(models.Model):
         if self.filtered(lambda p: p.code == 'demo' and p.state not in ('test', 'disabled')):
             raise UserError(_("Demo providers should never be enabled."))
 
+    # === CRUD METHODS ===#
+
     def _get_default_payment_method_codes(self):
         """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+        self.ensure_one()
         if self.code != 'demo':
-            return default_codes
+            return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES

--- a/addons/payment_demo/models/payment_transaction.py
+++ b/addons/payment_demo/models/payment_transaction.py
@@ -27,8 +27,8 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'demo':
             return
 
-        notification_data = {'reference': self.reference, 'simulated_state': 'done'}
-        self._handle_notification_data('demo', notification_data)
+        payment_data = {'reference': self.reference, 'simulated_state': 'done'}
+        self._process('demo', payment_data)
 
     def action_demo_set_canceled(self):
         """ Set the state of the demo transaction to 'cancel'.
@@ -41,8 +41,8 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'demo':
             return
 
-        notification_data = {'reference': self.reference, 'simulated_state': 'cancel'}
-        self._handle_notification_data('demo', notification_data)
+        payment_data = {'reference': self.reference, 'simulated_state': 'cancel'}
+        self._process('demo', payment_data)
 
     def action_demo_set_error(self):
         """ Set the state of the demo transaction to 'error'.
@@ -55,137 +55,76 @@ class PaymentTransaction(models.Model):
         if self.provider_code != 'demo':
             return
 
-        notification_data = {'reference': self.reference, 'simulated_state': 'error'}
-        self._handle_notification_data('demo', notification_data)
+        payment_data = {'reference': self.reference, 'simulated_state': 'error'}
+        self._process('demo', payment_data)
 
-    #=== BUSINESS METHODS ===#
+    # === BUSINESS METHODS === #
 
     def _send_payment_request(self):
-        """ Override of payment to simulate a payment request.
-
-        Note: self.ensure_one()
-
-        :return: None
-        """
-        super()._send_payment_request()
+        """Override of `payment` to simulate a payment request."""
         if self.provider_code != 'demo':
-            return
-
-        if not self.token_id:
-            raise UserError("Demo: " + _("The transaction is not linked to a token."))
+            return super()._send_payment_request()
 
         simulated_state = self.token_id.demo_simulated_state
-        notification_data = {'reference': self.reference, 'simulated_state': simulated_state}
-        self._handle_notification_data('demo', notification_data)
+        payment_data = {'reference': self.reference, 'simulated_state': simulated_state}
+        self._process('demo', payment_data)
 
-    def _send_refund_request(self, amount_to_refund=None):
-        """ Override of payment to simulate a refund.
-
-        Note: self.ensure_one()
-
-        :param dict kwargs: The keyword arguments.
-        :return: The refund transaction created to process the refund request.
-        :rtype: recordset of `payment.transaction`
-        """
-        refund_tx = super()._send_refund_request(amount_to_refund=amount_to_refund)
+    def _send_capture_request(self):
+        """Override of `payment` to simulate a capture request."""
         if self.provider_code != 'demo':
-            return refund_tx
+            return super()._send_capture_request()
 
-        notification_data = {'reference': refund_tx.reference, 'simulated_state': 'done'}
-        refund_tx._handle_notification_data('demo', notification_data)
-
-        return refund_tx
-
-    def _send_capture_request(self, amount_to_capture=None):
-        """ Override of `payment` to simulate a capture request. """
-        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
-        if self.provider_code != 'demo':
-            return child_capture_tx
-
-        tx = child_capture_tx or self
-        notification_data = {
-            'reference': tx.reference,
+        payment_data = {
+            'reference': self.reference,
             'simulated_state': 'done',
             'manual_capture': True,  # Distinguish manual captures from regular one-step captures.
         }
-        tx._handle_notification_data('demo', notification_data)
+        self._process('demo', payment_data)
 
-        return child_capture_tx
-
-    def _send_void_request(self, amount_to_void=None):
-        """ Override of `payment` to simulate a void request. """
-        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
+    def _send_void_request(self):
+        """Override of `payment` to simulate a void request."""
         if self.provider_code != 'demo':
-            return child_void_tx
+            return super()._send_void_request()
 
-        tx = child_void_tx or self
-        notification_data = {'reference': tx.reference, 'simulated_state': 'cancel'}
-        tx._handle_notification_data('demo', notification_data)
+        payment_data = {'reference': self.reference, 'simulated_state': 'cancel'}
+        self._process('demo', payment_data)
 
-        return child_void_tx
-
-    def _get_tx_from_notification_data(self, provider_code, notification_data):
-        """ Override of payment to find the transaction based on dummy data.
-
-        :param str provider_code: The code of the provider that handled the transaction
-        :param dict notification_data: The dummy notification data
-        :return: The transaction if found
-        :rtype: recordset of `payment.transaction`
-        :raise: ValidationError if the data match no transaction
-        """
-        tx = super()._get_tx_from_notification_data(provider_code, notification_data)
-        if provider_code != 'demo' or len(tx) == 1:
-            return tx
-
-        reference = notification_data.get('reference')
-        tx = self.search([('reference', '=', reference), ('provider_code', '=', 'demo')])
-        if not tx:
-            raise ValidationError(
-                "Demo: " + _("No transaction found matching reference %s.", reference)
-            )
-        return tx
-
-    def _compare_notification_data(self, notification_data):
-        """ Override of `payment` to skip the transaction comparison for dummy flows.
-
-        :param dict notification_data: The dummy notification data.
-        :return: None
-        """
+    def _send_refund_request(self):
+        """Override of `payment` to simulate a refund."""
         if self.provider_code != 'demo':
-            return super()._compare_notification_data(notification_data)
+            return super()._send_refund_request()
 
-    def _process_notification_data(self, notification_data):
-        """ Override of payment to process the transaction based on dummy data.
+        payment_data = {'reference': self.reference, 'simulated_state': 'done'}
+        self._process('demo', payment_data)
 
-        Note: self.ensure_one()
-
-        :param dict notification_data: The dummy notification data
-        :return: None
-        :raise: ValidationError if inconsistent data were received
-        """
-        super()._process_notification_data(notification_data)
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to skip the amount validation for demo flows."""
         if self.provider_code != 'demo':
-            return
+            return super()._extract_amount_data(payment_data)
+        return None
+
+    def _apply_updates(self, payment_data):
+        """Override of `payment` to update the transaction based on the payment data."""
+        if self.provider_code != 'demo':
+            return super()._apply_updates(payment_data)
 
         # Update the provider reference.
         self.provider_reference = f'demo-{self.reference}'
 
         # Create the token.
         if self.tokenize:
-            # The reasons why we immediately tokenize the transaction regardless of the state rather
-            # than waiting for the payment method to be validated ('authorized' or 'done') like the
-            # other payment providers do are:
+            # The reasons why we immediately tokenize the transaction instead of in `payment` are:
             # - To save the simulated state and payment details on the token while we have them.
             # - To allow customers to create tokens whose transactions will always end up in the
             #   said simulated state.
-            self._demo_tokenize_from_notification_data(notification_data)
+            self._tokenize(payment_data)
 
         # Update the payment state.
-        state = notification_data['simulated_state']
+        state = payment_data['simulated_state']
         if state == 'pending':
             self._set_pending()
         elif state == 'done':
-            if self.capture_manually and not notification_data.get('manual_capture'):
+            if self.capture_manually and not payment_data.get('manual_capture'):
                 self._set_authorized()
             else:
                 self._set_done()
@@ -198,29 +137,18 @@ class PaymentTransaction(models.Model):
         else:  # Simulate an error state.
             self._set_error(_("You selected the following demo payment status: %s", state))
 
-    def _demo_tokenize_from_notification_data(self, notification_data):
-        """ Create a new token based on the notification data.
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to extract the token values from the payment data."""
+        if self.provider_code != 'demo':
+            return super()._extract_token_values(payment_data)
 
-        Note: self.ensure_one()
+        # Do not tokenize the transaction twice as `_update_from_payment_data` already does.
+        if self.state in ('done', 'authorized'):
+            return {}
 
-        :param dict notification_data: The fake notification data to tokenize from.
-        :return: None
-        """
-        self.ensure_one()
-
-        state = notification_data['simulated_state']
-        token = self.env['payment.token'].create({
-            'provider_id': self.provider_id.id,
-            'payment_method_id': self.payment_method_id.id,
-            'payment_details': notification_data['payment_details'],
-            'partner_id': self.partner_id.id,
+        state = payment_data['simulated_state']
+        return {
+            'payment_details': payment_data['payment_details'],
             'provider_ref': 'fake provider reference',
             'demo_simulated_state': state,
-        })
-        self.write({
-            'token_id': token,
-            'tokenize': False,
-        })
-        _logger.info(
-            "Created token with id %s for partner with id %s.", token.id, self.partner_id.id
-        )
+        }

--- a/addons/payment_demo/tests/common.py
+++ b/addons/payment_demo/tests/common.py
@@ -11,7 +11,7 @@ class PaymentDemoCommon(PaymentCommon):
 
         cls.provider = cls._prepare_provider(code='demo')
 
-        cls.notification_data = {
+        cls.payment_data = {
             'reference': cls.reference,
             'payment_details': '1234',
             'simulated_state': 'done',

--- a/addons/payment_demo/tests/test_payment_transaction.py
+++ b/addons/payment_demo/tests/test_payment_transaction.py
@@ -12,62 +12,61 @@ from odoo.addons.payment_demo.tests.common import PaymentDemoCommon
 @tagged('-at_install', 'post_install')
 class TestPaymentTransaction(PaymentDemoCommon, PaymentHttpCommon):
 
-    def test_processing_notification_data_sets_transaction_pending(self):
-        """ Test that the transaction state is set to 'pending' when the notification data indicate
+    def test_apply_updates_sets_transaction_pending(self):
+        """ Test that the transaction state is set to 'pending' when the payment data indicate
         a pending payment. """
         tx = self._create_transaction('direct')
-        tx._process_notification_data(dict(self.notification_data, simulated_state='pending'))
+        tx._apply_updates(dict(self.payment_data, simulated_state='pending'))
         self.assertEqual(tx.state, 'pending')
 
-    def test_processing_notification_data_authorizes_transaction(self):
-        """ Test that the transaction state is set to 'authorize' when the notification data
+    def test_apply_updates_authorizes_transaction(self):
+        """ Test that the transaction state is set to 'authorize' when the payment data
         indicate a successful payment and manual capture is enabled. """
         self.provider.capture_manually = True
         tx = self._create_transaction('direct')
-        tx._process_notification_data(self.notification_data)
+        tx._apply_updates(self.payment_data)
         self.assertEqual(tx.state, 'authorized')
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicate a
+    def test_apply_updates_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicate a
         successful payment. """
         tx = self._create_transaction('direct')
-        tx._process_notification_data(self.notification_data)
+        tx._apply_updates(self.payment_data)
         self.assertEqual(tx.state, 'done')
 
-    def test_processing_notification_data_cancels_transaction(self):
-        """ Test that the transaction state is set to 'cancel' when the notification data indicate
+    def test_apply_updates_cancels_transaction(self):
+        """ Test that the transaction state is set to 'cancel' when the payment data indicate
         an unsuccessful payment. """
         tx = self._create_transaction('direct')
-        tx._process_notification_data(dict(self.notification_data, simulated_state='cancel'))
+        tx._apply_updates(dict(self.payment_data, simulated_state='cancel'))
         self.assertEqual(tx.state, 'cancel')
 
-    def test_processing_notification_data_sets_transaction_in_error(self):
-        """ Test that the transaction state is set to 'error' when the notification data indicate
+    def test_apply_updates_sets_transaction_in_error(self):
+        """ Test that the transaction state is set to 'error' when the payment data indicate
         an error during the payment. """
         tx = self._create_transaction('direct')
-        tx._process_notification_data(dict(self.notification_data, simulated_state='error'))
+        tx._apply_updates(dict(self.payment_data, simulated_state='error'))
         self.assertEqual(tx.state, 'error')
 
-    def test_processing_notification_data_tokenizes_transaction(self):
-        """ Test that the transaction is tokenized when it was requested and the notification data
+    def test_apply_updates_tokenizes_transaction(self):
+        """ Test that the transaction is tokenized when it was requested and the payment data
         include token data. """
         tx = self._create_transaction('direct', tokenize=True)
         with patch(
-            'odoo.addons.payment_demo.models.payment_transaction.PaymentTransaction'
-            '._demo_tokenize_from_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._tokenize'
         ) as tokenize_mock:
-            tx._process_notification_data(self.notification_data)
+            tx._apply_updates(self.payment_data)
         self.assertEqual(tokenize_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_demo.models.payment_transaction')
-    def test_processing_notification_data_propagates_simulated_state_to_token(self):
-        """ Test that the simulated state of the notification data is set on the token when
-        processing notification data. """
+    def test_apply_updates_propagates_simulated_state_to_token(self):
+        """ Test that the simulated state of the payment data is set on the token when
+        processing payment data. """
         for counter, state in enumerate(['pending', 'done', 'cancel', 'error']):
             tx = self._create_transaction(
                 'direct', reference=f'{self.reference}-{counter}', tokenize=True
             )
-            tx._process_notification_data(dict(self.notification_data, simulated_state=state))
+            tx._apply_updates(dict(self.payment_data, simulated_state=state))
             self.assertEqual(tx.token_id.demo_simulated_state, state)
 
     def test_making_a_payment_request_propagates_token_simulated_state_to_transaction(self):
@@ -78,25 +77,5 @@ class TestPaymentTransaction(PaymentDemoCommon, PaymentHttpCommon):
                 'direct', reference=f'{self.reference}-{counter}'
             )
             tx.token_id = self._create_token(demo_simulated_state=state)
-            tx._send_payment_request()
+            tx._charge_with_token()
             self.assertEqual(tx.state, tx.token_id.demo_simulated_state)
-
-    def test_send_full_capture_request_does_not_create_capture_tx(self):
-        self.provider.capture_manually = True
-        source_tx = self._create_transaction(flow='direct', state='authorized')
-        child_tx = source_tx._send_capture_request()
-        self.assertFalse(
-            child_tx, msg="Full capture should not create a child transaction."
-        )
-
-    def test_send_partial_capture_request_creates_capture_tx(self):
-        self.provider.capture_manually = True
-        source_tx = self._create_transaction(flow='direct', state='authorized')
-        child_tx = source_tx._send_capture_request(amount_to_capture=10)
-        self.assertTrue(
-            source_tx.child_transaction_ids,
-            msg="Partial capture should create a child transaction and linked it to the source tx.",
-        )
-        self.assertEqual(
-            child_tx.amount, 10, msg="Child transaction should have the requested amount."
-        )

--- a/addons/payment_demo/tests/test_processing_flows.py
+++ b/addons/payment_demo/tests/test_processing_flows.py
@@ -13,12 +13,11 @@ from odoo.addons.payment_demo.tests.common import PaymentDemoCommon
 class TestProcessingFlows(PaymentDemoCommon, PaymentHttpCommon):
 
     def test_portal_payment_triggers_processing(self):
-        """ Test that paying from the frontend triggers the processing of the notification data. """
+        """ Test that paying from the frontend triggers the processing of the payment data. """
         self._create_transaction(flow='direct')
         url = self._build_url(PaymentDemoController._simulation_url)
         with patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self.make_jsonrpc_request(url, params=self.notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self.make_jsonrpc_request(url, params=self.payment_data)
+        self.assertEqual(process_mock.call_count, 1)

--- a/addons/payment_dpo/tests/common.py
+++ b/addons/payment_dpo/tests/common.py
@@ -16,7 +16,7 @@ class DPOCommon(PaymentCommon):
 
         cls.provider = cls.dpo
 
-        cls.notification_data = {
+        cls.payment_data = {
             'TransID': '123456',
             'CompanyRef': 'Test Transaction',
             'CustomerCreditType': 'VISA',

--- a/addons/payment_dpo/tests/test_payment_transaction.py
+++ b/addons/payment_dpo/tests/test_payment_transaction.py
@@ -23,17 +23,17 @@ class TestPaymentTransaction(DPOCommon):
         ):
             self.assertEqual(tx._get_specific_rendering_values(None), expected_values)
 
-    def test_get_tx_from_notification_data_returns_tx(self):
-        """ Test that the transaction is returned from the notification data. """
+    def test_search_by_reference_returns_tx(self):
+        """ Test that the transaction is returned from the payment data. """
         tx = self._create_transaction(flow='redirect')
-        tx_found = self.env['payment.transaction']._get_tx_from_notification_data(
-            'dpo', self.notification_data
+        tx_found = self.env['payment.transaction']._search_by_reference(
+            'dpo', self.payment_data
         )
         self.assertEqual(tx, tx_found)
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicate a
+    def test_apply_updates_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.notification_data)
+        tx._apply_updates(self.payment_data)
         self.assertEqual(tx.state, 'done')

--- a/addons/payment_dpo/tests/test_processing_flows.py
+++ b/addons/payment_dpo/tests/test_processing_flows.py
@@ -16,12 +16,11 @@ class TestProcessingFlows(DPOCommon, PaymentHttpCommon):
     @mute_logger('odoo.addons.payment_dpo.controllers.main')
     def test_redirect_notification_triggers_processing(self):
         """ Test that receiving a valid redirect notification triggers the processing of the
-        notification data. """
+        payment data. """
         self._create_transaction('redirect')
         url = self._build_url(DPOController._return_url)
         with patch(
-            'odoo.addons.payment_dpo.controllers.main.DPOController'
-            '._verify_and_handle_notification_data'
-        ) as verify_and_handle_notification_data_mock:
-            self._make_http_get_request(url, params=self.notification_data)
-            self.assertEqual(verify_and_handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment_dpo.controllers.main.DPOController._verify_and_process'
+        ) as verify_and_process_mock:
+            self._make_http_get_request(url, params=self.payment_data)
+            self.assertEqual(verify_and_process_mock.call_count, 1)

--- a/addons/payment_flutterwave/controllers/main.py
+++ b/addons/payment_flutterwave/controllers/main.py
@@ -2,7 +2,6 @@
 
 import hmac
 import json
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
@@ -11,8 +10,10 @@ from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
+from odoo.addons.payment.logging import get_payment_logger
 
-_logger = logging.getLogger(__name__)
+
+_logger = get_payment_logger(__name__)
 
 
 class FlutterwaveController(http.Controller):
@@ -22,15 +23,14 @@ class FlutterwaveController(http.Controller):
 
     @http.route(_return_url, type='http', methods=['GET'], auth='public')
     def flutterwave_return_from_checkout(self, **data):
-        """ Process the notification data sent by Flutterwave after redirection from checkout.
+        """Process the payment data sent by Flutterwave after redirection from checkout.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         """
         _logger.info("Handling redirection from Flutterwave with data:\n%s", pprint.pformat(data))
 
-        # Handle the notification data.
         if data.get('status') != 'cancelled':
-            self._verify_and_handle_notification_data(data)
+            self._verify_and_process(data)
         else:  # The customer cancelled the payment by clicking on the close button.
             pass  # Don't try to process this case because the transaction id was not provided.
 
@@ -48,7 +48,7 @@ class FlutterwaveController(http.Controller):
 
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def flutterwave_webhook(self):
-        """ Process the notification data sent by Flutterwave to the webhook.
+        """Process the payment data sent by Flutterwave to the webhook.
 
         :return: An empty string to acknowledge the notification.
         :rtype: str
@@ -57,54 +57,54 @@ class FlutterwaveController(http.Controller):
         _logger.info("Notification received from Flutterwave with data:\n%s", pprint.pformat(data))
 
         if data['event'] == 'charge.completed':
-            try:
-                # Check the origin of the notification.
-                tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                    'flutterwave', data['data']
-                )
+            payment_data = data['data']
+            tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
+                'flutterwave', payment_data
+            )
+            if tx_sudo:
                 signature = request.httprequest.headers.get('verif-hash')
-                self._verify_notification_signature(signature, tx_sudo)
-
-                # Handle the notification data.
-                notification_data = data['data']
-                tx_sudo._handle_notification_data('flutterwave', notification_data)
-            except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-                _logger.exception("Unable to handle the notification data; skipping to acknowledge")
+                self._verify_signature(signature, tx_sudo)
+            tx_sudo._process('flutterwave', payment_data)
         return request.make_json_response('')
 
     @staticmethod
-    def _verify_notification_signature(received_signature, tx_sudo):
-        """ Check that the received signature matches the expected one.
+    def _verify_signature(received_signature, tx_sudo):
+        """Check that the received signature matches the expected one.
 
-        :param dict received_signature: The signature received with the notification data.
-        :param recordset tx_sudo: The sudoed transaction referenced by the notification data, as a
-                                  `payment.transaction` record.
+        :param dict received_signature: The signature received with the payment data.
+        :param payment.transaction tx_sudo: The sudoed transaction referenced by the payment data.
         :return: None
         :raise Forbidden: If the signatures don't match.
         """
         # Check for the received signature.
         if not received_signature:
-            _logger.warning("Received notification with missing signature.")
+            _logger.warning("Received payment data with missing signature.")
             raise Forbidden()
 
         # Compare the received signature with the expected signature.
         expected_signature = tx_sudo.provider_id.flutterwave_webhook_secret
         if not hmac.compare_digest(received_signature, expected_signature):
-            _logger.warning("Received notification with invalid signature.")
+            _logger.warning("Received payment data with invalid signature.")
             raise Forbidden()
 
     @staticmethod
-    def _verify_and_handle_notification_data(data):
-        """ Verify and process the notification data sent by Flutterwave.
+    def _verify_and_process(data):
+        """Verify and process the payment data sent by Flutterwave.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         :return: None
         """
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
             'flutterwave', data
         )
-        # Verify the notification data.
-        verified_data = tx_sudo.provider_id._flutterwave_make_request(
-            'transactions/verify_by_reference', payload={'tx_ref': tx_sudo.reference}, method='GET',
-        )['data']
-        tx_sudo._handle_notification_data('flutterwave', verified_data)
+        if not tx_sudo:
+            return
+
+        try:
+            verified_data = tx_sudo._send_api_request(
+                'GET', 'transactions/verify_by_reference', params={'tx_ref': tx_sudo.reference},
+            )
+        except ValidationError:
+            _logger.error("Unable to verify the payment data")
+        else:
+            tx_sudo._process('flutterwave', verified_data)

--- a/addons/payment_flutterwave/models/payment_provider.py
+++ b/addons/payment_flutterwave/models/payment_provider.py
@@ -1,20 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import pprint
-
-import requests
 from werkzeug.urls import url_join
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.const import REPORT_REASONS_MAPPING
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_flutterwave import const
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentProvider(models.Model):
@@ -48,6 +44,24 @@ class PaymentProvider(models.Model):
             'support_tokenization': True,
         })
 
+    def _get_supported_currencies(self):
+        """ Override of `payment` to return the supported currencies. """
+        supported_currencies = super()._get_supported_currencies()
+        if self.code == 'flutterwave':
+            supported_currencies = supported_currencies.filtered(
+                lambda c: c.name in const.SUPPORTED_CURRENCIES
+            )
+        return supported_currencies
+
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.code != 'flutterwave':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
     # === BUSINESS METHODS ===#
 
     @api.model
@@ -69,56 +83,28 @@ class PaymentProvider(models.Model):
 
         return providers
 
-    def _get_supported_currencies(self):
-        """ Override of `payment` to return the supported currencies. """
-        supported_currencies = super()._get_supported_currencies()
-        if self.code == 'flutterwave':
-            supported_currencies = supported_currencies.filtered(
-                lambda c: c.name in const.SUPPORTED_CURRENCIES
-            )
-        return supported_currencies
+    # === REQUEST HELPERS === #
 
-    def _flutterwave_make_request(self, endpoint, payload=None, method='POST'):
-        """ Make a request to Flutterwave API at the specified endpoint.
-
-        Note: self.ensure_one()
-
-        :param str endpoint: The endpoint to be reached by the request.
-        :param dict payload: The payload of the request.
-        :param str method: The HTTP method of the request.
-        :return The JSON-formatted content of the response.
-        :rtype: dict
-        :raise ValidationError: If an HTTP error occurs.
-        """
-        self.ensure_one()
-
-        url = url_join('https://api.flutterwave.com/v3/', endpoint)
-        headers = {'Authorization': f'Bearer {self.flutterwave_secret_key}'}
-        try:
-            if method == 'GET':
-                response = requests.get(url, params=payload, headers=headers, timeout=10)
-            else:
-                response = requests.post(url, json=payload, headers=headers, timeout=10)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                _logger.exception(
-                    "Invalid API request at %s with data:\n%s", url, pprint.pformat(payload),
-                )
-                raise ValidationError("Flutterwave: " + _(
-                    "The communication with the API failed. Flutterwave gave us the following "
-                    "information: '%s'", response.json().get('message', '')
-                ))
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.exception("Unable to reach endpoint at %s", url)
-            raise ValidationError(
-                "Flutterwave: " + _("Could not establish the connection to the API.")
-            )
-        return response.json()
-
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the request URL."""
         if self.code != 'flutterwave':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES
+            return super()._build_request_url(endpoint, **kwargs)
+        return url_join('https://api.flutterwave.com/v3/', endpoint)
+
+    def _build_request_headers(self, *args, **kwargs):
+        """Override of `payment` to build the request headers."""
+        if self.code != 'flutterwave':
+            return super()._build_request_headers(*args, **kwargs)
+        return {'Authorization': f'Bearer {self.flutterwave_secret_key}'}
+
+    def _parse_response_error(self, response):
+        """Override of `payment` to parse the error message."""
+        if self.code != 'flutterwave':
+            return super()._parse_response_error(response)
+        return response.json().get('message', '')
+
+    def _parse_response_content(self, response, **kwargs):
+        """Override of `payment` to parse the response content."""
+        if self.code != 'flutterwave':
+            return super()._parse_response_content(response, **kwargs)
+        return response.json()['data']

--- a/addons/payment_flutterwave/models/payment_transaction.py
+++ b/addons/payment_flutterwave/models/payment_transaction.py
@@ -1,19 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import pprint
-
 from werkzeug import urls
 
-from odoo import _, models
-from odoo.exceptions import UserError, ValidationError
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_flutterwave import const
 from odoo.addons.payment_flutterwave.controllers.main import FlutterwaveController
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentTransaction(models.Model):
@@ -27,13 +25,13 @@ class PaymentTransaction(models.Model):
 
         Note: `self.ensure_one()`
         """
-        res = super()._get_specific_processing_values(processing_values)
-        if self._flutterwave_is_authorization_pending():
-            res['redirect_form_html'] = self.env['ir.qweb']._render(
-                self.provider_id.redirect_form_view_id.id,
-                {'auth_url': self.provider_reference},
-            )
-        return res
+        if not self._flutterwave_is_authorization_pending():
+            return super()._get_specific_processing_values(processing_values)
+
+        return {'redirect_form_html': self.env['ir.qweb']._render(
+            self.provider_id.redirect_form_view_id.id,
+            {'auth_url': self.provider_reference},
+        )}
 
     def _get_specific_rendering_values(self, processing_values):
         """ Override of payment to return Flutterwave-specific rendering values.
@@ -68,29 +66,19 @@ class PaymentTransaction(models.Model):
                 self.payment_method_code, self.payment_method_code
             ),
         }
-        payment_link_data = self.provider_id._flutterwave_make_request('payments', payload=payload)
+        try:
+            payment_link_data = self._send_api_request('POST', 'payments', json=payload)
+        except ValidationError as error:
+            self._set_error(str(error))
+            return {}
 
         # Extract the payment link URL and embed it in the redirect form.
-        rendering_values = {
-            'api_url': payment_link_data['data']['link'],
-        }
-        return rendering_values
+        return {'api_url': payment_link_data['link']}
 
     def _send_payment_request(self):
-        """ Override of payment to send a payment request to Flutterwave.
-
-        Note: self.ensure_one()
-
-        :return: None
-        :raise UserError: If the transaction is not linked to a token.
-        """
-        super()._send_payment_request()
+        """Override of `payment` to send a payment request to Flutterwave."""
         if self.provider_code != 'flutterwave':
-            return
-
-        # Prepare the payment request to Flutterwave.
-        if not self.token_id:
-            raise UserError("Flutterwave: " + _("The transaction is not linked to a token."))
+            return super()._send_payment_request()
 
         first_name, last_name = payment_utils.split_partner_name(self.partner_name)
         base_url = self.provider_id.get_base_url()
@@ -107,96 +95,59 @@ class PaymentTransaction(models.Model):
             'redirect_url': urls.url_join(base_url, FlutterwaveController._auth_return_url),
         }
 
-        # Make the payment request to Flutterwave.
-        response_content = self.provider_id._flutterwave_make_request(
-            'tokenized-charges', payload=data
-        )
+        try:
+            response_content = self._send_api_request('POST', 'tokenized-charges', json=data)
+        except ValidationError as error:
+            self._set_error(str(error))
+        else:
+            self._process('flutterwave', response_content)
 
-        # Handle the payment request response.
-        _logger.info(
-            "payment request response for transaction with reference %s:\n%s",
-            self.reference, pprint.pformat(response_content)
-        )
-        self._handle_notification_data('flutterwave', response_content['data'])
+    @api.model
+    def _extract_reference(self, provider_code, payment_data):
+        """Override of `payment` to extract the reference from the payment data."""
+        if provider_code != 'flutterwave':
+            return super()._extract_reference(provider_code, payment_data)
+        return payment_data.get('tx_ref') or payment_data.get('txRef')
 
-    def _get_tx_from_notification_data(self, provider_code, notification_data):
-        """ Override of payment to find the transaction based on Flutterwave data.
-
-        :param str provider_code: The code of the provider that handled the transaction.
-        :param dict notification_data: The notification data sent by the provider.
-        :return: The transaction if found.
-        :rtype: recordset of `payment.transaction`
-        :raise ValidationError: If inconsistent data were received.
-        :raise ValidationError: If the data match no transaction.
-        """
-        tx = super()._get_tx_from_notification_data(provider_code, notification_data)
-        if provider_code != 'flutterwave' or len(tx) == 1:
-            return tx
-
-        reference = notification_data.get('tx_ref') or notification_data.get('txRef')
-        if not reference:
-            raise ValidationError("Flutterwave: " + _("Received data with missing reference."))
-
-        tx = self.search([('reference', '=', reference), ('provider_code', '=', 'flutterwave')])
-        if not tx:
-            raise ValidationError(
-                "Flutterwave: " + _("No transaction found matching reference %s.", reference)
-            )
-        return tx
-
-    def _compare_notification_data(self, notification_data):
-        """ Override of `payment` to compare the transaction based on Flutterwave data.
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If the transaction's amount and currency don't match the
-            notification data.
-        """
+    def _extract_amount_data(self, payment_data):
+        """Override of `payment` to extract the amount and currency from the payment data."""
         if self.provider_code != 'flutterwave':
-            return super()._compare_notification_data(notification_data)
+            return super()._extract_amount_data(payment_data)
 
-        amount = notification_data.get('amount')
-        currency_code = notification_data.get('currency')
-        self._validate_amount_and_currency(amount, currency_code)
+        amount = payment_data.get('amount')
+        currency_code = payment_data.get('currency')
+        return {
+            'amount': float(amount),
+            'currency_code': currency_code,
+        }
 
-    def _process_notification_data(self, notification_data):
-        """ Override of payment to process the transaction based on Flutterwave data.
-
-        Note: self.ensure_one()
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If inconsistent data were received.
-        """
-        super()._process_notification_data(notification_data)
+    def _apply_updates(self, payment_data):
+        """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != 'flutterwave':
-            return
+            return super()._apply_updates(payment_data)
 
         # Update the provider reference.
-        self.provider_reference = notification_data['id']
+        self.provider_reference = payment_data['id']
 
         # Update payment method.
-        payment_method_type = notification_data.get('payment_type', '')
+        payment_method_type = payment_data.get('payment_type', '')
         if payment_method_type == 'card':
-            payment_method_type = notification_data.get('card', {}).get('type').lower()
+            payment_method_type = payment_data.get('card', {}).get('type').lower()
         payment_method = self.env['payment.method']._get_from_code(
             payment_method_type, mapping=const.PAYMENT_METHODS_MAPPING
         )
         self.payment_method_id = payment_method or self.payment_method_id
 
         # Update the payment state.
-        payment_status = notification_data['status'].lower()
+        payment_status = payment_data['status'].lower()
         if payment_status in const.PAYMENT_STATUS_MAPPING['pending']:
-            auth_url = notification_data.get('meta', {}).get('authorization', {}).get('redirect')
+            auth_url = payment_data.get('meta', {}).get('authorization', {}).get('redirect')
             if auth_url:
                 # will be set back to the actual value after moving away from pending
                 self.provider_reference = auth_url
             self._set_pending()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['done']:
             self._set_done()
-            has_token_data = 'token' in notification_data.get('card', {})
-            if self.tokenize and has_token_data:
-                self._flutterwave_tokenize_from_notification_data(notification_data)
         elif payment_status in const.PAYMENT_STATUS_MAPPING['cancel']:
             self._set_canceled()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['error']:
@@ -206,42 +157,24 @@ class PaymentTransaction(models.Model):
             ))
         else:
             _logger.warning(
-                "Received data with invalid payment status (%s) for transaction with reference %s.",
+                "Received data with invalid payment status (%s) for transaction %s.",
                 payment_status, self.reference
             )
-            self._set_error("Flutterwave: " + _("Unknown payment status: %s", payment_status))
+            self._set_error(_("Unknown payment status: %s", payment_status))
 
-    def _flutterwave_tokenize_from_notification_data(self, notification_data):
-        """ Create a new token based on the notification data.
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to extract the token values from the payment data."""
+        if self.provider_code != 'flutterwave':
+            return super()._extract_token_values(payment_data)
 
-        Note: self.ensure_one()
+        if 'token' not in payment_data.get('card', {}):
+            return {}
 
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        """
-        self.ensure_one()
-
-        token = self.env['payment.token'].create({
-            'provider_id': self.provider_id.id,
-            'payment_method_id': self.payment_method_id.id,
-            'payment_details': notification_data['card']['last_4digits'],
-            'partner_id': self.partner_id.id,
-            'provider_ref': notification_data['card']['token'],
-            'flutterwave_customer_email': notification_data['customer']['email'],
-        })
-        self.write({
-            'token_id': token,
-            'tokenize': False,
-        })
-        _logger.info(
-            "created token with id %(token_id)s for partner with id %(partner_id)s from "
-            "transaction with reference %(ref)s",
-            {
-                'token_id': token.id,
-                'partner_id': self.partner_id.id,
-                'ref': self.reference,
-            },
-        )
+        return {
+            'payment_details': payment_data['card']['last_4digits'],
+            'provider_ref': payment_data['card']['token'],
+            'flutterwave_customer_email': payment_data['customer']['email'],
+        }
 
     def _flutterwave_is_authorization_pending(self):
         """ Filter Flutterwave token transactions that are awaiting external authorization.

--- a/addons/payment_flutterwave/tests/common.py
+++ b/addons/payment_flutterwave/tests/common.py
@@ -17,11 +17,11 @@ class FlutterwaveCommon(PaymentCommon):
 
         cls.provider = cls.flutterwave
 
-        cls.redirect_notification_data = {
+        cls.redirect_payment_data = {
             'status': 'successful',
             'tx_ref': cls.reference,
         }
-        cls.webhook_notification_data = {
+        cls.webhook_payment_data = {
             'event': 'charge.completed',
             'data': {
                 'tx_ref': cls.reference,

--- a/addons/payment_flutterwave/tests/test_payment_provider.py
+++ b/addons/payment_flutterwave/tests/test_payment_provider.py
@@ -1,5 +1,9 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
+import requests
+
 from odoo.tests import tagged
 
 from odoo.addons.payment_flutterwave.tests.common import FlutterwaveCommon
@@ -19,3 +23,9 @@ class TestPaymentProvider(FlutterwaveCommon):
             self.company_id, self.partner.id, 0., is_validation=True
         )
         self.assertNotIn(self.flutterwave, compatible_providers)
+
+    def test_parse_response_content(self):
+        response = requests.Response()
+        response._content = json.dumps({'data': 'value'}).encode('utf-8')
+        parsed_response = self.flutterwave._parse_response_content(response)
+        self.assertEqual(parsed_response, 'value')

--- a/addons/payment_flutterwave/tests/test_processing_flows.py
+++ b/addons/payment_flutterwave/tests/test_processing_flows.py
@@ -22,30 +22,28 @@ class TestProcessingFlows(FlutterwaveCommon, PaymentHttpCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(FlutterwaveController._return_url)
         with patch(
-            'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'
-            '._flutterwave_make_request', return_value=self.verification_data
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
+            return_value=self.verification_data,
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_get_request(url, params=self.redirect_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_get_request(url, params=self.redirect_payment_data)
+        self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_flutterwave.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification triggers the processing of the
-        notification data. """
+        payment data. """
         self._create_transaction('redirect')
         url = self._build_url(FlutterwaveController._webhook_url)
         with patch(
             'odoo.addons.payment_flutterwave.controllers.main.FlutterwaveController.'
-            '_verify_notification_signature'
+            '_verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_json_request(url, data=self.webhook_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_json_request(url, data=self.webhook_payment_data)
+        self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_flutterwave.controllers.main')
     def test_webhook_notification_triggers_signature_check(self):
@@ -54,12 +52,11 @@ class TestProcessingFlows(FlutterwaveCommon, PaymentHttpCommon):
         url = self._build_url(FlutterwaveController._webhook_url)
         with patch(
             'odoo.addons.payment_flutterwave.controllers.main.FlutterwaveController'
-            '._verify_notification_signature'
+            '._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_json_request(url, data=self.webhook_notification_data)
+            self._make_json_request(url, data=self.webhook_payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     def test_accept_webhook_notification_with_valid_signature(self):
@@ -67,7 +64,7 @@ class TestProcessingFlows(FlutterwaveCommon, PaymentHttpCommon):
         tx = self._create_transaction('redirect')
         self._assert_does_not_raise(
             Forbidden,
-            FlutterwaveController._verify_notification_signature,
+            FlutterwaveController._verify_signature,
             self.provider.flutterwave_webhook_secret,
             tx,
         )
@@ -76,12 +73,10 @@ class TestProcessingFlows(FlutterwaveCommon, PaymentHttpCommon):
     def test_reject_notification_with_missing_signature(self):
         """ Test the verification of a notification with a missing signature. """
         tx = self._create_transaction('redirect')
-        self.assertRaises(Forbidden, FlutterwaveController._verify_notification_signature, None, tx)
+        self.assertRaises(Forbidden, FlutterwaveController._verify_signature, None, tx)
 
     @mute_logger('odoo.addons.payment_flutterwave.controllers.main')
     def test_reject_notification_with_invalid_signature(self):
         """ Test the verification of a notification with an invalid signature. """
         tx = self._create_transaction('redirect')
-        self.assertRaises(
-            Forbidden, FlutterwaveController._verify_notification_signature, 'dummy', tx
-        )
+        self.assertRaises(Forbidden, FlutterwaveController._verify_signature, 'dummy', tx)

--- a/addons/payment_mercado_pago/tests/common.py
+++ b/addons/payment_mercado_pago/tests/common.py
@@ -15,11 +15,11 @@ class MercadoPagoCommon(PaymentCommon):
             'mercado_pago_access_token': 'TEST-4850554046279901-TEST-TEST',
         })
         cls.payment_id = '123456'
-        cls.redirect_notification_data = {
+        cls.redirect_payment_data = {
             'external_reference': cls.reference,
             'payment_id': cls.payment_id,
         }
-        cls.webhook_notification_data = {
+        cls.webhook_payment_data = {
             'action': 'payment.created',
             'data': {'id': cls.payment_id},
         }

--- a/addons/payment_mercado_pago/tests/test_payment_transaction.py
+++ b/addons/payment_mercado_pago/tests/test_payment_transaction.py
@@ -58,19 +58,19 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
         self.assertEqual(form_info['method'], 'get')
         self.assertDictEqual(form_info['inputs'], {})
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicate a
+    def test_apply_updates_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.verification_data)
+        tx._apply_updates(self.verification_data)
         self.assertEqual(tx.state, 'done')
 
     @mute_logger('odoo.addons.payment_mercado_pago.models.payment_transaction')
-    def test_processing_notification_data_rejects_transaction(self):
-        """ Test that the transaction state is set to 'error' when the notification data indicate a status of
+    def test_apply_updates_rejects_transaction(self):
+        """ Test that the transaction state is set to 'error' when the payment data indicate a status of
         404 error payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.verification_data_for_error_state)
+        tx._apply_updates(self.verification_data_for_error_state)
         self.assertEqual(tx.state, 'error')
 
     def test_cop_currency_rounding(self):

--- a/addons/payment_mercado_pago/tests/test_processing_flows.py
+++ b/addons/payment_mercado_pago/tests/test_processing_flows.py
@@ -20,27 +20,25 @@ class TestProcessingFlows(MercadoPagoCommon, PaymentHttpCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(MercadoPagoController._return_url)
         with patch(
-            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
-            '._mercado_pago_make_request', return_value=self.verification_data
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
+            return_value=self.verification_data,
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_get_request(url, params=self.redirect_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_get_request(url, params=self.redirect_payment_data)
+        self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_mercado_pago.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification triggers the processing of the
-        notification data. """
+        payment data. """
         tx = self._create_transaction(flow='redirect')
         url = self._build_url(f'{MercadoPagoController._webhook_url}/{tx.reference}')
         with patch(
-            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
-            '._mercado_pago_make_request', return_value=self.verification_data
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
+            return_value=self.verification_data,
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_json_request(url, data=self.webhook_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_json_request(url, data=self.webhook_payment_data)
+        self.assertEqual(process_mock.call_count, 1)

--- a/addons/payment_mollie/controllers/main.py
+++ b/addons/payment_mollie/controllers/main.py
@@ -1,14 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 import pprint
 
 from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
 
+from odoo.addons.payment.logging import get_payment_logger
 
-_logger = logging.getLogger(__name__)
+
+_logger = get_payment_logger(__name__)
 
 
 class MollieController(http.Controller):
@@ -20,7 +21,7 @@ class MollieController(http.Controller):
         save_session=False
     )
     def mollie_return_from_checkout(self, **data):
-        """ Process the notification data sent by Mollie after redirection from checkout.
+        """Process the payment data sent by Mollie after redirection from checkout.
 
         The route is flagged with `save_session=False` to prevent Odoo from assigning a new session
         to the user if they are redirected to this route with a POST request. Indeed, as the session
@@ -30,41 +31,42 @@ class MollieController(http.Controller):
         will satisfy any specification of the `SameSite` attribute, the session of the user will be
         retrieved and with it the transaction which will be immediately post-processed.
 
-        :param dict data: The notification data (only `id`) and the transaction reference (`ref`)
-                          embedded in the return URL
+        :param dict data: The payment data (only `id`) and the transaction reference (`ref`)
+                          embedded in the return URL.
         """
         _logger.info("handling redirection from Mollie with data:\n%s", pprint.pformat(data))
-        self._verify_and_handle_notification_data(data)
+        self._verify_and_process(data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def mollie_webhook(self, **data):
-        """ Process the notification data sent by Mollie to the webhook.
+        """Process the payment data sent by Mollie to the webhook.
 
-        :param dict data: The notification data (only `id`) and the transaction reference (`ref`)
+        :param dict data: The payment data (only `id`) and the transaction reference (`ref`)
                           embedded in the return URL
         :return: An empty string to acknowledge the notification
         :rtype: str
         """
         _logger.info("notification received from Mollie with data:\n%s", pprint.pformat(data))
-        try:
-            self._verify_and_handle_notification_data(data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed
-            _logger.exception("unable to handle the notification data; skipping to acknowledge")
+        self._verify_and_process(data)
         return ''  # Acknowledge the notification
 
     @staticmethod
-    def _verify_and_handle_notification_data(data):
-        """ Verify and process the notification data sent by Mollie.
+    def _verify_and_process(data):
+        """Verify and process the payment data sent by Mollie.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         :return: None
         """
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-            'mollie', data
-        )
-        # Verify the notification data.
-        verified_data = tx_sudo.provider_id._mollie_make_request(
-            f'/payments/{tx_sudo.provider_reference}', method="GET"
-        )
-        tx_sudo._handle_notification_data('mollie', verified_data)
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('mollie', data)
+        if not tx_sudo:
+            return
+
+        try:
+            verified_data = tx_sudo._send_api_request(
+                'GET', f'/payments/{tx_sudo.provider_reference}'
+            )
+        except ValidationError:
+            _logger.error("Unable to process the payment data")
+        else:
+            tx_sudo._process('mollie', verified_data)

--- a/addons/payment_mollie/models/payment_provider.py
+++ b/addons/payment_mollie/models/payment_provider.py
@@ -1,18 +1,14 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import pprint
-
-import requests
 from werkzeug import urls
 
 from odoo import _, fields, models, service
-from odoo.exceptions import ValidationError
 
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_mollie import const
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentProvider(models.Model):
@@ -27,7 +23,7 @@ class PaymentProvider(models.Model):
         required_if_provider="mollie", groups="base.group_system"
     )
 
-    #=== BUSINESS METHODS ===#
+    # === COMPUTE METHODS === #
 
     def _get_supported_currencies(self):
         """ Override of `payment` to return the supported currencies. """
@@ -38,55 +34,42 @@ class PaymentProvider(models.Model):
             )
         return supported_currencies
 
-    def _mollie_make_request(self, endpoint, data=None, method='POST'):
-        """ Make a request at mollie endpoint.
-
-        Note: self.ensure_one()
-
-        :param str endpoint: The endpoint to be reached by the request
-        :param dict data: The payload of the request
-        :param str method: The HTTP method of the request
-        :return The JSON-formatted content of the response
-        :rtype: dict
-        :raise: ValidationError if an HTTP error occurs
-        """
-        self.ensure_one()
-        endpoint = f'/v2/{endpoint.strip("/")}'
-        url = urls.url_join('https://api.mollie.com/', endpoint)
-
-        odoo_version = service.common.exp_version()['server_version']
-        module_version = self.env.ref('base.module_payment_mollie').installed_version
-        headers = {
-            "Accept": "application/json",
-            "Authorization": f'Bearer {self.mollie_api_key}',
-            "Content-Type": "application/json",
-            # See https://docs.mollie.com/integration-partners/user-agent-strings
-            "User-Agent": f'Odoo/{odoo_version} MollieNativeOdoo/{module_version}',
-        }
-
-        try:
-            response = requests.request(method, url, json=data, headers=headers, timeout=60)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                _logger.exception(
-                    "Invalid API request at %s with data:\n%s", url, pprint.pformat(data)
-                )
-                raise ValidationError(
-                    "Mollie: " + _(
-                        "The communication with the API failed. Mollie gave us the following "
-                        "information: %s", response.json().get('detail', '')
-                    ))
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.exception("Unable to reach endpoint at %s", url)
-            raise ValidationError(
-                "Mollie: " + _("Could not establish the connection to the API.")
-            )
-        return response.json()
+    # === CRUD METHODS === #
 
     def _get_default_payment_method_codes(self):
         """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+        self.ensure_one()
+
         if self.code != 'mollie':
-            return default_codes
+            return super()._get_default_payment_method_codes()
         return const.DEFAULT_PAYMENT_METHOD_CODES
+
+    # === REQUEST HELPERS === #
+
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the request URL."""
+        if self.code != 'mollie':
+            return super()._build_request_url(endpoint, **kwargs)
+        return urls.url_join('https://api.mollie.com/v2/', endpoint.strip('/'))
+
+    def _build_request_headers(self, *args, **kwargs):
+        """Override of `payment` to build the request headers."""
+        if self.code != 'mollie':
+            return super()._build_request_headers(*args, **kwargs)
+
+        odoo_version = service.common.exp_version()['server_version']
+        module_version = self.env.ref('base.module_payment_mollie').installed_version
+        return {
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {self.mollie_api_key}',
+            'Content-Type': 'application/json',
+            # See https://docs.mollie.com/integration-partners/user-agent-strings
+            'User-Agent': f'Odoo/{odoo_version} MollieNativeOdoo/{module_version}',
+        }
+
+    def _parse_response_error(self, response):
+        """Override of `payment` to parse the error message."""
+        if self.code != 'mollie':
+            return super()._parse_response_error(response)
+
+        return response.json().get('detail', '')

--- a/addons/payment_mollie/tests/common.py
+++ b/addons/payment_mollie/tests/common.py
@@ -15,7 +15,7 @@ class MollieCommon(PaymentCommon):
         cls.provider = cls.mollie
         cls.currency = cls.currency_euro
 
-        cls.notification_data = {
+        cls.payment_data = {
             'ref': cls.reference,
             'id': 'tr_ABCxyz0123',
         }

--- a/addons/payment_mollie/tests/test_mollie.py
+++ b/addons/payment_mollie/tests/test_mollie.py
@@ -30,12 +30,11 @@ class MollieTest(MollieCommon, PaymentHttpCommon):
         tx = self._create_transaction('redirect')
         url = self._build_url(MollieController._webhook_url)
         with patch(
-            'odoo.addons.payment_mollie.models.payment_provider.PaymentProvider'
-            '._mollie_make_request',
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
             return_value={
                 'status': 'paid',
                 'amount': {'value': str(self.amount), 'currency': self.currency.name},
             },
         ):
-            self._make_http_post_request(url, data=self.notification_data)
+            self._make_http_post_request(url, data=self.payment_data)
         self.assertEqual(tx.state, 'done')

--- a/addons/payment_nuvei/controllers/main.py
+++ b/addons/payment_nuvei/controllers/main.py
@@ -1,19 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import consteq
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class NuveiController(http.Controller):
@@ -22,59 +21,51 @@ class NuveiController(http.Controller):
 
     @http.route(_return_url, type='http', auth='public', methods=['GET'])
     def nuvei_return_from_checkout(self, tx_ref=None, error_access_token=None, **data):
-        """ Process the notification data sent by Nuvei after redirection.
+        """Process the payment data sent by Nuvei after redirection.
 
         :param str tx_ref: The optional reference of the transaction having been canceled/errored.
         :param str error_access_token: The optional access token to verify the authenticity of
                                        requests for errored payments.
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         """
         _logger.info("Handling redirection from Nuvei with data:\n%s", pprint.pformat(data))
         if tx_ref and error_access_token:
-            _logger.warning("Nuvei errored on transaction with reference: %s", tx_ref)
+            _logger.warning("Nuvei errored on transaction: %s.", tx_ref)
 
         tx_data = data or {'invoice_id': tx_ref}
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-            'nuvei', tx_data
-        )
-        self._verify_notification_signature(tx_sudo, data, error_access_token=error_access_token)
-
-        # Handle the notification data if there is any.
-        tx_sudo._handle_notification_data('nuvei', data)
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('nuvei', tx_data)
+        if tx_sudo:
+            self._verify_signature(
+                tx_sudo, data, error_access_token=error_access_token
+            )
+            tx_sudo._process('nuvei', data)
         return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def nuvei_webhook(self, **data):
-        """ Process the notification data sent by Nuvei to the webhook.
+        """Process the payment data sent by Nuvei to the webhook.
 
         See https://docs.nuvei.com/documentation/integration/webhooks/payment-dmns/.
 
-        :param dict data: The notification data.
+        :param dict data: The payment data.
         :return: The 'OK' string to acknowledge the notification.
         :rtype: str
         """
         _logger.info("Notification received from Nuvei with data:\n%s", pprint.pformat(data))
-        try:
-            # Check the integrity of the notification.
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'nuvei', data
-            )
-            self._verify_notification_signature(tx_sudo, data)
-
-            # Handle the notification data.
-            tx_sudo._handle_notification_data('nuvei', data)
-        except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-            _logger.exception("Unable to handle the notification data; skipping to acknowledge.")
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('nuvei', data)
+        if tx_sudo:
+            self._verify_signature(tx_sudo, data)
+            tx_sudo._process('nuvei', data)
 
         return 'OK'  # Acknowledge the notification.
 
     @staticmethod
-    def _verify_notification_signature(tx_sudo, notification_data, error_access_token=None):
-        """ Check that the received signature matches the expected one.
+    def _verify_signature(tx_sudo, payment_data, error_access_token=None):
+        """Check that the received signature matches the expected one.
 
         :param payment.transaction tx_sudo: The sudoed transaction referenced by the notification
                                             data.
-        :param dict notification_data: The notification data.
+        :param dict payment_data: The payment data.
         :param str error_access_token: The optional access token for verifying errored payments.
         :return: None
         :raise Forbidden: If the signatures don't match.
@@ -86,15 +77,15 @@ class NuveiController(http.Controller):
                 _logger.warning("Received cancel/error with invalid access token.")
                 raise Forbidden()
         else:  # The payment went through.
-            received_signature = notification_data.get('advanceResponseChecksum')
+            received_signature = payment_data.get('advanceResponseChecksum')
             if not received_signature:
-                _logger.warning("received notification with missing signature")
+                _logger.warning("Received payment data with missing signature")
                 raise Forbidden()
 
             # Compare the received signature with the expected signature computed from the data.
             expected_signature = tx_sudo.provider_id._nuvei_calculate_signature(
-                notification_data, incoming=True,
+                payment_data, incoming=True,
             )
             if not consteq(received_signature, expected_signature):
-                _logger.warning("received notification with invalid signature")
+                _logger.warning("Received payment data with invalid signature")
                 raise Forbidden()

--- a/addons/payment_nuvei/tests/common.py
+++ b/addons/payment_nuvei/tests/common.py
@@ -16,7 +16,7 @@ class NuveiCommon(PaymentHttpCommon):
 
         cls.provider = cls.nuvei
 
-        cls.notification_data = {
+        cls.payment_data = {
             "ppp_status": "OK",
             "currency": "USD",
             "PPP_TransactionID": "489616878",

--- a/addons/payment_nuvei/tests/test_payment_provider.py
+++ b/addons/payment_nuvei/tests/test_payment_provider.py
@@ -41,8 +41,8 @@ class TestPaymentProvider(NuveiCommon):
     def test_signature_calculation_for_incoming_data(self):
         """ Test that the calculated signature matches the expected signature for incoming data. """
         calculated_signature = self.provider._nuvei_calculate_signature(
-            self.notification_data, incoming=True
+            self.payment_data, incoming=True
         )
-        received_signature = self.notification_data.get('advanceResponseChecksum')
+        received_signature = self.payment_data.get('advanceResponseChecksum')
         self.assertEqual(calculated_signature, received_signature)
 

--- a/addons/payment_nuvei/tests/test_payment_transaction.py
+++ b/addons/payment_nuvei/tests/test_payment_transaction.py
@@ -122,34 +122,34 @@ class TestPaymentTransaction(NuveiCommon):
         input_keys.sort()
         self.assertListEqual(input_keys, expected_input_keys)
 
-    def test_processing_notification_data_confirms_transaction(self):
-        """ Test that the transaction state is set to 'done' when the notification data indicates a
+    def test_apply_updates_confirms_transaction(self):
+        """ Test that the transaction state is set to 'done' when the payment data indicates a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data(self.notification_data)
+        tx._apply_updates(self.payment_data)
         self.assertEqual(tx.state, 'done')
 
-    def test_processing_notification_data_sets_transaction_in_error(self):
-        """ Test that the transaction state is set to 'error' when the notification data indicates
+    def test_apply_updates_sets_transaction_in_error(self):
+        """ Test that the transaction state is set to 'error' when the payment data indicates
         that something went wrong. """
         tx = self._create_transaction(flow='redirect')
-        payload = dict(self.notification_data, Status='ERROR', Reason='Invalid Card')
-        tx._process_notification_data(payload)
+        payload = dict(self.payment_data, Status='ERROR', Reason='Invalid Card')
+        tx._apply_updates(payload)
         self.assertEqual(tx.state, 'error')
 
-    def test_processing_notification_data_sets_unknown_transaction_in_error(self):
-        """ Test that the transaction state is set to 'error' when the notification data returns
+    def test_apply_updates_sets_unknown_transaction_in_error(self):
+        """ Test that the transaction state is set to 'error' when the payment data returns
         something with an unknown state. """
         tx = self._create_transaction(flow='redirect')
-        payload = dict(self.notification_data, Status='???', Reason='Invalid Card')
-        tx._process_notification_data(payload)
+        payload = dict(self.payment_data, Status='???', Reason='Invalid Card')
+        tx._apply_updates(payload)
         self.assertEqual(tx.state, 'error')
 
-    def test_processing_notification_data_sets_transaction_to_cancel(self):
-        """ Test that the transaction state is set to 'cancel' when the notification data is
+    def test_processing_payment_data_sets_transaction_to_cancel(self):
+        """ Test that the transaction state is set to 'cancel' when the payment data is
         missing. """
         tx = self._create_transaction(flow='redirect')
-        tx._process_notification_data({})
+        tx._apply_updates({})
         self.assertEqual(tx.state_message, 'The customer left the payment page.')
         self.assertEqual(tx.state, 'cancel')
 

--- a/addons/payment_nuvei/tests/test_processing_flows.py
+++ b/addons/payment_nuvei/tests/test_processing_flows.py
@@ -21,30 +21,26 @@ class TestProcessingFlows(NuveiCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(NuveiController._return_url)
         with patch(
-            'odoo.addons.payment_nuvei.controllers.main.NuveiController'
-            '._verify_notification_signature'
+            'odoo.addons.payment_nuvei.controllers.main.NuveiController._verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_get_request(url, params=self.notification_data)
-            self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_get_request(url, params=self.payment_data)
+            self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_nuvei.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification triggers the processing of the
-        notification data. """
+        payment data. """
         self._create_transaction('redirect')
         url = self._build_url(NuveiController._webhook_url)
         with patch(
-            'odoo.addons.payment_nuvei.controllers.main.NuveiController'
-            '._verify_notification_signature'
+            'odoo.addons.payment_nuvei.controllers.main.NuveiController._verify_signature'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_http_post_request(url, data=self.notification_data)
-            self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_http_post_request(url, data=self.payment_data)
+            self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_nuvei.controllers.main')
     def test_redirect_notification_triggers_signature_check(self):
@@ -52,13 +48,11 @@ class TestProcessingFlows(NuveiCommon):
         self._create_transaction('redirect')
         url = self._build_url(NuveiController._return_url)
         with patch(
-            'odoo.addons.payment_nuvei.controllers.main.NuveiController'
-            '._verify_notification_signature'
+            'odoo.addons.payment_nuvei.controllers.main.NuveiController._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_http_get_request(url, params=self.notification_data)
+            self._make_http_get_request(url, params=self.payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_nuvei.controllers.main')
@@ -67,32 +61,30 @@ class TestProcessingFlows(NuveiCommon):
         self._create_transaction('redirect')
         url = self._build_url(NuveiController._webhook_url)
         with patch(
-            'odoo.addons.payment_nuvei.controllers.main.NuveiController'
-            '._verify_notification_signature'
+            'odoo.addons.payment_nuvei.controllers.main.NuveiController._verify_signature'
         ) as signature_check_mock, patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
         ):
-            self._make_http_post_request(url, data=self.notification_data)
+            self._make_http_post_request(url, data=self.payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     def test_accept_notification_with_valid_signature(self):
         """ Test the verification of a notification with a valid signature. """
         tx = self._create_transaction('redirect')
         self._assert_does_not_raise(
-            Forbidden, NuveiController._verify_notification_signature, tx, self.notification_data
+            Forbidden, NuveiController._verify_signature, tx, self.payment_data
         )
 
     @mute_logger('odoo.addons.payment_nuvei.controllers.main')
     def test_reject_notification_with_missing_signature(self):
         """ Test the verification of a notification with a missing signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.notification_data, advanceResponseChecksum=None)
-        self.assertRaises(Forbidden, NuveiController._verify_notification_signature, tx, payload)
+        payload = dict(self.payment_data, advanceResponseChecksum=None)
+        self.assertRaises(Forbidden, NuveiController._verify_signature, tx, payload)
 
     @mute_logger('odoo.addons.payment_nuvei.controllers.main')
     def test_reject_notification_with_invalid_signature(self):
         """ Test the verification of a notification with an invalid signature. """
         tx = self._create_transaction('redirect')
-        payload = dict(self.notification_data, advanceResponseChecksum='dummy')
-        self.assertRaises(Forbidden, NuveiController._verify_notification_signature, tx, payload)
+        payload = dict(self.payment_data, advanceResponseChecksum='dummy')
+        self.assertRaises(Forbidden, NuveiController._verify_signature, tx, payload)

--- a/addons/payment_paymob/models/payment_provider.py
+++ b/addons/payment_paymob/models/payment_provider.py
@@ -1,20 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import logging
-import pprint
 from datetime import timedelta
-
-import requests
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_paymob import const
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentProvider(models.Model):
@@ -41,7 +38,7 @@ class PaymentProvider(models.Model):
     paymob_access_token = fields.Char(groups='base.group_system')
     paymob_access_token_expiry = fields.Datetime(default='1970-01-01', groups='base.group_system')
 
-    # ==== CONSTRAINT METHODS === #
+    # === CONSTRAINT METHODS === #
 
     @api.constrains('available_currency_ids')
     def _check_available_country_currency_ids(self):
@@ -65,6 +62,15 @@ class PaymentProvider(models.Model):
                 ).search([('name', '=', currency_code)], limit=1)
                 provider.available_currency_ids = [Command.set(currency.ids)]
 
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.code != 'paymob':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
     # === ACTION METHODS === #
 
     def action_sync_paymob_payment_methods(self):
@@ -82,8 +88,8 @@ class PaymentProvider(models.Model):
             'is_standalone': 'false',
             'is_live': self.state == 'enabled',
         }
-        paymob_gateways_data = self._paymob_make_request(
-            '/api/ecommerce/integrations', payload=params, method='GET'
+        paymob_gateways_data = self._send_api_request(
+            'GET', '/api/ecommerce/integrations', params=params
         )['results']
         matched_gateways_data = self._match_paymob_payment_methods(paymob_gateways_data)
 
@@ -160,65 +166,17 @@ class PaymentProvider(models.Model):
                 payment_method_code = 'installments_eg'
             environment = 'live' if self.state == 'enabled' else 'test'
             payload = {'integration_name': f'{payment_method_code.replace("_", "")}{environment}'}
-            self._paymob_make_request(
-                f'/api/ecommerce/integrations/{gateway_data["id"]}', method='PUT', payload=payload
+            self._send_api_request(
+                'PUT', f'/api/ecommerce/integrations/{gateway_data["id"]}', json=payload
             )
 
-    # === BUSINESS METHODS === #
+    # === REQUEST HELPERS === #
 
-    def _paymob_make_request(
-        self, endpoint, payload=None, method='POST', is_refresh_token_request=False,
-        is_client_request=False,
-    ):
-        """ Make a request to Paymob API at the specified endpoint.
-
-        Note: self.ensure_one()
-
-        :param str endpoint: The endpoint to be reached by the request.
-        :param dict payload: The payload of the request.
-        :param str method: The method of the request.
-        :param bool is_refresh_token_request: Whether the request is for refreshing the access
-                                              token.
-        :param bool is_client_request: Whether the request is a client request or a backend request.
-                                       It will depend what auth will be sent the access token
-                                       generated from the api_key or the secret_key.
-        :return: The JSON-formatted content of the response.
-        :rtype: dict
-        :raise ValidationError: If an HTTP error occurs.
-        """
-        url = f'{self._paymob_get_api_url()}{endpoint}'
-        auth = ''
-        if not is_refresh_token_request and is_client_request:
-            auth = self.paymob_secret_key
-        elif not is_refresh_token_request:
-            auth = self._paymob_fetch_access_token()
-        headers = {'Authorization': f'Bearer {auth}'}
-        try:
-            if method in ['POST', 'PUT']:
-                response = requests.request(method, url, headers=headers, json=payload, timeout=10)
-            else:
-                response = requests.get(url, headers=headers, params=payload, timeout=10)
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                # Paymob errors: https://developers.paymob.com/egypt/error-codes
-                _logger.exception(
-                    "Invalid API request at %s with data:\n%s", url, pprint.pformat(payload)
-                )
-                msg = response.text
-                error_msg = _("The communication with the API failed. Details: %(msg)s", msg=msg)
-                if "This field may not be blank" in msg:
-                    missing_fields = ", ".join(json.loads(msg).get('billing_data', {}).keys())
-                    error_msg = _(
-                        "The following fields must be filled: %(fields)s", fields=missing_fields
-                    )
-                raise ValidationError(error_msg)
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.exception("Unable to reach endpoint at %s", url)
-            raise ValidationError(_("Could not establish the connection to the API."))
-        return response.json()
-
-    # === BUSINESS METHODS - GETTERS === #
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the request URL."""
+        if self.code != 'paymob':
+            return super()._build_request_url(endpoint, **kwargs)
+        return f'{self._paymob_get_api_url()}{endpoint}'
 
     def _paymob_get_api_url(self):
         """ Get the API URL according to the provider country.
@@ -233,6 +191,19 @@ class PaymentProvider(models.Model):
         url = f'https://{api_prefix}.paymob.com'
         return url
 
+    def _build_request_headers(
+        self, *args, is_refresh_token_request=False, is_client_request=False, **kwargs
+    ):
+        """Override of `payment` to build the request headers."""
+        if self.code != 'paymob':
+            return super()._build_request_headers(*args, **kwargs)
+        auth = ''
+        if not is_refresh_token_request and is_client_request:
+            auth = self.paymob_secret_key
+        elif not is_refresh_token_request:
+            auth = self._paymob_fetch_access_token()
+        return {'Authorization': f'Bearer {auth}'}
+
     def _paymob_fetch_access_token(self):
         """ Generate a new access token if it's expired, otherwise return the existing access token.
 
@@ -243,9 +214,10 @@ class PaymentProvider(models.Model):
         :raise ValidationError: If the access token can not be fetched.
         """
         if not self.paymob_access_token or fields.Datetime.now() > self.paymob_access_token_expiry:
-            response_content = self._paymob_make_request(
+            response_content = self._send_api_request(
+                'POST',
                 '/api/auth/tokens',
-                payload={'api_key': self.paymob_api_key},
+                json={'api_key': self.paymob_api_key},
                 is_refresh_token_request=True,
             )
             access_token = response_content['token']
@@ -257,9 +229,14 @@ class PaymentProvider(models.Model):
             })
         return self.paymob_access_token
 
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+    def _parse_response_error(self, response):
+        """Override of `payment` to parse the error message."""
         if self.code != 'paymob':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES
+            return super()._parse_response_error(response)
+
+        msg = response.text
+        # Paymob errors: https://developers.paymob.com/egypt/error-codes
+        if "This field may not be blank" in msg:
+            missing_fields = ", ".join(json.loads(msg).get('billing_data', {}).keys())
+            return _("The following fields must be filled: %(fields)s", fields=missing_fields)
+        return msg

--- a/addons/payment_paymob/tests/test_paymob.py
+++ b/addons/payment_paymob/tests/test_paymob.py
@@ -18,8 +18,8 @@ class PaymobTest(PaymobCommon, PaymentHttpCommon):
         URL_PARAMS corresponding to the response of API request. """
         tx = self._create_transaction('redirect')
         with patch(
-            'odoo.addons.payment_paymob.models.payment_provider.PaymentProvider'
-            '._paymob_make_request', return_value={'client_secret': 'dummy_secret'}
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
+            return_value={'client_secret': 'dummy_secret'},
         ):
             rendering_values = tx._get_specific_rendering_values(None)
         paymob_url = self.paymob._paymob_get_api_url()
@@ -32,13 +32,13 @@ class PaymobTest(PaymobCommon, PaymentHttpCommon):
         """ Test the processing of the paymob return data. """
         tx = self._create_transaction('redirect')
         with patch(
-            'odoo.addons.payment_paymob.models.payment_provider.PaymentProvider'
-            '._paymob_make_request', return_value={'id': 'dummy_id'}
+            'odoo.addons.payment.models.payment_provider.PaymentProvider._send_api_request',
+            return_value={'id': 'dummy_id'}
         ):
             tx._get_specific_rendering_values(None)  # Set provider reference here
             self.assertEqual(tx.provider_reference, self.redirection_data['id'])
             self.assertEqual(tx.state, 'draft')
-            tx._handle_notification_data('paymob', self.redirection_data)
+            tx._process('paymob', self.redirection_data)
             self.assertEqual(tx.state, 'done')
 
     @mute_logger('odoo.addons.payment_paymob.controllers.main')

--- a/addons/payment_paypal/controllers/main.py
+++ b/addons/payment_paypal/controllers/main.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
@@ -11,10 +9,11 @@ from odoo.exceptions import ValidationError
 from odoo.http import request
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_paypal import const
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaypalController(http.Controller):
@@ -23,31 +22,32 @@ class PaypalController(http.Controller):
 
     @http.route(_complete_url, type='jsonrpc', auth='public', methods=['POST'])
     def paypal_complete_order(self, order_id, reference):
-        """ Make a capture request and handle the notification data.
+        """Make a capture request and process the payment data.
 
         :param string order_id: The order id provided by PayPal to identify the order.
         :param str reference: The reference of the transaction, used to generate the idempotency
                               key.
         :return: None
         """
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
             'paypal', {'reference_id': reference}
         )
-        idempotency_key = payment_utils.generate_idempotency_key(
-            tx_sudo, scope='payment_request_controller'
-        )
-        response = tx_sudo.provider_id._paypal_make_request(
-            f'/v2/checkout/orders/{order_id}/capture', idempotency_key=idempotency_key
-        )
-        normalized_response = self._normalize_paypal_data(response)
-        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-            'paypal', normalized_response
-        )
-        tx_sudo._handle_notification_data('paypal', normalized_response)
+        if tx_sudo:
+            idempotency_key = payment_utils.generate_idempotency_key(
+                tx_sudo, scope='payment_request_controller'
+            )
+            response = tx_sudo._send_api_request(
+                'POST', f'/v2/checkout/orders/{order_id}/capture', idempotency_key=idempotency_key
+            )
+            normalized_response = self._normalize_paypal_data(response)
+            tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
+                'paypal', normalized_response
+            )
+            tx_sudo._process('paypal', normalized_response)
 
     @http.route(_webhook_url, type='http', auth='public', methods=['POST'], csrf=False)
     def paypal_webhook(self):
-        """ Process the notification data sent by PayPal to the webhook.
+        """Process the payment data sent by PayPal to the webhook.
 
         See https://developer.paypal.com/docs/api/webhooks/v1/.
 
@@ -56,24 +56,15 @@ class PaypalController(http.Controller):
         """
         data = request.get_json_data()
         if data.get('event_type') in const.HANDLED_WEBHOOK_EVENTS:
-            normalized_data = self._normalize_paypal_data(
-                data.get('resource'), from_webhook=True
-            )
             _logger.info("Notification received from PayPal with data:\n%s", pprint.pformat(data))
-            try:
-                # Check the origin and integrity of the notification.
-                tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                    'paypal', normalized_data
-                )
+            normalized_data = self._normalize_paypal_data(data.get('resource'), from_webhook=True)
+            # Check the origin and integrity of the notification.
+            tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference(
+                'paypal', normalized_data
+            )
+            if tx_sudo:
                 self._verify_notification_origin(data, tx_sudo)
-
-                # Handle the notification data.
-                tx_sudo._handle_notification_data('paypal', normalized_data)
-            except ValidationError:  # Acknowledge the notification to avoid getting spammed.
-                _logger.warning(
-                    "Unable to handle the notification data; skipping to acknowledge.",
-                    exc_info=True,
-                )
+                tx_sudo._process('paypal', normalized_data)
         return request.make_json_response('')
 
     def _normalize_paypal_data(self, data, from_webhook=False):
@@ -106,33 +97,37 @@ class PaypalController(http.Controller):
                     'txn_type': 'CAPTURE',
                 })
             else:
-                raise ValidationError("PayPal: " + _("Invalid response format, can't normalize."))
+                _logger.warning(_("Invalid response format, can't normalize."))
         return result
 
-    def _verify_notification_origin(self, notification_data, tx_sudo):
+    def _verify_notification_origin(self, payment_data, tx_sudo):
         """ Check that the notification was sent by PayPal.
 
         See https://developer.paypal.com/docs/api/webhooks/v1/#verify-webhook-signature_post.
 
-        :param dict notification_data: The notification data
-        :param recordset tx_sudo: The sudoed transaction referenced in the notification data, as a
-                                  `payment.transaction` record
+        :param dict payment_data: The payment data.
+        :param payment.transaction tx_sudo: The sudoed transaction referenced in the payment data.
         :return: None
         :raise Forbidden: If the notification origin can't be verified.
         """
         headers = request.httprequest.headers
-        data = json.dumps({
+        data = {
             'transmission_id': headers.get('PAYPAL-TRANSMISSION-ID'),
             'transmission_time': headers.get('PAYPAL-TRANSMISSION-TIME'),
             'cert_url': headers.get('PAYPAL-CERT-URL'),
             'auth_algo': headers.get('PAYPAL-AUTH-ALGO'),
             'transmission_sig': headers.get('PAYPAL-TRANSMISSION-SIG'),
             'webhook_id': tx_sudo.provider_id.paypal_webhook_id,
-            'webhook_event': notification_data,
-        })
-        verification = tx_sudo.provider_id._paypal_make_request(
-            '/v1/notifications/verify-webhook-signature', data=data
-        )
+            'webhook_event': payment_data,
+        }
+        try:
+            verification = tx_sudo._send_api_request(
+                'POST', '/v1/notifications/verify-webhook-signature', json=data
+            )
+        except ValidationError:
+            tx_sudo._set_error(_("Unable to verify the payment data"))
+            return
+
         if verification.get('verification_status') != 'SUCCESS':
-            _logger.warning("Received notification that was not verified by PayPal.")
+            _logger.warning("Received payment data that was not verified by PayPal.")
             raise Forbidden()

--- a/addons/payment_paypal/models/payment_provider.py
+++ b/addons/payment_paypal/models/payment_provider.py
@@ -1,21 +1,19 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-import logging
-import pprint
 from datetime import timedelta
 
-import requests
 from werkzeug import urls
 
 from odoo import _, fields, models
 from odoo.exceptions import UserError, ValidationError
 
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_paypal import const
 from odoo.addons.payment_paypal.controllers.main import PaypalController
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class PaymentProvider(models.Model):
@@ -45,6 +43,26 @@ class PaymentProvider(models.Model):
     )
     paypal_webhook_id = fields.Char(string="PayPal Webhook ID")
 
+    # === COMPUTE METHODS === #
+
+    def _get_supported_currencies(self):
+        """ Override of `payment` to return the supported currencies. """
+        supported_currencies = super()._get_supported_currencies()
+        if self.code == 'paypal':
+            supported_currencies = supported_currencies.filtered(
+                lambda c: c.name in const.SUPPORTED_CURRENCIES
+            )
+        return supported_currencies
+
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.code != 'paypal':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
     # === ACTION METHODS === #
 
     def action_paypal_create_webhook(self):
@@ -64,92 +82,34 @@ class PaymentProvider(models.Model):
             'url': urls.url_join(base_url, PaypalController._webhook_url),
             'event_types': [{'name': event_type} for event_type in const.HANDLED_WEBHOOK_EVENTS]
         }
-        webhook_data = self._paypal_make_request('/v1/notifications/webhooks', json_payload=data)
+        webhook_data = self._send_api_request('POST', '/v1/notifications/webhooks', json=data)
         self.paypal_webhook_id = webhook_data.get('id')
 
-    #=== BUSINESS METHODS ===#
+    # === BUSINESS METHODS === #
 
-    def _paypal_make_request(
-        self, endpoint, data=None, json_payload=None, auth=None, is_refresh_token_request=False,
-        idempotency_key=None,
-    ):
-        """ Make a request to Paypal API at the specified endpoint.
+    def _paypal_get_inline_form_values(self, currency=None):
+        """Return a serialized JSON of the required values to render the inline form.
 
-        Note: self.ensure_one()
+        Note: `self.ensure_one()`
 
-        :param str endpoint: The endpoint to be reached by the request.
-        :param dict data: The string payload of the request.
-        :param dict json_payload: The JSON-formatted payload of the request.
-        :param tuple auth: The authentication data.
-        :param bool is_refresh_token_request: Whether the request is for refreshing the access
-                                              token.
-        :param str idempotency_key: The idempotency key to pass in the request.
-        :return: The JSON-formatted content of the response.
-        :rtype: dict
-        :raise ValidationError: If an HTTP error occurs.
-        """
-        url = self._paypal_get_api_url() + endpoint
-        headers = {'Content-Type': 'application/json'}  # PayPal always wants JSON content-type.
-        if idempotency_key:
-            headers['PayPal-Request-Id'] = idempotency_key
-        if not is_refresh_token_request:
-            headers['Authorization'] = f'Bearer {self._paypal_fetch_access_token()}'
-        try:
-            response = requests.post(
-                url, headers=headers, data=data, json=json_payload, auth=auth, timeout=10
-            )
-            try:
-                response.raise_for_status()
-            except requests.exceptions.HTTPError:
-                payload = data or json_payload
-                # PayPal errors https://developer.paypal.com/api/rest/reference/orders/v2/errors/
-                _logger.exception(
-                    "Invalid API request at %s with data:\n%s", url, pprint.pformat(payload)
-                )
-                msg = response.json().get('message', '')
-                raise ValidationError(
-                    "PayPal: " + _("The communication with the API failed. Details: %s", msg)
-                )
-        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
-            _logger.exception("Unable to reach endpoint at %s", url)
-            raise ValidationError("PayPal: " + _("Could not establish the connection to the API."))
-        return response.json()
-
-    def _paypal_fetch_access_token(self):
-        """ Generate a new access token if it's expired, otherwise return the existing access token.
-
-        :return: A valid access token.
+        :param res.currency currency: The transaction currency.
+        :return: The JSON serial of the required values to render the inline form.
         :rtype: str
-        :raise ValidationError: If the access token can not be fetched.
         """
-        if fields.Datetime.now() > self.paypal_access_token_expiry - timedelta(minutes=5):
-            response_content = self._paypal_make_request(
-                '/v1/oauth2/token',
-                data={'grant_type': 'client_credentials'},
-                auth=(self.paypal_client_id, self.paypal_client_secret),
-                is_refresh_token_request=True,
-            )
-            access_token = response_content['access_token']
-            if not access_token:
-                raise ValidationError("PayPal: " + _("Could not generate a new access token."))
-            self.write({
-                'paypal_access_token': access_token,
-                'paypal_access_token_expiry': fields.Datetime.now() + timedelta(
-                    seconds=response_content['expires_in']
-                ),
-            })
-        return self.paypal_access_token
+        inline_form_values = {
+            'provider_id': self.id,
+            'client_id': self.paypal_client_id,
+            'currency_code': currency and currency.name,
+        }
+        return json.dumps(inline_form_values)
 
-    # === BUSINESS METHODS - GETTERS === #
+    # === REQUEST HELPERS === #
 
-    def _get_supported_currencies(self):
-        """ Override of `payment` to return the supported currencies. """
-        supported_currencies = super()._get_supported_currencies()
-        if self.code == 'paypal':
-            supported_currencies = supported_currencies.filtered(
-                lambda c: c.name in const.SUPPORTED_CURRENCIES
-            )
-        return supported_currencies
+    def _build_request_url(self, endpoint, **kwargs):
+        """Override of `payment` to build the request URL."""
+        if self.code != 'paypal':
+            return super()._build_request_url(endpoint, **kwargs)
+        return self._paypal_get_api_url() + endpoint
 
     def _paypal_get_api_url(self):
         """ Return the API URL according to the provider state.
@@ -166,25 +126,60 @@ class PaymentProvider(models.Model):
         else:
             return 'https://api-m.sandbox.paypal.com'
 
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
+    def _build_request_headers(
+        self, *args, idempotency_key=None, is_refresh_token_request=False, **kwargs
+    ):
+        """Override of `payment` to build the request headers."""
         if self.code != 'paypal':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES
+            return super()._build_request_headers(
+                *args,
+                idempotency_key=idempotency_key,
+                is_refresh_token_request=is_refresh_token_request,
+                **kwargs,
+            )
 
-    def _paypal_get_inline_form_values(self, currency=None):
-        """ Return a serialized JSON of the required values to render the inline form.
+        headers = {'Content-Type': 'application/json'}
+        if idempotency_key:
+            headers['PayPal-Request-Id'] = idempotency_key
+        if not is_refresh_token_request:
+            headers['Authorization'] = f'Bearer {self._paypal_fetch_access_token()}'
+        return headers
 
-        Note: `self.ensure_one()`
+    def _paypal_fetch_access_token(self):
+        """ Generate a new access token if it's expired, otherwise return the existing access token.
 
-        :param res.currency currency: The transaction currency.
-        :return: The JSON serial of the required values to render the inline form.
+        :return: A valid access token.
         :rtype: str
+        :raise ValidationError: If the access token can not be fetched.
         """
-        inline_form_values = {
-            'provider_id': self.id,
-            'client_id': self.paypal_client_id,
-            'currency_code': currency and currency.name,
-        }
-        return json.dumps(inline_form_values)
+        if fields.Datetime.now() > self.paypal_access_token_expiry - timedelta(minutes=5):
+            response_content = self._send_api_request(
+                'POST',
+                '/v1/oauth2/token',
+                data={'grant_type': 'client_credentials'},
+                is_refresh_token_request=True,
+            )
+            access_token = response_content['access_token']
+            if not access_token:
+                raise ValidationError(_("Could not generate a new access token."))
+            self.write({
+                'paypal_access_token': access_token,
+                'paypal_access_token_expiry': fields.Datetime.now() + timedelta(
+                    seconds=response_content['expires_in']
+                ),
+            })
+        return self.paypal_access_token
+
+    def _parse_response_error(self, response):
+        """Override of `payment` to parse the error message."""
+        if self.code != 'paypal':
+            return super()._parse_response_error(response)
+        return response.json().get('message', '')
+
+    def _build_request_auth(self, *, is_refresh_token_request=False, **kwargs):
+        """Override of `payment` to build the request Auth."""
+        if self.code != 'paypal' or not is_refresh_token_request:
+            return super()._build_request_auth(
+                is_refresh_token_request=is_refresh_token_request, **kwargs
+            )
+        return self.paypal_client_id, self.paypal_client_secret

--- a/addons/payment_paypal/tests/common.py
+++ b/addons/payment_paypal/tests/common.py
@@ -20,7 +20,7 @@ class PaypalCommon(PaymentCommon):
         cls.currency = cls.currency_euro
         cls.order_id = '123DUMMY456'
 
-        cls.notification_data = {
+        cls.payment_data = {
             'event_type': 'CHECKOUT.ORDER.APPROVED',
             'resource': {
                 'id': cls.order_id,

--- a/addons/payment_razorpay/controllers/onboarding.py
+++ b/addons/payment_razorpay/controllers/onboarding.py
@@ -46,11 +46,15 @@ class RazorpayController(Controller):
         # Request and set the OAuth tokens on the provider.
         action = request.env.ref('payment.action_payment_provider')
         redirect_url = f'/odoo/action-{action.id}/{int(provider_sudo.id)}'
-        if not authorization_code: # The user cancelled the authorization.
+        if not authorization_code:  # The user cancelled the authorization.
             return request.redirect(redirect_url)
+
+        proxy_payload = self.env['payment.provider']._prepare_json_rpc_payload(
+            {'authorization_code': authorization_code}
+        )
         try:
-            response_content = provider_sudo._razorpay_make_proxy_request(
-                '/get_access_token', payload={'authorization_code': authorization_code}
+            response_content = provider_sudo._send_api_request(
+                'POST', '/get_access_token', json=proxy_payload
             )
         except ValidationError as e:
             return request.render(

--- a/addons/payment_razorpay/tests/common.py
+++ b/addons/payment_razorpay/tests/common.py
@@ -24,7 +24,7 @@ class RazorpayCommon(PaymentCommon):
         cls.payment_id = 'pay_123'
         cls.refund_id = 'rfd_456'
         cls.order_id = 'order_789'
-        cls.redirect_notification_data = {
+        cls.redirect_payment_data = {
             'razorpay_payment_id': cls.payment_id,
             'razorpay_order_id': cls.order_id,
             'razorpay_signature': 'dummy',
@@ -57,7 +57,7 @@ class RazorpayCommon(PaymentCommon):
             'payment_id': cls.payment_id,
             'amount': cls.amount,
         }
-        cls.webhook_notification_data = {
+        cls.webhook_payment_data = {
             'event': 'payment.captured',
             'payload': {
                 'payment': {

--- a/addons/payment_stripe/const.py
+++ b/addons/payment_stripe/const.py
@@ -1,5 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.payment.const import SENSITIVE_KEYS as PAYMENT_SENSITIVE_KEYS
+
+SENSITIVE_KEYS = {'client_secret'}
+PAYMENT_SENSITIVE_KEYS.update(SENSITIVE_KEYS)  # Add Stripe-specific keys to the global set.
+
 API_VERSION = '2019-05-16'  # The API version of Stripe implemented in this module
 
 # Stripe proxy URL

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -1,20 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
-import pprint
-
 from werkzeug.urls import url_encode, url_join
 
-from odoo import _, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 from odoo.addons.payment_stripe import const
 from odoo.addons.payment_stripe import utils as stripe_utils
 from odoo.addons.payment_stripe.controllers.main import StripeController
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__, const.SENSITIVE_KEYS)
 
 
 class PaymentTransaction(models.Model):
@@ -29,101 +27,63 @@ class PaymentTransaction(models.Model):
         :return: The dict of provider-specific processing values
         :rtype: dict
         """
-        res = super()._get_specific_processing_values(processing_values)
         if self.provider_code != 'stripe' or self.operation == 'online_token':
-            return res
+            return super()._get_specific_processing_values(processing_values)
 
         intent = self._stripe_create_intent()
         base_url = self.provider_id.get_base_url()
         return {
-            'client_secret': intent['client_secret'],
+            'client_secret': intent['client_secret'] if intent else '',
             'return_url': url_join(
                 base_url,
                 f'{StripeController._return_url}?{url_encode({"reference": self.reference})}',
             ),
         }
 
-    def _get_specific_secret_keys(self):
-        """ Override of payment to return Stripe-specific secret keys.
-
-        Note: self.ensure_one() from `_get_processing_values`
-
-        :return: The provider-specific secret keys
-        :rtype: dict_keys
-        """
-        if self.provider_code == 'stripe':
-            return {'client_secret': None}.keys()
-        return super()._get_specific_secret_keys()
-
     def _send_payment_request(self):
-        """ Override of payment to send a payment request to Stripe with a confirmed PaymentIntent.
-
-        Note: self.ensure_one()
-
-        :return: None
-        :raise: UserError if the transaction is not linked to a token
-        """
-        super()._send_payment_request()
+        """Override of `payment` to send a payment request to Stripe."""
         if self.provider_code != 'stripe':
-            return
+            return super()._send_payment_request()
 
-        if not self.token_id:
-            raise UserError("Stripe: " + _("The transaction is not linked to a token."))
-
-        # Make the payment request to Stripe
+        # Send the payment request to Stripe.
         payment_intent = self._stripe_create_intent()
-        _logger.info(
-            "payment request response for transaction with reference %s:\n%s",
-            self.reference, pprint.pformat(payment_intent)
-        )
+
         if not payment_intent:  # The PI might be missing if Stripe failed to create it.
             return  # There is nothing to process; the transaction is in error at this point.
 
         # Handle the payment request response
-        notification_data = {'reference': self.reference}
-        StripeController._include_payment_intent_in_notification_data(
-            payment_intent, notification_data
+        payment_data = {'reference': self.reference}
+        StripeController._include_payment_intent_in_payment_data(
+            payment_intent, payment_data
         )
-        self._handle_notification_data('stripe', notification_data)
+        self._process('stripe', payment_data)
 
     def _stripe_create_intent(self):
         """ Create and return a PaymentIntent or a SetupIntent object, depending on the operation.
 
-        :return: The created PaymentIntent or SetupIntent object.
-        :rtype: dict
+        :return: The created PaymentIntent or SetupIntent object or None if creation failed.
+        :rtype: dict|None
         """
-        if self.operation == 'validation':
-            response = self.provider_id._stripe_make_request(
-                'setup_intents', payload=self._stripe_prepare_setup_intent_payload()
-            )
-        else:  # 'online_direct', 'online_token', 'offline'.
-            response = self.provider_id._stripe_make_request(
-                'payment_intents',
-                payload=self._stripe_prepare_payment_intent_payload(),
-                offline=self.operation == 'offline',
-                # Prevent multiple offline payments by token (e.g., due to a cursor rollback).
-                idempotency_key=payment_utils.generate_idempotency_key(
-                    self, scope='payment_intents_token'
-                ) if self.operation == 'offline' else None,
-            )
-
-        if 'error' not in response:
+        try:
+            if self.operation == 'validation':
+                response = self._send_api_request(
+                    'POST', 'setup_intents', data=self._stripe_prepare_setup_intent_payload(),
+                )
+            else:  # 'online_direct', 'online_token', 'offline'.
+                response = self._send_api_request(
+                    'POST',
+                    'payment_intents',
+                    data=self._stripe_prepare_payment_intent_payload(),
+                    offline=self.operation == 'offline',
+                    idempotency_key=payment_utils.generate_idempotency_key(
+                        self, scope='payment_intents'
+                    ),
+                )
+        except ValidationError as error:
+            self._set_error(str(error))
+            intent = None
+        else:
             intent = response
-        else:  # A processing error was returned in place of the intent.
-            # The request failed and no error was raised because we are in an offline payment flow.
-            # Extract the error from the response, log it, and set the transaction in error to let
-            # the calling module handle the issue without rolling back the cursor.
-            error_msg = response['error'].get('message')
-            _logger.warning(
-                "The creation of the intent failed.\n"
-                "Stripe gave us the following info about the problem:\n'%s'", error_msg
-            )
-            self._set_error("Stripe: " + _(
-                "The communication with the API failed.\n"
-                "Stripe gave us the following info about the problem:\n'%s'", error_msg
-            ))  # Flag transaction as in error now, as the intent status might have a valid value.
-            intent = response['error'].get('payment_intent') \
-                     or response['error'].get('setup_intent')  # Get the intent from the error.
 
         return intent
 
@@ -194,8 +154,8 @@ class PaymentTransaction(models.Model):
         :return: The Customer
         :rtype: dict
         """
-        customer = self.provider_id._stripe_make_request(
-            'customers', payload={
+        customer = self._send_api_request(
+            'POST', 'customers', data={
                 'address[city]': self.partner_city or None,
                 'address[country]': self.partner_country_id.code or None,
                 'address[line1]': self.partner_address or None,
@@ -247,168 +207,124 @@ class PaymentTransaction(models.Model):
 
         return mandate_options
 
-    def _send_refund_request(self, amount_to_refund=None):
-        """ Override of payment to send a refund request to Stripe.
-
-        Note: self.ensure_one()
-
-        :param float amount_to_refund: The amount to refund.
-        :return: The refund transaction created to process the refund request.
-        :rtype: recordset of `payment.transaction`
-        """
-        refund_tx = super()._send_refund_request(amount_to_refund=amount_to_refund)
+    def _send_refund_request(self):
+        """Override of `payment` to send a refund request to Stripe."""
         if self.provider_code != 'stripe':
-            return refund_tx
+            return super()._send_refund_request()
 
-        # Make the refund request to stripe.
-        data = self.provider_id._stripe_make_request(
-            'refunds', payload={
-                'payment_intent': self.provider_reference,
+        # Send the refund request to Stripe.
+        data = self._send_api_request(
+            'POST', 'refunds', data={
+                'payment_intent': self.source_transaction_id.provider_reference,
                 'amount': payment_utils.to_minor_currency_units(
-                    -refund_tx.amount,  # Refund transactions' amount is negative, inverse it.
-                    refund_tx.currency_id,
+                    -self.amount,  # Refund transactions' amount is negative, inverse it.
+                    self.currency_id,
                 ),
             }
         )
-        _logger.info(
-            "Refund request response for transaction wih reference %s:\n%s",
-            self.reference, pprint.pformat(data)
-        )
-        # Handle the refund request response.
-        notification_data = {}
-        StripeController._include_refund_in_notification_data(data, notification_data)
-        refund_tx._handle_notification_data('stripe', notification_data)
 
-        return refund_tx
+        # Process the refund request response.
+        payment_data = {}
+        StripeController._include_refund_in_payment_data(data, payment_data)
+        self._process('stripe', payment_data)
 
-    def _send_capture_request(self, amount_to_capture=None):
-        """ Override of `payment` to send a capture request to Stripe. """
-        child_capture_tx = super()._send_capture_request(amount_to_capture=amount_to_capture)
+    def _send_capture_request(self):
+        """Override of `payment` to send a capture request to Stripe."""
         if self.provider_code != 'stripe':
-            return child_capture_tx
+            return super()._send_capture_request()
 
         # Make the capture request to Stripe
-        payment_intent = self.provider_id._stripe_make_request(
-            f'payment_intents/{self.provider_reference}/capture'
-        )
-        _logger.info(
-            "capture request response for transaction with reference %s:\n%s",
-            self.reference, pprint.pformat(payment_intent)
+        payment_intent = self._send_api_request(
+            'POST', f'payment_intents/{self.source_transaction_id.provider_reference}/capture'
         )
 
-        # Handle the capture request response
-        notification_data = {'reference': self.reference}
-        StripeController._include_payment_intent_in_notification_data(
-            payment_intent, notification_data
+        # Process the capture request response.
+        payment_data = {'reference': self.reference}
+        StripeController._include_payment_intent_in_payment_data(
+            payment_intent, payment_data
         )
-        self._handle_notification_data('stripe', notification_data)
+        self._process('stripe', payment_data)
 
-        return child_capture_tx
-
-    def _send_void_request(self, amount_to_void=None):
-        """ Override of `payment` to send a void request to Stripe. """
-        child_void_tx = super()._send_void_request(amount_to_void=amount_to_void)
+    def _send_void_request(self):
+        """Override of `payment` to send a void request to Stripe."""
         if self.provider_code != 'stripe':
-            return child_void_tx
+            return super()._send_void_request()
 
         # Make the void request to Stripe
-        payment_intent = self.provider_id._stripe_make_request(
-            f'payment_intents/{self.provider_reference}/cancel'
-        )
-        _logger.info(
-            "void request response for transaction with reference %s:\n%s",
-            self.reference, pprint.pformat(payment_intent)
+        payment_intent = self._send_api_request(
+            'POST', f'payment_intents/{self.source_transaction_id.provider_reference}/cancel'
         )
 
-        # Handle the void request response
-        notification_data = {'reference': self.reference}
-        StripeController._include_payment_intent_in_notification_data(
-            payment_intent, notification_data
+        # Process the void request response.
+        payment_data = {'reference': self.reference}
+        StripeController._include_payment_intent_in_payment_data(
+            payment_intent, payment_data
         )
-        self._handle_notification_data('stripe', notification_data)
+        self._process('stripe', payment_data)
 
-        return child_void_tx
-
-    def _get_tx_from_notification_data(self, provider_code, notification_data):
+    @api.model
+    def _search_by_reference(self, provider_code, payment_data):
         """ Override of payment to find the transaction based on Stripe data.
 
         :param str provider_code: The code of the provider that handled the transaction
-        :param dict notification_data: The notification data sent by the provider
+        :param dict payment_data: The payment data sent by the provider
         :return: The transaction if found
-        :rtype: recordset of `payment.transaction`
-        :raise: ValidationError if inconsistent data were received
-        :raise: ValidationError if the data match no transaction
+        :rtype: payment.transaction
         """
-        tx = super()._get_tx_from_notification_data(provider_code, notification_data)
-        if provider_code != 'stripe' or len(tx) == 1:
-            return tx
+        if provider_code != 'stripe':
+            return super()._search_by_reference(provider_code, payment_data)
 
-        reference = notification_data.get('reference')
+        reference = payment_data.get('reference')
         if reference:
             tx = self.search([('reference', '=', reference), ('provider_code', '=', 'stripe')])
-        elif notification_data.get('event_type') == 'charge.refund.updated':
+        elif payment_data.get('event_type') == 'charge.refund.updated':
             # The webhook notifications sent for `charge.refund.updated` events only contain a
             # refund object that has no 'description' (the merchant reference) field. We thus search
             # the transaction by its provider reference which is the refund id for refund txs.
-            refund_id = notification_data['object_id']  # The object is a refund.
+            refund_id = payment_data['object_id']  # The object is a refund.
             tx = self.search(
                 [('provider_reference', '=', refund_id), ('provider_code', '=', 'stripe')]
             )
         else:
-            raise ValidationError("Stripe: " + _("Received data with missing merchant reference"))
+            _logger.warning("Received data with missing merchant reference")
+            tx = self
 
         if not tx:
-            raise ValidationError(
-                "Stripe: " + _("No transaction found matching reference %s.", reference)
-            )
+            _logger.warning("No transaction found matching reference %s.", reference)
+
         return tx
 
-    def _compare_notification_data(self, notification_data):
-        """ Override of `payment` to compare the transaction based on Stripe data.
-
-        :param dict notification_data: The notification data sent by the provider.
-        :return: None
-        :raise ValidationError: If the transaction's amount and currency don't match the
-            notification data.
-        """
+    def _extract_amount_data(self, payment_data):
+        """Override of payment to extract the amount and currency from the payment data."""
         if self.provider_code != 'stripe':
-            return super()._compare_notification_data(notification_data)
+            return super()._extract_amount_data(payment_data)
 
         if self.operation == 'validation':
-            payment_data = notification_data['setup_intent']
+            payment_data = payment_data['setup_intent']
         elif self.operation == 'refund':
-            payment_data = notification_data['refund']
+            payment_data = payment_data['refund']
         else:  # 'online_direct', 'online_token', 'offline'
-            payment_data = notification_data['payment_intent']
+            payment_data = payment_data['payment_intent']
         amount = payment_utils.to_major_currency_units(
             payment_data.get('amount', 0), self.currency_id
         )
         currency_code = payment_data.get('currency').upper()
-        self._validate_amount_and_currency(amount, currency_code)
+        return {
+            'amount': amount,
+            'currency_code': currency_code,
+        }
 
-    def _process_notification_data(self, notification_data):
-        """ Override of `payment` to process the transaction based on Stripe data.
-
-        Note: self.ensure_one()
-
-        :param dict notification_data: The notification data build from information passed to the
-                                       return route. Depending on the operation of the transaction,
-                                       the entries with the keys 'payment_intent', 'setup_intent'
-                                       and 'payment_method' can be populated with their
-                                       corresponding Stripe API objects.
-        :return: None
-        :raise: ValidationError if inconsistent data were received
-        """
-        super()._process_notification_data(notification_data)
+    def _apply_updates(self, payment_data):
+        """Override of `payment` to update the transaction based on the payment data."""
         if self.provider_code != 'stripe':
-            return
+            return super()._apply_updates(payment_data)
 
         # Update the payment method.
-        payment_method = notification_data.get('payment_method')
+        payment_method = payment_data.get('payment_method')
         if isinstance(payment_method, dict):  # capture/void/refund requests receive a string.
             payment_method_type = payment_method.get('type')
             if self.payment_method_id.code == payment_method_type == 'card':
-                payment_method_type = notification_data['payment_method']['card']['brand']
+                payment_method_type = payment_data['payment_method']['card']['brand']
             payment_method = self.env['payment.method']._get_from_code(
                 payment_method_type, mapping=const.PAYMENT_METHODS_MAPPING
             )
@@ -416,30 +332,23 @@ class PaymentTransaction(models.Model):
 
         # Update the provider reference and the payment state.
         if self.operation == 'validation':
-            self.provider_reference = notification_data['setup_intent']['id']
-            status = notification_data['setup_intent']['status']
+            self.provider_reference = payment_data['setup_intent']['id']
+            status = payment_data['setup_intent']['status']
         elif self.operation == 'refund':
-            self.provider_reference = notification_data['refund']['id']
-            status = notification_data['refund']['status']
+            self.provider_reference = payment_data['refund']['id']
+            status = payment_data['refund']['status']
         else:  # 'online_direct', 'online_token', 'offline'
-            self.provider_reference = notification_data['payment_intent']['id']
-            status = notification_data['payment_intent']['status']
+            self.provider_reference = payment_data['payment_intent']['id']
+            status = payment_data['payment_intent']['status']
         if not status:
-            raise ValidationError(
-                "Stripe: " + _("Received data with missing intent status.")
-            )
-        if status in const.STATUS_MAPPING['draft']:
+            self._set_error(_("Received data with missing intent status."))
+        elif status in const.STATUS_MAPPING['draft']:
             pass
         elif status in const.STATUS_MAPPING['pending']:
             self._set_pending()
         elif status in const.STATUS_MAPPING['authorized']:
-            if self.tokenize:
-                self._stripe_tokenize_from_notification_data(notification_data)
             self._set_authorized()
         elif status in const.STATUS_MAPPING['done']:
-            if self.tokenize:
-                self._stripe_tokenize_from_notification_data(notification_data)
-
             self._set_done()
 
             # Immediately post-process the transaction if it is a refund, as the post-processing
@@ -450,7 +359,7 @@ class PaymentTransaction(models.Model):
             self._set_canceled()
         elif status in const.STATUS_MAPPING['error']:
             if self.operation != 'refund':
-                last_payment_error = notification_data.get('payment_intent', {}).get(
+                last_payment_error = payment_data.get('payment_intent', {}).get(
                     'last_payment_error'
                 )
                 if last_payment_error:
@@ -465,63 +374,52 @@ class PaymentTransaction(models.Model):
                 ), extra_allowed_states=('done',))
         else:  # Classify unknown intent statuses as `error` tx state
             _logger.warning(
-                "received invalid payment status (%s) for transaction with reference %s",
+                "Received invalid payment status (%s) for transaction %s.",
                 status, self.reference
             )
-            self._set_error(_("Received data with invalid intent status: %s", status))
+            self._set_error(_("Received data with invalid intent status: %s.", status))
 
-    def _stripe_tokenize_from_notification_data(self, notification_data):
-        """ Create a new token based on the notification data.
+    def _extract_token_values(self, payment_data):
+        """Override of `payment` to return token data based on Stripe data.
 
-        :param dict notification_data: The notification data built with Stripe objects.
-                                       See `_process_notification_data`.
-        :return: None
+        Note: self.ensure_one() from :meth: `_tokenize`
+
+        :param dict payment_data: The payment data sent by the provider.
+        :return: Data to create a token.
+        :rtype: dict
         """
-        payment_method = notification_data.get('payment_method')
+        if self.provider_code != 'stripe':
+            return super()._extract_token_values(payment_data)
+
+        payment_method = payment_data.get('payment_method')
         if not payment_method:
-            _logger.warning(
-                "requested tokenization from notification data with missing payment method"
-            )
-            return
+            _logger.warning("requested tokenization from payment data with missing payment method")
+            return {}
 
         mandate = None
-        # Extract the Stripe objects from the notification data.
+        # Extract the Stripe objects from the payment data.
         if self.operation == 'online_direct':
-            customer_id = notification_data['payment_intent']['customer']
-            charges_data = notification_data['payment_intent']['charges']
+            customer_id = payment_data['payment_intent']['customer']
+            charges_data = payment_data['payment_intent']['charges']
             payment_method_details = charges_data['data'][0].get('payment_method_details')
             if payment_method_details:
                 mandate = payment_method_details[payment_method_details['type']].get("mandate")
         else:  # 'validation'
-            customer_id = notification_data['setup_intent']['customer']
+            customer_id = payment_data['setup_intent']['customer']
         # Another payment method (e.g., SEPA) might have been generated.
         if not payment_method[payment_method['type']]:
-            payment_methods = self.provider_id._stripe_make_request(
-                f'customers/{customer_id}/payment_methods', method='GET'
-            )
-            _logger.info("Received payment_methods response:\n%s", pprint.pformat(payment_methods))
+            try:
+                payment_methods = self._send_api_request(
+                    'GET', f'customers/{customer_id}/payment_methods'
+                )
+            except ValidationError as e:
+                self._set_error(str(e))
+                return {}
             payment_method = payment_methods['data'][0]
 
-        # Create the token.
-        token = self.env['payment.token'].create({
-            'provider_id': self.provider_id.id,
-            'payment_method_id': self.payment_method_id.id,
+        return {
             'payment_details': payment_method[payment_method['type']].get('last4'),
-            'partner_id': self.partner_id.id,
             'provider_ref': customer_id,
             'stripe_payment_method': payment_method['id'],
             'stripe_mandate': mandate,
-        })
-        self.write({
-            'token_id': token,
-            'tokenize': False,
-        })
-        _logger.info(
-            "created token with id %(token_id)s for partner with id %(partner_id)s from "
-            "transaction with reference %(ref)s",
-            {
-                'token_id': token.id,
-                'partner_id': self.partner_id.id,
-                'ref': self.reference,
-            },
-        )
+        }

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -23,7 +23,7 @@ class StripeCommon(PaymentCommon):
             'amount': payment_utils.to_minor_currency_units(cls.amount, cls.currency),
             'currency': cls.currency.name.lower(),
         }
-        cls.notification_data = {
+        cls.payment_data = {
             'data': {
                 'object': {
                     'id': 'pi_3KTk9zAlCFm536g81Wy7RCPH',
@@ -46,7 +46,7 @@ class StripeCommon(PaymentCommon):
             'status': 'succeeded',
             **cls.notification_amount_and_currency,
         }
-        cls.refund_notification_data = {
+        cls.refund_payment_data = {
             'data': {
                 'object': {
                     'id': 'ch_000000000000000000000000',
@@ -63,7 +63,7 @@ class StripeCommon(PaymentCommon):
             },
             'type': 'charge.refunded'
         }
-        cls.canceled_refund_notification_data = {
+        cls.canceled_refund_payment_data = {
             'data': {
                 'object': dict(cls.refund_object, status='failed'),
             },

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -25,7 +25,7 @@ class WorldlineCommon(PaymentCommon):
             'currencyCode': cls.currency.name,
         }
 
-        cls.notification_data = {
+        cls.payment_data = {
             'payment': {
                 'paymentOutput': {
                     'references': {
@@ -45,7 +45,7 @@ class WorldlineCommon(PaymentCommon):
             },
         }
 
-        cls.notification_data_insufficient_funds = {
+        cls.payment_data_insufficient_funds = {
             'errorId': 'ffffffff-fff-fffff-ffff-ffffffffffff',
             'errors': [{
                 'category': 'IO_ERROR',
@@ -106,7 +106,7 @@ class WorldlineCommon(PaymentCommon):
             },
         }
 
-        cls.notification_data_expired_card = {
+        cls.payment_data_expired_card = {
             'apiFullVersion': 'v1.1',
             'apiVersion': 'v1',
             'created': '2025-02-20T03:09:47.3706109+01:00',

--- a/addons/payment_xendit/controllers/main.py
+++ b/addons/payment_xendit/controllers/main.py
@@ -1,19 +1,18 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import logging
 import pprint
 
 from werkzeug.exceptions import Forbidden
 
 from odoo import http
-from odoo.exceptions import ValidationError
 from odoo.http import request
 from odoo.tools import consteq, str2bool
 
 from odoo.addons.payment import utils as payment_utils
+from odoo.addons.payment.logging import get_payment_logger
 
 
-_logger = logging.getLogger(__name__)
+_logger = get_payment_logger(__name__)
 
 
 class XenditController(http.Controller):
@@ -23,7 +22,7 @@ class XenditController(http.Controller):
 
     @http.route('/payment/xendit/payment', type='jsonrpc', auth='public')
     def xendit_payment(self, reference, token_ref):
-        """ Make a payment by token request and handle the response.
+        """Make a payment by token request and handle the response.
 
         :param str reference: The reference of the transaction.
         :param str token_ref: The reference of the Xendit token to use to make the payment.
@@ -34,25 +33,18 @@ class XenditController(http.Controller):
 
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def xendit_webhook(self):
-        """ Process the notification data sent by Xendit to the webhook.
+        """Process the payment data sent by Xendit to the webhook.
 
         :return: The 'accepted' string to acknowledge the notification.
         """
         data = request.get_json_data()
         _logger.info("Notification received from Xendit with data:\n%s", pprint.pformat(data))
 
-        try:
-            # Check the integrity of the notification.
-            received_token = request.httprequest.headers.get('x-callback-token')
-            tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
-                'xendit', data
-            )
+        received_token = request.httprequest.headers.get('x-callback-token')
+        tx_sudo = request.env['payment.transaction'].sudo()._search_by_reference('xendit', data)
+        if tx_sudo:
             self._verify_notification_token(received_token, tx_sudo)
-
-            # Handle the notification data.
-            tx_sudo._handle_notification_data('xendit', data)
-        except ValidationError:
-            _logger.exception("Unable to handle notification data; skipping to acknowledge.")
+            tx_sudo._process('xendit', data)
 
         return request.make_json_response(['accepted'], status=200)
 
@@ -72,16 +64,16 @@ class XenditController(http.Controller):
     def _verify_notification_token(self, received_token, tx_sudo):
         """ Check that the received token matches the saved webhook token.
 
-        :param str received_token: The callback token received with the notification data.
-        :param payment.transaction tx_sudo: The transaction referenced by the notification data.
+        :param str received_token: The callback token received with the payment data.
+        :param payment.transaction tx_sudo: The transaction referenced by the payment data.
         :return: None
         :raise Forbidden: If the tokens don't match.
         """
         # Check for the received token.
         if not received_token:
-            _logger.warning("Received notification with missing token.")
+            _logger.warning("Received payment data with missing token.")
             raise Forbidden()
 
         if not consteq(tx_sudo.provider_id.xendit_webhook_token, received_token):
-            _logger.warning("Received notification with invalid callback token %r.", received_token)
+            _logger.warning("Received payment data with invalid callback token %r.", received_token)
             raise Forbidden()

--- a/addons/payment_xendit/tests/common.py
+++ b/addons/payment_xendit/tests/common.py
@@ -17,7 +17,7 @@ class XenditCommon(PaymentCommon):
         cls.provider = cls.xendit
         cls.amount = 11100
         cls.currency = cls._enable_currency('IDR')
-        cls.webhook_notification_data = {
+        cls.webhook_payment_data = {
             'amount': cls.amount,
             'status': 'PAID',
             'created': '2023-07-12T09:31:13.111Z',
@@ -35,7 +35,7 @@ class XenditCommon(PaymentCommon):
             'payment_channel': 'BNI',
             'payment_destination': '880891384013',
         }
-        cls.charge_notification_data = {
+        cls.charge_payment_data = {
             'status': 'CAPTURED',
             'authorized_amount': cls.amount,
             'capture_amount': cls.amount,

--- a/addons/payment_xendit/tests/test_processing_flows.py
+++ b/addons/payment_xendit/tests/test_processing_flows.py
@@ -20,18 +20,17 @@ class TestProcessingFlow(XenditCommon, PaymentHttpCommon):
     @mute_logger('odoo.addons.payment_xendit.controllers.main')
     def test_webhook_notification_triggers_processing(self):
         """ Test that receiving a valid webhook notification and signature verified triggers the
-        processing of the notification data. """
+        processing of the payment data. """
         self._create_transaction('redirect')
         url = self._build_url(XenditController._webhook_url)
         with patch(
             'odoo.addons.payment_xendit.controllers.main.XenditController'
             '._verify_notification_token'
         ), patch(
-            'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
-            '._handle_notification_data'
-        ) as handle_notification_data_mock:
-            self._make_json_request(url, data=self.webhook_notification_data)
-        self.assertEqual(handle_notification_data_mock.call_count, 1)
+            'odoo.addons.payment.models.payment_transaction.PaymentTransaction._process'
+        ) as process_mock:
+            self._make_json_request(url, data=self.webhook_payment_data)
+        self.assertEqual(process_mock.call_count, 1)
 
     @mute_logger('odoo.addons.payment_xendit.controllers.main')
     def test_webhook_notification_triggers_signature_check(self):
@@ -42,7 +41,7 @@ class TestProcessingFlow(XenditCommon, PaymentHttpCommon):
             'odoo.addons.payment_xendit.controllers.main.XenditController.'
             '_verify_notification_token'
         ) as signature_check_mock:
-            self._make_json_request(url, data=self.webhook_notification_data)
+            self._make_json_request(url, data=self.webhook_payment_data)
             self.assertEqual(signature_check_mock.call_count, 1)
 
     def test_accept_webhook_notification_with_valid_signature(self):

--- a/addons/pos_online_payment/models/payment_transaction.py
+++ b/addons/pos_online_payment/models/payment_transaction.py
@@ -11,7 +11,7 @@ class PaymentTransaction(models.Model):
     pos_order_id = fields.Many2one('pos.order', string='POS Order', help='The Point of Sale order linked to the payment transaction', readonly=True)
 
     @api.model
-    def _compute_reference_prefix(self, provider_code, separator, **values):
+    def _compute_reference_prefix(self, separator, **values):
         """ Override of payment to compute the reference prefix based on POS-specific values.
 
         :return: The computed reference prefix if POS order id is found, the one of `super` otherwise
@@ -22,7 +22,7 @@ class PaymentTransaction(models.Model):
             pos_order = self.env['pos.order'].sudo().browse(pos_order_id).exists()
             if pos_order:
                 return pos_order.pos_reference
-        return super()._compute_reference_prefix(provider_code, separator, **values)
+        return super()._compute_reference_prefix(separator, **values)
 
     def _post_process(self):
         """ Override of payment to process POS online payments automatically. """

--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -50,7 +50,7 @@ class PosPaymentMethod(models.Model):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
             raise AccessError(_("Do not have access to fetch token from Stripe"))
         
-        return self.sudo()._get_stripe_payment_provider()._stripe_make_request('terminal/connection_tokens')
+        return self.sudo()._get_stripe_payment_provider()._send_api_request('POST', 'terminal/connection_tokens')
 
     def _stripe_calculate_amount(self, amount):
         currency = self.journal_id.currency_id or self.company_id.currency_id
@@ -78,7 +78,7 @@ class PosPaymentMethod(models.Model):
         elif currency.name == 'CAD' and self.company_id.country_code == 'CA':
             params.append(("payment_method_types[]", "interac_present"))
 
-        return self.sudo()._get_stripe_payment_provider()._stripe_make_request('payment_intents', params)
+        return self.sudo()._get_stripe_payment_provider()._send_api_request('POST', 'payment_intents', data=params)
 
     @api.model
     def stripe_capture_payment(self, paymentIntentId, amount=None):
@@ -100,7 +100,7 @@ class PosPaymentMethod(models.Model):
                 "amount_to_capture": self._stripe_calculate_amount(amount),
             }
 
-        return self.sudo()._get_stripe_payment_provider()._stripe_make_request(endpoint, data)
+        return self.sudo()._get_stripe_payment_provider()._send_api_request('POST', endpoint, data=data)
 
     def action_stripe_key(self):
         res_id = self._get_stripe_payment_provider().id

--- a/addons/sale/models/payment_transaction.py
+++ b/addons/sale/models/payment_transaction.py
@@ -218,14 +218,13 @@ class PaymentTransaction(models.Model):
                 tx.invoice_ids = [Command.set(invoices.ids)]
 
     @api.model
-    def _compute_reference_prefix(self, provider_code, separator, **values):
+    def _compute_reference_prefix(self, separator, **values):
         """ Override of payment to compute the reference prefix based on Sales-specific values.
 
         If the `values` parameter has an entry with 'sale_order_ids' as key and a list of (4, id, O)
         or (6, 0, ids) X2M command as value, the prefix is computed based on the sales order name(s)
         Otherwise, the computation is delegated to the super method.
 
-        :param str provider_code: The code of the provider handling the transaction
         :param str separator: The custom separator used to separate data references
         :param dict values: The transaction values used to compute the reference prefix. It should
                             have the structure {'sale_order_ids': [(X2M command), ...], ...}.
@@ -239,7 +238,7 @@ class PaymentTransaction(models.Model):
             orders = self.env['sale.order'].browse(order_ids).exists()
             if len(orders) == len(order_ids):  # All ids are valid
                 return separator.join(orders.mapped('name'))
-        return super()._compute_reference_prefix(provider_code, separator, **values)
+        return super()._compute_reference_prefix(separator, **values)
 
     @api.readonly
     def action_view_sales_orders(self):

--- a/addons/website_sale_collect/models/payment_provider.py
+++ b/addons/website_sale_collect/models/payment_provider.py
@@ -11,6 +11,17 @@ class PaymentProvider(models.Model):
 
     custom_mode = fields.Selection(selection_add=[('on_site', "Pay on site")])
 
+    # === CRUD METHODS === #
+
+    def _get_default_payment_method_codes(self):
+        """ Override of `payment` to return the default payment method codes. """
+        self.ensure_one()
+        if self.custom_mode != 'on_site':
+            return super()._get_default_payment_method_codes()
+        return const.DEFAULT_PAYMENT_METHOD_CODES
+
+    # === BUSINESS METHODS === #
+
     @api.model
     def _get_compatible_providers(
         self, company_id, *args, sale_order_id=None, website_id=None, report=None, **kwargs
@@ -52,10 +63,3 @@ class PaymentProvider(models.Model):
             )
 
         return compatible_providers
-
-    def _get_default_payment_method_codes(self):
-        """ Override of `payment` to return the default payment method codes. """
-        default_codes = super()._get_default_payment_method_codes()
-        if self.custom_mode != 'on_site':
-            return default_codes
-        return const.DEFAULT_PAYMENT_METHOD_CODES


### PR DESCRIPTION
This commit introduces a significant change in the paradigm of how the payment engine handles processing errors.

The previous mechanism relied on exceptions bubbling to signal processing errors to the callers (payment form, web client, cron). This approach posed two problems: it was necessary to catch and handle any exception raised by the payment engine, and transactions were not persisted if an error was encountered and the cursor rolled back.

The new approach consists of catching exceptions as soon as possible to prevent them from discarding database changes, setting the transaction to the 'error' state, and saving the error message on the transaction. It allows tracking transactions whose processing failed, and simplifies the handling of payment errors for applications integrating with online payments (e.g., Subscriptions).

A number of collateral changes are made to enable the state-based reporting and streamline the integration of new payment providers:

- A new `_send_api_request` util method is introduced on both the  `payment.provider` and `payment.transaction` models to handle all API requests for the providers and centralize the management of processing errors. A series of specific hook methods are introduced to allow providers to configure the requests: `_build_request_url`, `_build_request_headers`, `_build_request_auth`, `_parse_response_error`, and `_parse_response_content`.
- The processing-oriented methods (`*_from_notification_data`) are replaced by a new set of core and hook methods to centralize all the common logic involving error management. The overrides are kept to a bare minimum, consisting of only the provider-specific handling of transactions.
- Provider-specific overrides of core `payment` methods are no longer required to call the `super()` method. This is made possible by moving the common logic previously living in those core methods into new, high-level business methods: `_charge_with_token`, `_capture`, `_void`, and `_refund`.
- Action methods related to payment operations (capture, etc.) now display a toaster notification with the operation's result.
The capture and void payment operations now always create a child transaction to track the operation's progress and save any error message on the child transaction rather than the source one.
- Provider names are removed from the log messages and from displayed errors.
- A new `get_payment_logger` util method is introduced to configure the logger of a payment provider and automatically mask sensitive data (e.g., secret keys) from logs.

task-3648413

See also:

- https://github.com/odoo/enterprise/pull/87325
- https://github.com/odoo/documentation/pull/13888
