### PR TITLE
[FIX] pos_self_order: Fix kiosk combo price computation

### DIFF
--- a/addons/pos_self_order/static/src/app/components/timeout_popup/timeout_popup.js
+++ b/addons/pos_self_order/static/src/app/components/timeout_popup/timeout_popup.js
@@ -2,7 +2,7 @@ import { Component, onMounted, onWillUnmount, useState } from "@odoo/owl";
 
 export class TimeoutPopup extends Component {
     static template = "pos_self_order.TimeoutPopup";
-    static props = ["onTimeout"];
+    static props = ["close", "onTimeout"];
     setup() {
         this.state = useState({ time: 10 });
 

--- a/addons/pos_self_order/static/src/app/services/card_utils.js
+++ b/addons/pos_self_order/static/src/app/services/card_utils.js
@@ -18,7 +18,7 @@ export function computeProductPrice(selfOrder, productTemplate, selectedAttribut
 
 export function computeTotalComboPrice(selfOrder, productTemplate, comboValues, qty) {
     if (!comboValues || !comboValues.length) {
-        return computeInitialComboPrice(selfOrder, productTemplate);
+        return selfOrder.getProductDisplayPrice(productTemplate);
     }
 
     const baseLineValues = getOrderLineValues(
@@ -46,17 +46,6 @@ export function computeTotalComboPrice(selfOrder, productTemplate, comboValues, 
     return selfOrder.isTaxesIncludedInPrice()
         ? order.getTotalWithTaxOfLines(transientLines)
         : order.getTotalWithoutTaxOfLines(transientLines);
-}
-
-export function computeInitialComboPrice(selfOrder, productTemplate) {
-    const comboValues = productTemplate.combo_ids.map((combo) => {
-        const defaultItem = combo.combo_item_ids.find((item) => item.extra_price === 0);
-        return {
-            combo_item_id: defaultItem,
-            qty: 1,
-        };
-    });
-    return computeTotalComboPrice(selfOrder, productTemplate, comboValues, 1);
 }
 
 export function getOrderLineValues(

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -14,7 +14,7 @@ import { HWPrinter } from "@point_of_sale/app/utils/printer/hw_printer";
 import { renderToElement } from "@web/core/utils/render";
 import { TimeoutPopup } from "@pos_self_order/app/components/timeout_popup/timeout_popup";
 import { constructFullProductName, deduceUrl, random5Chars } from "@point_of_sale/utils";
-import { getOrderLineValues, computeInitialComboPrice } from "./card_utils";
+import { getOrderLineValues } from "./card_utils";
 import {
     getTaxesAfterFiscalPosition,
     getTaxesValues,
@@ -814,10 +814,6 @@ export class SelfOrder extends Reactive {
         return { pricelist_price: price, ...taxesData };
     }
     getProductDisplayPrice(productTemplate, product) {
-        if (productTemplate.isCombo()) {
-            return computeInitialComboPrice(this, productTemplate);
-        }
-
         const taxesData = this.getProductPriceInfo(productTemplate, product);
         if (this.isTaxesIncludedInPrice()) {
             return taxesData.total_included;


### PR DESCRIPTION
- Fix traceback in Kiosk combo price computation. Before this commit, if you have a combo product configured without any combo choices that have an `extra_price == 0`, a traceback occurred in the Kiosk. The price displayed under the combo card is now the combo base price (as it's done in PoS).
- Fix traceback in Kiosk when the `timeout_popup` was shown. We now add the default `close` props to fix this issue.

Steps to reproduce first issue:
- Configure a product combo with two combo choice that each have an `extra_price` defined
- Open Kiosk
- => Traceback when trying to load the product

Steps to reproduce the second issue:
- Open Kiosk
- Click any product to add it in the cart
- Wait 90s for the `timeout_popup` to be displayed
- => Traceback when trying to render the popup

task-id: 4797915


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
