### PR TITLE
[IMP] hw_drivers: support restarting via websocket

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -486,6 +486,7 @@ def disconnect_from_server():
         'screen_orientation': '',
         'browser_url': '',
         'iot_handlers_etag': '',
+        'last_websocket_message_id': '',
     })
     odoo_restart()
 


### PR DESCRIPTION
Enterprise PR: https://github.com/odoo/enterprise/pull/85749

This commit adds a websocket message type `restart_odoo` to allow
restarting via the websocket. This will be used to restart the IoT
box automatically after installing the `pos_blackbox_be` module.

Note that alongside this change we also now keep track of the last
message ID we received on the websocket. This was necessary
because without it, Odoo would re-send the restart message to us
resulting in a reboot loop, until the message eventually times out.
By sending Odoo the correct last message ID, it won't resend
messages to us that we have already received.

task-4787427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
