### PR TITLE
[IMP] account: rename audit trail search filters and group by

### DIFF
--- a/addons/account/views/mail_message_views.xml
+++ b/addons/account/views/mail_message_views.xml
@@ -44,14 +44,14 @@
                 ]"/>
                 <field string="Field" name="tracking_value_ids" filter_domain="[('tracking_value_ids.field_id', 'ilike', self)]"/>
                 <separator/>
-                <filter string="Update Only" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
-                <filter string="Create Only" name="create_only" domain="[('tracking_value_ids', '=', False)]" groups="base.group_system"/>
-                <filter string="Restricted Only" name="restricted_by_audit_trail" domain="[('account_audit_log_restricted', '=', True)]"/>
+                <filter string="Update" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
+                <filter string="Create" name="create_only" domain="[('tracking_value_ids', '=', False)]" groups="base.group_system"/>
+                <filter string="Restricted" name="restricted_by_audit_trail" domain="[('account_audit_log_restricted', '=', True)]"/>
                 <separator/>
                 <filter name="date" string="Date" date="date"/>
                 <group expand="0" string="Group By">
                     <filter string="Date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
-                    <filter string="Record" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
+                    <filter string="Updated Data" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
                 </group>
             </search>
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR renames filters and group by in search of audit trails.

task-4800729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
