### PR TITLE
[REF] web: use the field service to benefit from caching

### DIFF
--- a/addons/web/static/src/model/record.js
+++ b/addons/web/static/src/model/record.js
@@ -194,9 +194,9 @@ export class Record extends Component {
         if (fields) {
             this.fields = fields;
         } else {
-            const orm = useService("orm");
+            const fieldService = useService("field");
             onWillStart(async () => {
-                this.fields = await orm.call(resModel, "fields_get", [fieldNames], {});
+                this.fields = await fieldService.loadFields(resModel, { fieldNames });
             });
         }
     }


### PR DESCRIPTION
This commit modifies the 'Record' component so that it uses the field service instead of making an ORM call to `fields_get`. This takes advantage of the caching support implemented in [1].

[1] : https://github.com/odoo/odoo/commit/d13129f51e75365dd2c2e70b6a79eab15ecb4f73
