### PR TITLE
[FIX] analytic: runbot build error analytic single app tests

### DIFF
--- a/addons/analytic/tests/test_analytic_account.py
+++ b/addons/analytic/tests/test_analytic_account.py
@@ -74,7 +74,7 @@ class TestAnalyticAccount(TransactionCase):
         """ Removes access rights linked to timesheet and project as these add
         record rules blocking analytic flows; account overrides it"""
         if 'account.account' not in cls.env:
-            core_group_ids = cls.env.ref("hr_timesheet.group_hr_timesheet_user", raise_if_not_found=False) or cls.env['ir.rule']
+            core_group_ids = cls.env.ref("hr_timesheet.group_hr_timesheet_user", raise_if_not_found=False) or cls.env['res.groups']
             problematic_group_ids = cls.env.user.groups_id.filtered(lambda g: (g | g.trans_implied_ids) & core_group_ids)
             if problematic_group_ids:
                 cls.env.user.groups_id -= problematic_group_ids


### PR DESCRIPTION
Run any test of the `TestAnalyticAccount` class in single app: analytic.
> Error in the single app setup.

### Cause of the issue:

Since neither `account.account` nor the `hr_timesheet` is installed, these lines will crash:https://github.com/odoo/odoo/blob/786cc72a58079dd87f536cedf5c8b9098ff2b885/addons/analytic/tests/test_analytic_account.py#L76-L78 because `core_group_ids` is cls.env['ir.rule'] and `cls.env.user.groups_id` is a `res.groups` record set.

runbot-223137 and 223138
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
