### PR TITLE
[FIX] partnership: add (un)archive button in partner grade form view

### DIFF
--- a/addons/partnership/views/res_partner_grade_views.xml
+++ b/addons/partnership/views/res_partner_grade_views.xml
@@ -56,6 +56,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="active" invisible="1"/>
                             <field name="default_pricelist_id" groups="product.group_product_pricelist"/>
                         </group>
                     </group>


### PR DESCRIPTION
Before this commit, it was not possible to archive a partner grade from the form view, only from the list view. This commit adds this possibility.
