### PR TITLE
[FIX] web: favorite_management: runbot-error-162145

### DIFF
--- a/addons/web/static/tests/tours/favorite_management_tour.js
+++ b/addons/web/static/tests/tours/favorite_management_tour.js
@@ -5,8 +5,15 @@ registry.category("web_tour.tours").add("test_favorite_management", {
     url: "/odoo/apps",
     steps: () => [
         {
+            trigger:
+                ".o_kanban_renderer:not(:has(.o_kanban_record:contains(France - Localizations)))",
+        },
+        {
             trigger: ".o_facet_remove",
             run: "click",
+        },
+        {
+            trigger: ".o_kanban_renderer:has(.o_kanban_record:contains(France - Localizations))",
         },
         {
             trigger: ".o_searchview_dropdown_toggler",

--- a/addons/web/tests/test_favorite.py
+++ b/addons/web/tests/test_favorite.py
@@ -3,4 +3,6 @@ from odoo.tests.common import HttpCase, tagged
 @tagged('post_install', '-at_install')
 class TestFavorite(HttpCase):
     def test_favorite_management(self):
+        self.patch(self.env.registry.get("ir.module.module"), "_order", "sequence desc, id desc")
+        self.env["ir.module.module"]._get("l10n_fr").sequence = 100000
         self.start_tour("/odoo/apps", "test_favorite_management", login="admin")


### PR DESCRIPTION
Because of commit https://github.com/odoo/odoo/commit/b5ba14bc77a12268e5ce1e2a7aa7e48ba209f876
tours are faster and don't wait much between two steps.

Also, when removing or adding a facet in the search view, there is no
way to determine that the subsequent reload has been done.
The factet is removed or added immediately, the reload happens after.

So, before the refactoring of macro.js, we waited a little bit longer, allowing
the reload of the view to be done before going to the next step.

This commit mitigates this by making the dataset of the tour more dterministic in
order to be able to check that in the DOM.

It is possible that the problem occurs in 18.0 as well, so feel free to backport this fix.
runbot-error-162145
