### PR TITLE
[IMP] *: change cta button if pos_restaurant_appointment is installed

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -493,6 +493,10 @@ class Website(models.Model):
         }
 
     def configurator_set_menu_links(self, menu_company, module_data):
+        if self.env['ir.module.module'].search([('name', '=', 'pos_restaurant_appointment')]).state == 'installed':
+            appointment_menu = self.env['website.menu'].search([('url', '=', '/appointment'), ('website_id', '=', self.id)])
+            appointment_menu.unlink()
+
         menus = self.env['website.menu'].search([('url', 'in', list(module_data.keys())), ('website_id', '=', self.id)])
         for m in menus:
             m.sequence = module_data[m.url]['sequence']
@@ -608,6 +612,12 @@ class Website(models.Model):
 
         # Update CTA
         cta_data = website.get_cta_data(kwargs.get('website_purpose'), kwargs.get('website_type'))
+        if self.env['ir.module.module'].search([('name', '=', 'pos_restaurant_appointment')]).state == 'installed':
+            cta_data.update({
+                'cta_btn_text': self.env._('Book a Table'),
+                'cta_btn_href': '/appointment'
+            })
+
         if cta_data['cta_btn_text']:
             xpath_view = 'website.snippets'
             parent_view = self.env['website'].with_context(website_id=website.id).viewref(xpath_view)

--- a/addons/website/static/tests/tours/pos_cta_button.js
+++ b/addons/website/static/tests/tours/pos_cta_button.js
@@ -1,0 +1,67 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("pos_cta_button", {
+    url: "/website/configurator",
+    steps: () => [
+        // Configurator first screen
+        {
+            content: "Click next",
+            trigger: "button.o_configurator_show",
+            run: "click",
+        },
+        // Description screen
+        {
+            content: "Select a website type",
+            trigger: "button.o_change_website_type",
+            run: "click",
+        },
+        {
+            content: "Insert a website industry",
+            trigger: ".o_configurator_industry input",
+            run: "edit ab",
+        },
+        {
+            content: "Select a website industry from the autocomplete",
+            trigger: ".o_configurator_industry_wrapper ul li a:contains('abbey')",
+            run: "click",
+        },
+        {
+            content: "Choose an objective from the list",
+            trigger: "button.o_change_website_purpose",
+            run: "click",
+        },
+        // Palette screen
+        {
+            content: "Choose a palette card",
+            trigger: ".palette_card",
+            run: "click",
+        },
+        // Features screen
+        {
+            id: "build_website",
+            content: "Click on build my website",
+            trigger: "button.btn-primary",
+            run: "click",
+        },
+        {
+            content: "Loader should be shown",
+            trigger: ".o_website_loader_container",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Wait until the configurator is finishes",
+            trigger: ":iframe [data-view-xmlid='website.homepage']",
+            timeout: 30000,
+        },
+        // Website Preview Screen
+        {
+            content: "Check the appointment menu is removed",
+            trigger:
+                ":iframe .top_menu:not(:has(.nav-item a[href='/appointment']:contains('Appointment')))",
+        },
+        {
+            content: "Check the CTA button",
+            trigger: ":iframe a[href='/appointment'].btn_cta:contains('Book a Table')",
+        },
+    ],
+});

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -96,6 +96,11 @@ class TestConfigurator(TestConfiguratorCommon):
     def test_configurator_params_step(self):
         self.start_tour('/website/configurator/3', 'configurator_params_step', login='admin')
 
+    def test_pos_cta_button_configurator_flow(self):
+        website_test = self.env['website'].create({
+            'name': 'Test website'
+        })
+        self.start_tour('/website/force/%s?path=%%2Fwebsite%%2Fconfigurator' % website_test.id, 'pos_cta_button', login='admin')
 
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):

--- a/addons/website_sale/static/tests/tours/pos_cta_button.js
+++ b/addons/website_sale/static/tests/tours/pos_cta_button.js
@@ -1,0 +1,30 @@
+import { registry } from "@web/core/registry";
+import { patch } from "@web/core/utils/patch";
+import "@website/../tests/tours/pos_cta_button";
+
+/*
+ * @override of website tour to include eCommerce configuration steps
+ */
+patch(registry.category("web_tour.tours").get("pos_cta_button"), {
+    steps() {
+        const originalSteps = super.steps();
+        const websiteBuildStepIndex = originalSteps.findIndex(
+            (step) => step.id === "build_website"
+        );
+        originalSteps.splice(
+            websiteBuildStepIndex + 1,
+            0,
+            {
+                content: "Choose a shop page style",
+                trigger: ".o_configurator_screen:contains(online catalog) .button_area",
+                run: "click",
+            },
+            {
+                content: "Choose a product page style",
+                trigger: ".o_configurator_screen:contains(product page) .button_area",
+                run: "click",
+            }
+        );
+        return originalSteps;
+    },
+});


### PR DESCRIPTION
\* = website, website_sale

This improvement ensures that when the `pos_restaurant_appointment`
module is installed and the user completes the website setup using the
configurator (instead of skipping and starting from scratch), the
configurator updates the CTA button text to "Book a Table" and links it
to the `/appointment` page.

This POS CTA button will have the highest priority, overriding other
CTA buttons such as "Next Event" or "Schedule an Appointment".

Additionally, to avoid redundancy, the "Appointment" menu item is 
removed from the website when `pos_restaurant_appointment` is installed 
and the configurator flow is used.

If the user skips the configurator and starts from scratch, the CTA 
button remains unchanged and behaves as it did previously.

**Functional flow:**

1. Install `pos_restaurant_appointment` directly or follow the steps
below:  
   - Install the Point of Sale module.
   - Go to Point of Sale > Configuration > Settings.
   - Click on Create New Shop.
   - Enter the name of the shop and check the "Is a Bar/Restaurant"
   option.
   - On the same page, scroll to the "POS Interface" section and
   enable the "Bookings" checkbox.
   - Select an Appointment Type and Save the configuration.
2. Now, install the Website app, or create a new website from the
settings if it is already installed.
3. Once installed or created, you will be taken to the Website 
Configurator. 
4. Click "Let's do it" to go through the configurator
(do not click "Skip and start from scratch").
5. Once the configurator finishes, observe that the CTA button in the
header is set to "Book a Table", linking to `/appointment`, and the
Appointment menu item is removed.

task-4678541




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
