### PR TITLE
[FIX] Website: fix mega menu not visible on mobile device

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1692,6 +1692,7 @@ header {
         visibility: hidden;
         margin-top: $o-mega-menu-nav-height !important;
         border: none;
+        height: 100vh;
         max-height: 100vh;
         background-color: o-color('menu-custom') or o-color('menu');
         overflow-x: hidden;


### PR DESCRIPTION
Steps to reproduce the bug:

- Open the website editor.
- Create a mega menu.
- Save changes.
- Open the website in mobile.
- Scroll down to the bottom of the page.
- Open the hamburger menu.
- Click the mega menu link.
- The mega menu doesn't open.

The bug was introduced by commit [1], when the mega menu in the mobile navbar was changed to "position: fixed".

The issue happens because when the page is scrolled, the header gets a "transform: translate" applied to it. This creates a new coordinate system, which breaks the reference for the mega menu’s fixed positioning. As a result, the menu has no reliable reference to calculate its height.

This commit adds a CSS rule setting the height to 100vh as a fix. It ensures the mega menu always takes the full viewport height, regardless of the transformed parent.

[1]: https://github.com/odoo/odoo/commit/dc1a15539227c4c21837a7bce3fc4d81858d60b9

opw-4747373