### PR TITLE
[FIX] html_editor: fix an old typo

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1180,7 +1180,7 @@ export class HistoryPlugin extends Plugin {
     }
 
     _onDocumentBeforeInput(ev) {
-        if (this.editable.contains(ev.targget)) {
+        if (this.editable.contains(ev.target)) {
             return;
         }
         if (["historyUndo", "historyRedo"].includes(ev.inputType)) {


### PR DESCRIPTION
There was a typo in the history plugin, making an `if` statement useless. This fixes the typo.

Backport of https://github.com/odoo/odoo/pull/186917/commits/0269326853abd35e988359e776632b47febf2e60.