### PR TITLE
[FIX] base: properly fallback when no ir.default for partner lang

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -389,7 +389,7 @@ class ResPartner(models.Model):
         """ While creating / updating child contact, take the parent lang by
         default if any. 0therwise, fallback to default context / DB lang """
         for partner in self.filtered('parent_id'):
-            partner.lang = partner.parent_id.lang or self.default_get(['lang'])['lang'] or self.env.lang
+            partner.lang = partner.parent_id.lang or self.default_get(['lang']).get('lang') or self.env.lang
 
     @api.depends('lang')
     def _compute_active_lang_count(self):


### PR DESCRIPTION
To reproduce:
- remove default ir.default for res.partner "lang" field
- create a lead and fill both "Company Name" and "Contact Name"
- click on "Convert to Opportunity"
- choose option "Create a new customer"
- click "Create Oppportunity"

It crash because there is no default value for the lang field (provided in context or through ir.default)

This commit is a followup of odoo/odoo@7b90bf3abc8d to ensure we properly fallback when `default_get()` don't return a value.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
