### PR TITLE
[FIX] base: invalidate all forbidden recordset

### DIFF
--- a/odoo/orm/models.py
+++ b/odoo/orm/models.py
@@ -6648,6 +6648,9 @@ class BaseModel(metaclass=MetaModel):
         self._invalidate_cache(fnames, self._ids)
 
     def _invalidate_cache(self, fnames: Collection[str] | None = None, ids: Sequence[IdType] | None = None) -> None:
+        if ids is not None and not ids:  # Avoid invalidating field_inverses for no reason
+            return
+
         if fnames is None:
             fields = self._fields.values()
         else:


### PR DESCRIPTION
The commit 0b143489d8b6730cd790c1f9e33d9720995f1baf introduced a fix that invalidates the cache for all forbidden records when an AccessError was created. However, in debug mode, it only invalidates the first six records, which was an error.
Commit 381d2a595a24a8d010bf6ec98046ab1f4847044b partially breaks the previous commit by only invalidating the first six records.

The initial fix was reintroduced, and making working in debug mode too. A test was added to cover this case once and for all.

#### [FIX] core: fix inefficient invalidate_recordset on empty recordset

If when we call invalidate_recordset() with an empty record, we actually invalidate all inverse fields for no reason.
That because the code block of the invalidation of inverses fields doesn't depends on ids.