### PR TITLE
[FIX] point_of_sale: fix preset timing runbot error

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.js
@@ -21,6 +21,7 @@ import { PresetSlotsPopup } from "@point_of_sale/app/components/popups/preset_sl
 import { makeAwaitable } from "@point_of_sale/app/utils/make_awaitable_dialog";
 import { _t } from "@web/core/l10n/translation";
 import { openCustomerDisplay } from "@point_of_sale/customer_display/utils";
+import { useAsyncLockedMethod } from "@point_of_sale/app/hooks/hooks";
 
 const { DateTime } = luxon;
 
@@ -55,6 +56,7 @@ export class Navbar extends Component {
             this.isSystemUser = await user.hasGroup("base.group_system");
         });
         useExternalListener(document, "keydown", this.handleKeydown.bind(this));
+        this.openPresetTiming = useAsyncLockedMethod(this.openPresetTiming);
     }
 
     handleKeydown(event) {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -713,6 +713,7 @@ registry.category("web_tour.tours").add("test_preset_timing", {
             Chrome.clickPresetTimingSlot(),
             Chrome.selectPresetTimingSlotHour("12:00"),
             Chrome.presetTimingSlotIs("12:00"),
+            Chrome.isSynced(),
             Chrome.clickPresetTimingSlot(),
             Chrome.selectPresetTimingSlotHour("15:00"),
             Chrome.presetTimingSlotIs("15:00"),


### PR DESCRIPTION
Fix runbot error when using preset timing in tour. Now we have an async lock for the function `openPresetTiming` so when opening this popup we make sure the previous one is finished. Also, inside the tour `test_preset_timing` we added a step to wait for the synchronization to be finished before opening the preset timing popup again.

runbot error: 213368



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
