### PR TITLE
[FIX] web_editor: video selector error handling

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/video_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/video_selector.js
@@ -83,12 +83,16 @@ export class VideoSelector extends Component {
 
         onMounted(async () => {
             await Promise.all(this.props.vimeoPreviewIds.map(async (videoId) => {
-                const { thumbnail_url: thumbnailSrc } = await this.http.get(`https://vimeo.com/api/oembed.json?url=http%3A//vimeo.com/${encodeURIComponent(videoId)}`);
-                this.state.vimeoPreviews.push({
-                    id: videoId,
-                    thumbnailSrc,
-                    src: `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`
-                });
+                try {
+                    const { thumbnail_url: thumbnailSrc } = await this.http.get(`https://vimeo.com/api/oembed.json?url=http%3A//vimeo.com/${encodeURIComponent(videoId)}`);
+                    this.state.vimeoPreviews.push({
+                        id: videoId,
+                        thumbnailSrc,
+                        src: `https://player.vimeo.com/video/${encodeURIComponent(videoId)}`
+                    });
+                } catch (err) {
+                    console.warn(`Could not get video #${videoId} from vimeo: ${err}`);
+                }
             }));
         });
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When fetching videos from vimeo, if the video is
deleted, an error is shown to the user which also
block test `test_snippet_background_video`.

Current behavior before PR:
1. Install website
2. Start `website_snippet_background_video` tour
3. You'll get an error if a video is missing

Desired behavior after PR is merged:
Now, with the error handling, a warning will be
simply outputed for the missing video instead
of a blocking message



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
