### PR TITLE
[FIX] account_peppol: phone number error during registration

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -85,6 +85,11 @@ class ResCompany(models.Model):
     # HELPER METHODS
     # -------------------------------------------------------------------------
 
+    @api.model
+    def _check_phonenumbers_import(self):
+        if not phonenumbers:
+            raise ValidationError(_("Please install the phonenumbers library."))
+
     def _sanitize_peppol_phone_number(self, phone_number=None):
         self.ensure_one()
 
@@ -93,8 +98,7 @@ class ResCompany(models.Model):
             "For example: +32123456789, where +32 is the country code.\n"
             "Currently, only European countries are supported.")
 
-        if not phonenumbers:
-            raise ValidationError(_("Please install the phonenumbers library."))
+        self._check_phonenumbers_import()
 
         phone_number = phone_number or self.account_peppol_phone_number
         if not phone_number:

--- a/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
+++ b/addons/account_peppol/static/src/components/res_config_settings_buttons/res_config_settings_buttons.js
@@ -91,9 +91,11 @@ class PeppolSettingsButtons extends Component {
         });
     }
 
-    deregister() {
+    async deregister() {
         if (this.ediMode === 'demo' || !['sender', 'smp_registration', 'receiver'].includes(this.proxyState)) {
-            this._callConfigMethod("button_deregister_peppol_participant");
+            await this._callConfigMethod("button_deregister_peppol_participant");
+            // Discard any changes
+            this.props.record._discard();
         } else if (['sender', 'smp_registration', 'receiver'].includes(this.proxyState)) {
             this.showConfirmation(
                 "This will delete your Peppol registration.",

--- a/addons/account_peppol/wizard/peppol_registration.py
+++ b/addons/account_peppol/wizard/peppol_registration.py
@@ -73,13 +73,14 @@ class PeppolRegistration(models.TransientModel):
 
     @api.onchange('phone_number')
     def _onchange_phone_number(self):
+        self.env['res.company']._check_phonenumbers_import()
         for wizard in self:
             if wizard.phone_number:
-                wizard.company_id._sanitize_peppol_phone_number(wizard.phone_number)
+                # The `phone_number` we set is not necessarily valid (may fail `_sanitize_peppol_phone_number`)
                 with contextlib.suppress(phonenumbers.NumberParseException):
                     parsed_phone_number = phonenumbers.parse(
                         wizard.phone_number,
-                        region=self.company_id.country_code,
+                        region=wizard.company_id.country_code,
                     )
                     wizard.phone_number = phonenumbers.format_number(
                         parsed_phone_number,


### PR DESCRIPTION
Steps to reproduce on runbot:
1. Select company "My Belgian Company" (`l10n_be` and `account_peppol`) should be installed
2. Settings -> Accounting -> PEPPOL Electronic Invoicing -> Activate Electronic Invoicing
3. Ensure `+32470123456` is given as the phone number
4. Remove the country prefix from the phone number
5. A validation error is raised complaining about the phone number format

The validation should only be performed when we click on the "Activate Peppol" button.. When editing the phone number the wizard should try to auto-format the given phone number before validating.
In case there is no country prefix it should assume the phone number is from the country of the company.

Since commit 7cd8c87e3fcacfefa6c789449eec32a3c5577089 the validation is performed before the auto-formating. There a call to the validation logic (`_sanitize_peppol_phone_number`) was added before the auto-formatting logic. (It was mainly just done to ensure that an external dependency is installed.) But there we do not (and should not) assume the country prefix of the phone number. The phone number is used during the registration process. A missing country prefix could lead to a failed registration.

After this commit
- the validation is only performed when we click on the "Activate Peppol" button.
- the auto-formatting is performed after editing the phone number
- the changes are not stored on the company when clicking on "Discard"
- fix a `self` in a `for ... in self`

part of
task-4791098
