### PR TITLE
[FIX] website_project: allow form w/o task partner_name


### DIFF
--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -60,7 +60,8 @@ class WebsiteForm(form.WebsiteForm):
                 data['record']['email_cc'] = values['email_from']
                 if values.get('partner_phone'):
                     data['record']['partner_phone'] = values['partner_phone']
-                data['record']['partner_name'] = values['partner_name']
+                if values.get('partner_name'):
+                    data['record']['partner_name'] = values['partner_name']
                 if values.get('partner_company_name'):
                     data['record']['partner_company_name'] = values['partner_company_name']
         return data


### PR DESCRIPTION

Scenario:
- add a form with studio
- change its action to "Create a Task"
- delete the field "Full Name"
- send the form with an unknown email

Result: an error happens

Cause: if the email does not find a user, the code expects the
partner_name to always be present, even if it is an optional field.

Fix: make the code work without partner_name field.

opw-4773357
