### PR TITLE
[FIX] sale: fix amount format in down payment description

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -4,7 +4,7 @@
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.fields import Command
-from odoo.tools import format_date, frozendict
+from odoo.tools import format_date, formatLang, frozendict
 
 
 class SaleAdvancePaymentInv(models.TransientModel):
@@ -421,7 +421,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         self.ensure_one()
         context = {'lang': order.partner_id.lang}
         if self.advance_payment_method == 'percentage':
-            name = _("Down payment of %s%%", self.amount)
+            name = _("Down payment of %s%%", formatLang(self.env(context=context), self.amount))
         else:
             name = _('Down Payment')
         del context


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1.  Go to Sales > Create a Quotation
2.  Add Customer > Set Customer's lang to French or German
3.  Add a product, confirm the quotation
4.  Click "Create Invoice" > Select "Down Payment (percentage)"
5.  Set amount (e.g., 20.5%) and create the invoice

<b>Issue:</b>
 - When creating a down payment invoice using the "percentage" option, description text is translated
 correctly to partner's language (e.g., French or German), but amount in description remains formatted
 using English conventions (e.g. "20.5%" instead of "20,5 %" in French or German).

<b>Cause:</b>
- This happens because the amount is inserted as a raw float without localization.

<b>Solution:</b>
- This fix uses `formatLang()` with the correct context to format the percentage amount according to the 
 partner's language (i.e., proper decimal separator).

<b>opw-4743326</b>
