### PR TITLE
[FIX] mail: hide done activities from activity views

### DIFF
--- a/addons/mail/static/src/views/web/activity/activity_model.js
+++ b/addons/mail/static/src/views/web/activity/activity_model.js
@@ -21,7 +21,7 @@ export class ActivityModel extends RelationalModel {
             domain: params.domain || this.env.searchModel._domain,
             limit: params.limit || this.initialLimit,
             offset: params.offset || 0,
-            fetch_done: true,
+            fetch_done: false,
         });
     }
 }


### PR DESCRIPTION
Until [1] activity views used to display done activities only if they were marked as keep_done.

This was not the default so now lots of activities appear in the view even though we don't typically care about "done" activities in that view.

As done activities can be checked in other ways we would rather not show any that is done and let users handle that in other ways.

task-4788330

[1]: d290f3f3f23e5204c244c15cf96fdf354d8a65aa