### PR TITLE
[IMP] account, hr_expense: linked attachment

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -102,6 +102,7 @@ class AccountBankStatement(models.Model):
         comodel_name='ir.attachment',
         string="Attachments",
     )
+    linked_attachment_ids = fields.One2many(comodel_name='ir.attachment', inverse_name='res_id')
 
     _journal_id_date_desc_id_desc_idx = models.Index("(journal_id, date DESC, id DESC)")
     _first_line_index_idx = models.Index("(journal_id, first_line_index)")

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -331,6 +331,7 @@ class AccountMove(models.Model):
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
     company_price_include = fields.Selection(related='company_id.account_price_include', readonly=True)
     attachment_ids = fields.One2many('ir.attachment', 'res_id', domain=[('res_model', '=', 'account.move')], string='Attachments')
+    linked_attachment_ids = fields.One2many(comodel_name='ir.attachment', inverse_name='res_id')
     audit_trail_message_ids = fields.One2many(
         'mail.message',
         'res_id',
@@ -6393,7 +6394,7 @@ class AccountMove(models.Model):
 
         for invoice, attachments in attachments_per_invoice.items():
             if invoice == self:
-                invoice.attachment_ids |= attachments
+                invoice.linked_attachment_ids |= attachments
                 new_message.attachment_ids = attachments.ids
                 message_values.update({'res_id': self.id, 'attachment_ids': [Command.link(attachment.id) for attachment in attachments]})
                 super(AccountMove, invoice)._message_post_after_hook(new_message, message_values)
@@ -6404,7 +6405,7 @@ class AccountMove(models.Model):
                     'res_id': invoice.id,
                     'attachment_ids': [Command.link(attachment.id) for attachment in attachments],
                 }
-                invoice.attachment_ids |= attachments
+                invoice.linked_attachment_ids |= attachments
                 invoice.message_ids = [Command.set(sub_new_message.id)]
                 super(AccountMove, invoice)._message_post_after_hook(sub_new_message, sub_message_values)
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3010,18 +3010,13 @@ class AccountMoveLine(models.Model):
         """Get all the the lines matched with the lines in self."""
         return self._filter_reconciled_by_number(self._reconciled_by_number())
 
-    def _get_attachment_domains(self):
-        self.ensure_one()
-        domains = [[
-            ('res_model', '=', 'account.move'),
-            ('res_id', '=', self.move_id.id),
-            ('res_field', 'in', (False, 'invoice_pdf_report_file')),
-        ]]
-        if self.statement_id:
-            domains.append([('res_model', '=', 'account.bank.statement'), ('res_id', '=', self.statement_id.id)])
-        if self.payment_id:
-            domains.append([('res_model', '=', 'account.payment'), ('res_id', '=', self.payment_id.id)])
-        return domains
+    def _get_attachments(self):
+        return (
+            self.move_id.linked_attachment_ids
+            + self.move_id.invoice_pdf_report_id
+            + self.payment_id.linked_attachment_ids
+            + self.statement_id.linked_attachment_ids
+        )
 
     @api.model
     def _get_tax_exigible_domain(self):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -192,6 +192,7 @@ class AccountPayment(models.Model):
     # used to get and display duplicate move warning if partner, amount and date match existing payments
     duplicate_payment_ids = fields.Many2many(comodel_name='account.payment', compute='_compute_duplicate_payment_ids')
     attachment_ids = fields.One2many('ir.attachment', 'res_id', string='Attachments')
+    linked_attachment_ids = fields.One2many(comodel_name='ir.attachment', inverse_name='res_id')
 
     _check_amount_not_negative = models.Constraint(
         'CHECK(amount >= 0.0)',

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -1416,14 +1416,14 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
 
         statement = self.env['account.bank.statement'].create({
             'name': 'test_statement',
-            'attachment_ids': [Command.set(attachment.ids)],
+            'linked_attachment_ids': [Command.set(attachment.ids)],
         })
 
         attachment = self.env['ir.attachment'].create(attachment_vals)
 
-        statement.write({'attachment_ids': [Command.link(attachment.id)]})
+        statement.write({'linked_attachment_ids': [Command.link(attachment.id)]})
 
-        self.assertRecordValues(statement.attachment_ids, [
+        self.assertRecordValues(statement.linked_attachment_ids, [
             {'res_id': statement.id, 'res_model': 'account.bank.statement'},
             {'res_id': statement.id, 'res_model': 'account.bank.statement'},
         ])

--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -13,11 +13,8 @@ class AccountMoveLine(models.Model):
     def _check_payable_receivable(self):
         super(AccountMoveLine, self.filtered(lambda line: line.expense_id.payment_mode != 'company_account'))._check_payable_receivable()
 
-    def _get_attachment_domains(self):
-        attachment_domains = super(AccountMoveLine, self)._get_attachment_domains()
-        if self.expense_id:
-            attachment_domains.append([('res_model', '=', 'hr.expense'), ('res_id', '=', self.expense_id.id)])
-        return attachment_domains
+    def _get_attachments(self):
+        return super()._get_attachments() + self.expense_id.linked_attachment_ids
 
     def _compute_totals(self):
         expenses = self.filtered('expense_id')

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -118,6 +118,7 @@ class HrExpense(models.Model):
         domain=[('res_model', '=', 'hr.expense')],
         string="Attachments",
     )
+    linked_attachment_ids = fields.One2many(comodel_name='ir.attachment', inverse_name='res_id')
     state = fields.Selection(
         selection=[
             # Pre-Approval states


### PR DESCRIPTION
In the enterprise PR, we had to do a search for each move_line to get his attachment which was really poor in terms of performance. To solves that we added a one2many field in each model that are linked to the move_line. The return function that will give the attachment can be overwritten by other module like expense

no task id




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
