### PR TITLE
[FIX] mail: fix email_to in log

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -593,8 +593,8 @@ class MailMail(models.Model):
                         mail.message_id,
                         tools.email_normalize(msg['from']),  # FROM should not change, so last msg good enough
                         ', '.join(
-                            repr(tools.mail.email_anonymize(tools.email_normalize(m['email_to'])))
-                            for m in email_list
+                            repr(tools.mail.email_anonymize(tools.email_normalize(e)))
+                            for m in email_list for e in m['email_to']
                         ),
                     )
                     _logger.info("Total emails tried by SMTP: %s", len(email_list))


### PR DESCRIPTION
The `email_to` value is an list. When normalizing the emails the value is [wrapped in a list](https://github.com/odoo/odoo/blob/13e9833e0bc809a26843890363586f61a37d061c/odoo/tools/mail.py#L618) and passed to `getaddresses`. If the user is running python3.7 this will cause an [error](https://upgradeci.odoo.com/upgradeci/run/204121).




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
