### PR TITLE
[IMP] spreadsheet: use smalluuid instead of uuidv4

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_view_plugin.js
@@ -560,7 +560,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         }
         this.exportSheetWithActiveFilters(data);
         data.sheets[data.sheets.length - 1] = {
-            ...createEmptyExcelSheet(uuidGenerator.uuidv4(), _t("Active Filters")),
+            ...createEmptyExcelSheet(uuidGenerator.smallUuid(), _t("Active Filters")),
             ...data.sheets.at(-1),
         };
     }
@@ -600,7 +600,7 @@ export class GlobalFiltersCoreViewPlugin extends OdooCoreViewPlugin {
         const styleId = getItemId({ bold: true }, data.styles);
 
         const sheet = {
-            ...createEmptySheet(uuidGenerator.uuidv4(), _t("Active Filters")),
+            ...createEmptySheet(uuidGenerator.smallUuid(), _t("Active Filters")),
             cells,
             formats,
             styles: {

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin.test.js
@@ -793,7 +793,7 @@ test("Remove odoo chart when sheet is deleted", async () => {
     const { model } = await createSpreadsheetWithChart({ type: "odoo_line" });
     const sheetId = model.getters.getActiveSheetId();
     model.dispatch("CREATE_SHEET", {
-        sheetId: model.uuidGenerator.uuidv4(),
+        sheetId: model.uuidGenerator.smallUuid(),
         position: model.getters.getSheetIds().length,
     });
     expect(model.getters.getOdooChartIds().length).toBe(1);

--- a/addons/spreadsheet/static/tests/helpers/chart.js
+++ b/addons/spreadsheet/static/tests/helpers/chart.js
@@ -69,8 +69,8 @@ function getChartDefinition(type) {
         background: "#FFFFFF",
         legendPosition: "top",
         verticalAxisPosition: "left",
-        dataSourceId: uuidGenerator.uuidv4(),
-        id: uuidGenerator.uuidv4(),
+        dataSourceId: uuidGenerator.smallUuid(),
+        id: uuidGenerator.smallUuid(),
         type,
     };
 }

--- a/addons/spreadsheet/static/tests/helpers/commands.js
+++ b/addons/spreadsheet/static/tests/helpers/commands.js
@@ -301,7 +301,7 @@ export function updatePivotMeasureDisplay(model, pivotId, measureId, display) {
 }
 
 export function createSheet(model, data = {}) {
-    const sheetId = data.sheetId || model.uuidGenerator.uuidv4();
+    const sheetId = data.sheetId || model.uuidGenerator.smallUuid();
     return model.dispatch("CREATE_SHEET", {
         position: data.position !== undefined ? data.position : 1,
         sheetId,


### PR DESCRIPTION
Since https://github.com/odoo/o-spreadsheet/pull/5704, a new uuid generator has been added to spreadsheet, with the benefit of being smaller and more efficient than the previous one. This commit updates the code to use the new uuid generator instead of the old one.

Task: 4709008

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
