### PR TITLE
[FIX] l10n_ar: fix fiscal position configuration after revamp

### DIFF
--- a/addons/l10n_ar/data/template/account.fiscal.position-ar_ri.csv
+++ b/addons/l10n_ar/data/template/account.fiscal.position-ar_ri.csv
@@ -1,5 +1,5 @@
 "id","name","auto_apply","l10n_ar_afip_responsibility_type_ids","name@es","country_id"
-"l10n_ar_domestic_fiscal_position","AR Domestic","1","l10n_ar.res_EXT","Compras / Ventas al exterior","base.ar"
+"l10n_ar_domestic_fiscal_position","AR Domestic","1","","Compras / Ventas al exterior","base.ar"
 "fiscal_position_template_exempt_operations","Purchases / Sales abroad","1","l10n_ar.res_EXT","Compras / Ventas al exterior",""
 "fiscal_position_template_free_zone","Purchases / Sales Free Trade Zone","1","l10n_ar.res_IVA_LIB","Compras / Ventas Zona Franca",""
 "fiscal_position_template_iva_no_corresponde","Purchases VAT in the correspondent","1","l10n_ar.res_IVAE,l10n_ar.res_RM","Compras IVA no corresponde",""

--- a/addons/l10n_ar/data/template/account.tax-ar_ri.csv
+++ b/addons/l10n_ar/data/template/account.tax-ar_ri.csv
@@ -19,7 +19,7 @@
 "","","","","","","","","","","tax","invoice","ri_iva_debito_fiscal","","","","",""
 "","","","","","","","","","","base","refund","","","","","",""
 "","","","","","","","","","","tax","refund","ri_iva_credito_fiscal","","","","",""
-"ri_tax_vat_exento_compras","Exempt","VAT Exempt","0% EXEMPT","","2","fixed","0.0","tax_group_iva_exento","purchase","base","invoice","","IVA Exen","IVA Exento","IVA Exento","fiscal_position_template_free_zone,l10n_ar_domestic_fiscal_position","ri_tax_vat_21_compras,ri_tax_vat_10_compras,ri_tax_vat_0_compras,ri_tax_vat_27_compras"
+"ri_tax_vat_exento_compras","Exempt","VAT Exempt","0% EXEMPT","","2","fixed","0.0","tax_group_iva_exento","purchase","base","invoice","","IVA Exen","IVA Exento","IVA Exento","fiscal_position_template_free_zone","ri_tax_vat_21_compras,ri_tax_vat_10_compras,ri_tax_vat_0_compras,ri_tax_vat_27_compras"
 "","","","","","","","","","","tax","invoice","ri_iva_credito_fiscal","","","","",""
 "","","","","","","","","","","base","refund","","","","","",""
 "","","","","","","","","","","tax","refund","ri_iva_debito_fiscal","","","","",""


### PR DESCRIPTION
Fix 1: In tax `0% EXEMPT` (Purchase), remove the fiscal position AR Domestic from the field Fiscal Position. This causes the tax to appear on vendor bills using “AR Domestic”, even when not applicable.

Fix 2: In fiscal position `AR Domestic`, clear the field AFIP Responsibility Type. It should not include `Cliente del exterior`. This value is incorrect for domestic fiscal position and should be removed.

Task-4794985

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
