### PR TITLE
[IMP] mail: add mail template model

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -626,10 +626,7 @@ class MailActivity(models.Model):
             "state",
             "summary",
             Store.Many("attachment_ids", ["name"]),
-            Store.Attr(
-                "mail_template_ids",
-                lambda activity: activity.mail_template_ids._read_format(["name"]),
-            ),
+            Store.Many("mail_template_ids", ["name"]),
             Store.One("persona", value=lambda activity: activity.user_id.partner_id),
         ]
 

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -10,6 +10,7 @@ declare module "models" {
     import { Failure as FailureClass } from "@mail/core/common/failure_model";
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
+    import { MailTemplate as MailTemplateClass } from "@mail/core/common/mail_template_model";
     import { Message as MessageClass } from "@mail/core/common/message_model";
     import { MessageLinkPreview as MessageLinkPreviewClass } from "@mail/core/common/message_link_preview_model";
     import { MessageReactions as MessageReactionsClass } from "@mail/core/common/message_reactions_model";
@@ -33,6 +34,7 @@ declare module "models" {
     export interface Failure extends FailureClass {}
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
+    export interface MailTemplate extends MailTemplateClass {}
     export interface Message extends MessageClass {}
     export interface MessageLinkPreview extends MessageLinkPreviewClass {}
     export interface MessageReactions extends MessageReactionsClass {}
@@ -59,6 +61,7 @@ declare module "models" {
         "mail.message": StaticMailRecord<Message, typeof MessageClass>;
         "mail.message.link.preview": StaticMailRecord<MessageLinkPreview, typeof MessageLinkPreviewClass>;
         "mail.notification": StaticMailRecord<Notification, typeof NotificationClass>;
+        "mail.template": StaticMailRecord<MailTemplate, typeof MailTemplateClass>;
         MessageReactions: StaticMailRecord<MessageReactions, typeof MessageReactionsClass>;
         Persona: StaticMailRecord<Persona, typeof PersonaClass>;
         "res.country": StaticMailRecord<Country, typeof CountryClass>;
@@ -83,6 +86,7 @@ declare module "models" {
         "mail.message": Message;
         "mail.message.link.preview": MessageLinkPreview;
         "mail.notification": Notification;
+        "mail.template": MailTemplate;
         MessageReactions: MessageReactions;
         Persona: Persona;
         "res.country": Country;

--- a/addons/mail/static/src/core/common/activity_model.js
+++ b/addons/mail/static/src/core/common/activity_model.js
@@ -52,8 +52,7 @@ export class Activity extends Record {
     feedback;
     /** @type {string} */
     icon = "fa-tasks";
-    /** @type {Object[]} */
-    mail_template_ids;
+    mail_template_ids = fields.Many("mail.template");
     note = fields.Html("");
     persona = fields.One("Persona");
     /** @type {number|false} */

--- a/addons/mail/static/src/core/common/mail_template_model.js
+++ b/addons/mail/static/src/core/common/mail_template_model.js
@@ -1,0 +1,11 @@
+import { Record } from "@mail/model/record";
+
+export class MailTemplate extends Record {
+    static id = "id";
+    static _name = "mail.template";
+    /** @type {number} */
+    id;
+    /** @type {String} */
+    name;
+}
+MailTemplate.register();


### PR DESCRIPTION
The mail activity model returns "mail_template_ids" as a plain object. This commit adapts it to use the "_to_store" mechanisme.

task-4676076

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
