### PR TITLE
[FIX] web_editor: fix underline/strike on gradient text

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -769,9 +769,19 @@ export const editorCommands = {
         if (isEmptyBlock(range.endContainer)) {
             selectionNodes.push(range.endContainer, ...descendants(range.endContainer));
         }
-        const selectedNodes = mode === "backgroundColor"
+        let selectedNodes = mode === "backgroundColor"
             ? selectionNodes.filter(node => !closestElement(node, 'table.o_selected_table'))
             : selectionNodes;
+        const findTopMostDecoration = (current) => {
+            const decoration = closestElement(current.parentNode, "s, u");
+            return decoration?.textContent === current.textContent
+                ? findTopMostDecoration(decoration)
+                : current;
+        };
+        selectedNodes = selectedNodes.map((node) => {
+            return findTopMostDecoration(node);
+        });
+
         const selectedFieldNodes = new Set(getSelectedNodes(editor.editable)
                 .map(n => closestElement(n, "*[t-field],*[t-out],*[t-esc]"))
                 .filter(Boolean));

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -293,6 +293,20 @@ describe('applyColor', () => {
             contentAfter: '<div style="background-image:none"><p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);">[ab<strong>cd</strong>ef]</font></p></div>'
         });
     });
+    it("should keep font element on top of underline/strike (1)", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><u>[abc]</u></p>',
+            stepFunction: setColor("linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)", "color"),
+            contentAfter: '<p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);"><u>[abc]</u></font></p>'
+        });
+    });
+    it("should keep font element on top of underline/strike (2)", async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><u><s>[abc]</s></u></p>',
+            stepFunction: setColor("linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%)", "color"),
+            contentAfter: '<p><font class="text-gradient" style="background-image: linear-gradient(135deg, rgb(255, 174, 127) 0%, rgb(109, 204, 0) 100%);"><u><s>[abc]</s></u></font></p>'
+        });
+    });
 });
 describe('rgbToHex', () => {
     it('should convert an rgb color to hexadecimal', async () => {

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -871,6 +871,27 @@ section, .oe_img_bg, [data-oe-shape-data] {
     .fa {
         display: inherit;
     }
+
+    %o-text-gradient-decoration {
+        background-size: 100% 0.1em;
+        background-repeat: repeat-x;
+        background-image: inherit !important;
+        text-decoration-color: transparent !important;
+        color: transparent;
+        caret-color: black;
+    }
+    * {
+        background-size: 0px;
+        background-image: inherit !important;
+    }
+    s:not(font[style*="-webkit-text-fill-color"] s) {
+        @extend %o-text-gradient-decoration;
+        background-position: 0 50%;
+    }
+    u:not(font[style*="-webkit-text-fill-color"] u) {
+        @extend %o-text-gradient-decoration;
+        background-position: 0 95%;
+    }
 }
 
 /* QWEB */


### PR DESCRIPTION
Problem:
Using `-webkit-text-fill-color: transparent;` in `.text-gradient`
is required for gradient text, but it also causes underline (`<u>`)
and strikethrough (`<s>`) styles to become invisible, since those
decorations rely on the text fill color.

This results in the lines under `u` and `s` elements not being
rendered when gradient text is applied.

Solution:
Render the underline and strikethrough manually using a
`background-image` (gradient) applied to `s` and `u` tags.
This simulates the missing lines while keeping the gradient
text style.

Steps to reproduce:
1. Add a text block in the website editor.
2. Apply a text color gradient.
3. Apply underline or strikethrough.
→ The underline/strikethrough is not visible.

opw-4797201

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
