### PR TITLE
[FIX] web_editor: fix non-deterministic tests relying on selectionchange

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
@@ -333,6 +333,9 @@ export async function testEditor(Editor = OdooEditor, spec, options = {}) {
             }
         }
 
+        // Wait for selectionchange handlers to react before any actual testing.
+        await Promise.resolve();
+
         if (spec.stepFunction) {
             try {
                 await spec.stepFunction(editor);


### PR DESCRIPTION
The selectionchange event is triggered in the next microtask tick.

Any test that relies on the effect of a selectionchange but does not explicitely wait for it before running its step function or checking its expected result is likely to fail non-deterministically on newer versions of Chrome. This is basically a generalized version of the fix at https://github.com/odoo/odoo/pull/206969.