### PR TITLE
[REV] account: make accounting fields not required

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -540,6 +540,7 @@ class ResPartner(models.Model):
     duplicated_bank_account_partners_count = fields.Integer(
         compute='_compute_duplicated_bank_account_partners_count',
     )
+    # DEPRECATED, DO NOT USE, TO BE REMOVED IN MASTER
     is_coa_installed = fields.Boolean(store=False, default=lambda partner: bool(partner.env.company.chart_template_id))
 
     def _compute_bank_count(self):

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -250,10 +250,9 @@
                                 />
                             </group>
                             <group string="Accounting Entries" name="accounting_entries" groups="account.group_account_readonly">
-                                <field name="is_coa_installed" invisible="1"/>
                                 <field name="currency_id" invisible="1"/>
-                                <field name="property_account_receivable_id" attrs="{'required': [('is_coa_installed', '=', True)]}"/>
-                                <field name="property_account_payable_id" attrs="{'required': [('is_coa_installed', '=', True)]}"/>
+                                <field name="property_account_receivable_id"/>
+                                <field name="property_account_payable_id"/>
                             </group>
                             <group string="Credit Limits"
                                    name="credit_limits"


### PR DESCRIPTION
This reverts commit d413a9895742594d064084cd6dafbf1f2ec97221.

This fix was decided after https://github.com/odoo/enterprise/pull/74127
that was trying to prevent invoicing users to see accounting features,
when it seemed to be unwanted to have the two property accounts fields
required while having no CoA installed.

The issue is, now when having Accounting installed, we can create a user
without having CoA as these two fields are not required anymore, but
we end up with a error message when creating an invoice ('no CoA
installed') although we could be have added accounts manually instead
of installing a CoAi (which is not possible for invoicing user).
In this situation, we should be able to create a contact, and having these
fields required will force the user to create them.

Finally, it is ok to revert the full chain, as the original issue is
fixed by this commit https://github.com/odoo/enterprise/commit/68f6c1f9fd3ff6762c98e1a405ade035129efce0
