### PR TITLE
[FIX] hw_drivers: don't send devices before checkout

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -118,8 +118,6 @@ class ConnectionManager(Thread):
         self.new_database_url = url
         # Save DB URL and token
         helpers.save_conf_server(url, token, db_uuid, enterprise_code)
-        # Notify the DB, so that the kanban view already shows the IoT Box
-        manager.send_all_devices()
         # Switch git branch before restarting, this avoids restarting twice
         helpers.check_git_branch()
         # Restart to get a certificate, load the IoT handlers...


### PR DESCRIPTION
Before this commit, the connection manager would send the IoT devices to the DB before checking out to the correct git branch. This was intended to give the user a quicker response that the IoT connection was successful.

However, due to the change of identifier from MAC address to serial number, connecting an IoT to a DB in master results in the following behaviour:
  - IoT starts in saas-18.1, connects to DB
  - It posts to `/iot/setup` before checking out, using its MAC as the identifier
  - The IoT box appears in the Odoo backend with the MAC identifier and its current devices
  - After checking out, the IoT calls `/iot/setup` again but with the serial number
  - The Odoo backend rejects the call because it thinks it is a new IoT box, but the token doesn't match

The end result is that it is impossible to connect new devices to the Odoo database, unless the IoT is disconnected and re-paired.

To fix this, we will simply stop sending the devices early.

task-4797337

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
