### PR TITLE
[IMP] pos_self_order: better message for inactive session

### DIFF
--- a/addons/pos_self_order/i18n/pos_self_order.pot
+++ b/addons/pos_self_order/i18n/pos_self_order.pot
@@ -662,7 +662,7 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/pos_self_order/static/src/app/components/timeout_popup/timeout_popup.xml:0
 msgid ""
-"It seems there hasn't been any activity on this kiosk. Would you like to "
+"Would you like to "
 "continue?"
 msgstr ""
 

--- a/addons/pos_self_order/static/src/app/components/timeout_popup/timeout_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/timeout_popup/timeout_popup.xml
@@ -11,7 +11,7 @@
                             </div>
                             <div class="mt-4 text-center">
                                 <h1>Session Inactive</h1>
-                                <span class="text-muted">It seems there hasn't been any activity on this kiosk. Would you like to continue?</span>
+                                <span class="text-muted">Would you like to continue?</span>
                                 <div class="display-1 my-3 pb-3 fw-bold text-center text-danger">
                                     <t t-esc="this.state.time"/>
                                 </div>


### PR DESCRIPTION
Before this commit:
----------------
-The inactive session message was unclear.
    
After this commit:
-------------------------
-The message is now clearer and more professional.
    
Task-4797948