### PR TITLE
[FIX] mail: make partner presence test deterministic

### DIFF
--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -27,6 +27,9 @@ QUnit.test("Member list and settings menu are exclusive", async () => {
 
 QUnit.test("subscribe to known partner presences", async () => {
     patchWebsocketWorkerWithCleanup({
+        // Force update doesn't matter in this test and is non-deterministic, since the subscription
+        // content depends on whether add_channels runs first (both are debounced).
+        _forceUpdateChannels() {},
         _sendToServer({ event_name, data }) {
             if (event_name === "subscribe") {
                 step(`subscribe - [${data.channels}]`);


### PR DESCRIPTION
The `subscribe to known partner presences` test ensures that a bus subscription is sent when discovering a new partner whose presence needs tracking. However, the test triggers a channel join, which itself causes a bus subscription.

Since both `add_channel` and `force_update_channels` are debounced, the outcome depends on which one executes first. As a result, `force_update_channels` may or may not include the newly added channel, making the test non-deterministic.

In practice, this doesn't matter: if `force_update_channels` omits the new channel, `add_channel` will later update the subscription as needed.

This commit resolves the issue by ignoring `force_update_channels` in the test, since it's irrelevant in this context.

fixes runbot-161223,182043,182044
