### PR TITLE
[FIX] website_sale: show select quantity based on editor

### DIFF
--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -19,7 +19,13 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
     def website_sale_combo_configurator_get_data(self, *args, **kwargs):
         self._populate_currency_and_pricelist(kwargs)
         request.update_context(display_default_code=False)  # Hide internal product reference
-        return super().sale_combo_configurator_get_data(*args, **kwargs)
+        res = super().sale_combo_configurator_get_data(*args, **kwargs)
+        res.update({
+            'show_quantity': (
+                bool(request.website.is_view_active('website_sale.product_quantity'))
+            ),
+        })
+        return res
 
     @route(
         route='/website_sale/combo_configurator/get_price',

--- a/addons/website_sale/static/src/js/website_sale_configurators.js
+++ b/addons/website_sale/static/src/js/website_sale_configurators.js
@@ -22,7 +22,7 @@ WebsiteSale.include({
     },
 
     async _openDialog(isOnProductPage) {
-        const { combos, ...remainingData } = await rpc(
+        const { combos, show_quantity, ...remainingData } = await rpc(
             '/website_sale/combo_configurator/get_data',
             {
                 product_tmpl_id: this.rootProduct.product_template_id,
@@ -52,7 +52,7 @@ WebsiteSale.include({
                 );
             }
             // If some combo choices need to be configured, open the combo configurator.
-            return this._openComboConfigurator(combos, remainingData);
+            return this._openComboConfigurator(combos, remainingData, show_quantity);
         }
         if (this.isBuyNow) {
             return this._submitForm();
@@ -66,7 +66,7 @@ WebsiteSale.include({
             }
         );
         if (shouldShowProductConfigurator) {
-            return this._openProductConfigurator(isOnProductPage);
+            return this._openProductConfigurator(isOnProductPage, show_quantity);
         }
         return this._submitForm();
     },
@@ -75,8 +75,9 @@ WebsiteSale.include({
      * Opens the product configurator dialog.
      *
      * @param isOnProductPage Whether the user is currently on the product page.
+     * @param showQuantity Whether the quantity selector is shown.
      */
-    _openProductConfigurator(isOnProductPage) {
+    _openProductConfigurator(isOnProductPage, showQuantity) {
         this.call('dialog', 'add', ProductConfiguratorDialog, {
             productTemplateId: this.rootProduct.product_template_id,
             ptavIds: this.rootProduct.variant_values,
@@ -92,7 +93,7 @@ WebsiteSale.include({
             isFrontend: true,
             options: {
                 isMainProductConfigurable: !isOnProductPage,
-                showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
+                showQuantity: showQuantity,
             },
             save: async (mainProduct, optionalProducts, options) => {
                 this._trackProducts([mainProduct, ...optionalProducts]);
@@ -114,8 +115,9 @@ WebsiteSale.include({
      *
      * @param combos The combos of the product.
      * @param remainingData Other data needed to open the combo configurator.
+     * @param showQuantity Whether the quantity selector is shown.
      */
-    _openComboConfigurator(combos, remainingData) {
+    _openComboConfigurator(combos, remainingData, showQuantity) {
         this.call('dialog', 'add', ComboConfiguratorDialog, {
             combos: combos.map(combo => new ProductCombo(combo)),
             ...remainingData,
@@ -123,7 +125,7 @@ WebsiteSale.include({
             edit: false,
             isFrontend: true,
             options: {
-                showQuantity: Boolean(document.querySelector('.js_add_cart_json')),
+                showQuantity: showQuantity,
             },
             save: (comboProductData, selectedComboItems, options) =>
                 this.addComboProductToCart(


### PR DESCRIPTION
Currently the show quantity setting visible on /product page does not apply on the product and combo configurator.

We want to uniformize the behavior and if the setting is enabled then view the quantity selector everywhere depending on whether its visible on /product

opw-4716312
opw-4781159

Backport of https://github.com/odoo/odoo/pull/209116




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
