### PR TITLE
[FIX] html_editor: issues with icon

### DIFF
--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -118,8 +118,6 @@ export class IconPlugin extends Plugin {
         ],
         /** Handlers */
         selectionchange_handlers: this.normalizeIconSelection.bind(this),
-        /** Overrides */
-        color_apply_overrides: this.applyIconColor.bind(this),
     };
 
     /**
@@ -207,14 +205,5 @@ export class IconPlugin extends Plugin {
             return;
         }
         return selectedIcon.classList.contains("fa-spin");
-    }
-
-    applyIconColor(color, mode) {
-        const selectedIcon = this.getTargetedIcon();
-        if (!selectedIcon) {
-            return;
-        }
-        this.dependencies.color.colorElement(selectedIcon, color, mode);
-        return true;
     }
 }

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -158,6 +158,7 @@ export class IconPlugin extends Plugin {
             return;
         }
         selectedIcon.classList.toggle("fa-spin");
+        this.dependencies.history.addStep();
     }
 
     hasIconSize(size) {

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -2,6 +2,8 @@ import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 import { ColorSelector } from "../font/color_selector";
+import { isZWS } from "@html_editor/utils/dom_info";
+import { nodeSize } from "@html_editor/utils/position";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -43,14 +45,7 @@ export class IconPlugin extends Plugin {
         toolbar_namespaces: [
             {
                 id: "icon",
-                isApplied: (targetedNodes) =>
-                    targetedNodes.every(
-                        (node) =>
-                            // All nodes should be icons, its ZWS child or its ancestors
-                            node.classList?.contains("fa") ||
-                            node.parentElement.classList.contains("fa") ||
-                            (node.querySelector?.(".fa") && node.isContentEditable !== false)
-                    ),
+                isApplied: this.isSelectingOnlyIcons.bind(this),
             },
         ],
         toolbar_groups: [
@@ -121,6 +116,9 @@ export class IconPlugin extends Plugin {
                 isActive: () => this.hasSpinIcon(),
             },
         ],
+        /** Handlers */
+        selectionchange_handlers: this.normalizeIconSelection.bind(this),
+        /** Overrides */
         color_apply_overrides: this.applyIconColor.bind(this),
     };
 
@@ -134,6 +132,35 @@ export class IconPlugin extends Plugin {
     getTargetedIcon() {
         const targetedNodes = this.dependencies.selection.getTargetedNodes();
         return targetedNodes.find((node) => node.classList?.contains?.("fa"));
+    }
+
+    isSelectingOnlyIcons(targetedNodes = this.dependencies.selection.getTargetedNodes()) {
+        return (
+            targetedNodes.length &&
+            targetedNodes.every(
+                (node) =>
+                    // All nodes should be icons, its ZWS child or its ancestors
+                    node.classList?.contains("fa") ||
+                    node.parentElement.classList.contains("fa") ||
+                    (node.querySelector?.(".fa") && node.isContentEditable !== false)
+            )
+        );
+    }
+
+    normalizeIconSelection() {
+        const { anchorNode, focusNode } = this.document.getSelection();
+        if (this.isSelectingOnlyIcons() && (isZWS(anchorNode) || isZWS(focusNode))) {
+            const selectedIcon = this.getSelectedIcon();
+            this.dependencies.selection.setSelection(
+                {
+                    anchorNode: selectedIcon,
+                    anchorOffset: 0,
+                    focusNode: selectedIcon,
+                    focusOffset: nodeSize(selectedIcon),
+                },
+                { normalize: false }
+            );
+        }
     }
 
     resizeIcon({ size }) {

--- a/addons/html_editor/static/tests/color.test.js
+++ b/addons/html_editor/static/tests/color.test.js
@@ -558,3 +558,38 @@ test("should not split unsplittable element when applying color", async () => {
             '<div style="color: rgb(255, 0, 0);"><p>t<font style="color: rgb(0, 0, 255);">[es]</font>t</p></div>',
     });
 });
+
+test("should be able to apply color on icon along with text", async () => {
+    await testEditor({
+        contentBefore:
+            '<p>a[bc\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeffde]f</p>',
+        stepFunction: setColor("rgb(255, 0, 0)", "color"),
+        contentAfterEdit:
+            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
+        contentAfter:
+            '<p>a<font style="color: rgb(255, 0, 0);">[bc</font><font style="color: rgb(255, 0, 0);"><span class="fa fa-glass"></span></font><font style="color: rgb(255, 0, 0);">de]</font>f</p>',
+    });
+});
+
+test("should be able to change color of an icon", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</font></p>',
+        stepFunction: setColor("rgb(255, 255, 0)", "color"),
+        contentAfterEdit:
+            '<p><font style="color: rgb(255, 255, 0);">\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</font></p>',
+        contentAfter:
+            '<p><font style="color: rgb(255, 255, 0);">[<span class="fa fa-glass"></span>]</font></p>',
+    });
+});
+
+test("should be able to remove color of an icon", async () => {
+    await testEditor({
+        contentBefore:
+            '<p><font style="color: rgb(255, 0, 0);">\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</font></p>',
+        stepFunction: setColor("", "color"),
+        contentAfterEdit:
+            '<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>',
+        contentAfter: '<p>[<span class="fa fa-glass"></span>]</p>',
+    });
+});

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -85,6 +85,25 @@ test("should add opacity to custom background colors but not to theme colors", a
     expect(backgroundColor).toBe("rgb(113, 75, 103)");
 });
 
+test("default opacity should get applied when applying background color to icon", async () => {
+    const { el } = await setupEditor('<p>[ab<span class="fa fa-glass"></span>cd]</p>');
+
+    await waitFor(".o-we-toolbar");
+    expect(".o_font_color_selector").toHaveCount(0);
+
+    await click(".o-select-color-background");
+    await animationFrame();
+    expect(".o_font_color_selector").toHaveCount(1);
+
+    await click(".o_color_button[data-color='#FF0000']");
+    await animationFrame();
+    await expectElementCount(".o-we-toolbar", 1);
+    expect(".o_font_color_selector").toHaveCount(0); // selector closed
+    expect(getContent(el)).toBe(
+        `<p><font style="background-color: rgba(255, 0, 0, 0.6);">[ab</font><font style="background-color: rgba(255, 0, 0, 0.6);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font><font style="background-color: rgba(255, 0, 0, 0.6);">cd]</font></p>`
+    );
+});
+
 test("can render and apply color theme", async () => {
     await setupEditor("<p>[test]</p>");
 
@@ -610,12 +629,12 @@ describe("color preview", () => {
             <table class="table table-bordered o_table o_selected_table">
                 <tbody>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
+                        <td class="" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
                             <p>[<br></p>
                         </td>
                     </tr>
                     <tr>
-                        <td class="" style="background-color: rgb(206, 0, 0); ${defaultTextColor}">
+                        <td class="" style="background-color: rgba(206, 0, 0, 0.6); ${defaultTextColor}">
                             <p>]<br></p>
                         </td>
                     </tr>

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, waitFor } from "@odoo/hoot-dom";
+import { click, tick, waitFor } from "@odoo/hoot-dom";
 import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
@@ -236,4 +236,19 @@ test("Should be able to undo after adding spin effect to an icon", async () => {
     expect(".btn-group[name='icon_spin']").not.toHaveClass("active");
     expect("span.fa-glass").toHaveCount(1);
     expect("span.fa-glass.fa-spin").toHaveCount(0);
+});
+
+test("Icon should be fully selected if the selection covers the ZWS inside the span", async () => {
+    const { el } = await setupEditor('<p><span class="fa fa-glass"></span></p>');
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    setContent(
+        el,
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">[]\u200b</span>\ufeff</p>`
+    );
+    await tick();
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
 });

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -166,7 +166,7 @@ test("Can spin an icon", async () => {
 });
 
 test("Can set icon color", async () => {
-    await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
+    const { el } = await setupEditor(`<p><span class="fa fa-glass">[]</span></p>`);
     await waitFor(".o-we-toolbar");
     expect(".o_font_color_selector").toHaveCount(0);
     await click(".o-select-color-foreground");
@@ -176,7 +176,9 @@ test("Can set icon color", async () => {
     await animationFrame();
     await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
-    expect("span.fa-glass").toHaveStyle({ color: "rgb(107, 173, 222)" });
+    expect(getContent(el)).toBe(
+        `<p>[<font style="color: rgb(107, 173, 222);">\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</font>]</p>`
+    );
 });
 
 test("Can undo to 1x size after applying 2x size", async () => {

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -204,3 +204,36 @@ test("Can undo to 1x size after applying 2x size", async () => {
     expect("span.fa-glass").toHaveCount(1);
     expect("span.fa-glass.fa-2x").toHaveCount(0);
 });
+
+test("Should be able to undo after adding spin effect to an icon", async () => {
+    const { el, editor } = await setupEditor('<p><span class="fa fa-glass"></span></p>');
+    expect(getContent(el)).toBe(
+        `<p>\ufeff<span class="fa fa-glass" contenteditable="false">\u200b</span>\ufeff</p>`
+    );
+    // Selection normalization include U+FEFF, moving the cursor outside the
+    // icon and triggering the normal toolbar. To prevent this, we exclude
+    // U+FEFF from selection.
+    setSelection({
+        anchorNode: el.firstChild,
+        anchorOffset: 1,
+        focusNode: el.firstChild,
+        focusOffset: 2,
+    });
+    editor.shared.history.stageSelection();
+    expect(getContent(el)).toBe(
+        `<p>\ufeff[<span class="fa fa-glass" contenteditable="false">\u200b</span>]\ufeff</p>`
+    );
+    await waitFor(".o-we-toolbar");
+    expect(".btn-group[name='icon_spin']").toHaveCount(1);
+    expect(".btn-group[name='icon_spin']").not.toHaveClass("active");
+    await click("button[name='icon_spin']");
+    await animationFrame();
+    expect("span.fa-glass.fa-spin").toHaveCount(1);
+    expect(".btn-group[name='icon_spin'] button").toHaveClass("active");
+    undo(editor);
+    await animationFrame();
+    expect("span.fa-glass.fa-spin").toHaveCount(0);
+    expect(".btn-group[name='icon_spin']").not.toHaveClass("active");
+    expect("span.fa-glass").toHaveCount(1);
+    expect("span.fa-glass.fa-spin").toHaveCount(0);
+});

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -45,7 +45,7 @@ test("can color cells", async () => {
     await tick();
 
     const cells = queryAll("td");
-    expect(cells[0]).toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
-    expect(cells[1]).toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
-    expect(cells[2]).not.toHaveStyle({ "background-color": "rgb(107, 173, 222)" });
+    expect(cells[0]).toHaveStyle({ "background-color": "rgba(107, 173, 222, 0.6)" });
+    expect(cells[1]).toHaveStyle({ "background-color": "rgba(107, 173, 222, 0.6)" });
+    expect(cells[2]).not.toHaveStyle({ "background-color": "rgba(107, 173, 222, 0.6)" });
 });


### PR DESCRIPTION
**Current behavior before PR:**

- Applying a spin effect to an icon doesn't not create a history step, which causes the undo functionality to fail.
- The spin icon in the toolbar was not highlighted after applying the effect.
- When some text is selected along with icon, trying to apply color only affects the icon, the text remains uncolored.


**Desired behavior after PR:**

Now,
- History step is created after adding spin effect to an icon, allowing undo to work properly.
- The spin icon in the toolbar is properly highlighted to reflect the applied effect.
- This PR removes `color_apply_overrides` from icon_plugin to let color_plugin handle coloring the icons ensuring that the selected text is also colored along with icon.
- This PR also makes sure that default 60% opacity is applied when applying solid background color on icons or table cells.

task-4794673

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
