### PR TITLE
[FIX] pos_restaurant: prevent duplicate preparation tickets on order btn

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1576,8 +1576,7 @@ export class PosStore extends WithLazyGetterTrap {
                 if (reprint && orderDone) {
                     return;
                 }
-
-                this.printChanges(order, orderChange, reprint);
+                await this.printChanges(order, orderChange, reprint);
             } catch (e) {
                 console.info("Failed in printing the changes in the order", e);
             }

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.js
@@ -1,6 +1,7 @@
 import { patch } from "@web/core/utils/patch";
 import { ActionpadWidget } from "@point_of_sale/app/screens/product_screen/action_pad/action_pad";
 import { TicketScreen } from "@point_of_sale/app/screens/ticket_screen/ticket_screen";
+import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 
 /**
  * @props partner
@@ -16,6 +17,7 @@ patch(ActionpadWidget, {
 patch(ActionpadWidget.prototype, {
     setup() {
         super.setup();
+        this.doSubmitOrder = useTrackedAsync(() => this.submitOrder());
     },
     get swapButton() {
         return (
@@ -31,8 +33,7 @@ patch(ActionpadWidget.prototype, {
         return hasChange;
     },
     async submitOrder() {
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.showDefault();
+        await this.pos.submitOrder();
     },
     hasQuantity(order) {
         if (!order) {

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/actionpad_widget/actionpad_widget.xml
@@ -15,8 +15,9 @@
             <div t-if="this.swapButton and currentOrder" class="d-flex gap-2 flex-fill">
                 <button
                     class="submit-order h-100 button btn btn-lg d-flex align-items-center w-50 flex-fill position-relative px-3 highlight btn-primary justify-content-between"
-                    t-on-click="() => this.submitOrder()"
+                    t-on-click="() => doSubmitOrder.call()"
                     t-if="!this.currentOrder.isDirectSale and this.displayCategoryCount.length"
+                    t-att-disabled="doSubmitOrder.status === 'loading'"
                 >
                     <t t-if="!(ui.isSmall or displayCategoryCount.length > 2) or (!displayCategoryCount.length and ui.isSmall)">Order</t>
                     <div t-attf-class="{{ !(displayCategoryCount.length > 2) ? 'd-flex flex-column align-items-end gap-1' : 'row row-cols-2 g-1 gx-2' }} {{ isCategoryCountOverflow ? 'mt-n3' : ''}}">
@@ -35,8 +36,9 @@
                 </button>
                 <button
                     class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
-                    t-on-click="() => this.submitOrder()"
-                    t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint">
+                    t-on-click="() => doSubmitOrder.call()"
+                    t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint"
+                    t-att-disabled="doSubmitOrder.status === 'loading'">
                     <i class="fa fa-cutlery" aria-hidden="true"></i>
                 </button>
                 <button

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.js
@@ -3,6 +3,7 @@ import { SWITCHSIGN, DECIMAL } from "@point_of_sale/app/components/numpad/numpad
 import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
 import { useBus } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
+import { useTrackedAsync } from "@point_of_sale/app/hooks/hooks";
 
 patch(ProductScreen.prototype, {
     /**
@@ -12,6 +13,7 @@ patch(ProductScreen.prototype, {
         super.setup(...arguments);
         this.state.tableBuffer = "";
         this.state.isValidBuffer = true;
+        this.doSubmitOrder = useTrackedAsync(() => this.submitOrder());
         useBus(this.numberBuffer, "buffer-update", ({ detail: value }) => {
             this.checkIsValid(value);
         });
@@ -48,9 +50,7 @@ patch(ProductScreen.prototype, {
         return this.pos.categoryCount.slice(0, 3);
     },
     async submitOrder() {
-        this.pos.addPendingOrder([this.currentOrder.id]);
-        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
-        this.pos.showScreen(this.pos.defaultScreen, {}, this.pos.defaultScreen == "ProductScreen");
+        await this.pos.submitOrder();
     },
     get primaryReviewButton() {
         return (

--- a/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/pos_restaurant/static/src/app/screens/product_screen/product_screen.xml
@@ -8,7 +8,8 @@
                     <button
                         t-if="!this.currentOrder.isDirectSale and nbrOfChanges"
                         class="btn-switchpane pay-button btn btn-lg flex-grow-1 position-relative lh-sm overflow-hidden"
-                        t-on-click="submitOrder"
+                        t-on-click="() => doSubmitOrder.call()"
+                        t-att-disabled="doSubmitOrder.status === 'loading'"
                         t-attf-class="{{ primaryOrderButton ? 'btn-primary' : 'btn-light' }}">
                         <!-- Replace the payment button by the order button -->
                         <span class="d-block">Order</span>
@@ -23,8 +24,9 @@
                     </button>
                     <button
                             class="h-100 button btn btn-secondary btn-lg d-flex flex-row align-items-center justify-content-center"
-                            t-on-click="() => this.submitOrder()"
-                            t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint">
+                            t-on-click="() => doSubmitOrder.call()"
+                            t-elif="this.pos.unwatched.printers.length and this.currentOrder.uiState.lastPrint"
+                            t-att-disabled="doSubmitOrder.status === 'loading'">
                         <i class="fa fa-cutlery" aria-hidden="true"></i>
                     </button>
                     <button

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -319,6 +319,12 @@ patch(PosStore.prototype, {
         }
         return super.addLineToCurrentOrder(vals, opts, configure);
     },
+    async submitOrder() {
+        const order = this.getOrder();
+        this.addPendingOrder([order.id]);
+        await this.sendOrderInPreparationUpdateLastChange(order);
+        this.showDefault();
+    },
     async getServerOrders() {
         if (this.config.module_pos_restaurant) {
             const tableIds = [].concat(


### PR DESCRIPTION
- Ensure that multiple (rapid) clicks on the order button no longer print duplicate preparation tickets.
- Await for the order to be printed, as it's done in `saas-18.2` since the following PR (https://github.com/odoo/odoo/pull/204444).

Steps to reproduce:
- Connect a preparation printer to the restaurant
- Make an order
- Spam the order btn to send the order to the kitchen
- => Multiple preparation ticket for the same order are printed

task-id: 4752376



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
