### PR TITLE
[FIX] l10n_es_edi_tbai: add exemption for sujeto_agricultura taxes

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -125,9 +125,15 @@
                                 <CompraBienesCorrientesGastosBienesInversion t-out="tax['code']"/>
                                 <InversionSujetoPasivo t-out="'N' if tax['rec'].l10n_es_type != 'sujeto_isp' else 'S'"/>
                                 <BaseImponible t-out="format_float(tax['base'])"/>
+                            <t t-if="tax['rec'].l10n_es_type == 'sujeto_agricultura'">
+                                <PorcentajeCompensacionREAGYP t-out="tax['rec'].amount"/>
+                                <ImporteCompensacionREAGYP t-out="format_float(tax['tax'])"/>
+                            </t>
+                            <t t-else="">
                                 <TipoImpositivo t-out="tax['rec'].amount"/>
                                 <CuotaIVASoportada t-out="format_float(tax['tax'])"/>
                                 <CuotaIVADeducible t-out="format_float(tax['tax']) if tax['rec'].l10n_es_type != 'no_deducible' else '0.00'"/>
+                            </t>
                             </DetalleIVA>
                         </IVA>
                     </t>

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -641,13 +641,23 @@ class AccountEdiFormat(models.Model):
         mod_303_11 = self.env.ref('l10n_es.mod_303_11')
         tax_tags = invoice.invoice_line_ids.tax_ids.invoice_repartition_line_ids.tag_ids
         intracom = bool(tax_tags & (mod_303_10 + mod_303_11))
-        values['regime_key'] = ['09'] if intracom else ['01']
+        # Special regime for agriculture, livestock and fishing https://sede.agenciatributaria.gob.es/Sede/iva/regimenes-tributacion-iva/regimen-especial-agricultura-ganaderia-pesca.html
+        reagyp = invoice.invoice_line_ids.tax_ids.filtered(lambda t: t.l10n_es_type == 'sujeto_agricultura')
+        if intracom:
+            values['regime_key'] = ['09']
+        elif reagyp:
+            values['regime_key'] = ['02']
+        else:
+            values['regime_key'] = ['01']
         # Credit notes (factura rectificativa)
         values['is_refund'] = invoice.move_type == 'in_refund'
         if values['is_refund']:
             values['credit_note_code'] = invoice.l10n_es_tbai_refund_reason
             values['credit_note_invoice'] = invoice.reversed_entry_id
-        values['tipofactura'] = 'F1'
+        if reagyp:
+            values['tipofactura'] = 'F6'
+        else:
+            values['tipofactura'] = 'F1'
         return values
 
     def _l10n_es_tbai_prepare_values_bi(self, invoice, invoice_xml, cancel=False):


### PR DESCRIPTION
When trying to send a vendor bill that uses a tax with l10n_es_type 'sujeto_agricultura' with TicketBAI using the agency bizkaia, we are faced with an error code. This is due to the amount of these taxes being different than what is allowed (10.5% and 12%).

The two 'sujeto_agricultura' taxes are actually part of a special regime and should be exempted when sent [reference](https://sede.agenciatributaria.gob.es/Sede/iva/regimenes-tributacion-iva/regimen-especial-agricultura-ganaderia-pesca.html)

This PR adapts the data sent to Bizkaia, in a similar manner as https://github.com/odoo/odoo/pull/196017 did for SII, by setting `ClaveRegimenIvaOpTrascendencia` to `02` and `TipoFactura` to `06` if we have a 'sujeto_agricultura' tax. [reference](https://sede.agenciatributaria.gob.es/static_files/Sede/Procedimiento_ayuda/G417/FicherosSuministros/V_1_1/Validaciones_ErroresSII_v1.1.pdf)

opw-4781267

