### PR TITLE
[FIX] hw_drivers: certificate error causes crash

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -338,10 +338,16 @@ def load_certificate():
     if response.status != 200:
         return "ERR_IOT_HTTPS_LOAD_REQUEST_STATUS %s\n\n%s" % (response.status, response.reason)
 
-    result = json.loads(response.data.decode()).get('result', {})
-    error = result.get('error')
-    if error:
-        _logger.error("An error received from odoo.com while trying to get the certificate: %s", error)
+    response_body = json.loads(response.data.decode())
+    server_error = response_body.get('error')
+    if server_error:
+        _logger.error("A server error received from odoo.com while trying to get the certificate: %s", server_error)
+        return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
+
+    result = response_body.get('result', {})
+    certificate_error = result.get('error')
+    if certificate_error:
+        _logger.error("An error received from odoo.com while trying to get the certificate: %s", certificate_error)
         return "ERR_IOT_HTTPS_LOAD_REQUEST_NO_RESULT"
 
     write_file('odoo-subject.conf', result['subject_cn'])


### PR DESCRIPTION
When the `odoo-enterprise/iot/x509` encounters an unexpected error, we still get an OK response but the result is empty and instead there is an error object returned. Before this commit, we never checked for this error object and so continued to process an empty result, causing a crash.

After this commit, we check for these errors and log them, with a different message to distinguish them from the existing errors that we already check for.

task-4793795

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
