### PR TITLE
[FIX] stock: apply company style to stockpicking_operations

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -3,9 +3,9 @@
     <data>
 
         <template id="report_picking">
-            <t t-call="web.report_layout">
-                <div class="article o_report_layout_standard">
-                    <t t-foreach="docs" t-as="o">
+            <t t-call="web.html_container">
+                <t t-foreach="docs" t-as="o">
+                    <t t-call="web.external_layout">
                         <t t-set="address" t-value="None"/>
                         <div class="page o_report_stockpicking_operations">
                             <div class="row justify-content-between">
@@ -241,7 +241,7 @@
                             <div class="oe_structure"></div>
                         </div>
                     </t>
-                </div>
+                </t>
             </t>
         </template>
         <template id="report_picking_type_label">


### PR DESCRIPTION
Issue
-----
Printed pickings don't have company style applied to them.

Steps to reproduce
-----
- Install Stock app
- In Settings, choose some document layout (eg bubble)
- Create a delivery for some product and print it

-> The generated pdf doesn't have any specific styling applied

Cause
-----
When revamping the layout of stockpicking operations in 3816156 the layout used was changed from `web.external_layout` to `web.report_layout`. This change made the new reports not use the company wide styling because it was handled in the `external_layout`, see
https://github.com/odoo/odoo/blob/381615636185b88585e5ca112e43b6a7d81e1895/addons/web/views/report_templates.xml#L759-L760

This change was unexpected as `report_layout` is not supposed to be used directly by templates.
https://github.com/odoo/odoo/blob/381615636185b88585e5ca112e43b6a7d81e1895/addons/web/views/report_templates.xml#L4-L6 Reports should still use the `external_layout` which is the public layout. https://github.com/odoo/odoo/blob/381615636185b88585e5ca112e43b6a7d81e1895/addons/web/views/report_templates.xml#L741-L743

Visual comparison
-----
Left is before the fix (using `report_layout`), right is after the fix (back to using `external_layout`)

![image](https://github.com/user-attachments/assets/24db922f-6b11-47bd-90ac-d64cf93c1bbf)

-----
Ticket:
opw-4702089
