### PR TITLE
[FIX] web: make exports sensitive on current context

### DIFF
--- a/addons/web/static/src/views/view_hook.js
+++ b/addons/web/static/src/views/view_hook.js
@@ -161,7 +161,7 @@ export function useExportRecords(env, context, getDefaultExportList) {
             data: {
                 data: JSON.stringify({
                     import_compat,
-                    context,
+                    context: root.context,
                     domain: root.domain,
                     fields: exportedFields,
                     groupby: root.groupBy,
@@ -179,7 +179,7 @@ export function useExportRecords(env, context, getDefaultExportList) {
     return () => {
         const root = model.root;
         model.dialog.add(ExportDataDialog, {
-            context,
+            context: root.context,
             defaultExportList: getDefaultExportList(),
             download: _downloadExport,
             getExportedFields: _getExportedFields,


### PR DESCRIPTION
### Steps to reproduce:

- In the settings enable Multi-Step Routes
- Inventory > Configuration > Warehouse Management > Warehouses
- Create a second Warehouse WH2
- Inventory > Reporting > Stock
- Click on the "Warehouse 2" of the left panel
> This updates the results
- Click on the wheel icon of the control panel > export All
#### > the values are exported for the commutative value of all warehouses

### Cause of the issue:

Click on a specific warehouse on the left panel actually updates the warehouse_id key of the context (on the listController). And this context is used to determine the values returned by the `web_search_read` performed on the `product.product` model. For instance the computed quantity fields are warehouse dependent:
https://github.com/odoo/odoo/blob/dba8ec896cc4d3cc93fc10f40c809a1ab863d46d/addons/stock/models/product.py#L131-L135 Now, the issue is that eventBus added by the list controller to export data's (and which needs to be initialised in the setup of the component as it setup hooks) is relying on the value of the context in the setup of the of the listController:
https://github.com/odoo/odoo/blob/dba8ec896cc4d3cc93fc10f40c809a1ab863d46d/addons/web/static/src/views/list/list_controller.js#L186-L188 https://github.com/odoo/odoo/blob/dba8ec896cc4d3cc93fc10f40c809a1ab863d46d/addons/web/static/src/views/view_hook.js#L126-L130 In particular, the parameter of the method will not be re-evaluated as `this.props.context` where this is the controller at the time of the callback the values of the export.

### Fix:

While the `env` provided at the initialization of the enventBus is a in the setup of the Controller is an immutable object, `env.resModel.root` correspond to the representation of the present record/records and hence carries the context of the current representation. It is therefore a valid object to rely on at callback time.

### Note:

The issue is not reproducible prior to saas-18.2 since the refactoring of the export system has been done in commit 1e4e40cf78fe8151dffdcb19df2688787084732c

opw-4736830
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
