### PR TITLE
[16.0][FIX] purchase_stock: count vendor returns in qty_received

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -360,7 +360,7 @@ class PurchaseOrderLine(models.Model):
                 for move in line._get_po_line_moves():
                     if move.state == 'done':
                         if move._is_purchase_return():
-                            if move.to_refund:
+                            if move.to_refund or line.product_qty < 0.0:
                                 total -= move.product_uom._compute_quantity(move.product_uom_qty, line.product_uom, rounding_method='HALF-UP')
                         elif move.origin_returned_move_id and move.origin_returned_move_id._is_dropshipped() and not move._is_dropshipped_returned():
                             # Edge case: the dropship is returned to the stock, no to the supplier.


### PR DESCRIPTION
When a purchase order uses a negative quantity to return goods, the subsequent delivery to the vendor was ignored in the PO line qty_received.

Before:
qty_received stayed at 0.0, so vendor credit notes with Control Policy = 'On received quantities' could not be processed.

After:
The outgoing move is now included, decreasing qty_received by the returned amount. This keeps PO accounting correct and lets the credit-note workflow complete.

@qrtl QT5390

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
