### PR TITLE
[FIX] point_of_sale: auto-reconcile POS customer account move lines

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1030,7 +1030,7 @@ class PosSession(models.Model):
         # Entries related to 'pay_later' payment method- should not be excluded from follow-ups
         for val in vals:
             val['blocked'] = False
-        MoveLine.create(vals)
+        data['pay_later_move_lines'] = MoveLine.create(vals)
         return data
 
     def _create_combine_account_payment(self, payment_method, amounts, diff_amount):
@@ -1226,7 +1226,7 @@ class PosSession(models.Model):
         stock_output_lines = data.get('stock_output_lines')
         payment_method_to_receivable_lines = data.get('payment_method_to_receivable_lines')
         payment_to_receivable_lines = data.get('payment_to_receivable_lines')
-
+        pay_later_move_lines = data.get('pay_later_move_lines')
 
         all_lines = (
               split_cash_statement_lines
@@ -1272,6 +1272,27 @@ class PosSession(models.Model):
             ( stock_output_lines[account_id]
             | stock_account_move_lines.filtered(lambda aml: aml.account_id == account_id)
             ).filtered(lambda aml: not aml.reconciled).with_context(no_cash_basis=True).reconcile()
+
+        # reconcile customer receivable move lines
+        if pay_later_move_lines:
+            account_ids = pay_later_move_lines.mapped("account_id")
+            partner_ids = pay_later_move_lines.mapped("partner_id")
+            pay_later_move_lines |= pay_later_move_lines.search(
+                [
+                    "|",
+                    ("journal_id", "=", self.config_id.journal_id.id),
+                    "&",
+                    ("move_type", "=", "out_invoice"),
+                    ("move_id.pos_order_ids", "!=", False),
+                    ("account_id", "in", account_ids.ids),
+                    ("partner_id", "in", partner_ids.ids),
+                    ("reconciled", "=", False),
+                ]
+            )
+
+            for partner in pay_later_move_lines.mapped("partner_id"):
+                pay_later_move_lines.filtered(lambda p: p.partner_id.id == partner.id).reconcile()
+
         return data
 
     def _get_rounding_difference_vals(self, amount, amount_converted):


### PR DESCRIPTION
### Problem:
When paying a PoS order using customer account, an account move line debiting Account Receivable will be created. Settling this amount inside the PoS (by depositing money) will create another account move line crediting Account Receivable (represents the payment). The second move line is considered, by Odoo, as an outstanding amount, and this amount can be used to pay another invoice (sale order invoice). The moves affecting Account Receivable are still correct. However, unreconciling the two lines created from PoS will cause a confusion for clients who may use this amount to pay other invoices.

This PR covers versions 17.4 to 18.1, as reconciliation logic differs in later versions.

### How to reproduce:
    * Open a PoS session.
    * Create an order and pay using customer account.
    * Settle this customer's account (inside PoS).
    * Create a Sale Order and invoice it (or just an invoice).
    * The amount settled can be used as outstanding amount and can be used to pay the created invoice.

opw-4794793

enterprise PR: https://github.com/odoo/enterprise/pull/85900
