### PR TITLE
[FIX] sale_stock: fix decrease sol qty to zero test

### DIFF
--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -1605,6 +1605,7 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         """
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         warehouse.delivery_steps = 'pick_ship'
+        (self.product_a + self.product_b).write({'type': 'consu'})
 
         so = self.env['sale.order'].create({
             'partner_id': self.partner_a.id,


### PR DESCRIPTION
Issue:
Before this commit, product_a and product_b were overridden by another module, setting their type to 'product' instead of the expected 'consu'. This led to unexpected values for both the quantity and the state.

Fix:
Set the product type explicitly to 'consu', which is the expected value.

runbot-70732