### PR TITLE
[16.0][FIX] hr_holidays: Error when selecting time off from a different timezone

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -121,8 +121,8 @@ class HolidaysRequest(models.Model):
             new_values.update([('request_date_from', date_from), ('request_date_to', date_to)])
 
             employee = self.env['hr.employee'].browse(values['employee_id']) if values.get('employee_id') else self.env.user.employee_id
-            default_start_time = self._get_start_or_end_from_attendance(7, datetime.now().date(), employee).time()
-            default_end_time = self._get_start_or_end_from_attendance(19, datetime.now().date(), employee).time()
+            default_start_time = self._get_start_or_end_from_attendance(7, values['date_from'].date(), employee).time()
+            default_end_time = self._get_start_or_end_from_attendance(19, values['date_to'].date(), employee).time()
             if values['date_from'].time() == default_start_time and values['date_to'].time() == default_end_time:
                 attendance_from, attendance_to = self._get_attendances(employee, date_from, date_to)
                 new_values['date_from'] = self._get_start_or_end_from_attendance(attendance_from.hour_from, date_from, employee)


### PR DESCRIPTION
When selecting an absence for a future date that falls in a different timezone (this can happen in the case of Spain), the default processing of the start and end dates may be using an incorrect timezone.
![error de ausencias](https://github.com/user-attachments/assets/bb90053d-282b-4c43-a3fa-efe8ec7f9b32)
(The next time change in Spain will occur on Sunday, 26 October 2025)

The correct approach would be to base it on the timezone of the start/end dates selected in the calendar.
![ausencias corregido](https://github.com/user-attachments/assets/69adf769-4b13-439a-bd72-2cc0d8f71220)

cc @Tecnativa TT56343

ping @sergio-teruel @victoralmau 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
