### PR TITLE
[FIX] account: properly generate cash basis taxes in multivat setups

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -879,13 +879,14 @@ class AccountChartTemplate(models.AbstractModel):
         if taxes_in_country:
             return
 
-        def create_foreign_tax_account(existing_account, additional_label):
+        def create_foreign_tax_account(existing_account, additional_label, reconcilable=False):
             new_code = self.env['account.account'].with_company(company)._search_new_account_code(existing_account.code)
             return self.env['account.account'].create({
                 'name': f"{existing_account.name} - {additional_label}",
                 'code': new_code,
                 'account_type': existing_account.account_type,
                 'company_ids': [Command.link(company.id)],
+                'reconcile': reconcilable,
             })
 
         existing_accounts = {'': None, None: None}  # keeps tracks of the created account by foreign xml_id
@@ -952,26 +953,32 @@ class AccountChartTemplate(models.AbstractModel):
         local_cash_basis_tax = self.env["account.tax"].search([
             *self.env['account.tax']._check_company_domain(company),
             ('country_id', '=', company.account_fiscal_country_id.id),
+            ('tax_exigibility', '=', 'on_payment'),
             ('cash_basis_transition_account_id', '!=', False)
         ], limit=1)
-        for tax_template in tax_data.values():
-            account_xml_id = tax_template.get('cash_basis_transition_account_id')
-            if account_xml_id in existing_accounts:
-                continue
+        has_cash_basis = False
+        for tax_template in sorted(tax_data.values(), key=lambda x: any(rep_line.get('account_id') for _command, _id, rep_line in x.get('repartition_line_ids', [])), reverse=True):
+            if tax_template.get('tax_exigibility') == 'on_payment':
+                has_cash_basis = True
 
-            if local_cash_basis_tax:
-                existing_accounts[account_xml_id] = create_foreign_tax_account(
-                    local_cash_basis_tax.cash_basis_transition_account_id,
-                    _("Cash basis transition account")
-                ).id
-                continue
+                account_xml_id = tax_template.get('cash_basis_transition_account_id')
+                if account_xml_id not in existing_accounts:
+                    if local_cash_basis_tax:
+                        existing_accounts[account_xml_id] = create_foreign_tax_account(
+                            local_cash_basis_tax.cash_basis_transition_account_id,
+                            _("Cash basis transition account"),
+                            reconcilable=True,
+                        ).id
 
-            account_id = [rep_line['account_id'] for _command, _id, rep_line in tax_template['repartition_line_ids'] if rep_line.get('account_id')]
-            if account_id:
-                local_account = self.env['account.account'].browse(existing_accounts[account_id[0]])
-                existing_accounts[account_xml_id] = create_foreign_tax_account(local_account, _("Cash basis transition account")).id
-                continue
-            existing_accounts[account_xml_id] = None
+                    elif account_ids := [rep_line['account_id'] for _command, _id, rep_line in tax_template.get('repartition_line_ids', []) if rep_line.get('account_id')]:
+                        local_account = self.env['account.account'].browse(existing_accounts[account_ids[0]])
+                        existing_accounts[account_xml_id] = create_foreign_tax_account(local_account, _("Cash basis transition account"), reconcilable=True).id
+
+                    else:
+                        existing_accounts[account_xml_id] = None
+
+        if has_cash_basis:
+            company.tax_exigibility = True
 
         # Assign the account based on the map
         for field, account_name in field_and_names:
@@ -989,7 +996,8 @@ class AccountChartTemplate(models.AbstractModel):
                 rep_line['account_id'] = existing_accounts.get(rep_line.get('account_id'))
 
             account_xml_id = tax_template.get('cash_basis_transition_account_id')
-            tax_template['cash_basis_transition_account_id'] = existing_accounts[account_xml_id]
+            if account_xml_id:
+                tax_template['cash_basis_transition_account_id'] = existing_accounts[account_xml_id]
 
         data = {
             'account.tax.group': tax_group_data,

--- a/addons/account/tests/test_multivat.py
+++ b/addons/account/tests/test_multivat.py
@@ -117,20 +117,21 @@ def data_method_provider(chart_template_name, country_code):
     return test_data_getter
 
 
-def _tax_vals(name, amount, external_id_prefix):
+def _tax_vals(name, amount, external_id_prefix, cash_basis=False, account_on_repartition=True):
     return {
         'name': name,
         'amount': amount,
         'type_tax_use': 'purchase',
         'tax_group_id': 'tax_group_taxes',
-        'cash_basis_transition_account_id': f'{external_id_prefix}test_account_cash_basis_transition_account_id',
+        'cash_basis_transition_account_id': f'{external_id_prefix}test_account_cash_basis_transition_account_id' if cash_basis else False,
+        'tax_exigibility': 'on_payment' if cash_basis else 'on_invoice',
         'repartition_line_ids': [
             Command.create({'document_type': 'invoice', 'factor_percent': 100, 'repartition_type': 'base'}),
             Command.create({'document_type': 'invoice', 'factor_percent': 100, 'repartition_type': 'tax',
-                           'account_id': f'{external_id_prefix}test_account_tax_recoverable_template'}),
+                           'account_id': f'{external_id_prefix}test_account_tax_recoverable_template' if account_on_repartition else False}),
             Command.create({'document_type': 'refund', 'factor_percent': 100, 'repartition_type': 'base'}),
             Command.create({'document_type': 'refund', 'factor_percent': 100, 'repartition_type': 'tax',
-                           'account_id': f'{external_id_prefix}test_account_tax_recoverable_template'}),
+                           'account_id': f'{external_id_prefix}test_account_tax_recoverable_template' if account_on_repartition else False}),
         ]
     }
 
@@ -217,14 +218,12 @@ class TestMultiVAT(AccountTestInvoicingCommon):
 
         tax = self.env["account.chart.template"].ref('foreign_test_tax_1_template')
         self.assertEqual(tax.country_id.code, 'FR')
-        self.assertEqual(tax.cash_basis_transition_account_id.code, '451501')
         _base_line, tax_line = tax.invoice_repartition_line_ids
         self.assertEqual(tax_line.account_id.code, '411001',
                          "The foreign tax account should be a new account with a code close to the local tax account code")
 
         tax = self.env["account.chart.template"].ref('foreign_test_tax_2_template')
         self.assertEqual(tax.country_id.code, 'FR')
-        self.assertEqual(tax.cash_basis_transition_account_id.code, '451501')
         _base_line, tax_line = tax.invoice_repartition_line_ids
         self.assertEqual(tax_line.account_id.code, '411001',
                          "The previously created tax account should be reused for similar tax")
@@ -242,3 +241,34 @@ class TestMultiVAT(AccountTestInvoicingCommon):
                 for i, child in enumerate(record.children_tax_ids):
                     child_tax = self.env["account.chart.template"].ref(children_taxes[xml_id][i], raise_if_not_found=False)
                     self.assertEqual(child.id, child_tax.id)
+
+    def test_multivat_cash_basis(self):
+        def wrap_data_getter_for_caba(data_getter):
+            def caba_data_getter(self, template_code):
+                rslt = data_getter(self, template_code)
+
+                rslt['account.tax']['es.caba_0_tax'] = _tax_vals("Dudu 0", 0, 'es', cash_basis=True, account_on_repartition=False)
+                rslt['account.tax']['es.caba_42_tax'] = _tax_vals("Dudu 42", 42, 'es', cash_basis=True)
+
+                return rslt
+
+            return caba_data_getter
+
+        foreign_country = self.env.ref("base.es")
+        foreign_vat_fpos = self.env["account.fiscal.position"].create({
+            "name": "ES foreign VAT",
+            "auto_apply": True,
+            "country_id": foreign_country.id,
+            "foreign_vat": "ESA12345674",
+        })
+
+        test_get_data = wrap_data_getter_for_caba(data_method_provider("foreign", "es"))
+        with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True):
+            foreign_vat_fpos.action_create_foreign_taxes()
+
+        created_taxes = self.env.ref('local_es.caba_0_tax') + self.env.ref('local_es.caba_42_tax')
+        for tax in created_taxes:
+            self.assertEqual(tax.tax_exigibility, 'on_payment')
+            self.assertEqual(tax.cash_basis_transition_account_id.code, '411005')
+
+        self.assertTrue(self.env.company.tax_exigibility, "Creating foreign cash basis taxes should enable the cash basis setting on the company.")


### PR DESCRIPTION
To reproduce the issue:

1) Create a Belgian company, with CoA installed
2) Make a foreign VAT fiscal position in France for this company 3) Click on the button in the fiscal position's banner to generate the French taxes

=> Some of the generated taxes are cash basis. All of them should have a transition account, but it's not the case (some have, some haven't).

This is due to the fact 0% cash basis taxes exist in France, and they are treated before some other taxes due to the order we declare them in in the csv. When creating those 0% taxes, the transition account had to be mapped. Since Belgium does not have any cash basis taxe, we relied on the first account used in the tax repartition of the tax to convert. However, those 0% taxes obviously had no account there (since they're 0% anyway), so we ended up not entering this condition https://github.com/odoo/odoo/blob/18.0/addons/account/models/chart_template.py#L970 and mapping the transition account to None. Because of that, we did not create any equivalent for that account, for any of the taxes using it.

This commit solves that by sorting the tax templates to first treat those with accounts in their tax repartition.

We also fix here the fact that instantiating such cash basis taxes did not enable the "cash basis" setting on the company ; which didn't make any sense, and caused an error message when trying to edit the settings afterwards.
