### PR TITLE
[IMP] repair: remove repair option from operation type

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -178,12 +178,9 @@ class RepairOrder(models.Model):
 
     # Return Binding
     picking_id = fields.Many2one(
-        'stock.picking', 'Return', check_company=True, index='btree_not_null',
+        'stock.picking', 'Transfer', check_company=True, index='btree_not_null',
         domain="[('return_id', '!=', False), ('product_id', '=?', product_id)]",
-        copy=False, help="Return Order from which the product to be repaired comes from.")
-    is_returned = fields.Boolean(
-        "Returned", compute='_compute_is_returned',
-        help="True if this repair is linked to a Return Order and the order is 'Done'. False otherwise.")
+        copy=False, help="Transfer from which the product to be repaired is picked")
     picking_product_ids = fields.One2many('product.product', compute='_compute_picking_product_ids')
     picking_product_id = fields.Many2one(related="picking_id.product_id")
     allowed_lot_ids = fields.One2many('stock.lot', compute='_compute_allowed_lot_ids')
@@ -319,12 +316,6 @@ class RepairOrder(models.Model):
                 repair.is_parts_available = True
             elif repair.parts_availability_state == 'late':
                 repair.is_parts_late = True
-
-    @api.depends('picking_id', 'picking_id.state')
-    def _compute_is_returned(self):
-        self.is_returned = False
-        returned = self.filtered(lambda r: r.picking_id and r.picking_id.state == 'done')
-        returned.is_returned = True
 
     @api.depends('move_ids.quantity', 'move_ids.product_uom_qty', 'move_ids.product_uom.rounding')
     def _compute_has_uncomplete_moves(self):

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -44,7 +44,6 @@
                 <field name="user_id" optional="hide" widget='many2one_avatar_user'/>
                 <field name="partner_id" readonly="1" optional="show"/>
                 <field name="picking_id" optional="hide"/>
-                <field name="is_returned" optional="hide"/>
                 <field name="sale_order_id" optional="show"/>
                 <field name="location_id" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" readonly="1" optional="show"/>
@@ -116,7 +115,7 @@
                                 <field name="product_qty" readonly="tracking == 'serial' or state in ('done', 'cancel')"/>
                                 <field name="product_uom" groups="uom.group_uom" widget="many2one_uom" readonly="state != 'draft'"/>
                             </div>
-                            <field name="picking_id" invisible="not is_returned" options="{'no_create': True}"/>
+                            <field name="picking_id" invisible="not picking_id" options="{'no_create': True}"/>
                             <field name="under_warranty" readonly="state in ['cancel', 'done']"/>
                         </group>
                         <group>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -21,12 +21,6 @@
                 <field name="default_remove_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
                 <field name="default_recycle_location_dest_id" options="{'no_create': True}" invisible="code != 'repair_operation'" required="code == 'repair_operation'"/>
             </xpath>
-            <xpath expr="//group[@name='locations']" position="after">
-                <field name="return_type_of_ids" invisible="1"/>
-                <group string="Repairs" invisible="not return_type_of_ids">
-                    <field name="is_repairable"/>
-                </group>
-            </xpath>
             <xpath expr="//group[@name='stock_picking_type_lot']" position="attributes">
                 <attribute name="invisible">code not in ['incoming', 'outgoing', 'internal', 'repair_operation']</attribute>
             </xpath>
@@ -41,10 +35,6 @@
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='%(stock.act_stock_return_picking)d']" position="after">
-                <field name="is_repairable" invisible="1"/>
-                <button string="Repair" name="action_repair_return" type="object" invisible="not is_repairable" data-hotkey="shift+k"/>
-            </xpath>
             <xpath expr="//button[@name='action_see_packages']" position="after">
                 <field name="repair_ids" invisible="1"/>
                 <button name="action_view_repairs" type="object"
@@ -146,5 +136,14 @@
                 </div>
             </xpath>
         </field>
+    </record>
+
+    <record id="action_create_repair_order" model="ir.actions.server">
+        <field name="name">Create Repair</field>
+        <field name="model_id" ref="repair.model_stock_picking"/>
+        <field name="binding_model_id" ref="repair.model_stock_picking"/>
+        <field name="binding_view_types">form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_repair_return()</field>
     </record>
 </odoo>


### PR DESCRIPTION
- Removed the “Repair Order from Return” checkbox from operation type
  configuration.

- Added a new "Create Repair" server action directly on stock transfers,
  offering the same functionality.

- This change simplifies the process, allowing users to create repair orders
  without needing to configure operation types in advance. Users can initiate
  repair orders directly from transfers via a clear action button, enhancing
  usability and simplifying setup.

Task ID: [4778453](https://www.odoo.com/odoo/project/966/tasks/4778453)