### PR TITLE
[FIX] base: prevent crash from missing savepoint during demo data loading

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -230,6 +230,7 @@ class ResCompany(models.Model):
             not tools.config['test_enable']
             and (self.env.registry.ready or not self.env.registry._init)
             and not modules.module.current_test
+            and not self.env.context.get('install_mode')  # due to savepoint when importing the file
         )
         if uninstalled_modules and is_ready_and_not_test:
             return uninstalled_modules.button_immediate_install()


### PR DESCRIPTION
The system would crash with an `InvalidSavepointSpecification` when trying to close a savepoint that did not exist, particularly during demo data loading in the `Point of sale` installation.


**Steps to Produce**:-
1. Install **Point of Sale**.
2. Go to **Settings** and **activate developer mode**.
3. Then click on **load demo data**.


**Error**:-
`InvalidSavepointSpecification: savepoint 1db45150-3239-11f0-b788-d843ae8a6626
 does not exist`

`KeyError :('ir.model.data', <function IrModelData. _ xmlid_lookup at
 0x7a05b4edbf60>, 'base.demo_failure_todo')`

`InFailedSqlTransaction: current transaction is aborted, commands ignored until
 end of transaction block`


**Solution**:-
 - During a normal web transaction, we trigger installation of **l10n** which commits the transaction.
 - So, We need to avoid calling the **install_l10n_modules** for **install_demo**.
   

**Sentry**:-6600322360


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
