### PR TITLE
[FIX] mrp: avoid auto-consumption when lot number is removed

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1279,7 +1279,7 @@ class MrpProduction(models.Model):
 
             new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
             move._set_quantity_done(new_qty)
-            if not move.manual_consumption or pick_manual_consumption_moves:
+            if (not move.manual_consumption or pick_manual_consumption_moves) and move.quantity:
                 move.picked = True
 
     def _should_postpone_date_finished(self, date_finished):


### PR DESCRIPTION
Issue:
-------------------------
In a Manufacturing Order, when a lot number is assigned to a product and then removed, the components are consumed automatically.

Steps to Reproduce:
-------------------------
- Create an MO for a lot-tracked product.
- Assign a lot number to the product, then remove the assigned lot number.
- Notice that the component is automatically marked as Consumed.

With this commit:
-------------------------
Previously, removing the lot number triggered an `onchange`, which called `_set_qty_producing`. This method auto-marked the component as consumed. As a result, users cannot re-reserve the components using the Check Availability button unless they manually uncheck the Consumed field.

This commit updates the logic to ensure that removing an assigned lot does not trigger component consumption. This allows users to reassign and re-reserve components smoothly in the production flow.

Task ID: [4797711](https://www.odoo.com/odoo/all-tasks/4797711)