### PR TITLE
[IMP] mail: prevent infinite mirror effect during screen sharing 

### DIFF
--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -313,5 +313,19 @@ export class Call extends Component {
         this.state.isFullscreen = Boolean(
             document.webkitFullscreenElement || document.fullscreenElement
         );
+        if (
+            this.rtc.state.sourceScreenStream &&
+            this.rtc.displaySurface !== "browser" &&
+            this.state.isFullscreen
+        ) {
+            this.rtc.showMirroringWarning();
+        } else if (!this.state.isFullscreen) {
+            if (this.rtc.removeMirroringWarning) {
+                this.rtc.removeMirroringWarning();
+            }
+            if (this.rtc.state.screenTrack) {
+                this.rtc.state.screenTrack.enabled = true;
+            }
+        }
     }
 }

--- a/addons/mail/static/src/discuss/call/common/call_actions.js
+++ b/addons/mail/static/src/discuss/call/common/call_actions.js
@@ -68,7 +68,11 @@ callActionsRegistry
         isActive: (component) => component.rtc.selfSession?.is_screen_sharing_on,
         icon: "fa-desktop",
         activeClass: "text-success",
-        select: (component) => component.rtc.toggleVideo("screen"),
+        select: (component) => {
+            component.rtc.removeMirroringWarning
+                ? component.rtc.removeMirroringWarning()
+                : component.rtc.toggleVideo("screen");
+        },
         sequence: 40,
     })
     .add("blur-background", {

--- a/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.js
+++ b/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.js
@@ -1,0 +1,13 @@
+import { Component } from "@odoo/owl";
+
+/**
+ * @typedef {Object} Props
+ * @property {Function} onClose
+ * @extends {Component<Props, Env>}
+ */
+export class CallInfiniteMirroringWarning extends Component {
+    static template = "discuss.CallInfiniteMirroringWarning";
+    static props = {
+        onClose: { type: Function },
+    };
+}

--- a/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.scss
+++ b/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.scss
@@ -1,0 +1,8 @@
+.o-discuss-CallInfiniteMirroringWarning {
+    background-color: RGB(17, 24, 39);
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.o-discuss-CallInfiniteMirroringWarning-dismiss {
+    color: rgba(255, 255, 255, 0.9);
+}

--- a/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.xml
+++ b/addons/mail/static/src/discuss/call/common/call_infinite_mirroring_warning.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="discuss.CallInfiniteMirroringWarning">
+        <div class="d-flex justify-content-start align-items-start position-fixed bottom-0 start-0 w-100 h-100 pe-none">
+            <div class="d-flex o-discuss-CallInfiniteMirroringWarning rounded justify-content-between fs-3 w-100 m-5 px-3 py-2 pe-auto">
+                <div class="d-flex align-items-center fs-4">
+                    Please share a specific window or tab or another monitor to avoid the infinite mirror effect.
+                </div>
+                <div class="d-flex gap-2">
+                    <button class="btn btn-link text-info fs-4" t-on-click="() => this.props.onClose({ stopScreensharing: true })">
+                        Stop sharing
+                    </button>
+                    <button class="o-discuss-CallInfiniteMirroringWarning-dismiss border-0 bg-transparent opacity-50 opacity-100-hover pe-auto" t-on-click="() => this.props.onClose()">
+                        <i class="fa fa-lg fa-times-circle"/>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.js
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.js
@@ -38,6 +38,7 @@ export class CallParticipantCard extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.rootHover = useHover("root");
+        this.resumeStreamHover = useHover("resumeStream");
         this.isMobileOS = isMobileOS();
         this.dragPos = undefined;
         this.isDrag = false;

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -7,6 +7,7 @@
                 'o-isTalking': !props.minimized and isTalking,
                 'o-isInvitation opacity-50': !rtcSession,
                 'o-inset': props.inset,
+                'pe-none': rtc.removeMirroringWarning,
                 'o-small': props.inset and (ui.isSmall or props.minimized),
                 'o-active': isActiveRtcSession and !props.inset and props.compact,
                 'p-1 rounded-1': !isActiveRtcSession,
@@ -20,7 +21,14 @@
             t-ref="root"
         >
             <!-- card -->
-            <CallParticipantVideo t-if="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
+            <t t-if="!props.isSidebarItem and props.cardData.type === 'screen' and rtc.state.screenTrack and !rtc.state.screenTrack.enabled">
+                <div class="o-text-white display-4 gap-3">
+                    <button class="pe-auto bg-transparent o-text-white border-0 opacity-25 opacity-75-hover" t-ref="resumeStream" t-on-click.stop="() => (this.rtc.state.screenTrack.enabled = true)">
+                        <i class="fa fa-fw" t-att-class="{ 'fa-play': resumeStreamHover.isHover, 'fa-pause': !resumeStreamHover.isHover }"/> <span><t t-if="resumeStreamHover.isHover">Resume stream</t><t t-else="">Stream paused</t></span>
+                    </button>
+                </div>
+            </t>
+            <CallParticipantVideo t-elif="hasVideo" session="rtcSession" type="props.cardData.type" inset="props.inset"/>
             <div t-else="" class="o-discuss-CallParticipantCard-avatar d-flex align-items-center justify-content-center h-100 w-100 rounded-1" t-att-class="{ 'o-minimized': props.minimized, 'o-isRemoteVideo': isRemoteVideo }" draggable="false">
                 <img t-if="!showRemoteWarning" alt="Avatar" class="h-100 rounded-circle border-5 o_object_fit_cover" t-att-src="channelMember?.persona.avatarUrl" draggable="false" t-att-class="{
                     'o-isTalking': isTalking,


### PR DESCRIPTION
Before this commit, sharing the entire current screen resulted in an infinite mirror effect in full screen. This is a problem because this can look atrocious on some machine and browsers.

This commit solves the solution as follow:
When users is sharing entire screen and enters full-screen mode, a warning is displayed and lets user now of potential infinite mirror effect. The stream is paused to prevent it being triggered immediately. User can choose to read hint and decide either stop screen sharing, dismiss notification and/or resume stream by clicking on pause/play icon.

Note that most browsers expose "entire screen" mode, but they do not tell whether the entire monitor is the same as the one with call. The warning shows regardless of "entire monitor" being selected, so user can decide whether this is good or not. The browsers that do not expose "entire screen" mode, such as Firefox, will always display this warning on entering full screen mode with screen sharing active.

Task-id:4450257