### PR TITLE
[FIX] base: prevent error when adding submenu without specifying menu item name

### DIFF
--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -53,7 +53,7 @@ class IrUiMenu(models.Model):
         if level <= 0:
             return '...'
         if self.parent_id:
-            return self.parent_id._get_full_name(level - 1) + MENU_ITEM_SEPARATOR + (self.name or "")
+            return (self.parent_id._get_full_name(level - 1) or "") + MENU_ITEM_SEPARATOR + (self.name or "")
         else:
             return self.name
 


### PR DESCRIPTION
This error occurs when attempting to create a submenu item under a menu item.

Steps to reproduce:

 - Go to `menu items`.
 - Click `New` > In `Submenus` click `Add a line`

`TypeError: unsupported operand type(s) for +: 'bool' and 'str'`

This error occurs when attempting to create a submenu item under a menu item that does not have a name. Since the menu item record has not been saved yet, the system assigns a new ID to the menu item and sets its name to False. When computing the complete name for the submenu item, the menu(parent menu) item's name is False, which causes the error.

https://github.com/odoo/odoo/blob/d2ea23f252f0f8f329e2b0ff96de6ee2a14b922f/odoo/addons/base/models/ir_ui_menu.py#L56

This commit ensures that if the parent menu item record has not been saved and its name is False, an empty string is used in its place.

sentry-6368548342

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
