### PR TITLE
[FIX] bus: has missed notification missing parameter

### DIFF
--- a/addons/bus/static/src/outdated_page_watcher_service.js
+++ b/addons/bus/static/src/outdated_page_watcher_service.js
@@ -47,7 +47,7 @@ export class OutdatedPageWatcherService {
     }
 
     async checkHasMissedNotifications() {
-        if (!this.multi_tab.isOnMainTab()) {
+        if (!this.multi_tab.isOnMainTab() || !this.lastNotificationId) {
             return;
         }
         const hasMissedNotifications = await rpc(

--- a/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
+++ b/addons/bus/static/tests/legacy/outdated_page_watcher_tests.js
@@ -25,6 +25,7 @@ QUnit.test("disconnect during bus gc should ask for reload", async () => {
             }
         },
     });
+    env.services.multi_tab.setSharedValue("last_notification_id", 1);
     env.services.bus_service.start();
     await waitForBusEvent(env, "connect");
     pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
@@ -47,6 +48,7 @@ QUnit.test("reconnect after going offline after bus gc should ask for reload", a
             }
         },
     });
+    env.services.multi_tab.setSharedValue("last_notification_id", 1);
     env.services.bus_service.start();
     await waitForBusEvent(env, "connect");
     browser.dispatchEvent(new Event("offline"));


### PR DESCRIPTION
When no notification was received before bus disconnection, the `has_missed_notifications` route is missing a parameter, leading to an error. This commit fixes the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
