### PR TITLE
[FIX] html_editor: fix color selector unit test

### DIFF
--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -17,6 +17,7 @@ import { getContent, setSelection } from "./_helpers/selection";
 import { contains } from "@web/../tests/web_test_helpers";
 import { execCommand } from "./_helpers/userCommands";
 import { expandToolbar } from "./_helpers/toolbar";
+import { getCSSVariableValue, getHtmlStyle } from "@html_editor/utils/formatting";
 
 test("can set foreground color", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
@@ -626,8 +627,10 @@ test("custom tab color navigation using keys", async () => {
     await press("Tab");
     await press("Tab");
     await press("Tab");
+    const htmlStyle = getHtmlStyle(document);
+    const defaultColor = getCSSVariableValue("body-color", htmlStyle);
     expect(getActiveElement()).toBe(
-        queryFirst('.o_font_color_selector button[data-color="#374151"]')
+        queryFirst(`.o_font_color_selector button[data-color="${defaultColor.toLowerCase()}"]`)
     );
     await press("ArrowDown");
     expect(getActiveElement()).toBe(


### PR DESCRIPTION
After merging the commit [1], the unit test fails in community version. This happens because the value of selected text color is `--body-color`, which is different in community then the enterprise. This PR aims to fix the test case.

[1]: https://github.com/odoo/odoo/commit/1c60ca5052c91c4b9a163f843c50de443ebbc78a




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
