### PR TITLE
[FIX] mail: message actions mobile mailbox easier to use

### DIFF
--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -178,6 +178,10 @@
 .o-mail-Message-openActionMobile {
     opacity: 10% !important;
 
+    .o-mail-Message.o-card & {
+        opacity: 15% !important;
+    }
+
     &:active {
         opacity: 75% !important;
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -17,6 +17,7 @@
                 t-ref="root"
                 t-if="message.exists()"
             >
+                <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1"><t t-call="mail.Message.actions"/></div>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
                     <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
                         <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view rounded-3" t-att-class="getAvatarContainerAttClass()">
@@ -30,7 +31,7 @@
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
-                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note }" name="header">
+                        <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline lh-1" t-att-class="{ 'mb-1': !message.is_note, 'pe-2': props.asCard and isMobileOS }" name="header">
                             <span t-if="authorName and shouldDisplayAuthorName" class="o-mail-Message-author smaller" t-att-class="getAuthorAttClass()">
                                 <strong class="me-1" t-esc="authorName"/>
                             </span>
@@ -53,7 +54,7 @@
                                 </span>
                             </div>
                             <t t-if="isAlignedRight" t-call="mail.Message.notification"/>
-                            <t t-if="!message.bubbleColor" t-call="mail.Message.actions"/>
+                            <t t-if="!message.bubbleColor and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
                         <div
                             class="o-mail-Message-contentContainer position-relative d-flex"
@@ -119,7 +120,7 @@
                                             </div>
                                         </t>
                                     </t>
-                                    <t t-if="message.bubbleColor and message.hasTextContent and !env.inChatWindow" t-call="mail.Message.actions"/>
+                                    <t t-if="message.bubbleColor and message.hasTextContent and !env.inChatWindow and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                                 </div>
                                 <div class="position-relative">
                                     <AttachmentList
@@ -131,7 +132,7 @@
                                 </div>
                                 <LinkPreviewList t-if="message.link_preview_ids.length > 0 and store.hasLinkPreviewFeature and !message.linkPreviewSquash" linkPreviews="message.link_preview_ids" deletable="props.message.editable"/>
                             </div>
-                            <t t-if="message.bubbleColor and (!message.hasTextContent or env.inChatWindow)" t-call="mail.Message.actions"/>
+                            <t t-if="message.bubbleColor and (!message.hasTextContent or env.inChatWindow) and !(props.asCard and isMobileOS)" t-call="mail.Message.actions"/>
                         </div>
                         <MessageReactions message="message" openReactionMenu="openReactionMenu" t-if="message.reactions.length"/>
                     </div>
@@ -149,8 +150,8 @@
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,
-            'mt-1': message.bubbleColor,
-            'my-n2': !message.bubbleColor,
+            'mt-1': message.bubbleColor and !props.asCard and !isMobileOS,
+            'my-n2': !message.bubbleColor and !props.asCard and !isMobileOS,
             'invisible': !isActive and !isMobileOS,
             'o-expanded': optionsDropdown.isOpen
         }"


### PR DESCRIPTION
Before this commit, message actions are placed based on the type of message and its content:

- when message has bubble layout, they are placed next to the 1st line of bubble
- when message contains only attachments, they are placed next to the start of 1st attachment row
- otherwise, they are placed next to message header

The last case is a last resort which happens in non-discuss channels such as logged notes or tracking values and so on. All of them do not have "squashed" messages and the best natural placement is there in header. Message header is intended to be thin in content, so that it doesn't overpower with message content. However, message actions need to be big enough to be reached with a thumb. These considerations led to a compromise of thin header with message actions with negative margins.

This works well when message header is on a single line, but when it wraps to new line this doesn't look good because the negative margin puts it partially inside the header content.

This commit fixes the issue by changing the placement of message actions in mobile when displayed as a card, like on Inbox and History: the "..." is moved to the top-right corner of card.

This works because the card layout makes the top-right corner a natural position. This make it work like kanban views.

Note that this placement is best only in mobile: the card are short in width to make reaching message actions easy. In desktop, the message card can take almost the width of screen, so it makes it less practical than currently, close to message content.

Before
![Screenshot 2025-05-13 at 16 55 06](https://github.com/user-attachments/assets/7ce26c5d-f3a3-41fb-8a60-3736146eec7f)
After
![Screenshot 2025-05-13 at 16 54 27](https://github.com/user-attachments/assets/844e1d98-49a7-44b3-b8c9-68755385a863)
