### PR TITLE
[FIX] web_editor: exclude non-editable blocks from selection

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -451,7 +451,13 @@ export const editorCommands = {
     // Change tags
     setTag(editor, tagName, extraClass = "") {
         const range = getDeepRange(editor.editable, { correctTripleClick: true });
-        const selectedBlocks = [...new Set(getTraversedNodes(editor.editable, range).map(closestBlock))];
+        const selectedBlocks = [
+            ...new Set(
+                getTraversedNodes(editor.editable, range)
+                    .map(closestBlock)
+                    .filter((block) => block.isContentEditable)
+            ),
+        ];
         const deepestSelectedBlocks = selectedBlocks.filter(block => (
             !descendants(block).some(descendant => selectedBlocks.includes(descendant)) &&
             block.isContentEditable


### PR DESCRIPTION
Problem:
When selecting multi-line highlighted text that includes inline SVGs, the `selectedBlocks` includes both the parent `<p>` and the inner `<svg>` elements. These SVGs are incorrectly considered the deepest blocks, which prevents the parent `<p>` from being used to apply text styles (since styles can't be applied on `<svg>` elements).

Example:
```
<p>
    <span class="o_text_highlight">
        <span class="o_text_highlight_item">text<svg></span>
        <span class="o_text_highlight_item">text<svg></span>
    </span>
</p>
```

As a result, style changes (like font) on the selection do nothing.

Solution:
Filter out non-editable blocks (e.g., `<svg>`) from `selectedBlocks` to ensure valid blocks like `<p>` are correctly handled as the deepest block.

Steps to reproduce:
1. Go to Website.
2. Add a paragraph with multiple lines of text.
3. Select all text and apply highlight.
4. Try to change the text style on the same selection. → The style change has no effect.

opw-4438171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
