### PR TITLE
[FIX] l10n_in_withholding: remove warning from tds payment wizard.

### DIFF
--- a/addons/l10n_in_withholding/i18n/l10n_in_withholding.pot
+++ b/addons/l10n_in_withholding/i18n/l10n_in_withholding.pot
@@ -395,15 +395,6 @@ msgid ""
 msgstr ""
 
 #. module: l10n_in_withholding
-#. odoo-python
-#: code:addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py:0
-#, python-format
-msgid ""
-"Warning: The base amount of TDS lines is greater than the untaxed amount of "
-"the %s"
-msgstr ""
-
-#. module: l10n_in_withholding
 #: model:ir.model.fields,field_description:l10n_in_withholding.field_l10n_in_withhold_wizard_line__withhold_id
 msgid "Withhold"
 msgstr ""

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -118,8 +118,6 @@ class L10nInWithholdWizard(models.TransientModel):
             precision = self.currency_id.decimal_places
             if wizard.related_move_id and float_compare(wizard.related_move_id.amount_untaxed, sum(line.base for line in wizard.withhold_line_ids), precision_digits=precision) < 0:
                 warning_message = _("Warning: The base amount of TDS lines is greater than the amount of the %s", wizard.type_name)
-            elif wizard.related_payment_id and float_compare(wizard.related_payment_id.amount, sum(line.base for line in wizard.withhold_line_ids), precision_digits=precision) < 0:
-                warning_message = _("Warning: The base amount of TDS lines is greater than the untaxed amount of the %s", wizard.type_name)
             wizard.warning_message = warning_message
 
     def _get_withhold_type(self):


### PR DESCRIPTION
Before this commit:
- A warning was shown in the TDS payment wizard when the base amount used for TDS calculation was greater than the amount being paid.
- However, this warning was misleading, as the TDS base amount can exceed the paid amount.

After this commit:
- The warning has been removed from the TDS payment wizard.

task-4787113