### PR TITLE
[PERF] calendar_attendee: improve speed of recordset subtraction

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -110,10 +110,11 @@ class Attendee(models.Model):
         """
         if force_send:
             force_send_limit = int(self.env['ir.config_parameter'].sudo().get_param('mail.mail_force_send_limit', 100))
-        notified_attendees = self
+        notified_attendees_ids = set(self.ids)
         for event, attendees in self.grouped('event_id').items():
             if event._skip_send_mail_status_update():
-                notified_attendees -= attendees
+                notified_attendees_ids -= set(attendees.ids)
+        notified_attendees = self.browse(notified_attendees_ids)
         if isinstance(mail_template, str):
             raise ValueError('Template should be a template record, not an XML ID anymore.')
         if self.env['ir.config_parameter'].sudo().get_param('calendar.block_mail') or self._context.get("no_mail_to_attendees"):


### PR DESCRIPTION
This change uses python set subtraction over recordset \_\_sub\_\_ on calendar.attendees.

Before this change, when doing a large calendar synchronization such as setting up Google Calendar, notified_attendees could be a large recordset of calendar.attendees. When performing a recordset subtraction in _notify_attendees, this uses \_\_sub\_\_ and browse multiple times. Synchronizing around 5000 events took about ~350 seconds (on my own calendar data), where _notify_attendees took ~313 seconds (83%). 

After this change, _notify_attendees takes ~1 second operating on the same synchronization.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
