### PR TITLE
[FIX] l10n_it_edi: use date instead of invoice_date on self invoices

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -132,7 +132,7 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento t-out="document_type"/>
                 <Divisa t-out="currency.name"/>
-                <Data t-out="format_date(record.invoice_date)"/>
+                <Data t-out="format_date(record.date if is_self_invoice else record.invoice_date)"/>
                 <Numero t-out="format_alphanumeric(record.name, -20)"/>
                 <DatiBollo t-if="record.l10n_it_stamp_duty">
                     <BolloVirtuale t-translation="off">SI</BolloVirtuale>
@@ -155,18 +155,18 @@
             <t t-if="reconciled_moves">
                 <DatiFattureCollegate t-foreach="reconciled_moves" t-as="reconciled_move">
                     <IdDocumento t-out="format_alphanumeric(reconciled_move.name, -20)"/>
-                    <Data t-out="format_date(reconciled_move.invoice_date)"/>
+                    <Data t-out="format_date(reconciled_move.date if reconciled_move.l10n_it_edi_is_self_invoice else reconciled_move.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <t t-elif="record.reversed_entry_id">
                 <DatiFattureCollegate>
                     <IdDocumento t-out="format_alphanumeric(record.reversed_entry_id.name, -20)"/>
-                    <Data t-out="format_date(record.reversed_entry_id.invoice_date)"/>
+                    <Data t-out="format_date(record.reversed_entry_id.date if record.reversed_entry_id.l10n_it_edi_is_self_invoice else record.reversed_entry_id.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">
                 <IdDocumento t-out="format_alphanumeric(downpayment_move.name, -20)"/>
-                <Data t-out="format_date(downpayment_move.invoice_date)"/>
+                <Data t-out="format_date(downpayment_move.date if downpayment_move.l10n_it_edi_is_self_invoice else downpayment_move.invoice_date)"/>
             </DatiFattureCollegate>
             <DatiDDT t-if="record.l10n_it_ddt_id">
                 <NumeroDDT t-out="format_alphanumeric(record.l10n_it_ddt_id.name, -20)"/>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
@@ -9,7 +9,7 @@
                 <IdPaese>IT</IdPaese>
                 <IdCodice>01234560157</IdCodice>
             </IdTrasmittente>
-            <ProgressivoInvio>2022030001</ProgressivoInvio>
+            <ProgressivoInvio>2022040001</ProgressivoInvio>
             <FormatoTrasmissione>FPR12</FormatoTrasmissione>
             <CodiceDestinatario>0803HR0</CodiceDestinatario>
             <ContattiTrasmittente>
@@ -59,8 +59,8 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento>TD18</TipoDocumento>
                 <Divisa>EUR</Divisa>
-                <Data>2022-03-24</Data>
-                <Numero>BILL/2022/03/0001</Numero>
+                <Data>2022-04-01</Data>
+                <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>832.42</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
@@ -9,7 +9,7 @@
                 <IdPaese>IT</IdPaese>
                 <IdCodice>01234560157</IdCodice>
             </IdTrasmittente>
-            <ProgressivoInvio>2022030001</ProgressivoInvio>
+            <ProgressivoInvio>2022040001</ProgressivoInvio>
             <FormatoTrasmissione>FPR12</FormatoTrasmissione>
             <CodiceDestinatario>0803HR0</CodiceDestinatario>
             <ContattiTrasmittente>
@@ -59,8 +59,8 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento>TD19</TipoDocumento>
                 <Divisa>EUR</Divisa>
-                <Data>2022-03-24</Data>
-                <Numero>BILL/2022/03/0001</Numero>
+                <Data>2022-04-01</Data>
+                <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>1808.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_san_marino.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_san_marino.xml
@@ -9,7 +9,7 @@
                 <IdPaese>IT</IdPaese>
                 <IdCodice>01234560157</IdCodice>
             </IdTrasmittente>
-            <ProgressivoInvio>2022030001</ProgressivoInvio>
+            <ProgressivoInvio>2022040001</ProgressivoInvio>
             <FormatoTrasmissione>FPR12</FormatoTrasmissione>
             <CodiceDestinatario>0803HR0</CodiceDestinatario>
             <ContattiTrasmittente>
@@ -59,8 +59,8 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento>TD28</TipoDocumento>
                 <Divisa>EUR</Divisa>
-                <Data>2022-03-24</Data>
-                <Numero>BILL/2022/03/0001</Numero>
+                <Data>2022-04-01</Data>
+                <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>1808.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
@@ -9,7 +9,7 @@
                 <IdPaese>IT</IdPaese>
                 <IdCodice>01234560157</IdCodice>
             </IdTrasmittente>
-            <ProgressivoInvio>2022030001</ProgressivoInvio>
+            <ProgressivoInvio>2022040001</ProgressivoInvio>
             <FormatoTrasmissione>FPR12</FormatoTrasmissione>
             <CodiceDestinatario>0803HR0</CodiceDestinatario>
             <ContattiTrasmittente>
@@ -59,17 +59,17 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento>TD18</TipoDocumento>
                 <Divisa>EUR</Divisa>
-                <Data>2022-03-24</Data>
-                <Numero>RBILL/2022/03/0001</Numero>
+                <Data>2022-04-01</Data>
+                <Numero>RBILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>-1392.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
-                <IdDocumento>BILL/2022/03/0001</IdDocumento>
-                <Data>2022-03-24</Data>
+                <IdDocumento>BILL/2022/04/0001</IdDocumento>
+                <Data>2022-04-01</Data>
             </DatiFattureCollegate>
             <DatiFattureCollegate>
-                <IdDocumento>BILL/2022/03/0002</IdDocumento>
-                <Data>2022-03-24</Data>
+                <IdDocumento>BILL/2022/04/0002</IdDocumento>
+                <Data>2022-04-01</Data>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
+++ b/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
@@ -166,6 +166,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'move_type': 'in_invoice',
             'invoice_date': '2022-03-24',
             'invoice_date_due': '2022-03-24',
+            'date': '2022-04-01',
             'partner_id': self.french_partner.id,
             'partner_bank_id': self.test_bank.id,
             'invoice_line_ids': [
@@ -186,6 +187,7 @@ class TestItEdiReverseCharge(TestItEdi):
         credit_note = self.env['account.move'].with_company(self.company).create({
             'invoice_date': '2022-03-24',
             'invoice_date_due': '2022-03-24',
+            'date': '2022-04-01',
             'move_type': 'in_refund',
             'partner_id': self.french_partner.id,
             'invoice_line_ids': [
@@ -213,6 +215,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'move_type': 'in_invoice',
             'invoice_date': '2022-03-24',
             'invoice_date_due': '2022-03-24',
+            'date': '2022-04-01',
             'partner_id': self.french_partner.id,
             'partner_bank_id': self.test_bank.id,
             'invoice_line_ids': [
@@ -237,6 +240,7 @@ class TestItEdiReverseCharge(TestItEdi):
         bill = self.env['account.move'].with_company(self.company).create({
             'move_type': 'in_invoice',
             'invoice_date': '2022-03-24',
+            'date': '2022-04-01',
             'invoice_date_due': '2022-03-24',
             'partner_id': self.san_marino_partner.id,
             'partner_bank_id': self.test_bank.id,


### PR DESCRIPTION
When generating the self-invoice XML, the system incorrectly uses the invoice_date field, which reflects the supplier’s invoice date. However, for self-invoices in Italy, the date field (i.e., the accounting date) should be used instead.

According to Italian regulations, self-invoices must be issued within 15 days of the transaction, and the invoice date must fall within the month the invoice is received. Using the supplier’s invoice date (e.g., April 2025) when the invoice is actually received in May 2025 results in non-compliance.

References
Official: https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE-Esterometro-V_1.9_2024-03-05.pdf/67fe4c2d-1174-e8de-f1ee-cea77b7f5203 , page 14 
Extra: https://www.fiscoetasse.com/approfondimenti/16247-reverse-charge-interno-e-reverse-charge-esterno.html , entry 5

![image](https://github.com/user-attachments/assets/e593f463-a13a-460e-b125-9fbaaa674366)

