### PR TITLE
[IMP] im_livechat: open form view directly from pivot if only one record

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -6,7 +6,7 @@
             <field name="name">im_livechat.report.channel.pivot</field>
             <field name="model">im_livechat.report.channel</field>
             <field name="arch" type="xml">
-                <pivot string="Livechat Support Statistics" sample="1" display_quantity="1">
+                <pivot string="Livechat Support Statistics" sample="1" display_quantity="1" js_class="im_livechat.report_channel_pivot_view">
                     <field name="has_call" type="measure" invisible="1"/>
                     <field name="call_duration_hour" type="measure" widget="float_time"/>
                     <field name="partner_id" type="row"/>

--- a/addons/im_livechat/static/src/views/lazy/im_livechat_report_pivot_renderer.js
+++ b/addons/im_livechat/static/src/views/lazy/im_livechat_report_pivot_renderer.js
@@ -1,0 +1,42 @@
+import { registry } from "@web/core/registry";
+import { PivotRenderer } from "@web/views/pivot/pivot_renderer";
+import { pivotView } from "@web/views/pivot/pivot_view";
+
+export class ImLiveChatReportPivotRenderer extends PivotRenderer {
+    setup() {
+        super.setup();
+        this.recordCount = 0;
+    }
+
+    openView(domain, views, context, newWindow) {
+        if (this.recordCount !== 1) {
+            super.openView(domain, views, context, newWindow);
+            return;
+        }
+        this.model.orm
+            .search(this.model.metaData.resModel, domain, { limit: 1 })
+            .then(([reportId]) => {
+                this.actionService.doAction({
+                    name: this.model.metaData.title,
+                    type: "ir.actions.act_window",
+                    res_model: this.model.metaData.resModel,
+                    res_id: reportId,
+                    views: [[false, "form"]],
+                    target: "current",
+                    context,
+                });
+            });
+    }
+
+    onOpenView(cell, newWindow) {
+        [this.recordCount] = this.model.data.counts[JSON.stringify(cell.groupId)];
+        super.onOpenView(cell, newWindow);
+    }
+}
+
+export const ImLiveChatReportPivotView = {
+    ...pivotView,
+    Renderer: ImLiveChatReportPivotRenderer,
+};
+
+registry.category("views").add("im_livechat.report_channel_pivot_view", ImLiveChatReportPivotView);

--- a/addons/im_livechat/static/tests/tours/im_livechat_report_pivot_redirect_tour.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_report_pivot_redirect_tour.js
@@ -1,0 +1,36 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("im_livechat_report_pivot_redirect_tour", {
+    steps: () => [
+        {
+            content: "open command palette",
+            trigger: "body",
+            run: "press ctrl+k",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill /Reporting",
+        },
+        {
+            trigger: ".o_command:contains(Agents)",
+            run: "click",
+        },
+        {
+            content: "click on a cell that has a single related record",
+            trigger: ".o_pivot table tbody tr:eq(2) td:eq(0)",
+            run: "click",
+        },
+        { trigger: ".o-mail-Discuss" },
+        {
+            content: "go back to the pivot view.",
+            trigger: ".o_back_button",
+            run: "click",
+        },
+        {
+            content: "click on a cell that has more than one related record",
+            trigger: ".o_pivot table tbody tr:eq(0) td:eq(0)",
+            run: "click",
+        },
+        { trigger: ".o_list_view" },
+    ],
+});

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -3,8 +3,9 @@
 from freezegun import freeze_time
 from unittest.mock import patch
 
+from odoo import Command
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
-from odoo.tests.common import tagged
+from odoo.tests.common import new_test_user, tagged
 
 
 @tagged("post_install", "-at_install")
@@ -68,3 +69,35 @@ class TestImLivechatReport(TestImLivechatCommon):
     def _create_message(cls, channel, author, date):
         with patch.object(cls.env.cr, 'now', lambda: date):
             return channel.message_post(author_id=author.id, body=f'Message {date}')
+
+    def test_redirect_to_form_from_pivot(self):
+        operator_1 = new_test_user(self.env, login="operator_1", groups="im_livechat.im_livechat_group_manager")
+        operator_2 = new_test_user(self.env, login="operator_2")
+        [partner_1, partner_2] = self.env["res.partner"].create([{"name": "test 1"}, {"name": "test 2"}])
+        [channel_1, channel_2, channel_3] = self.env["discuss.channel"].create(
+            [{
+                "name": "test 1",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator_1.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": partner_1.id})],
+            },
+            {
+                "name": "test 2",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator_1.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": partner_2.id})],
+            },
+            {
+                "name": "test 3",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator_2.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": partner_2.id})],
+            }]
+        )
+        self._create_message(channel_1, operator_1.partner_id, "2025-06-26 10:05:00")
+        self._create_message(channel_2, operator_1.partner_id, "2025-06-26 10:15:00")
+        self._create_message(channel_3, operator_2.partner_id, "2025-06-26 10:25:00")
+        self.start_tour("/odoo", "im_livechat_report_pivot_redirect_tour", login="operator_1")


### PR DESCRIPTION
**Purpose of this PR**:

For Livechat Support Channel Report when a pivot cell is clicked and the resulting domain returns only one record,
the form view is now opened directly, bypassing the list view.

**task**-[4753032](https://www.odoo.com/odoo/all-tasks/4753032)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr