### PR TITLE
[17.0][FIX] web_editor: Do not display attachments from HTML editor in the chatter

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -3586,7 +3586,6 @@ export class Wysiwyg extends Component {
                 data: imageData,
                 is_image: true,
                 res_model: resModel,
-                res_id: resId,
             },
         );
         if (attachment.mimetype === 'image/webp') {

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -716,7 +716,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
             if (route === '/web_editor/attachment/add_data') {
                 // Check that the correct record model and id were sent.
                 assert.equal(args.res_model, 'partner');
-                assert.equal(args.res_id, 1);
+                assert.equal(args.res_id, undefined);
                 return {
                     image_src: '/test_image_url.png',
                     access_token: '1234',


### PR DESCRIPTION
Before this commit, every image added through the HTML editor was displayed in the chatter after saving the record. This behavior did not occur in previous versions.

To prevent this, we avoid passing the `res_id` parameter, so the attachment is created but not linked to any record, and therefore not shown in the chatter.

Before

https://github.com/user-attachments/assets/b0fa7e95-47c2-44ec-99bc-55c5e279e655



After

https://github.com/user-attachments/assets/1d3a678d-69a5-4608-9232-a42b488aae36



This change was introduced in this PR: https://github.com/odoo/odoo/pull/131776

TT56108
@cammarosano @dmo-odoo @pedrobaeza could you please review this

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr


