### PR TITLE
[IMP] purchase: apply improvements on the upload bills functionality

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from pytz import timezone
-
+from ast import literal_eval
 from markupsafe import escape, Markup
 from werkzeug.urls import url_encode
 
@@ -711,7 +711,7 @@ class PurchaseOrder(models.Model):
             return self.action_view_invoice(invoices)
 
         if len(invoices) != 1:
-            raise ValidationError(_("You can only upload a bill for a single partner at a time."))
+            raise ValidationError(_("You can only upload a bill for a single vendor at a time."))
         invoices.with_context(skip_is_manually_modified=True)._extend_with_attachments(attachments, new=True)
 
         invoices.with_context(
@@ -847,6 +847,8 @@ class PurchaseOrder(models.Model):
         else:
             result = {'type': 'ir.actions.act_window_close'}
 
+        result['context'] = literal_eval(result['context'])
+        result['context']['default_partner_id'] = self.partner_id.id
         return result
 
     @api.model

--- a/addons/purchase/static/src/components/purchase_file_uploader/purchase_file_uploader.js
+++ b/addons/purchase/static/src/components/purchase_file_uploader/purchase_file_uploader.js
@@ -2,6 +2,8 @@ import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 import { FileUploader } from "@web/views/fields/file_handler";
+import { WarningDialog } from "@web/core/errors/error_dialogs";
+import { _t } from "@web/core/l10n/translation";
 
 import { Component } from "@odoo/owl";
 
@@ -17,6 +19,7 @@ export class PurchaseFileUploader extends Component {
     setup() {
         this.orm = useService("orm");
         this.action = useService("action");
+        this.dialog = useService("dialog");
         this.attachmentIdsToProcess = [];
     }
 
@@ -33,6 +36,20 @@ export class PurchaseFileUploader extends Component {
             return this.props.record.data.id;
         }
         return this.props.list.getResIds(true);
+    }
+
+    onClick(ev) {
+        if (this.env.config.viewType !== "list") {
+            return;
+        }
+        const vendorSet = new Set(this.props.list.selection.map((record) => record.data.partner_id.id));
+        if (vendorSet.size > 1) {
+            this.dialog.add(WarningDialog, {
+                title: _t("Validation Error"),
+                message: _t("You can only upload a bill for a single vendor at a time."),
+            });
+            return false;
+        }
     }
 
     async onFileUploaded(file) {

--- a/addons/purchase/static/src/components/purchase_file_uploader/purchase_file_uploader.xml
+++ b/addons/purchase/static/src/components/purchase_file_uploader/purchase_file_uploader.xml
@@ -4,6 +4,7 @@
             acceptedFileExtensions="props.acceptedFileExtensions"
             fileUploadClass="'document_file_uploader'"
             multiUpload="true"
+            onClick.bind="onClick"
             onUploaded.bind="onFileUploaded"
             onUploadComplete.bind="onUploadComplete">
             <t t-set-slot="toggler">


### PR DESCRIPTION
This commit will apply the following improvements in the **Upload Bills** functionality: 

1. change validation Error message to use 'vendor' instead of 'partner' when uploading bills to multiple vendors. 
2. make this validation error appears once the user click on 'Upload Bills' instead of appearing after uploading the files. 
3. auto-fill the vendor when uploading bills from the 'Vendor Bills' smart button in the PO.

Task-4748285