### PR TITLE
[FIX] stock: correct supplier info in an inter-wh transfer

### DIFF
--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -5,6 +5,8 @@ from freezegun import freeze_time
 from odoo.addons.stock.tests.common import TestStockCommon
 
 from odoo import fields
+from odoo.fields import Command
+from odoo.tests import Form
 
 
 class TestReplenishWizard(TestStockCommon):
@@ -503,3 +505,31 @@ class TestReplenishWizard(TestStockCommon):
             'product_uom_id': self.uom_unit.id,
         })
         self.assertTrue(replenish_wizard._get_route_domain(self.product1.product_tmpl_id))
+
+    def test_inter_wh_replenish(self):
+        """ Test that the replenish order has the correct supplier in a replenish between
+        warehouses of the same company.
+        """
+        main_warehouse = self.wh
+        second_warehouse = self.env['stock.warehouse'].create({
+            'name': 'Second Warehouse',
+            'code': 'WH02',
+        })
+        main_warehouse.write({
+            'resupply_wh_ids': [Command.set(second_warehouse.ids)]
+        })
+        interwh_route = self.env['stock.route'].search([('supplied_wh_id', '=', main_warehouse.id), ('supplier_wh_id', '=', second_warehouse.id)])
+
+        self.product1.route_ids = [Command.link(interwh_route.id)]
+
+        wizard_form = Form(self.env['product.replenish'].with_context(default_product_tmpl_id=self.product1.product_tmpl_id.id))
+        wizard_form.route_id = interwh_route
+        wizard = wizard_form.save()
+        generated_picking = wizard.launch_replenishment()
+        links = generated_picking.get("params", {}).get("links")
+        url = links and links[0].get("url", "") or ""
+        stock_picking_id, model_name = self.url_extract_rec_id_and_model(url)
+
+        stock_picking_id = self.env[model_name[0]].browse(int(stock_picking_id[0]))
+
+        self.assertEqual(stock_picking_id.partner_id, second_warehouse.partner_id)

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -23,12 +23,18 @@ class ProductReplenish(models.TransientModel):
                     *self.env['stock.warehouse']._check_company_domain(company),
                 ], limit=1).id
             orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', 'in', [product_tmpl_id.product_variant_id.id, product_id.id]), ("warehouse_id", "=", res['warehouse_id'])], limit=1)
-            res['supplier_id'] = False
-            if orderpoint:
+            if orderpoint.route_id:
+                res['route_id'] = orderpoint.route_id.id
+            if orderpoint.supplier_id:
                 res['supplier_id'] = orderpoint.supplier_id.id
-            elif product_tmpl_id.seller_ids:
-                res['supplier_id'] = product_tmpl_id.seller_ids[0].id
         return res
+
+    @api.onchange('route_id')
+    def _onchange_supplier_id(self):
+        if self.show_vendor and not self.supplier_id and self.product_tmpl_id.seller_ids:
+            self.supplier_id = self.product_tmpl_id.seller_ids[0].id
+        elif not self.show_vendor:
+            self.supplier_id = False
 
     @api.depends('route_id', 'supplier_id')
     def _compute_date_planned(self):


### PR DESCRIPTION
When creating an inter-wh transfer, the replenish order was showing the product's supplier in the Received From (partner_id) field and not the correct wh.

Steps to reproduce:
-------------------
* In Inventory, activate Multi-step Routes
* Create a new WH that can be Resupplied From another WH
* On a product, in the Inventory tab, activate the Route 'ABC: Supply Product from XYZ'
* On the forecast of that product, click on Replenish
* Match fields: Warehouse = ABC, Preferred Route = 'ABC: Supply Product from XYZ'
* Confirm
* Open the generated order

> Observation:
> The field Receive From contains the supplier of the product instead of the supplying WH.

Why the fix:
------------
The supplier_id was automatically set with the product's supplier_id. It's not correct for every routes. It's now updated accordingly to the route used and if we need the vendor.

opw-4717654


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
