### PR TITLE
[FIX] website: fix submenu accordion and transparent header

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -403,7 +403,9 @@ body {
 
         .accordion-button {
             &:not(.collapsed) {
-                background-color: shade-color($-navbar-mobile-bg-color, 5%);
+                @if $-navbar-mobile-bg-color != null {
+                    background-color: shade-color($-navbar-mobile-bg-color, 5%);
+                }
             }
 
             // Replace the default chevron with our Odoo UI icon so it adapts to


### PR DESCRIPTION
Step to reproduce the issue:

- Enter Website edit mode.
- Click on the header.
- Open the colorpicker of the header in the options.
- Click the trash bin icon.
- Bug: the CSS of the website is broken.

The issue was introduced by this commit [1], where the SCSS `shade-color` function was added to generate the color of the submenu accordion button in the mobile navbar. When no color is selected for the header (which happens after following the steps above), a CSS error occurs because the `shade-color` function requires a valid color to work properly.

[1]: https://github.com/odoo/odoo/commit/b975377fe688f10497b75598c0c50bd7b0758367

opw-4793368