### PR TITLE
[IMP] im_livechat: add a buffer time option

### DIFF
--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -143,6 +143,7 @@
                                 </group>
                                 <group string="Session Limits">
                                     <group>
+                                        <field name="buffer_time"/>
                                         <field name="max_sessions_mode" widget="radio" options="{'horizontal': true}"/>
                                         <field name="max_sessions" invisible="max_sessions_mode != 'limited'"/>
                                         <field name="block_assignment_during_call"/>


### PR DESCRIPTION
This PR adds a buffer time option for operators. This means that the dispatcher will try to wait for this amount of time before assigning a new chat to this operator.

This prevents the operator to have multiple new chats while the previous ones are not yet handled/examinated.

To be noted that this option is best-effort and is not enforced if the operator is the only suited candidate.

task-4770867

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
