### PR TITLE
[FIX] hr_expense: filter payment methods of active journals only

### DIFF
--- a/addons/hr_expense/models/res_company.py
+++ b/addons/hr_expense/models/res_company.py
@@ -23,5 +23,5 @@ class ResCompany(models.Model):
         "account.payment.method.line",
         string="Payment methods available for expenses paid by company",
         check_company=True,
-        domain="[('payment_type', '=', 'outbound'), ('journal_id', '!=', False)]",
+        domain="[('payment_type', '=', 'outbound'), ('journal_id', '!=', False), ('journal_id.active', '=', True)]",
     )


### PR DESCRIPTION
**Steps to reproduce:**
1. Accounting > Configuration Menu > Journals
2. Archive a Journals with outgoing payment method
3. Go to Expenses > Configuration Menu
4. Settings > Payment methods Under Accounting
5. Notice that the payment methods from archived journals are still visible

**Issue:**
- In this commit https://github.com/odoo/odoo/commit/c4f21085f8f77d8786eb1bc9494ae0fc1327b8b8
  the overridden action_archived method was removed, which previously prevented journals with 
  linked payment methods from being archived.

**Solution:**
- Update the company_expense_allowed_payment_method_line_ids field's domain field to include only payment methods from  active journals

opw-4745525