### PR TITLE
[FIX] point_of_sale: two picking for single pos order

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -516,6 +516,11 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'Order should be in paid state.'
         )
 
+        self.assertEqual(
+            len(self.pos_order_pos1.picking_ids),
+            1,
+            'Only 1 Picking should be created for 1 pos order.'
+        )
         # I test that the pickings are created as expected during payment
         # One picking attached and having all the positive move lines in the correct state
         self.assertEqual(


### PR DESCRIPTION
Before this commit:
===================
Two pickings were being created for existing POS orders when the order was paid.

After this commit:
===================
If an order is not in the draft state, there's no need to call _process_order, which was causing multiple pickings to be created for a single POS order.

A check has been added to verify the state of the existing order before processing.

opw-4790841


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
