### PR TITLE
[FIX] mail: better align message actions in mobile mailbox

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -203,9 +203,9 @@
 
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile p-2 mt-n2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
-        'me-n2': isMobileOS and !mobileExpanded and isAlignedRight,
-        'ms-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
+        'o-mail-Message-openActionMobile p-2 mt-n3 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
+        'ms-n2': isMobileOS and !mobileExpanded and isAlignedRight,
+        'me-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
         'px-2 py-0': !isMobileOS,
         'rounded-start-1': !isMobileOS and isReverse,
         'rounded-end-1': !isMobileOS and !isReverse,


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/209689

PR above put message actions in top-right corner of card. When message in mailbox was bubble and takes more than 1 line, there was overlap between bubble and this expand button.

This commit fixes it with placing expand button "..." closer to card corner. Also condition with aligned right of message were mistakenly inverted, which is also fixed by this commit.