### PR TITLE
[FIX] ai,*: prevent error when pin message in discuss

### DIFF
--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
@@ -13,26 +13,6 @@ import { disableAnimations } from "@odoo/hoot-mock";
 describe.current.tags("desktop");
 defineMailModels();
 
-test("Pin message", async () => {
-    const pyEnv = await startServer();
-    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
-    pyEnv["mail.message"].create({
-        body: "Hello world!",
-        model: "discuss.channel",
-        res_id: channelId,
-    });
-    await start();
-    await openDiscuss(channelId);
-    await click(".o-mail-Discuss-header button[title='Pinned Messages']");
-    await contains(".o-discuss-PinnedMessagesPanel p", {
-        text: "This channel doesn't have any pinned messages.",
-    });
-    await click(".o-mail-Message [title='Expand']");
-    await click(".dropdown-item", { text: "Pin" });
-    await click(".modal-footer button", { text: "Yeah, pin it!" });
-    await contains(".o-discuss-PinnedMessagesPanel .o-mail-Message", { text: "Hello world!" });
-});
-
 test("Unpin message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });


### PR DESCRIPTION
*=mail,test_discuss_full_enterprise

**Current behavior before PR:**

Pinning a message would throw an error if the associated thread was not present on the message.

**Desired behavior after PR is merged:**

This commit ensures that pinning a message works properly.

**Task**-4805076

related: [enterprise#85862](https://github.com/odoo/enterprise/pull/85862)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
