### PR TITLE
[IMP] base: add server actions code history

### DIFF
--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -105,6 +105,7 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_ir_actions_act_window_view_group_system","ir_actions_act_window_view_group_system","model_ir_actions_act_window_view","group_system",1,1,1,1
 "access_ir_actions_act_url_group_system","ir_actions_act_url_group_system","model_ir_actions_act_url","group_system",1,1,1,1
 "access_ir_actions_server_group_system","ir_actions_server_group_system","model_ir_actions_server","group_system",1,1,1,1
+"access_ir_actions_server_history_group_system","ir_actions_server_history_group_system","model_ir_actions_server_history","group_system",1,1,1,0
 "access_ir_embedded_actions_group_user","ir_embedded_actions_group_user","model_ir_embedded_actions","group_user",1,1,1,1
 "access_ir_actions_client","ir_actions_client all","model_ir_actions_client","group_system",1,1,1,1
 "access_res_bank_group_system","res_bank_group_system","model_res_bank","group_system",1,1,1,1
@@ -122,6 +123,7 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_report_layout","access_report_layout","model_report_layout","group_user",1,1,1,1
 "access_wizard_ir_model_menu_create","access.wizard.ir.model.menu.create","model_wizard_ir_model_menu_create","base.group_system",1,1,1,0
 "access_reset_view_arch_wizard","access.reset.view.arch.wizard","model_reset_view_arch_wizard","base.group_erp_manager",1,1,1,0
+"access_server_action_history_wizard","access.server.action.history.wizard","model_server_action_history_wizard","group_system",1,1,1,0
 "access_ir_demo","access.ir.demo","model_ir_demo","base.group_system",1,1,1,0
 "access_ir_demo_failure","access.ir.demo_failure","model_ir_demo_failure","base.group_system",1,1,1,0
 "access_ir_demo_failure_wizard","access.ir.demo_failure.wizard","model_ir_demo_failure_wizard","base.group_system",1,1,1,0

--- a/odoo/addons/base/views/ir_actions_views.xml
+++ b/odoo/addons/base/views/ir_actions_views.xml
@@ -307,6 +307,28 @@
 
         <!-- ir.actions.server -->
 
+        <record id="server_action_history_wizard_view" model="ir.ui.view">
+            <field name="name">Server Action History Wizard</field>
+            <field name="model">server.action.history.wizard</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group>
+                        <group>
+                            <field name="revision" required="1" widget="selection"/>
+                        </group>
+                    </group>
+                    <field name="code_diff" invisible="not code_diff"/>
+                    <div class="alert alert-warning my-2" role="alert" invisible="code_diff">
+                        <span>No diff available</span>
+                    </div>
+                    <footer>
+                        <button string="Restore Revision" name="restore_revision" type="object" class="btn-primary" invisible="not code_diff" data-hotkey="q"/>
+                        <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x" />
+                    </footer>
+                </form>
+            </field>
+        </record>
+
         <record id="view_server_action_form" model="ir.ui.view">
             <field name="name">Server Action</field>
             <field name="model">ir.actions.server</field>
@@ -324,6 +346,9 @@
                                 class="btn-primary"
                                 invisible="model_name != 'ir.actions.server' or state != 'code'"
                                 help="Run this action manually."/>
+                        <button name="history_wizard_action" string="Code History" type="object"
+                                invisible="not show_code_history"
+                                help="View code history and restore a previous version"/>
                     </header>
                     <sheet>
                         <div class="oe_button_box" name="button_box">
@@ -464,6 +489,12 @@
                                         <li>To return an action, assign: <code>action = {...}</code></li>
                                         <li>To notify progress for CRON call and re-trigger a call if there is remaining tasks, use <code>env['ir.cron']._notify_progress(done=task_done_count, remaining=task_remaining_count)</code></li>
                                     </ul>
+                                    <p>
+                                        <widget name="documentation_link"
+                                                path="/developer/reference/backend/orm.html"
+                                                label="ORM API Documentation"
+                                                icon="oi oi-fw oi-arrow-right me-1"/>
+                                    </p>
                                     <div >
                                         <p>Example of Python code:</p>
                                         <pre style='white-space: pre-wrap'>partner_name = record.name + '_code'

--- a/odoo/addons/base/views/ir_cron_views.xml
+++ b/odoo/addons/base/views/ir_cron_views.xml
@@ -14,6 +14,7 @@
                 </xpath>
                 <xpath expr="//button[@name='run']" position="replace">
                 </xpath>
+                <xpath expr="//button[@name='history_wizard_action']" position="replace"/>
                 <xpath expr="//notebook" position="before">
                     <group>
                         <group>

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1731,6 +1731,7 @@ def get_diff(data_from, data_to, custom_style=False, dark_color_scheme=False):
                 table.diff { width: 100%%; }
                 table.diff th.diff_header { width: 50%%; }
                 table.diff td.diff_header { white-space: nowrap; }
+                table.diff td.diff_header + td { width: 50%%; }
                 table.diff td { word-break: break-all; vertical-align: top; }
                 table.diff .diff_chg, table.diff .diff_sub, table.diff .diff_add {
                     display: inline-block;


### PR DESCRIPTION
This commit adds a wizard to view the code history of a server action,
allowing to revert to an older version of the action's code.

Also, this commit:
- removes the default python code for server actions, as it duplicates
  the Help tab information and is not useful.
- adds a link to the ORM API documentation in the Help tab.

Task id: opw-4392608