### PR TITLE
[FIX] mail: fix info displayed on activity

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -609,6 +609,15 @@ class MailActivity(models.Model):
     def activity_format(self):
         return Store(self).get_result()
 
+    def _to_store(self, store, fields, **kwargs):
+        readable_fields = [field for field in fields if isinstance(field, str)]
+        store_fields = set(fields) - set(readable_fields)
+        records = self._read_format(list(readable_fields))
+        for record, record_data in zip(self, records):
+            store.add_model_values(record._name, record_data)
+        if store_fields:
+            store.add_records_fields(self, list(store_fields))
+
     def _to_store_defaults(self):
         return [
             "activity_category",


### PR DESCRIPTION
This commit fixes an issue introduced by de26b96cda16 where some fields of the activity records weren't properly read. Notably `activity_type_id` and `create_uid` which only returned their ID instead of returning (ID, name).

This led to a wrong display of the additional informations inside the activities in the Chatter. Where the type of activity and its creator were empty. To fix this, we reimplement the _to_store method so that we properly read the fields while letting the store add their specific fields.

task-4794562

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
