### PR TITLE
[FIX] l10n_in_ewaybill: incorrect valid upto date incase of irn

### DIFF
--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -425,7 +425,7 @@ class L10nInEwaybill(models.Model):
         return {}
 
     def _handle_internal_warning_if_present(self, response):
-        if warnings := response.get('odoo_warning'):
+        if warnings := response.pop('odoo_warning', False):
             for warning in warnings:
                 if warning.get('message_post'):
                     odoobot = self.env.ref('base.partner_root')
@@ -500,10 +500,10 @@ class L10nInEwaybill(models.Model):
         self._write_successfully_response({
             'name': name,
             'state': 'generated',
-            'ewaybill_date': self._indian_timezone_to_odoo_utc(
+            'ewaybill_date': self._convert_str_datetime_to_date(
                 response_data['ewayBillDate']
             ),
-            'ewaybill_expiry_date': self._indian_timezone_to_odoo_utc(
+            'ewaybill_expiry_date': self._convert_str_datetime_to_date(
                 response_data.get('validUpto')
             ),
             **self._l10n_in_ewaybill_handle_zero_distance_alert_if_present(response_data)
@@ -515,6 +515,7 @@ class L10nInEwaybill(models.Model):
         """
             This method is used to convert date from Indian timezone to UTC
         """
+        # TODO remove in master
         if not str_date:
             return False
         try:
@@ -529,6 +530,24 @@ class L10nInEwaybill(models.Model):
                 return fields.Datetime.to_string(fields.Datetime.now())
         utc_time = local_time.astimezone(pytz.utc)
         return fields.Datetime.to_string(utc_time)
+
+    @api.model
+    def _convert_str_datetime_to_date(self, str_datetime):
+        """
+        Expected datetime formats:
+        - 25/05/2025 11:59:00 PM
+        - 09/04/2025 23:59:59 (trailing with extra whitespace)
+        - 2025-05-24 23:59:00
+        """
+        if not str_datetime:
+            return False
+        str_date = str_datetime[:10]  # Extract the date
+        if re.match(r"\d{2}/\d{2}/\d{4}", str_date):
+            return datetime.strptime(str_date, "%d/%m/%Y")
+        elif re.match(r"\d{4}-\d{2}-\d{2}", str_date):
+            return datetime.strptime(str_date, "%Y-%m-%d")
+        _logger.error("L10nINEwaybill Invalid date format: %s", str_datetime)
+        return False
 
     @api.model
     def _get_partner_state_code(self, partner):
@@ -677,8 +696,8 @@ class L10nInEwaybill(models.Model):
             ewb_name = res_json.get("ewayBillNo") or res_json.get("EwbNo")
             if not ewb_name:
                 return False
-            ewb_date = self._indian_timezone_to_odoo_utc(res_json.get("ewayBillDate") or res_json.get("EwbDt"))
-            ewb_validity = self._indian_timezone_to_odoo_utc(res_json.get("validUpto") or res_json.get("EwbValidTill"))
+            ewb_date = self._convert_str_datetime_to_date(res_json.get("ewayBillDate") or res_json.get("EwbDt"))
+            ewb_validity = self._convert_str_datetime_to_date(res_json.get("validUpto") or res_json.get("EwbValidTill"))
             self.write({
                 "name": ewb_name,
                 "ewaybill_date": ewb_date,

--- a/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_irn/models/l10n_in_ewaybill.py
@@ -80,10 +80,10 @@ class L10nInEwaybill(models.Model):
         self._write_successfully_response({
             'name': name,
             'state': 'generated',
-            'ewaybill_date': self._indian_timezone_to_odoo_utc(
+            'ewaybill_date': self._convert_str_datetime_to_date(
                 response_data['EwbDt']
             ),
-            'ewaybill_expiry_date': self._indian_timezone_to_odoo_utc(
+            'ewaybill_expiry_date': self._convert_str_datetime_to_date(
                 response_data.get('EwbValidTill')
             ),
             **self._l10n_in_ewaybill_handle_zero_distance_alert_if_present(response_data)


### PR DESCRIPTION
Before this commit:
We did not handle the date format in case the ewaybill is generated through IRN.

After this commit:
We handle the format where the ewaybill is generated through IRN




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
