### PR TITLE
[FIX] base: prevent error when clicking 'Show All' during module uninstall

### DIFF
--- a/odoo/addons/base/wizard/base_module_uninstall.py
+++ b/odoo/addons/base/wizard/base_module_uninstall.py
@@ -50,7 +50,9 @@ class BaseModuleUninstall(models.TransientModel):
                     return xids and all(xid.split('.')[0] in module_names for xid in xids)
 
                 # find the models that have all their XIDs in the given modules
-                self.model_ids = ir_models.filtered(lost).sorted('name')
+                wizard.model_ids = ir_models.filtered(lost).sorted('name')
+            else:
+                wizard.model_ids = False
 
     @api.onchange('module_ids')
     def _onchange_module_ids(self):


### PR DESCRIPTION
Currently, an error occurs when a user uninstall a module and immediately click the Show All checkbox.

**Steps to produce:**

- Install any module.
- Uninstall that module and quickly click the `Show All` checkbox.

**Error:**
`ValueError: Compute method failed to assign base.module.uninstall(1,).model_ids`

**Root Cause:**
At [1], if `module_ids` is empty, no value is assigned to `model_ids`.

[1]
https://github.com/odoo/odoo/blob/f52d5aff1afa99fa0e8953545b09ad1f7c813b2f/odoo/addons/base/wizard/base_module_uninstall.py#L45-L53

This commit ensures that each record in the compute method is explicitly assigned a value for `model_ids`, thereby preventing the Value error.

sentry-6600637515
