### PR TITLE
[FIX] web: wait the main view reload before closing the dialog

### DIFF
--- a/addons/web/static/src/core/dialog/dialog_service.js
+++ b/addons/web/static/src/core/dialog/dialog_service.js
@@ -65,7 +65,8 @@ export const dialogService = {
                     subEnv,
                 },
                 {
-                    onRemove: (closeParams) => {
+                    onRemove: async (closeParams) => {
+                        await options.onClose?.(closeParams);
                         stack.splice(
                             stack.findIndex((d) => d.id === id),
                             1
@@ -76,7 +77,6 @@ export const dialogService = {
                         } else {
                             document.body.classList.remove("modal-open");
                         }
-                        options.onClose?.(closeParams);
                     },
                     rootId: options.context?.root?.el.getRootNode()?.host?.id,
                 }

--- a/addons/web/static/src/core/overlay/overlay_service.js
+++ b/addons/web/static/src/core/overlay/overlay_service.js
@@ -24,9 +24,9 @@ export const overlayService = {
             props: { overlays },
         });
 
-        const remove = (id, onRemove = () => {}, removeParams) => {
+        const remove = async (id, onRemove = () => {}, removeParams) => {
             if (id in overlays) {
-                onRemove(removeParams);
+                await onRemove(removeParams);
                 delete overlays[id];
             }
         };

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -658,7 +658,7 @@ export class FormController extends Component {
             this.props.onDiscard(this.model.root);
         }
         if (this.env.inDialog) {
-            this.env.dialogData.close();
+            await this.env.dialogData.close();
         } else if (this.model.root.isNew) {
             this.env.config.historyBack();
         }

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -818,7 +818,7 @@ test(`list view with adjacent buttons and optional field`, async () => {
     expect(`.o_data_row:eq(0) td.o_list_button`).toHaveCount(2);
 });
 
-test(`wait the view reload before closing the dialog`, async () => {
+test(`wait the view reload before closing the dialog (save)`, async () => {
     let searchReadDef;
     onRpc("web_search_read", () => searchReadDef);
     Foo._views = {
@@ -857,6 +857,47 @@ test(`wait the view reload before closing the dialog`, async () => {
     await animationFrame();
     expect(`.o_dialog`).toHaveCount(0);
     expect(`tbody .o_list_char:eq(0)`).toHaveText("plop");
+});
+
+test(`wait the view reload before closing the dialog (cancel)`, async () => {
+    let searchReadDef;
+    onRpc("web_search_read", () => searchReadDef);
+    Foo._views = {
+        form: `<form><field name="foo"/></form>`,
+    };
+    onRpc("/web/dataset/call_button/foo/a", () => ({
+        type: "ir.actions.act_window",
+        name: "Archive Action",
+        res_model: "foo",
+        res_id: 1,
+        view_mode: "form",
+        target: "new",
+        views: [[false, "form"]],
+    }));
+
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list editable="bottom">
+                <field name="foo"/>
+                <button name="a" type="object" icon="fa-car"/>
+            </list>
+        `,
+    });
+    searchReadDef = new Deferred();
+    await contains(`tbody .o_list_button button:eq(0)`).click();
+    expect(`.o_dialog`).toHaveCount(1);
+    await contains(`.o_form_renderer .o_field_widget[name='foo'] input`).edit("plop");
+    await contains(`.o_dialog .o_form_button_cancel`).click();
+
+    await animationFrame(); // not needed but to be sure that the dialog is not closed.
+    expect(`.o_dialog`).toHaveCount(1);
+    searchReadDef.resolve();
+
+    await animationFrame();
+    expect(`.o_dialog`).toHaveCount(0);
+    expect(`tbody .o_list_char:eq(0)`).toHaveText("yop");
 });
 
 test(`list view with adjacent buttons with invisible modifier`, async () => {


### PR DESCRIPTION
- On a slow connection;
- In a list view (or a form view), click on a button (a view button);
- Make some changes and click on the Discard button;
- Make some changes in the main view.

Because the connection is slow, the main view reloads after the user has made some changes. This causes some issues, for example : the changes may be lost, editable list views may become uneditable, forcing the user to click again.

This happens because on the action service, the callback function (`onClose`) is called after the dialog is closed. In the case of a view button, the callback function will reload the main view.

This commit, is related to [1], in which an almost identical issue was resolved. The difference is that in previous commit the user clicked on the `Save` button in the dialog; whereas in this commit, it is the `Discard` button that is causing the issues.

This commit changes that order, we will wait for the execution of the callback to complete before closing the dialog.

[1] : https://github.com/odoo/odoo/commit/31c00161fd3a77c9fbd260754cb8c142fcb0d652
