### PR TITLE
[FIX] website{_event}: prevent error when search string has multiple spaces

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -449,6 +449,9 @@ class EventEvent(models.Model):
             return Domain('address_id', operator, domain)
         if operator == 'ilike' and isinstance(value, str):
             return Domain('address_id', 'any', make_codomain(value))
+        # for the trivial "empty" case, there is no empty address
+        if operator == 'in' and (not value or not any(value)):
+            return Domain(False)
         return NotImplemented
 
     # seats

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -344,7 +344,7 @@ class WebsiteSearchableMixin(models.AbstractModel):
         """
         domains = domain_list.copy()
         if search:
-            for search_term in search.split(' '):
+            for search_term in search.split():
                 subdomains = [[(field, 'ilike', escape_psql(search_term))] for field in fields]
                 if extra:
                     subdomains.append(extra(self.env, search_term))

--- a/addons/website_event/tests/__init__.py
+++ b/addons/website_event/tests/__init__.py
@@ -5,4 +5,5 @@ from . import test_event_internals
 from . import test_event_mail
 from . import test_event_menus
 from . import test_event_visitor
+from . import test_fuzzy
 from . import test_website_event

--- a/addons/website_event/tests/test_fuzzy.py
+++ b/addons/website_event/tests/test_fuzzy.py
@@ -1,0 +1,47 @@
+from datetime import datetime, timedelta
+
+from odoo.http import request
+from odoo.tests import tagged
+
+from odoo.addons.website.tests.test_fuzzy import TestAutoComplete
+from odoo.addons.website.tools import MockRequest
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteEventAutocomplete(TestAutoComplete):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.event = cls.env['event.event'].create({
+            'name': "Latest Singing Event",
+            'website_published': True,
+            'date_begin': datetime.today() - timedelta(days=1),
+            'date_end': datetime.today() + timedelta(days=1),
+        })
+
+    def test_autocomplete_search_for_multiple_spaces(self):
+        """Tests that autocomplete handles multiple spaces in the search term correctly."""
+        with MockRequest(self.env, website=self.website):
+            options = {
+                "allowFuzzy": True,
+                "display_currency": request.website.company_id.currency_id.id,
+                "displayDescription": True,
+                "displayDetail": False,
+                "displayExtraLink": True,
+                "displayImage": True,
+                "order": "name asc",
+            }
+            result = self.WebsiteController.autocomplete(
+                search_type="all",
+                term="latest   singing        event   ",
+                max_nb_chars=75,
+                options=options,
+            )
+            expected = self.WebsiteController.autocomplete(
+                search_type="all",
+                term="latest singing event",
+                max_nb_chars=75,
+                options=options,
+            )
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Currently an error occurs when a user searches for events on the website.

Steps to Reproduce:

 - Install the website_event module.
 - Go to the website and search a string that contains multiple spaces.

NotImplementedError

This error occurs because search.split(' ') returns a list containing empty strings when the input includes 
multiple consecutive spaces. The issue occurs after merging this commit [2]. When the opt(_optimize_like_str) 
with [('address_search', 'ilike', '')] (as self ) with event.event model we got an != operator from here due to 
we don't have value(search_term) but we have result. This changes [3] raise an NotImplemented since 
the != operator not supported.

This commit ensures that if _search_address_search gets 'Falsy' and '[Falsy]'value with the 'in' operator, 
it returns Domain(False). Also updates split(' ')to split() so that multiple spaces are treated as a single 
separator, preventing errors.

[1] https://github.com/odoo/odoo/blob/f52d5aff1afa99fa0e8953545b09ad1f7c813b2f/odoo/orm/domains.py

[2] https://github.com/odoo/odoo/commit/92301a5b300dec1ddfca44dc35318b83d67c56fa

[3 ] https://github.com/odoo/odoo/commit/92301a5b300dec1ddfca44dc35318b83d67c56fa#diff-90e43e2412e3476af2026b2726a51ce6050371753243825268e3a21df4fca940R405

sentry-6600544271


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
