### PR TITLE
[FIX] website_sale: disable unused template header on onboarding

### DIFF
--- a/addons/website_sale/const.py
+++ b/addons/website_sale/const.py
@@ -2,12 +2,9 @@ import re
 
 from odoo.tools.translate import LazyTranslate
 
-
 _lt = LazyTranslate(__name__, default_lang='en_US')
 
 # Website configurator
-
-DEFAULT_HEADER_VIEW_XMLID = 'website.template_header_default'
 
 SHOP_PAGE_STYLE_MAPPING = {
     'classic_grid': {
@@ -15,11 +12,9 @@ SHOP_PAGE_STYLE_MAPPING = {
         'img_src': '/website_sale/static/src/img/configurator/shop/classic_grid.jpg',
         'views': {
             'enable': [
-            #    'website.template_header_sales_one',  # Header
+                'website.template_header_sales_one',  # Header
             ],
-            'disable': [
-            #    DEFAULT_HEADER_VIEW_XMLID
-            ],
+            'disable': [],
         },
         'website_fields': {},  # Default
     },
@@ -33,8 +28,8 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_thumb_4_5',  # Style/Images size
                 'website_sale.products_attributes_top',  # Filters
                 'website_sale.floating_bar',  # Toolbar/floating
-            #    'website.template_header_search',  # Header
-            #    'website.header_width_full',  # Header width
+                'website.template_header_search',  # Header
+                'website.header_width_full',  # Header width
             ],
             'disable': [
                 'website_sale.products_design_card',  # Style
@@ -42,8 +37,7 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_thumb_4_3',  # Images size
                 'website_sale.products_thumb_2_3',  # Images size
                 'website_sale.products_attributes',  # Filters
-            #    'website.header_width_small',  # Header width
-            #    DEFAULT_HEADER_VIEW_XMLID,
+                'website.header_width_small',  # Header width
             ],
         },
         'website_fields': {
@@ -58,11 +52,9 @@ SHOP_PAGE_STYLE_MAPPING = {
             'enable': [
                 'website_sale.products_list_view',  # Listview layout
                 'website_sale.products_description',  # Description
-            #    'website.template_header_sales_two',  # Header
+                'website.template_header_sales_two',  # Header
             ],
-            'disable': [
-            #    DEFAULT_HEADER_VIEW_XMLID
-            ],
+            'disable': [],
         },
         'website_fields': {},
     },
@@ -75,14 +67,13 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_categories',  # Categories sidebar
                 'website_sale.option_collapse_products_categories',  # Categories/Collapse
                 'website_sale.products_attributes_top',  # Filters
-            #    'website.template_header_sales_four',  # Header
+                'website.template_header_sales_four',  # Header
             ],
             'disable': [
                 'website_sale.products_design_thumbs',  # Style
                 'website_sale.products_design_grid',  # Style
                 'website_sale.products_categories_top',  # Categories top
                 'website_sale.products_attributes',  # Filters
-            #    DEFAULT_HEADER_VIEW_XMLID,
             ],
         },
         'website_fields': {
@@ -99,12 +90,11 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_categories',  # Categories sidebar
                 'website_sale.products_attributes_top',  # Filters
                 'website_sale.floating_bar',  # Toolbar/floating
-            #    'website.template_header_sales_three',  # Header
+                'website.template_header_sales_three',  # Header
             ],
             'disable': [
                 'website_sale.products_categories_top',  # Categories top
                 'website_sale.products_attributes',  # Filters
-            #    DEFAULT_HEADER_VIEW_XMLID,
             ],
         },
         'website_fields': {
@@ -121,7 +111,7 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_thumb_4_3',  # Style/Images sizes (Landscape)
                 'website_sale.products_categories',  # Categories/Sidebar
                 'website_sale.products_attributes_top',  # Filters
-            #    'website.template_header_stretch',  # Header
+                'website.template_header_stretch',  # Header
             ],
             'disable': [
                 'website_sale.products_design_card',  # Style
@@ -130,7 +120,6 @@ SHOP_PAGE_STYLE_MAPPING = {
                 'website_sale.products_thumb_2_3',  # Style/Images sizes
                 'website_sale.products_categories_top',  # Categories/Top
                 'website_sale.products_attributes',  # Filters
-            #    DEFAULT_HEADER_VIEW_XMLID,
             ],
         },
         'website_fields': {


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have a new database with `website_sale`;
2. go to `/website/configurator`;
3. set up a website for sales;
4. pick a product page style & a design theme with different headers;
5. finish setting up website.

Issue
-----
> `ValidationError: Element '<xpath expr="//header//nav">' cannot be located in parent view`

Cause
-----
When calling `configurator_apply` in `website_sale`, it only disables the default header template in order to enable the desired header template for the product page.

Issue is that when using a non-default design theme, these may activate a different header template themselves, which is why the `//header//nav` xpath has already been replaced once, causing an error attempting to replace it again.

Solution
--------
Use the `_header_templates` list from `theme.utils` to get all header templates to disable before enabling a new one.

opw-4795208