### PR TITLE
[FIX] crm: avoid cascading crm.lead2opportunity.partner wizard

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert.py
+++ b/addons/crm/tests/test_crm_lead_convert.py
@@ -461,6 +461,36 @@ class TestLeadConvert(crm_common.TestLeadConvertCommon):
         convert.action_apply()
         self.assertEqual(self.lead_1.type, 'opportunity')
 
+    @users('user_sales_manager')
+    def test_lead_merge_last_created(self):
+        """
+        Test convert wizard is not deleted in merge mode when the original assigned lead is deleted
+        """
+        date = Datetime.from_string('2020-01-20 16:00:00')
+        self.crm_lead_dt_mock.now.return_value = date
+
+        last_lead = self.env['crm.lead'].create({
+            'name': f'Duplicate of {self.lead_1.contact_name}',
+            'type': 'lead', 'user_id': False, 'team_id': self.lead_1.team_id.id,
+            'contact_name': f'Duplicate of {self.lead_1.contact_name}',
+            'email_from': self.lead_1.email_from,
+            'probability': 10,
+        })
+
+        convert = self.env['crm.lead2opportunity.partner'].with_context({
+            'active_model': 'crm.lead',
+            'active_id': last_lead.id,
+            'active_ids': last_lead.ids,
+        }).create({})
+
+        # test main lead on wizard
+        self.assertEqual(convert.lead_id, last_lead)
+        convert.action_apply()
+        self.assertTrue(convert.exists(), 'Wizard cannot be deleted via cascade!')
+        self.assertEqual(convert.lead_id, self.lead_1, "Lead must be the result opportunity!")
+        self.assertEqual(self.lead_1.type, 'opportunity')
+        self.assertFalse(last_lead.exists(), 'The last lead must be merged with the first one!')
+
     @users('user_sales_salesman')
     def test_lead_merge_user(self):
         """ Test convert wizard working in merge mode with sales user """

--- a/addons/crm/wizard/crm_lead_to_opportunity.py
+++ b/addons/crm/wizard/crm_lead_to_opportunity.py
@@ -130,6 +130,9 @@ class Lead2OpportunityPartner(models.TransientModel):
                     'user_id': self.user_id.id,
                     'team_id': self.team_id.id,
                 })
+        if self.lead_id != result_opportunity:
+            # Prevent unwanted cascade during unlinks, keeping other operations and overrides possible
+            self.write({'lead_id': result_opportunity})
         (to_merge - result_opportunity).sudo().unlink()
         return result_opportunity
 


### PR DESCRIPTION
## Issue:

When converting a lead to an opportunity, a wizard
(`crm.lead2opportunity.partner`) is shown. This allows merging
duplicated leads.

However, if the most recently created lead is selected as the primary,
the wizard record may be deleted unexpectedly. This usually goes
unnoticed in the UI, as the wizard disappears after the operation.

The issue becomes critical when overriding the conversion flow via a
custom module or in future changes to the core logic. In those cases,
the deletion of the wizard can lead to empty recordsets and errors.

#### Affected versions: 16.0 and later.

## Explanation

The `crm.lead2opportunity.partner` model has a `Many2one` field
`lead_id` that is being deleting on cascade which is the default
for m2o fields on transient models.

During lead conversion, action_apply() calls _action_merge() or
_action_convert(). In _action_merge(), non-primary leads are
unlinked. If the primary lead is the last created one, it differs
from the one referenced by the wizard. This causes lead_id to be
unset, triggering the cascade and deleting the wizard.

## Impact:

If a custom module overrides action_apply() or _action_merge() and
calls super() first, it may operate on an empty recordset, leading
to failures when trying to access data or call methods.

## To reproduce:

With debugger:

- Set a breakpoint on the unlink call inside _action_merge
- After unlink, calling self.exists() on the wizard will return an empty recordset

With a custom module:

- Override action_apply() or _action_merge()
- Call super() first
- Try to merge leads and select the most recent one as primary
- The wizard record will be deleted before your custom logic executes, and will raise a "Record does not exist or has been deleted."

OPW-4773172

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
