### PR TITLE
[FIX] payment_custom: show full QR code

### DIFF
--- a/addons/payment_custom/views/payment_custom_templates.xml
+++ b/addons/payment_custom/views/payment_custom_templates.xml
@@ -34,7 +34,7 @@
                     <hr class="d-inline d-md-none w-100"/>
                     <div class="vr d-none d-md-block h-100 mx-auto"/>
                 </div>
-                <div class="o_qr_code_card card order-1 order-md-3 bg-info">
+                <div class="o_qr_code_card card order-1 order-md-3 bg-info flex-shrink-0">
                     <div class="card-body d-flex flex-column align-items-center justify-content-center pb-3">
                         <img class="mb-2 border border-dark rounded" t-att-src="qr_code"/>
                         <small class="text-center text-wrap lh-sm">Scan me in your banking app</small>


### PR DESCRIPTION
__Current behavior before commit:__
The QR code on the payment page is cropped when the Pending Message of the payment provider has a long line.

__Description of the fix:__
Set `flex-shrink-0` to the QR code card so it doesn't shrink.

__Steps to show the cropped QR code:__
1. Install sale_management and website
2. Set company currency to EUR
3. Enable QR Codes under Customer Payments in Settings
4. Enable Online Payment (and disable Online Signature) under Quotations & Orders
5. In Payment Providers, install SEPA Direct Debit. Select Test mode, check Enable QR Codes, and publish it.
6. **In Messages tab, put a very long line as Pending Message**
7. Go to the Journal "Bank" and set a random IBAN as Account number
8. Create a new Quote with a non 0 price and click on Preview and pay the order
9. The QR code is cropped

opw-4735003
