### PR TITLE
[FIX] sale_stock: fix barcode duplication tour

### DIFF
--- a/addons/sale_stock/tests/test_packaging_tours.py
+++ b/addons/sale_stock/tests/test_packaging_tours.py
@@ -23,6 +23,8 @@ class TestPackagingTours(HttpCase):
             })]
         })
         url = self._get_product_url(product_a.product_tmpl_id.id)
-        self.env.user.write({'groups_id': [Command.link(self.env.ref('uom.group_uom').id)]})
+        self.env['res.config.settings'].create({
+            'group_uom': True,
+        }).execute()
         with mute_logger('odoo.sql_db', 'odoo.http'):
             self.start_tour(url, 'test_barcode_duplication_error', login='admin', timeout=60)


### PR DESCRIPTION
This commit ensures that the group `uom.group_uom` is correctly applied on the test user, so that the tour doesn't fail on the step looking for "Packagings" field on the product view which happened in some [single module tests](https://runbot.odoo.com/odoo/runbot.build.error/222678).

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
