### PR TITLE
[PERF] project: Speed up `project.project` kanban's view

### DIFF
--- a/addons/project/models/__init__.py
+++ b/addons/project/models/__init__.py
@@ -16,5 +16,6 @@ from . import project_collaborator
 from . import project_update
 from . import res_config_settings
 from . import res_partner
+from . import res_users
 from . import digest_digest
 from . import ir_ui_menu

--- a/addons/project/models/res_users.py
+++ b/addons/project/models/res_users.py
@@ -1,0 +1,8 @@
+from odoo import models, fields
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    favorite_project_ids = fields.Many2many('project.project', 'project_favorite_user_rel', 'user_id', 'project_id',
+                                            string='Favorite Projects', export_string_translation=False, copy=False)

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -59,6 +59,9 @@ class RatingRating(models.Model):
         'Rating should be between 0 and 5',
     )
 
+    _consumed_idx = models.Index('(res_model, res_id, write_date) WHERE consumed IS TRUE')
+    _parent_consumed_idx = models.Index('(parent_res_model, parent_res_id, write_date) WHERE consumed IS TRUE')
+
     @api.depends('res_model', 'res_id')
     def _compute_res_name(self):
         for rating in self:


### PR DESCRIPTION
Description
-----------
The project task's `is_template` field was previously indexed for `TRUE` values, making lookups for template tasks efficient due to their small number. However, filtering for non-template tasks ( `is_template = FALSE`) became slow since it requires scanning a large number of records. This impacted performance in domains like `__compute_task_count`. This commit optimizes the query by first fetching template tasks and filtering them out in Python rather than relying on database-level filtering.

Additionally, this commit adds a new field
`res.users.favorite_project_ids` as the inverse relation of `project.project.favorite_user_ids`. This improves `_compute_is_favorite` performance by checking if a project exists in a user's favorites rather than searching through all users who favorited a project. The latter approach was slower due to the larger search space of user-project relationships.

Finally, new indexes are added to `rating.rating` for consumed ratings to optimize `_compute_rating_percentage_satisfaction`. Since most rating lookups include the condition `('consumed', '=', True)`, these indexes will improve query performance across the rating system.

Benchmark
----------
On odoo.com, opening the kanban view of projects, with six favorite projects (typical setup):

| Before | After | Speed up |
|--------|-------|----------|
| 1.1s   | 300ms | 3.7x     |

Reference
---------
task-4794928


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
