### PR TITLE
[FIX] pos_sale_loyalty: ignore sale loyalty

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/loyalty.js
+++ b/addons/pos_loyalty/static/src/overrides/models/loyalty.js
@@ -745,6 +745,10 @@ patch(Order.prototype, {
         }
         return true;
     },
+    isLineValidForLoyaltyPoints(line) {
+        // This method should be overriden in other modules
+        return true;
+    },
     /**
      * Computes how much points each program gives.
      *
@@ -761,6 +765,9 @@ patch(Order.prototype, {
             const rewardProgram = reward && reward.program_id;
             // Skip lines for automatic discounts.
             if (isDiscount && rewardProgram.trigger === "auto") {
+                continue;
+            }
+            if (!this.isLineValidForLoyaltyPoints(line)) {
                 continue;
             }
             for (const program of programs) {

--- a/addons/pos_sale_loyalty/static/src/overrides/models/models.js
+++ b/addons/pos_sale_loyalty/static/src/overrides/models/models.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 
-import { Orderline } from "@point_of_sale/app/store/models";
+import { Orderline, Order } from "@point_of_sale/app/store/models";
 import { patch } from "@web/core/utils/patch";
 
 patch(Orderline.prototype, {
@@ -22,3 +22,10 @@ patch(Orderline.prototype, {
         }
     },
 });
+
+patch(Order.prototype, {
+    isLineValidForLoyaltyPoints(line) {
+        const result = super.isLineValidForLoyaltyPoints(line);
+        return !line.sale_order_origin_id && result
+    }
+})

--- a/addons/pos_sale_loyalty/static/tests/tours/PosSaleLoyaltyTour.js
+++ b/addons/pos_sale_loyalty/static/tests/tours/PosSaleLoyaltyTour.js
@@ -23,3 +23,15 @@ registry
             ReceiptScreen.isShown(),
         ].flat(),
     });
+
+registry
+    .category("web_tour.tours")
+    .add('test_pos_sale_loyalty_ignored_in_pos', {
+        test: true,
+        steps: () => [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickQuotationButton(),
+            ProductScreen.selectFirstOrder(),
+            ProductScreen.totalAmountIs(90),
+        ].flat(),
+    });

--- a/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
+++ b/addons/pos_sale_loyalty/tests/test_pos_sale_loyalty.py
@@ -43,3 +43,42 @@ class TestPoSSaleLoyalty(TestPointOfSaleHttpCommon):
         self.main_pos_config.open_ui()
         self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, "PosSaleLoyaltyTour1", login="accountman")
         self.assertEqual(self.env['loyalty.card'].search_count([('partner_id', '=', self.partner_a.id)]), 1)
+
+    def test_pos_sale_loyalty_ignored_in_pos(self):
+        """Test that the loyalty program already applied in sales are not applied again in PoS"""
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': 'Test Loyalty Program',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [
+                (0, 0, {
+                    'reward_point_mode': 'order',
+                    'minimum_amount': 1,
+                    'minimum_qty': 0,
+                    'reward_point_amount': 1,
+                }),
+            ],
+            'reward_ids': [
+                (0, 0, {
+                    'reward_type': 'discount',
+                    'discount': 10,
+                    'required_points': 1,
+                    'discount_mode': 'percent',
+                    'discount_applicability': 'order',
+                }),
+            ],
+        })
+        sale_order = self.env['sale.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {
+                'product_id': self.desk_organizer.id,
+                'product_uom_qty': 1,
+                'price_unit': 100,
+            })]
+        })
+        sale_order.action_open_reward_wizard()
+        self.assertEqual(sale_order.amount_total, 90.0)
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/web?config_id=%d" % self.main_pos_config.id, "test_pos_sale_loyalty_ignored_in_pos", login="accountman")


### PR DESCRIPTION
When a loyalty program is already applied in a sale order, the same loyalty program could also be triggered in the POS.

Steps to reproduce:
-------------------
* Create a simple loyalty program with a discount of 10% on order that is applied automatically if the total of the order is more than 1$
* Create a sale order with a product of 10$ and apply the loyalty program
* You will have a disount of 1$ in the sale order
* Open the PoS and settle the order
* A new discount will appear in the PoS with a discount of 0.9$.
> Observation: You now have 2 discounts coming from the same program

Why the fix:
------------
We now adapt the `_programIsApplicable` function to check if the program was already used in the sale order. If it was, we ignore the program in the PoS.

opw-4381890