### PR TITLE
[IMP] stock: make lot/sn clickable in traceability report

### DIFF
--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.js
@@ -102,16 +102,13 @@ export class TraceabilityReport extends Component {
         });
     }
 
-    onCLickOpenLot(line) {
+    onClickOpenLot(line) {
         this.actionService.doAction({
-            type: "ir.actions.client",
-            tag: "stock_report_generic",
-            name: line.lot_name !== undefined && line.lot_name.toString(),
-            context: {
-                active_id: line.lot_id,
-                active_model: "stock.lot",
-                url: "/stock/output_format/stock?active_id=:active_id&active_model=:active_model",
-            },
+            type: 'ir.actions.act_window',
+            res_model: 'stock.lot',
+            res_id: line.lot_id,
+            views: [[false, 'form']],
+            target: 'current',
         });
     }
 

--- a/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
+++ b/addons/stock/static/src/client_actions/stock_traceability_report_backend.xml
@@ -68,7 +68,7 @@
                             <a class="o_stock_report_partner_action" href="#" t-on-click.prevent="() => this.onClickPartner(line)" t-esc="col"/>
                         </span>
                         <span t-elif="col and line.lot_name === col">
-                            <span class="o_stock_report_lot_action" t-esc="col" />
+                            <a class="o_stock_report_lot_action" href="#" t-on-click.prevent="() => this.onClickOpenLot(line)" t-esc="col"/>
                         </span>
                         <t t-elif="col" t-esc="col"/>
                     </td>


### PR DESCRIPTION
Improves navigation in the traceability report by making lot/SN clickable. 
Clicking on a lot or serial number now opens its corresponding form view.

Task: [4780057](https://www.odoo.com/odoo/project/966/tasks/4780057)