### PR TITLE
[FIX] hr_holidays: add access to the user_id field for buttons rendering

### DIFF
--- a/addons/hr_holidays/static/tests/leave_card.test.js
+++ b/addons/hr_holidays/static/tests/leave_card.test.js
@@ -1,0 +1,84 @@
+import { HrLeave } from "@hr_holidays/../tests/mock_server/mock_models/hr_leave";
+import { ResUsers } from "@hr_holidays/../tests/mock_server/mock_models/res_users";
+import { defineHrHolidaysModels } from "@hr_holidays/../tests/hr_holidays_test_helpers";
+import { mountView, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { clickDate } from "@web/../tests/views/calendar/calendar_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { mockDate } from "@odoo/hoot-mock";
+import { click, waitFor } from "@odoo/hoot-dom";
+import { user } from "@web/core/user";
+
+describe.current.tags("desktop");
+defineHrHolidaysModels();
+
+test("Test request creator buttons", async() => {
+    mockDate("2024-01-03 12:00:00", 0);
+    patchWithCleanup(user, { userId: 100 });
+
+    HrLeave._views = {
+         "form,hr_leave_view_form_dashboard_new_time_off": `
+            <form>
+                <field name="state"/>
+                <field name="holiday_status_id"/>
+                <field name="employee_id"/>
+                <field name="user_id"/>
+                <field name="can_cancel"/>
+            </form>
+        `,
+    };
+
+    HrLeave._records = [
+        {
+            'id': 1, 'state': 'confirm', 'holiday_status_id': 55, 'employee_id': 100,
+            'user_id': 100, 'date_from': '2024-01-09 09:00:00', 'date_to': '2024-01-09 18:00:00'
+        },
+        {
+            'id': 2, 'state': 'validate1', 'holiday_status_id': 55, 'employee_id': 100,
+            'can_cancel': true, 'user_id': 100, 'date_from': '2024-01-10 09:00:00', 'date_to': '2024-01-10 18:00:00'
+        },
+    ]
+
+    ResUsers._records = [
+        ...ResUsers._records,
+        { 'id': 100, 'name': "User 1", 'employee_id': 100 },
+    ]
+
+    onRpc("get_mandatory_days", () => ({}));
+    onRpc("get_unusual_days", () => ({}));
+    onRpc("get_allocation_data_request", () => ({}));
+    onRpc("get_special_days_data", () => ({bankHolidays: [], mandatoryDays: []}));
+    onRpc("has_accrual_allocation", () => false);
+    onRpc("get_allocation_requests_amount", () => 0);
+
+    await mountView({
+            type: "calendar",
+            resModel: "hr.leave",
+            arch: `
+            <calendar js_class="time_off_calendar_dashboard"
+                    string="Time Off Request"
+                    form_view_id="hr_leave_view_form_dashboard_new_time_off"
+                    event_open_popup="true"
+                    date_start="date_from"
+                    date_stop="date_to"
+                    quick_create="0"
+                    show_date_picker="0"
+                    show_unusual_days="True"
+                    hide_time="True"
+                    mode="year">
+                <field name="display_name" string=""/>
+                <field name="holiday_status_id" filters="1" invisible="1" color="color"/>
+                <field name="state" invisible="1"/>
+                <field name="is_hatched" invisible="1" />
+                <field name="is_striked" invisible="1"/>
+            </calendar>`,
+            context: user.context
+        });
+    await clickDate("2024-01-09");
+    await click(".o_cw_popover_link");
+    await waitFor("button:contains(Delete Time Off)");
+    await click(".btn-close");
+    await clickDate("2024-01-10");
+    await click(".o_cw_popover_link");
+    await waitFor("button:contains(Cancel Time Off)");
+})
+

--- a/addons/hr_holidays/static/tests/mock_server/mock_models/hr_leave.js
+++ b/addons/hr_holidays/static/tests/mock_server/mock_models/hr_leave.js
@@ -7,6 +7,9 @@ export class HrLeave extends models.Model {
     employee_id = fields.Many2one({
         relation: "hr.employee",
     });
+    user_id = fields.Many2one({
+        relation: "res.users"
+    });
     department_id = fields.Many2one({
         relation: "hr.department",
     });
@@ -27,4 +30,7 @@ export class HrLeave extends models.Model {
             ["hour", "Hours"],
         ],
     });
+    can_cancel = fields.Boolean();
+    is_hatched = fields.Boolean();
+    is_striked = fields.Boolean();
 }

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -285,6 +285,7 @@
         <field name="arch" type="xml">
             <form string="Time Off Request" class="o_hr_leave_form" duplicate="false">
             <field name="employee_id" invisible="1"/> <!-- for the employee's default value-->
+            <field name="user_id" invisible="1"/> <!-- for conditional rendering of buttons on card -->
             <header>
                 <button string="Approve" name="action_approve" type="object" class="oe_highlight" invisible="not can_approve or not id"/>
                 <button string="Validate" name="action_approve" invisible="not can_validate or can_approve or not id" type="object" class="oe_highlight"/>


### PR DESCRIPTION
On the Time Off dashboard, the time off cards can show delete and cancel options depending on multiple conditions. Before the fix, the delete and cancel buttons were never appearing. This was due to the fact that the conditions for the rendering of these buttons was based on the field "user_id" of the hr_leave, which was not accessible as it was not included in the view.

This PR fixes the issue by adding the "user_id" field in the hr_leave form view (invisible) so that the front-end can access the field.

task-4781387
