### PR TITLE
[FIX] html_editor: do not add FEFFs inside uneditables

### DIFF
--- a/addons/html_editor/static/src/core/protected_node_plugin.js
+++ b/addons/html_editor/static/src/core/protected_node_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "../plugin";
 import { isProtecting, isUnprotecting } from "../utils/dom_info";
 import { childNodes } from "../utils/dom_traversal";
+import { withSequence } from "@html_editor/utils/resource";
 
 const PROTECTED_SELECTOR = `[data-oe-protected="true"],[data-oe-protected=""]`;
 const UNPROTECTED_SELECTOR = `[data-oe-protected="false"]`;
@@ -16,7 +17,7 @@ export class ProtectedNodePlugin extends Plugin {
     resources = {
         /** Handlers */
         clean_for_save_handlers: ({ root }) => this.cleanForSave(root),
-        normalize_handlers: this.normalize.bind(this),
+        normalize_handlers: withSequence(0, this.normalize.bind(this)),
         before_filter_mutation_record_handlers: this.beforeFilteringMutationRecords.bind(this),
 
         unsplittable_node_predicates: [

--- a/addons/html_editor/static/src/main/feff_plugin.js
+++ b/addons/html_editor/static/src/main/feff_plugin.js
@@ -93,7 +93,9 @@ export class FeffPlugin extends Plugin {
             return [];
         }
         const elements = [...selectElements(root, combinedSelector)];
+        const isEditable = (node) => node.parentElement?.isContentEditable;
         const feffNodes = elements
+            .filter(isEditable)
             .flatMap((el) => {
                 const addFeff = (position) => this.addFeff(el, position, cursors);
                 return [

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -89,7 +89,7 @@ test("should not normalize protected elements children (true)", async () => {
                     <ul><li><p>abc</p><p><br></p></li></ul>
                 </div>
                 <div data-oe-protected="true" contenteditable="false">
-                    <p>\ufeff<i class="fa"></i>\ufeff</p>
+                    <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                 </div>
                 `),
@@ -124,7 +124,7 @@ test("should normalize unprotected elements children (false)", async () => {
                 `),
         contentAfterEdit: unformat(`
                 <div data-oe-protected="true" contenteditable="false">
-                    <p>\ufeff<i class="fa"></i>\ufeff</p>
+                    <p><i class="fa"></i></p>
                     <ul><li>abc<p><br></p></li></ul>
                     <div data-oe-protected="false" contenteditable="true">
                         <p>\ufeff<i class="fa" contenteditable="false">\u200B</i>\ufeff</p>

--- a/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
+++ b/addons/html_editor/static/tests/embedded_components_plugins/toggle_block.test.js
@@ -76,7 +76,7 @@ describe("deleteBackward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -119,7 +119,7 @@ describe("deleteBackward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -237,7 +237,7 @@ describe("deleteForward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -311,7 +311,7 @@ describe("deleteForward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -358,7 +358,7 @@ describe("deleteForward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-right"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -408,7 +408,7 @@ describe("deleteForward applied to toggle", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -477,7 +477,7 @@ describe("Enter applied to toggle title", () => {
                 <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                     <div class="d-flex flex-row align-items-center">
                         <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                            \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                            <i class="fa align-self-center fa-caret-down"></i>
                         </button>
                         <div class="flex-fill ms-1">
                             <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -525,7 +525,7 @@ describe("Enter applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" data-embedded-props='{ "toggleBlockId": "1" }' contenteditable="false">
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-right"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -584,7 +584,7 @@ describe("Enter applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -664,7 +664,7 @@ describe("Tab applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -677,7 +677,7 @@ describe("Tab applied to toggle title", () => {
                         <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                             <div class="d-flex flex-row align-items-center">
                                 <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                                    \ufeff<i class="fa align-self-center fa-caret-right"></i>\ufeff
+                                    <i class="fa align-self-center fa-caret-right"></i>
                                 </button>
                                 <div class="flex-fill ms-1">
                                     <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -731,7 +731,7 @@ describe("Tab applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -744,7 +744,7 @@ describe("Tab applied to toggle title", () => {
                         <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                             <div class="d-flex flex-row align-items-center">
                                 <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                                    \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                                    <i class="fa align-self-center fa-caret-down"></i>
                                 </button>
                                 <div class="flex-fill ms-1">
                                     <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -800,7 +800,7 @@ describe("Shift+Tab applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "1" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">
@@ -817,7 +817,7 @@ describe("Shift+Tab applied to toggle title", () => {
             <div data-embedded="toggleBlock" data-oe-protected="true" contenteditable="false" data-embedded-props='{ "toggleBlockId": "2" }'>
                 <div class="d-flex flex-row align-items-center">
                     <button class="btn p-0 border-0 align-items-center justify-content-center btn-light">
-                        \ufeff<i class="fa align-self-center fa-caret-down"></i>\ufeff
+                        <i class="fa align-self-center fa-caret-down"></i>
                     </button>
                     <div class="flex-fill ms-1">
                         <div data-embedded-editable="title" data-oe-protected="false" contenteditable="true">

--- a/addons/html_editor/static/tests/insert/html.test.js
+++ b/addons/html_editor/static/tests/insert/html.test.js
@@ -391,7 +391,7 @@ describe("not collapsed selection", () => {
                 );
             },
             contentAfterEdit:
-                '<p>\ufeff<i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>\ufeff[]</p>',
+                '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
             contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]</p>',
         });
     });

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -17,7 +17,7 @@ test("add 3 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 });
 
@@ -29,7 +29,7 @@ test("add 5 star elements", async () => {
 
     await press("Enter");
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 });
 
@@ -41,19 +41,19 @@ test("select star rating", async () => {
     await click("i.fa-star-o:first");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 
     await click("i.fa-star-o:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i><i class="o_stars fa fa-star" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 
     await click("i.fa-star:last");
     await animationFrame();
     expect(getContent(el)).toBe(
-        `<p>\u200B<span contenteditable="false" class="o_stars">\ufeff<i class="fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff<i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i>\ufeff</span>\u200B[]</p>`
+        `<p>\u200B<span contenteditable="false" class="o_stars"><i class="fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i><i class="o_stars fa fa-star-o" contenteditable="false">\u200B</i></span>\u200B[]</p>`
     );
 });
 


### PR DESCRIPTION
Before this commit:

- FeffPlugin adds padding to elements matching the selectors in selectors_for_feff_providers regardless whether their parents are contenteditable or not. The same plugin does not remove on save the FEFFs added to non-contenteditable elements.

After this commit:

- The FEFF plugin skips non-contenteditable elements.
- The normalize handler of ProtectedNodePlugin is called before the normalize handler of FeffPlugin, to ensure that protected elements are marked as non-contenteditable before being processed by FeffPlugin.

task-4795471
