### PR TITLE
[FIX] website_event_sale: ensure email in abandoned cart  test

### DIFF
--- a/addons/website_event_sale/tests/test_website_event_sale_cart.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_cart.py
@@ -23,6 +23,8 @@ class TestWebsiteEventSaleCart(TestWebsiteEventSaleCommon, TestWebsiteSaleCartAb
         })
 
         cls.partner_admin = cls.env.ref('base.partner_admin')
+        if not cls.partner_admin.email:
+            cls.partner_admin.email = 'base@partner.admin'
 
     def test_sold_out_event_cart_reminder(self):
         """Check that abandoned cart emails aren't sent for sold out tickets."""


### PR DESCRIPTION
Versions
--------
- saas-18.1
- saas-18.2

Steps
-----
1. Install `website_event_sale` without demo data;
2. run `test_sold_out_event_cart_reminder`.

Issue
-----
Test fails.

Cause
-----
The test uses `base.partner_admin` to test sending an email.
As of saas-18.1, this partner record no longer gets created with an email value when demo data is disabled. This causes the test to fail unexpectedly, as it cannot send an email without email address.

Solution
--------
Ensure the record has an `email` value.

runbot-223119
