### PR TITLE
[FIX] config: remove empty paths

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -528,17 +528,20 @@ class configmanager(object):
         else:
             self.options['addons_path'] = ",".join(
                 self._normalize(x)
-                for x in self.options['addons_path'].split(','))
+                for x in self.options['addons_path'].split(',')
+                if x.strip())
 
         self.options["upgrade_path"] = (
             ",".join(self._normalize(x)
-                for x in self.options['upgrade_path'].split(','))
+                for x in self.options['upgrade_path'].split(',')
+                if x.strip())
             if self.options['upgrade_path']
             else ""
         )
         self.options["pre_upgrade_scripts"] = (
             ",".join(self._normalize(x)
-                for x in self.options['pre_upgrade_scripts'].split(','))
+                for x in self.options['pre_upgrade_scripts'].split(',')
+                if x.strip())
             if self.options['pre_upgrade_scripts']
             else ""
         )


### PR DESCRIPTION
### Before this commit:
Empty paths in the config file are invalid but not verified, resulting in cryptic errors.

### After this commit:
Empty paths are ignored, to prevent errors in the config.

opw-4744154
