### PR TITLE
[FIX] fleet, mail, web: prevent UI glitch in activity view

### DIFF
--- a/addons/fleet/views/fleet_vehicle_cost_views.xml
+++ b/addons/fleet/views/fleet_vehicle_cost_views.xml
@@ -163,9 +163,7 @@
                 <templates>
                     <div t-name="activity-box">
                         <field name="user_id" widget="many2one_avatar_user"/>
-                        <div class="ms-2">
-                            <field name="vehicle_id" display="full" class="o_text_block"/>
-                        </div>
+                        <field name="vehicle_id" display="full" class="o_text_block"/>
                     </div>
                 </templates>
             </activity>

--- a/addons/mail/static/src/views/web/activity/activity_controller.scss
+++ b/addons/mail/static/src/views/web/activity/activity_controller.scss
@@ -67,6 +67,16 @@
         display: flex;
         flex: 1 1 auto;
         align-items: center;
+        height: 100%;
+
+        span.o_m2o_avatar {
+            width: 32px;
+            justify-content: center;
+
+            i.fa-pencil {
+                font-size: x-large;
+            }
+        }
 
         .o_m2o_avatar > img, > img {
             object-fit: cover;

--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -7,7 +7,7 @@
                 <t t-slot="avatar"/>
             </t>
             <t t-elif="!props.readonly">
-                <span class="o_avatar o_m2o_avatar">
+                <span class="o_avatar o_m2o_avatar d-flex">
                     <a class="o_quick_assign btn-link d-flex align-items-center text-dark" href="#" role="button" tabIndex="-1" aria-label="Assign" data-tooltip="Assign" t-on-click.stop.prevent="(e) => this.openAssignPopover(e.currentTarget)">
                         <i class="fa fa-user-plus"/>
                     </a>


### PR DESCRIPTION
**Before this PR:**
There is a UI glitch in the activity view during owner assignment.
See-https://www.awesomescreenshot.com/image/54530043?key=326a3d74f8d12ed55708afa79ce3efac

**A few impacted views:**
fleet_vehicle_log_contract_view_activity
helpdesk_ticket_view_activity
hr_applicant_view_activity
project_project_view_activity
survey_survey_view_activity

**Technical:**
Since the default display property of a <span> is inline, it also prevents the
width property from taking effect, so it doesn't correctly support properties
such as margin-right here, leading to layout issues. Applying d-flex fixes the
layout problem.

Related ENT PR-https://github.com/odoo/enterprise/pull/82203

**Task**-4637016
