### PR TITLE
[IMP] web_tour: stop tour through pointer content

### DIFF
--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.js
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.js
@@ -1,4 +1,6 @@
 import { Component, useEffect, useRef } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+import { browser } from "@web/core/browser/browser";
 import { usePosition } from "@web/core/position/position_hook";
 
 /**
@@ -47,6 +49,7 @@ export class TourPointer extends Component {
     static height = 28; // in pixels
 
     setup() {
+        this.orm = useService("orm");
         const positionOptions = {
             margin: 6,
             onPositioned: (pointer, position) => {
@@ -175,5 +178,10 @@ export class TourPointer extends Component {
 
     get position() {
         return this.props.pointerState.position || "top";
+    }
+
+    async onStopClicked() {
+        await this.orm.call("res.users", "switch_tour_enabled", [false]);
+        browser.location.reload();
     }
 }

--- a/addons/web_tour/static/src/tour_pointer/tour_pointer.xml
+++ b/addons/web_tour/static/src/tour_pointer/tour_pointer.xml
@@ -23,7 +23,12 @@
                 class="o_tour_pointer_content rounded overflow-hidden px-3 py-2 w-100 h-100 position-relative"
                 t-att-class="{ 'invisible': !isOpen }"
             >
-                <t t-out="content" />
+                <span>
+                    <t t-out="content" />
+                </span>
+                <div class="d-flex justify-content-end">
+                    <button class="btn btn-link" t-on-click="onStopClicked">Stop Tour</button>
+                </div>
             </div>
         </div>
         <div class="o_tour_dropzone position-fixed pe-none" t-if="props.pointerState.isVisible and props.pointerState.isZone" t-ref="zone" style="border: 3px dashed #714b67;"/>

--- a/addons/web_tour/static/tests/tour_interactive.test.js
+++ b/addons/web_tour/static/tests/tour_interactive.test.js
@@ -280,7 +280,7 @@ test("hovering to the anchor element should show the content and not when conten
     await contains("button.inc").hover();
     await animationFrame();
     expect(".o_tour_pointer_content:not(.invisible)").toHaveCount(1);
-    expect(".o_tour_pointer_content:not(.invisible)").toHaveText("content");
+    expect(".o_tour_pointer_content:not(.invisible) span").toHaveText("content");
     await contains(".other").hover();
     await animationFrame();
     expect(".o_tour_pointer_content.invisible").toHaveCount(1);
@@ -407,7 +407,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
     expect(firstOpenWidth).toBe("28px");
 
     await contains("button.inc").hover();
-    expect(".o_tour_pointer").toHaveText(content);
+    expect(".o_tour_pointer span").toHaveText(content);
     expect(".o_tour_pointer").toHaveClass("o_open");
     await contains(".interval input").hover();
     expect(".o_tour_pointer").not.toHaveClass("o_open");
@@ -419,7 +419,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
     expect(".o_tour_pointer").toHaveCount(1);
     await contains(".o_tour_pointer").hover();
     await animationFrame();
-    expect(".o_tour_pointer").toHaveText("Scroll up to reach the next step.");
+    expect(".o_tour_pointer span").toHaveText("Scroll up to reach the next step.");
     await contains(".o_tour_pointer").click();
 
     await runAllTimers();
@@ -432,7 +432,7 @@ test("scrolling to next step should update the pointer's height", async (assert)
     await contains("button.inc").hover();
     await animationFrame();
     expect(".o_tour_pointer").toHaveClass("o_open");
-    expect(".o_tour_pointer").toHaveText(content);
+    expect(".o_tour_pointer span").toHaveText(content);
     await contains(".interval input").hover();
     const secondOpenHeight = queryFirst(".o_tour_pointer").style.height;
     const secondOpenWidth = queryFirst(".o_tour_pointer").style.width;


### PR DESCRIPTION
Now, if there is a content in the pointer of the tour, a button-link allows you to stop the tours more easily than activate debug mode and changing the onboarding option in the debug menu.

TASK-ID: 4717949

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
