### PR TITLE
[FIX] core: prevent _name_search crash on type mismatch

### DIFF
--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -112,9 +112,9 @@ class TestResCurrency(TransactionCase):
             {"name": "1971-01-01", "rate": 1.5, "currency_id": currency_B.id},
             {"name": "1972-01-01", "rate": 0.69, "currency_id": currency_B.id},
         ])
-        # should not try to match field 'rate' (float field)
-        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "1971-01-01"]]), 2)
         # should not try to match field 'name' (date field)
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "1971-01-01"]]), 2)
+        # should not try to match field 'rate' (float field)
         self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "0.69"]]), 1)
         # should not try to match any of 'name' and 'rate'
         self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "irrelevant"]]), 0)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1783,7 +1783,7 @@ class BaseModel(metaclass=MetaModel):
                     continue
                 try:
                     domains.append([(field_name, operator, field.convert_to_write(name, self))])
-                except ValueError:
+                except (ValueError, TypeError):
                     pass  # ignore that case if the value doesn't match the field type
             domain += aggregator(domains)
 


### PR DESCRIPTION
Encountered an issue where `_name_search` would crash if a search term couldn’t be converted to all expected field types — specifically when using a string like "1971-01-01" that gets interpreted as a date, but also hits a float field in the comodel.

This happened when searching currencies by exchange rates, which involve both a date field (`name`) and a float field (`rate`) in `res.currency.rate`. The original implementation only caught `ValueError` during type conversion, but in my case it was raising a `TypeError` when attempting to convert a `datetime.date` to a float.

To fix this, I expanded the exception handling to also catch `TypeError`, ensuring `_name_search` gracefully skips over fields where conversion is invalid. This aligns with the intended behavior described in the original fix — to silently ignore incompatible fields instead of failing.

Failing in Distro Build , python version >=3.10  raises a `TypeError`
build_error-110207

