### PR TITLE
[FIX] mrp: fix error when clicking on plan button in mo

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1567,7 +1567,7 @@ class MrpProduction(models.Model):
         for workorder in final_workorders:
             workorder._plan_workorder(replan)
 
-        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'])
+        workorders = self.workorder_ids.filtered(lambda w: w.state not in ['done', 'cancel'] and w.leave_id)
         if not workorders:
             return
 

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5239,6 +5239,27 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(unbuild_order.state, 'done')
         self.assertEqual(unbuild_order.product_qty, 1.23456)
 
+    def test_mo_plan_with_multiple_workorders(self):
+        mo = self.env['mrp.production'].create({
+            'product_id': self.product.id,
+            'workorder_ids': [
+                Command.create({
+                    'name': 'OP1',
+                    'product_uom_id': self.product_1.uom_id.id,
+                    'workcenter_id': self.workcenter_1.id,
+                }),
+                Command.create({
+                    'name': 'OP2',
+                    'product_uom_id': self.product_1.uom_id.id,
+                    'workcenter_id': self.workcenter_1.id,
+                    'duration': 60,
+                })
+            ],
+        })
+        mo.action_confirm()
+        mo.button_plan()
+        self.assertTrue(mo.is_planned)
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
When user clicks the plan button in the mo,
A traceback will appear.

Steps to reproduce the error:
- Create a new MO > Select any product > Add 2 workorders
- Confirm
- Set Real duration in any workorder
- Click on Plan button

Traceback:
```
File "/home/odoo/src/odoo/addons/mrp/models/mrp_production.py", line 1583, in _plan_workorders
    'date_start': min([workorder.leave_id.date_from for workorder in workorders]),
TypeError: '<' not supported between instances of 'datetime.datetime' and 'bool'
```

The error occurs due to changes introduced in the following commit: https://github.com/odoo/odoo/commit/e587fecca81081a1861b353b85f1d8ed68503973

After this commit, modifying the real duration of a work order sets its status to ``In Progress``.
As a result, the resource calendar leave is no longer created for that workorder. https://github.com/odoo/odoo/blob/3fb37cbc59adc2caace8efcdae418d2466a9b750/addons/mrp/models/mrp_workorder.py#L529-L530

So, here ``leave_id.date_from`` becomes False.
https://github.com/odoo/odoo/blob/3fb37cbc59adc2caace8efcdae418d2466a9b750/addons/mrp/models/mrp_production.py#L1575-L1576

So, It will lead to the above traceback.

sentry-6595147036

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
