### PR TITLE
[IMP] account: change payment state tag colors for better UX clarity

### DIFF
--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -26,7 +26,7 @@
                     <field name="currency_id" string="Payment Currency" optional="hide"/>
                     <field name="activity_ids" widget="list_activity" optional="hide"/>
                     <field name="amount_company_currency_signed" widget="monetary" string="Amount" sum="Total"/>
-                    <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'in_process'"/>
+                    <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'in_process'" decoration-success="state == 'paid'"/>
                 </list>
             </field>
         </record>


### PR DESCRIPTION
Before this commit:
- 'In Progress' payment states were shown with a green tag, which could misleadingly suggest that the payment process was complete.
- 'Paid' payment states were shown with a grey tag, implying that some action might still be pending.

After this commit:
- 'In Progress' tags are now orange, signaling that further actions (such as batching or reconciliation) are still required.
- 'Paid' tags are now green, indicating that the process is fully complete and no further user action is needed.

Task Id: 4797098


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
