### PR TITLE
[FIX] website_blog: prevent last blog post cover edition


### DIFF
--- a/addons/website_blog/views/snippets/s_blog_posts.xml
+++ b/addons/website_blog/views/snippets/s_blog_posts.xml
@@ -18,7 +18,7 @@
                 <t t-set="_record" t-value="record"/>
                 <t t-set="_resize_height" t-value="256"/>
                 <t t-set="_resize_width" t-value="256"/>
-                <t t-set="additionnal_classes" t-value="'w-100 h-100 bg-200 position-absolute'"/>
+                <t t-set="additionnal_classes" t-value="'w-100 h-100 bg-200 position-absolute o_snippet_not_selectable'"/>
             </t>
         </a>
         <div class="ps-2">
@@ -69,7 +69,7 @@
                 <t t-set="_record" t-value="record"/>
                 <t t-set="_resize_height" t-value="512"/>
                 <t t-set="_resize_width" t-value="512"/>
-                <t t-set="additionnal_classes" t-value="'thumb'"/>
+                <t t-set="additionnal_classes" t-value="'thumb o_snippet_not_selectable'"/>
             </t>
         </a>
     </figure>
@@ -84,7 +84,7 @@
                     <t t-set="_record" t-value="record"/>
                     <t t-set="_resize_height" t-value="512"/>
                     <t t-set="_resize_width" t-value="512"/>
-                    <t t-set="additionnal_classes" t-value="'thumb'"/>
+                    <t t-set="additionnal_classes" t-value="'thumb o_snippet_not_selectable'"/>
                 </t>
             </a>
             <div class="card-body">


### PR DESCRIPTION
Scenario:
- insert the last blog posts widget in a page
- open editor and edit (eg. Filter Intensity) the cover of a post
- save

Result: the change is lost

Cause: the content of the widget is dynamic, and we delete the content
in cleanForSave (that call the destroy of the widget) before saving, so
the change are not saved.

Fix: make the dynamically added cover widget unselectable, the cover of
the blog post can still be changed in other locations (blog post list,
blog post page).

opw-4633287

__PR NOTE:__ in verson before 18.0, the cover was not selectable probably from the .o_not_editable on `.s_dynamic_snippet_content` ancestor element. I've not found what changed (there was some change to dynamic snippet and widget blog post) that make it selectable now.