### PR TITLE
[IMP] base, hr, mail, web: make ui changes on avatar widget

### DIFF
--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -50,7 +50,7 @@
                         <t t-set="website_url" t-value="object.get_base_url()"></t>
                         Your Odoo domain is: <b><a t-att-href='website_url' t-out="website_url or ''">http://yourcompany.odoo.com</a></b><br />
                         Your sign in email is: <b><a t-attf-href="/web/login?login={{ object.email }}" target="_blank" t-out="object.email or ''">mark.brown23@example.com</a></b><br /><br />
-                        Never heard of Odoo? It’s an all-in-one business software loved by 7+ million users. It will considerably improve your experience at work and increase your productivity.
+                        Never heard of Odoo? It’s an all-in-one business software loved by 12+ million users. It will considerably improve your experience at work and increase your productivity.
                         <br /><br />
                         Have a look at the <a href="https://www.odoo.com/page/tour?utm_source=db&amp;utm_medium=auth" t-attf-style="color: {{object.company_id.email_secondary_color or '#875A7B'}};">Odoo Tour</a> to discover the tool.
                         <br /><br />

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -160,7 +160,7 @@
                         <field name="job_id" invisible="is_pool_applicant"/>
                         <field name="talent_pool_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not is_pool_applicant"/>
                         <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
-                        <field name="interviewer_ids" options="{'no_create': True, 'no_create_edit': True}" widget="many2many_avatar_user" invisible="is_pool_applicant" placeholder="Who can access applicants" />
+                        <field name="interviewer_ids" options="{'no_create': True}" widget="many2many_avatar_user" invisible="is_pool_applicant" placeholder="Who can access applicants" />
                         <field name="date_closed" invisible="not date_closed" />
                         <field name="categ_ids" placeholder="e.g. Trainee" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                     </group>

--- a/addons/mail/static/src/views/web/fields/avatar_autocomplete/avatar_many2x_autocomplete.js
+++ b/addons/mail/static/src/views/web/fields/avatar_autocomplete/avatar_many2x_autocomplete.js
@@ -1,0 +1,45 @@
+import { _t } from "@web/core/l10n/translation";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
+import { AvatarUserFormViewDialog } from "@mail/views/web/view_dialog/avatar_user_form_view_dialog";
+
+export class Many2XAvatarUserAutocomplete extends Many2XAutocomplete {
+    get actionSuggestions() {
+        return [
+            {
+                enabled: () => this.activeActions.create,
+                build: (request) => {
+                    const label = request
+                        ? _t(`Invite "%s"`, request)
+                        : _t("Invite teammates via email");
+                    return {
+                        cssClass:
+                            "o_m2o_dropdown_option o_m2o_dropdown_option_create text-indent-3",
+                        label: label,
+                        data: { slotName: "inviteTeammates", label: label },
+                        onSelect: () => this.slowCreate(request),
+                    };
+                },
+            },
+            {
+                enabled: this.addSearchMoreSuggestion.bind(this),
+                build: this.buildSearchMoreSuggestion.bind(this),
+            },
+        ];
+    }
+
+    get createDialog() {
+        return AvatarUserFormViewDialog;
+    }
+
+    get createDialogSize() {
+        return "md";
+    }
+
+    slowCreate(request) {
+        return this.openMany2X({
+            context: this.getCreationContext(request),
+            nextRecordsContext: this.props.context,
+            title: _t("Invite teammates"),
+        });
+    }
+}

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
@@ -13,6 +13,7 @@ import {
     kanbanMany2ManyTagsAvatarField,
     KanbanMany2ManyTagsAvatarFieldTagsList,
 } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
+import { Many2XAvatarUserAutocomplete } from "../avatar_autocomplete/avatar_many2x_autocomplete";
 
 export class Many2ManyAvatarUserTagsList extends TagsList {
     static template = "mail.Many2ManyAvatarUserTagsList";
@@ -59,9 +60,11 @@ const WithUserChatter = (T) =>
     };
 
 export class Many2ManyTagsAvatarUserField extends WithUserChatter(Many2ManyTagsAvatarField) {
+    static template = "mail.Many2ManyTagsAvatarUserField";
     static components = {
         ...Many2ManyTagsAvatarField.components,
         TagsList: Many2ManyAvatarUserTagsList,
+        Many2XAutocomplete: Many2XAvatarUserAutocomplete,
     };
 }
 
@@ -103,6 +106,7 @@ export class ListMany2ManyTagsAvatarUserField extends WithUserChatter(
     static components = {
         ...ListMany2ManyTagsAvatarField.components,
         TagsList: Many2ManyAvatarUserTagsList,
+        Many2XAutocomplete: Many2XAvatarUserAutocomplete,
     };
 
     get displayText() {

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.scss
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.scss
@@ -22,3 +22,8 @@
         }
     }
 }
+.o_field_many2many_avatar_user {
+    .text-indent-3 {
+      text-indent: 3px !important;
+    }
+}

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
+    <t t-name="mail.Many2ManyTagsAvatarUserField" t-inherit="web.Many2ManyTagsAvatarField" t-inherit-mode="primary">
+        <xpath expr="//Many2XAutocomplete" position="inside">
+            <t t-set-slot="inviteTeammates" t-slot-scope="inviteTeammatesScope">
+                <i class="fa fa-envelope-o fa-lg me-2 d-inline"/>
+                <t t-out="inviteTeammatesScope.label"/>
+            </t>
+        </xpath>
+    </t>
+
     <t t-name="mail.Many2ManyAvatarUserTagsList" t-inherit="web.TagsList" t-inherit-mode="primary">
         <img position="attributes">
             <attribute name="t-on-click.stop.prevent">tag.onImageClicked</attribute>
@@ -16,6 +25,12 @@
         <TagsList position="attributes">
             <attribute name="displayText">displayText</attribute>
         </TagsList>
+        <xpath expr="//Many2XAutocomplete" position="inside">
+            <t t-set-slot="inviteTeammates" t-slot-scope="inviteTeammatesScope">
+                <i class="fa fa-envelope-o fa-lg me-2 d-inline"/>
+                <t t-out="inviteTeammatesScope.label"/>
+            </t>
+        </xpath>
     </t>
 
     <t t-name="mail.KanbanMany2ManyTagsAvatarUserField" t-inherit="web.KanbanMany2ManyTagsAvatarField" t-inherit-mode="primary">

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -9,10 +9,18 @@ import {
     Many2OneField,
 } from "@web/views/fields/many2one/many2one_field";
 import { Avatar } from "../avatar/avatar";
+import { Many2XAvatarUserAutocomplete } from "../avatar_autocomplete/avatar_many2x_autocomplete";
+
+class Many2OneAvatarUser extends Many2One {
+    static components = {
+        ...Many2One.components,
+        Many2XAutocomplete: Many2XAvatarUserAutocomplete,
+    };
+}
 
 export class Many2OneAvatarUserField extends Component {
     static template = "mail.Many2OneAvatarUserField";
-    static components = { Avatar, Many2One };
+    static components = { Avatar, Many2OneAvatarUser };
     static props = {
         ...Many2OneField.props,
         withCommand: { type: Boolean },

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.scss
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.scss
@@ -1,0 +1,5 @@
+.o_field_many2one_avatar_user {
+    .text-indent-3 {
+      text-indent: 3px !important;
+    }
+}

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -6,14 +6,18 @@
             <t t-if="value !== false">
                 <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
             </t>
-            <Many2One t-props="m2oProps" cssClass="'w-100'">
+            <Many2OneAvatarUser t-props="m2oProps" cssClass="'w-100'">
+                <t t-set-slot="inviteTeammates" t-slot-scope="inviteTeammatesScope">
+                    <i class="fa fa-envelope-o fa-lg me-2 d-inline"/>
+                    <t t-out="inviteTeammatesScope.label"/>
+                </t>
                 <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
                         <Avatar resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
                         <t t-out="autoCompleteItemScope.label"/>
                     </div>
                 </t>
-            </Many2One>
+            </Many2OneAvatarUser>
         </div>
     </t>
 

--- a/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.js
+++ b/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.js
@@ -1,0 +1,22 @@
+import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
+import { onMounted } from "@odoo/owl";
+
+export class AvatarUserFormViewDialog extends FormViewDialog {
+    setup() {
+        super.setup();
+        Object.assign(this.viewProps, {
+            buttonTemplate: this.props.isToMany
+                ? "mail.UserFormViewDialog.ToMany.buttons"
+                : "mail.UserFormViewDialog.ToOne.buttons",
+        });
+
+        onMounted(() => {
+            setTimeout(() => {
+                const input = this.modalRef.el.querySelector("#name_0");
+                if (input) {
+                    input.focus();
+                }
+            });
+        });
+    }
+}

--- a/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.xml
+++ b/addons/mail/static/src/views/web/view_dialog/avatar_user_form_view_dialog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.UserFormViewDialog.ToMany.buttons" t-inherit="web.FormViewDialog.ToMany.buttons">
+        <xpath expr="//button[hasclass('o_form_button_save')]" position="replace" mode="inner">
+            Send Invitation
+        </xpath>
+        <xpath expr="//button[hasclass('o_form_button_save_new')]" position="replace">
+            <button class="btn btn-secondary o_form_button_save_new" t-on-click="() => this.saveButtonClicked({saveAndNew: true})" data-hotkey="n">
+                Send &amp; New Invitation
+            </button>
+        </xpath>
+    </t>
+
+    <t t-name="mail.UserFormViewDialog.ToOne.buttons" t-inherit="web.FormViewDialog.ToOne.buttons">
+        <xpath expr="//button[hasclass('o_form_button_save')]" position="replace" mode="inner">
+            Send Invitation
+        </xpath>
+    </t>
+</templates>

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -76,7 +76,7 @@
                         </group>
                         <group>
                             <field name="active" invisible="1"/>
-                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
+                            <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]"/>
                             <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "always_range": "1"}' required="date_start or date" />
                             <field name="date" invisible="1" required="date_start"/>
                         </group>
@@ -236,7 +236,7 @@
                         optional="hide"
                         invisible="not allow_milestones or is_template"
                     />
-                    <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True, 'no_create_edit': True}"/>
+                    <field name="user_id" optional="show" string="Project Manager" widget="many2one_avatar_user" options="{'no_open':True, 'no_create': True}"/>
                     <field name="last_update_color" column_invisible="True"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
                     <field name="last_update_status" string="Status" nolabel="1" width="20px" optional="show" widget="project_state_selection" invisible="is_template"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -415,7 +415,7 @@
                                 invisible="not project_id or not allow_milestones"/>
                             <field name="user_ids"
                                 class="o_task_user_field"
-                                options="{'no_open': True, 'no_quick_create': True}"
+                                options="{'no_open': True}"
                                 widget="many2many_avatar_user"/>
                             <field name="role_ids" invisible="not (is_template and has_project_template)" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" placeholder="Assign at project creation"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}" context="{'project_id': project_id}"/>
@@ -603,7 +603,7 @@
                                domain="[('type_ids', 'in', context.get('default_stage_id')), ('is_template', 'in', [is_template, False])] if context.get('default_stage_id') else [('is_template', 'in', [is_template, False])]"
                                required="is_template"
                         />
-                        <field name="user_ids" options="{'no_open': True, 'no_quick_create': True}"
+                        <field name="user_ids" options="{'no_open': True}"
                             widget="many2many_avatar_user"/>
                         <field name="company_id" invisible="1"/>
                         <field name="parent_id" invisible="1" groups="base.group_no_one"/>

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -65,7 +65,7 @@
                   js_class="todo_list">
                 <field name="state" widget="todo_done_checkmark" nolabel="1" width="20px"/>
                 <field name="name"/>
-                <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
+                <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user"/>
                 <field name="priority" widget="priority" optional="hidden" width="70px"/>
                 <field name="date_deadline" optional="show" widget="remaining_days"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
@@ -108,7 +108,6 @@
                             <field name="user_ids"
                                 widget="many2many_avatar_user"
                                 required="1"
-                                options="{'no_quick_create': True}"
                                 placeholder="Assignees"/>
                             <field name="tag_ids"
                                 widget="many2many_tags"
@@ -163,7 +162,7 @@
                                default_focus="1"/>
                         <field name="user_ids"
                                class="o_task_user_field"
-                               options="{'no_open': True, 'no_quick_create': True}"
+                               options="{'no_open': True}"
                                widget="many2many_avatar_user"/>
                         <field name="tag_ids" widget="many2many_tags"
                                options="{'color_field': 'color', 'no_create_edit': True}"

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -266,6 +266,8 @@ export class Many2XAutocomplete extends Component {
                     }
                     autoCompleteInput.focus();
                 },
+                component: this.createDialog,
+                size: this.createDialogSize,
             });
 
         this.selectCreate = useSelectCreate({
@@ -302,16 +304,25 @@ export class Many2XAutocomplete extends Component {
     get sources() {
         return [this.optionsSource, ...this.props.otherSources];
     }
+
     get optionsSource() {
         return {
             placeholder: _t("Loading..."),
             options: this.loadOptionsSource.bind(this),
-            optionSlot: this.props.slots?.autoCompleteItem ? "option" : undefined,
+            optionSlot: "option",
         };
     }
 
     get activeActions() {
         return this.props.activeActions || {};
+    }
+
+    get createDialog() {
+        return FormViewDialog;
+    }
+
+    get createDialogSize() {
+        return "lg";
     }
 
     getCreationContext(value) {
@@ -327,14 +338,6 @@ export class Many2XAutocomplete extends Component {
     }
     onCancel() {
         this.props.setInputFloats(false);
-    }
-
-    abortableSearch(name) {
-        const originalPromise = this.search(name);
-        return {
-            promise: originalPromise,
-            abort: originalPromise.abort ? originalPromise.abort.bind(originalPromise) : () => {},
-        };
     }
 
     get searchSpecification() {
@@ -357,15 +360,12 @@ export class Many2XAutocomplete extends Component {
             specification: this.searchSpecification,
         });
     }
-    mapRecordToOption(record, request) {
-        const label = record.__formatted_display_name || record.display_name;
-        return {
-            data: { record },
-            label: label
-                ? highlightText(request, odoomark(label), "text-primary fw-bold")
-                : _t("Unnamed"),
-            onSelect: () => this.props.update([record]),
-        };
+
+    slowCreate(request) {
+        return this.openMany2X({
+            context: this.getCreationContext(request),
+            nextRecordsContext: this.props.context,
+        });
     }
 
     onQuickCreateError(error, request) {
@@ -373,96 +373,154 @@ export class Many2XAutocomplete extends Component {
             error instanceof RPCError &&
             error.exceptionName === "odoo.exceptions.ValidationError"
         ) {
-            return this.openMany2X({
-                context: this.getCreationContext(request),
-                nextRecordsContext: this.props.context,
-            });
+            return this.slowCreate(request);
         } else {
             throw error;
         }
     }
-    async loadOptionsSource(request) {
-        if (this.lastProm) {
-            this.lastProm.abort(false);
-            this.lastProm = null;
-        }
-        const canCreateEdit =
-            "createEdit" in this.activeActions
-                ? this.activeActions.createEdit
-                : this.activeActions.create;
-        let addSearchMore = true;
 
-        const options = [];
+    async loadOptionsSource(request) {
+        this.__lastSuggestionsLoadPromise?.abort(false);
+        return this.suggest(request, (promise) => {
+            this.__lastSuggestionsLoadPromise = promise;
+            return promise;
+        });
+    }
+
+    async suggest(request, lock) {
+        const suggestions = [];
+        /** @type {Record<string, any>[] | null} */
+        let records = null;
+
         if (request.length < this.props.searchThreshold) {
-            if (!this.props.value) {
-                options.push({
-                    cssClass: "o_m2o_start_typing",
-                    label:
-                        this.props.searchThreshold > 1
-                            ? _t("Start typing %s characters", this.props.searchThreshold)
-                            : _t("Start typing..."),
-                });
+            if (this.addStartTypingSuggestion()) {
+                suggestions.push(this.buildStartTypingSuggestion());
             }
         } else {
-            this.lastProm = this.abortableSearch(request);
-            const records = await this.lastProm.promise;
-            addSearchMore = records.length > 0;
+            records = await lock(this.search(request));
             if (records.length) {
                 for (const record of records) {
-                    options.push(this.mapRecordToOption(record, request));
+                    suggestions.push(this.buildRecordSuggestion(request, record));
                 }
-            } else if (!this.activeActions.createEdit && !this.props.quickCreate) {
-                options.push({
-                    cssClass: "o_m2o_no_result",
-                    label: _t("No records"),
-                });
+            } else if (this.addNoRecordsSuggestion()) {
+                suggestions.push(this.buildNoRecordsSuggestion());
             }
         }
 
-        const slowCreate = () =>
-            this.openMany2X({
-                context: this.getCreationContext(request),
-                nextRecordsContext: this.props.context,
-            });
-        if (request.length) {
-            if (this.props.quickCreate) {
-                options.push({
-                    cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create",
-                    label: _t('Create "%s"', request),
-                    onSelect: async () => {
-                        try {
-                            await this.props.quickCreate(request);
-                        } catch (e) {
-                            this.onQuickCreateError(e, request);
-                        }
-                    },
-                });
+        for (const action of this.actionSuggestions) {
+            const enabled = action.enabled ?? (() => true);
+            if (enabled({ request, records })) {
+                suggestions.push(action.build(request));
             }
-
-            if (canCreateEdit) {
-                options.push({
-                    cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create_edit",
-                    label: _t("Create and edit..."),
-                    onSelect: slowCreate,
-                });
-            }
-        } else if (canCreateEdit && !addSearchMore) {
-            options.push({
-                cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create_new",
-                label: _t("Create..."),
-                onSelect: slowCreate,
-            });
         }
 
-        if (addSearchMore) {
-            options.push({
-                cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_search_more",
-                label: this.SearchMoreButtonLabel,
-                onSelect: this.onSearchMore.bind(this, request),
-            });
-        }
+        return suggestions;
+    }
 
-        return options;
+    get actionSuggestions() {
+        return [
+            {
+                // create
+                enabled: this.addCreateSuggestion.bind(this),
+                build: this.buildCreateSuggestion.bind(this),
+            },
+            {
+                // create and edit
+                enabled: this.addCreateEditSuggestion.bind(this),
+                build: this.buildCreateEditSuggestion.bind(this),
+            },
+            {
+                // search more
+                enabled: this.addSearchMoreSuggestion.bind(this),
+                build: this.buildSearchMoreSuggestion.bind(this),
+            },
+        ];
+    }
+
+    addCreateSuggestion({ request }) {
+        return !!this.props.quickCreate && request.length > 0;
+    }
+
+    addCreateEditSuggestion({ records, request }) {
+        return (
+            (this.activeActions.createEdit ?? this.activeActions.create) &&
+            (request.length > 0 || records?.length === 0)
+        );
+    }
+
+    addNoRecordsSuggestion() {
+        return !this.activeActions.createEdit && !this.props.quickCreate;
+    }
+
+    addSearchMoreSuggestion({ records, request }) {
+        return request.length < this.props.searchThreshold || records?.length > 0;
+    }
+
+    addStartTypingSuggestion() {
+        return !this.props.value;
+    }
+
+    buildCreateSuggestion(request) {
+        return {
+            cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create",
+            data: { slotName: "createItem" },
+            label: _t('Create "%s"', request),
+            onSelect: async () => {
+                try {
+                    await this.props.quickCreate(request);
+                } catch (e) {
+                    this.onQuickCreateError(e, request);
+                }
+            },
+        };
+    }
+
+    buildCreateEditSuggestion(request) {
+        return {
+            cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create_edit",
+            data: { slotName: "createEditItem" },
+            label: request.length > 0 ? _t("Create and edit...") : _t("Create..."),
+            onSelect: () => this.slowCreate(request),
+        };
+    }
+
+    buildNoRecordsSuggestion() {
+        return {
+            cssClass: "o_m2o_no_result",
+            data: { slotName: "noRecordsItem" },
+            label: _t("No records"),
+        };
+    }
+
+    buildRecordSuggestion(request, record) {
+        const label = record.__formatted_display_name || record.display_name;
+        return {
+            data: { record, slotName: "autoCompleteItem" },
+            label: label
+                ? highlightText(request, odoomark(label), "text-primary fw-bold")
+                : _t("Unnamed"),
+            onSelect: () => this.props.update([record]),
+        };
+    }
+
+    buildSearchMoreSuggestion(request) {
+        return {
+            cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_search_more",
+            data: { slotName: "searchMoreItem" },
+            label: this.SearchMoreButtonLabel,
+            onSelect: this.onSearchMore.bind(this, request),
+        };
+    }
+
+    buildStartTypingSuggestion() {
+        return {
+            cssClass: "o_m2o_start_typing",
+            data: { slotName: "startTypingItem" },
+            label:
+                this.props.searchThreshold > 1
+                    ? _t("Start typing %s characters", this.props.searchThreshold)
+                    : _t("Start typing..."),
+        };
     }
 
     get SearchMoreButtonLabel() {
@@ -520,6 +578,8 @@ export function useOpenMany2XRecord({
     activeActions,
     isToMany,
     onClose = (isNew) => {},
+    component = FormViewDialog,
+    size = "lg",
 }) {
     const addDialog = useOwnedDialogs();
     const orm = useService("orm");
@@ -545,7 +605,7 @@ export function useOpenMany2XRecord({
         const readonly = !(resId ? canWrite : canCreate);
 
         addDialog(
-            FormViewDialog,
+            component,
             {
                 preventCreate: !canCreate,
                 preventEdit: !canWrite,
@@ -559,6 +619,7 @@ export function useOpenMany2XRecord({
                 onRecordSaved,
                 onRecordDiscarded,
                 isToMany,
+                size,
             },
             {
                 onClose: () => {

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -34,11 +34,8 @@
         />
         <AutoComplete t-else="" t-props="autoCompleteProps">
             <t t-set-slot="option" t-slot-scope="optionScope">
-                <t t-if="optionScope.data.record">
-                    <t t-slot="autoCompleteItem" t-props="optionScope.data" label="optionScope.label"/>
-                </t>
-                <t t-else="">
-                    <t t-esc="optionScope.label"/>
+                <t t-slot="{{ optionScope.data.slotName }}" t-props="optionScope.data" label="optionScope.label">
+                    <t t-out="optionScope.label"/>
                 </t>
             </t>
         </AutoComplete>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -60,9 +60,6 @@
             <field name="arch" type="xml">
                 <form string="Users">
                     <sheet>
-                        <div class="alert alert-info text-center mb-3" invisible="id &gt; 0" role="alert">
-                            You are inviting a new user.
-                        </div>
                         <div class="d-flex gap-3">
                             <field name="image_1920" widget="contact_image" options="{'preview_image': 'avatar_128', 'zoom': true, 'size': [130,130], 'img_class': 'rounded-4'}"/>
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
@@ -73,7 +70,8 @@
                                 <div class="d-flex align-items-baseline w-100">
                                     <field name="email" invisible="1"/> <!-- needed to update partner's email from on_change_login() -->
                                     <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
-                                    <field name="login" class="w-100" placeholder="Email"/>
+                                    <field name="email_domain_placeholder" invisible="1" /> <!-- needed to compute the placeholder whenever the dialog opens -->
+                                    <field name="login" class="w-100" options="{'placeholder_field': 'email_domain_placeholder'}"/>
                                 </div>
                                 <div class="d-flex align-items-baseline w-100">
                                     <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>


### PR DESCRIPTION
This PR makes the following changes in the flow of the form view dialog, which opens through the avatar widget when we invite the user. Also, it made some changes in Many2Xautocomplete so we can easily customize the options.

- Earlier, customizing the options of Many2XAutocomplete was a bit complex as
  option definitions were in the `loadOptionsSource`, which were pushed based on
  the various conditions.
- This PR introduces dedicated entry points in the `Many2XAutocomplete`
  component by building each option through a separate method.
- This structure makes it easier for external components to override or extend
  the default suggestion behavior in a clean and modular way.
- Make the slot for the Many2XAutocomplete component dynamic instead of using a
  fixed one, the autoCompleteItem slot. This way, slots can be passed within the
  data key of each option, allowing the widget templates to set those slots
  dynamically. If no slots are specified, the component should default to
  displaying the optionScope.label content. This approach will enable more
  flexible rendering of options.
- Besides this, we also make the dialog used in useOpenMany2XRecord customizable
  by adding it to the static properties components. The default fallback will be
  FormViewDialog.
- Useful for cases where we want to show a custom dialog with extra options, a
  different layout, or special behavior when creating/editing records from
  autocomplete.
- Customized `FormViewDialog` to replace default footer buttons and passed that
  to Many2XAutocomplete.
- Extended Many2XAutocomplete to use a custom AvatarUserFormViewDialog instead
  of the default FormViewDialog.
- Added inviteTeammates options by overriding actionSuggestions.
- Also customized slowCreate to modify the dialog title.
- Set the `inviteTeammates` slot with an icon and a label for the avatar user
  widget.
- Added dynamic placeholder text for the email field, based on the domain
  of the currently logged-in user.
- Set the `create_employee` field to `true` by default, ensuring that an
  the employee is always created when adding an internal user.
- Since an email is mandatory when creating a user, the `quick_create` option
  automatically falls back to `create_and_edit`. As a result, from the user's
  perspective, both `quick_create` and `create_and_edit` effectively serve the
  same purpose.
- This PR removes both of the options from wherever we have used them
  with the Many2xAvatarUser widget.

Task-4613146