### PR TITLE
[FIX] mail: no flicker "message removed" when posting only files

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -844,6 +844,7 @@ export class Thread extends Record {
             tmpMsg = this.store["mail.message"].insert(
                 {
                     ...tmpData,
+                    attachment_ids: attachments,
                     body: prettyContent,
                     isPending: true,
                     thread: this,

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1886,6 +1886,21 @@ test("warning on send with shortcut when attempting to post message with still-u
     await contains(".o_notification", { text: "Please wait while the file is uploading." });
 });
 
+test("post attachment-only message shows optimistically the new message with attachment", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "test" });
+    onRpcBefore("/mail/message/post", async () => await new Deferred());
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Composer input[type=file]");
+    const file = new File(["hello, world"], "text.txt", { type: "text/plain" });
+    await editInput(document.body, ".o-mail-Composer input[type=file]", [file]);
+    await contains(".o-mail-AttachmentCard:not(:has(.fa.fa-circle-o-notch)):contains('text.txt')");
+    await press("Enter");
+    await contains(".o-mail-Message");
+    await contains(".o-mail-Message .o-mail-AttachmentCard:contains('text.txt')");
+});
+
 test("failure on loading messages should display error", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -115,7 +115,8 @@ registry.category("web_tour.tours").add("create_thread_for_attachment_without_bo
         },
         {
             content: "Hover on attachment",
-            trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("file2.txt")',
+            trigger:
+                '.o-mail-Message:not(:has(.o-mail-Message-pendingProgress)) .o-mail-AttachmentCard:contains("file2.txt")',
             run: "hover",
         },
         {


### PR DESCRIPTION
Before this commit, when posting a message containing only files, the message list shows the new message with "this message has been removed" for a very short time.

This happens because the pending message was considered empty, due to lack of attachments in pending message.
The pending message is the optimistical behaviour of showing the message that is being posted immediately on UI before receiving response data from server.

This commit fixes the issue by showing attachments of just sent message in the pending preview.

Task-4776054

Posting a message with Avatar.jpg:
Before / After
![Screenshot 2025-05-13 at 19 12 21](https://github.com/user-attachments/assets/58e0bd66-51f8-4e2f-ac23-bf5b6eb0735f) ![Screenshot 2025-05-13 at 19 11 49](https://github.com/user-attachments/assets/d8a7a620-0c94-4bba-bfb6-3658d3b06547)
