### PR TITLE
[FIX] web: list: compute correct widths for all date(time) formats

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -14,6 +14,7 @@ import { registry } from "@web/core/registry";
 import { ensureArray } from "@web/core/utils/arrays";
 import { exprToBoolean } from "@web/core/utils/strings";
 import { standardFieldProps } from "../standard_field_props";
+import { FIELD_WIDTHS } from "@web/views/list/column_width_hook";
 
 /**
  * @typedef {luxon.DateTime} DateTime
@@ -348,6 +349,8 @@ export const dateTimeField = {
         showTime: exprToBoolean(options.show_time ?? true),
     }),
     supportedTypes: ["datetime"],
+    listViewWidth: ({ options }) =>
+        exprToBoolean(options.show_time ?? true) ? FIELD_WIDTHS.datetime : FIELD_WIDTHS.date,
 };
 
 export const dateRangeField = {
@@ -378,7 +381,15 @@ export const dateRangeField = {
         },
     ],
     supportedTypes: ["date", "datetime"],
-    listViewWidth: ({ type }) => (type === "datetime" ? 294 : 180),
+    listViewWidth: ({ type, options }) => {
+        let width;
+        if (type === "datetime" && exprToBoolean(options.show_time ?? true)) {
+            width = FIELD_WIDTHS.datetime;
+        } else {
+            width = FIELD_WIDTHS.date;
+        }
+        return 2 * width + 30; // 30px for the arrow and the gaps
+    },
     isValid: (record, fieldname, fieldInfo) => {
         if (fieldInfo.widget === "daterange") {
             if (

--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -1,6 +1,9 @@
+import { renderToElement } from "@web/core/utils/render";
 import { useDebounced } from "@web/core/utils/timing";
+import { formatDate, formatDateTime } from "@web/core/l10n/dates";
+import { localization } from "@web/core/l10n/localization";
 
-import { useComponent, useEffect, useExternalListener } from "@odoo/owl";
+import { useComponent, useEffect, useExternalListener, xml } from "@odoo/owl";
 
 // This file defines a hook that encapsulates the column width logic of the list view. This logic
 // aims at optimizing the available space between columns and, once computed, at freezing the table
@@ -50,11 +53,23 @@ const DEFAULT_MIN_WIDTH = 80;
 const SELECTOR_WIDTH = 20;
 const OPEN_FORM_VIEW_BUTTON_WIDTH = 54;
 const DELETE_BUTTON_WIDTH = 12;
-const FIELD_WIDTHS = {
+let _dateFieldWidth = null; // computed dynamically, lazily, see @computeOptimalDateWidths
+let _datetimeFieldWidth = null; // computed dynamically, lazily, see @computeOptimalDateWidths
+export const FIELD_WIDTHS = Object.freeze({
     boolean: [20, 100], // [minWidth, maxWidth]
     char: [80], // only minWidth, no maxWidth
-    date: 80, // minWidth = maxWidth
-    datetime: 145,
+    get date() {
+        if (!_dateFieldWidth) {
+            computeOptimalDateWidths();
+        }
+        return _dateFieldWidth;
+    },
+    get datetime() {
+        if (!_datetimeFieldWidth) {
+            computeOptimalDateWidths();
+        }
+        return _datetimeFieldWidth;
+    },
     float: 93,
     integer: 71,
     many2many: [80],
@@ -65,7 +80,59 @@ const FIELD_WIDTHS = {
     reference: [80],
     selection: [80],
     text: [80, 1200],
-};
+});
+
+export function resetDateFieldWidths() {
+    // useful for tests
+    _dateFieldWidth = null;
+    _datetimeFieldWidth = null;
+}
+
+/**
+ * Compute ideal date and datetime widths. There's no static value for them as they depend on the
+ * localization. Moreover, as we want to have the exact minimum width necessary, it also depends on
+ * the fonts (we never want to see "..." in date fields). So we render date(time) values, we insert
+ * them into the DOM and compute their width.
+ */
+function computeOptimalDateWidths() {
+    const dates = [];
+    const datetimes = [];
+    const { dateFormat, timeFormat } = localization;
+    // generate a date for each month if date format contains MMMM or MMM (full or abbrev. month)
+    for (let month = 1; month <= (/(?<!')MMM/.test(dateFormat) ? 12 : 1); month++) {
+        // generate a date for each day if date format contains cccc or ccc (full or abbrev. day)
+        for (let day = 1; day <= (/(?<!')ccc/.test(dateFormat) ? 7 : 1); day++) {
+            dates.push(formatDate(luxon.DateTime.local(2017, month, day)));
+            datetimes.push(formatDateTime(luxon.DateTime.local(2017, month, day, 8, 0, 0)));
+            if (/(?<!')a/.test(timeFormat)) {
+                // generate a date in the afternoon if time is displayed with AM/PM or equivalent
+                datetimes.push(formatDateTime(luxon.DateTime.local(2017, month, day, 20, 0, 0)));
+            }
+        }
+    }
+    const template = xml`
+        <div class="invisible" style="font-variant-numeric: tabular-nums;">
+            <div class="dates">
+                <div t-foreach="dates" t-as="date" t-key="date_index">
+                    <span t-esc="date"/>
+                </div>
+            </div>
+            <div class="datetimes">
+                <div t-foreach="datetimes" t-as="datetime" t-key="datetime_index">
+                    <span t-esc="datetime"/>
+                </div>
+            </div>
+        </div>`;
+    const div = renderToElement(template, { dates, datetimes });
+    document.body.append(div);
+    const dateSpans = div.querySelectorAll(".dates span");
+    const dateWidths = [...dateSpans].map((span) => span.getBoundingClientRect().width);
+    const datetimeSpans = div.querySelectorAll(".datetimes span");
+    const datetimeWidths = [...datetimeSpans].map((span) => span.getBoundingClientRect().width);
+    document.body.removeChild(div);
+    _dateFieldWidth = Math.ceil(Math.max(...dateWidths)) + 1;
+    _datetimeFieldWidth = Math.ceil(Math.max(...datetimeWidths)) + 1;
+}
 
 /**
  * Compute ideal widths based on the rules described on top of this file.
@@ -220,7 +287,11 @@ function getWidthSpecs(columns) {
                 if (column.field.listViewWidth) {
                     width = column.field.listViewWidth;
                     if (typeof width === "function") {
-                        width = width({ type: column.fieldType, hasLabel: column.hasLabel });
+                        width = width({
+                            type: column.fieldType,
+                            hasLabel: column.hasLabel,
+                            options: column.options,
+                        });
                     }
                 } else {
                     width = FIELD_WIDTHS[column.widget || column.fieldType];
@@ -378,9 +449,9 @@ export function useMagicColumnWidths(tableRef, getState) {
 
             // Store current column widths to freeze them
             const headers = [...table.querySelectorAll("thead th")];
-            columnWidths = headers.map((th) => {
-                return th.getBoundingClientRect().width - getHorizontalPadding(th);
-            });
+            columnWidths = headers.map(
+                (th) => th.getBoundingClientRect().width - getHorizontalPadding(th)
+            );
 
             // Ignores the 'left mouse button down' event as it used to start resizing
             if (ev.type === "pointerdown" && ev.button === 0) {

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1,7 +1,8 @@
-import { beforeEach, expect, test } from "@odoo/hoot";
+import { after, beforeEach, expect, test } from "@odoo/hoot";
 import {
     queryAll,
     queryAllProperties,
+    queryAllTexts,
     queryAllValues,
     queryFirst,
     queryValue,
@@ -13,12 +14,14 @@ import {
     clickSave,
     contains,
     defineModels,
+    defineParams,
     fields,
     models,
     mountView,
     onRpc,
     pagerNext,
 } from "../../web_test_helpers";
+import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
 
 function getPickerCell(expr) {
     return queryAll(`.o_datetime_picker .o_date_item_cell:contains(/^${expr}$/)`);
@@ -811,6 +814,9 @@ test("list daterange with empty start date and end date", async () => {
 
 test("list daterange: column widths", async () => {
     await resize({ width: 800 });
+    document.body.style.fontFamily = "sans-serif";
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
 
     Partner._fields.char_field = fields.Char();
     Partner._fields.date_end = fields.Date();
@@ -830,11 +836,80 @@ test("list daterange: column widths", async () => {
 
     expect(".o_data_row").toHaveCount(1);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 189, 304, 267]);
+    expect(columnWidths).toEqual([40, 183, 300, 277]);
+});
+
+test("list daterange: column widths (fancy format)", async () => {
+    await resize({ width: 800 });
+    document.body.style.fontFamily = "sans-serif";
+
+    defineParams({
+        lang_parameters: {
+            date_format: "%a, %d %B %Y",
+            time_format: "%H:%M:%S %p",
+        },
+    });
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
+
+    Partner._fields.char_field = fields.Char();
+    Partner._fields.date_end = fields.Date();
+    Partner._records[0].date_end = "2017-02-04";
+    Partner._records[0].datetime_end = "2017-02-09 17:00:00";
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <tree>
+                <field name="date" widget="daterange" options="{'end_date_field': 'date_end'}" />
+                <field name="datetime" widget="daterange" options="{'end_date_field': 'datetime_end'}" />
+                <field name="char_field" />
+            </tree>`,
+    });
+
+    expect(".o_data_row").toHaveCount(1);
+    expect(queryAllTexts(".o_data_cell")).toEqual([
+        "Fri, 03 February 2017\nSat, 04 February 2017",
+        "Wed, 08 February 2017 15:30:00 PM\nThu, 09 February 2017 22:30:00 PM",
+        "",
+    ]);
+    const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
+    expect(columnWidths).toEqual([40, 361, 527, 100]);
+});
+
+test("list daterange: column widths (show_time=false)", async () => {
+    await resize({ width: 800 });
+    document.body.style.fontFamily = "sans-serif";
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
+
+    Partner._fields.char_field = fields.Char();
+    Partner._fields.date_end = fields.Date();
+    Partner._records[0].date_end = "2017-02-04";
+    Partner._records[0].datetime_end = "2017-02-09 17:00:00";
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <tree>
+                <field name="datetime" widget="daterange" options="{'show_time': false, 'end_date_field': 'datetime_end'}" />
+                <field name="char_field" />
+            </tree>`,
+    });
+
+    expect(".o_data_row").toHaveCount(1);
+    expect(queryAllTexts(".o_data_cell")).toEqual(["02/08/2017\n02/09/2017", ""]);
+    const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
+    expect(columnWidths).toEqual([40, 183, 577]);
 });
 
 test("list daterange: column widths (no record)", async () => {
     await resize({ width: 800 });
+    document.body.style.fontFamily = "sans-serif";
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
 
     Partner._fields.char_field = fields.Char();
     Partner._fields.date_end = fields.Date();
@@ -853,7 +928,7 @@ test("list daterange: column widths (no record)", async () => {
 
     expect(".o_data_row").toHaveCount(0);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 189, 304, 267]);
+    expect(columnWidths).toEqual([40, 183, 300, 277]);
 });
 
 test("always range: related end date, both start date and end date empty", async () => {

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
-import { queryAllProperties, queryOne, queryRect, resize } from "@odoo/hoot-dom";
+import { after, beforeEach, describe, expect, getFixture, test } from "@odoo/hoot";
+import { queryAllProperties, queryAllTexts, queryOne, queryRect, resize } from "@odoo/hoot-dom";
 import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
 import {
     contains,
     defineModels,
+    defineParams,
     fields,
     models,
     mountView,
@@ -15,7 +16,9 @@ import {
     toggleSearchBarMenu,
     webModels,
 } from "@web/../tests/web_test_helpers";
+
 import { registry } from "@web/core/registry";
+import { resetDateFieldWidths } from "@web/views/list/column_width_hook";
 
 describe.current.tags("desktop");
 
@@ -122,7 +125,10 @@ class Currency extends models.Model {
 
 defineModels([Foo, Bar, Currency, ResCompany, ResPartner, ResUsers]);
 
-beforeEach(() => resize({ width: 800 }));
+beforeEach(() => {
+    resize({ width: 800 });
+    document.body.style.fontFamily = "sans-serif";
+});
 
 function getColumnWidths(root) {
     return queryAllProperties(".o_list_table thead th", "offsetWidth", { root });
@@ -147,7 +153,7 @@ test(`width computation: no record, lot of fields`, async () => {
                 <field name="currency_id"/>
             </tree>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 89, 154, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 100]);
 });
 
 test(`width computation: no record, few fields`, async () => {
@@ -214,7 +220,7 @@ test(`width computation: with records, lot of fields`, async () => {
                 <field name="currency_id"/>
             </tree>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 89, 154, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 100]);
 });
 
 test(`width computation: with records, lot of fields, grouped`, async () => {
@@ -237,7 +243,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 89, 154, 114, 45]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 45]);
 });
 
 test(`width computation: with records, few fields`, async () => {
@@ -266,7 +272,7 @@ test(`width computation: with records, no relative fields`, async () => {
                 <field name="date"/>
             </tree>`,
     });
-    expect(getColumnWidths()).toEqual([40, 201, 172, 194, 192]);
+    expect(getColumnWidths()).toEqual([40, 203, 174, 196, 186]);
 });
 
 test(`width computation: with records, very long text field`, async () => {
@@ -312,7 +318,7 @@ test(`width computation: with records, lot of fields, long texts`, async () => {
                 <field name="currency_id"/>
             </tree>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 102, 89, 89, 154, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 102, 81, 89, 139, 114, 100]);
 });
 
 test(`width computation: editable list, overflowing table`, async () => {
@@ -449,6 +455,35 @@ test(`width computation: list with width attribute in arch`, async () => {
     expect(getColumnWidths()).toEqual([40, 61, 72, 102, 524]);
 });
 
+test(`width computation: date and datetime with fancy formats`, async () => {
+    defineParams({
+        lang_parameters: {
+            date_format: "%a, %d %B %Y",
+            time_format: "%H:%M:%S %p",
+        },
+    });
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
+
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <tree>
+                <field name="foo"/>
+                <field name="date"/>
+                <field name="datetime"/>
+            </tree>`,
+    });
+
+    expect(queryAllTexts(".o_data_row:eq(0) .o_data_cell")).toEqual([
+        "yop",
+        "Wed, 25 January 2017",
+        "Mon, 12 December 2016 11:55:05 AM",
+    ]);
+    expect(getColumnWidths()).toEqual([40, 325, 170, 265]);
+});
+
 test(`width computation: width attribute in arch and overflowing table`, async () => {
     Foo._records[0].text =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
@@ -469,7 +504,7 @@ test(`width computation: width attribute in arch and overflowing table`, async (
             </tree>
         `,
     });
-    expect(getColumnWidths()).toEqual([40, 154, 210, 396]);
+    expect(getColumnWidths()).toEqual([40, 139, 210, 411]);
 });
 
 test(`width computation: no record, nameless and stringless buttons`, async () => {
@@ -490,22 +525,6 @@ test(`width computation: no record, nameless and stringless buttons`, async () =
     expect(columnWidths[0]).toBe(40);
     expect(columnWidths[1]).toBeGreaterThan(300);
     expect(columnWidths[2]).toBeGreaterThan(300);
-});
-
-test(`width computation: no record, datetime field with date widget`, async () => {
-    Foo._records = [];
-
-    await mountView({
-        resModel: "foo",
-        type: "list",
-        arch: `
-            <tree editable="top">
-                <field name="datetime" widget="date"/>
-                <field name="text"/>
-            </tree>
-        `,
-    });
-    expect(getColumnWidths()).toEqual([40, 89, 671]);
 });
 
 test(`width computation: x2many`, async () => {
@@ -1125,20 +1144,20 @@ test(`freeze widths: toggle optional fields`, async () => {
         `,
     });
 
-    expect(getColumnWidths()).toEqual([40, 89, 484, 154, 32]);
+    expect(getColumnWidths()).toEqual([40, 81, 507, 139, 32]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input:eq(0)").click();
-    expect(getColumnWidths()).toEqual([40, 89, 381, 102, 155, 32]);
+    expect(getColumnWidths()).toEqual([40, 81, 405, 102, 140, 32]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 89, 536, 102, 32]);
+    expect(getColumnWidths()).toEqual([40, 81, 544, 102, 32]);
 
     await contains(".dropdown-item input:eq(2)").click();
-    expect(getColumnWidths()).toEqual([40, 89, 89, 102, 447, 32]);
+    expect(getColumnWidths()).toEqual([40, 81, 89, 102, 455, 32]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 89, 89, 103, 155, 291, 32]);
+    expect(getColumnWidths()).toEqual([40, 81, 89, 103, 140, 315, 32]);
 });
 
 test(`freeze widths: x2many, add first record`, async () => {
@@ -1235,16 +1254,16 @@ test(`freeze widths: x2many, toggle optional field`, async () => {
             </form>`,
     });
 
-    expect(getColumnWidths()).toEqual([100, 636, 32]);
+    expect(getColumnWidths()).toEqual([92, 644, 32]);
 
     // create a record to store the current widths, but discard it directly to keep
     // the list empty (otherwise, the browser automatically computes the optimal widths)
     await contains(".o_field_x2many_list_row_add a").click();
-    expect(getColumnWidths()).toEqual([100, 636, 32]);
+    expect(getColumnWidths()).toEqual([92, 644, 32]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input").click();
-    expect(getColumnWidths()).toEqual([100, 555, 80, 32]);
+    expect(getColumnWidths()).toEqual([92, 563, 80, 32]);
 });
 
 // manually resize columns


### PR DESCRIPTION
In list views, we have a custom logic for column widths which aims at optimizing as much as possible the available space, and freezing the table such that it doesn't flicker upon user interaction (like editing, adding records, browsing through pages...).

This logic defines, for some field types, the exact width that values need to be properly displayed, especially for dates and datetimes for which we know upfront the format, i.e. the length of values.

However, before this commit, the logic was incorrect. It didn't take into the account the fact that date and time formats are language dependant. It assumed that the required space for the english formats (+ a bit of security margin) was enough. Moreover, the fonts may obviously has an impact as well (some fonts requiring more space to display the same text, than others).

As a consequence, on macos and, for instance, in deutch, date and datetime values were trimmed, which is something we never want: dates and datetimes should always be fully displayed. This is even worse in some languages, like arabic, basque or chinese, in which the month and/or the day of week is displayed in letters.

This commit comes with a more elaborated solution to deal with those variable date and time formats + fonts. We no longer hardcode the ideal widths of dates and datetimes, but instead compute it (lazily) once, by rendering values in the DOM.

This commit also improves the datetime and daterange cases with option "show_time" set to false: in that case, we know those fields only require the width of date values, not datetime, so we can shrink their columns.

Task~4801116
