### PR TITLE
[FIX] mrp_subcontracting: add stock picking origin to subcontracted MO

### DIFF
--- a/addons/mrp_subcontracting/models/stock_picking.py
+++ b/addons/mrp_subcontracting/models/stock_picking.py
@@ -159,7 +159,8 @@ class StockPicking(models.Model):
             'location_dest_id': subcontracting_location.id,
             'product_qty': subcontract_move.product_uom_qty or subcontract_move.quantity,
             'picking_type_id': warehouse.subcontracting_type_id.id,
-            'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay)
+            'date_start': subcontract_move.date - relativedelta(days=bom.produce_delay),
+            'origin': self.name,
         }
         return vals
 

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -123,6 +123,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
@@ -203,6 +204,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
@@ -273,6 +275,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         picking_receipt.move_ids.picked = True
         picking_receipt.button_validate()
         self.assertEqual(mo.state, 'done')
+        self.assertEqual(mo.origin, picking_receipt.name)
 
         # Available quantities should be negative at the subcontracting location for each components
         avail_qty_comp1 = self.env['stock.quant']._get_available_quantity(self.comp1, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)


### PR DESCRIPTION
This commit ensures that the 'Source' field of a subcontracted MO is automatically filled with the name of the receipt that led to its creation.

Steps to reproduce the bug:
- Create a storable product “P3”:
    - route: Drop-ship
    - Vendor: vendor P3
    - BoM:
        - type: subcontracting
        - Subcontractors: Vendor P3 - Components:
            - P2:
                - Vendor: Vendor P2
                - Route: drop-ship subcontractor on order
                - BoM:
                    - Type: Subcontracting
                    - subcontractor: Vendor P2
                    - Components:
                        - P1:
                            - Vendor: Vendor of product P1
                            - Route: Drop-ship subcontractor on order

- Create a quotation:
    - Customer: Azure Interior
    - Product: P3
- Confirm the quotation -> A purchase order is created for P3
- Open the PO
- Confirm it
- A purchase order is created for P2, and an MO is generated for P3
- Confirm the PO for P2 → an MO is created for P2

Problem:
The Origin field is not set for either MO, preventing the linkage between parent and child MOs.

Backport of:
https://github.com/odoo/odoo/commit/cca6c7abc1adcf688123a1e41033a3e25daf8d6a

opw-4788501
