### PR TITLE
[FIX] mail: soft_reload when applying an activity plan

### DIFF
--- a/addons/mail/wizard/mail_activity_schedule.py
+++ b/addons/mail/wizard/mail_activity_schedule.py
@@ -234,14 +234,7 @@ class MailActivitySchedule(models.TransientModel):
             record.message_post(body=body)
 
         if len(applied_on) == 1:
-            return {
-                'type': 'ir.actions.act_window',
-                'res_model': self.res_model,
-                'res_id': applied_on.id,
-                'name': applied_on.display_name,
-                'view_mode': 'form',
-                'views': [(False, "form")],
-            }
+            return {'type': 'ir.actions.client', 'tag': 'soft_reload'}
 
         return {
             'type': 'ir.actions.act_window',


### PR DESCRIPTION
Scheduling a custom activity plan on a single record should do a `soft_reload` of the current view in order to avoid breadcrumbs pollution.

The most frequent use case for that action is scheduling a plan from the chatter of the form view of a record, and retriggering an unnamed default form act_window would only restrict possible operations for the user.

After this commit, the current view will be reloaded and the user will most probably be able to see its enabled plan in the chatter.

task-4525830
