### PR TITLE
[FIX] product: prevent error on setting pricelist on unsaved product variant

### DIFF
--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -118,6 +118,8 @@ class Pricelist(models.Model):
         :rtype: float
         """
         self and self.ensure_one()  # self is at most one record
+        if not product:
+            return {}
         return self._compute_price_rule(product, *args, **kwargs)[product.id][0]
 
     def _get_product_price_rule(self, product, *args, **kwargs):


### PR DESCRIPTION
An error occurs when a user attempts to set the **Pricer Sales Pricelist** on a product variant that has not yet been saved.

**Steps to reproduce:**
- Install the `pos_pricer` module.
- Open the form view of **Product Variants**.
- Without saving the record, try to add a **Pricer Sales Pricelist**.
- Observe the error.

**Error:**
`KeyError: False`

**Cause:**
When the product variant is unsaved, `product.id` is `False`, leading to a `KeyError` at [1], because `False` is not a valid key in the result of method `_compute_price_rule()`.

[1] - https://github.com/odoo/odoo/blob/d352cfcfe0fe8c161392f3c39ea3e64b7c98bd69/addons/product/models/product_pricelist.py#L140

This commit ensures that users can add a 'Pricer Sales Pricelist' to a product variant, even before saving it.

Sentry - 6598605111