### PR TITLE
[FIX] stock{,_dropshipping}: show all delivered SN in partner report

### DIFF
--- a/addons/stock_dropshipping/report/stock_lot_customer.py
+++ b/addons/stock_dropshipping/report/stock_lot_customer.py
@@ -7,6 +7,7 @@ class StockLotReport(models.Model):
     _inherit = 'stock.lot.report'
 
     def _join_on_picking_type_and_partner(self):
+        # todo remove master
         return """
             JOIN stock_picking_type AS type
             ON picking.picking_type_id = type.id and (type.code = 'outgoing' or type.code = 'dropship')
@@ -17,3 +18,6 @@ class StockLotReport(models.Model):
                 ELSE picking.partner_id
             END
         """
+
+    def _outgoing_operation_types(self):
+        return super()._outgoing_operation_types() + ",'dropship'"


### PR DESCRIPTION
The Customer Lot Report displays all SN delivered to a partner. To
do so, the SQL query is mainly based on SML. The problem is that it
only considers SML linked to a picking through the field
`picking_id`. However, this field is not required and it is possible
to have an SML without any value for that field, still linked to a
picking through its SM (RPC, data import...)

This commit therefore add a `join` on the SM, so we can find the
picking in all cases.

Moreover, [1] has been merged to get the customer of a dropshipping
(tldr: the partner of a dropship is the supplier). However, now that we
have the SM of the SML, we can simplify a lot the code and rather
use the partner of the SM:
https://github.com/odoo/odoo/blob/24235855d01e52df314479e0437c0308864edc23/addons/stock/models/stock_move.py#L95-L99

[1] https://github.com/odoo/odoo/commit/bace02e0355f3ed657421ca452af0b17ef4886bc

OPW-4559129