### PR TITLE
[FIX] mass_mailing: allow user to delete attachment after sending test email

### DIFF
--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -66,6 +66,7 @@ class TestMassMailing(models.TransientModel):
         with file_open("mass_mailing/static/src/scss/mass_mailing_mail.scss", "r") as fd:
             styles = fd.read()
         for valid_email in valid_emails:
+            attachments = mailing.attachment_ids.copy(default={'res_model': 'res.users', 'res_id': self.env.user.id})
             mail_values = {
                 'email_from': mailing.email_from,
                 'reply_to': mailing.reply_to,
@@ -77,7 +78,7 @@ class TestMassMailing(models.TransientModel):
                 }, minimal_qcontext=True),
                 'is_notification': True,
                 'mailing_id': mailing.id,
-                'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
+                'attachment_ids': [(4, attachment.id) for attachment in attachments],
                 'auto_delete': False,  # they are manually deleted after notifying the document
                 'mail_server_id': mailing.mail_server_id.id,
                 'model': 'res.users',

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -116,6 +116,41 @@ class TestMailingTest(TestMassMailCommon):
         self.assertIn('/unsubscribe_from_list', body_html)  # Isn't replaced
         self.assertIn('http://www.example.com/view', body_html)  # Isn't replaced
 
+    @users('user_marketing')
+    def test_mailing_test_correct_model(self):
+        """ Testing that an internal user without being an admin is able to delete attachments
+        after sending a test email. """
+        mailing = self.test_mailing_bl.with_env(self.env)
+        attachment = self.env['ir.attachment'].create({
+                'datas': 'IA==',  # a non-empty base64 content.
+                'name': 'attachment_test',
+                'res_name': 'test',
+            })
+        mailing['attachment_ids'] = [attachment.id]
+        attachment['access_token'] = attachment._generate_access_token()
+
+        self.authenticate(user='user_marketing', password='user_marketing')
+        mailing_test = self.env['mailing.mailing.test'].create({
+            'email_to': 'test@test.com',
+            'mass_mailing_id': mailing.id,
+        })
+
+        with self.mock_mail_gateway():
+            mailing_test.send_mail_test()
+
+        test_mail_attachment = self.env['mail.mail'].sudo().search([('mailing_id', '=', mailing.id)]).attachment_ids
+        self.assertNotEqual(attachment, test_mail_attachment)
+        self.assertEqual(test_mail_attachment.res_model, 'res.users')
+
+        self.make_jsonrpc_request(
+            route='/mail/attachment/delete',
+            params={
+                'attachment_id': attachment['id'],
+                'access_token': attachment['access_token'],
+            },
+        )
+        self.assertFalse(attachment.exists())
+
     def test_mailing_test_equals_reality(self):
         """ Check that both test and real emails will format the qweb and inline
         placeholders correctly in body and subject. """


### PR DESCRIPTION
### Description of the issue this PR addresses:
When a user lacking in Administration Access Rights tries to delete an attachment after sending out a test email, it throws a traceback. This is due to the ```_get_with_access``` function trying to call the ```_get_mail_message_access``` on the res.users model. This function isn't implemented for res.users. 

[This commit](https://github.com/odoo/odoo/commit/8a9981e78a438ceb53a4fdc0445ebed2170c6624) added the res.users as the model into the list of values being passed in when sending out a test email to allow links to be replaced inside the emails being sent out. The primary field to allow that to happen was the res_id field. Removing the model from the list of values still allows for the links to be replaced correctly. 

This commit would fix the traceback occurring due to the ```_get_with_access``` function trying to call an unimplemented function on the res.users model and allow the user to delete the attachment after sending out a test email.

opw-4621212

### Steps to reproduce issue on Runbot:
1. Create a new user in Settings -> Users. This can be a  duplicate of Mitchell Admin
2. Change the “Administration” rights to None (i.e choose blank in the dropdown)
3. Change password to something so we can log in on an incognito browser.
4. Open an incognito browser and login as the new user.
5. Go to Email Marketing and create a new mailing. Add a sample document in the attachment in the settings tab of this mailing. Save it.
6. Test this mailing and send the test email
7. Now click on the attachment logo next to the activities button and try to delete the attachment. The traceback appears.
8. If we try to delete the attachment before sending the test email, we are able to delete it without error.
9. If we select either “Access Rights” or “Settings” in the Administration rights for this user, we do not get the error.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
