### PR TITLE
[IMP] account,account_peppol: status tracking

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -102,6 +102,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/css/account_bank_and_cash.css',
             'account/static/src/css/account.css',
             'account/static/src/css/account_payment.scss',
+            'account/static/src/scss/account.scss',
             'account/static/src/scss/account_journal_dashboard.scss',
             'account/static/src/scss/account_searchpanel.scss',
             'account/static/src/scss/account_payment_term.scss',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -633,7 +633,6 @@ class AccountMove(models.Model):
     is_move_sent = fields.Boolean(
         readonly=True,
         copy=False,
-        tracking=True,
         help="It indicates that the invoice/payment has been sent or the PDF has been generated.",
     )
     is_being_sent = fields.Boolean(

--- a/addons/account/static/src/scss/account.scss
+++ b/addons/account/static/src/scss/account.scss
@@ -1,0 +1,4 @@
+.gray_ribbon {
+    color: $o-gray-600 !important;
+    background-color: $o-gray-200 !important;
+}

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -236,8 +236,8 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             composer.action_send_and_print(allow_fallback_pdf=True)
             self.env.cr.flush()  # force tracking message
 
-        self.assertEqual(len(self._new_msgs), 2, 'Should produce 2 messages: one for posting template, one for tracking')
-        print_msg, track_msg = self._new_msgs[0], self._new_msgs[1]
+        self.assertEqual(len(self._new_msgs), 1, 'Should produce 1 message (for posting template)')
+        print_msg = self._new_msgs[0]
         self.assertNotified(
             print_msg,
             [{
@@ -257,10 +257,6 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                          'Should take invoice_user_id email')
         self.assertEqual(print_msg.notified_partner_ids, test_customer + self.user_accountman.partner_id)
         self.assertEqual(print_msg.subject, f'{self.env.user.company_id.name} Invoice (Ref {test_move.name})')
-        # tracking: is_move_sent
-        self.assertEqual(track_msg.author_id, self.env.user.partner_id)
-        self.assertEqual(track_msg.email_from, self.env.user.email_formatted)
-        self.assertTrue('is_move_sent' in track_msg.tracking_value_ids.field_id.mapped('name'))
         # sent email
         self.assertMailMail(
             test_customer,
@@ -323,8 +319,8 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             composer.action_send_and_print()
             self.env.cr.flush()  # force tracking message
 
-        self.assertEqual(len(self._new_msgs), 2, 'Should produce 2 messages: one for posting template, one for tracking')
-        print_msg, track_msg = self._new_msgs[0], self._new_msgs[1]
+        self.assertEqual(len(self._new_msgs), 1, 'Should produce 1 message (for posting template)')
+        print_msg = self._new_msgs[0]
         self.assertNotified(
             print_msg,
             [{
@@ -344,10 +340,6 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
                          'Should take invoice_user_id email')
         self.assertEqual(print_msg.notified_partner_ids, test_customer + self.user_accountman.partner_id)
         self.assertEqual(print_msg.subject, f'SpanishSubject for {test_move.name}')
-        # tracking: is_move_sent
-        self.assertEqual(track_msg.author_id, self.env.user.partner_id)
-        self.assertEqual(track_msg.email_from, self.env.user.email_formatted)
-        self.assertTrue('is_move_sent' in track_msg.tracking_value_ids.field_id.mapped('name'))
         # sent email
         self.assertMailMail(
             test_customer,

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -911,6 +911,9 @@
                             </button>
                         </div>
 
+                        <widget name="web_ribbon" title="Sent"
+                                bg_color="gray_ribbon"
+                                invisible="not is_move_sent or payment_state != 'not_paid' or move_type not in ('out_invoice', 'out_refund', 'out_receipt')"/>
                         <!-- Payment status for invoices / receipts -->
                         <widget name="web_ribbon" title="Paid"
                                 invisible="payment_state != 'paid' or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"/>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -272,7 +272,6 @@ class Account_Edi_Proxy_ClientUser(models.Model):
                         continue
 
                     move.peppol_move_state = content['state']
-                    move._message_log(body=_('Peppol status update: %s', content['state']))
 
                 edi_user._call_peppol_proxy(
                     "/api/peppol/1/ack",

--- a/addons/account_peppol/models/account_move_send.py
+++ b/addons/account_peppol/models/account_move_send.py
@@ -218,7 +218,7 @@ class AccountMoveSend(models.AbstractModel):
                     invoice.peppol_message_uuid = message['message_uuid']
                     invoice.peppol_move_state = 'processing'
                     invoices |= invoice
-                log_message = _('The document has been sent to the Peppol Access Point for processing')
+                log_message = _('The document has been sent to Peppol for processing')
                 invoices._message_log_batch(bodies={invoice.id: log_message for invoice in invoices})
                 self.env.ref('account_peppol.ir_cron_peppol_get_message_status')._trigger(at=fields.Datetime.now() + timedelta(minutes=5))
 

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -201,7 +201,7 @@ class TestPeppolMessage(TestAccountMoveSendCommon, MailCommon):
 
         wizard.sending_methods = ['peppol']
         wizard.action_send_and_print()
-        self.assertEqual(self._get_mail_message(move).preview, 'The document has been sent to the Peppol Access Point for processing')
+        self.assertEqual(self._get_mail_message(move).preview, 'The document has been sent to Peppol for processing')
 
     def test_send_peppol_alerts_not_valid_partner(self):
         move = self.create_move(self.invalid_partner)


### PR DESCRIPTION
#### [IMP] account: ribbon for is_move_sent instead of tracking
Instead of tracking the `is_move_sent` field we show a ribbon
if the move is sent (but there is no payment information yet).

#### [IMP] account_peppol: small misc. UI improvements
- Speak of "Peppol" instead of "Peppol Access Point"
- Remove status update from the chatter

#### Info
part of
task-4791098
