### PR TITLE
[FIX] website: remove overflow in header menu sales 3

### DIFF
--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -1242,7 +1242,7 @@
                     <t t-call="website.placeholder_header_brand">
                         <t t-set="_link_class" t-valuef="me-4"/>
                     </t>
-                    <div class="ms-auto">
+                    <div class="flex-fill min-w-0">
                         <ul class="o_header_sales_three_small_links navbar-nav justify-content-end align-items-center gap-2 w-100 o_header_separator">
                             <!-- Language Selector -->
                             <t t-call="website.placeholder_header_language_selector">


### PR DESCRIPTION
When using the template `template_header_sales_three` on website, if there are more `nav-item` than the viewport, the extra menu items are overflowing instead of displayed in the `o_extra_menu_items` dropdown.

This happened because of the header layout relies on an extra `div` to display the content in 2 rows. The div inside the flex layout doesn't have a width and thus overflows.

`flex-fill` allows the element to have the width of the content/maximum available width in association with `min-w-0` to allow the element to shrink to not overflow the container.

task-4724803


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
