### PR TITLE
[IMP] account_python_tax: use ast to validate tax

### DIFF
--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -1,21 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import re
+import json
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 from odoo.tools.safe_eval import safe_eval
 
-
-REGEX_FORMULA_OBJECT = re.compile(r'((?:product\[\')(?P<field>\w+)(?:\'\]))+')
-
-FORMULA_ALLOWED_TOKENS = {
-    '(', ')',
-    '+', '-', '*', '/', ',', '<', '>', '<=', '>=',
-    'and', 'or', 'None',
-    'base', 'quantity', 'price_unit',
-    'min', 'max',
-}
+from odoo.addons.account_tax_python.tools.formula_utils import check_formula, normalize_formula
 
 
 class AccountTax(models.Model):
@@ -40,7 +31,7 @@ class AccountTax(models.Model):
     def _check_amount_type_code_formula(self):
         for tax in self:
             if tax.amount_type == 'code':
-                tax._check_formula()
+                self._check_and_normalize_formula(tax.formula)
 
     @api.model
     def _eval_taxes_computation_prepare_product_fields(self):
@@ -57,71 +48,33 @@ class AccountTax(models.Model):
                 tax.formula_decoded_info = None
                 continue
 
-            formula = (tax.formula or '0.0').strip()
-            formula_decoded_info = {
-                'js_formula': formula,
-                'py_formula': formula,
+            py_formula, accessed_fields = self._check_and_normalize_formula(tax.formula)
+
+            tax.formula_decoded_info = {
+                'js_formula': py_formula,
+                'py_formula': py_formula,
+                'product_fields': list(accessed_fields),
             }
-            product_fields = set()
 
-            groups = re.findall(r'((?:product\.)(?P<field>\w+))+', formula) or []
-            Product = self.env['product.product']
-            for group in groups:
-                field_name = group[1]
-                if field_name in Product and not Product._fields[field_name].relational:
-                    product_fields.add(field_name)
-                    formula_decoded_info['py_formula'] = formula_decoded_info['py_formula'].replace(f"product.{field_name}", f"product['{field_name}']")
-
-            formula_decoded_info['product_fields'] = list(product_fields)
-            tax.formula_decoded_info = formula_decoded_info
-
-    def _check_formula(self):
+    @api.model
+    def _check_and_normalize_formula(self, formula):
         """ Check the formula is passing the minimum check to ensure the compatibility between both evaluation
         in python & javascript.
         """
-        self.ensure_one()
 
-        def get_number_size(formula, i):
-            starting_i = i
-            seen_separator = False
-            while i < len(formula):
-                if formula[i].isnumeric():
-                    i += 1
-                elif formula[i] == '.' and (i - starting_i) > 0 and not seen_separator:
-                    i += 1
-                    seen_separator = True
-                else:
-                    break
-            return i - starting_i
+        def is_field_serializable(field_name):
+            assert isinstance(field_name, str), "Field name must be a string"
+            field = self.env['product.product']._fields.get(field_name)
+            return isinstance(field, fields.Field) and not field.relational
 
-        formula_decoded_info = self.formula_decoded_info
-        allowed_tokens = FORMULA_ALLOWED_TOKENS.union(f"product['{field_name}']" for field_name in formula_decoded_info['product_fields'])
-        formula = formula_decoded_info['py_formula']
+        transformed_formula, accessed_fields = normalize_formula(
+            self.env,
+            (formula or '0.0').strip(),
+            field_predicate=is_field_serializable,
+        )
+        check_formula(self.env, transformed_formula)
+        return transformed_formula, accessed_fields
 
-        i = 0
-        while i < len(formula):
-
-            if formula[i] == ' ':
-                i += 1
-                continue
-
-            continue_needed = False
-            for token in allowed_tokens:
-                if formula[i:i + len(token)] == token:
-                    i += len(token)
-                    continue_needed = True
-                    break
-            if continue_needed:
-                continue
-
-            number_size = get_number_size(formula, i)
-            if number_size > 0:
-                i += number_size
-                continue
-
-            raise ValidationError(_("Malformed formula '%(formula)s' at position %(position)s", formula=formula, position=i))
-
-    @api.model
     def _eval_tax_amount_formula(self, raw_base, evaluation_context):
         """ Evaluate the formula of the tax passed as parameter.
 
@@ -132,7 +85,7 @@ class AccountTax(models.Model):
         :param evaluation_context:  The context created by '_eval_taxes_computation_prepare_context'.
         :return:                    The tax base amount.
         """
-        self._check_formula()
+        normalized_formula, accessed_fields = self._check_and_normalize_formula(self.formula_decoded_info['py_formula'])
 
         # Safe eval.
         formula_context = {
@@ -140,11 +93,14 @@ class AccountTax(models.Model):
             'quantity': evaluation_context['quantity'],
             'product': evaluation_context['product'],
             'base': raw_base,
-            'min': min,
-            'max': max,
         }
+        assert accessed_fields <= formula_context['product'].keys(), "product fields used in formula must be present in the product dict"
         try:
-            return safe_eval(self.formula_decoded_info['py_formula'], formula_context)
+            formula_context = json.loads(json.dumps(formula_context))
+        except TypeError:
+            raise ValidationError(_("Only primitive types are allowed in python tax formula context."))
+        try:
+            return safe_eval(normalized_formula, formula_context)
         except ZeroDivisionError:
             return 0.0
 

--- a/addons/account_tax_python/tests/test_taxes_computation.py
+++ b/addons/account_tax_python/tests/test_taxes_computation.py
@@ -2,6 +2,8 @@ from odoo.addons.account_tax_python.tests.common import TestTaxCommonAccountTaxP
 from odoo.tests import tagged
 from odoo.exceptions import ValidationError
 
+from odoo.addons.account_tax_python.tools.formula_utils import check_formula, normalize_formula
+
 
 @tagged('post_install', '-at_install')
 class TestTaxesComputation(TestTaxCommonAccountTaxPython):
@@ -43,7 +45,7 @@ class TestTaxesComputation(TestTaxCommonAccountTaxPython):
             product_values={'volume': 100.0},
         )
         self.assert_python_taxes_computation(
-            "product.volume > 100 and 10 or 5",
+            'product["volume"] > 100 and 10 or 5',
             100.0,
             {
                 'total_included': 110.0,
@@ -55,7 +57,7 @@ class TestTaxesComputation(TestTaxCommonAccountTaxPython):
             product_values={'volume': 105.0},
         )
         self.assert_python_taxes_computation(
-            "product.volume > 100 and 10 or 5",
+            "product['volume'] > 100 and 10 or 5",
             100.0,
             {
                 'total_included': 105.0,
@@ -88,22 +90,139 @@ class TestTaxesComputation(TestTaxCommonAccountTaxPython):
             },
             product_values={'volume': 0.0},
         )
+        self.assert_python_taxes_computation(
+            "max(product.volume, 5.0) + 0.0 + -.0",
+            100.0,
+            {
+                'total_included': 105.0,
+                'total_excluded': 100.0,
+                'taxes_data': (
+                    (100.0, 5.0),
+                ),
+            },
+            product_values={'volume': 0.0},
+        )
+        self.assert_python_taxes_computation(
+            "(max(product.volume, 5.0) + base * 0.05) and None",
+            100.0,
+            {
+                "total_included": 100.0,
+                "total_excluded": 100.0,
+                "taxes_data": (),
+            },
+            product_values={"volume": 0.0},
+        )
+        self.assert_python_taxes_computation(
+            "min(max(price_unit, quantity), base) * 0.10 + (5 < product['volume'] < 10 and 1.0 or 0.0)",
+            20.0,
+            {
+                "total_excluded": 20.0,
+                "total_included": 23.0,
+                "taxes_data": (
+                    (20.0, 3.0),
+                ),
+            },
+            product_values={"volume": 7.0},
+        )
         self._run_js_tests()
 
     def test_invalid_formula(self):
-        # You have no access to relational field.
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='product.product_tmpl_id')
-        # You don't have access to any record.
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='product.sudo()')
-        # You are restricted to min max but that's it: no python collection.
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='tuple(1, 2, 3)')
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='set(1, 2, 3)')
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='[1, 2, 3]')
-        # No access to builtins that are not part of the whitelist.
-        with self.assertRaises(ValidationError):
-            self.python_tax(formula='range(1, 10)')
+        invalid_formulas = [
+            'product.product_tmpl_id',  # no relational fields
+            'product.sudo()',  # You don't have access to any record.
+            'tuple(1, 2, 3)',  # only min/max functions, no other callables
+            'set(1, 2, 3)',
+            '[1, 2, 3]',
+            '1,',
+            '{1, 2}',
+            '{1: 2}',
+            '(i for _ in product)',
+            '"test"',  # strings are only allowed in subscripts of product
+            'product[min("volume", "price")]',
+            'product()',
+            'product[0]',
+            'product[:10]',
+            'product["field_that_does_not_exist"]',
+            'product.field_that_does_not_exist',
+            'product.ids',
+            'product._fields',
+            'product._cr',
+            'range(1, 10)',
+        ]
+
+        for formula in invalid_formulas:
+            with self.subTest(formula=formula):
+                with self.assertRaises(ValidationError):
+                    self.python_tax(formula=formula)
+
+    def test_ast_transformer_normalizes(self):
+        # this test simply checks that the AST transformer does not raise any error when
+        # collecting attributes and rewriting the formula, and also to list a couple of edge cases.
+        # of course all these weird edge cases must be filtered out by the validator later on
+        valid_cases = [
+            (
+                "((10_000 / product.__dunders__) * (product['shall'] - product[\"n0t\"] + ((product._pass)))) -.01",
+                "10000 / product['__dunders__'] * (product['shall'] - product['n0t'] + product['_pass']) - 0.01",
+                {"__dunders__", "shall", "n0t", "_pass"}
+            ),
+            (
+                "-bob[eats(product . sandwich)] + +product. \\\nwith_fries_inside and product['IS_THE_WAY']",
+                "-bob[eats(product['sandwich'])] + +product['with_fries_inside'] and product['IS_THE_WAY']",
+                {"sandwich", "with_fries_inside", "IS_THE_WAY"}
+            ),
+            (
+                "(product.help_youself, product['with some']) if product[None] else product.tarte_al_djote['grault']",
+                "(product['help_youself'], product['with some']) if product[None] else product['tarte_al_djote']['grault']",
+                {"help_youself", "with some", "tarte_al_djote"}
+            ),
+        ]
+
+        for formula, expected_normalized, expected_fields in valid_cases:
+            with self.subTest(code=formula):
+                normalized_formula, accessed_fields = normalize_formula(self.env, formula)
+                self.assertEqual(accessed_fields, expected_fields)
+                self.assertEqual(normalized_formula, expected_normalized)
+
+    def test_ast_validator(self):
+        to_fail = [
+            # no attributes
+            # transformer pass before validation rewrote attrs to subscripts,
+            # so we don't allow attributes in validation step
+            "product.field",
+            "isinstance",
+            "product.env",
+            "(None for _ in ()).gi_frame.f_builtins['__import__']",
+
+            # only whitelisted nodes (no tuples, sets, dicts, lists, etc)
+            "1,",
+            "product,",
+            "min(1, 2),",
+            "()",
+            "{}",
+            "[]",
+            "{1: product}",
+            "{1, 2}",
+            "[product]",
+            "(None for _ in product)",
+
+            # only string subscripts of product are allowed
+            "product[None]",
+            "product[1]",
+            "product[:]",
+            "not_product['field']",
+
+            # no arbitrary function calls
+            "product['a_callable']()",
+            "product()",
+            "(min or max)(1, 2)",
+            "isinstance(1, ())",
+
+            # no arbitrary name load
+            "a",
+            "__builtins__",
+            "isinstance",
+        ]
+        for formula in to_fail:
+            with self.subTest(code=formula):
+                with self.assertRaises(ValidationError):
+                    check_formula(self.env, formula)

--- a/addons/account_tax_python/tools/formula_utils.py
+++ b/addons/account_tax_python/tools/formula_utils.py
@@ -1,0 +1,160 @@
+import ast
+
+from odoo.exceptions import ValidationError
+
+
+_ALLOWED_FUNCS = ('min', 'max')
+_ALLOWED_NAMES = ('price_unit', 'quantity', 'base', 'product')
+_ALLOWED_CONSTANT_T = (int, float, type(None))
+
+
+_NODE_WHITELIST = (
+    ast.Expression, ast.Name, ast.Call, ast.Subscript,  # expr
+    ast.Constant,                                       # constants
+    ast.BinOp, ast.Add, ast.Sub, ast.Mult, ast.Div,     # binops
+    ast.BoolOp, ast.And, ast.Or,                        # boolops
+    ast.Compare, ast.Lt, ast.LtE, ast.Gt, ast.GtE,      # comparisons
+    ast.UnaryOp, ast.UAdd, ast.USub                     # unary ops
+)
+
+
+class ProductFieldRewriter(ast.NodeTransformer):
+    """
+    - Rewrites  product.foo -> product['foo']
+    - Collects every field name accessed (through product.foo or product['foo'])
+    """
+
+    FIELD_NAME = "product"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.accessed_fields: set[str] = set()
+
+    def visit_Attribute(self, node: ast.Attribute):
+        node = self.generic_visit(node)
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id == self.FIELD_NAME
+        ):
+            # fail early if AST specs ever change
+            assert isinstance(node.attr, str), "Attribute name must be a string"
+
+            self.accessed_fields.add(node.attr)
+            return ast.Subscript(
+                value=node.value,
+                slice=ast.Constant(node.attr),
+                ctx=node.ctx,
+            )
+        return node
+
+    def visit_Subscript(self, node: ast.Subscript):
+        node = self.generic_visit(node)
+        if (
+            isinstance(node.value, ast.Name)
+            and node.value.id == self.FIELD_NAME
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+        ):
+            self.accessed_fields.add(node.slice.value)
+        return node
+
+
+class TaxFormulaValidator(ast.NodeVisitor):
+    """
+    Walks AST and rejects anything that is not needed or not reproducible in pyjs.
+
+    The ast must be transformed by ProductFieldRewriter before being passed to this validator as
+    this visitor does not whitelist Attribute nodes
+    """
+    def __init__(self, env):
+        self.env = env
+        super().__init__()
+
+    def visit(self, node):
+        if not isinstance(node, _NODE_WHITELIST):
+            raise ValidationError(self.env._("Invalid AST node: %s", type(node).__name__))
+        super().visit(node)
+
+    def visit_Constant(self, node: ast.Constant):
+        if not isinstance(node.value, _ALLOWED_CONSTANT_T):
+            raise ValidationError(self.env._("Only int, float or None are allowed as constant values"))
+
+    def visit_Name(self, node: ast.Name):
+        if node.id not in _ALLOWED_NAMES:
+            raise ValidationError(self.env._("Unknown identifier: %s", str(node.id)))
+        if not isinstance(node.ctx, ast.Load):
+            raise ValidationError(self.env._("Only read access to identifiers is allowed"))
+
+    def visit_Call(self, node: ast.Call):
+        if not (
+            isinstance(node.func, ast.Name)
+            and node.func.id in _ALLOWED_FUNCS
+            and isinstance(node.func.ctx, ast.Load)
+        ):
+            raise ValidationError(self.env._("Unknown function call"))
+        # don't visit node.func: it's already validated and min/max aren't allowed as normal Name identifiers
+        for arg in node.args:
+            self.visit(arg)
+        if node.keywords:
+            raise ValidationError(self.env._("Kwargs are not allowed"))
+
+    def visit_Subscript(self, node: ast.Subscript):
+        # Only allow string constants as subscripts (e.g., product["type"])
+        # They are not allowed elsewhere in the formula
+        if not (
+            isinstance(node.value, ast.Name)
+            and node.value.id == "product"
+            and isinstance(node.slice, ast.Constant)
+            and isinstance(node.slice.value, str)
+            and isinstance(node.ctx, ast.Load)
+        ):
+            raise ValidationError(self.env._("Only product['string'] read-access is allowed"))
+
+        self.visit(node.value)
+
+
+def check_formula(env, formula: str) -> str:
+    """
+    This helper function checks that the formula is compatible with pyjs
+    by checking that the AST only uses allowed nodes in the appropriate context
+    and raises a ValidationError if not.
+    """
+    assert isinstance(formula, str), "Formula must be a string"
+
+    try:
+        tree = ast.parse(formula, mode="eval")
+    except (SyntaxError, ValueError):
+        raise ValidationError(env._("Invalid formula"))
+
+    # `env` is needed to generate localized error messages.
+    # Odoo's `_()` translation looks for `env` in the caller's local scope and one frame above it,
+    # but AST traversal is recursive and hides the original context in a deep frame stack
+    TaxFormulaValidator(env).visit(tree)
+
+
+def normalize_formula(env, formula: str, field_predicate=None) -> tuple[str, set[str]]:
+    """
+    This helper function collects all field access and rewrites
+    all attribute accesses to product to subscript accesses
+
+    e.g.: product.field to product['field'] access & collect all accessed product fields.
+
+    :return (normalized formula, set of accessed product attributes & fields)
+    """
+    assert isinstance(formula, str), "Formula must be a string"
+
+    try:
+        tree = ast.parse(formula, mode="eval")
+    except (SyntaxError, ValueError):
+        raise ValidationError(env._("Invalid formula"))
+
+    transformer = ProductFieldRewriter()
+    transformed_tree = transformer.visit(tree)
+    ast.fix_missing_locations(transformed_tree)  # puts back lineno/col_offset for safe_eval's compile
+
+    if callable(field_predicate):
+        for field in transformer.accessed_fields:
+            if not field_predicate(field):
+                raise ValidationError(env._("Field '%s' is not accessible", field))
+
+    return ast.unparse(transformed_tree), transformer.accessed_fields


### PR DESCRIPTION
Up until now python tax formula was parsed using simple regex with custom token parsing. This method had its limits tho, such as you could with no issue generate ast nodes such as tuples, for example which would not work with the JS tax. This commit is a more permanent solution with actual AST parsing and validation with a whitelist-only approach.

In this commit we do a two-step pass on formulas with ast. 
- First one is the transfomer which simply collects all accessed fields (through subscripts and through attribute access) and rewrites all attributes to subscritps (because 2nd validaiton step does not allow attributes). 
- The second step valides the formula AST against a whitelist of nodes. If any node is not whitelisted explicitly, we will get a validation error. 

This allows us to be much more granular in what we allow or not.

todo:
- [x] test edge cases that we now handle
- [x] fix lazy translation not working (it only goes up to 1 frame `f_back` above current one for `f_locals` containing `env` or `cr`)
- [x] add an ast transformer & collector to stop using regex to replace attribute access by subscript access (e.g. `product.field` -> `product["field"]`

no-task
