### PR TITLE
[FIX] web: don't dump unserializable field values

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -193,7 +193,7 @@ class RawRecordDialog extends Component {
 }
 
 export function viewRawRecord({ component, env }) {
-    const { resId, resModel } = component.model.config;
+    const { resId, resModel, fields } = component.model.config;
     if (!resId) {
         return null;
     }
@@ -202,7 +202,10 @@ export function viewRawRecord({ component, env }) {
         type: "item",
         description,
         callback: async () => {
-            const records = await component.model.orm.read(resModel, [resId]);
+            const serializableFields = Object.entries(fields).reduce(
+                (acc, [k, v]) => v.type !== "binary" ? acc.concat(k) : acc, []
+            );
+            const records = await component.model.orm.read(resModel, [resId], serializableFields);
             env.services.dialog.add(RawRecordDialog, {
                 title: _t("Data: %(model)s(%(id)s)", { model: resModel, id: resId }),
                 record: records[0],


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable developer mode;
2. go to Settings / Technical / Database Structure / Attachments;
3. open a PDF attachement;
4. open developer tools;
5. click on Record / Data.

Issue
-----
> Connection lost. Trying to reconnect...

Traceback in logger:
> `UnicodeDecodeError: 'utf-8' codec can't decode byte ...`

Cause
-----
Commit 5ef4c07ada1b4 moved the `json_default` function from `date_utils` to `json`, with the purpose of letting it serialize objects besides `date` & `datetime`.

When used for raw data of binary files like PDF, it encounters values that cannot be represented in UTF-8, and because `decode` defaults to strict error handling, an exception is thrown.

Solution
--------
When sending the `read` request to the ORM, only request fields of that aren't of type `binary` to ensure they're serializable.

opw-4717657