### PR TITLE
[FIX] purchase_stock: prevent error when modifying received quantity on RFQ

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -51,7 +51,7 @@ class PurchaseOrderLine(models.Model):
     def _compute_qty_received(self):
         from_stock_lines = self.filtered(lambda order_line: order_line.qty_received_method == 'stock_moves')
         super(PurchaseOrderLine, self - from_stock_lines)._compute_qty_received()
-        for line in self:
+        for line in self._origin:
             if line.qty_received_method == 'stock_moves':
                 total = 0.0
                 # In case of a BOM in kit, the products delivered do not correspond to the products in


### PR DESCRIPTION
Currently, an error occurs if a user makes the **Received Quantity** field editable on an RFQ order line and modifies it directly.

**Steps to reproduce:**
- Install the `purchase_stock` and web_studio modules.
- Create a new **Request for Quotation (RFQ)** with at least one product, then **confirm** it.
- Using **Studio**, make the **Received** field editable in the products list view (disable the *readonly* property).
- Modify the **Received Quantity** of the product.

**Error:**
`KeyError: <NewId origin=9>`

**Cause:**
When the received quantity is modified, the `_track_qty_received` method tries to post a message on the PO. This calls `message_post_with_source`, which renders a QWeb view using `record.id` - [1].

However, for unsaved records, `record.id` is a temporary `NewId`, which cannot be used in the rendering context, resulting in a `KeyError`.

[1] - https://github.com/odoo/odoo/blob/84160b97ca28a8ac641a7a74f024292a6e758033/addons/mail/models/mail_thread.py#L2573-L2578

This commit ensures that the computation and message tracking are applied to the original saved record with a valid ID.

Sentry - 6597371221
