### PR TITLE
[FIX] mail, im_livechat: update type definitions

### DIFF
--- a/addons/hr_holidays/static/src/@types/models.d.ts
+++ b/addons/hr_holidays/static/src/@types/models.d.ts
@@ -1,5 +1,5 @@
 declare module "models" {
     export interface Persona {
-        outOfOfficeText: Readonly<string>;
+        outOfOfficeDateEndText: Readonly<string>;
     }
 }

--- a/addons/hr_holidays/static/src/persona_model_patch.js
+++ b/addons/hr_holidays/static/src/persona_model_patch.js
@@ -27,6 +27,7 @@ patch(Persona.prototype, {
             return super.updateImStatus(...arguments);
         }
     },
+    /** @returns {string} */
     get outOfOfficeDateEndText() {
         if (!this.leave_date_to) {
             return "";

--- a/addons/im_livechat/static/src/core/common/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/common/@types/models.d.ts
@@ -22,8 +22,8 @@ declare module "models" {
         chatbotStep: ChatbotStep;
     }
     export interface Persona {
-        livechat_languages: String[];
         livechat_expertise: String[];
+        livechat_languages: String[];
     }
     export interface Store {
         Chatbot: StaticMailRecord<Chatbot, typeof ChatbotClass>;

--- a/addons/im_livechat/static/src/core/common/persona_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/persona_model_patch.js
@@ -6,7 +6,9 @@ import { patch } from "@web/core/utils/patch";
 const personaPatch = {
     setup() {
         super.setup();
+        /** @type {String[]} */
         this.livechat_languages = [];
+        /** @type {String[]} */
         this.livechat_expertise = [];
     },
     _computeDisplayName() {

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -6,7 +6,8 @@ declare module "models" {
     import { ChatWindow as ChatWindowClass } from "@mail/core/common/chat_window_model";
     import { Composer as ComposerClass } from "@mail/core/common/composer_model";
     import { Country as CountryClass } from "@mail/core/common/country_model";
-    import { DataResponse as DataResponseClass } from "@mail/core/common/data_request_model";
+    import { DataResponse as DataResponseClass } from "@mail/core/common/data_response_model";
+    import { DiscussCallHistory as DiscussCallHistoryClass } from "@mail/core/common/discuss_call_history_model";
     import { Failure as FailureClass } from "@mail/core/common/failure_model";
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
@@ -15,8 +16,8 @@ declare module "models" {
     import { MessageReactions as MessageReactionsClass } from "@mail/core/common/message_reactions_model";
     import { Notification as NotificationClass } from "@mail/core/common/notification_model";
     import { Persona as PersonaClass } from "@mail/core/common/persona_model";
-    import { ResGroupsPrivilege as ResGroupsPrivilegeClass } from "@mail/core/common/res_groups_privilege_model";
     import { ResGroups as ResGroupsClass } from "@mail/core/common/res_groups_model";
+    import { ResGroupsPrivilege as ResGroupsPrivilegeClass } from "@mail/core/common/res_groups_privilege_model";
     import { ResRole as ResRoleClass } from "@mail/core/common/res_role_model";
     import { Settings as SettingsClass } from "@mail/core/common/settings_model";
     import { Thread as ThreadClass } from "@mail/core/common/thread_model";
@@ -30,6 +31,7 @@ declare module "models" {
     export interface Composer extends ComposerClass {}
     export interface Country extends CountryClass {}
     export interface DataResponse extends DataResponseClass {}
+    export interface DiscussCallHistory extends DiscussCallHistoryClass {}
     export interface Failure extends FailureClass {}
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
@@ -38,8 +40,8 @@ declare module "models" {
     export interface MessageReactions extends MessageReactionsClass {}
     export interface Notification extends NotificationClass {}
     export interface Persona extends PersonaClass {}
-    export interface ResGroupsPrivilege extends ResGroupsPrivilegeClass {}
     export interface ResGroups extends ResGroupsClass {}
+    export interface ResGroupsPrivilege extends ResGroupsPrivilegeClass {}
     export interface ResRole extends ResRoleClass {}
     export interface Settings extends SettingsClass {}
     export interface Thread extends ThreadClass {}
@@ -50,6 +52,7 @@ declare module "models" {
         ChatWindow: StaticMailRecord<ChatWindow, typeof ChatWindowClass>;
         Composer: StaticMailRecord<Composer, typeof ComposerClass>;
         DataResponse: StaticMailRecord<DataResponse, typeof DataResponseClass>;
+        "discuss.call.history": StaticMailRecord<DiscussCallHistory, typeof DiscussCallHistoryClass>;
         Failure: StaticMailRecord<Failure, typeof FailureClass>;
         "ir.attachment": StaticMailRecord<Attachment, typeof AttachmentClass>;
         "mail.activity": StaticMailRecord<Activity, typeof ActivityClass>;
@@ -63,6 +66,7 @@ declare module "models" {
         Persona: StaticMailRecord<Persona, typeof PersonaClass>;
         "res.country": StaticMailRecord<Country, typeof CountryClass>;
         "res.groups": StaticMailRecord<ResGroups, typeof ResGroupsClass>;
+        "res.groups.privilege": StaticMailRecord<ResGroupsPrivilege, typeof ResGroupsPrivilegeClass>;
         "res.role": StaticMailRecord<ResRole, typeof ResRoleClass>;
         Settings: StaticMailRecord<Settings, typeof SettingsClass>;
         Thread: StaticMailRecord<Thread, typeof ThreadClass>;
@@ -74,6 +78,7 @@ declare module "models" {
         ChatWindow: ChatWindow;
         Composer: Composer;
         DataResponse: DataResponse;
+        "discuss.call.history": DiscussCallHistory;
         Failure: Failure;
         "ir.attachment": Attachment;
         "mail.activity": Activity;
@@ -86,8 +91,8 @@ declare module "models" {
         MessageReactions: MessageReactions;
         Persona: Persona;
         "res.country": Country;
-        "res.groups.privilege": ResGroupsPrivilege;
         "res.groups": ResGroups;
+        "res.groups.privilege": ResGroupsPrivilege;
         "res.role": ResRole;
         Settings: Settings;
         Thread: Thread;

--- a/addons/mail/static/src/core/web/@types/models.d.ts
+++ b/addons/mail/static/src/core/web/@types/models.d.ts
@@ -27,6 +27,7 @@ declare module "models" {
     }
     export interface Thread {
         activities: Activity[];
+        follow: () => Promise<void>;
         loadMoreFollowers: () => Promise<void>;
         loadMoreRecipients: () => Promise<void>;
         recipients: Follower[];

--- a/addons/mail/static/src/discuss/call/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/call/common/@types/models.d.ts
@@ -27,9 +27,11 @@ declare module "models" {
         cancelRtcInvitationTimeout: number|undefined;
         hadSelfSession: boolean;
         lastSessionIds: Set<number>;
-        rtcInvitingSession: RtcSession;
+        promoteFullscreen: typeof CALL_PROMOTE_FULLSCREEN[keyof CALL_PROMOTE_FULLSCREEN];
         rtc_session_ids: RtcSession[];
-        videoCount: Readonly<number>;
+        rtcInvitingSession: RtcSession;
+        videoCount: number;
+        videoCountNotSelf: number;
     }
 
     export interface Models {

--- a/addons/mail/static/src/discuss/call/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/call/common/thread_model_patch.js
@@ -24,6 +24,7 @@ const ThreadPatch = {
                 this.store.allActiveRtcSessions.delete(r);
             },
         });
+        /** @type {typeof CALL_PROMOTE_FULLSCREEN[keyof CALL_PROMOTE_FULLSCREEN]} */
         this.promoteFullscreen = CALL_PROMOTE_FULLSCREEN.DISABLED;
         this.hadSelfSession = false;
         /** @type {Set<number>} */

--- a/addons/mail/static/src/discuss/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/common/@types/models.d.ts
@@ -49,6 +49,9 @@ declare module "models" {
         lastInterestDt: luxon.DateTime;
         lastMessageSeenByAllId: undefined|number;
         lastSelfMessageSeenByEveryone: Message;
+        markedAsUnread: boolean;
+        markingAsRead: boolean;
+        markReadSequential: () => Promise<any>;
         member_count: number|undefined;
         membersThatCanSeen: Readonly<ChannelMember[]>;
         name: string;

--- a/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
+++ b/addons/mail/static/src/discuss/core/public_web/@types/models.d.ts
@@ -8,6 +8,7 @@ declare module "models" {
         channels: DiscussAppCategory;
         chats: DiscussAppCategory;
         computeChats: () => object;
+        unreadChannels: Thread[];
     }
     export interface Message {
         linkedSubChannel: Thread;
@@ -21,6 +22,7 @@ declare module "models" {
     }
     export interface Thread {
         _computeDiscussAppCategory: () => undefined|unknown;
+        appAsUnreadChannels: DiscussApp;
         createSubChannel: (param0: { initialMessage: Message, name: string }) => Promise<void>;
         discussAppCategory: DiscussAppCategory;
         displayInSidebar: boolean;


### PR DESCRIPTION
Re-generate type definitions for mail and live chat modules as some changes were made to the models without updating the type files.