### PR TITLE
[FIX] website_*: review subnav styling

### DIFF
--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -8,7 +8,7 @@
     <t t-set="wblog_nav_offcanvas" t-value="len(blogs) > 4"/>
     <t t-set="wblog_all_title_string">All Blogs</t>
 
-    <nav t-attf-class="navbar navbar-expand-lg navbar-light pt-4 pb-0 px-0 #{additionnal_classes}">
+    <nav t-attf-class="navbar navbar-expand-lg pt-4 pb-0 px-0 #{additionnal_classes}">
         <div t-attf-class="container gap-2 w-100 #{wblog_nav_offcanvas and 'flex-nowrap' or 'flex-wrap flex-sm-nowrap'}">
             <!-- Desktop -->
             <ul t-if="len(blogs) > 1" class="navbar-nav d-none d-lg-flex flex-wrap">

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -103,7 +103,7 @@
 <template id="detail" name="Job Detail" track="1">
     <t t-call="website.layout">
         <!-- Topbar -->
-        <nav class="navbar navbar-light border-top shadow-sm d-print-none">
+        <nav class="navbar border-top shadow-sm d-print-none">
             <div class="container">
                 <div class="d-flex flex-column flex-md-row flex-md-wrap flex-lg-nowrap justify-content-between w-100">
                     <!-- Title -->

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -672,7 +672,7 @@
     <div t-if="not invite_preview" class="o_wslides_lesson_nav mb-4">
         <div class="container">
             <div class="row">
-                <nav class="navbar navbar-expand-lg navbar-light bg-transparent col">
+                <nav class="navbar navbar-expand-lg col">
                     <a class="navbar-brand d-lg-none" href="#">Filter &amp; order</a>
 
                     <div class="ms-auto d-lg-none" t-if="search_slide_category or search">

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -22,7 +22,7 @@
             </section>
             </div>
             <div class="container mt16 o_wslides_home_nav position-relative">
-                <nav class="navbar navbar-expand-lg navbar-light shadow-sm">
+                <nav class="o_cc o_cc1 navbar navbar-expand-lg px-2 shadow-sm">
                     <t t-call="website.website_search_box_input">
                         <t t-set="_form_classes" t-valuef="o_wslides_nav_navbar_right order-lg-3"/>
                         <t t-set="search_type" t-valuef="slides"/>
@@ -195,7 +195,7 @@
             </div>
             <div class="container mt16 o_wslides_home_nav position-relative">
                 <!-- Navbar dynamically composed using displayed channel tag groups. -->
-                <nav class="navbar navbar-expand-md navbar-light shadow-sm ps-0">
+                <nav class="o_cc o_cc1 navbar navbar-expand-md shadow-sm px-2">
                     <div class="navbar-nav border-end">
                         <a class="nav-link nav-item px-3" href="/slides"><i class="oi oi-chevron-left"/></a>
                     </div>


### PR DESCRIPTION
*: website_blogs, website_slides, website_hr_recruitment 

The subnav is taking the background color of the main nav. It should match the bg-color instead.

On `website_slides` the current subnav's content stick to the edges of the subnav. This PR adds some horizontal spacing to these navs.

task-4555621

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
