### PR TITLE
[FIX] mail: fix crash when loading message with no body

### DIFF
--- a/addons/mail/models/discuss/mail_message.py
+++ b/addons/mail/models/discuss/mail_message.py
@@ -14,7 +14,7 @@ class MailMessage(models.Model):
             Store.Many(
                 "call_history_ids",
                 ["duration_hour", "end_dt"],
-                predicate=lambda m: 'data-oe-type="call"' in m.body,
+                predicate=lambda m: m.body and 'data-oe-type="call"' in m.body,
             ),
         ]
 


### PR DESCRIPTION
Following odoo/odoo@eaffe784d90a, ensure we don't crash when loading message where body is `False`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
