### PR TITLE
[FIX] stock: add quantity field dependency lot gen

### DIFF
--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -38,7 +38,7 @@ export class GenerateDialog extends Component {
             if (this.props.mode === 'generate') {
                 this.nextSerialCount.el.value = this.props.move.data.product_uom_qty || 2;
                 if (this.props.move.data.has_tracking === 'lot') {
-                    this.totalReceived.el.value = this.props.move.data.quantity;
+                    this.totalReceived.el.value = this.props.move.data.quantity || this.props.move.data.product_uom_qty;
                 }
             }
         });


### PR DESCRIPTION
**Steps to Reproduce :**

1. Install MRP.
2. Create a Bill of Materials (BOM) and add a component with lot tracking.
3. Create and confirm a Manufacturing Order (MO) with BOM.
4. Navigate to the shop floor and click on Generate Serials/Lots.
5. The error appears when trying to generate the lot .

**Issue :**

Error raised when try to Generate Serials/Lots during the manufacturing
process.

`TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'`

**Cause:**

This error occurs because the quantity field is undefined when
Generate Serials/Lots is triggered, the quantity field is not being passed in
the context, and its value is undefined, which is leading to a division by [none](https://github.com/odoo/odoo/blob/18.0/addons/stock/models/stock_move.py#L993).

**Solution:**

To fix this, we added the stock move’s demand quantity as a fallback.This ensures the 
quantity field value is present and its value correctly passed during lot generation.

opw-4763600

Enterprise: https://github.com/odoo/enterprise/pull/88739