### PR TITLE
[FIX] sale: fix amount format in down payment description

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -7,6 +7,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.tools import float_is_zero
+from odoo.tools.misc import formatLang
 
 
 class SaleAdvancePaymentInv(models.TransientModel):
@@ -275,7 +276,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         self.ensure_one()
         context = {'lang': order.partner_id.lang}
         if self.advance_payment_method == 'percentage':
-            name = _("Down payment of %s%%", self.amount)
+            name = _("Down payment of %s%%", formatLang(self.env(context=context), self.amount, digits=1))
         else:
             name = _('Down Payment')
         del context


### PR DESCRIPTION
Steps to reproduce:
1. Go to Sales > Create a Quotation
2. Add Customer > Set Customer's lang to French or German
3. Add a product, confirm the quotation
4. Click "Create Invoice" > Select "Down Payment (percentage)"
5. Set amount (e.g., 20.5%) and create the invoice

Issue:
When creating a down payment invoice using "percentage" option, the description text is translated correctly to partner's language (e.g., French or German), but amount in description remains formatted using English conventions (e.g. "20.5%" instead of "20,5 %" in French or German).

Cause:
This happens because the amount is inserted as a raw float without localization.

Solution:
This fix uses `formatLang()` with the correct context to format the percentage amount according to the partner's language (i.e., proper decimal separator).

opw : 4743326
