### PR TITLE
[FIX] web: list: recompute column widths when width changes

### DIFF
--- a/addons/web/static/src/core/utils/timing.js
+++ b/addons/web/static/src/core/utils/timing.js
@@ -180,16 +180,18 @@ export function throttleForAnimation(func) {
  * @param {string} [options.execBeforeUnmount=false] executes the callback if the debounced function
  *      has been called and not resolved before destroying the component.
  * @param {boolean} [options.immediate=false] whether the function should be called on
- *      the leading edge instead of the trailing edge.
+ *      the leading edge of the timeout.
+ * @param {boolean} [options.trailing=!options.immediate] whether the function should be called on
+ *      the trailing edge of the timeout.
  * @returns {T & { cancel: () => void }}
  */
 export function useDebounced(
     callback,
     delay,
-    { execBeforeUnmount = false, immediate = false } = {}
+    { execBeforeUnmount = false, immediate = false, trailing = !immediate } = {}
 ) {
     const component = useComponent();
-    const debounced = debounce(callback.bind(component), delay, immediate);
+    const debounced = debounce(callback.bind(component), delay, { leading: immediate, trailing });
     onWillUnmount(() => debounced.cancel(execBeforeUnmount));
     return debounced;
 }

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -676,7 +676,7 @@ test(`width computation: x2many, editable list, with invisible modifier on x2man
     expect(columnWidths[1]).toBeGreaterThan(500);
 });
 
-test.todo(`width computation: widths are re-computed on window resize`, async () => {
+test(`width computation: widths are re-computed on window resize`, async () => {
     Foo._records[0].text =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
         "Sed blandit, justo nec tincidunt feugiat, mi justo suscipit libero, sit amet tempus " +
@@ -686,21 +686,42 @@ test.todo(`width computation: widths are re-computed on window resize`, async ()
         resModel: "foo",
         type: "list",
         arch: `
-            <tree editable="bottom">
-                <field name="datetime"/>
+            <tree>
+                <field name="int_field"/>
                 <field name="text"/>
             </tree>
         `,
     });
-    const initialTextWidth = queryRect(`th[data-name="text"]`).width;
-    const selectorWidth = queryRect(`th.o_list_record_selector:eq(0)`).width;
 
-    resize({ width: queryRect(getFixture()).width / 2 });
-    await animationFrame();
-    const postResizeTextWidth = queryRect(`th[data-name="text"]`).width;
-    const postResizeSelectorWidth = queryRect(`th.o_list_record_selector:eq(0)`).width;
-    expect(postResizeTextWidth).toBeLessThan(initialTextWidth);
-    expect(selectorWidth).toBe(postResizeSelectorWidth);
+    expect(getColumnWidths()).toEqual([40, 80, 680]);
+
+    resize({ width: queryRect(getFixture()).width * 1.2 });
+    await runAllTimers();
+    expect(getColumnWidths()).toEqual([40, 80, 840]);
+});
+
+test(`width computation: widths are re-computed on parent resize`, async () => {
+    Foo._records[0].text =
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+        "Sed blandit, justo nec tincidunt feugiat, mi justo suscipit libero, sit amet tempus " +
+        "ipsum purus bibendum est.";
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <tree>
+                <field name="int_field"/>
+                <field name="text"/>
+            </tree>
+        `,
+    });
+
+    expect(getColumnWidths()).toEqual([40, 80, 680]);
+
+    queryOne(".o_list_renderer").style.width = "600px";
+    await runAllTimers();
+    expect(getColumnWidths()).toEqual([40, 80, 480]);
 });
 
 test(`width computation: button columns don't have a max width`, async () => {


### PR DESCRIPTION
The usecase occurs in x2many lists in form views. The total width of the table's parent div may change, for instance if a scrollbar appears on the sheet at some point. When this happens, the widths must be recomputed, to properly fit with the new available space. Before this commit, we only listened to window resize, not to the parent div itself.

This could lead to an horizontal scrollbar being sometimes displayed, for instance:
 - with the chatter below the form view, as it is loaded asynchronously, when it contains messages such that there's no (vertical) scrollbar before it is loaded, and there's one after.
 - with the document previewer, as its width changes when it is loaded.

This commit fixes the issue by using a resize observer to listen to the parent div directly, instead of on a window, which is more accurate.

Bug reported by our cto

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
