### PR TITLE
[FIX] point_of_sale: save record updates in indexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
+++ b/addons/point_of_sale/static/src/app/models/utils/indexed_db.js
@@ -59,7 +59,7 @@ export default class IndexedDB {
                         delete alreadyExists.write_date;
                     }
 
-                    if (alreadyExists && JSON.stringify(alreadyExists) !== JSON.stringify(data)) {
+                    if (alreadyExists && JSON.stringify(alreadyExists) === JSON.stringify(data)) {
                         delete arrData[idx];
                     }
                 }


### PR DESCRIPTION
After commit https://github.com/odoo/odoo/commit/692992a25dc8f583ef70517088ec963a8d30802b, updates to existing records in indexedDB were not properly saved due to incorrect logic. As a result, changes to records were not persisted in the local database.

This commit corrects the update logic to ensure that modifications to existing records are correctly saved in indexedDB.

opw-4802025

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
