### PR TITLE
[IMP] product: Make name in 'product.category' translatable

### DIFF
--- a/addons/product/models/product_category.py
+++ b/addons/product/models/product_category.py
@@ -14,7 +14,7 @@ class ProductCategory(models.Model):
     _rec_name = 'complete_name'
     _order = 'complete_name'
 
-    name = fields.Char('Name', index='trigram', required=True)
+    name = fields.Char('Name', index='trigram', required=True, translate=True)
     complete_name = fields.Char(
         'Complete Name', compute='_compute_complete_name', recursive=True,
         store=True)


### PR DESCRIPTION
The 'name' field of 'product.category' must be translatable to support multilingual environments. Product categories are visible to users and customers across various parts of Odoo, including e-commerce, sales, inventory, and reports. Translating category names ensures a consistent user experience and proper localization for users operating in different languages.
