### PR TITLE
[FIX] html_editor: ensure consistent padding on Chrome versions

### DIFF
--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -385,12 +385,12 @@ describe("Selection collapsed", () => {
             test("should keep the list-style when add li", async () => {
                 await testEditor({
                     contentBefore: unformat(`
-                            <ul>
+                            <ul style="font-size: 14px; font-family: sans-serif;">
                                 <li style="list-style: cambodian;">a[]</li>
                             </ul>`),
                     stepFunction: splitBlock,
                     contentAfter: unformat(`
-                        <ul style="padding-inline-start: 36px;">
+                        <ul style="font-size: 14px; font-family: sans-serif; padding-inline-start: 36px;">
                             <li style="list-style: cambodian;">a</li>
                             <li style="list-style: cambodian;">[]<br></li>
                         </ul>`),


### PR DESCRIPTION
Problem:
The test is failing due to inconsistent `font-size` rendering across different Chrome versions, which affects `padding-inline-start`.

Solution:
Explicitly set `font-size` and `font-family` to ensure consistent `padding-inline-start` calculation across Chrome versions.


runbot-xxxxx
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
