### PR TITLE
[FIX] test_website_modules: increase timeout of the step to avoid error

### DIFF
--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -24,6 +24,7 @@ tour.register('configurator_flow', {
     {
         content: "click next",
         trigger: 'button.o_configurator_show',
+        timeout: 20000,  /* previous step create a new website, this could take a long time */
     },
     // Description screen
     {


### PR DESCRIPTION
The failing step is creating a new website, which could take a long
time. Increasing the timeout for the next step should prevent the error.

runbot-error-104332

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
