### PR TITLE
[FIX] crm, project: remove allow_order option from non-stored field view

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -727,7 +727,7 @@
                     <field name="priority" optional="hide" widget="priority"/>
                     <field name="activity_ids" optional="hide" widget="list_activity"/>
                     <field name="activity_user_id" optional="hide" string="Activity by" widget="many2one_avatar_user"/>
-                    <field name="my_activity_date_deadline" optional="hide" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}"/>
+                    <field name="my_activity_date_deadline" optional="hide" string="My Deadline" widget="remaining_days"/>
                     <field name="campaign_id" optional="hide"/>
                     <field name="medium_id" optional="hide"/>
                     <field name="source_id" optional="hide"/>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -487,7 +487,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide" decoration-danger="date_deadline and date_deadline &lt; current_date"/>
                                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="hide"/>
-                                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}" optional="hide"/>
+                                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" optional="hide"/>
                                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
@@ -532,7 +532,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide" decoration-danger="date_deadline and date_deadline &lt; current_date"/>
                                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="hide"/>
-                                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}" optional="hide"/>
+                                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" optional="hide"/>
                                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>


### PR DESCRIPTION
Currently, an error occurs when a user tries to add a sub-task and clicks multiple times on the `My Deadline` column (which is not stored) before saving. This prevents the user from successfully adding sub-tasks.

**Steps to produce:**

- Install the `project` module.
- Navigate to `Project > Tasks > All Tasks` and open any task.
- In the `Sub-tasks` page, unhide the `My Deadline` field.
- `Add a line` and click multiple times on `My Deadline`, then try to `save`.

**Error:**
`ValueError: Cannot convert project.task.my_activity_date_deadline to SQL because it is not stored`

**Root Cause:**
At [1] and [2], the field `my_activity_date_deadline` is a computed field with `store=False`, meaning it does not exist in the database. The view, however, incorrectly sets `options={allow_order: 1}` on the column, which causes Odoo to generate an `SQL ORDER BY` on this `non-stored` field.

[1] https://github.com/odoo/odoo/blob/dfdf1c43fd3f2a39c205ccf97f139c2e1fcd213e/addons/project/views/project_task_views.xml#L490
[2] https://github.com/odoo/odoo/blob/dfdf1c43fd3f2a39c205ccf97f139c2e1fcd213e/addons/project/views/project_task_views.xml#L535

This commit ensures the `My Deadline` field is no longer sortable by removing the `allow_order` option from its column definition, preventing `Value error` triggered by attempting to sort on a non-stored field.

sentry - 6604203533
