### PR TITLE
[FIX] *: resolve error when locale code is invalid for language

### DIFF
--- a/addons/hr_holidays/report/holidays_summary_report.py
+++ b/addons/hr_holidays/report/holidays_summary_report.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools.misc import format_date, get_lang
+from odoo.tools.misc import babel_locale_parse, format_date, get_lang
 
 COLORS_MAP = {
     0: 'lightgrey',
@@ -52,7 +52,7 @@ class HrHolidaySummaryReport(models.AbstractModel):
         start_date = fields.Date.from_string(start_date)
         for x in range(0, 60):
             color = '#ababab' if self._date_is_day_off(start_date) else ''
-            res.append({'day_str': babel.dates.get_day_names('abbreviated', locale=get_lang(self.env).code)[start_date.weekday()], 'day': start_date.day, 'color': color})
+            res.append({'day_str': babel.dates.get_day_names('abbreviated', locale=babel_locale_parse(get_lang(self.env).code).language)[start_date.weekday()], 'day': start_date.day, 'color': color})
             start_date = start_date + relativedelta(days=1)
         return res
 
@@ -66,7 +66,7 @@ class HrHolidaySummaryReport(models.AbstractModel):
             if last_date > end_date:
                 last_date = end_date
             month_days = (last_date - start_date).days + 1
-            res.append({'month_name': babel.dates.get_month_names(locale=get_lang(self.env).code)[start_date.month], 'days': month_days})
+            res.append({'month_name': babel.dates.get_month_names(locale=babel_locale_parse(get_lang(self.env).code).language)[start_date.month], 'days': month_days})
             start_date += relativedelta(day=1, months=+1)
         return res
 

--- a/addons/hr_holidays/static/src/views/hooks.js
+++ b/addons/hr_holidays/static/src/views/hooks.js
@@ -4,12 +4,12 @@ import { _t } from "@web/core/l10n/translation";
 import { useService, useOwnedDialogs } from "@web/core/utils/hooks";
 import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
 import { useComponent } from "@odoo/owl";
+import { parseLocal } from "@web/core/utils/misc";
 import { pyToJsLocale } from "@web/core/l10n/utils";
 
 export function formatNumber(lang, number, maxDecimals = 2) {
     const userLang = pyToJsLocale(lang);
-
-    const numberFormat = new Intl.NumberFormat(userLang, { maximumFractionDigits: maxDecimals });
+    const numberFormat = new Intl.NumberFormat(parseLocal(userLang), { maximumFractionDigits: maxDecimals });
     return numberFormat.format(number);
 }
 

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -8,6 +8,7 @@ import { deserializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { pyToJsLocale } from "@web/core/l10n/utils";
 import { Deferred } from "@web/core/utils/concurrency";
+import { parseLocal } from "@web/core/utils/misc";
 
 /**
  * @typedef SuggestedRecipient
@@ -388,9 +389,9 @@ export class Thread extends Record {
             return this.custom_channel_name || this.chatPartner.nameOrDisplayName;
         }
         if (this.type === "group" && !this.name) {
+            const userLang = parseLocal(this._store.env.services["user"].lang);
             const listFormatter = new Intl.ListFormat(
-                this._store.env.services["user"].lang &&
-                    pyToJsLocale(this._store.env.services["user"].lang),
+                userLang && pyToJsLocale(userLang),
                 { type: "conjunction", style: "long" }
             );
             return listFormatter.format(

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -33,6 +33,7 @@ import { useService } from "@web/core/utils/hooks";
 import { escape } from "@web/core/utils/strings";
 import { useThrottleForAnimation } from "@web/core/utils/timing";
 import { FileUploader } from "@web/views/fields/file_handler";
+import { parseLocal } from "@web/core/utils/misc";
 
 export const DELAY_FOR_SPINNER = 1000;
 
@@ -244,9 +245,9 @@ export class Chatter extends Component {
                     partner.email || _t("no email address")
                 )}">${escape(text)}</span>`;
             });
+        const userLang = parseLocal(this.store.env.services["user"].lang);
         const formatter = new Intl.ListFormat(
-            this.store.env.services["user"].lang &&
-                pyToJsLocale(this.store.env.services["user"].lang),
+            userLang && pyToJsLocale(userLang),
             { type: "unit" }
         );
         if (this.state.thread && this.state.thread.recipients.length > 5) {

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -11,7 +11,7 @@ from odoo.exceptions import AccessError
 from odoo.http import request, Response
 from odoo.osv import expression
 from odoo.tools import consteq
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import babel_locale_parse, get_lang
 
 
 class PortalMailGroup(http.Controller):
@@ -34,11 +34,11 @@ class PortalMailGroup(http.Controller):
 
         date_groups = []
 
-        locale = get_lang(request.env).code
+        locale = babel_locale_parse(get_lang(request.env).code)
         fmt = models.READ_GROUP_DISPLAY_FORMAT['month']
         interval = models.READ_GROUP_TIME_GRANULARITY['month']
         for start, count in results:
-            label = babel.dates.format_datetime(start, format=fmt, locale=locale)
+            label = babel.dates.format_datetime(start, format=fmt, locale=locale.language)
             date_groups.append({
                 'date': label,
                 'date_begin': fields.Date.to_string(start),

--- a/addons/sales_team/models/crm_team.py
+++ b/addons/sales_team/models/crm_team.py
@@ -4,13 +4,13 @@
 import json
 import random
 
-from babel.dates import format_date
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.release import version
+from odoo.tools.misc import format_date
 
 
 class CrmTeam(models.Model):
@@ -356,10 +356,10 @@ class CrmTeam(models.Model):
                       "en_US"      December 28th           "28 Dec-3 Jan"
             """
             if (start_date + relativedelta(days=6)).month == start_date.month:
-                short_name_from = format_date(start_date, 'd', locale=locale)
+                short_name_from = format_date(self.env, start_date, date_format='d')
             else:
-                short_name_from = format_date(start_date, 'd MMM', locale=locale)
-            short_name_to = format_date(start_date + relativedelta(days=6), 'd MMM', locale=locale)
+                short_name_from = format_date(self.env, start_date, date_format='d MMM')
+            short_name_to = format_date(self.env, start_date + relativedelta(days=6), date_format='d MMM')
             return short_name_from + '-' + short_name_to
 
         self.ensure_one()

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import babel.dates
 from json import dumps
 from datetime import datetime, time
 
@@ -9,7 +8,7 @@ from datetime import datetime, time
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv.expression import AND
 from odoo.tools import get_month, subtract, format_date
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import format_datetime, get_lang
 
 
 class StockReplenishmentInfo(models.TransientModel):
@@ -82,7 +81,7 @@ class StockReplenishmentInfo(models.TransientModel):
             fmt = models.READ_GROUP_DISPLAY_FORMAT['month']
             for month, product_qty_sum in quantity_by_month_out:
                 replenishment_history.append({
-                    'name': babel.dates.format_datetime(month, format=fmt, locale=locale),
+                    'name': format_datetime(self.env, month, dt_format=fmt),
                     'quantity': product_qty_sum - quantity_by_month_returned.get(month, 0),
                     'uom_name': replenishment_report.product_id.uom_id.display_name,
                 })

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -13,7 +13,7 @@ from odoo.fields import Command
 from odoo.models import BaseModel, NewId
 from odoo.osv.expression import AND, TRUE_DOMAIN, normalize_domain
 from odoo.tools import date_utils, unique
-from odoo.tools.misc import OrderedSet, get_lang
+from odoo.tools.misc import OrderedSet, babel_locale_parse, get_lang
 from odoo.exceptions import UserError
 from collections import defaultdict
 
@@ -336,7 +336,7 @@ class Base(models.AbstractModel):
 
             # Again, imitating what _read_group_format_result and _read_group_prepare_data do
             if group_by_value and field_type in ['date', 'datetime']:
-                locale = get_lang(self.env).code
+                locale = babel_locale_parse(get_lang(self.env).code)
                 group_by_value = fields.Datetime.to_datetime(group_by_value)
                 if group_by_modifier != 'week':
                     # start_of(v, 'week') does not take into account the locale

--- a/addons/web/static/lib/Chart/Chart.js
+++ b/addons/web/static/lib/Chart/Chart.js
@@ -1502,7 +1502,7 @@
         const cacheKey = locale + JSON.stringify(options);
         let formatter = intlCache.get(cacheKey);
         if (!formatter) {
-            formatter = new Intl.NumberFormat(locale, options);
+            formatter = new Intl.NumberFormat(parseLocal(locale), options);
             intlCache.set(cacheKey, formatter);
         }
         return formatter;
@@ -1510,7 +1510,15 @@
     function formatNumber(num, locale, options) {
         return getNumberFormat(locale, options).format(num);
     }
-  
+
+    function parseLocal(locale) {
+      try {
+          return new Intl.Locale(locale) && locale;
+      } catch {
+          return "en-US";
+      }
+    }
+
     const formatters = {
      values (value) {
             return isArray(value) ?  value : '' + value;

--- a/addons/web/static/lib/fullcalendar/core/main.js
+++ b/addons/web/static/lib/fullcalendar/core/main.js
@@ -1687,12 +1687,12 @@ Docs & License: https://fullcalendar.io/
         extendedSettings = __assign({}, extendedSettings); // copy
         sanitizeSettings(standardDateProps, extendedSettings);
         standardDateProps.timeZone = 'UTC'; // we leverage the only guaranteed timeZone for our UTC markers
-        var normalFormat = new Intl.DateTimeFormat(context.locale.codes, standardDateProps);
+        var normalFormat = new Intl.DateTimeFormat(parseLocal(context.locale.codes), standardDateProps);
         var zeroFormat; // needed?
         if (extendedSettings.omitZeroMinute) {
             var zeroProps = __assign({}, standardDateProps);
             delete zeroProps.minute; // seconds and ms were already considered in sanitizeSettings
-            zeroFormat = new Intl.DateTimeFormat(context.locale.codes, zeroProps);
+            zeroFormat = new Intl.DateTimeFormat(parseLocal(context.locale.codes), zeroProps);
         }
         return function (date) {
             var marker = date.marker;
@@ -4649,9 +4649,17 @@ Docs & License: https://fullcalendar.io/
             codeArg: codeArg,
             codes: codes,
             week: week,
-            simpleNumberFormat: new Intl.NumberFormat(codeArg),
+            simpleNumberFormat: new Intl.NumberFormat(parseLocal(codeArg)),
             options: merged
         };
+    }
+
+    function parseLocal(locale) {
+      try {
+        return new Intl.Locale(locale) && locale;
+      } catch {
+        return "en-US";
+      }
     }
 
     var OptionsManager = /** @class */ (function () {

--- a/addons/web/static/lib/luxon/luxon.js
+++ b/addons/web/static/lib/luxon/luxon.js
@@ -617,6 +617,7 @@ var luxon = (function (exports) {
     const key = JSON.stringify([locString, cacheKeyOpts]);
     let inf = intlRelCache[key];
     if (!inf) {
+      locString = Locale.parseLocal(locString);
       inf = new Intl.RelativeTimeFormat(locString, opts);
       intlRelCache[key] = inf;
     }
@@ -887,12 +888,21 @@ var luxon = (function (exports) {
     }
 
     static create(locale, numberingSystem, outputCalendar, defaultToEN = false) {
-      const specifiedLocale = locale || Settings.defaultLocale;
+      const specifiedLocale = this.parseLocal(locale || Settings.defaultLocale);
       // the system locale is useful for human readable strings but annoying for parsing/formatting known formats
       const localeR = specifiedLocale || (defaultToEN ? "en-US" : systemLocale());
       const numberingSystemR = numberingSystem || Settings.defaultNumberingSystem;
       const outputCalendarR = outputCalendar || Settings.defaultOutputCalendar;
       return new Locale(localeR, numberingSystemR, outputCalendarR, specifiedLocale);
+    }
+
+    static parseLocal(localeStr) {
+      try {
+          new Intl.Locale(localeStr);
+          return localeStr;
+      } catch {
+          return "en-US";
+      }
     }
 
     static resetCache() {
@@ -1595,6 +1605,7 @@ var luxon = (function (exports) {
 
     const modified = { timeZoneName: offsetFormat, ...intlOpts };
 
+    locale = Locale.parseLocal(locale);
     const parsed = new Intl.DateTimeFormat(locale, modified)
       .formatToParts(date)
       .find((m) => m.type.toLowerCase() === "timezonename");

--- a/addons/web/static/src/core/utils/misc.js
+++ b/addons/web/static/src/core/utils/misc.js
@@ -27,3 +27,15 @@ export function markEventHandled(ev, markName) {
     }
     eventHandledWeakMap.get(ev).push(markName);
 }
+/**
+ * Returns the valid locale code or defaults to "en-US" if invalid.
+ *
+ * @param {string} locale
+ */
+export function parseLocal(locale) {
+    try {
+        return new Intl.Locale(locale) && locale;
+    } catch {
+        return "en-US";
+    }
+}

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_invite_users.js
@@ -7,6 +7,7 @@ import { unique } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
 
 import { Component, useState, onWillStart } from "@odoo/owl";
+import { parseLocal } from "@web/core/utils/misc";
 import { standardWidgetProps } from "@web/views/widgets/standard_widget_props";
 
 class ResConfigInviteUsers extends Component {
@@ -64,7 +65,7 @@ class ResConfigInviteUsers extends Component {
         }
         if (invalidEmails.length) {
             const errorMessage = (() => {
-                const listFormatter = new Intl.ListFormat(pyToJsLocale(this.user.lang), {
+                const listFormatter = new Intl.ListFormat(pyToJsLocale(parseLocal(this.user.lang)), {
                     type: "conjunction",
                     style: "long",
                 });

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -12,7 +12,7 @@ from odoo.addons.http_routing.models.ir_http import slug, unslug
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.http import request
 from odoo.tools import html2plaintext
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import babel_locale_parse, get_lang
 from odoo.tools import sql
 
 
@@ -36,7 +36,7 @@ class WebsiteBlog(http.Controller):
         groups = request.env['blog.post']._read_group(
             dom, groupby=['post_date:month'])
 
-        locale = get_lang(request.env).code
+        locale = babel_locale_parse(get_lang(request.env).code).language
         tzinfo = pytz.timezone(request.context.get('tz', 'utc') or 'utc')
         fmt = tools.DEFAULT_SERVER_DATETIME_FORMAT
 

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -13,7 +13,7 @@ from odoo import fields, http, _
 from odoo.addons.website.controllers.main import QueryURL
 from odoo.http import request
 from odoo.osv import expression
-from odoo.tools.misc import get_lang
+from odoo.tools.misc import babel_locale_parse, get_lang
 from odoo.tools import lazy
 from odoo.exceptions import UserError
 
@@ -406,7 +406,7 @@ class WebsiteEventController(http.Controller):
     def get_formated_date(self, event):
         start_date = fields.Datetime.from_string(event.date_begin).date()
         end_date = fields.Datetime.from_string(event.date_end).date()
-        month = babel.dates.get_month_names('abbreviated', locale=get_lang(event.env).code)[start_date.month]
+        month = babel.dates.get_month_names('abbreviated', locale=babel_locale_parse(get_lang(event.env).code).language)[start_date.month]
         return ('%s %s%s') % (month, start_date.strftime("%e"), (end_date != start_date and ("-" + end_date.strftime("%e")) or ""))
 
     def _extract_searched_event_tags(self, searches):

--- a/addons/website_event_meet/controllers/website_event_main.py
+++ b/addons/website_event_meet/controllers/website_event_main.py
@@ -11,7 +11,6 @@ from odoo.addons.website_event.controllers import main
 class WebsiteEventController(main.WebsiteEventController):
     def _prepare_event_register_values(self, event, **post):
         values = super(WebsiteEventController, self)._prepare_event_register_values(event, **post)
-
         if "from_room_id" in post and not event.is_ongoing:
             meeting_room = request.env["event.meeting.room"].browse(int(post["from_room_id"])).sudo().exists()
             if meeting_room and meeting_room.is_published:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -57,7 +57,7 @@ from . import api
 from . import tools
 from .exceptions import AccessError, MissingError, ValidationError, UserError
 from .tools import (
-    clean_context, config, CountingStream, date_utils, discardattr,
+    babel_locale_parse, clean_context, config, CountingStream, date_utils, discardattr,
     DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT, frozendict,
     get_lang, LastOrderedSet, lazy_classproperty, OrderedSet, ormcache,
     partition, populate, Query, ReversedIterable, split_every, unique, SQL, groupby
@@ -2478,7 +2478,7 @@ class BaseModel(metaclass=MetaModel):
             field = self._fields[field_name]
 
             if field.type in ('date', 'datetime'):
-                locale = get_lang(self.env).code
+                locale = babel_locale_parse(get_lang(self.env).code)
                 fmt = DEFAULT_SERVER_DATETIME_FORMAT if field.type == 'datetime' else DEFAULT_SERVER_DATE_FORMAT
                 granularity = group.split(':')[1] if ':' in group else 'month'
                 interval = READ_GROUP_TIME_GRANULARITY[granularity]
@@ -2513,12 +2513,12 @@ class BaseModel(metaclass=MetaModel):
 
                             label = babel.dates.format_datetime(
                                 range_start, format=READ_GROUP_DISPLAY_FORMAT[granularity],
-                                tzinfo=tzinfo, locale=locale
+                                tzinfo=tzinfo, locale=locale.language
                             )
                         else:
                             label = babel.dates.format_date(
                                 value, format=READ_GROUP_DISPLAY_FORMAT[granularity],
-                                locale=locale
+                                locale=locale.language
                             )
                         if granularity == 'week':
                             year, week = date_utils.weeknumber(
@@ -2653,7 +2653,7 @@ class BaseModel(metaclass=MetaModel):
                 row[group] = babel.dates.format_date(
                     row[group],
                     format=READ_GROUP_DISPLAY_FORMAT[func],
-                    locale=get_lang(self.env).code
+                    locale=babel_locale_parse(get_lang(self.env).code)
                 )
         else:
             for row in rows_dict:


### PR DESCRIPTION
```
* = {account, hr_holidays, mail_group, sales_team, stock, web, website_blog, 
website_event, website_event_meet, odoo}
```

**Steps to reproduce:**
- Install the **Accounting** module.
- Navigate to `Settings > Translations > Languages.`
- Create a new language with the **Locale Code** set to `Indonesia`.
- Activate the language and switch the language to it.
- Open the **Accounting** application.

**Error:**
`UnknownLocaleError: unknown locale 'Indonesia'`

Currently, an error is produced when babel functions such as `format_date`, `format_datetime`, or `format_time` are used with an invalid or unrecognized locale code (e.g., "Indonesia"), raises an `UnknownLocaleError`.

This commit handles unknown locale codes by using `babel_locale_parse()` along with Odoo's built-in functions such as `format_date` and `format_datetime`, which safely parse the given locale. If the provided locale code is invalid, the system sets to a default locale to prevent errors.

**References:**
1) https://github.com/odoo/odoo/pull/64169/files 
2) https://github.com/odoo/odoo/blob/54edf27b406690184c2dc953772e454cb4458ee0/odoo/tools/misc.py#L1445

Sentry - 6599701875