### PR TITLE
[IMP] *: fix manifest website

### DIFF
--- a/addons/l10n_es_edi_facturae/__manifest__.py
+++ b/addons/l10n_es_edi_facturae/__manifest__.py
@@ -4,13 +4,13 @@
     'name': 'Spain - Facturae EDI',
     'version': '1.0',
     'category': 'Accounting/Localizations/EDI',
-    'website': 'https://www.facturae.gob.es/face/Paginas/FACE.aspx',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/accounting/customer_invoices/electronic_invoicing/spain.html',
     'description': """
 This module create the Facturae file required to send the invoices information to the General State Administrations.
 It allows the export and signature of the signing of Facturae files.
-The current version of Facturae supported is the 3.2.2
+The current version of Facturae supported is the 3.2.2.
 
-for more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
+For more informations, see https://www.facturae.gob.es/face/Paginas/FACE.aspx
     """,
     'depends': [
         'certificate',

--- a/addons/l10n_hu_edi/__manifest__.py
+++ b/addons/l10n_hu_edi/__manifest__.py
@@ -8,8 +8,10 @@
     'description': """
 * Electronically report invoices to the NAV (Hungarian Tax Agency) when issuing physical (paper) invoices.
 * Perform the Tax Audit Export (Adóhatósági Ellenőrzési Adatszolgáltatás) in NAV 3.0 format.
+
+https://www.odootech.hu
     """,
-    'website': 'https://www.odootech.hu',
+    'website': 'https://www.odoo.com/documentation/master/applications/finance/accounting/customer_invoices/electronic_invoicing/hungary.html',
     'depends': ['account_debit_note', 'base_iban', 'l10n_hu'],
     'data': [
         'security/ir.model.access.csv',

--- a/addons/payment_mollie/__manifest__.py
+++ b/addons/payment_mollie/__manifest__.py
@@ -5,10 +5,13 @@
     'version': '1.0',
     'category': 'Accounting/Payment Providers',
     'sequence': 350,
-    'summary': "A Dutch payment provider covering several European countries.",
+    'summary': """
+A Dutch payment provider covering several European countries.
+
+https://www.mollie.com""",
     'description': " ",  # Non-empty string to avoid loading the README file.
     'author': 'Odoo S.A., Applix BV, Droggol Infotech Pvt. Ltd.',
-    'website': 'https://www.mollie.com',
+    'website': 'https://www.odoo.com/documentation/latest/applications/finance/payment_providers/mollie.html',
     'depends': ['payment'],
     'data': [
         'views/payment_mollie_templates.xml',


### PR DESCRIPTION
All modules from odoo/odoo should have website: https://www.odoo.com
