### PR TITLE
[FIX] mail: channels and thread should not be visible after archived

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -329,6 +329,10 @@ class Channel(models.Model):
                     diff[key] = value
             if diff:
                 channel._bus_send_store(channel, diff)
+            if not vals.get("active", True):
+                for sub_channel in channel.sub_channel_ids:
+                    sub_channel.active = False
+                channel._bus_send("discuss.channel/delete", {"id": channel.id})
         if vals.get('group_ids'):
             self._subscribe_users_automatically()
         return result


### PR DESCRIPTION
Current behavior before PR:

- Archived channels and threads remain visible in Discuss until the page is refreshed.
- Archiving a channel does not affect its subchannels.

Desired behavior after PR is merged:

- Archived channels and threads are instantly removed from the Discuss view without requiring a page refresh.
- Archiving a channel also archives and hides its subchannels.

task-id: 4764934

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
