### PR TITLE
[PERF] project_timesheet_holidays: Speed up `_search_is_timeoff_task`

### DIFF
--- a/addons/project_timesheet_holidays/models/account_analytic.py
+++ b/addons/project_timesheet_holidays/models/account_analytic.py
@@ -13,6 +13,8 @@ class AccountAnalyticLine(models.Model):
     global_leave_id = fields.Many2one("resource.calendar.leaves", string="Global Time Off", index='btree_not_null', ondelete='cascade', export_string_translation=False)
     task_id = fields.Many2one(domain="[('allow_timesheets', '=', True), ('project_id', '=?', project_id), ('has_template_ancestor', '=', False), ('is_timeoff_task', '=', False)]")
 
+    _timeoff_timesheet_idx = models.Index('(task_id) WHERE (global_leave_id IS NOT NULL OR holiday_id IS NOT NULL) AND project_id IS NOT NULL')
+
     def _get_redirect_action(self):
         leave_form_view_id = self.env.ref('hr_holidays.hr_leave_view_form').id
         action_data = {

--- a/addons/project_timesheet_holidays/models/project_task.py
+++ b/addons/project_timesheet_holidays/models/project_task.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, _
+from odoo.osv.expression import TRUE_DOMAIN
+from odoo.tools import OrderedSet
 
 
 class ProjectTask(models.Model):
@@ -26,14 +28,32 @@ class ProjectTask(models.Model):
         (self - timeoff_tasks).is_timeoff_task = False
 
     def _search_is_timeoff_task(self, operator, value):
-        if operator not in ('in', 'not in'):
+        if operator not in ('in', 'not in') or not isinstance(value, (bool, tuple, list, OrderedSet)):
             return NotImplemented
-        timesheet_read_group = self.env['account.analytic.line']._read_group(
-            [('task_id', '!=', False), '|', ('holiday_id', '!=', False), ('global_leave_id', '!=', False)],
-            [],
-            ['task_id:recordset'],
-        )
-        [timeoff_tasks] = timesheet_read_group[0]
+
+        if not isinstance(value, bool):
+            # value is assumed to be an iterable of bools
+            if all(value):
+                value = True
+            elif all(not v for v in value):
+                value = False
+            else:
+                # Both True and False are being searched
+                # -> all tasks are valid
+                return TRUE_DOMAIN
+
+        timeoff_tasks_ids = {row[0] for row in self.env.execute_query(
+            self.env['account.analytic.line']._search(
+                [('task_id', '!=', False), '|', ('holiday_id', '!=', False), ('global_leave_id', '!=', False)],
+            ).select('DISTINCT task_id')
+        )}
+
         if self.env.company.leave_timesheet_task_id:
-            timeoff_tasks |= self.env.company.leave_timesheet_task_id
-        return [('id', operator, timeoff_tasks.ids)]
+            timeoff_tasks_ids.add(self.env.company.leave_timesheet_task_id.id)
+
+        op = 'in'
+        positive_search = (operator == 'in' and value is True) or (operator == 'not in' and value is False)
+        if not positive_search:
+            op = 'not in'
+
+        return [('id', op, tuple(timeoff_tasks_ids))]


### PR DESCRIPTION
Description
-----------
Fixed `_search_is_timeoff_task` to properly handle the `value` parameter which previously ignored its value and always searched for timeoff tasks.

Improved performance by:
- Replacing `_read_group` with `search + DISTINCT` to avoid unnecessary ordering.
- Adding a partial index on timeoff timesheets to optimize lookups without scanning holiday/leave indexes. The index stays small due to low timeoff vs regular timesheet ratio.

Benchmark
---------
On odoo.com, the `web_name_search` of tasks from the timesheet timer on a consulting project took:

| Before | After  | Speed up |
|--------|--------|----------|
| 1s     | ~120ms | 8x       |

Reference
---------
task-4801619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
