### PR TITLE
[FIX] l10n_br_sales: Display taxes in sales quotation PDF

### DIFF
--- a/addons/l10n_br_sales/report/sale_order_templates.xml
+++ b/addons/l10n_br_sales/report/sale_order_templates.xml
@@ -11,16 +11,11 @@
     </template>
 
     <template id="report_saleorder_document_brazil" inherit_id="sale.report_saleorder_document" primary="True">
-        <th name="th_taxes" position="replace"/>
-        <td name="td_taxes" position="replace"/>
         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
             <attribute name="t-value">current_subtotal + line.price_total</attribute>
         </t>
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field">line.price_total</attribute>
         </span>
-        <xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
-            <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
-        </xpath>
     </template>
 </odoo>


### PR DESCRIPTION
**Issue**
When printing a sales quotation PDF with the Brazilian localization (l10n_br), product tax information is not displayed.

**Steps to Reproduce**
1. Install the Sales app and the Brazilian localization (l10n_br)
2. Create a new quotation
3. Add a product with tax applied and confirm
4. Print the quotation via the gear icon

**Root Cause**
The ‘l10n_br_sales’ module overrides the ‘sale.report_saleorder_document’ template and replaces tax-related fields (‘th_taxes’ and ‘td_taxes’) without rendering the necessary tax values. Additionally, the original call to ‘sale.document_tax_totals’ is replaced with a custom implementation that only displays the total amount with taxes, omitting the untaxed amount and the breakdown of individual tax percentages.

opw-4784819
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
