### PR TITLE
[FIX] base_import: prevent TypeError when imported data field is invalid

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1597,9 +1597,9 @@ class Base_ImportImport(models.TransientModel):
 
                 # merge data if necessary
                 if field_type == 'char':
-                    new_record.append(' '.join(record[idx] for idx in indexes if record[idx]))
+                    new_record.append(' '.join(str(record[idx]) for idx in indexes if record[idx]))
                 elif field_type == 'text':
-                    new_record.append('\n'.join(record[idx] for idx in indexes if record[idx]))
+                    new_record.append('\n'.join(str(record[idx]) for idx in indexes if record[idx]))
                 elif field_type == 'many2many':
                     new_record.append(','.join(record[idx] for idx in indexes if record[idx]))
                 else:


### PR DESCRIPTION
Currently, if a `date or datetime` field is mapped with a `string or character` field error will be encountered.

**Steps to Reproduce:**
1) Install the `Accounting` module.
2) Import [this](https://docs.google.com/spreadsheets/d/1k_s_V7Q-zA9uQUaQblsJtBHC4VlEFM-w/edit?usp=sharing&ouid=101212513075316114369&rtpof=true&sd=true) file in Account Journal. 
3) Map `Date` with `Account Number`.
4) Click on **Test**, error will be encountered.

**Error:**
`TypeError: sequence item 0: expected str instance, datetime.date found`

**Root Cause:**
The `_handle_multi_mapping` method assumes that all values in the input data are strings. However, when a `datetime.date` or `datetime.datetime` object is encountered, Python raises a `TypeError` during concatenation at [1]

[1]- https://github.com/odoo/odoo/blob/81415d2fab4cfa07897f6a806e5d8a3108cd9c2b/addons/base_import/models/base_import.py#L1599-L1602

**Solution:**
This commit prevents error by ensuring that the `imported fields` are converted to `String` before concatenation.

sentry-6591445640
