### PR TITLE
[FIX] iot_base: fix test print traceback

### DIFF
--- a/addons/iot_base/static/src/device_controller.js
+++ b/addons/iot_base/static/src/device_controller.js
@@ -30,7 +30,7 @@ export class DeviceController {
      * @param callback - function to call when the listener is triggered
      * @param fallback - if true, no notification will be displayed on fail
      */
-    addListener(callback, fallback = false) {
+    addListener(callback, fallback = true) {
         return this.iotLongpolling.addListener(this.iotIp, [this.identifier], this.id, callback, fallback);
     }
     removeListener() {

--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -36,7 +36,7 @@ export class IoTLongpolling {
      * @param {boolean} fallback if true, no notification will be displayed on fail
      * @param {Callback} callback
      */
-    async addListener(iot_ip, devices, listener_id, callback, fallback = false) {
+    async addListener(iot_ip, devices, listener_id, callback, fallback = true) {
         if (!this._listeners[iot_ip]) {
             this._listeners[iot_ip] = {
                 last_event: 0,
@@ -86,7 +86,16 @@ export class IoTLongpolling {
             device_identifier: device_identifier,
             data: JSON.stringify(data),
         };
-        return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback);
+        return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback).then(
+            (result) => {
+                return result
+            },
+            (e) => {
+                if (e.name === "TimeoutError") {
+                    this._onError();
+                }
+            }
+        );
     }
 
     /**
@@ -95,7 +104,7 @@ export class IoTLongpolling {
      * @param {string} iot_ip
      * @param {boolean} fallback if true, no notification will be displayed on fail
      */
-    startPolling(iot_ip, fallback = false) {
+    startPolling(iot_ip, fallback = true) {
         if (iot_ip) {
             if (!this._listeners[iot_ip].rpc) {
                 this._poll(iot_ip, fallback);
@@ -161,11 +170,11 @@ export class IoTLongpolling {
      * @param {string} iot_ip
      * @param {boolean} fallback if true, no notification will be displayed on fail
      */
-    _poll(iot_ip, fallback = false) {
+    _poll(iot_ip, fallback = true) {
         const listener = this._listeners[iot_ip];
 
         // The backend has a maximum cycle time of 50 seconds so give +10 seconds
-        this._rpcIoT(iot_ip, this.pollRoute, { listener: listener }, 60000).then(
+        this._rpcIoT(iot_ip, this.pollRoute, { listener: listener }, 60000, fallback).then(
             (result) => {
                 this._retries = 0;
                 this._listeners[iot_ip].rpc = false;
@@ -181,8 +190,6 @@ export class IoTLongpolling {
             (e) => {
                 if (e.name === "TimeoutError") {
                     this._onError();
-                } else if (!fallback) {
-                    this._doWarnFail(iot_ip);
                 }
             }
         );


### PR DESCRIPTION
This PR fixes the following traceback obtained when trying to use "TEST" button on a printer:

```
UncaughtPromiseError

Uncaught Promise > Longpolling action failed

Occured on 80411781-master-all.runbot234.odoo.com on 2025-05-15 14:26:31 GMT

Error: Longpolling action failed
    at IoTLongpolling._rpcIoT
(https://80411781-master-all.runbot234.odoo.com/web/assets/9c3695c/web.assets_web.min.js:21349:7)
```

+ it also fixed the logic behind overkill "Connection to IoT Box failed" notifications, reducing their number to one at a time
Now only the action method the user actually does triggers such a notification and the polling doesn't trigger any

