### PR TITLE
[FIX] web_editor, website: prevent snippet tabs nav items removal

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1705,7 +1705,8 @@ export function isUnremovable(node) {
             (node.classList.contains('o_editable') || node.getAttribute('t-set') || node.getAttribute('t-call'))) ||
         (node.classList && node.classList.contains('oe_unremovable')) ||
         (node.nodeName === 'SPAN' && node.parentElement && node.parentElement.getAttribute('data-oe-type') === 'monetary') ||
-        (node.ownerDocument && node.ownerDocument.defaultWindow && !ancestors(node).find(ancestor => ancestor.oid === 'root')) // Node is in DOM but not in editable.
+        (node.ownerDocument && node.ownerDocument.defaultWindow && !ancestors(node).find(ancestor => ancestor.oid === 'root')) || // Node is in DOM but not in editable.
+        (node.dataset && node.dataset.bsToggle === 'tab')
     );
 }
 

--- a/addons/website/static/tests/tours/snippet_tabs.js
+++ b/addons/website/static/tests/tours/snippet_tabs.js
@@ -1,0 +1,81 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("snippet_tabs", {
+    edition: true,
+    url: "/",
+}, () => [
+    wTourUtils.dragNDrop({
+        id: "s_tabs",
+        name: "Tabs",
+    }),
+    {
+        content: "Double click on the first tab link to select all the text",
+        trigger: "iframe .s_tabs .nav-link.active",
+        run: "dblclick",
+    },
+    {
+        content: "Change the text of the tab link",
+        trigger: "iframe .s_tabs .nav-link.active",
+        run() {
+            this.$anchor[0].dispatchEvent(new InputEvent("input", {
+                inputType: "insertText",
+                bubbles: true,
+                data: "Tab #1"
+            }));
+        },
+    },
+    {
+        content: "Check that the first tab link is still there and has the new text",
+        trigger: "iframe .s_tabs .nav-link.active:contains('Tab #1')",
+    },
+    {
+        content: "Double click on the third tab link to select all the text",
+        trigger: "iframe .s_tabs .nav-item:nth-of-type(3) .nav-link:not('.active')",
+        run: "dblclick",
+    },
+    {
+        content: "Remove the text of the tab link and add a new text",
+        trigger: "iframe .s_tabs .nav-item:nth-of-type(3) .nav-link.active:not(:contains('Tab #1'))",
+        run() {
+            this.$anchor[0].dispatchEvent(new KeyboardEvent("keydown", {
+                key: "Backspace",
+                bubbles: true
+            }));
+            this.$anchor[0].dispatchEvent(new InputEvent("input", {
+                inputType: "insertText",
+                bubbles: true,
+                data: "Tab #3"
+            }));
+        },
+    },
+    {
+        content: "Check that the third tab link is still there and has the new text",
+        trigger: "iframe .s_tabs .nav-item:nth-of-type(3) .nav-link.active:contains('Tab #3')",
+    },
+    wTourUtils.changeOption("NavTabs", "we-button[data-remove-item]"),
+    {
+        content: "Check that only 2 tab panes remain",
+        trigger: "iframe .s_tabs .s_tabs_content",
+        run() {
+            if (this.$anchor[0].querySelectorAll(".tab-pane").length !== 2) {
+                console.error("There should be exactly 2 tab panes in the DOM.");
+            }
+        },
+    },
+    {
+        content: "Check that the first tab link is active",
+        trigger: "iframe .s_tabs .nav-item:nth-of-type(1) .nav-link.active",
+    },
+    wTourUtils.changeOption("NavTabs", "we-button[data-add-item]"),
+    {
+        content: "Check there are 3 tab panes",
+        trigger: "iframe .s_tabs .s_tabs_content",
+        run() {
+            if (this.$anchor[0].querySelectorAll(".tab-pane").length !== 3) {
+                console.error("There should be exactly 3 tab panes in the DOM.");
+            }
+        },
+    },
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -135,3 +135,6 @@ class TestSnippets(HttpCase):
 
     def test_snippet_popup_open_on_top(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_open_on_top', login='admin')
+
+    def test_tabs_snippet(self):
+        self.start_tour(self.env["website"].get_client_action_url("/"), "snippet_tabs", login="admin")


### PR DESCRIPTION
**[FIX] web_editor, website: prevent snippet tabs nav items removal**

Steps to reproduce:

1. Go to Website edit mode.
2. Add a "Tabs" block.
3. Double-click a tab title to select it.
4. Start typing a new title.

:white_check_mark: Expected: The tab title is replaced with the new text.
:x: Actual: The tab is deleted and merged with the next one.

This commit fixes the bug by preventing the deletion of elements with the `data-bs-toggle: 'tab'` attribute.
These are clearly not elements that an user should ever be allowed to delete.

This commit also adds a test for the "Tab" snippet to prevent the bug from coming back.
It also covers other flows that were previously known to be buggy in the "Tabs" snippet.

opw-4791238