### PR TITLE
[FIX] website: smooth scrolling mobile 100vh cover


### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1288,16 +1288,43 @@ registry.FullScreenHeight = publicWidget.Widget.extend({
      * @private
      */
     _computeIdealHeight() {
-        const windowHeight = $(window).outerHeight();
-        if (this.inModal) {
-            return windowHeight;
+        // Compute the smallest viewport height (svh) to use to set up the ideal
+        // height of the element, which won't flicker based on the viewport
+        // resize in mobile (when its browser UI changes).
+        // TODO: should try to use svh directly, combined with `calc` and
+        // CSS variables to avoid this JS as much as possible... but see below:
+        // can't because of Arc browser).
+        const viewportWidth = window.innerWidth;
+        const viewportHeight = window.innerHeight;
+        if (!this.smallestViewportHeight
+                // Update svh definition only if the viewport resize seems to
+                // not be to a mobile browser UI change (e.g. Arc browser
+                // mistakenly changes svh while its UI changes at the moment).
+                || Math.abs(viewportWidth - this.previousViewportWidth) > 15
+                || Math.abs(viewportHeight - this.previousViewportHeight) > 150) {
+            this.previousViewportWidth = viewportWidth;
+            this.previousViewportHeight = viewportHeight;
+            const el = document.createElement('div');
+            el.classList.add('vh-100');
+            el.style.position = 'fixed';
+            el.style.top = '0';
+            el.style.pointerEvents = 'none';
+            el.style.visibility = 'hidden';
+            el.style.setProperty('height', '100svh', 'important');
+            document.body.appendChild(el);
+            this.smallestViewportHeight = parseFloat(el.getBoundingClientRect().height);
+            document.body.removeChild(el);
         }
 
-        // Doing it that way allows to considerer fixed headers, hidden headers,
+        if (this.inModal) {
+            return this.smallestViewportHeight;
+        }
+
+        // Doing it that way allows to consider fixed headers, hidden headers,
         // connected users, ...
         const firstContentEl = $('#wrapwrap > main > :first-child')[0]; // first child to consider the padding-top of main
         const mainTopPos = firstContentEl.getBoundingClientRect().top + document.documentElement.scrollTop;
-        return (windowHeight - mainTopPos);
+        return (this.smallestViewportHeight - mainTopPos);
     },
 });
 

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -1257,7 +1257,10 @@ registry.FullScreenHeight = publicWidget.Widget.extend({
             // rules may alter the full-screen-height class behavior in some
             // cases (blog...).
             this._adaptSize();
-            $(window).on('resize.FullScreenHeight', debounce(() => this._adaptSize(), 250));
+            $(window).on('resize.FullScreenHeight', debounce(() => this._adaptSize(), 250, {
+                leading: true,
+                trailing: true,
+            }));
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -786,6 +786,9 @@ table.table_desc tr td {
     flex-direction: column;
     justify-content: space-around;
     min-height: 100vh !important;
+    // See JS: this is overridden for multiple reasons, including the fact that
+    // Arc browser does not support this correctly at the moment.
+    min-height: 100svh !important;
 }
 .o_half_screen_height {
     @extend .o_full_screen_height;


### PR DESCRIPTION
Scenario:

- add a cover snippet with 100% height at the top of the page
- open the page on a mobile (eg. safari on iOS)
- scroll down the page

Result: there is a vertical jittering of the content of cover snippet
when going down.

Cause: we are setting the size in pixel to {viewport height} - {height
of stuff (menu, logged in user bar, ...)} but the mobile browser changes
the viewport height when going down and hiding the address bar UI, so
the fixed pixel height is only updated when the code is called again
instead of being adapted smoothly.

Fix: set the height of the cover using 100dvh minus the size of the
content, so the height is increased/decreased smoothly by the
application of CSS.

opw-4575726
