### PR TITLE
[FIX] point_of_sale,stock: preserve existing operation types

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -375,7 +375,7 @@ class Warehouse(models.Model):
 
         for picking_type, values in data.items():
             if self[picking_type]:
-                self[picking_type].sudo().sequence_id.write(sequence_data[picking_type])
+                self[picking_type].sudo().sequence_id.write({'company_id': self.company_id.id})
                 self[picking_type].write(values)
             else:
                 data[picking_type].update(create_data[picking_type])

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -898,3 +898,11 @@ class TestWarehouse(TestStockCommon):
         self.assertRecordValues(ship, [{
             'picking_type_id': warehouse.out_type_id.id, 'company_id': companies.ids[0], 'location_id': warehouse.wh_output_stock_loc_id.id,
         }])
+
+    def test_sequence_preservation_on_step_change(self):
+        out_type = self.warehouse_1.out_type_id
+        sequence = out_type.sequence_id
+        end_of_prefix = 'LOREM/'
+        sequence.prefix += end_of_prefix
+        self.warehouse_1.delivery_steps = 'pick_ship'
+        self.assertTrue(sequence.prefix.endswith(end_of_prefix))


### PR DESCRIPTION
Installing PoS will change some values on existing operations types.

To reproduce the issue
1. Install stock
2. Operations Types, edit Delivery:
   - Change the barcode
3. Install point_of_sale

Error: the barcode of Delivery is reset

When installing PoS, it will execute a generic method that creates
and updates all operation types:
https://github.com/odoo/odoo/blob/0bc90e7d74bd0792b9af7464256ba8770d894a25/addons/point_of_sale/data/point_of_sale_data.xml#L4
https://github.com/odoo/odoo/blob/14e9a698e333c3d6d2f7830353c34311de9ecb2c/addons/point_of_sale/models/stock_warehouse.py#L45-L50
https://github.com/odoo/odoo/blob/03478253c166238442d2f81f095de9fbcdfb265f/addons/stock/models/stock_warehouse.py#L350-L356
Thanks to this, the PoS operation type will be created. However, as
said in its docstring, the method will also update the existing
operation types. For instance, for Delivery:
https://github.com/odoo/odoo/blob/03478253c166238442d2f81f095de9fbcdfb265f/addons/stock/models/stock_warehouse.py#L1003-L1006
Its barcode and default source location will be reset. The update
will also reset the sequence prefix.

As said by the method name in PoS (`_create_missing_pos_picking_types`),
the idea here is just to create missing PoS types.

Similar issue with repair: the operations types of the user-created
wh will be reset.

OPW-4668505