### PR TITLE
[FIX] html_editor: characters disappearing from link popover on discard

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -468,7 +468,7 @@ export class LinkPlugin extends Plugin {
             }
         };
 
-        const restoreSavePoint = this.dependencies.history.makeSavePoint();
+        this.restoreSavePoint = this.dependencies.history.makeSavePoint();
         const props = {
             linkElement,
             isImage: isImage,
@@ -481,7 +481,7 @@ export class LinkPlugin extends Plugin {
             },
             onChange: applyCallback,
             onDiscard: () => {
-                restoreSavePoint();
+                this.restoreSavePoint();
                 if (linkElement.isConnected) {
                     this.openLinkTools(linkElement);
                 }
@@ -499,6 +499,9 @@ export class LinkPlugin extends Plugin {
             onClose: () => {
                 this.linkInDocument = null;
                 this.overlay.close();
+            },
+            onEdit: () => {
+                this.restoreSavePoint = this.dependencies.history.makeSavePoint();
             },
             getInternalMetaData: this.getInternalMetaData,
             getExternalMetaData: this.getExternalMetaData,

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -14,6 +14,7 @@ export class LinkPopover extends Component {
         onRemove: Function,
         onCopy: Function,
         onClose: Function,
+        onEdit: Function,
         getInternalMetaData: Function,
         getExternalMetaData: Function,
         getAttachmentMetadata: Function,
@@ -113,6 +114,7 @@ export class LinkPopover extends Component {
     }
     onClickEdit() {
         this.state.editing = true;
+        this.props.onEdit();
         this.state.url = this.props.linkElement.href;
 
         const textContent = cleanZWChars(this.props.linkElement.textContent);

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -142,6 +142,21 @@ describe("popover should switch UI depending on editing state", () => {
         expect(".o_we_edit_link").toHaveCount(1);
         expect(".o_we_remove_link").toHaveCount(1);
     });
+    test("changes to link text done before clicking on edit button should be kept if discard button is pressed", async () => {
+        const { editor, el } = await setupEditor(
+            '<p>this is a <a href="http://test.com/">link[]</a></p>'
+        );
+        await waitFor(".o-we-linkpopover", { timeout: 1500 });
+        await insertText(editor, "ABCD");
+        // Discard should not remove changes done directly to the link text
+        await click(".o_we_edit_link");
+        await waitFor(".o_we_href_input_link");
+        await click(".o_we_discard_link");
+        await waitFor(".o_we_edit_link");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p>this is a <a href="http://test.com/">linkABCD[]</a></p>'
+        );
+    });
 });
 
 describe("popover should edit,copy,remove the link", () => {


### PR DESCRIPTION
Before the commit, changes made to the link text from outside the edit popover would not be saved if discard is clicked in the edit popover.

Steps to reproduce:
- click on a link
- whitout clicking on the edit link button, change the link text
- click the edit link button and then click discard
- the changes done to the link text have been deleted
