### PR TITLE
[FIX] payment_stripe: allow payment when tokenization disabled

### DIFF
--- a/addons/payment_stripe/models/payment_provider.py
+++ b/addons/payment_stripe/models/payment_provider.py
@@ -500,7 +500,8 @@ class PaymentProvider(models.Model):
                 },
             },
             'is_tokenization_required': (
-                not PaymentPortal._compute_show_tokenize_input_mapping(self, **kwargs)[self.id]
+                self.allow_tokenization
+                and self._is_tokenization_required(**kwargs)
                 and payment_method_sudo.support_tokenization
             ),
             'payment_methods_mapping': const.PAYMENT_METHODS_MAPPING,


### PR DESCRIPTION
177d4cb fixed an issue that prevented to use of a non-tokenizable payment method to pay for a subscription if the "Allow saving payment method" setting was enabled on a Stripe provider.

This fix introduced a bug that prevented customers from paying if the "Allow saving payment method" setting was disabled on a Stripe provider.

After this commit, both behaviors should allow receiving payment with Stripe.

opw-4787854
