### PR TITLE
[FIX] account: Prevent crash when previewing invoices without lines

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4442,7 +4442,7 @@ class AccountMove(models.Model):
             payment_state = 'partially_paid'
 
         term_lines = self.line_ids.filtered(lambda line: line.display_type == 'payment_term')
-        epd_installment = term_lines._get_epd_data()
+        epd_installment = term_lines and term_lines._get_epd_data()
         discount_date = epd_installment and epd_installment['line'].discount_date
         epd_info = {}
         if epd_installment and discount_date:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4605,3 +4605,17 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
             "<p>Manually written terms by user</p>",
             "Narration should be preserved after partner change when invoice terms are disabled"
         )
+
+    def test_invoice_with_no_lines(self):
+        """
+        Test that previewing an invoice with no lines doesn't crash.
+        """
+        # Create invoice with no lines
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_a.id,
+            'invoice_date': fields.Date.today(),
+            'currency_id': self.currency_data['currency'].id,
+        })
+        values = invoice._get_invoice_portal_extra_values()
+        self.assertIn('payment_state', values)


### PR DESCRIPTION
Previewing an invoice that has no invoice lines causes a crash . The error happens when trying t o compute early payment discount info and assumes at least one payment term line is present. When there aren't any, it fails with a `ValueError` due to a call to `ensure_one()` on an empty recordset.

this commit simply skips the discount logic when there are no payment term lines.

Steps to reproduce:
Accountant -> invoices
New invoice with no lines
Click on the preview button.

OPW-4657488


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
