### PR TITLE
[FIX] mrp,sale_mrp: kit adapt qty when packaging changed

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -113,8 +113,14 @@ class StockMoveLine(models.Model):
             line = aggregated_move_lines[key]
             bom_id = line['bom']
             kit_qty_ordered, kit_qty_done = kit_qty[bom_id.id]
-            line['packaging_qty'] = line['packaging']._compute_qty(kit_qty_ordered, bom_id.product_uom_id)
-            line['packaging_quantity'] = line['packaging']._compute_qty(kit_qty_done, bom_id.product_uom_id)
+            if line['packaging'].product_id == line['product']:
+                # If packaging has been set directly on the move
+                line['packaging_qty'] = line['packaging']._compute_qty(line['qty_ordered'], line['product_uom'])
+                line['packaging_quantity'] = line['packaging']._compute_qty(line['quantity'], line['product_uom'])
+            else:
+                # If packaging comes from the kit
+                line['packaging_qty'] = line['packaging']._compute_qty(kit_qty_ordered, bom_id.product_uom_id)
+                line['packaging_quantity'] = line['packaging']._compute_qty(kit_qty_done, bom_id.product_uom_id)
             aggregated_move_lines[key] = line
 
         non_kit_ml = super()._compute_packaging_qtys(non_kit_ml)

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -709,3 +709,56 @@ class TestSaleMrpKitBom(TransactionCase):
         sol.with_user(user_admin).write({'product_uom_qty': 5})
 
         self.assertEqual(sum(sol.move_ids.mapped('product_uom_qty')), 5)
+
+    def test_SO_kit_delivery_change_to_comp_packaging(self):
+        """
+        Test that when selling a kit, and changing the packaging on the stock move
+        to the packaging of the comp, the correct quantity is computed when printing
+        """
+        grp_pack = self.env.ref('product.group_stock_packaging')
+        self.env.user.write({'groups_id': [(4, grp_pack.id, 0)]})
+        kit_product = self._create_product('Kit', 'product', 1)
+        comp_product = self._create_product('Component', 'product', 1)
+        comp_product.uom_id = self.env.ref('uom.product_uom_gram').id
+        packaging_final_prod = self.env['product.packaging'].create({
+            'name': "packs of 9",
+            'product_id': kit_product.id,
+            'qty': 9.0,
+        })
+        packaging_comp = self.env['product.packaging'].create({
+            'name': "pack of 0.45 g",
+            'product_id': comp_product.id,
+            'product_uom_id': self.env.ref('uom.product_uom_gram').id,
+            'qty': 0.45,
+        })
+        self.env['mrp.bom'].create({
+            'product_tmpl_id': kit_product.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'type': 'phantom',
+            'bom_line_ids': [
+                Command.create({
+                    'product_id': comp_product.id,
+                    'product_qty': 0.1,
+                    'product_uom_id': self.env.ref('uom.product_uom_gram').id
+
+                }),
+            ]
+        })
+        so = self.env['sale.order'].create({
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+            'order_line': [
+                Command.create({
+                    'name': kit_product.name,
+                    'product_id': kit_product.id,
+                    'product_uom_qty': 9,
+                    'product_packaging_id': packaging_final_prod.id
+            })],
+        })
+        so.action_confirm()
+        so.picking_ids.move_ids.product_packaging_id = packaging_comp
+        so.picking_ids.move_ids.write({'quantity': 0.9})
+
+        so.picking_ids.button_validate()
+        aggr_prod_qty = so.picking_ids.move_ids.move_line_ids[0]._get_aggregated_product_quantities(kit_name='Kit')
+        key = f"{comp_product.id}_{comp_product.display_name}__{comp_product.uom_id.id}_{packaging_comp}_{kit_product.bom_ids.id}"
+        self.assertEqual(aggr_prod_qty[key]['packaging_quantity'], 2)


### PR DESCRIPTION
**Problem:**
When a kit sale order is created with a package for the kit
product, inside the delivery for the component of the BOM
the package is the package of the kit product

**Steps to reproduce:**
- Inside Settings/Sales activate the "Product Packagings"
setting
- Create a new product (the final product)
- Inside the inventory tab add a packaging line for a pack of
9 units
- Create a new product (the comp product)
- In the general information tab, set a unit of mesure of g
- In the inventory tab add a packaging line for a pack of
0.9 g
- Set an on hand quantity for the comp product
- Create a new BOM for the final product
- Add a a line with the comp product for a quantity of 0.1 g
- Select kit
- Create a new quotation and select your kit product
- Select your packaging > Confirm
- Click on the delivery smart button
- In the operations tab change the packaging of the stock move
to the packaging of the comp
- validate and print

**Current behavior:**
An error message appears

**Cause of the issue:**

When _compute_packaging_qtys calls _compute_qty (the method of the
product.packaging model):
bom_id.product_uom_qty is the uom of the final product (here: Units)
but line['packaging'] is the packaging of the comp that
we set manually on the stock move
https://github.com/odoo/odoo/blob/8244b0bcdb470ff6eb95e2613903fb9175f2c435/addons/mrp/models/stock_move.py#L116
So inside _compute_qty, when _compute_qty (the method of the uom.uom model)
is called, qty_uom is Units and self.product_uom_id is g
https://github.com/odoo/odoo/blob/8244b0bcdb470ff6eb95e2613903fb9175f2c435/addons/product/models/product_packaging.py#L79
which triggers an error inside _compute_qty
https://github.com/odoo/odoo/blob/8244b0bcdb470ff6eb95e2613903fb9175f2c435/addons/uom/models/uom_uom.py#L223-L227

opw-4781180