### PR TITLE
[IMP] mail, *: Activity revamp finishing touches

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -17,7 +17,7 @@ class MailActivity(models.Model):
             'default_activity_type_id': self.activity_type_id.id,
             'default_res_id': self.env.context.get('default_res_id'),
             'default_res_model': self.env.context.get('default_res_model'),
-            'default_name': self.summary or self.res_name,
+            'default_name': self.res_name,
             'default_description': self.note if not is_html_empty(self.note) else '',
             'default_activity_ids': [(6, 0, self.ids)],
             'default_partner_ids': self.user_id.partner_id.ids,

--- a/addons/calendar/views/mail_activity_views.xml
+++ b/addons/calendar/views/mail_activity_views.xml
@@ -27,10 +27,10 @@
             <xpath expr="//field[@name='summary']" position="attributes">
                 <attribute name="invisible" add="activity_category == 'meeting'" separator="or"/>
             </xpath>
-            <xpath expr="//field[@name='summary']" position="after">
+            <xpath expr="//field[@name='note']" position="before">
                 <div invisible="activity_category != 'meeting'" class="text-muted text-center w-100">
                     <div>
-                        <i class="fa fa-3x fa-calendar p-5" title="Calendar" aria-hidden="true"/>
+                        <i class="fa fa-9x fa-calendar p-3" title="Calendar" aria-hidden="true"/>
                     </div>
                     <p>Schedule a meeting in your calendar</p>
                 </div>
@@ -39,7 +39,7 @@
                   <field name="calendar_event_id" invisible="1" />
                   <button string="Schedule"
                         close="1"
-                        invisible="activity_category not in ['meeting'] or calendar_event_id"
+                        invisible="activity_category != 'meeting' or calendar_event_id"
                         name="action_create_calendar_event"
                         type="object"
                         class="btn-primary"/>

--- a/addons/calendar/wizard/mail_activity_schedule_views.xml
+++ b/addons/calendar/wizard/mail_activity_schedule_views.xml
@@ -18,13 +18,13 @@
             <xpath expr="//field[@name='note']" position="attributes">
                 <attribute name="invisible">activity_category == 'meeting'</attribute>
             </xpath>
-            <xpath expr="//field[@name='summary']" position="attributes">
+            <xpath expr="//group[@name='summary_group']" position="attributes">
                 <attribute name="invisible">activity_category == 'meeting'</attribute>
             </xpath>
-            <xpath expr="//field[@name='summary']" position="after">
+            <xpath expr="//field[@name='note']" position="before">
                 <div invisible="activity_category != 'meeting'" class="text-muted text-center w-100">
                     <div>
-                        <i class="fa fa-3x fa-calendar p-5" title="Calendar" aria-hidden="true"/>
+                        <i class="fa fa-9x fa-calendar p-3" title="Calendar" aria-hidden="true"/>
                     </div>
                     <p>Schedule a meeting in your calendar</p>
                 </div>

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1338,6 +1338,7 @@ class CrmLead(models.Model):
         }
         return action
 
+    # Deprecated in 18.3 onwards
     def action_snooze(self):
         self.ensure_one()
         my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]

--- a/addons/hr/tests/test_mail_activity_plan.py
+++ b/addons/hr/tests/test_mail_activity_plan.py
@@ -231,15 +231,15 @@ class TestActivitySchedule(ActivityScheduleHRCase):
             self.employee_manager.user_id = False
             form = self._instantiate_activity_schedule_wizard(employees)
             form.plan_id = self.plan_onboarding
-            self.assertTrue(form.has_error)
-            n_error = form.error.count('<li>')
-            self.assertEqual(n_error, 2 * len(employees))
-            self.assertIn(f"The user of {self.employee_1.name}'s coach is not set.", form.error)
-            self.assertIn(f'The manager of {self.employee_1.name} should be linked to a user.', form.error)
+            self.assertTrue(form.has_warning)
+            n_warning = form.warning.count('<li>')
+            self.assertEqual(n_warning, 2 * len(employees))
+            self.assertIn(f"The user of {self.employee_1.name}'s coach is not set.", form.warning)
+            self.assertIn(f'The manager of {self.employee_1.name} should be linked to a user.', form.warning)
             if len(employees) > 1:
-                self.assertIn(f"The user of {self.employee_2.name}'s coach is not set.", form.error)
-                self.assertIn(f'The manager of {self.employee_2.name} should be linked to a user.', form.error)
-            with self.assertRaises(ValidationError):
-                form.save()
+                self.assertIn(f"The user of {self.employee_2.name}'s coach is not set.", form.warning)
+                self.assertIn(f'The manager of {self.employee_2.name} should be linked to a user.', form.warning)
+            # should save without error, with coach
+            form.save()
             self.employee_coach.user_id = self.user_coach
             self.employee_manager.user_id = self.user_manager

--- a/addons/hr_fleet/models/mail_activity_plan_template.py
+++ b/addons/hr_fleet/models/mail_activity_plan_template.py
@@ -24,12 +24,14 @@ class MailActivityPlanTemplate(models.Model):
             employee_id = self.env['hr.employee'].browse(employee._origin.id)
             vehicle = employee_id.car_ids[:1]
             error = False
+            warning = False
             if not vehicle:
                 error = _('Employee %s is not linked to a vehicle.', employee_id.name)
             if vehicle and not vehicle.manager_id:
-                error = _("The vehicle of employee %(employee)s is not linked to a fleet manager.", employee=employee_id.name)
+                warning = _("The vehicle of employee %(employee)s is not linked to a fleet manager, assigning to you.", employee=employee_id.name)
             return {
-                'responsible': vehicle.manager_id,
+                'responsible': vehicle.manager_id or self.env.user,
                 'error': error,
+                'warning': warning
             }
         return super()._determine_responsible(on_demand_responsible, employee)

--- a/addons/hr_fleet/tests/test_mail_activity_plan.py
+++ b/addons/hr_fleet/tests/test_mail_activity_plan.py
@@ -66,12 +66,12 @@ class TestActivitySchedule(ActivityScheduleHRCase):
         self.employee_1.car_ids[0].manager_id = False
         form = self._instantiate_activity_schedule_wizard(employees)
         form.plan_id = self.plan_fleet
-        self.assertTrue(form.has_error)
-        n_error = form.error.count('<li>')
-        self.assertEqual(n_error, 1)
-        self.assertIn(f"The vehicle of employee {self.employee_1.name} is not linked to a fleet manager.", form.error)
-        with self.assertRaises(ValidationError):
-            form.save()
+        self.assertTrue(form.has_warning)
+        n_warning = form.warning.count('<li>')
+        self.assertEqual(n_warning, 1)
+        self.assertIn(f"The vehicle of employee {self.employee_1.name} is not linked to a fleet manager, assigning to you.", form.warning)
+        # assert form can now be saved without raising an error
+        form.save()
 
         self.employee_1.car_ids = self.env["fleet.vehicle"]
         form = self._instantiate_activity_schedule_wizard(employees)

--- a/addons/mail/data/mail_activity_type_data.xml
+++ b/addons/mail/data/mail_activity_type_data.xml
@@ -26,11 +26,11 @@
             <field name="summary">To-Do</field>
             <field name="icon">fa-check</field>
             <field name="delay_count">5</field>
-            <field name="sequence">12</field>
+            <field name="sequence">2</field>
         </record>
         <record id="mail_activity_data_upload_document" model="mail.activity.type">
-            <field name="name">Upload Document</field>
-            <field name="summary">Upload Document</field>
+            <field name="name">Document</field>
+            <field name="summary">Document</field>
             <field name="icon">fa-upload</field>
             <field name="delay_count">5</field>
             <field name="sequence">25</field>

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -585,6 +585,7 @@ class MailActivity(models.Model):
             'views': [(False, 'form')],
         }
 
+    # Deprecated in 18.3 onwards
     def action_snooze(self):
         today = date.today()
         for activity in self:

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -318,6 +318,24 @@ class MailActivityMixin(models.AbstractModel):
             ]).unlink()
         return res
 
+    # Reschedules next my activity to Today
+    def action_reschedule_my_next_today(self):
+        self.ensure_one()
+        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        my_next_activity.action_reschedule_today()
+
+    # Reschedules next my activity to Tomorrow
+    def action_reschedule_my_next_tomorrow(self):
+        self.ensure_one()
+        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        my_next_activity.action_reschedule_tomorrow()
+
+    # Reschedules next my activity to Next Monday
+    def action_reschedule_my_next_nextweek(self):
+        self.ensure_one()
+        my_next_activity = self.activity_ids.filtered(lambda activity: activity.user_id == self.env.user)[:1]
+        my_next_activity.action_reschedule_nextweek()
+
     def activity_send_mail(self, template_id):
         """ Automatically send an email based on the given mail.template, given
         its ID. """

--- a/addons/mail/models/mail_activity_plan.py
+++ b/addons/mail/models/mail_activity_plan.py
@@ -13,7 +13,7 @@ class MailActivityPlan(models.Model):
         return [
             (model.model, model.name)
             for model in self.env['ir.model'].sudo().search(
-                ['&', ('is_mail_thread', '=', True), ('transient', '=', False)])
+                ['&', ('is_mail_activity', '=', True), ('transient', '=', False)])
         ]
 
     name = fields.Char('Name', required=True)

--- a/addons/mail/models/mail_activity_plan_template.py
+++ b/addons/mail/models/mail_activity_plan_template.py
@@ -149,6 +149,7 @@ class MailActivityPlanTemplate(models.Model):
         """
         self.ensure_one()
         error = False
+        warning = False
         if self.responsible_type == 'other':
             responsible = self.responsible_id
         elif self.responsible_type == 'on_demand':
@@ -162,4 +163,5 @@ class MailActivityPlanTemplate(models.Model):
         return {
             'responsible': responsible,
             'error': error,
+            'warning': warning,
         }

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -385,7 +385,7 @@ class ResUsers(models.Model):
             if activity.res_model:
                 activities_rec_groups[activity.res_model][activity.res_id] += activity
             else:
-                activities_model_groups["mail.activity"] += activity
+                activities_rec_groups["mail.activity"][False] += activity
         model_activity_states = {
             'mail.activity': {'overdue_count': 0, 'today_count': 0, 'planned_count': 0, 'total_count': 0}
         }
@@ -404,23 +404,23 @@ class ResUsers(models.Model):
                     allowed_company_ids=user_company_ids)._filtered_access('read')
             model_activity_states[model_name] = {'overdue_count': 0, 'today_count': 0, 'planned_count': 0, 'total_count': 0}
             for record_id, activities in activities_by_record.items():
-                if record_id in unallowed_records.ids:
+                if record_id in unallowed_records.ids or not record_id:
                     model_key = 'mail.activity'
                     activities_model_groups['mail.activity'] += activities
                 elif record_id in allowed_records.ids:
                     model_key = model_name
                     activities_model_groups[model_name] += activities
-                else:
+                elif record_id:
                     continue
 
                 if 'overdue' in activities.mapped('state'):
                     model_activity_states[model_key]['overdue_count'] += 1
                     model_activity_states[model_key]['total_count'] += 1
-                if 'today' in activities.mapped('state'):
+                elif 'today' in activities.mapped('state'):
                     model_activity_states[model_key]['today_count'] += 1
                     model_activity_states[model_key]['total_count'] += 1
                 else:
-                    model_activity_states[model_name]['planned_count'] += 1
+                    model_activity_states[model_key]['planned_count'] += 1
 
         model_ids = [self.env["ir.model"]._get_id(name) for name in activities_model_groups]
         user_activities = {}

--- a/addons/mail/static/src/core/web/activity_model_patch.js
+++ b/addons/mail/static/src/core/web/activity_model_patch.js
@@ -31,11 +31,11 @@ patch(Activity.prototype, {
                     context: {
                         default_res_model: this.res_model,
                         default_res_id: this.res_id,
+                        dialog_size: "large",
                     },
                 },
-                { 
+                {
                     onClose: resolve,
-                    additionalContext: { dialog_size: "medium" },
                 }
             )
         );

--- a/addons/mail/static/src/core/web/command_palette.js
+++ b/addons/mail/static/src/core/web/command_palette.js
@@ -1,0 +1,29 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+
+const commandProviderRegistry = registry.category("command_provider");
+
+commandProviderRegistry.add("activity", {
+    provide: (env, options) => [
+        {
+            name: _t("Show My Activities"),
+            category: "activity",
+            action() {
+                env.services.action.doAction("mail.mail_activity_action_my", {
+                    target: "current",
+                    clearBreadcrumbs: true,
+                });
+            },
+        },
+        {
+            name: _t("Show All Activities"),
+            category: "activity",
+            action() {
+                env.services.action.doAction("mail.mail_activity_action", {
+                    target: "current",
+                    clearBreadcrumbs: true,
+                });
+            },
+        },
+    ],
+});

--- a/addons/mail/static/src/core/web/store_service_patch.js
+++ b/addons/mail/static/src/core/web/store_service_patch.js
@@ -93,10 +93,10 @@ const StorePatch = {
                     target: "new",
                     context,
                 },
-                { 
+                {
                     onClose: resolve,
-                    additionalContext: { 
-                        dialog_size: "medium",
+                    additionalContext: {
+                        dialog_size: "large",
                     },
                 }
             )

--- a/addons/mail/static/src/views/fields/activity_model_selector/activity_model_selector.js
+++ b/addons/mail/static/src/views/fields/activity_model_selector/activity_model_selector.js
@@ -8,10 +8,10 @@ import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 /** largely taken from documents' DocumentsDetailPanel, which selects arbitrary models and records
-  * through two interactions:
-  * 1- select the model through a list of accesible and appropriate models (getAvailableResModels)
-  * 2- select one of this model's records through a tree view in a new dialog that opens
-  **/
+ * through two interactions:
+ * 1- select the model through a list of accesible and appropriate models (getAvailableResModels)
+ * 2- select one of this model's records through a tree view in a new dialog that opens
+ **/
 
 // Small hack, memoize uses the first argument as cache key, but we need the orm which will not be the same.
 const getAvailableResModels = memoize((_null, orm) =>
@@ -19,7 +19,6 @@ const getAvailableResModels = memoize((_null, orm) =>
 );
 
 class ActivityModelSelector extends Component {
-
     static components = { ModelSelector };
     static template = "mail.ActivityModelSelector";
     static props = standardFieldProps;
@@ -33,9 +32,7 @@ class ActivityModelSelector extends Component {
             resModelName: this.props.record.data.res_model_name || "",
             models: [],
         });
-        getAvailableResModels(null, this.orm).then((models) => (
-            this.state.models = models
-        ));
+        getAvailableResModels(null, this.orm).then((models) => (this.state.models = models));
     }
 
     async onModelSelected(value) {
@@ -50,16 +47,39 @@ class ActivityModelSelector extends Component {
                     multiSelect: false,
                     resModel: this.state.resModel,
                     onSelected: async (resId) => {
-                        await this.props.record.update({
-                            res_model: this.state.resModel,
-                            res_ids: resId,
-                        }, { save: false })
-                        const record = await this.orm.read(
-                            this.props.record.data.res_model,
-                            this.props.record.data.res_ids,
-                            ['name']
-                        )
-                        this.state.resModelName = record[0].name;
+                        /* Changing the model linked to the activity also changes available activity types.
+                         * This in turn triggers a recompute of all fields dependent on activity types, including
+                         * summary and notes, which may already have been edited (especially summary as the user is
+                         * likely to fill out the wizard in order).
+                         * To prevent this, current summary and notes are saved and will be recovered after the model
+                         * has been changed.
+                         *
+                         * todo guce make cleaner
+                         */
+                        const persistDataThroughModelChange = {
+                            summary: this.props.record.data.summary,
+                            note: this.props.record.data.note,
+                        };
+
+                        await this.props.record.update(
+                            {
+                                res_model: this.state.resModel,
+                                res_ids: resId,
+                            },
+                            { save: false }
+                        );
+                        const recordInfo = await this.orm.call(
+                            this.state.resModel,
+                            "name_search",
+                            [],
+                            {
+                                domain: [["id", "in", resId]],
+                            }
+                        );
+                        this.state.resModelName = recordInfo[0][1];
+
+                        // recover saved inputs
+                        this.props.record.update(persistDataThroughModelChange);
                     },
                 },
                 {
@@ -74,14 +94,20 @@ class ActivityModelSelector extends Component {
     }
 
     onRecordReset() {
+        // information to persist current summary and notes through model_id changes
+        const persistDataThroughModelChange = {
+            summary: this.props.record.data.summary,
+            note: this.props.record.data.note,
+        };
         this.props.record.update({
             res_model: false,
             res_ids: false,
-        })
+        });
+        this.props.record.update(persistDataThroughModelChange);
         return this.onModelSelected({ technical: false, label: false });
     }
 }
 
 registry.category("fields").add("activity_model_selector", {
-    component: ActivityModelSelector
-})
+    component: ActivityModelSelector,
+});

--- a/addons/mail/static/src/views/fields/activity_model_selector/activity_model_selector.xml
+++ b/addons/mail/static/src/views/fields/activity_model_selector/activity_model_selector.xml
@@ -1,12 +1,18 @@
 <templates xml:space="preserve">
-    <div t-name="mail.ActivityModelSelector" class="o_field_widget o_field_many2one">
-        <div class="o_input_dropdown">
-            <ModelSelector
+    <div t-name="mail.ActivityModelSelector" class="o_field_widget o_field_many2one flex-row">
+        <t t-if="state.resModelName">
+            <span t-out="state.resModelName" class="text-truncate"/>
+            <button t-on-click="() => this.onRecordReset()" class="btn fa fa-close"/>
+        </t>
+        <t t-else="">
+            <div class="o_input_dropdown">
+                <ModelSelector
                 value="state.resModelName"
                 onModelSelected.bind="onModelSelected"
                 models="this.state.models"
                 placeholder.translate="No linked model"
-            />
-        </div>
+                />
+            </div>
+        </t>
     </div>
 </templates>

--- a/addons/mail/static/src/views/fields/badge_selection_icons/badge_selection_icons_field.js
+++ b/addons/mail/static/src/views/fields/badge_selection_icons/badge_selection_icons_field.js
@@ -2,14 +2,17 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { getFieldDomain } from "@web/model/relational_model/utils";
 import { useSpecialData } from "@web/views/fields/relational_utils";
-import { badgeSelectionField, BadgeSelectionField } from "@web/views/fields/badge_selection/badge_selection_field";
+import {
+    badgeSelectionField,
+    BadgeSelectionField,
+} from "@web/views/fields/badge_selection/badge_selection_field";
 
 /**
  * @typedef BadgeSelectionIconsField
  * Overrides the standard BadgeSelectionField and inserts FontAwesome icons before each option's title.
  * Only compatible with Many2one selectors. Related options should have an "icon" field, the name
  * of which should be specified through the iconField prop.
- * 
+ *
  * Special props:
  * @param {String} iconField The name of the field on which the icon is stored on the many2one option
  * @param {String} defaultIcon If the field pointed through iconField is empty on the related record, a default fa icon can be specified.
@@ -17,15 +20,26 @@ import { badgeSelectionField, BadgeSelectionField } from "@web/views/fields/badg
 export class BadgeSelectionWithIconsField extends BadgeSelectionField {
     static props = {
         ...BadgeSelectionField.props,
-        iconField: { type: String, },
-        defaultIcon: { type: String, optional: true, default: "fa-check"}
+        iconField: { type: String },
+        defaultIcon: { type: String, optional: true, default: "fa-check" },
     };
     static template = "mail.BadgeSelectionIconsField";
 
-    // todo guce postfreeze: replace override to use the base setup()
+    /**
+     * many2one fields use attribute "specialData" to store information pertaining to many2one relations.
+     * As such, this.specialData is used by the inherited BadgeSelectionField to store the Many2one selection options for this field.
+     *
+     * todo guce postfreeze: use overriden setup()?
+     * Not sure that's a practical option however, as the overriden setup() essentially does what this method does,
+     * but without the fetched iconField, so this logic essentially overwrites the result of the overriden method?
+     * (maybe setup() should be called and then the results enriched with a call to search_read?)
+     *
+     * overriding setup() isn't obvious due to stuff happening with useSpecialData, which hasn't been called
+     * even as the overriden setup() returns; perhaps useSpecialData() is some sort of hook that will be used later
+     * in the execution stack
+     */
     async setup() {
         this.type = this.props.record.fields[this.props.name].type;
-        // this.specialData is used by the inherited BadgeSelectionField to store the Many2one selection options for this field
         this.specialData = useSpecialData(async (orm, props) => {
             const domain = getFieldDomain(props.record, props.name, props.domain);
             const { relation } = props.record.fields[props.name];
@@ -39,7 +53,7 @@ export class BadgeSelectionWithIconsField extends BadgeSelectionField {
                     option[2] = props.defaultIcon;
                 }
                 return option;
-            })
+            });
         });
     }
 }
@@ -54,5 +68,5 @@ export const badgeSelectionWithIconsField = {
         iconField: fieldInfo.attrs.iconField,
         defaultIcon: fieldInfo.attrs.defaultIcon,
     }),
-}
+};
 registry.category("fields").add("selection_badge_icons", badgeSelectionWithIconsField);

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -104,11 +104,11 @@ export class ActivityController extends Component {
                     default_res_id: resId,
                     default_res_model: this.props.resModel,
                     default_activity_type_id: activityTypeId,
+                    dialog_size: "large",
                 },
             },
             {
                 onClose: () => this.model.load(this.getSearchProps()),
-                additionalContext: { dialog_size: "medium" },
             }
         );
     }

--- a/addons/mail/static/src/views/web/list/activity_list_reschedule.js
+++ b/addons/mail/static/src/views/web/list/activity_list_reschedule.js
@@ -6,7 +6,12 @@ import { useService } from "@web/core/utils/hooks";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 const { DateTime } = luxon;
 
+/**
+ * This widget displays a small dropdown allowing users to reschedule the
+ * selected activity to certain dates in the near future.
+ */
 
+// Version of the widget to use on mail.activity lists
 class ActivityListRescheduleDropdown extends Component {
     static components = { Dropdown, DropdownItem };
     static props = {
@@ -14,30 +19,47 @@ class ActivityListRescheduleDropdown extends Component {
     };
     setup() {
         this.orm = useService("orm");
+        this.action = useService("action");
         const today = DateTime.now().startOf("day");
         this.targetDays = {
             today: {
-                newDeadline: today,
                 displayDay: today.weekdayShort,
+                actionName: "action_reschedule_today",
             },
             tomorrow: {
-                newDeadline: today.plus({days: 1}),
-                displayDay: today.plus({days: 1}).weekdayShort,
+                displayDay: today.plus({ days: 1 }).weekdayShort,
+                actionName: "action_reschedule_tomorrow",
             },
             nextWeek: {
-                newDeadline: today.plus({weeks: 1}).startOf("week"),
-                displayDay: today.plus({weeks: 1}).startOf("week").weekdayShort,
-            }
-
-        }
+                displayDay: today.plus({ weeks: 1 }).startOf("week").weekdayShort,
+                actionName: "action_reschedule_nextweek",
+            },
+        };
     }
     static template = "mail.ActivityListRescheduleDropdown";
 
-    async rescheduleActivity(click, newDeadline) {
-        await this.props.record.update({
-            ["date_deadline"]: newDeadline,
-        }, { save: true });
+    async rescheduleActivity(click, actionName) {
+        await this.action.doActionButton({
+            type: "object",
+            name: actionName,
+            resModel: this.props.record.resModel,
+            resId: this.props.record.resId,
+            onClose: async () => {
+                await this.props.record.model.root.load();
+                this.props.record.model.notify();
+            },
+        });
         return this.props.record;
+    }
+}
+
+// Version of the widget to use on lists of records inheriting from mail.activity.mixin
+class ActivityMixinListRescheduleDropdown extends ActivityListRescheduleDropdown {
+    setup() {
+        super.setup();
+        this.targetDays.today.actionName = "action_reschedule_my_next_today";
+        this.targetDays.tomorrow.actionName = "action_reschedule_my_next_tomorrow";
+        this.targetDays.nextWeek.actionName = "action_reschedule_my_next_nextweek";
     }
 }
 
@@ -48,5 +70,15 @@ registry.category("view_widgets").add("activity_list_reschedule_dropdown", {
         return {
             readonly,
         };
-    }
+    },
+});
+
+registry.category("view_widgets").add("activity_mixin_list_reschedule_dropdown", {
+    component: ActivityMixinListRescheduleDropdown,
+    extractProps: ({ attrs }) => {
+        const { readonly } = attrs;
+        return {
+            readonly,
+        };
+    },
 });

--- a/addons/mail/static/src/views/web/list/activity_list_reschedule.xml
+++ b/addons/mail/static/src/views/web/list/activity_list_reschedule.xml
@@ -6,7 +6,7 @@
             </button>
 
             <t t-set-slot="content">
-                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.today.newDeadline)">
+                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.today.actionName)">
                     <div class="d-flex justify-content-between">
                         <span>
                             <i class="oi oi-schedule-today me-1"/> Today
@@ -14,7 +14,7 @@
                         <span t-out="targetDays.today.displayDay" class="ms-2 text-muted"/>
                     </div>
                 </DropdownItem>
-                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.tomorrow.newDeadline)">
+                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.tomorrow.actionName)">
                     <div class="d-flex justify-content-between">
                         <span>
                             <i class="oi oi-schedule-tomorrow me-1"/> Tomorrow
@@ -22,7 +22,7 @@
                         <span t-out="targetDays.tomorrow.displayDay" class="ms-2 text-muted"/>
                     </div>
                 </DropdownItem>
-                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.nextWeek.newDeadline)">
+                <DropdownItem onSelected="(ev) => this.rescheduleActivity(ev, targetDays.nextWeek.actionName)">
                     <div class="d-flex justify-content-between">
                         <span>
                             <i class="oi oi-schedule-later me-1"/> Next Week

--- a/addons/mail/static/src/views/web/list/archive_disabled_list_controller.js
+++ b/addons/mail/static/src/views/web/list/archive_disabled_list_controller.js
@@ -1,17 +1,27 @@
 import { useService } from "@web/core/utils/hooks";
 import { ListController } from "@web/views/list/list_controller";
 
+/* todo guce:
+ * Should this component be renamed?
+ * The logic for activity creation without a record set has been applied here because it was useful in the same places
+ * that not showing an archival option made sense, but the component is misnommed as a result.
+ */
 export class ArchiveDisabledListController extends ListController {
     setup() {
         super.setup();
         this.archiveEnabled = false;
-        this.store = useService("mail.store")
+        this.store = useService("mail.store");
     }
 
     async createRecord() {
-        return this.store.scheduleActivity(
-            this.props.resModel != "mail.activity" ? this.props.resModel : false,
-            false
-        )
+        return this.store
+            .scheduleActivity(
+                this.props.resModel != "mail.activity" ? this.props.resModel : false,
+                false
+            )
+            .then(async () => {
+                // Refresh view once new activity has been added
+                await this.model.root.load();
+            });
     }
 }

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -424,6 +424,7 @@ test("activity click on edit should pass correct context", async () => {
             expect(action.context).toEqual({
                 default_res_model: "res.partner",
                 default_res_id: partnerId,
+                dialog_size: "large",
             });
             return super.doAction(...arguments);
         },

--- a/addons/mail/views/mail_activity_plan_template_views.xml
+++ b/addons/mail/views/mail_activity_plan_template_views.xml
@@ -28,7 +28,7 @@
                             <field name="activity_type_id"/>
                             <field name="summary" placeholder="e.g. Discuss Proposal"/>
                             <field name="responsible_type"/>
-                            <field name="responsible_id" invisible="responsible_type != 'other'"/>
+                            <field name="responsible_id" invisible="responsible_type != 'other'" required="responsible_type == 'other'"/>
                             <label for="delay_count"/>
                             <div>
                                 <field class="oe_inline pe-1 o_input_3ch" name="delay_count"/>

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -201,7 +201,7 @@
         <field name="model">mail.activity</field>
         <field name="priority">32</field>
         <field name="arch" type="xml">
-            <form string="Log an Activity" create="true" delete="false">
+            <form string="Log an Activity" create="false" delete="false">
                 <header>
                     <button string="Mark Done" class="btn-primary"
                             name="action_done_redirect_to_other" type="object"/>
@@ -282,10 +282,10 @@
                     <button name="action_reschedule_tomorrow" type="object" string="Tomorrow" icon="fa-calendar-plus-o"/>
                     <button name="action_reschedule_nextweek" type="object" string="Next Week" icon="fa-calendar-o"/>
                 </header>
-                <field name="res_name" string="Name"/>
+                <field name="summary" string="Summary"/>
                 <field name="activity_type_id"/>
                 <field name="user_id" widget="many2one_avatar_user"/>
-                <field name="summary"/>
+                <field name="res_name" string="Linked to"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
                 <button name="action_done" type="object" string="Done" icon="fa-check" invisible="active == False"/>
@@ -378,7 +378,7 @@
         <field name="res_model">mail.activity</field>
         <field name="view_mode">list,form</field>
         <field name="search_view_id" ref="mail.mail_activity_view_search"/>
-        <field name="domain">[('id', 'in', active_ids)]</field>
+        <field name="domain">['|', ('id', 'in', context.get('active_ids')), '&amp;', ('res_model', '=', False), ('user_id', '=', uid)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No activities.

--- a/addons/mail/wizard/mail_activity_schedule_views.xml
+++ b/addons/mail/wizard/mail_activity_schedule_views.xml
@@ -10,6 +10,7 @@
                     <field name="chaining_type" invisible="1"/>
                     <field name="company_id" invisible="1"/>
                     <field name="has_error" invisible="1"/>
+                    <field name="has_warning" invisible="1"/>
                     <field name="plan_has_user_on_demand" invisible="1"/>
                     <field name="res_ids" invisible="1"/>
                     <field name="plan_available_ids" invisible="1"/>
@@ -41,7 +42,10 @@
                                     iconField="icon"
                                     nolabel="1"
                                     />
-                            <field name="summary" placeholder="e.g. Discuss Proposal" class="fs-3 pb-2"/>
+                            <group name="summary_group" colspan="2">
+                                <label for="summary" class="o_form_label fs-3"/>
+                                <field string="Summary" name="summary" placeholder="e.g. Discuss Proposal" class="fs-3 w-100" nolabel="1"/>
+                            </group>
                             <group>
                                 <field name="res_model" widget="activity_model_selector" string="Link to"
                                     invisible="id or context.get('active_model')"/>
@@ -52,6 +56,9 @@
                         </group>
                         <div role="alert" class="alert alert-danger mb8" invisible="not has_error">
                             <field name="error"/>
+                        </div>
+                        <div role="alert" class="alert alert-warning mb8" invisible="not has_warning">
+                            <field name="warning"/>
                         </div>
                     </sheet>
                     <footer invisible="plan_id">

--- a/addons/test_mail/data/data.xml
+++ b/addons/test_mail/data/data.xml
@@ -37,8 +37,8 @@
         <field name="triggered_next_type_id" ref="test_mail.mail_act_test_chained_2"/>
     </record>
     <record id="mail_act_test_upload_document" model="mail.activity.type">
-        <field name="name">Upload Document</field>
-        <field name="summary">Upload Document</field>
+        <field name="name">Document</field>
+        <field name="summary">Document</field>
         <field name="delay_count">5</field>
         <field name="category">upload_file</field>
         <field name="res_model">mail.test.activity</field>

--- a/addons/test_mail/static/tests/activity.test.js
+++ b/addons/test_mail/static/tests/activity.test.js
@@ -214,6 +214,7 @@ test("activity view: simple activity rendering", async () => {
                     default_res_id: mailTestActivityIds[1],
                     default_res_model: "mail.test.activity",
                     default_activity_type_id: mailActivityTypeIds[2],
+                    dialog_size: "large",
                 },
                 res_id: false,
                 res_model: "mail.activity",

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -344,7 +344,7 @@ class TestActivityFlow(TestActivityCommon):
             self.env.flush_all()
 
 
-@tests.tagged("mail_activity")
+@tests.tagged("mail_activity", "post_install", "-at_install")
 class TestActivitySystray(TestActivityCommon, HttpCase):
     """Test for systray_get_activities"""
 
@@ -394,7 +394,7 @@ class TestActivitySystray(TestActivityCommon, HttpCase):
             if record.get("model") == self.test_lead_records._name
         )
         self.assertEqual(total_lead_count, 2)
-        self.assertEqual(data["Store"]["activityCounter"], 4)
+        self.assertEqual(data["Store"]["activityCounter"], 5)
 
 
 @tests.tagged('mail_activity')
@@ -456,7 +456,7 @@ class TestActivityViewHelpers(TestActivityCommon):
                 next((t for t in activity_data['activity_types'] if t['id'] == self.type_upload.id), {}),
                 {
                     'id': self.type_upload.id,
-                    'name': 'Upload Document',
+                    'name': 'Document',
                     'template_ids': [],
                 })
 

--- a/addons/test_mail/tests/test_mail_activity_plan.py
+++ b/addons/test_mail/tests/test_mail_activity_plan.py
@@ -151,40 +151,10 @@ class TestActivitySchedule(ActivityScheduleCase):
                 for record in test_records:
                     self.assertActivityDoneOnRecord(record, self.activity_type_call)
 
-                # 3. LOG DONE ACTIVITIES, PREPARE SCHEDULE NEXT
-                with freeze_time(self.reference_now):
-                    form = self._instantiate_activity_schedule_wizard(test_records)
-                    form.activity_type_id = self.activity_type_todo
-                    form.activity_user_id = self.user_admin
-                    with self._mock_activities():
-                        wizard_res = form.save().with_context(
-                            mail_activity_quick_update=True
-                        ).action_schedule_activities_done_and_schedule()
-                self.assertDictEqual(wizard_res, {
-                    'name': "Schedule Activity On Selected Records" if len(test_records) > 1 else "Schedule Activity",
-                    'context': {
-                        'active_id': test_records[0].id,
-                        'active_ids': test_records.ids,
-                        'active_model': test_records._name,
-                        'mail_activity_quick_update': True,
-                        'default_previous_activity_type_id': 4,
-                        'activity_previous_deadline': self.reference_now.date() + timedelta(days=4),
-                        'default_res_ids': repr(test_records.ids),
-                        'default_res_model': test_records._name,
-                    },
-                    'view_mode': 'form',
-                    'res_model': 'mail.activity.schedule',
-                    'views': [(False, 'form')],
-                    'type': 'ir.actions.act_window',
-                    'target': 'new',
-                })
-                for record in test_records:
-                    self.assertActivityDoneOnRecord(record, self.activity_type_todo)
-
-                # 4. CONTINUE WITH SCHEDULE ACTIVITIES
+                # 3. CONTINUE WITH SCHEDULE ACTIVITIES
                 # implies deadline addition on top of previous activities
                 with freeze_time(self.reference_now):
-                    form = Form(self.env['mail.activity.schedule'].with_context(wizard_res['context']))
+                    form = self._instantiate_activity_schedule_wizard(test_records)
                     form.activity_type_id = self.activity_type_call
                     form.activity_user_id = self.user_admin
                     with self._mock_activities():
@@ -196,7 +166,7 @@ class TestActivitySchedule(ActivityScheduleCase):
                     self.assertActivityCreatedOnRecord(record, {
                         'activity_type_id': self.activity_type_call,
                         'automated': False,
-                        'date_deadline': self.reference_now.date() + timedelta(days=5),  # both types delays
+                        'date_deadline': self.reference_now.date() + timedelta(days=1),  # activity call delay
                         'note': False,
                         'summary': 'TodoSumCallSummary',
                         'user_id': self.user_admin,

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -331,8 +331,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     def test_activity_mixin(self):
         record = self.env['mail.test.activity'].create({'name': 'Test'})
 
-        # todo guce postfreeze fix: admin 5 employee 5
-        with self.assertQueryCount(admin=12, employee=12):
+        # todo guce postfreeze fix: 5 5 -> admin 12 employee 12 ->  9 9?
+        with self.assertQueryCount(admin=5, employee=5):
             activity = record.action_start('Test Start')
             # read activity_type to normalize cache between enterprise and community
             # voip module read activity_type during create leading to one less query in enterprise on action_close
@@ -340,8 +340,8 @@ class TestBaseAPIPerformance(BaseMailPerformance):
 
         record.write({'name': 'Dupe write'})
 
-        # todo guce postgreeze fix: admin 15 employee 14
-        with self.assertQueryCount(admin=17, employee=17):  # tm: 11 / 11
+        # todo guce postfreeze fix: admin 15 employee 14 -> became 22 17?
+        with self.assertQueryCount(admin=15, employee=14):  # tm: 11 / 11
             record.action_close('Dupe feedback')
 
         self.assertEqual(record.activity_ids, self.env['mail.activity'])


### PR DESCRIPTION
task-4592571 changed up the way activities function, but not everything was completed before the end of the freeze; in addition, it included a number of bugs/crashes/usage inconveniences.

This commit adds:

- CRM module now uses the Activity Reschedule field widget, instead of the previous "Snooze 7d" button
- The command palette (accessible through Ctrl+K is enriched with new "Show My Activities" and "Show All Activities" options
- Calendar quick create event form: Cleaner way to set videoconferencing options
- Activities: "To-do" is now the first activity in the list
- HR activity plans now assign current user as responsible by default if target employee doesn't have a coach/fleet manager/etc

This commit also fixes:
- Activity model selector now allows to clear selection
- Activity count in the systray correctly displays the count of model-less activities in the "Other" section
- Fixed a crash when selecting the "Activity overview" option in the "Technical settings" dropdown
- Activity model selector: Fixed a crash when selecting a record without a "name" field (display_name instead)
- "All activities" and "Other activities" lists: After creating a new activity through the activity wizard, the list is refreshed so the user can see the new activity

task-4747156

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
