### PR TITLE
[FIX] web_editor: fix the snippets preview dialog testing behaviour

### DIFF
--- a/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
+++ b/addons/web_editor/static/src/js/editor/add_snippet_dialog.js
@@ -90,7 +90,7 @@ export class AddSnippetDialog extends Component {
     }
 
     get iframeDocument() {
-        return this.iframeRef.el.contentDocument;
+        return this.iframeRef.el?.contentDocument;
     }
     /**
      * Gets snippet groups.


### PR DESCRIPTION
The adaptations from [1] and [2] added some code to the snippet preview
dialog, mainly to adapt text highlights in the snippets content
(starting from `18.0`) and enable the snippets preview interactions
(starting from `18.3`) [A].

In a runbot test context, the snippet selection happens too fast that
the code from [A] (linked to the async behaviour of `insertSnippets`)
can still process the snippets dialog `iframeDocument` (lost after the
dialog being closed on snippet selection).

The goal of this commit is to fix this behaviour by simply taking into
consideration the fact that the preview content can be lost (since in
a real use case, a user will select a snippet in a reasonable time).

[1]: https://github.com/odoo/odoo/commit/1aaf483c5d3b8e8816cfbea7da96ac007a42d492

[2]: https://github.com/odoo/odoo/commit/e008c92fcad2b8cc160586ba6ab94bc077b9bf3d

Remark: This commit will be adapted on `18.3` to fix the code from [2].

runbot-190596