### PR TITLE
[PERF] hr_expense: restrict `manager_id` to internal users

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -79,7 +79,7 @@ class HrExpense(models.Model):
         comodel_name='res.users',
         string="Manager",
         compute='_compute_from_employee_id', store=True,
-        domain=lambda self: ['|', ('employee_id.expense_manager_id', 'in', self.env.user.id), ('all_group_ids', 'in', self.env.ref('hr_expense.group_hr_expense_team_approver').ids)],
+        domain=lambda self: [('share', '=', False), '|', ('employee_id.expense_manager_id', 'in', self.env.user.id), ('all_group_ids', 'in', self.env.ref('hr_expense.group_hr_expense_team_approver').ids)],
         copy=False,
         tracking=True,
     )


### PR DESCRIPTION
Description
-----------
When name-searching for a user to be assigned as a manager on an expense, we're currently looking at all users, including portal users, which is a significantly larger search space than just internal users.

This leads to a sub-optimal query plan that ignores trigram indexes for matching the `ILIKE` pattern. This occurs due to a corner case in Postgres where, when an order and limit are provided with a `btree` index, it estimates that scanning that index will find matching records faster than scanning the `trigram` index.

To address this implicitly, we restrict the users considered to internal users only, as it makes little sense to propose portal users as managers. As a side effect, this significantly alters the query plan to what we expect - a scan of the trigram index on `res.partner.name`.

Benchmark
----------
On odoo.com, a `name_search` of an employee with their trigram took:

| Before | After |
|--------|-------|
| 20s    | 20ms  |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
