### PR TITLE
[IMP] google_calendar: allow to sync users with self recordset

### DIFF
--- a/addons/google_calendar/models/res_users.py
+++ b/addons/google_calendar/models/res_users.py
@@ -128,7 +128,12 @@ class ResUsers(models.Model):
     @api.model
     def _sync_all_google_calendar(self):
         """ Cron job """
-        users = self.env['res.users'].sudo().search([('google_calendar_rtoken', '!=', False), ('google_synchronization_stopped', '=', False)])
+        domain = [('google_calendar_rtoken', '!=', False), ('google_synchronization_stopped', '=', False)]
+        # google_calendar_token_validity is not stored on res.users
+        if not self:
+            users = self.env['res.users'].sudo().search(domain).sorted('google_calendar_token_validity')
+        else:
+            users = self.filtered_domain(domain).sorted('google_calendar_token_validity')
         google = GoogleCalendarService(self.env['google.service'])
         for user in users:
             _logger.info("Calendar Synchro - Starting synchronization for %s", user)


### PR DESCRIPTION
Before this commit, the sync cron of google could only work by performing a search on the users and starting the sync. But the cron could timeout with a large amount of users. As users were fetched in the same order, some users could never be synced. This change allows to create several cron with different type of user in self (by company, department, etc) to allow distribute the sync effort over several crons.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
