### PR TITLE
[IMP] html_editor, mail: prepare AI-enabled mail templates

### DIFF
--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -15,6 +15,7 @@ export class BannerPlugin extends Plugin {
     static id = "banner";
     // sanitize plugin is required to handle `contenteditable` attribute.
     static dependencies = ["baseContainer", "history", "dom", "emoji", "selection", "sanitize"];
+    static shared = ["insertBanner"];
     resources = {
         user_commands: [
             {
@@ -91,7 +92,10 @@ export class BannerPlugin extends Plugin {
         });
     }
 
-    insertBanner(title, emoji, alertClass) {
+    insertBanner(title, emoji, alertClass, containerClass = "", contentClass = "") {
+        containerClass = containerClass ? `${containerClass} ` : "";
+        contentClass = contentClass ? `${contentClass} ` : "";
+
         const selection = this.dependencies.selection.getEditableSelection();
         const blockEl = closestBlock(selection.anchorNode);
         let baseContainer;
@@ -109,11 +113,11 @@ export class BannerPlugin extends Plugin {
         const baseContainerHtml = baseContainer.outerHTML;
         const bannerElement = parseHTML(
             this.document,
-            `<div class="o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
+            `<div class="${containerClass}o_editor_banner user-select-none o-contenteditable-false lh-1 d-flex align-items-center alert alert-${alertClass} pb-0 pt-3" data-oe-role="status">
                 <i class="o_editor_banner_icon mb-3 fst-normal" data-oe-aria-label="${htmlEscape(
                     title
                 )}">${emoji}</i>
-                <div class="o_editor_banner_content o-contenteditable-true w-100 px-3">
+                <div class="${contentClass}o_editor_banner_content o-contenteditable-true w-100 px-3">
                     ${baseContainerHtml}
                 </div>
             </div>`

--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -545,6 +545,10 @@ class MailRenderMixin(models.AbstractModel):
         return scheduled_date
 
     @api.model
+    def _render_template_get_valid_options(self):
+        return {'post_process', 'preserve_comments'}
+
+    @api.model
     def _render_template(self, template_src, model, res_ids, engine='inline_template',
                          add_context=None, options=None):
         """ Render the given string on records designed by model / res_ids using
@@ -586,7 +590,7 @@ class MailRenderMixin(models.AbstractModel):
                 _('Template rendering supports only inline_template, qweb, or qweb_view (view or raw); received %(engine)s instead.',
                   engine=engine)
             )
-        valid_render_options = {'post_process', 'preserve_comments'}
+        valid_render_options = self._render_template_get_valid_options()
         if not set((options or {}).keys()) <= valid_render_options:
             raise ValueError(
                 _('Those values are not supported as options when rendering: %(param_names)s',

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -183,7 +183,7 @@ class MailTemplate(models.Model):
             if self.env[model]._abstract:
                 raise ValidationError(_('You may not define a template on an abstract model: %s', model))
 
-    def _check_can_be_rendered(self, fnames=None):
+    def _check_can_be_rendered(self, fnames=None, render_options=None):
         dynamic_fnames = self._get_dynamic_field_names()
 
         for template in self:
@@ -197,7 +197,7 @@ class MailTemplate(models.Model):
             fnames = fnames & dynamic_fnames if fnames else dynamic_fnames
             for fname in fnames:
                 try:
-                    template._render_field(fname, record.ids)
+                    template._render_field(fname, record.ids, options=render_options)
                 except Exception as e:
                     raise ValidationError(
                         _("Oops! We couldn't save your template due to an issue with this value: %(template_txt)s. Correct it and try again.",


### PR DESCRIPTION
In this commit, we start sharing the `insertBanner` method of the
`banner_plugin` to accomodate for a new plugin introduced in `ai` module. We
also modify the `insertBanner` method to allow custom classes for the banner
container and content.

Task-4762393