### PR TITLE
[REV] core: reflect inherits done via delegate fields

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1,5 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import inspect
 import itertools
 import logging
 import random
@@ -1378,12 +1377,6 @@ class IrModelInherit(models.Model):
                 ] + [
                     (model_id, get_model_id(parent_name), get_field_id(field))
                     for parent_name, field in cls._inherits.items()
-                ] + [
-                    (model_id, get_model_id(field.comodel_name), get_field_id(field_name))
-                    for (field_name, field) in inspect.getmembers(cls)
-                    if isinstance(field, fields.Many2one)
-                    if field.type == 'many2one' and not field.related and field.delegate
-                    if field_name not in cls._inherits.values()
                 ]
 
                 for item in items:

--- a/odoo/addons/base/tests/test_ir_model.py
+++ b/odoo/addons/base/tests/test_ir_model.py
@@ -357,11 +357,3 @@ class TestIrModelInherit(TransactionCase):
         self.assertEqual(len(imi), 1)
         self.assertEqual(imi.parent_id.model, "res.partner")
         self.assertEqual(imi.parent_field_id.name, "partner_id")
-
-    def test_delegate_field(self):
-        imi = self.env["ir.model.inherit"].search(
-            [("model_id.model", "=", "ir.cron"), ("parent_field_id", "!=", False)]
-        )
-        self.assertEqual(len(imi), 1)
-        self.assertEqual(imi.parent_id.model, "ir.actions.server")
-        self.assertEqual(imi.parent_field_id.name, "ir_actions_server_id")


### PR DESCRIPTION
Since 56a666c10a74e18efa824a5797241626ac8e28fc, the declaration of `_inherits` is now required.
We can thus revert 6577920cb657a8c7f099dd05dfdd19e209de9a19, as it is not needed anymore.