### PR TITLE
[FIX] sale_project: cogs label in profitability dashboard

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -477,6 +477,7 @@ class Project(models.Model):
             'materials': _lt('Materials'),
             'other_invoice_revenues': _lt('Customer Invoices'),
             'downpayments': _lt('Down Payments'),
+            'cost_of_goods_sold': _lt('Cost of Goods Sold'),
         }
 
     def _get_profitability_sequence_per_invoice_type(self):


### PR DESCRIPTION
before this commit, in the profitability dashboard the cogs section is show with label cost_of_goods_sold

![Screenshot from 2025-05-14 13-42-45](https://github.com/user-attachments/assets/e2201e18-d30d-4178-891b-080318cb469c)

after this commit, the label will be shown as Cost of Goods Sold

![Screenshot from 2025-05-14 13-27-47](https://github.com/user-attachments/assets/8660b851-a27e-4f69-ab89-461999c187dd)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
