### PR TITLE
[FIX] resource_mail,hr: fix avatar card in employee

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -317,3 +317,6 @@ class HrEmployeeBase(models.AbstractModel):
             calendar = employee.resource_calendar_id or employee.company_id.resource_calendar_id
             calendar_periods_by_employee[employee] = [(start, stop, calendar)]
         return calendar_periods_by_employee
+
+    def get_avatar_card_data(self, fields):
+        return self._read_format(fields)

--- a/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
+++ b/addons/hr/static/tests/legacy/m2x_avatar_employee_tests.js
@@ -215,7 +215,7 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
                             },
                         });
                     }
-                    if (route === "/web/dataset/call_kw/resource.resource/get_avatar_card_data") {
+                    if (route === "/web/dataset/call_kw/hr.employee.public/get_avatar_card_data") {
                         const resourceIdArray = args.args[0];
                         const resourceId = resourceIdArray[0];
                         const resources = pyEnv['hr.employee.public'].search_read([['id', '=', resourceId]]);
@@ -537,8 +537,8 @@ QUnit.module("M2XAvatarEmployee", ({ beforeEach }) => {
                 )[1]
             );
             assert.verifySteps([
-                `read resource.resource ${employeeId_1}`,
-                `read resource.resource ${employeeId_2}`,
+                `read hr.employee ${employeeId_1}`,
+                `read hr.employee ${employeeId_2}`,
             ]);
         }
     );

--- a/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
+++ b/addons/hr_skills/static/tests/many2one_avatar_employee.test.js
@@ -28,7 +28,7 @@ test("many2one_avatar_employee widget in kanban view with skills on avatar card"
     pyEnv["m2o.avatar.employee"].create([{ employee_id: pierreEid }]);
     await start();
 
-    onRpc("resource.resource", "get_avatar_card_data", (params) => {
+    onRpc("hr.employee", "get_avatar_card_data", (params) => {
         const resourceIdArray = params.args[0];
         const resourceId = resourceIdArray[0];
         const resources = pyEnv['hr.employee.public'].read([resourceId]);

--- a/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
+++ b/addons/resource_mail/static/src/components/avatar_card_resource/avatar_card_resource_popover.js
@@ -29,7 +29,7 @@ export class AvatarCardResourcePopover extends AvatarCardPopover {
     }
 
     async onWillStart() {
-        [this.record] = await this.orm.call('resource.resource', 'get_avatar_card_data', [[this.props.id], this.fieldNames], {});
+        [this.record] = await this.orm.call(this.props.recordModel, 'get_avatar_card_data', [[this.props.id], this.fieldNames], {});
         await Promise.all(this.loadAdditionalData());
     }
 


### PR DESCRIPTION
Steps to reproduce:
- When the planning module is not installed and we click on employee avatar
- This leads to a traceback, especially when the related employee data is
  available only in hr.employee.public or hr.employee.

Cause:
- The avatar card component was using a hardcoded model instead of dynamically
  using props.record.model.

 Although a custom get_avatar_card_data method was introduced to centralize data
 logic, it was not implemented on all relevant models (hr.employee,
 hr.employee.public), which caused traceback in  certain setups.

Solution:
- Replaced the hardcoded model with props.record.model to dynamically
  resolve the model.
- Added the get_avatar_card_data method to hr.employee.base to ensure
  compatibility.

Ensured the logic works correctly even when the planning module is not installed.

Follow-up to:
- Commit : https://github.com/odoo/odoo/pull/187171 https://github.com/odoo/enterprise/pull/75121
- prevent component destruction which moved avatar card data fetching into a parent method to avoid lifecycle issues.

Related task-4210513
task - 4777570