### PR TITLE
[FIX] mrp: prevent error on creating a new manufacturing operation

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -107,6 +107,7 @@ class MrpRoutingWorkcenter(models.Model):
             quantity = self.env.context.get('quantity', operation.bom_id.product_qty or 1)
             unit = self.env.context.get('unit', operation.bom_id.product_uom_id)
             (capacity, setup, cleanup) = workcenter._get_capacity(product, unit, operation.bom_id.product_qty or 1)
+            capacity = capacity or 1
             operation.cycle_number = float_round(quantity / capacity, precision_digits=0, rounding_method="UP")
             operation.time_total = setup + cleanup + operation.cycle_number * operation.time_cycle * 100.0 / (workcenter.time_efficiency or 100.0)
             operation.show_time_total = operation.cycle_number > 1 or not float_is_zero(setup + cleanup, precision_digits=0)


### PR DESCRIPTION
A divide-by-zero error occurs when creating a new manufacturing operation from the configuration due to zero capacity being used in the operation cycle calculation.

**Steps to reproduce:**
* Install mrp with demo data
* Go to `mrp>configurations>Operations>New`

`ZeroDivisionError: float division by zero`

**Solution:**
* Setting the capacity value to be one if it is zero, fixes the following issue.

**Sentry-6600762870**

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
