### PR TITLE
[FIX] web: list: can resize columns in rtl

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -1716,7 +1716,8 @@ export class ListRenderer extends Component {
         const resizeHeader = (ev) => {
             ev.preventDefault();
             ev.stopPropagation();
-            const delta = ev.clientX - initialX;
+            let delta = ev.clientX - initialX;
+            delta = this.isRTL ? -delta : delta;
             const newWidth = Math.max(10, initialWidth + delta);
             const tableDelta = newWidth - initialWidth;
             th.style.width = `${Math.floor(newWidth)}px`;


### PR DESCRIPTION
Before this commit, resizing columns in list views when being in right-to-left didn't work as expected: when resizing a column, the column was resized in the opposite direction. This commit makes it work.

opw~4782197

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
