### PR TITLE
[FIX] base: modulo compare weekday in test

### DIFF
--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -221,7 +221,7 @@ class TestIrSequenceGenerate(BaseCase):
             isoyear, isoweek, weekday = datetime.now().isocalendar()
             self.assertEqual(
                 env['ir.sequence'].next_by_code('test_sequence_type_9'),
-                f"{isoyear}/{isoyear % 100}/1/{isoweek}/{weekday}",
+                f"{isoyear}/{isoyear % 100}/1/{isoweek}/{weekday % 7}",
             )
 
     @classmethod


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Run `test_ir_sequence_iso_directives` on a Sunday.

Issue
-----
Test fails on the weekday.

Cause
-----
The sequence considers Sunday to be day `0`, whereas the control, based on `datetime.isocalendar` considers Sunday to be day `7`.

Solution
--------
Compare on the weekday, modulo 7.

runbot-223209