### PR TITLE
[FIX] l10n_latam_check: Syntax corrections and improvements

### DIFF
--- a/addons/l10n_latam_check/i18n/es_419.po
+++ b/addons/l10n_latam_check/i18n/es_419.po
@@ -779,6 +779,15 @@ msgstr ""
 "mismo partner sin agrupar"
 
 #. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+msgid ""
+"You have selected some payments that are not checks. Please call this action "
+"from the Third Party Checks menu"
+msgstr ""
+"Ha seleccionado algunos pagos que no son cheques. Por favor, llame a esta acción "
+"desde el menú Cheques de terceros"
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
 msgid "open"
 msgstr "abrir"

--- a/addons/l10n_latam_check/i18n/l10n_latam_check.pot
+++ b/addons/l10n_latam_check/i18n/l10n_latam_check.pot
@@ -744,6 +744,12 @@ msgid ""
 msgstr ""
 
 #. module: l10n_latam_check
+#: code:addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer
+"You have selected some payments that are not checks. Please call this action "
+"from the Third Party Checks menu"
+msgstr ""
+
+#. module: l10n_latam_check
 #: model_terms:ir.ui.view,arch_db:l10n_latam_check.view_account_payment_form_inherited
 msgid "open"
 msgstr ""

--- a/addons/l10n_latam_check/models/account_journal.py
+++ b/addons/l10n_latam_check/models/account_journal.py
@@ -21,6 +21,7 @@ class AccountJournal(models.Model):
         res.add("own_checks")
         return res
 
+    @api.model_create_multi
     def create(self, vals_list):
         journals = super().create(vals_list)
         inbound_payment_accounts = self.env['account.account'].search([

--- a/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
+++ b/addons/l10n_latam_check/wizards/l10n_latam_payment_mass_transfer.py
@@ -53,7 +53,7 @@ class L10nLatamPaymentMassTransfer(models.TransientModel):
                 raise UserError(_("The register payment wizard should only be called on account.payment records."))
             checks = self.env['l10n_latam.check'].browse(self._context.get('active_ids', []))
             if checks.filtered(lambda x: x.payment_method_line_id.code != 'new_third_party_checks'):
-                raise 'You have select some payments that are not checks. Please call this action from the Third Party Checks menu'
+                raise UserError(_('You have selected some payments that are not checks. Please call this action from the Third Party Checks menu'))
             elif not all(check.payment_id.state != 'draft' for check in checks):
                 raise UserError(_("All the selected checks must be posted"))
             currency_ids = checks.mapped('currency_id')


### PR DESCRIPTION
This commit addresses minor syntax issues and enhances the `l10n_latam_check` module.

Specifically, it includes the following changes:

- Added the `@api.model_create_multi` decorator to the journal creation process for improved efficiency and consistency.
- Updated one of the `raise` statements in the `default_get` method of the `l10n_latam.payment.mass.transfer` model to raise a `UserError`, providing a more user-friendly error message in relevant scenarios.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
