### PR TITLE
[FIX] point_of_sale, pos_restaurant: fix preset name in restaurant mode

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1860,6 +1860,14 @@ export class PosStore extends WithLazyGetterTrap {
     async selectPricelist(pricelist) {
         await this.getOrder().setPricelist(pricelist);
     }
+    async handleSelectNamePreset(order) {
+        if (!order.partner_id) {
+            const partner = await this.selectPartner();
+            if (!partner) {
+                return;
+            }
+        }
+    }
     async selectPreset(preset = false, order = this.getOrder()) {
         if (!preset) {
             const selectionList = this.models["pos.preset"].map((preset) => ({
@@ -1885,11 +1893,8 @@ export class PosStore extends WithLazyGetterTrap {
                 }
             }
 
-            if (preset.identification === "name" && !order.floating_order_name && !order.table_id) {
-                order.floating_order_name = order.getPartner()?.name;
-                if (!order.floating_order_name) {
-                    this.editFloatingOrderName(order);
-                }
+            if (preset.identification === "name") {
+                this.handleSelectNamePreset(order);
             }
 
             if (preset.use_timing && !order.preset_time) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -12,7 +12,6 @@ import { scan_barcode, negateStep } from "@point_of_sale/../tests/generic_helper
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
-import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
 
 registry.category("web_tour.tours").add("ProductScreenTour", {
@@ -688,15 +687,14 @@ registry.category("web_tour.tours").add("test_fiscal_position_tax_group_labels",
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("test_preset_timing", {
+registry.category("web_tour.tours").add("test_preset_timing_retail", {
     steps: () =>
         [
             Chrome.startPoS(),
             Dialog.confirm("Open Register"),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
-            ProductScreen.selectPreset("Eat in", "Takeaway"),
-            TextInputPopup.inputText("John"),
-            Dialog.confirm(),
+            ProductScreen.selectPreset("Eat in", "Delivery"),
+            PartnerList.clickPartner("A simple PoS man!"),
             Chrome.clickPresetTimingSlot(),
             Chrome.selectPresetTimingSlotHour("12:00"),
             Chrome.presetTimingSlotIs("12:00"),
@@ -706,8 +704,8 @@ registry.category("web_tour.tours").add("test_preset_timing", {
             Chrome.createFloatingOrder(),
             ProductScreen.clickDisplayedProduct("Desk Organizer"),
             Chrome.clickOrders(),
-            TicketScreen.nthRowContains(1, "John"),
-            TicketScreen.nthRowContains(1, "Takeaway", false),
+            TicketScreen.nthRowContains(1, "A simple PoS man!"),
+            TicketScreen.nthRowContains(1, "Delivery", false),
             TicketScreen.nthRowContains(2, "002"),
             TicketScreen.nthRowContains(2, "Eat in", false),
         ].flat(),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1961,16 +1961,12 @@ class TestUi(TestPointOfSaleHttpCommon):
         n_draft_order = self.env['pos.order'].search_count([('state', '=', 'draft')], limit=1)
         self.assertEqual(n_draft_order, 0, 'There should be no draft orders created')
 
-    def test_preset_timing(self):
+    def test_preset_timing_retail(self):
         """
         Test to set order preset hour inside a tour
         """
         self.preset_eat_in = self.env['pos.preset'].create({
             'name': 'Eat in',
-        })
-        self.preset_takeaway = self.env['pos.preset'].create({
-            'name': 'Takeaway',
-            'identification': 'name',
         })
         self.preset_delivery = self.env['pos.preset'].create({
             'name': 'Delivery',
@@ -1979,7 +1975,7 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.write({
             'use_presets': True,
             'default_preset_id': self.preset_eat_in.id,
-            'available_preset_ids': [(6, 0, [self.preset_takeaway.id, self.preset_delivery.id])],
+            'available_preset_ids': [(6, 0, [self.preset_delivery.id])],
         })
         resource_calendar = self.env['resource.calendar'].create({
             'name': 'Takeaway',
@@ -1991,11 +1987,11 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'day_period': 'morning',
             }) for day in range(0, 7)],
         })
-        self.preset_takeaway.write({
+        self.preset_delivery.write({
             'use_timing': True,
             'resource_calendar_id': resource_calendar
         })
-        self.start_pos_tour('test_preset_timing')
+        self.start_pos_tour('test_preset_timing_retail')
 
     def test_quantity_package_of_non_basic_unit(self):
         pack_of_12_inch = self.env['uom.uom'].create({

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -393,6 +393,19 @@ patch(PosStore.prototype, {
 
         this.showScreen(screenName || "ProductScreen", props);
     },
+    async handleSelectNamePreset(order) {
+        if (this.config.module_pos_restaurant) {
+            const orderPreset = order.preset_id;
+            if (orderPreset && !order.floating_order_name && !order.table_id) {
+                order.floating_order_name = order.getPartner()?.name;
+                if (!order.floating_order_name) {
+                    this.editFloatingOrderName(order);
+                }
+            }
+        } else {
+            return super.handleSelectNamePreset(...arguments);
+        }
+    },
     findTable(tableNumber) {
         const find_table = (t) => t.table_number === parseInt(tableNumber);
         return (

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -19,6 +19,7 @@ import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { renderToElement } from "@web/core/utils/render";
 import { delay } from "@odoo/hoot-dom";
+import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -577,6 +578,33 @@ registry.category("web_tour.tours").add("FinishResidualOrder", {
             PaymentScreen.clickPaymentMethod("Bank"),
             PaymentScreen.clickValidate(),
             ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_preset_timing_restaurant", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickNewOrder(),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.selectPreset("Eat in", "Takeaway"),
+            TextInputPopup.inputText("John"),
+            Dialog.confirm(),
+            Chrome.clickPresetTimingSlot(),
+            Chrome.selectPresetTimingSlotHour("12:00"),
+            Chrome.presetTimingSlotIs("12:00"),
+            Chrome.clickPresetTimingSlot(),
+            Chrome.selectPresetTimingSlotHour("15:00"),
+            Chrome.presetTimingSlotIs("15:00"),
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.clickOrders(),
+            TicketScreen.nthRowContains(1, "John"),
+            TicketScreen.nthRowContains(1, "Takeaway", false),
+            TicketScreen.nthRowContains(2, "002"),
+            TicketScreen.nthRowContains(2, "Eat in", false),
         ].flat(),
 });
 

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -501,6 +501,38 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('RefundQtyTour')
 
+    def test_preset_timing_restaurant(self):
+        """
+        Test to set order preset hour inside a tour
+        """
+        self.preset_eat_in = self.env['pos.preset'].create({
+            'name': 'Eat in',
+        })
+        self.preset_takeaway = self.env['pos.preset'].create({
+            'name': 'Takeaway',
+            'identification': 'name',
+        })
+        self.main_pos_config.write({
+            'use_presets': True,
+            'default_preset_id': self.preset_eat_in.id,
+            'available_preset_ids': [(6, 0, [self.preset_takeaway.id])],
+        })
+        resource_calendar = self.env['resource.calendar'].create({
+            'name': 'Takeaway',
+            'attendance_ids': [(0, 0, {
+                'name': 'Takeaway',
+                'dayofweek': str(day),
+                'hour_from': 0,
+                'hour_to': 24,
+                'day_period': 'morning',
+            }) for day in range(0, 7)],
+        })
+        self.preset_takeaway.write({
+            'use_timing': True,
+            'resource_calendar_id': resource_calendar
+        })
+        self.start_pos_tour('test_preset_timing_restaurant')
+
     def test_restaurant_preset_takeout_tour(self):
         self.pos_config.write({
             'printer_ids': False,


### PR DESCRIPTION
- Avoid traceback when using name-based preset without module `pos_restaurant` installed.
- Since we cannot change the name of a floating order in POS, move floating order name logic to `pos_restaurant` to prevent errors when using presets with `identification = name` in POS without the `pos_restaurant` module installed.
- Adapt tests so in `point_of_sale` we test preset with `identification = address` (delivery) and in `pos_restaurant` we test preset with `identification = name` (take out).

Steps to reproduce:
- Install `point_of_sale` (without `pos_restaurant`).
- Enable presets in settings and create a preset with `identification = name`.
- Open a session in POS and create a new order.
- Select the preset in the order.
- => Traceback occurs.

task-id: 4794324


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
