### PR TITLE
[FIX] html_editor: fix discard on link creation

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -497,7 +497,11 @@ export class LinkPlugin extends Plugin {
             onChange: applyCallback,
             onDiscard: () => {
                 restoreSavePoint();
-                this.openLinkTools(linkElement);
+                if (this.linkInDocument?.isConnected) {
+                    this.openLinkTools(linkElement);
+                } else {
+                    this.closeLinkTools();
+                }
                 this.dependencies.selection.focusEditable();
             },
             onRemove: () => {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -717,6 +717,28 @@ describe("Link formatting in the popover", () => {
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             '<p><a href="http://test.com/">link1[]</a></p>'
         );
+        await waitFor(".o-we-linkpopover"); // popover should be open because link already existed
+    });
+    test("clicking the discard button should revert the link creation", async () => {
+        const { el } = await setupEditor("<p>[link1]</p>");
+        await waitFor(".o-we-toolbar");
+        await click(".o-we-toolbar .fa-link");
+
+        await contains(".o-we-linkpopover input.o_we_href_input_link").edit("#", {
+            confirm: false,
+        });
+
+        await click('select[name="link_type"]');
+        await select("secondary");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="#" class="btn btn-fill-secondary">link1</a></p>'
+        );
+        await click(".o_we_discard_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[link1]</p>");
+        await animationFrame();
+        await waitForNone(".o-we-linkpopover"); // popover should be closed
+        await animationFrame();
+        await waitFor(".o-we-toolbar"); // toolbar should re open
     });
     test("when no label input, the link should have the content of the url", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");


### PR DESCRIPTION
Since the changes from #206596,
the discard button didn't work properly during link creation.

On discard, the system tried to call `openLinkTools` on a link not connected to the editable document.

We added a check to ensure the link was already present before edition to avoid this problem.

task-4800555


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
