### PR TITLE
[FIX] website_sale: fix error when configuring website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -327,8 +327,6 @@ class Website(models.Model):
                 })
             except AccessError:
                 logger.warning("API is unreachable for the category generation")
-            if not response:
-                logger.warning("API response is empty for the categories generation")
                 return None
 
             if response['status'] == 'success':


### PR DESCRIPTION
If an AccessError occurs during category generation while configuring
the website, it results in a traceback.

Traceback:
```
File "/home/odoo/src/odoo/addons/website_sale/models/website.py", line 330, in generate_categories
    if not response:
UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
```

https://github.com/odoo/odoo/blob/101437b08887a234623da81dc3101d262c3e972b/addons/website_sale/models/website.py#L322-L332
Here, If an AccessError occurs during the category generation,
the ``response`` variable is not initialized, resulting in an UnboundLocalError
when the code later tries to access ``response`` outside the try block.

sentry-6600425803

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
