### PR TITLE
[IMP] point_of_sale: move spinner to left of search bar

### DIFF
--- a/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/components/navbar/navbar.xml
@@ -30,6 +30,11 @@
             </div>
             <div class="pos-rightheader flex-grow-1">
                 <div class="status-buttons d-flex flex-grow-1 align-items-center justify-content-end gap-1">
+                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status btn btn-light btn-lg lh-lg h-100 pe-none">
+                        <span t-if="this.pos.data.network.unsyncData.length > 0" t-esc="this.pos.data.network.unsyncData.length" />
+                        <div t-if="this.pos.data.network.offline" class="fa fa-fw fa-chain-broken text-danger"/>
+                        <div t-else="" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>
+                    </div>
                     <Input tModel="[pos, 'searchProductWord']"
                     class="ui.isSmall ? 'p-0' : 'w-100 w-xl-50 me-0 me-lg-2'"
                     isSmall="ui.isSmall"
@@ -42,11 +47,6 @@
                     <button class="btn btn-light btn-lg lh-lg" t-if="isBarcodeScannerSupported() and ['ProductScreen', 'TicketScreen'].includes(this.pos.router.state.current) and !pos.config.module_pos_restaurant" t-on-click="onClickScan">
                         <i class="fa fa-fw fa-lg fa-barcode" /><span t-if="this.pos.scanning" class="ms-1">Stop</span>
                     </button>
-                    <div t-if="this.pos.data.network.offline or this.pos.data.network.loading" class="oe_status btn btn-light btn-lg lh-lg h-100 pe-none">
-                        <span t-if="this.pos.data.network.unsyncData.length > 0" t-esc="this.pos.data.network.unsyncData.length" />
-                        <div t-if="this.pos.data.network.offline" class="fa fa-fw fa-chain-broken text-danger"/>
-                        <div t-else="" class="fa fa-fw fa-spin fa-circle-o-notch text-warning"/>
-                    </div>
                     <!-- No need to show the cashier name on small screens -->
                     <CashierName t-if="!ui.isSmall"/>
                     <Dropdown>


### PR DESCRIPTION
Prior to this commit, whenever the spinner was shown, it would pop up on the right of the search bar and shift the search bar to the left. This was disorienting because the spinner doesn't appear for very long, so the search bar would shift and shift back very quickly.

This commit moves the spinner to the left of the search bar, so that the search bar doesn't shift when the spinner appears.

### Old behavior on mobile
https://github.com/user-attachments/assets/e13a1238-ebac-4c2f-bae2-3caa164a6634

### New behavior on mobile
https://github.com/user-attachments/assets/5f83b6bc-b9fa-4b93-b1a9-baac8c033822

### Old behavior on desktop 
https://github.com/user-attachments/assets/92d3ed87-4e37-4632-96be-65e67d3045f2

### New behavior on desktop
https://github.com/user-attachments/assets/98da5958-2c43-4083-bac9-d06c8d9355f3