### PR TITLE
[FIX] core: hide "failed to fetch" errors after tour termination

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1359,8 +1359,9 @@ which leads to stray network requests and inconsistencies."""
             message += '\n' + stack
 
         if self._result.done():
-            self._logger.getChild('browser').error(
-                "Exception received after termination: %s", message)
+            if 'failed to fetch' not in message.casefold():
+                self._logger.getChild('browser').error(
+                    "Exception received after termination: %s", message)
             return
 
         self.take_screenshot()


### PR DESCRIPTION
After more discussion and consideration, this error is considered to have relatively low value and furthermore to possibly be triggered by the chrome shutdown itself e.g. `Page.stopLoading` is documented as

> Force the page stop all navigations and pending resource fetches.

so that can be the source of "failed to fetch" errors, maybe (didn't actually test it).

Note that this is hooked to `_result.done()` aka `not _result.running()`, so there is a window where the issue can still occur (at least as a result of `stopLoading`) while we're waiting for service workers to shut down as well as pending responses. If this is still an issue, we may want to add a separate flag and set it right before or after the `Page.stopLoading` call.

Hides runbot errors 54858, 55676, 109214, 109473, 110840, 134469, 162284, 162340, 193182, 198562, and 199232
