### PR TITLE
[FIX] event: prevent QR code from overlapping badge content

### DIFF
--- a/addons/event/report/event_event_templates.xml
+++ b/addons/event/report/event_event_templates.xml
@@ -356,7 +356,7 @@
                 <t t-set="first_ticket" t-value="event.event_ticket_ids[0] if event.event_ticket_ids else None"/>
                 <t t-set="ticket" t-value="attendee.event_ticket_id if attendee else first_ticket"/>
                 <div t-if="ticket" class="text-center w-100" t-attf-style="background-color: {{ticket.color or '#875A7B'}};">
-                    <div class="p-3 fs-3" t-out="ticket.name"/>
+                    <div class="p-2 fs-5" t-out="ticket.name"/>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Steps to reproduce:
1. Go to Events.
2. Create a new event with a long name.
3. Add a product.
4. Print the "Badge Example".

Issue:
When printing a badge from an event with a long name, the QR code overlaps or clips the information above it, making the badge unreadable.

Cause:
The issue is due to the large font size used for the event name.

Solution:
Reduced the font size of the event title to fs-5 to ensure enough spacing is maintained between the text and the QR code, avoiding layout overlap.

opw : 4783750

Before FIX:
![image](https://github.com/user-attachments/assets/bff09804-7824-454a-9523-1834ee0af4f4)

After FIX:
![image](https://github.com/user-attachments/assets/a85b1df9-c2e9-4f67-b99c-fb3f207702a3)