### PR TITLE
[PERF] web: improving validation of domain

### DIFF
--- a/addons/web/controllers/domain.py
+++ b/addons/web/controllers/domain.py
@@ -10,7 +10,7 @@ from odoo.tools.misc import mute_logger
 class Domain(Controller):
 
     @http.route('/web/domain/validate', type='jsonrpc', auth="user")
-    def validate(self, model, domain):
+    def validate(self, model, domain, context=None):
         """ Parse `domain` and verify that it can be used to search on `model`
         :return: True when the domain is valid, otherwise False
         :raises ValidationError: if `model` is invalid
@@ -21,7 +21,7 @@ class Domain(Controller):
         try:
             # go through the motions of preparing the final SQL for the domain,
             # so that anything invalid will raise an exception.
-            query = Model.sudo()._search(domain)
+            query = Model.with_context(context)._search(domain)
 
             # Execute the search in EXPLAIN mode, to have the query parser
             # verify it. EXPLAIN will make sure the query is never actually executed

--- a/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.js
+++ b/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.js
@@ -89,6 +89,7 @@ export class DomainSelectorDialog extends Component {
             isValid = await rpc("/web/domain/validate", {
                 model: this.props.resModel,
                 domain,
+                context: user.context,
             });
         }
         if (!isValid) {

--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -12,6 +12,7 @@ import { useRecordObserver } from "@web/model/relational_model/utils";
 import { useGetDomainFacets } from "@web/search/utils/misc";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { standardFieldProps } from "../standard_field_props";
+import { user } from "@web/core/user";
 
 export class DomainField extends Component {
     static template = "web.DomainField";
@@ -234,7 +235,7 @@ export class DomainField extends Component {
         if (domain.isInvalid) {
             return false;
         }
-        return rpc("/web/domain/validate", { model: resModel, domain });
+        return rpc("/web/domain/validate", { model: resModel, domain, context: user.context });
     }
 
     update(domain, isDebugEdited = false) {

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -2,7 +2,7 @@ import { expect, getFixture, test } from "@odoo/hoot";
 import { queryAllTexts, scroll } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockDate } from "@odoo/hoot-mock";
 import { getPickerCell } from "@web/../tests/core/datetime/datetime_test_helpers";
-import { SELECTORS } from "@web/../tests/core/domain_selector/domain_selector_helpers";
+import { SELECTORS, userContext } from "@web/../tests/core/domain_selector/domain_selector_helpers";
 import {
     Country,
     Partner,
@@ -952,6 +952,7 @@ test("quick check on save if domain has been edited via the debug input", async 
         expect(params).toEqual({
             domain: [["id", "!=", false]],
             model: "partner",
+            context: userContext,
         });
         return true;
     });

--- a/addons/web/static/tests/core/domain_selector/domain_selector_helpers.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector_helpers.js
@@ -5,3 +5,10 @@ export const SELECTORS = {
     debugArea: ".o_domain_selector_debug_container textarea",
     resetButton: ".o_domain_selector_row > button",
 };
+
+export const userContext = {
+    allowed_company_ids: [1],
+    lang: "en",
+    tz: "taht",
+    uid: 7,
+};


### PR DESCRIPTION
Issue -->

When creating a domain using the domain selector dialog box, a RPC call is made to `/web/domain/validate` path. The `validate` controller method takes in the model and domain, builds a query using `_search` to check for validity. The issue arises when a field in the domain has a search method associated with it. If there are any additional searches done within these methods, such as in the `_search_qty_to_order` method, the search occurs on all companies. This happens as the `allowed_company_ids` context is not available.

Solution -->

Pass the context in the RPC call and to the controller to be used in the `_search` call. This passes on the `allowed_company_ids` context key onto the process, which filters rows returned by any possible searches 
made down the call stack.

opw-4677895

