### PR TITLE
[FIX] stock: Merge moves with price_unit rounding errors

### DIFF
--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -429,14 +429,19 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         self.assertEqual(len(purchase_order.picking_ids.move_line_ids), 1)
         self.assertEqual(purchase_order.picking_ids.move_line_ids.quantity_product_uom, 7)
 
-
+        # -- Decrease the quantity -- #
         purchase_order.order_line.product_qty = 4
-        # updating quantity shouldn't create a seperate stock move
+        # updating quantity shouldn't create a separate stock move
         # the new stock move (-3) should be merged with the previous
-        purchase_order.button_confirm()
         self.assertEqual(len(purchase_order.picking_ids), 1)
         self.assertEqual(len(purchase_order.picking_ids.move_line_ids), 1)
         self.assertEqual(purchase_order.picking_ids.move_line_ids.quantity_product_uom, 4)
+
+        # -- Increase the quantity -- #
+        purchase_order.order_line.product_qty = 14
+        self.assertEqual(len(purchase_order.picking_ids), 1)
+        self.assertEqual(len(purchase_order.picking_ids.move_line_ids), 1)
+        self.assertEqual(purchase_order.picking_ids.move_line_ids.quantity_product_uom, 14)
 
     def test_message_qty_already_received(self):
         self.env.user.write({'company_id': self.company_data['company'].id})

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1012,7 +1012,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
-        return ['description_picking', 'price_unit']
+        return ['description_picking']
 
     def _clean_merged(self):
         """Cleanup hook used when merging moves"""
@@ -1021,6 +1021,27 @@ Please change the quantity done or the rounding precision of your unit of measur
     def _update_candidate_moves_list(self, candidate_moves_set):
         for picking in self.mapped('picking_id'):
             candidate_moves_set.add(picking.move_ids)
+
+    def _merge_move_itemgetter(self, distinct_fields, excluded_fields=None):
+        field_names = [
+            f_name for f_name in distinct_fields
+            if f_name != 'price_unit' and (excluded_fields is None or f_name not in excluded_fields)
+        ]
+        base_getter = itemgetter(*field_names)
+
+        if 'price_unit' not in distinct_fields:
+            return base_getter
+
+        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
+        currency_prec = self.company_id.currency_id.decimal_places
+        price_precision = min(currency_prec, price_unit_prec)
+
+        def _get_formatted_price_unit(move):
+            # Round and Cast the price_unit into a string so that rounding errors do not prevent the merge
+            rounded_price_unit = float_round(move.price_unit, precision_digits=price_precision)
+            return "{:.{p}f}".format(rounded_price_unit, p=price_precision)
+
+        return lambda move: base_getter(move) + (_get_formatted_price_unit(move),)
 
     def _merge_moves(self, merge_into=False):
         """ This method will, for each move in `self`, go up in their linked picking and try to
@@ -1050,13 +1071,13 @@ Please change the quantity done or the rounding precision of your unit of measur
         # Detach their picking as they will either get absorbed or create a backorder, so no extra logs will be put in the chatter
         neg_qty_moves.picking_id = False
         excluded_fields = self._prepare_merge_negative_moves_excluded_distinct_fields()
-        neg_key = itemgetter(*[field for field in distinct_fields if field not in excluded_fields])
+        neg_key = self._merge_move_itemgetter(distinct_fields, excluded_fields)
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
 
         for candidate_moves in candidate_moves_set:
             # First step find move to merge.
             candidate_moves = candidate_moves.filtered(lambda m: m.state not in ('done', 'cancel', 'draft')) - neg_qty_moves
-            for __, g in groupby(candidate_moves, key=itemgetter(*distinct_fields)):
+            for __, g in groupby(candidate_moves, key=self._merge_move_itemgetter(distinct_fields)):
                 moves = self.env['stock.move'].concat(*g)
                 # Merge all positive moves together
                 if len(moves) > 1:
@@ -1074,27 +1095,24 @@ Please change the quantity done or the rounding precision of your unit of measur
         for neg_move in neg_qty_moves:
             # Check all the candidates that matches the same limited key, and adjust their quantities to absorb negative moves
             for pos_move in moves_by_neg_key.get(neg_key(neg_move), []):
-                currency_prec = pos_move.product_id.currency_id.decimal_places
-                rounding = min(currency_prec, price_unit_prec)
-                if float_compare(pos_move.price_unit, neg_move.price_unit, precision_digits=rounding) == 0:
-                    new_total_value = pos_move.product_qty * pos_move.price_unit + neg_move.product_qty * neg_move.price_unit
-                    # If quantity can be fully absorbed by a single move, update its quantity and remove the negative move
-                    if float_compare(pos_move.product_uom_qty, abs(neg_move.product_uom_qty), precision_rounding=pos_move.product_uom.rounding) >= 0:
-                        pos_move.product_uom_qty += neg_move.product_uom_qty
-                        pos_move.write({
-                            'price_unit': float_round(new_total_value / pos_move.product_qty, precision_digits=price_unit_prec) if pos_move.product_qty else 0,
-                            'move_dest_ids': [Command.link(m.id) for m in neg_move.mapped('move_dest_ids') if m.location_id == pos_move.location_dest_id],
-                            'move_orig_ids': [Command.link(m.id) for m in neg_move.mapped('move_orig_ids') if m.location_dest_id == pos_move.location_id],
-                        })
-                        merged_moves |= pos_move
-                        moves_to_unlink |= neg_move
-                        if float_is_zero(pos_move.product_uom_qty, precision_rounding=pos_move.product_uom.rounding):
-                            moves_to_cancel |= pos_move
-                        break
-                    neg_move.product_uom_qty += pos_move.product_uom_qty
-                    neg_move.price_unit = float_round(new_total_value / neg_move.product_qty, precision_digits=price_unit_prec)
-                    pos_move.product_uom_qty = 0
-                    moves_to_cancel |= pos_move
+                new_total_value = pos_move.product_qty * pos_move.price_unit + neg_move.product_qty * neg_move.price_unit
+                # If quantity can be fully absorbed by a single move, update its quantity and remove the negative move
+                if float_compare(pos_move.product_uom_qty, abs(neg_move.product_uom_qty), precision_rounding=pos_move.product_uom.rounding) >= 0:
+                    pos_move.product_uom_qty += neg_move.product_uom_qty
+                    pos_move.write({
+                        'price_unit': float_round(new_total_value / pos_move.product_qty, precision_digits=price_unit_prec) if pos_move.product_qty else 0,
+                        'move_dest_ids': [Command.link(m.id) for m in neg_move.mapped('move_dest_ids') if m.location_id == pos_move.location_dest_id],
+                        'move_orig_ids': [Command.link(m.id) for m in neg_move.mapped('move_orig_ids') if m.location_dest_id == pos_move.location_id],
+                    })
+                    merged_moves |= pos_move
+                    moves_to_unlink |= neg_move
+                    if float_is_zero(pos_move.product_uom_qty, precision_rounding=pos_move.product_uom.rounding):
+                        moves_to_cancel |= pos_move
+                    break
+                neg_move.product_uom_qty += pos_move.product_uom_qty
+                neg_move.price_unit = float_round(new_total_value / neg_move.product_qty, precision_digits=price_unit_prec)
+                pos_move.product_uom_qty = 0
+                moves_to_cancel |= pos_move
 
         # We are using propagate to False in order to not cancel destination moves merged in moves[0]
         (moves_to_unlink | moves_to_cancel)._clean_merged()


### PR DESCRIPTION
To be able to merge moves, the 'price_unit' fields needs to be equal. However, if the product price decimal accuracy is higher than the currency decimal accuracy, then price_unit that looks the same are actually not, and prevent the merge.

It can happen in 2 situations:
- Python rounding precision: 55.55 != 55.5500000000001
- Tax involvement: If a tax is present on the Purchase Order, then the price unit will be recomputed to check the tax, with something similar to `CURRENCY_ROUND(price_unit * qty) / qty`, and because the currency rounding is less precise, the resulting price_unit will vary depending on the quantity.

A similar issue was already fixed in this commit: a7f08f0b4c87aeb60315d07c2e0a5fc4c7a21e50 ,but only for decrease of quantity.

This fix attempts to fix the increase of quantity. The main issue when fixing this problem is that we can't simply use float_compare, this is because the move values are fetched with _itemgetter_, and are 'compared' when _groupby_ is using these values as dictionary key.

The idea is to create a custom _itemgetter_, that will cast the price_unit as a string using the correct precision.

So, the list of values used in the group by will now look like this:
```
(product.product(84,), 'make_to_stock', ..., '25.67')
```
While it previously looked like this:
```
(product.product(84,), 'make_to_stock', ...,  25.668000000000003)
```

---

## How to reproduce
- Create a Storable product.
- Change the decimal accuracy of product price to 5.
- Create a purchase order for 10 units of P, and a price unit of 25.66803.
- Ensure a tax is set on the PO
- Confirm the order
- Edit the PO line quantity to 13 => The receipt has 2 lines of P, one for the first 10 units and the other for the added 3 units

https://github.com/user-attachments/assets/d93f697f-126a-44e5-b134-5bfc8f3ccc68

---

Test results without fix:
```
2021-01-14 09:12:15,000 21884 ERROR oes_17_test odoo.addons.purchase_stock.tests.test_purchase_order: FAIL: TestPurchaseOrder.test_05_po_update_qty_stock_move_merge
Traceback (most recent call last):
  File "/home/odoo/projects/odoo-src/multiverse/src/17.0/odoo/addons/purchase_stock/tests/test_purchase_order.py", line 442, in test_05_po_update_qty_stock_move_merge
    self.assertEqual(len(purchase_order.picking_ids.move_line_ids), 1)
AssertionError: 2 != 1
```

---
OPW-4675425

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
