### PR TITLE
[IMP] point_of_sale: add missing documentation links to payment providers

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -357,7 +357,7 @@
                                     <button name="open_payment_method_form" icon="oi-arrow-right" type="object" string="Payment method" class="btn-link"
                                         context="{'selection': 'stripe', 'config_ids': [pos_config_id], 'provider_name': 'Stripe'}" invisible="not module_pos_stripe" />
                                 </setting>
-                                <setting title="The transactions are processed by Viva.com on terminal or tap on phone." string="Viva.com" help="Accept payments with Viva.com on a terminal or tap on phone">
+                                <setting title="The transactions are processed by Viva.com on terminal or tap on phone." string="Viva.com" help="Accept payments with Viva.com on a terminal or tap on phone" documentation="/applications/sales/point_of_sale/payment_methods/terminals/viva_com.html">
                                     <field name="module_pos_viva_com"/>
                                     <button name="open_payment_method_form" icon="oi-arrow-right" type="object" string="Payment method" class="btn-link"
                                         context="{'selection': 'viva_com', 'config_ids': [pos_config_id], 'provider_name': 'Viva.com'}" invisible="not module_pos_viva_com" />
@@ -367,7 +367,7 @@
                                     <button name="open_payment_method_form" icon="oi-arrow-right" type="object" string="Payment method" class="btn-link"
                                         context="{'selection': 'paytm', 'config_ids': [pos_config_id], 'provider_name': 'Razorpay'}" invisible="not module_pos_razorpay" />
                                 </setting>
-                                <setting title="The transactions are processed by Mercado Pago on terminal" string="Mercado Pago" help="Accept payments with Mercado Pago on a terminal">
+                                <setting title="The transactions are processed by Mercado Pago on terminal" string="Mercado Pago" help="Accept payments with Mercado Pago on a terminal" documentation="/applications/sales/point_of_sale/payment_methods/terminals/mercado_pago.html">
                                     <field name="module_pos_mercado_pago"/>
                                     <button name="open_payment_method_form" icon="oi-arrow-right" type="object" string="Payment method" class="btn-link"
                                         context="{'selection': 'mercado_pago', 'config_ids': [pos_config_id], 'provider_name': 'Mercado Pago'}" invisible="not module_pos_mercado_pago" />


### PR DESCRIPTION
Before this commit:
--------------------------
- Viva Wallet and Mercado Pago were missing documentation links in
  POS configuration.

After this commit:
--------------------------------------
- Added missing links for Viva Wallet and Mercado Pago.

Task: 4797691

Related PR: https://github.com/odoo/enterprise/pull/85614