### PR TITLE
[FIX] base: fix computation of display name when partner has no name

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -986,8 +986,8 @@ class ResPartner(models.Model):
     )
     def _compute_display_name(self):
         for partner in self:
-            name = partner.name
             if partner._context.get("formatted_display_name"):
+                name = partner.name or ''
                 if partner.parent_id or partner.company_name:
                     name = f"{partner.company_name or partner.parent_id.name} \t --{partner.name}--"
 


### PR DESCRIPTION
The partner `name` field is not technically required. Following refactoring in odoo/odoo@29f747543758, ensure that we don't crash when computing display name for such partner (where name is empty, i.e equal to `False`)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
