### PR TITLE
[PERF] hr_holidays: batch Public Holidays creation

### DIFF
--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -66,6 +66,7 @@ class CalendarLeaves(models.Model):
         self.env.add_to_compute(self.env['hr.leave']._fields['number_of_days'], leaves)
         self.env.add_to_compute(self.env['hr.leave']._fields['duration_display'], leaves)
         sick_time_status = self.env.ref('hr_holidays.holiday_status_sl', raise_if_not_found=False)
+        leaves_to_recreate = self.env['hr.leave']
         for previous_duration, leave, state in zip(previous_durations, leaves, previous_states):
             duration_difference = previous_duration - leave.number_of_days
             message = False
@@ -79,12 +80,13 @@ class CalendarLeaves(models.Model):
                 leave._check_validity()
                 if leave.state == 'validate':
                     # recreate the resource leave that were removed by writing state to draft
-                    leave.sudo()._create_resource_leave()
+                    leaves_to_recreate |= leave
             except ValidationError:
                 leave.action_refuse()
                 message = _("Due to a change in global time offs, this leave no longer has the required amount of available allocation and has been set to refused. Please review this leave.")
             if message:
                 leave._notify_change(message)
+        leaves_to_recreate.sudo()._create_resource_leave()
 
     def _convert_timezone(self, utc_naive_datetime, tz_from, tz_to):
         """


### PR DESCRIPTION
Importing new public holidays from an xlsx file can take quite some time at the moment because Odoo has to
reclaim past time off if it overlaps with one of the new public holidays. Currently this whole process
is not properly batched. There is a single record
creation in `hr_holidays:_reevaluate_leaves` and a single record write in `planning:_compute_allocated_hours`.

This commit optimizes the Public Holidays creation by batching the two methods mentioned above. Batching the create call is straightforward. Batching the write might seem useless at first as UPDATE queries are already batched on the ORM level. But actually the performance bottleneck comes from the post-processing done after writing a new `planning_slot.allocated_hours` value. By grouping the slots by allocated_hours we can speed up this post-processing.

#### speedup

Trying to import 72 new Public Holidays that lead to writing allocated hours on 85 planning slots

 - 2min -> 4.76s

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
