### PR TITLE
[FIX] point_of_sale: correctly generate preset slots

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -96,26 +96,22 @@ export class PosPreset extends Base {
         // Compute slots for next 7 days
         for (const i of [...Array(7).keys()]) {
             const dateNow = DateTime.now().plus({ days: i });
+            const getDateTime = (hour) =>
+                DateTime.fromObject({
+                    year: dateNow.year,
+                    month: dateNow.month,
+                    day: dateNow.day,
+                    hour: Math.floor(hour),
+                    minute: Math.round((hour % 1) * 60),
+                });
             const dayOfWeek = (dateNow.weekday - 1).toString();
             const date = DateTime.now().plus({ days: i }).toFormat("yyyy-MM-dd");
             const attToday = this.attendance_ids.filter((a) => a.dayofweek === dayOfWeek);
             slots[date] = [];
 
             for (const attendance of attToday) {
-                const dateOpening = DateTime.fromObject({
-                    year: dateNow.year,
-                    month: dateNow.month,
-                    day: dateNow.day,
-                    hour: Math.floor(attendance.hour_from),
-                    minute: (attendance.hour_from % 1) * 60,
-                });
-                const dateClosing = DateTime.fromObject({
-                    year: dateNow.year,
-                    month: dateNow.month,
-                    day: dateNow.day,
-                    hour: Math.floor(attendance.hour_to),
-                    minute: (attendance.hour_to % 1) * 60,
-                });
+                const dateOpening = getDateTime(attendance.hour_from);
+                const dateClosing = getDateTime(attendance.hour_to);
 
                 let start = dateOpening;
                 while (start >= dateOpening && start <= dateClosing && interval > 0) {


### PR DESCRIPTION
Before this commit, if the start or end minute was set to a non-integer value (e.g., 59), no slots would be available for selection, which prevented sales. This was due to floating-point precision issues when generating time slots.

opw-4793086

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
