### PR TITLE
[FIX] l10n_jo_edi: Fixed partial credit notes lines indecies

### DIFF
--- a/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
+++ b/addons/l10n_jo_edi/models/account_edi_xml_ubl_21_jo.py
@@ -63,6 +63,27 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
     def _get_payment_method_code(self, invoice):
         return PAYMENT_CODES_MAP.get(invoice.company_id.l10n_jo_edi_taxpayer_type, {}).get('receivable', '')
 
+    def _get_line_edi_id(self, line, default_id):
+        if not line.is_refund:  # in case it's invoice not credit note
+            return default_id
+
+        refund_move = line.move_id
+        invoice_move = refund_move.reversed_entry_id
+        invoice_lines = invoice_move.invoice_line_ids.filtered(lambda line: line.display_type not in ('line_note', 'line_section'))
+        n = len(invoice_lines)
+
+        line_id = -1
+        for invoice_line_id, invoice_line in enumerate(invoice_lines, 1):
+            if line.product_id == invoice_line.product_id \
+                    and line.name == invoice_line.name \
+                    and line.price_unit == invoice_line.price_unit:
+                line_id = invoice_line_id
+                break
+        if line_id == -1:
+            line_id = n + default_id
+
+        return line_id
+
     def _aggregate_totals(self, vals):
         """
         This method is needed to ensure that units sum up to total values.
@@ -267,7 +288,7 @@ class AccountEdiXmlUBL21JO(models.AbstractModel):
         return {
             'currency': JO_CURRENCY,
             'currency_dp': self._get_currency_decimal_places(),
-            'id': line_id + 1,
+            'id': self._get_line_edi_id(line, default_id=line_id + 1),
             'line_quantity': line.quantity,
             'line_quantity_attrs': {'unitCode': self._get_uom_unece_code()},
             'line_extension_amount': self._get_line_taxable_amount(line),

--- a/addons/l10n_jo_edi/tests/test_files/type_2.xml
+++ b/addons/l10n_jo_edi/tests/test_files/type_2.xml
@@ -78,7 +78,7 @@
 		<cbc:PayableAmount currencyID="JO">130.680</cbc:PayableAmount>
 	</cac:LegalMonetaryTotal>
 	<cac:InvoiceLine>
-		<cbc:ID>1</cbc:ID>
+		<cbc:ID>2</cbc:ID>
 		<cbc:InvoicedQuantity unitCode="PCE">44.0</cbc:InvoicedQuantity>
 		<cbc:LineExtensionAmount currencyID="JO">130.680</cbc:LineExtensionAmount>
 		<cac:Item>


### PR DESCRIPTION
JoFotara portal expects credit notes lines ids (in the XML) to match those of the original invoice.
This expectation was not satisfied before, causing partial credit notes submission to fail. This commit solves this issue.

task-4752035




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
