### PR TITLE
[FIX] stock: keep move receipt moves assigned

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2037,7 +2037,7 @@ Please change the quantity done or the rounding precision of your unit of measur
             rounding = move.product_uom.rounding
             if move.state in ('cancel', 'done') or (move.state == 'draft' and not move.quantity):
                 continue
-            elif float_compare(move.quantity, move.product_uom_qty, precision_rounding=rounding) >= 0:
+            elif move._should_bypass_reservation() or float_compare(move.quantity, move.product_uom_qty, precision_rounding=rounding) >= 0:
                 moves_state_to_write['assigned'].add(move.id)
             elif move.quantity and float_compare(move.quantity, move.product_uom_qty, precision_rounding=rounding) <= 0:
                 moves_state_to_write['partially_available'].add(move.id)

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -435,3 +435,20 @@ registry.category("web_tour.tours").add("test_add_new_line_in_detailled_op", {
         },
     ],
 });
+
+registry.category("web_tour.tours").add('test_receipt_move_state_after_generate', {
+    test: true,
+    steps: () => [
+        { trigger: ".o_list_view.o_field_x2many .o_data_row button[name='Open Move']" },
+        { trigger: ".modal-content", isCheck: true },
+        { trigger: ".o_widget_generate_serials button" },
+        {
+            trigger: 'div[name=next_serial] input',
+            run: 'text sn_01',
+        },
+        { trigger: "button:contains('Generate')" },
+        { trigger: '.modal-footer .o_form_button_save' },
+        { trigger: '.o_form_button_save' },
+        { trigger: ".o_form_renderer.o_form_saved", isCheck: true },
+    ]
+});


### PR DESCRIPTION
Steps to reproduce:
- Create a product tracked by serial numbers
- Create a reception for 3 of that product
- Open the move details
- Generate Serial/Lots
- Take any first serial then generate and save

Issue:
The move has now the confirmed state rather than assigned.

When going through the generate serial process, it will issue two commands, one to unlink the previous move lines and one to create the new ones with their serial numbers
- Processing the Command.Delete will unlink the move lines
- This triggers a recompute_state, and since no move lines are found, the state is put to confirmed
- Processing the Command.Create will add the new move lines
- This should trigger a recompute_state as well, but since the move should bypass reservation (as it's a receipt), it doesn't recompute.

Thus the move stays as confirmed, even though it is fully assigned.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
