### PR TITLE
[FIX] website_event_track_quiz: show the community_menu field on event form

### DIFF
--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -16,16 +16,16 @@
             </div>
             <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div name="event_menu_configuration" groups="base.group_no_one">
-                    <label for="website_menu" string="Website Submenu"/>
-                    <field name="website_menu"/>
+                    <label for="website_menu" string="Website Submenu" class="me-0"/>
+                    <field name="website_menu" class="me-3"/>
                     <!-- hidden sub-menus, they are triggered all at once based on "website_menu" -->
                     <field name="introduction_menu" invisible="1"/>
                     <field name="location_menu" invisible="1"/>
                     <field name="register_menu" invisible="1"/>
-                    <label for="menu_register_cta" string="Extra Register Button"/>
-                    <field name="menu_register_cta"/>
-                    <label for="community_menu" string="Community" invisible="1"/>
-                    <field name="community_menu" invisible="1"/>
+                    <label for="menu_register_cta" string="Extra Register Button" class="me-0"/>
+                    <field name="menu_register_cta" class="me-3"/>
+                    <label for="community_menu" string="Community" invisible="1" class="me-0"/>
+                    <field name="community_menu" invisible="1" class="me-3"/>
                 </div>
             </xpath>
         </field>

--- a/addons/website_event/views/event_type_views.xml
+++ b/addons/website_event/views/event_type_views.xml
@@ -7,15 +7,15 @@
         <field name="inherit_id" ref="event.view_event_type_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="after">
-                    <span name="website_menu">
+                    <span name="website_menu" class="me-3">
                         <label for="website_menu" string="Website Submenu"/>
                         <field name="website_menu"/>
                     </span>
-                    <span name="community_menu" invisible="1">
+                    <span name="community_menu" invisible="1" class="me-3">
                         <label for="community_menu" string="Community"/>
                         <field name="community_menu"/>
                     </span>
-                    <span name="menu_register_cta" class="d-inline-block">
+                    <span name="menu_register_cta" class="d-inline-block me-3">
                         <label for="menu_register_cta" string="Register Button"/>
                         <field name="menu_register_cta"/>
                     </span>

--- a/addons/website_event_booth/views/event_event_views.xml
+++ b/addons/website_event_booth/views/event_event_views.xml
@@ -10,8 +10,8 @@
                 <field name="exhibition_map"/>
             </field>
             <field name="website_menu" position="after">
-                <label for="booth_menu"/>
-                <field name="booth_menu"/>
+                <label for="booth_menu" class="me-0"/>
+                <field name="booth_menu" class="me-3"/>
             </field>
         </field>
     </record>

--- a/addons/website_event_booth/views/event_type_views.xml
+++ b/addons/website_event_booth/views/event_type_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//span[@name='website_menu']" position='after'>
-                <span>
+                <span class="me-3">
                     <label for="booth_menu" string="Booth Menu Item"/>
                     <field name="booth_menu"/>
                 </span>

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -16,8 +16,8 @@
                 </button>
             </field>
             <xpath expr="//label[@for='community_menu']" position="before">
-                <label for="exhibitor_menu"/>
-                <field name="exhibitor_menu"/>
+                <label for="exhibitor_menu" class="me-0"/>
+                <field name="exhibitor_menu" class="me-3"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_exhibitor/views/event_type_views.xml
+++ b/addons/website_event_exhibitor/views/event_type_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
                 <xpath expr="//span[@name='community_menu']" position='before'>
-                <span name="exhibitor_menu">
+                <span name="exhibitor_menu" class="me-3">
                     <label for="exhibitor_menu" string="Exhibitors Menu Item"/>
                     <field name="exhibitor_menu"/>
                 </span>

--- a/addons/website_event_track/views/event_event_views.xml
+++ b/addons/website_event_track/views/event_event_views.xml
@@ -16,10 +16,10 @@
                 </button>
             </xpath>
             <xpath expr="//field[@name='website_menu']" position="after">
-                <label for="website_track" string="Showcase Tracks"/>
-                <field name="website_track"/>
-                <label for="website_track_proposal" string="Allow Track Proposals"/>
-                <field name="website_track_proposal"/>
+                <label for="website_track" string="Showcase Tracks" class="me-0"/>
+                <field name="website_track" class="me-3"/>
+                <label for="website_track_proposal" string="Allow Track Proposals" class="me-0"/>
+                <field name="website_track_proposal" class="me-3"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track/views/event_type_views.xml
+++ b/addons/website_event_track/views/event_type_views.xml
@@ -7,11 +7,11 @@
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
                 <xpath expr="//span[@name='website_menu']" position='after'>
-                <span>
+                <span class="me-3">
                     <label for="website_track" string="Tracks Menu Item"/>
                     <field name="website_track"/>
                 </span>
-                <span name="website_track_proposal">
+                <span name="website_track_proposal" class="me-3">
                     <label for="website_track_proposal" string="Track Proposals Menu Item"/>
                     <field name="website_track_proposal"/>
                 </span>

--- a/addons/website_event_track_quiz/views/event_event_views.xml
+++ b/addons/website_event_track_quiz/views/event_event_views.xml
@@ -9,6 +9,9 @@
             <xpath expr="//label[@for='community_menu']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
+            <xpath expr="//field[@name='community_menu']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
On the event form, there is no field for the community label. This commit displays that field, allowing users to specify if the "Community" tab should be displayed for specific events on the website.

Reproduce:
The dev mode must be activated in the settings. On the event form, there is a community label with no field.

related odoo/odoo@2cc1c17193e6ed8841935e5c79a53503a759cf5b

task-4750239