### PR TITLE
[FIX] mail: make message sound test deterministic

### DIFF
--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -1502,7 +1502,7 @@ test("message sound on receiving new message (push notif enabled)", async () => 
             thread_model: "discuss.channel",
         })
     );
-    await waitFor(".o-mail-ChatBubble .badge:contains(1)");
+    await waitFor(".o-mail-ChatBubble .badge:contains(1)", { timeout: 3000 });
     await waitForSteps(["sound:new-message"]);
     // simulate message sound settings turned off
     browser.localStorage.setItem("mail.user_setting.message_sound", false);
@@ -1517,7 +1517,7 @@ test("message sound on receiving new message (push notif enabled)", async () => 
             thread_model: "discuss.channel",
         })
     );
-    await waitFor(".o-mail-ChatBubble .badge:contains(2)");
+    await waitFor(".o-mail-ChatBubble .badge:contains(2)", { timeout: 3000 });
     expect.verifySteps([]);
     // simulate message sound settings turned on
     browser.localStorage.setItem("mail.user_setting.message_sound", null);
@@ -1532,7 +1532,7 @@ test("message sound on receiving new message (push notif enabled)", async () => 
             thread_model: "discuss.channel",
         })
     );
-    await waitFor(".o-mail-ChatBubble .badge:contains(3)");
+    await waitFor(".o-mail-ChatBubble .badge:contains(3)", { timeout: 3000 });
     await waitForSteps(["sound:new-message"]);
 });
 


### PR DESCRIPTION
Before this commit, the `message sound on receiving new message` was sometimes failing. It occurs because the test uses the `waitFor` web method to wait for the message unread counter to change. However, `waitFor` has a much smaller timeout than `contains` (200ms vs 3s).

In this particular scenario, receiving the bus notification, fetching the channel and rendering the chat hub initially can take a little bit more time than 200ms, making the test fail.

This commit increases the time out to match the `contains` one for this test.

fixes runbot-159866

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
