### PR TITLE
[FIX] web: display tag tooltip on hover when possible

### DIFF
--- a/addons/web/static/src/core/tags_list/tags_list.xml
+++ b/addons/web/static/src/core/tags_list/tags_list.xml
@@ -13,7 +13,7 @@
                 t-attf-class="{{ !tag.img ? 'o_tag_color_' + (tag.colorIndex ? tag.colorIndex : '0') : '' }}"
                 tabindex="-1"
                 t-att-data-color="tag.colorIndex"
-                t-att-title="tag.text"
+                t-att-title="tag.hoverText or tag.text"
                 t-on-click="(ev) => tag.onClick and tag.onClick(ev)"
                 t-on-keydown="tag.onKeydown">
 

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.js
@@ -159,6 +159,7 @@ export class Many2ManyTagsField extends Component {
                 }
                 this.onTagKeydown(ev);
             },
+            hoverText: record.data.tooltip || record.data.display_name,
         };
     }
 
@@ -241,12 +242,24 @@ export const many2ManyTagsField = {
             availableTypes: ["integer"],
             help: _t("Set an integer field to use colors with the tags."),
         },
+        {
+            label: _t("Hover field"),
+            name: "hover_field",
+            type: "field",
+            availableTypes: ["char"],
+            help: _t(
+                "Specifies the name of a Char field whose value will be displayed as a tooltip when hovering over a tag."
+            ),
+        },
     ],
     supportedTypes: ["many2many"],
     relatedFields: ({ options }) => {
         const relatedFields = [{ name: "display_name", type: "char" }];
         if (options.color_field) {
             relatedFields.push({ name: options.color_field, type: "integer", readonly: false });
+        }
+        if (options.hover_field) {
+            relatedFields.push({ name: options.hover_field, type: "char", readonly: false });
         }
         return relatedFields;
     },


### PR DESCRIPTION
Before this commit
---
The tooltip shown on hover over document tags was always the tag name. This ignored the "Tooltip" field available on document tags. (The tooltip was not fetched.)

After this commit
---
We fetch and display the custom tooltip defined in the "Tooltip" field of the tag.

Reproduce
---
- install documents
- add "Tooltip" string to a TAG in Documents/Configuration/Tags
- open documents kanban view and over onto the TAG
- BUG: tag name is apearing on hover (instead of tooltip string)

opw-4567814


A sibling https://github.com/odoo/enterprise/pull/79496 updating xml and utilizing this change