### PR TITLE
[FIX] mail: thread should not be visible after archived

### DIFF
--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -200,7 +200,7 @@ class ChannelController(http.Controller):
         channel = request.env["discuss.channel"].search([("id", "=", parent_channel_id)])
         if not channel:
             raise NotFound()
-        domain = [("parent_channel_id", "=", channel.id)]
+        domain = [("parent_channel_id", "=", channel.id), ("active", "=", True)]
         if before:
             domain.append(("id", "<", before))
         if search_term:

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -397,6 +397,8 @@ class DiscussChannel(models.Model):
                     diff.append(field_name)
             if diff:
                 channel._bus_send_store(channel, diff)
+            if 'active' in vals and vals.get('active') is not True and channel.parent_channel_id:
+                channel._bus_send("discuss.channel/delete", {"id": channel.id})
         if vals.get('group_ids'):
             self._subscribe_users_automatically()
         return result


### PR DESCRIPTION
Current behavior before PR:

If a thread is archived, it still appears in the Discuss. It's only hidden after page refresh.

Desired behavior after PR is merged:

When a thread is archived, it will be instantly hidden from the Discuss, no page refresh needed.

task-id: 4764934

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
