### PR TITLE
[FIX] payment_custom: test dependencies on non dependencies

### DIFF
--- a/addons/payment_custom/tests/test_payment_transaction.py
+++ b/addons/payment_custom/tests/test_payment_transaction.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import unittest
 
 from odoo import Command, fields
 from odoo.tests import tagged
@@ -12,6 +13,9 @@ class TestPaymentTransaction(PaymentCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        if 'product.product' not in cls.env:
+            raise unittest.SkipTest("requires product")
 
         cls.provider = cls._prepare_provider(code='custom')
         cls.product = cls.env['product.product'].create({


### PR DESCRIPTION
Backport of 56d2d8b303e9c7909d29aa532cb0d717a7b57ed2

`payment` does not depend on `account`, it thus can't unconditionally use `account` groups. Skip tests if `account` is not installed (matches `account_custom` behaviour).

`account_custom` does not depend on `product`, so can't use `product.product` unconditionally.

runbot-163119