### PR TITLE
[FIX] base: prevent contact name and info from being cut

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -134,15 +134,15 @@
                             <field name="avatar_128" invisible="1"/> <!-- Needed in contact_image widget -->
                             <div class="d-flex flex-column flex-grow-1">
                                 <field name="company_type" widget="radio" options="{'horizontal': true}"/>
-                                <h1 class="mb-0 w-75">
+                                <h1 class="mb-0 w-md-75">
                                     <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Lumber Inc" invisible="not is_company" required="type == 'contact'"/>
                                     <field options="{'line_breaks': False}" widget="text" class="text-break d-block" name="name" default_focus="1" placeholder="e.g. Brandon Freeman" invisible="is_company" required="type == 'contact'"/>
                                 </h1>
-                                <div class="d-flex align-items-baseline w-50">
+                                <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
                                     <field name="email" class="w-100" widget="email" required="user_ids" placeholder="Email"/>
                                 </div>
-                                <div class="d-flex align-items-baseline w-50">
+                                <div class="d-flex align-items-baseline w-md-50">
                                     <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
                                     <field name="phone" class="w-100" widget="phone" placeholder="Phone"/>
                                 </div>


### PR DESCRIPTION
This PR aims to prevent the name and contact information of a contact from being cut short within the form view.

Prior to this commit, the width of the name and information were defined using `w-*` utility classes, which was working well in desktop but was causing a misalignment with the other inputs of the form view in mobile, as well as cutting the labels short.

To prevent this issue, we simply replicate what has been done in other module and apply these utility classes only above `medium` devices.

task-4793732

| Master | This PR |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/63c33a66-0e9c-4212-9b6f-a95c97fa18d3) | ![image](https://github.com/user-attachments/assets/d9c20eb5-1211-45a5-9f3d-948462d6793b) | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
