### PR TITLE
[IMP] l10n_in_ewaybill_irn: Add dispatch/export details to EWayBill JSON

### DIFF
--- a/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
+++ b/addons/l10n_in_ewaybill_irn/tests/test_ewaybill_irn.py
@@ -9,36 +9,102 @@ class TestEwaybillJson(L10nInTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.invoice = cls.init_invoice("out_invoice", post=True, products=cls.product_a)
-        attachment = cls.env['ir.attachment'].create({
-            'name': 'einvoice.json',
+        cls.invoice_a = cls.init_invoice("out_invoice", post=True, products=cls.product_a, partner=cls.partner_a)
+        cls.invoice_b = cls.init_invoice("out_invoice", post=True, products=cls.product_a, partner=cls.partner_foreign)
+        cls.partner_foreign_address = cls.env['res.partner'].create({
+            'name': "Foreign Partner Port Address",
+            'commercial_partner_id': cls.partner_foreign.id,
+            'country_id': cls.country_in.id,
+            'state_id': cls.state_in_gj.id,
+            'street': "Post Box No. 1 Mundra",
+            'city': "Kutch",
+            'zip': "370421",
+        })
+        attachment_a = cls.env['ir.attachment'].create({
+            'name': 'einvoice_a.json',
             'res_model': 'account.move',
-            'res_id': cls.invoice.id,
+            'res_id': cls.invoice_a.id,
             'raw': b'{"Irn": "1234567890"}',
         })
-        cls.invoice.edi_document_ids = cls.env['account.edi.document'].create({
+        attachment_b = cls.env['ir.attachment'].create({
+            'name': 'einvoice_b.json',
+            'res_model': 'account.move',
+            'res_id': cls.invoice_b.id,
+            'raw': b'{"Irn": "1234567890"}',
+        })
+        cls.invoice_a.edi_document_ids = cls.env['account.edi.document'].create({
             'edi_format_id': cls.env.ref('l10n_in_edi.edi_in_einvoice_json_1_03').id,
             'state': 'sent',
-            'attachment_id': attachment.id,
-            'move_id': cls.invoice.id,
+            'attachment_id': attachment_a.id,
+            'move_id': cls.invoice_a.id,
         })
+        cls.invoice_b.edi_document_ids = cls.env['account.edi.document'].create({
+            'edi_format_id': cls.env.ref('l10n_in_edi.edi_in_einvoice_json_1_03').id,
+            'state': 'sent',
+            'attachment_id': attachment_b.id,
+            'move_id': cls.invoice_b.id,
+        })
+        cls.invoice_b.l10n_in_gst_treatment = 'overseas'
 
     def test_ewaybill_irn(self):
-        ewaybill = self.env['l10n.in.ewaybill'].create({
-            'account_move_id': self.invoice.id,
+        ewaybill_a = self.env['l10n.in.ewaybill'].create({
+            'account_move_id': self.invoice_a.id,
             'distance': 20,
             'mode': "1",
             'vehicle_no': "GJ11AA1234",
             'vehicle_type': "R",
         })
-        self.assertTrue(ewaybill.is_process_through_irn)
+        ewaybill_b = self.env['l10n.in.ewaybill'].create({
+            'account_move_id': self.invoice_b.id,
+            'distance': 20,
+            'mode': "1",
+            'vehicle_no': "GJ11AA1234",
+            'vehicle_type': "R",
+        })
+        ewaybill_b.write({
+            'partner_ship_to_id': self.partner_foreign_address.id,
+        })
+        self.assertTrue(ewaybill_a.is_process_through_irn)
+        self.assertTrue(ewaybill_b.is_process_through_irn)
         self.assertDictEqual(
-            ewaybill._ewaybill_generate_irn_json(),
+            ewaybill_a._ewaybill_generate_irn_json(),
             {
                 'Irn': "1234567890",
                 'Distance': '20',
                 'TransMode': '1',
                 'VehNo': 'GJ11AA1234',
-                'VehType': 'R'
+                'VehType': 'R',
+                'DispDtls': {
+                    'Addr1': 'Khodiyar Chowk',
+                    'Loc': 'Amreli',
+                    'Pin': 365220,
+                    'Stcd': '24',
+                    'Addr2': 'Sala Number 3',
+                    'Nm': 'Default Company'
+                }
+            }
+        )
+        self.assertDictEqual(
+            ewaybill_b._ewaybill_generate_irn_json(),
+            {
+                'Irn': "1234567890",
+                'Distance': '20',
+                'TransMode': '1',
+                'VehNo': 'GJ11AA1234',
+                'VehType': 'R',
+                'DispDtls': {
+                    'Addr1': 'Khodiyar Chowk',
+                    'Loc': 'Amreli',
+                    'Pin': 365220,
+                    'Stcd': '24',
+                    'Addr2': 'Sala Number 3',
+                    'Nm': 'Default Company'
+                },
+                'ExpShipDtls': {
+                    'Addr1': 'Post Box No. 1 Mundra',
+                    'Loc': 'Kutch',
+                    'Pin': 370421,
+                    'Stcd': '24'
+                }
             }
         )

--- a/addons/l10n_in_ewaybill_irn/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_irn/views/l10n_in_ewaybill_views.xml
@@ -8,9 +8,6 @@
             <xpath expr="//group[@name='document_details']" position="attributes">
                 <attribute name="invisible">is_process_through_irn</attribute>
             </xpath>
-            <xpath expr="//group[@name='partners']" position="attributes">
-                <attribute name='invisible'>is_process_through_irn</attribute>
-            </xpath>
             <xpath expr="//field[@name='type_id']" position="attributes">
                 <attribute name='required'>not is_process_through_irn</attribute>
             </xpath>


### PR DESCRIPTION
Previously, e-waybills generated through IRN did not include
dispatch details (`DispDtls`) and export shipping details (`ExpShipDtls`)
in the JSON payload.

In this commit:
----
- Added `DispDtls` to include dispatch location details
  (name, address, city, PIN, state TIN) from the shipping-from partner.
- Added `ExpShipDtls` to include shipping destination details
  (address, city, PIN, state TIN) from the shipping-to partner.
- The `ExpShipDtls` (export shipping details) is included only
  for overseas transactions.

> `DispDtls`: the company from which the goods are dispatched
> `ExpShipDtls`: the entity to which the goods are shipped to

----
Refer: https://einv-apisandbox.nic.in/version1.03/ewaybill-generation-irn.html#JSONSchema