### PR TITLE
[FIX] website: adapt comment for switch theme preview bypass

### DIFF
--- a/addons/website/static/src/components/views/theme_preview_form.js
+++ b/addons/website/static/src/components/views/theme_preview_form.js
@@ -61,6 +61,7 @@ class ThemePreviewFormController extends FormController {
         useLoaderOnClick();
 
         // TODO adapt theme previews then remove this
+        // ... or remove the feature entirely ? See task-3454790.
         onMounted(() => {
             setTimeout(() => {
                 document.querySelector('button[name="button_choose_theme"]')?.click();

--- a/addons/website/static/src/scss/website.backend.scss
+++ b/addons/website/static/src/scss/website.backend.scss
@@ -142,6 +142,7 @@
 }
 
 // TODO adapt theme previews then remove this
+// ... or remove the feature entirely ? See task-3454790.
 .o_preview_frame::after {
     content: "";
     position: absolute;


### PR DESCRIPTION
The theme preview feature before selection was disabled in [1]. This commit precises the TODO comment that was added with it.

It comes alongside a theme repo commit which actually disables the related nightly test of the feature... that was red since then.

[1]: https://github.com/odoo/odoo/commit/7cb71e9479df0ee9af0b7ad39302857666726177

Related to task-3454790
