### PR TITLE
[FIX] account_edi_ubl_cii: NL ID constraints for BIS3 and NLCIUS

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -78,9 +78,13 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         for vals in vals_list:
             vals.pop('registration_address_vals', None)
             if partner.country_code == 'NL':
+                # For NL, VAT can be used as a Peppol endpoint, but KVK/OIN has to be used as PartyLegalEntity/CompanyID
+                # To implement a workaround on stable, company_registry field is used without recording whether
+                # the number is a KVK or OIN, and the length of the number (8 = KVK, 9 = OIN) is used to determine the type
+                nl_id = partner.company_registry if partner.peppol_eas not in ('0106', '0190') else partner.peppol_endpoint
                 vals.update({
-                    'company_id': partner.peppol_endpoint,
-                    'company_id_attrs': {'schemeID': partner.peppol_eas},
+                    'company_id': nl_id,
+                    'company_id_attrs': {'schemeID': '0190' if len(nl_id) == 9 else '0106'},
                 })
             if partner.country_id.code == "LU":
                 if 'l10n_lu_peppol_identifier' in partner._fields and partner.l10n_lu_peppol_identifier:
@@ -389,9 +393,12 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 # [NL-R-003] For suppliers in the Netherlands, the legal entity identifier MUST be either a
                 # KVK or OIN number (schemeID 0106 or 0190)
                 'nl_r_003': _(
-                    "%s should have a KVK or OIN number: the Peppol e-address (EAS) should be '0106' or '0190'.",
+                    "%s should have a KVK or OIN number set in Company ID field or as Peppol e-address (EAS code 0106 or 0190).",
                     vals['supplier'].display_name
-                ) if vals['supplier'].peppol_eas not in ('0106', '0190') else '',
+                ) if (
+                    not vals['supplier'].peppol_eas in ('0106', '0190') and
+                    (not vals['supplier'].company_registry or len(vals['supplier'].company_registry) not in (8, 9))
+                ) else '',
 
                 # [NL-R-007] For suppliers in the Netherlands, the supplier MUST provide a means of payment
                 # (cac:PaymentMeans) if the payment is from customer to supplier
@@ -410,9 +417,12 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                     # [NL-R-005] For suppliers in the Netherlands, if the customer is in the Netherlands,
                     # the customer’s legal entity identifier MUST be either a KVK or OIN number (schemeID 0106 or 0190)
                     'nl_r_005': _(
-                        "%s should have a KVK or OIN number: the Peppol e-address (EAS) should be '0106' or '0190'.",
+                        "%s should have a KVK or OIN number set in Company ID field or as Peppol e-address (EAS code 0106 or 0190).",
                         vals['customer'].display_name
-                    ) if vals['customer'].commercial_partner_id.peppol_eas not in ('0106', '0190') else '',
+                    ) if (
+                        not vals['customer'].commercial_partner_id.peppol_eas in ('0106', '0190') and
+                        (not vals['customer'].commercial_partner_id.company_registry or len(vals['customer'].commercial_partner_id.company_registry) not in (8, 9))
+                    ) else '',
                 })
 
         if vals['supplier'].country_id.code == 'NO':

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_invoice.xml
@@ -54,9 +54,9 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0106">1234567</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>1234567</cbc:ID>
+        <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
@@ -77,7 +77,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0106">1234567</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0190">123456789</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_files/from_odoo/nlcius_out_refund.xml
@@ -58,9 +58,9 @@
   </cac:AccountingSupplierParty>
   <cac:AccountingCustomerParty>
     <cac:Party>
-      <cbc:EndpointID schemeID="0106">1234567</cbc:EndpointID>
+      <cbc:EndpointID schemeID="9944">NL41452B11</cbc:EndpointID>
       <cac:PartyIdentification>
-        <cbc:ID>1234567</cbc:ID>
+        <cbc:ID>NL41452B11</cbc:ID>
       </cac:PartyIdentification>
       <cac:PartyName>
         <cbc:Name>partner_2</cbc:Name>
@@ -81,7 +81,7 @@
       </cac:PartyTaxScheme>
       <cac:PartyLegalEntity>
         <cbc:RegistrationName>partner_2</cbc:RegistrationName>
-        <cbc:CompanyID schemeID="0106">1234567</cbc:CompanyID>
+        <cbc:CompanyID schemeID="0190">123456789</cbc:CompanyID>
       </cac:PartyLegalEntity>
       <cac:Contact>
         <cbc:Name>partner_2</cbc:Name>

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_nl.py
@@ -36,8 +36,9 @@ class TestUBLNL(TestUBLCommon):
             'vat': 'NL41452B11',
             'country_id': cls.env.ref('base.nl').id,
             'bank_ids': [(0, 0, {'acc_number': 'NL93999574162167'})],
-            'peppol_eas': '0106',
-            'peppol_endpoint': '1234567',
+            'peppol_eas': '9944',
+            'peppol_endpoint': 'NL41452B11',
+            'company_registry': '123456789',
             'ref': 'ref_partner_2',
         })
 


### PR DESCRIPTION
Issue:
In Odoo, it is impossible to generate an NLCIUS document for a partner with a valid Peppol endpoint using their Netherlands VAT (schemeID=9944) instead of a Dutch KVK/OIN identification number (schemeID=0106/0190). The latter is required for the PartyLegalEntity section of the document, but shares fields with the Peppol endpoint values, thus the two are incompatible. 

Solution:
When the Peppol endpoint is not set to KVK/OIN, the number is instead taken from the generic res_partner.company_registration field which is used for similar purposes for other locales, and the length of the number is used to determine the type.

Addresses ticket-4624350

task-4624366

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
