### PR TITLE
[FIX] account: apply Bank St line regex on narration

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -28,7 +28,6 @@ class AccountReconcileModelLine(models.Model):
             ('percentage', 'Percentage of balance'),
             ('percentage_st_line', 'Percentage of statement line'),
             ('regex', 'From label'),
-            ('from_transaction_details', 'From Transaction Details'),
         ],
         required=True,
         default='percentage',
@@ -71,7 +70,7 @@ class AccountReconcileModelLine(models.Model):
                 raise UserError(_("Balance percentage can't be 0"))
             if record.amount_type == 'percentage' and record.amount == 0:
                 raise UserError(_("Statement line percentage can't be 0"))
-            if record.amount_type in {'regex', 'from_transaction_details'}:
+            if record.amount_type == 'regex':
                 try:
                     re.compile(record.amount_string)
                 except re.error:


### PR DESCRIPTION
We don't want the user to differentiate the places where to apply the regex search (reco model) on statement lines. We thus apply it on the label, the transaction details and the narration altogether, returning on the first match. We don't need the "from_transaction_details" selection option anymore.

task-4749338