### PR TITLE
[FIX] purchase: show purchased quantity in smart button if product is archived

### DIFF
--- a/addons/purchase/models/product.py
+++ b/addons/purchase/models/product.py
@@ -31,8 +31,10 @@ class ProductTemplate(models.Model):
                 product.purchase_method = default_purchase_method
 
     def _compute_purchased_product_qty(self):
-        for template in self:
-            template.purchased_product_qty = float_round(sum([p.purchased_product_qty for p in template.product_variant_ids]), precision_rounding=template.uom_id.rounding)
+        for template in self.with_context(active_test=False):
+            template.purchased_product_qty = float_round(sum(p.purchased_product_qty for
+                p in template.product_variant_ids), precision_rounding=template.uom_id.rounding
+            )
 
     @api.model
     def get_import_templates(self):
@@ -46,7 +48,10 @@ class ProductTemplate(models.Model):
 
     def action_view_po(self):
         action = self.env["ir.actions.actions"]._for_xml_id("purchase.action_purchase_history")
-        action['domain'] = ['&', ('state', 'in', ['purchase', 'done']), ('product_id', 'in', self.product_variant_ids.ids)]
+        action['domain'] = [
+            ('state', 'in', ['purchase', 'done']),
+            ('product_id', 'in', self.with_context(active_test=False).product_variant_ids.ids),
+        ]
         action['display_name'] = _("Purchase History for %s", self.display_name)
         return action
 

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -559,3 +559,33 @@ class TestPurchase(AccountTestInvoicingCommon):
         po = po_form.save()
 
         self.assertEqual(po.order_line[0].price_unit, 3.0)
+
+    def test_action_view_po_when_product_template_archived(self):
+        """
+        Test to ensure that the purchased_product_qty value remains the same
+        after archiving the product template. Also check that the purchased smart
+        button returns the correct purchase order lines.
+        """
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'product_qty': 10,
+                    'price_unit': 1,
+                }),
+            ],
+        })
+        po.button_confirm()
+        product_tmpl = self.product_a.product_tmpl_id
+        self.assertEqual(product_tmpl.purchased_product_qty, 10)
+
+        product_tmpl.action_archive()
+        # Need to flush the recordsets to recalculate the purchased_product_qty after archiving
+        product_tmpl.invalidate_recordset()
+
+        self.assertEqual(product_tmpl.purchased_product_qty, 10)
+
+        action = product_tmpl.action_view_po()
+        action_record = self.env[action['res_model']].search(action['domain'])
+        self.assertEqual(action_record, po.order_line)


### PR DESCRIPTION
<b>Steps to reproduce :</b>

1) Install the Purchase module
2) Create and confirm a Purchase Order with a product and quantity 
3) From the Purchase Order, open the product and archive it

<b>Issue:</b>
Before archiving the product, the `Purchased` smart button correctly displays 
the total purchased quantity.

However, after archiving the product template, this smart button displays `0.0`, 
even though purchases exist.

Additionally, clicking the button opens a blank purchase order line view instead 
of showing related records if the product is archived.

<b>Cause:-</b>
Archiving a product template sets active=False on the template and its variants. 
The computed field `purchased_product_qty` relies on the variants to calculate the total. 
Because the variants are inactive post-archival, the compute method sees no records, 
resulting in a displayed value of 0.0.

Similarly, the smart button action uses the active variants in its domain, 
so it fails to find any related purchase order lines.

<b>Solution:</b>

The context is now explicitly set with active_test=False when computing 
the purchased_product_qty and when generating the domain for the smart button action.

This ensures that even inactive variants are included in the calculation and the view logic, 
preserving the correct purchased quantity and showing the relevant purchase lines after archival.

opw-4781578
