### PR TITLE
[FIX] point_of_sale: fix category name in chinese

### DIFF
--- a/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
+++ b/addons/point_of_sale/static/src/app/components/category_selector/category_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.CategorySelector">
-        <div t-attf-class="{{this.pos.config.show_category_images ? 'd-flex flex-wrap category-list' : 'd-grid product-list'}} gap-1 gap-lg-2 p-2">
+        <div t-attf-class="{{this.pos.config.show_category_images ? 'category-list' : 'product-list'}} d-grid gap-1 gap-lg-2 p-2">
             <t t-foreach="this.getCategoriesAndSub()" t-as="category" t-key="category.id">
                 <button t-on-click="() => this.pos.setSelectedCategory(category.id)"
                     t-attf-class="o_colorlist_item_color_{{!category.isSelected and !category.isChildren ? 'transparent_': ''}}{{category.color or 'none'}}"

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -24,7 +24,6 @@
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    max-width: min-content;
 }
 
 .btn-switchpane, .pay-order-button {


### PR DESCRIPTION
**Issue**
Using `max-width: min-content `combined with `d-flex`  caused Chinese characters to stack vertically, as each character is treated like a word and with a 2-line height, only first two 2 characters were visible

**solution:**
Switch to grid layout and remove max-width to ensure label width isn't constrained by its content length.

opw-4766145

Current behavior before PR:
![before fixx](https://github.com/user-attachments/assets/a4f37635-611b-4d99-accb-0dc302cf1712)


Desired behavior after PR is merged:
![after fixx](https://github.com/user-attachments/assets/08d01501-6704-4ddf-8c70-c590f6863f1b)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
