### PR TITLE
[FIX] pos*: fix pos register config cannot open

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -178,12 +178,17 @@ export class PosStore extends WithLazyGetterTrap {
         this.navigate(page, params);
     }
 
-    get defaultPage() {
+    getOpenFreeOrder() {
         let openOrder = this.models["pos.order"].find((o) => o.state === "draft");
 
         if (!openOrder) {
             openOrder = this.addNewOrder();
         }
+        return openOrder;
+    }
+
+    get defaultPage() {
+        const openOrder = this.getOpenFreeOrder();
 
         return {
             page: "ProductScreen",

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -27,6 +27,15 @@ patch(PosStore.prototype, {
             ? { page: "LoginScreen", params: {} }
             : this.defaultPage;
     },
+    getOpenFreeOrder() {
+        if (this.config.module_pos_restaurant) {
+            return (
+                this.models["pos.order"].find((o) => o.state === "draft" && o.isDirectSale) ||
+                this.addNewOrder()
+            );
+        }
+        return super.getOpenFreeOrder(...arguments);
+    },
     get defaultPage() {
         const screen = super.defaultPage;
         if (this.config.module_pos_restaurant) {
@@ -36,6 +45,9 @@ patch(PosStore.prototype, {
             };
             screen.page = screens[this.config.default_screen];
             screen.params = {};
+            if (this.config.default_screen === "register") {
+                screen.params.orderUuid = this.getOpenFreeOrder().uuid;
+            }
         }
         return screen;
     },

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -163,7 +163,7 @@ registry.category("web_tour.tours").add("pos_restaurant_sync", {
                     "acknowledge printing error ( because we don't have printer in the test. )",
             },
             Chrome.isSyncStatusConnected(),
-            TicketScreen.selectOrder("005"),
+            TicketScreen.selectOrder("007"),
             TicketScreen.loadSelectedOrder(),
             ProductScreen.isShown(),
             Chrome.clickPlanButton(),


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

Before this commit, the restaurant configurations set with "Register" as default screen could not be opened in the POS. This was due to the fact that the get defaultPage method did not passed the correct params and thus the router was failing to show the good page.

This commit fixes the issue by passing a draft direct sale order in this case.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
