### PR TITLE
[FIX] base: avoid duplicated sequence ranges

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -320,6 +320,14 @@ class IrSequenceDateRange(models.Model):
     _rec_name = "sequence_id"
     _allow_sudo_commands = False
 
+    _sql_constraints = [
+        (
+            'unique_range_per_sequence',
+            'UNIQUE(sequence_id, date_from, date_to)',
+            "You cannot create two date ranges for the same sequence with the same date range.",
+        ),
+    ]
+
     def _get_number_next_actual(self):
         '''Return number from ir_sequence row when no_gap implementation,
         and number from postgres sequence when standard implementation.'''


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
if 2 concurrent requests are generating a sequence number on a sequence that requires a new range odoo will create 2 ranges with the same start and end date. Both request will then return the same sequence number.

Current behavior before PR:
Duplicated sequence numbers are generated

Desired behavior after PR is merged:
Raise an error if two date ranges for the same sequence with the same date range are created and avoid sequence number duplication

Script I used to reproduce the issue:
```python
import threading
import xmlrpc.client

url = 'http://localhost:8069'
db = 'db_name'
username = 'admin'
password = 'admin'

common = xmlrpc.client.ServerProxy('{}/xmlrpc/2/common'.format(url))
uid = common.authenticate(db, username, password, {})
models = xmlrpc.client.ServerProxy('{}/xmlrpc/2/object'.format(url))

models.execute_kw(db, uid, password, 'ir.sequence', 'unlink', [models.execute_kw(db, uid, password, 'ir.sequence', 'search', [[('code', '=', 'test.sequence')]])])

models.execute_kw(db, uid, password, 'ir.sequence', 'create', [{
    'name': 'Test Sequence',
    'code': 'test.sequence',
    'prefix': 'TEST-',
    'suffix': '/%(month)s/%(range_year)s/10001',
    'padding': 1,
    'number_increment': 1,
    'use_date_range': True,
}])

def get_sequence_number():
    return models.execute_kw(db, uid, password, 'ir.sequence', 'next_by_code', ['test.sequence'])

for i in range(5):
    threading.Thread(target=get_sequence_number).start()
```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
