### PR TITLE
[FIX] mrp: avoid non-kit reservation due to company context

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -519,7 +519,7 @@ class StockMove(models.Model):
         return super(StockMove, moves)._action_done(cancel_backorder)
 
     def _should_bypass_reservation(self, forced_location=False):
-        return super()._should_bypass_reservation(forced_location) or self.product_id.is_kits
+        return super()._should_bypass_reservation(forced_location) or self.product_id.with_company(self.company_id).is_kits
 
     def action_explode(self):
         """ Explodes pickings """

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1840,6 +1840,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         moves_mto = moves_to_assign.filtered(lambda m: m.move_orig_ids and not m._should_bypass_reservation())
         quants_cache = self.env['stock.quant']._get_quants_by_products_locations(moves_mto.product_id, moves_mto.location_id)
         for move in moves_to_assign:
+            move = move.with_company(move.company_id)
             rounding = roundings[move]
             if not force_qty:
                 missing_reserved_uom_quantity = move.product_uom_qty - reserved_availability[move]


### PR DESCRIPTION
### Steps to reproduce:

- Have 2 companies: COMP1 and COMP2
- Create a storable product P with a kit bom for attached to COMP1.
- With COMP2 create a delivery for 1 unit of P.
> If you click on check availability the move should not be assigned.
- As COMP1 and with COMP2 active, click on check availability once more
#### > The move is assigned.

### Cause of the issue:

Checking the availability will launch a call of the `action_assign` of the stock picking. During this call, the moves that shoudl by pass the reservation process will automatically be reserved: https://github.com/odoo/odoo/blob/9b0c1c416eaa0df64fbe28c5672f2590a218f315/addons/stock/models/stock_move.py#L1852-L1853 However, kit products are flagged to bypass the reservation process by these lines:
https://github.com/odoo/odoo/blob/9b0c1c416eaa0df64fbe28c5672f2590a218f315/addons/mrp/models/stock_move.py#L521-L522 The issue with this line being that the product is a kit form COMP1 and not for COMP2 (the context is used to determine this in the compute method):
https://github.com/odoo/odoo/blob/9b0c1c416eaa0df64fbe28c5672f2590a218f315/addons/mrp/models/product.py#L38-L40

### Note:

The issue can not be reproduced prior to 18.0, since the override of the `_should_bypass_reservation` was introduced by commit 4e1d46869e6c2d1ff473317179393007522a10a3

opw-4660233
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
