### PR TITLE
[FIX] point_of_sale: register outstanding account id on pos payments

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1136,6 +1136,11 @@ class PosSession(models.Model):
             'company_id': self.company_id.id,
         })
 
+        # In community the outstanding account is computed on the creation of account.payment records
+        accounting_installed = self.env['account.move']._get_invoice_in_payment_state() == 'in_payment'
+        if not account_payment.outstanding_account_id and accounting_installed:
+            account_payment.outstanding_account_id = account_payment._get_outstanding_account(account_payment.payment_type)
+
         if float_compare(amounts['amount'], 0, precision_rounding=self.currency_id.rounding) < 0:
             # revert the accounts because account.payment doesn't accept negative amount.
             account_payment.write({


### PR DESCRIPTION
Why the fix:
------------
This fix https://github.com/odoo/odoo/commit/9002edacd210730a97f5ddc9459cfaa1fb9631bd wasn't fully forward ported.
On 18.2, the fix had to include this one https://github.com/odoo/odoo/commit/180c46f8ab0df68cd469ddf4bc68895f0e7b8e12 and the part were we fetch the oustanding account if there is none after creation was forgotten. We now re-introduce it.

opw-4317320

