### PR TITLE
[FIX] web: show property field labels in calendar popover

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -48,7 +48,7 @@
                     <t t-set="fieldType" t-value="props.model.fields[fieldId].type"/>
                     <t t-if="!isInvisible(fieldInfo, slot.record)">
                         <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.attrs.class"  t-att-data-tooltip="fieldType === 'html' ? '' : getFormattedValue(fieldId, slot.record)">
-                            <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel">
+                            <span class="fw-bold me-2" t-if="!fieldInfo.options.noLabel and fieldInfo.type !== 'properties'">
                                 <t t-if="fieldInfo.options.icon">
                                     <i t-attf-class="fa-fw {{fieldInfo.options.icon}} text-400" />
                                 </t>

--- a/addons/web/static/src/views/fields/properties/calendar_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/calendar_properties_field.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import { propertiesField, PropertiesField } from "./properties_field";
+
+export class CalendarPropertiesField extends PropertiesField {
+    static template = "web.CalendarPropertiesField";
+    async checkDefinitionWriteAccess() {
+        return false;
+    }
+}
+
+export const calendarPropertiesField = {
+    ...propertiesField,
+    component: CalendarPropertiesField,
+};
+
+registry.category("fields").add("calendar.properties", calendarPropertiesField);

--- a/addons/web/static/src/views/fields/properties/calendar_properties_field.xml
+++ b/addons/web/static/src/views/fields/properties/calendar_properties_field.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <div t-name="web.CalendarPropertiesField" t-ref="properties" class="d-flex flex-column gap-3">
+        <div class="o_calendar_property_field d-flex"
+            t-foreach="propertiesList"
+            t-as="propertyConfiguration"
+            t-key="propertyConfiguration.name"
+            t-if="propertyConfiguration.value and propertyConfiguration.view_in_cards">
+            <span class="fw-bold me-2" t-out="propertyConfiguration.string"/>
+            <div class="text-truncate">
+                <PropertyValue
+                    id="generateUniqueDomID()"
+                    canChangeDefinition="state.canChangeDefinition"
+                    comodel="propertyConfiguration.comodel || ''"
+                    context="props.context"
+                    domain="propertyConfiguration.domain || '[]'"
+                    readonly="props.readonly"
+                    selection="propertyConfiguration.selection"
+                    string="propertyConfiguration.string"
+                    tags="propertyConfiguration.tags"
+                    type="propertyConfiguration.type"
+                    value="propertyConfiguration.value"
+                    onChange.bind="() => {}"
+                    onTagsChange.bind="() => {}"
+                />
+            </div>
+        </div>
+    </div>
+</templates>

--- a/addons/web/static/src/views/fields/properties/card_properties_field.js
+++ b/addons/web/static/src/views/fields/properties/card_properties_field.js
@@ -15,6 +15,5 @@ export const cardPropertiesField = {
     component: CardPropertiesField,
 };
 
-registry.category("fields").add("calendar.properties", cardPropertiesField);
 registry.category("fields").add("kanban.properties", cardPropertiesField);
 registry.category("fields").add("hierarchy.properties", cardPropertiesField);

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -4772,7 +4772,13 @@ test(`calendar render properties in popover`, async () => {
 
     await clickEvent(1);
     const popover = getMockEnv().isSmall ? ".modal" : ".o_popover";
-    expect(queryAllTexts(`${popover} .o_field_properties .o_card_property_field`)).toEqual([
+    // Labels:
+    expect(queryAllTexts(`${popover} .o_calendar_property_field span.fw-bold`)).toEqual([
+        "My Char",
+        "My Selection",
+    ]);
+    // Values:
+    expect(queryAllTexts(`${popover} .o_calendar_property_field div.text-truncate`)).toEqual([
         "hello",
         "B",
     ]);


### PR DESCRIPTION
Backport of 18affd81cbdd321e428b729602f91dc06988929f

Steps:
------
* Add properties (displayed on card) to a task of a project
* Open the card view of the task in the calendar view of the project

Previously, the calendar popover displayed property field values using the label of the container field. This commit updates the behavior to display each property field with its respective label, ensuring consistency with the appearance of standard fields.

opw-4767059

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
