### PR TITLE
[FIX] website, web_editor: resolve navigation in contenteditable spans

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -7386,8 +7386,194 @@ X[]
                     `),
                 });
             });
+            it('should select text highlight (collapsed)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">[]def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowUp', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">]abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">[def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
+            it('should select text highlight (collapsed) (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def[]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowUp', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">]def[
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
+            it('should select text highlight (non collapsed)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">[def]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowUp', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">]abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">[def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
         });
         describe('ArrowDown', () => {
+            it('should select text highlight (non collapsed)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">[abc]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">[abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">]def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
+            it('should select text highlight (collapsed)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">[]abc
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">[abc]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
+            it('should select text highlight (collapsed) (2)', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc[]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p style="margin-bottom: 0px;">
+                            <span class="o_text_highlight o_translate_inline o_text_highlight_underline" style="--text-highlight-width: 2px;">
+                                <span style="display: inline-flex;" class="o_text_highlight_item a">abc[
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                                <span style="display: inline-flex;" class="o_text_highlight_item b">def]
+                                    <svg fill="none" class="o_text_highlight_svg o_content_no_merge position-absolute overflow-visible top-0 start-0 w-100 h-100 pe-none"><path stroke-width="var(--text-highlight-width)" stroke="var(--text-highlight-color)" stroke-linecap="round" d="M 0,19 h 516.515625" class="o_text_highlight_path_underline"></path></svg>
+                                </span>
+                            </span>
+                        </p>
+                    `),
+                });
+            });
             it('should select banner forwards', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: unformat(`

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -2519,13 +2519,15 @@ input[value*="data-oe-translation-initial-sha"] {
     // Text highlight SVG container.
     > .o_text_highlight_item {
         position: relative;
-        display: inline-block;
+        display: inline-flex;
         line-height: normal;
         white-space: pre-wrap;
         isolation: isolate;
 
         > * {
             text-decoration: none;
+            display: inline;
+            white-space: nowrap;
         }
         svg {
             z-index: -1;


### PR DESCRIPTION
Problem:
In Chrome, when using contenteditable paragraphs with nested spans having `display: inline-block`, pressing the down arrow key would incorrectly jump to the end of the paragraph instead of the next line.

Reproduction snippet:
```
<p contenteditable="true">
  <span>
    <span style="display: inline-block;">First line of text</span>
    <span style="display: inline-block;">Second line of text</span>
    <span style="display: inline-block;">Third line of text</span>
  </span>
</p>
```

Solution:
Changed display properties to use inline-flex for parent elements while ensuring child elements maintain inline flow.

Fixes keyboard navigation in Chrome by altering how the browser calculates caret positions between nested elements.

Prevents unwanted line breaks within nested elements.

Maintains proper text wrapping at container boundaries.

Steps to reproduce:
- Go to website.
- Add paragraph (two lines or more).
- Select all the text within the paragraph.
- Apply "Highlight" to the selection.
- Put caret on the first line.
- Press Arrow down. → The caret goes to the end of the last line instead of the next one.

opw-4438171

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
