### PR TITLE
[FIX] website_event_exhibitor: unknown qweb directive error on exhibitor more info button

### DIFF
--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
@@ -1,8 +1,9 @@
 import { Component, onWillStart, markup } from "@odoo/owl";
 import { Dialog } from "@web/core/dialog/dialog";
 import { rpc } from "@web/core/network/rpc";
-import { formatDuration } from "@web/core/l10n/dates";
+import { formatDuration, deserializeDateTime } from "@web/core/l10n/dates";
 
+const { DateTime } = luxon;
 export class ExhibitorConnectClosedDialog extends Component {
     static template = "website_event_exhibitor.ExhibitorConnectClosedDialog";
     static components = { Dialog };
@@ -25,6 +26,10 @@ export class ExhibitorConnectClosedDialog extends Component {
         sponsorData.website_description = sponsorData.website_description || "";
         sponsorData.website_description = markup(sponsorData.website_description);
         this.formatEventStartRemaining = formatDuration(sponsorData.event_start_remaining, true);
+        this.formatEventDateBegin = deserializeDateTime(
+            sponsorData.event_date_begin,
+            { tz: sponsorData.event_date_tz }
+        ).toLocaleString(DateTime.DATETIME_MED);
         this.sponsorData = sponsorData;
     }
 }

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
@@ -9,6 +9,7 @@ export class ExhibitorConnectClosedDialog extends Component {
     static components = { Dialog };
     static props = {
         sponsorId: Number,
+        close: Function,
     };
 
     setup() {

--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
@@ -29,8 +29,7 @@
                         </span>
                         <span class="my-0" t-else="">
                             starts on
-                            <span t-out="sponsorData.event_date_begin"
-                                t-options='{"widget": "datetime", "show_seconds": False, "tz_name": sponsorData.event_date_tz, "format": "medium"}'/>
+                            <span t-out="formatEventDateBegin"/>
                         </span>
                     </div>
                 </t>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -57,7 +57,7 @@
                     starts on
                     <span t-field="sponsor.event_id.date_begin"
                         t-options="{'format': 'medium', 'tz_name': sponsor.event_id.date_tz}"/>
-                    <span>(<t t-if="website_visitor_timezone != sponsor.event_id.date_tz" t-out="event.date_tz"/>)</span>
+                    <span t-if="website_visitor_timezone != sponsor.event_id.date_tz">(<t t-out="event.date_tz"/>)</span>
                 </span>
                 <br/>
                 <span t-if="is_event_user">Attendees will be able to join to meet <b t-out="sponsor.partner_name"/> .</span>


### PR DESCRIPTION
**Steps to reproduce**:
1. Install the website_event app
2. Enable Online Exhibitors in settings
3. Open any upcoming event and check website submenu and showcase exhibitors
4. Click on the sponsor smart button
5. Create a new sponsor with type 'Exhibitor'
6. Now click on Go to website smart button and make it publish
7. Open private window in browser and go to exhibitor page by cliking on
8. Go to Event > Modified upcoming event > exhibitors submenu
9. Now click on more info button inside the exhibitor card
10. Observe the console error or Error if Debug mode is on.

**Issue**:
- The dialog displayed for non-event managers attempts to use
  t-options within a <span> tag,  causing Unknown QWeb directive error.

- Missing prop error in Debug mode

**Solution**:
- Replace the t-options logic with a dedicated property of the object with
  correct format of date_begin field
- Add close prop in ExhibitorConnectClosedDialog

**UI Improvement:**
- notice on the next exhibitor page we're displaying:
  ```<span>(<t t-if="website_visitor_timezone != sponsor.event_id.date_tz" t-out="event.date_tz"/>)</span>```
  It would be nice to remove the parentheses when the condition doesn't pass,
  as it currently results in empty brackets () being shown

opw-4737183