### PR TITLE
[FIX] pos_loyalty: do not create cards for programs over max_usage

### DIFF
--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -105,7 +105,10 @@
                             <label for="limit_usage" invisible="program_type in ('gift_card', 'ewallet')"/>
                             <span invisible="program_type in ('gift_card', 'ewallet')">
                                 <field name="limit_usage" class="oe_inline"/>
-                                <span invisible="not limit_usage"> to <field name="max_usage" class="oe_inline"/> usages</span>
+                                <span invisible="not limit_usage">
+                                    to <field name="max_usage" class="oe_inline"/> usages
+                                    <span class="text-muted">(<field name="total_order_count" class="oe_inline" readonly="1"/> used)</span>
+                                </span>
                             </span>
                             <field name="company_id" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -25,7 +25,7 @@ class PosConfig(models.Model):
             '|', ('pos_config_ids', '=', self.id), ('pos_config_ids', '=', False),
             '|', ('date_from', '=', False), ('date_from', '<=', today),
             '|', ('date_to', '=', False), ('date_to', '>=', today)
-        ])
+        ]).filtered(lambda p: not p.limit_usage or p.sudo().total_order_count < p.max_usage)
 
     def _check_before_creating_new_session(self):
         self.ensure_one()

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -316,3 +316,34 @@ registry.category("web_tour.tours").add("test_not_create_loyalty_card_expired_pr
             PosLoyalty.finalizeOrder("Cash", "15.3"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("PosOrderClaimReward", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner"),
+            ProductScreen.addOrderline("Desk Organizer", "3"),
+            PosLoyalty.isPointsDisplayed(true),
+            PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
+            PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
+            PosLoyalty.finalizeOrder("Cash", "15.3"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PosOrderNoPoints", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Test Partner 2"),
+            ProductScreen.addOrderline("Desk Organizer", "3"),
+            PosLoyalty.isPointsDisplayed(false),
+            PosLoyalty.finalizeOrder("Cash", "15.3"),
+        ].flat(),
+});

--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyTourMethods.js
@@ -138,6 +138,15 @@ export function customerIs(name) {
         },
     ];
 }
+export function isPointsDisplayed(isDisplayed) {
+    return [
+        {
+            trigger: isDisplayed
+                ? '.loyalty-points-title'
+                : 'body:not(:has(.loyalty-points-title))',
+        },
+    ];
+}
 export function pointsAwardedAre(points_str) {
     return [
         {


### PR DESCRIPTION
Currently, loyalty cards with 0 points are being created for programs that have exceeded their max usage. Loyalty points are also erroneously being displayed for usage-exceeded programs when the tab is opened for the first time. And, it is not clear to the user when the max usage has been exceeded.

Steps to reproduce
-----
1. Create a loyalty program with a limited usage
2. Validate orders with the program up to the max usage
3. Refresh the tab and start another order with a new customer
4. Won points are still being displayed in the left pane
5. Validate the order, a loyalty card with 0 points is created

Cause
-----
Programs over the max usage are not being filtered out.

Fix
-----
Apply similar logic from https://github.com/odoo/odoo/pull/208134 and filter out programs over the max usage in `_get_program_ids()` Also, add the `total_order_count` to the form view next to `max_usage` so that it is clear that when the max usage is hit.
![image](https://github.com/user-attachments/assets/31055a3a-70ec-4547-85ed-662aac45014c)

opw-4744372