### PR TITLE
[IMP] website: handle punycode safely in systray

### DIFF
--- a/addons/website/static/src/systray_items/website_switcher.js
+++ b/addons/website/static/src/systray_items/website_switcher.js
@@ -38,7 +38,15 @@ export class WebsiteSwitcherSystray extends Component {
                         && !wUtils.isHTTPSorNakedDomainRedirection(website.domain, window.location.origin)) {
                     const { location: { pathname, search, hash } } = this.websiteService.contentWindow;
                     const path = pathname + search + hash;
-                    window.location.href = `${encodeURI(website.domain)}/odoo/action-website.website_preview?path=${encodeURIComponent(path)}&website_id=${encodeURIComponent(website.id)}`;
+                    // Automatically converts Unicode domains (e.g. düsseldorf.com) to
+                    // punycode (ASCII-safe) using the native URL API
+                    const url = new URL("/web", website.domain);
+                    url.hash = new URLSearchParams({
+                        action: "website.website_preview",
+                        path: path,
+                        website_id: website.id,
+                    });
+                    window.location.href = url;
                 } else {
                     this.websiteService.goToWebsite({ websiteId: website.id, path: "", lang: "default" });
                     if (!website.domain) {


### PR DESCRIPTION
Replaced manual string concatenation with the native URL and URLSearchParams APIs for constructing the website preview URL. This change offers several benefits:

- Automatically handles Unicode domains (e.g., düsseldorf.com) by converting them to punycode, ensuring compatibility with browsers and network protocols.
- Prevents encoding issues by leveraging URLSearchParams for query parameters, reducing the risk of malformed URLs.
- Improves readability and maintainability by avoiding complex template literals and manual encoding.

This makes the URL generation more robust and future-proof.

task-4756915
