### PR TITLE
[FIX] point_of_sale: add default weight on scale error

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/scale_screen/scale_screen.js
@@ -25,6 +25,7 @@ export class ScaleScreen extends Component {
     }
 
     onError(message) {
+        this.props.getPayload(null);
         this.dialog.add(
             AlertDialog,
             {

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -835,7 +835,7 @@ export class PosStore extends Reactive {
                 const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen);
                 if (weight) {
                     values.qty = weight;
-                } else {
+                } else if (weight !== null) {
                     return;
                 }
             } else {


### PR DESCRIPTION
In odoo/odoo#208571, a fix was made to prevent 1 unit of weight from added when cancelling weighing. However, this also changed the behaviour when a scale error (such as IoT box being disconnected) occurs, preventing the product from being manually entered.

In this commit, we amend the condition to only stop adding the order line if the user closes the scale popup, but still add it on error.

opw-4643243

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
