### PR TITLE
[FIX] web: user switch tour: wait for logged out

### DIFF
--- a/addons/web/static/tests/tours/user_switch_tour.js
+++ b/addons/web/static/tests/tours/user_switch_tour.js
@@ -12,6 +12,11 @@ function logout() {
             trigger: ".dropdown-item[data-menu=logout]",
             run: "click",
         },
+        {
+            // Wait and check we are logged out
+            // o_database_list is used in the case website is not installed and only portal is.
+            trigger: ".oe_website_login_container, .o_database_list",
+        },
     ];
 }
 


### PR DESCRIPTION
Since the changes in the tour engine, steps are slightly faster.

This commit adds a step in the user switch tour to wait to be actually logged out before continuing

runbot-error-135106
runbot-error-135070

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
