### PR TITLE
[FIX] website: handle concurrent update failure errors while updating footer

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -709,20 +709,24 @@ class Website(models.Model):
             'website.template_footer_minimalist',
         ]
         for footer_id in footer_ids:
-            try:
-                view_id = self.env['website'].viewref(footer_id)
-                if view_id:
-                    # Deliberately hardcode dynamic code inside the view arch,
-                    # it will be transformed into static nodes after a save/edit
-                    # thanks to the t-ignore in parents node.
+            view_id = self.env['website'].viewref(footer_id)
+            if view_id:
+                # Deliberately hardcode dynamic code inside the view arch,
+                # it will be transformed into static nodes after a save/edit
+                # thanks to the t-ignore in parents node.
+                try:
                     arch_string = etree.fromstring(view_id.arch_db)
-                    el = arch_string.xpath("//t[@t-set='configurator_footer_links']")[0]
-                    el.attrib['t-value'] = json.dumps(footer_links)
+                except etree.XMLSyntaxError as e:
+                    # The xml view could have been modified in the backend, we don't
+                    # want the xpath error to break the configurator feature
+                    logger.warning("Failed to update footer links in view %s: %s", footer_id, e)
+                else:
+                    el = arch_string.xpath("//t[@t-set='configurator_footer_links']")
+                    if not el:
+                        logger.warning("No 'configurator_footer_links' found in view %s", footer_id)
+                        continue
+                    el[0].attrib['t-value'] = json.dumps(footer_links)
                     view_id.with_context(website_id=website.id).write({'arch_db': etree.tostring(arch_string)})
-            except Exception as e:
-                # The xml view could have been modified in the backend, we don't
-                # want the xpath error to break the configurator feature
-                logger.warning(e)
 
         # Load suggestion from iap for selected pages
         industry_id = kwargs['industry_id']


### PR DESCRIPTION
Updating website footer views sometimes fails with "could not serialize
access due to concurrent update" errors due to concurrent database writes,
causing transaction aborts and breaking the update process.

Error: `InFailedSqlTransaction:
current transaction is aborted, commands ignored until end of transaction block`

The issue arises because the exception block at [1] catches and silently
suppresses all exceptions, including critical `serialization errors`. These
serialization errors cause the current database transaction to fail. However,
since the exception is caught and not properly handled or propagated,
execution continues within the context of the failed transaction. As a
result, subsequent operations fail with an `InFailedSqlTransaction` error.

This commit addresses the issue by specifically handling the
`etree.XMLSyntaxError` raised by `etree.fromstring(view_id.arch_db)`.
The error is safely caught and logged with an appropriate message.
Additionally, it adds logging when the `configurator_footer_links` element
is not found in the view and prevents further execution in that case.

All other exceptions, including database-related errors, are no longer
caught at this level; instead, they are allowed to propagate and are
handled at the request level, where automatic retries are triggered.

handled at the request level, where automatic retries are triggered.

[1]:- https://github.com/odoo/odoo/blob/5cc57cc0ca8ee17060905b692727ed965e197f61/addons/website/models/website.py#L722-L725

sentry-5665538920
