### PR TITLE
[IMP] web: improve UX for empty M2x with no search results

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -371,9 +371,9 @@ export class Many2XAutocomplete extends Component {
             error instanceof RPCError &&
             error.exceptionName === "odoo.exceptions.ValidationError"
         ) {
-            return this.openMany2X({  
-                context: this.getCreationContext(request),  
-                nextRecordsContext: this.props.context,  
+            return this.openMany2X({
+                context: this.getCreationContext(request),
+                nextRecordsContext: this.props.context,
             });
         } else {
             throw error;
@@ -423,13 +423,12 @@ export class Many2XAutocomplete extends Component {
             }
         }
 
+        const slowCreate = () =>
+            this.openMany2X({
+                context: this.getCreationContext(request),
+                nextRecordsContext: this.props.context,
+            });
         if (request.length) {
-            const slowCreate = () =>
-                this.openMany2X({
-                    context: this.getCreationContext(request),
-                    nextRecordsContext: this.props.context,
-                });
-
             if (this.props.quickCreate) {
                 options.push({
                     label: _t('Create "%s"', request),
@@ -451,6 +450,12 @@ export class Many2XAutocomplete extends Component {
                     action: slowCreate,
                 });
             }
+        } else if (canCreateEdit && !addSearchMore) {
+            options.push({
+                label: _t("Create..."),
+                classList: "o_m2o_dropdown_option o_m2o_dropdown_option_create_new",
+                action: slowCreate,
+            });
         }
 
         if (!this.props.noSearchMore && addSearchMore) {

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -1900,3 +1900,41 @@ test("`this` inside rendererProps should reference the component", async () => {
     await contains(".o_field_x2many_list_row_add a").click();
     expect.verifySteps(["onAdd", "selectCreate"]);
 });
+
+test("empty many2many tags field with no result", async () => {
+    class M2M extends models.Model {
+        m2m = fields.Many2many({ relation: "m2m" });
+    }
+    defineModels([M2M]);
+    await mountView({
+        type: "form",
+        resModel: "m2m",
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="m2m" widget="many2many_tags"/>
+                    </group>
+                </sheet>
+            </form>`,
+    });
+
+    await contains(".o_field_many2many_selection input").click();
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveText("Create...");
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
+
+    await contains(".dropdown-menu li.o_m2o_dropdown_option").click();
+    expect(".o_dialog").toHaveCount(1);
+    expect(".o_dialog .o_field_many2many_selection input").toHaveValue("");
+    press("Esc");
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(0);
+
+    await contains(".o_field_many2many_selection input").edit("abc", { confirm: false });
+    await runAllTimers();
+
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(2);
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
+    expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(0);
+});

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -947,6 +947,44 @@ test("empty readonly many2one field", async () => {
     expect(".o_field_widget[name=trululu] .o_many2one").toHaveText("");
 });
 
+test("empty many2one field with no result", async () => {
+    class M2O extends models.Model {
+        m2o = fields.Many2one({ relation: "m2o" });
+    }
+    defineModels([M2O]);
+    await mountView({
+        type: "form",
+        resModel: "m2o",
+        arch: `
+            <form>
+                <sheet>
+                    <group>
+                        <field name="m2o" />
+                    </group>
+                </sheet>
+            </form>`,
+    });
+
+    await contains(".o_field_many2one input").click();
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(1);
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveText("Create...");
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
+
+    await contains(".dropdown-menu li.o_m2o_dropdown_option").click();
+    expect(".o_dialog").toHaveCount(1);
+    expect(".o_dialog .o_field_many2one[name=m2o] input").toHaveValue("");
+    press("Esc");
+    await animationFrame();
+    expect(".o_dialog").toHaveCount(0);
+
+    await contains(".o_field_many2one input").edit("abc", { confirm: false });
+    await runAllTimers();
+
+    expect(".dropdown-menu li.o_m2o_dropdown_option").toHaveCount(2);
+    expect(".dropdown-menu li.o_m2o_start_typing").toHaveCount(0);
+    expect(".dropdown-menu li.o_m2o_no_result").toHaveCount(0);
+});
+
 test("empty many2one field with node options", async () => {
     expect.assertions(2);
 


### PR DESCRIPTION
This commit updates the behavior of empty many2one/many2many fields with no search results (when createEdit is enabled) to show a new "Create..." option. This option behaves like "Create and Edit" but does not prefill any initial value.

task-4789664
