### PR TITLE
[IMP] web, *: manage groups in list view

### DIFF
--- a/addons/base_automation/static/src/group_config_menu_patch.js
+++ b/addons/base_automation/static/src/group_config_menu_patch.js
@@ -3,7 +3,7 @@ import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
-import { KanbanHeader } from "@web/views/kanban/kanban_header";
+import { GroupConfigMenu } from "@web/views/view_components/group_config_menu";
 import { TRIGGER_FILTERS } from "./utils";
 
 const SUPPORTED_TRIGGERS = [
@@ -46,10 +46,11 @@ function enrichContext(context, group) {
     return { ...context, default_trigger: "on_create_or_write" };
 }
 
-patch(KanbanHeader.prototype, {
+patch(GroupConfigMenu.prototype, {
     setup() {
         super.setup();
         this.action = useService("action");
+        this.orm = useService("orm");
     },
 
     /**
@@ -82,7 +83,7 @@ patch(KanbanHeader.prototype, {
     },
 });
 
-registry.category("kanban_header_config_items").add(
+registry.category("group_config_items").add(
     "open_automations",
     {
         label: _t("Automations"),

--- a/addons/base_automation/static/tests/kanban_header_patch.test.js
+++ b/addons/base_automation/static/tests/kanban_header_patch.test.js
@@ -81,15 +81,15 @@ test("basic grouped rendering with automations", async () => {
     expect(".o_kanban_group:first-child .o_kanban_record").toHaveCount(1);
     expect(".o_kanban_group:nth-child(2) .o_kanban_record").toHaveCount(3);
 
-    await contains(".o_kanban_group:eq(0) .o_kanban_config .dropdown-toggle", {
+    await contains(".o_kanban_group:eq(0) .o_group_config .dropdown-toggle", {
         visible: false,
     }).click();
 
     // check available actions in kanban header's config dropdown
     expect(".o-dropdown--menu .o_kanban_toggle_fold").toHaveCount(1);
     expect(".o-dropdown--menu .o_column_automations").toHaveCount(1);
-    expect(".o-dropdown--menu .o_column_edit").toHaveCount(0);
-    expect(".o-dropdown--menu .o_column_delete").toHaveCount(0);
+    expect(".o-dropdown--menu .o_group_edit").toHaveCount(0);
+    expect(".o-dropdown--menu .o_group_delete").toHaveCount(0);
     expect(".o-dropdown--menu .o_column_archive_records").toHaveCount(0);
     expect(".o-dropdown--menu .o_column_unarchive_records").toHaveCount(0);
     expect.verifySteps([]);

--- a/addons/project/static/src/views/project_project_kanban/project_project_group_config_menu.js
+++ b/addons/project/static/src/views/project_project_kanban/project_project_group_config_menu.js
@@ -1,0 +1,23 @@
+import { useService } from "@web/core/utils/hooks";
+import { GroupConfigMenu } from "@web/views/view_components/group_config_menu";
+
+export class ProjectProjectGroupConfigMenu extends GroupConfigMenu {
+    setup() {
+        super.setup();
+        this.action = useService("action");
+    }
+
+    async deleteGroup() {
+        if (this.group.groupByField.name === "stage_id") {
+            const action = await this.group.model.orm.call(
+                this.group.groupByField.relation,
+                "unlink_wizard",
+                [this.group.value],
+                { context: this.group.context }
+            );
+            this.action.doAction(action);
+            return;
+        }
+        super.deleteGroup();
+    }
+}

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_header.js
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_header.js
@@ -1,32 +1,9 @@
 import { KanbanHeader } from "@web/views/kanban/kanban_header";
-import { useService } from "@web/core/utils/hooks";
-import { onWillStart } from "@odoo/owl";
-import { user } from "@web/core/user";
+import { ProjectProjectGroupConfigMenu } from "./project_project_group_config_menu";
 
 export class ProjectProjectKanbanHeader extends KanbanHeader {
-    setup() {
-        super.setup();
-        this.action = useService("action");
-        onWillStart(async () => {
-            this.isProjectManager = await user.hasGroup('project.group_project_manager');
-        });
-    }
-
-    async deleteGroup() {
-        if (this.group.groupByField.name === 'stage_id') {
-            const action = await this.group.model.orm.call(
-                this.group.groupByField.relation,
-                'unlink_wizard',
-                [this.group.value],
-                { context: this.group.context },
-            );
-            this.action.doAction(action);
-            return;
-        }
-        super.deleteGroup();
-    }
-
-    canArchiveGroup() {
-        return super.canArchiveGroup() && this.isProjectManager;
-    }
+    static components = {
+        ...KanbanHeader.components,
+        GroupConfigMenu: ProjectProjectGroupConfigMenu,
+    };
 }

--- a/addons/project/static/src/views/project_project_list/project_project_list_renderer.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_renderer.js
@@ -1,7 +1,13 @@
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { getRawValue } from "@web/views/kanban/kanban_record";
+import { ProjectTaskGroupConfigMenu } from "../project_task_kanban/project_task_group_config_menu";
 
 export class ProjectProjectListRenderer extends ListRenderer {
+    static components = {
+        ...ListRenderer.components,
+        GroupConfigMenu: ProjectTaskGroupConfigMenu,
+    };
+
     isCellReadonly(column, record) {
         let readonly = super.isCellReadonly(column, record);
         const { selection } = this.props.list;

--- a/addons/project/static/src/views/project_task_kanban/project_task_group_config_menu.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_group_config_menu.js
@@ -1,0 +1,42 @@
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
+import { useService } from "@web/core/utils/hooks";
+import { GroupConfigMenu } from "@web/views/view_components/group_config_menu";
+
+export class ProjectTaskGroupConfigMenu extends GroupConfigMenu {
+    setup() {
+        super.setup();
+        this.action = useService("action");
+
+        this.isProjectManager = false;
+        onWillStart(async () => {
+            if (this.props.list.isGroupedByStage) {
+                this.isProjectManager = await user.hasGroup("project.group_project_manager");
+            }
+        });
+    }
+
+    async deleteGroup() {
+        if (this.group.groupByField.name === "stage_id") {
+            const action = await this.group.model.orm.call(
+                this.group.groupByField.relation,
+                "unlink_wizard",
+                [this.group.value],
+                { context: this.group.context }
+            );
+            this.action.doAction(action);
+            return;
+        }
+        super.deleteGroup();
+    }
+
+    canEditGroup() {
+        return super.canEditGroup() && (!this.props.list.isGroupedByStage || this.isProjectManager);
+    }
+
+    canDeleteGroup() {
+        return (
+            super.canDeleteGroup() && (!this.props.list.isGroupedByStage || this.isProjectManager)
+        );
+    }
+}

--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_header.js
@@ -1,42 +1,9 @@
-import { user } from "@web/core/user";
-import { useService } from '@web/core/utils/hooks';
 import { KanbanHeader } from "@web/views/kanban/kanban_header";
-import { onWillStart } from "@odoo/owl";
+import { ProjectTaskGroupConfigMenu } from "./project_task_group_config_menu";
 
 export class ProjectTaskKanbanHeader extends KanbanHeader {
-    setup() {
-        super.setup();
-        this.action = useService('action');
-
-        this.isProjectManager = false;
-        onWillStart(this.onWillStart);
-    }
-
-    async onWillStart() {
-        if (this.props.list.isGroupedByStage) { // no need to check it if not grouped by stage
-            this.isProjectManager = await user.hasGroup('project.group_project_manager');
-        }
-    }
-
-    async deleteGroup() {
-        if (this.group.groupByField.name === 'stage_id') {
-            const action = await this.group.model.orm.call(
-                this.group.groupByField.relation,
-                'unlink_wizard',
-                [this.group.value],
-                { context: this.group.context },
-            );
-            this.action.doAction(action);
-            return;
-        }
-        super.deleteGroup();
-    }
-
-    canEditGroup(group) {
-        return super.canEditGroup(group) && (!this.props.list.isGroupedByStage || this.isProjectManager);
-    }
-
-    canDeleteGroup(group) {
-        return super.canDeleteGroup(group) && (!this.props.list.isGroupedByStage || this.isProjectManager);
-    }
+    static components = {
+        ...KanbanHeader.components,
+        GroupConfigMenu: ProjectTaskGroupConfigMenu,
+    };
 }

--- a/addons/project/static/src/views/project_task_list/project_task_list_renderer.js
+++ b/addons/project/static/src/views/project_task_list/project_task_list_renderer.js
@@ -1,7 +1,13 @@
 import { ListRenderer } from "@web/views/list/list_renderer";
 import { getRawValue } from "@web/views/kanban/kanban_record";
+import { ProjectTaskGroupConfigMenu } from "../project_task_kanban/project_task_group_config_menu";
 
 export class ProjectTaskListRenderer extends ListRenderer {
+    static components = {
+        ...ListRenderer.components,
+        GroupConfigMenu: ProjectTaskGroupConfigMenu,
+    };
+
     /**
      * This method prevents from computing the selection once for each cell when
      * rendering the list. Indeed, `selection` is a getter which browses all

--- a/addons/project/static/tests/tours/personal_stage_tour.js
+++ b/addons/project/static/tests/tours/personal_stage_tour.js
@@ -16,10 +16,10 @@ registry.category("web_tour.tours").add('personal_stage_tour', {
     trigger: "body:not(.o_column_quick_create)",
 }, {
     content: "Check that there is no create column",
-    trigger: "body:not(.o_column_edit)",
+    trigger: "body:not(.o_group_edit)",
 }, {
     content: "Check that there is no create column",
-    trigger: "body:not(.o_column_delete)",
+    trigger: "body:not(.o_group_delete)",
 }, {
     content: "Go to tasks",
     trigger: 'button[data-menu-xmlid="project.menu_project_management"]',
@@ -46,7 +46,7 @@ registry.category("web_tour.tours").add('personal_stage_tour', {
     run: "hover && click .o_kanban_header:contains(Never) .dropdown-toggle",
 }, {
     content: "Try editing inbox",
-    trigger: ".dropdown-item.o_column_edit",
+    trigger: ".dropdown-item.o_group_edit",
     run: "click",
 }, {
     content: "Change title",

--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -83,7 +83,7 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: ".o_kanban_group:nth-child(2) .o_kanban_header",
     run: "hover && click .o_kanban_group:nth-child(2) .o_kanban_header .dropdown-toggle",
 }, {
-    trigger: ".dropdown-item.o_column_edit",
+    trigger: ".dropdown-item.o_group_edit",
     run: "click",
 }, {
     trigger: ".modal .o_field_widget[name=fold] input",

--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -259,7 +259,7 @@ registry.category("web_tour.tours").add("test_open_automation_from_grouped_kanba
     steps: () => [
         {
             trigger: ".o_kanban_header:contains(test tag)",
-            run: "hover && click .o_kanban_view .o_kanban_config button.dropdown-toggle",
+            run: "hover && click .o_kanban_view .o_group_config button.dropdown-toggle",
         },
         {
             trigger: ".dropdown-menu .o_column_automations",

--- a/addons/web/static/src/@types/registries/registries.d.ts
+++ b/addons/web/static/src/@types/registries/registries.d.ts
@@ -49,13 +49,12 @@ declare module "registries" {
             canArchiveGroup: boolean;
             canDeleteGroup: boolean;
             canEditGroup: boolean;
-            canQuickCreate: boolean;
         };
         props: object;
     }
-    export interface KanbanHeaderConfigItemsRegistryItemShape {
+    export interface GroupConfigItemsRegistryItemShape {
         label: String;
-        method: string;
+        method: string | (() => {});
         isVisible: boolean | ((params: KanbanHeaderConfigItemsFnParams) => boolean);
         class: string | ((params: KanbanHeaderConfigItemsFnParams) => (string | string[] | { [key: string]: boolean }));
     }
@@ -92,7 +91,7 @@ declare module "registries" {
         favoriteMenu: FavoriteMenuRegistryItemShape;
         formatters: FormattersRegistryItemShape;
         form_compilers: FormCompilersRegistryItemShape;
-        kanban_header_config_items: KanbanHeaderConfigItemsRegistryItemShape;
+        group_config_items: GroupConfigItemsRegistryItemShape;
         lazy_components: LazyComponentsRegistryItemShape;
         main_components: MainComponentsRegistryItemShape;
         parsers: ParsersRegistryItemShape;

--- a/addons/web/static/src/core/dropdown/dropdown.js
+++ b/addons/web/static/src/core/dropdown/dropdown.js
@@ -139,23 +139,13 @@ export class Dropdown extends Component {
             ...deepMerge(this.nesting.navigationOptions, this.props.navigationOptions),
         });
 
-        // Set up UI active element related behavior ---------------------------
-        let activeEl;
         this.uiService = useService("ui");
-        useEffect(
-            () => {
-                Promise.resolve().then(() => {
-                    activeEl = this.uiService.activeElement;
-                });
-            },
-            () => []
-        );
 
         const getPosition = () => this.position;
         this.popover = usePopover(DropdownPopover, {
             animation: false,
             arrow: false,
-            closeOnClickAway: (target) => this.popoverCloseOnClickAway(target, activeEl),
+            closeOnClickAway: (target) => this.popoverCloseOnClickAway(target),
             closeOnEscape: false, // Handled via navigation and prevents closing root of nested dropdown
             env: this.__owl__.childEnv,
             holdOnHover: this.props.holdOnHover,
@@ -245,12 +235,12 @@ export class Dropdown extends Component {
         }
     }
 
-    popoverCloseOnClickAway(target, activeEl) {
+    popoverCloseOnClickAway(target) {
         const rootNode = target.getRootNode();
         if (rootNode instanceof ShadowRoot) {
             target = rootNode.host;
         }
-        return this.uiService.getActiveElementOf(target) === activeEl;
+        return this.uiService.getActiveElementOf(target) === this.activeEl;
     }
 
     setTargetElement(target) {
@@ -344,6 +334,7 @@ export class Dropdown extends Component {
 
     onOpened() {
         this._focusedElBeforeOpen = document.activeElement;
+        this.activeEl = this.uiService.activeElement;
         this.navigation.update();
         this.props.onOpened?.();
         this.props.onStateChanged?.(true);
@@ -363,6 +354,7 @@ export class Dropdown extends Component {
     onClosed() {
         this.navigation.update();
         this.props.onStateChanged?.(false);
+        delete this.activeEl;
 
         if (this.target) {
             this.target.ariaExpanded = false;

--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -238,6 +238,7 @@ export class DynamicGroupList extends DynamicList {
         };
         const nextConfigGroups = { ...this.config.groups };
         const domain = Domain.and([this.domain, [[this.groupByField.name, "=", id]]]).toList();
+        const groupBy = this.groupBy.slice(1);
         nextConfigGroups[id] = {
             ...commonConfig,
             context,
@@ -248,16 +249,16 @@ export class DynamicGroupList extends DynamicList {
                 ...commonConfig,
                 context,
                 domain: domain,
-                groupBy: [],
+                groupBy,
                 orderBy: this.orderBy,
             },
         };
         this.model._updateConfig(this.config, { groups: nextConfigGroups }, { reload: false });
 
         const data = {
+            aggregates: {},
             count: 0,
             length: 0,
-            records: [],
             __domain: domain,
             [this.groupByField.name]: [id, groupName],
             value: id,
@@ -265,6 +266,11 @@ export class DynamicGroupList extends DynamicList {
             displayName: groupName,
             rawValue: [id, groupName],
         };
+        if (groupBy.length) {
+            data.groups = [];
+        } else {
+            data.records = [];
+        }
 
         const group = this._createGroupDatapoint(data);
         if (lastGroup) {

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -223,22 +223,8 @@
     // Kanban Grouped Layout - Column default
     .o_kanban_group {
         .o_kanban_header > .o_kanban_header_title {
-            &:hover .o_kanban_config,
-            .o_kanban_config.show {
+            &:hover .o_group_config {
                 visibility: visible;
-            }
-
-            .o_kanban_config {
-                visibility: hidden;
-                @include media-breakpoint-down(md) {
-                    visibility: visible;
-                }
-            }
-        }
-
-        .o_kanban_header {
-            .o-dropdown--kanban-config-menu {
-                cursor: default;
             }
         }
 

--- a/addons/web/static/src/views/kanban/kanban_header.scss
+++ b/addons/web/static/src/views/kanban/kanban_header.scss
@@ -1,4 +1,0 @@
-
-.o-dropdown--kanban-config-menu {
-    cursor: default;
-}

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -17,20 +17,7 @@
                     <span t-if="!progressBar and !props.list.model.useSampleModel" t-esc="'(' + group.count + ')'"/>
                 </div>
                 <t t-if="env.isSmall or !group.isFolded">
-                    <div class="o_kanban_config d-print-none">
-                        <Dropdown menuClass="'o-dropdown--kanban-config-menu'" position="'bottom-end'">
-                            <button class="btn px-2">
-                                <i class="fa fa-gear opacity-50 opacity-100-hover" role="img" aria-label="Settings" title="Settings"/>
-                            </button>
-                            <t t-set-slot="content">
-                                <t t-foreach="configItems" t-as="item" t-key="item.key">
-                                    <DropdownItem t-if="item.isVisible" class="item.class" onSelected="() => this[item.method]()">
-                                        <t t-esc="item.label"/>
-                                    </DropdownItem>
-                                </t>
-                            </t>
-                        </Dropdown>
-                    </div>
+                    <GroupConfigMenu t-props="configMenuProps"/>
                     <button t-if="canQuickCreate()" class="o_kanban_quick_add d-print-none btn pe-2 me-n2" t-on-click="() => this.quickCreate()">
                         <i class="fa fa-plus opacity-75 opacity-100-hover" role="img" aria-label="Quick add" title="Quick add"/>
                     </button>

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -190,6 +190,8 @@ export class ListArchParser {
                     ...getActiveActions(xmlDoc),
                     exportXlsx: exprToBoolean(xmlDoc.getAttribute("export_xlsx"), true),
                     createGroup: exprToBoolean(xmlDoc.getAttribute("group_create"), true),
+                    editGroup: exprToBoolean(xmlDoc.getAttribute("group_edit"), true),
+                    deleteGroup: exprToBoolean(xmlDoc.getAttribute("group_delete"), true),
                 };
                 treeAttr.activeActions = activeActions;
 

--- a/addons/web/static/src/views/list/list_arch_parser.js
+++ b/addons/web/static/src/views/list/list_arch_parser.js
@@ -189,6 +189,7 @@ export class ListArchParser {
                 const activeActions = {
                     ...getActiveActions(xmlDoc),
                     exportXlsx: exprToBoolean(xmlDoc.getAttribute("export_xlsx"), true),
+                    createGroup: exprToBoolean(xmlDoc.getAttribute("group_create"), true),
                 };
                 treeAttr.activeActions = activeActions;
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -413,8 +413,9 @@ export class ListRenderer extends Component {
     }
 
     get canCreateGroup() {
-        const { activeActions } = this.props.archInfo;
-        return activeActions.createGroup && this.props.list.groupByField.type === "many2one";
+        const { archInfo, list, readonly } = this.props;
+        const { activeActions } = archInfo;
+        return !readonly && activeActions.createGroup && list.groupByField.type === "many2one";
     }
 
     get canResequenceRows() {

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -266,6 +266,9 @@
 
         // Grouped list views
         tbody > tr.o_group_header {
+            &:hover .o_group_config {
+                visibility: visible;
+            }
             > th,
             > td {
                 vertical-align: middle;

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -189,11 +189,15 @@
         }
 
         tfoot {
+            .o_list_group_input {
+                max-width: 300px;
+            }
             > tr > td {
                 color: $o-list-footer-color;
                 background-color: $o-list-footer-bg-color;
                 font-weight: $o-list-footer-font-weight;
                 @include o-text-overflow(table-cell);
+                vertical-align: baseline;
             }
 
             .o_list_number {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -234,6 +234,7 @@
                     <div t-if="showGroupPager(group)" t-on-click.stop="" class="ms-auto">
                         <Pager t-props="getGroupPagerProps(group)"/>
                     </div>
+                    <GroupConfigMenu t-if="showGroupConfigMenu(group)" t-props="getGroupConfigMenuProps(group)"/>
                 </div>
             </th>
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -93,15 +93,32 @@
                 </tbody>
                 <tfoot t-on-click="() => props.list.leaveEditMode()" class="o_list_footer cursor-default" t-att-class="{o_sample_data_disabled: props.list.model.useSampleModel}">
                     <tr>
-                        <td t-if="hasSelectors"/>
-                        <t t-foreach="columns" t-as="column" t-key="column.id">
-                            <t t-set="aggregate" t-value="aggregates[column.name]"/>
-                            <td t-if="aggregate" class="o_list_number" >
-                                <span t-esc="aggregate.value" t-att-data-tooltip="aggregate.help"/>
-                            </td>
-                            <td t-elif="column.type != 'field'" class="w-print-auto"/>
-                            <td t-else=""/>
-                        </t>
+                        <td t-att-colspan="getGroupNameCellColSpan()">
+                            <button
+                                t-if="props.list.isGrouped and canCreateGroup and !state.showGroupInput"
+                                class="btn btn-link o_list_group_add"
+                                t-on-click.stop.prevent="() => this.state.showGroupInput = true"
+                            >
+                                Add a <t t-out="this.props.list.groupByField.string"/>
+                            </button>
+                            <div t-elif="state.showGroupInput" class="input-group mb-1">
+                                <input type="text"
+                                    class="form-control bg-view o_list_group_input"
+                                    t-attf-placeholder="{{ this.props.list.groupByField.string }}..."
+                                    t-ref="groupInput"
+                                    t-on-keydown="(ev) => this.onGroupInputKeydown(ev)"
+                                />
+                                <button class="btn btn-primary o_list_group_confirm" type="button" t-on-click="addNewGroup">
+                                    <i class="fa fa-check"/>
+                                </button>
+                                <button class="btn btn-danger o_list_group_cancel" type="button" t-on-click="() => this.state.showGroupInput = false">
+                                    <i class="fa fa-times"/>
+                                </button>
+                            </div>
+                        </td>
+                        <td t-foreach="getAggregateColumns()" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
+                            <span t-if="column.type === 'field' and aggregates[column.name]" t-esc="aggregates[column.name].value" t-att-data-tooltip="aggregates[column.name].help"/>
+                        </td>
                         <td t-if="hasOpenFormViewColumn" class="w-print-0 p-print-0"/>
                         <td t-if="displayOptionalFields or activeActions.onDelete" class="w-print-0 p-print-0" />
                     </tr>

--- a/addons/web/static/src/views/view_components/group_config_menu.js
+++ b/addons/web/static/src/views/view_components/group_config_menu.js
@@ -1,0 +1,103 @@
+import { Component } from "@odoo/owl";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { isRelational } from "@web/model/relational_model/utils";
+import { FormViewDialog } from "@web/views/view_dialogs/form_view_dialog";
+
+export class GroupConfigMenu extends Component {
+    static template = "web.GroupConfigMenu";
+    static components = { Dropdown, DropdownItem };
+    static props = {
+        activeActions: { type: Object },
+        configItems: { type: Object },
+        deleteGroup: { type: Function },
+        dialogClose: { type: Array },
+        group: { type: Object },
+        list: { type: Object },
+    };
+    setup() {
+        this.dialog = useService("dialog");
+    }
+
+    get configItems() {
+        const args = { permissions: this.permissions };
+        return this.props.configItems.map(([key, desc]) => ({
+            key,
+            label: desc.label,
+            class: typeof desc.class === "function" ? desc.class(args) : desc.class,
+            isVisible: typeof desc.isVisible === "function" ? desc.isVisible(args) : desc.isVisible,
+            method: typeof desc.method === "function" ? desc.method : this[desc.method].bind(this),
+        }));
+    }
+
+    get group() {
+        return this.props.group;
+    }
+
+    get permissions() {
+        return ["canDeleteGroup", "canEditGroup"].reduce((o, key) => {
+            Object.defineProperty(o, key, { get: () => this[key]() });
+            return o;
+        }, {});
+    }
+
+    deleteGroup() {
+        this.dialog.add(ConfirmationDialog, {
+            body: _t("Are you sure you want to delete this column?"),
+            confirm: () => this.props.deleteGroup(this.group),
+            confirmLabel: _t("Delete"),
+            cancel: () => {},
+        });
+    }
+
+    editGroup() {
+        const { context, displayName, groupByField, value } = this.group;
+        this.props.dialogClose.push(
+            this.dialog.add(FormViewDialog, {
+                context,
+                resId: value,
+                resModel: groupByField.relation,
+                title: _t("Edit: %s", displayName),
+                onRecordSaved: () => this.props.list.load(),
+            })
+        );
+    }
+
+    canDeleteGroup() {
+        const { deleteGroup } = this.props.activeActions;
+        const { groupByField, value } = this.group;
+        return deleteGroup && isRelational(groupByField) && value;
+    }
+
+    canEditGroup() {
+        const { editGroup } = this.props.activeActions;
+        const { groupByField, value } = this.group;
+        return editGroup && isRelational(groupByField) && value;
+    }
+}
+
+const groupConfigItems = registry.category("group_config_items");
+groupConfigItems.add(
+    "edit_group",
+    {
+        label: _t("Edit"),
+        isVisible: ({ permissions }) => permissions.canEditGroup,
+        class: "o_group_edit",
+        method: "editGroup",
+    },
+    { sequence: 20 }
+);
+groupConfigItems.add(
+    "delete_group",
+    {
+        label: _t("Delete"),
+        isVisible: ({ permissions }) => permissions.canDeleteGroup,
+        class: "o_group_delete",
+        method: "deleteGroup",
+    },
+    { sequence: 30 }
+);

--- a/addons/web/static/src/views/view_components/group_config_menu.scss
+++ b/addons/web/static/src/views/view_components/group_config_menu.scss
@@ -1,0 +1,14 @@
+.o_group_config.show {
+    visibility: visible;
+}
+
+.o_group_config {
+    visibility: hidden;
+    @include media-breakpoint-down(md) {
+        visibility: visible;
+    }
+}
+
+.o-dropdown--group-config-menu {
+    cursor: default;
+}

--- a/addons/web/static/src/views/view_components/group_config_menu.xml
+++ b/addons/web/static/src/views/view_components/group_config_menu.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.GroupConfigMenu">
+        <div class="o_group_config d-print-none d-flex">
+            <Dropdown menuClass="'o-dropdown--group-config-menu'" position="'bottom-end'">
+                <button class="btn px-2 py-0" tabindex="-1">
+                    <i class="fa fa-gear opacity-50 opacity-100-hover" role="img" aria-label="Settings" title="Settings"/>
+                </button>
+                <t t-set-slot="content">
+                    <t t-foreach="configItems" t-as="item" t-key="item.key">
+                        <DropdownItem t-if="item.isVisible" class="item.class" onSelected="() => item.method()">
+                            <t t-esc="item.label"/>
+                        </DropdownItem>
+                    </t>
+                </t>
+            </Dropdown>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/tests/_framework/kanban_test_helpers.js
+++ b/addons/web/static/tests/_framework/kanban_test_helpers.js
@@ -127,7 +127,7 @@ export async function quickCreateKanbanRecord(columnIndex = 0) {
  */
 export async function toggleKanbanColumnActions(columnIndex = 0) {
     const column = getKanbanColumn(columnIndex);
-    await contains(".o_kanban_config .dropdown-toggle", { root: column, visible: false }).click();
+    await contains(".o_group_config .dropdown-toggle", { root: column, visible: false }).click();
     return (buttonText) => {
         const menu = getDropdownMenu(column);
         return contains(`.dropdown-item:contains(/\\b${buttonText}\\b/i)`, { root: menu }).click();

--- a/addons/web/static/tests/legacy/views/kanban/helpers.js
+++ b/addons/web/static/tests/legacy/views/kanban/helpers.js
@@ -106,17 +106,6 @@ export async function validateColumn(target) {
     await click(target, ".o_column_quick_create .o_kanban_add");
 }
 
-export async function toggleColumnActions(target, columnIndex) {
-    const group = getColumn(target, columnIndex);
-    await click(group, ".o_kanban_config .dropdown-toggle");
-    const buttons = getDropdownMenu(target, group).querySelectorAll(".dropdown-item");
-    return (buttonText) => {
-        const re = new RegExp(`\\b${buttonText}\\b`, "i");
-        const button = [...buttons].find((b) => re.test(b.innerText));
-        return click(button);
-    };
-}
-
 export async function loadMore(target, columnIndex) {
     await click(getColumn(target, columnIndex), ".o_kanban_load_more button");
 }

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -506,12 +506,10 @@ test("basic grouped rendering", async () => {
 
     // check available actions in kanban header's config dropdown
     expect(".o-dropdown--menu .o_kanban_toggle_fold").toHaveCount(1);
-    expect(".o_kanban_header:first-child .o_kanban_config .o_column_edit").toHaveCount(0);
-    expect(".o_kanban_header:first-child .o_kanban_config .o_column_delete").toHaveCount(0);
-    expect(".o_kanban_header:first-child .o_kanban_config .o_column_archive_records").toHaveCount(
-        0
-    );
-    expect(".o_kanban_header:first-child .o_kanban_config .o_column_unarchive_records").toHaveCount(
+    expect(".o_kanban_header:first-child .o_group_config .o_group_edit").toHaveCount(0);
+    expect(".o_kanban_header:first-child .o_group_config .o_group_delete").toHaveCount(0);
+    expect(".o_kanban_header:first-child .o_group_config .o_column_archive_records").toHaveCount(0);
+    expect(".o_kanban_header:first-child .o_group_config .o_column_unarchive_records").toHaveCount(
         0
     );
 
@@ -5615,10 +5613,10 @@ test("delete a column in grouped on m2o", async () => {
             message: "should be able to fold the column",
         }
     );
-    expect(queryAll(".o_column_edit", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(1, {
+    expect(queryAll(".o_group_edit", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(1, {
         message: "should be able to edit the column",
     });
-    expect(queryAll(".o_column_delete", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(1, {
+    expect(queryAll(".o_group_delete", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(1, {
         message: "should be able to delete the column",
     });
     expect(
@@ -5660,10 +5658,10 @@ test("delete a column in grouped on m2o", async () => {
             message: "should be able to fold the column",
         }
     );
-    expect(queryAll(".o_column_edit", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(0, {
+    expect(queryAll(".o_group_edit", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(0, {
         message: "should be able to edit the column",
     });
-    expect(queryAll(".o_column_delete", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(0, {
+    expect(queryAll(".o_group_delete", { root: getKanbanColumnDropdownMenu(0) })).toHaveCount(0, {
         message: "should not be able to delete the column",
     });
     expect(
@@ -7247,7 +7245,7 @@ test("empty grouped kanban with sample data: cannot fold a column", async () => 
 
     await toggleKanbanColumnActions(0);
 
-    expect(getDropdownMenu(".o_kanban_config").querySelector(".o_kanban_toggle_fold")).toHaveClass(
+    expect(getDropdownMenu(".o_group_config").querySelector(".o_kanban_toggle_fold")).toHaveClass(
         "disabled"
     );
 });
@@ -7898,7 +7896,7 @@ test("open config dropdown on kanban with records and groups draggable off", asy
         groupBy: ["product_id"],
     });
 
-    expect(".o_kanban_group .o_kanban_config").toHaveCount(2);
+    expect(".o_kanban_group .o_group_config").toHaveCount(2);
     expect(".o-dropdown--menu").toHaveCount(0);
 
     await toggleKanbanColumnActions(0);
@@ -12935,7 +12933,7 @@ test("Kanban: no reset of the groupby when a non-empty column is deleted", async
 
     // check availability of delete action in kanban header's config dropdown
     await toggleKanbanColumnActions(2);
-    expect(queryAll(".o_column_delete", { root: getKanbanColumnDropdownMenu(2) })).toHaveCount(1, {
+    expect(queryAll(".o_group_delete", { root: getKanbanColumnDropdownMenu(2) })).toHaveCount(1, {
         message: "should be able to delete the column",
     });
 

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -362,6 +362,35 @@ test("SelectCreateDialog list view is readonly", async () => {
 });
 
 test.tags("desktop");
+test("SelectCreateDialog list view is readonly (grouped by m2o)", async () => {
+    Partner._views.search = /* xml */ `
+        <search>
+            <group expand="0" string="Group By">
+                <filter name="groupby_instrument" context="{'group_by' : 'instrument'}"/>
+            </group>
+        </search>
+    `;
+    Partner._views.list = /* xml */ `
+        <list string="Partner">
+            <field name="name"/>
+            <field name="foo"/>
+        </list>
+    `;
+
+    await mountWithCleanup(WebClient);
+
+    getService("dialog").add(SelectCreateDialog, {
+        resModel: "partner",
+        context: {
+            search_default_groupby_instrument: true,
+        },
+    });
+    await animationFrame();
+    expect(".o_group_header").toHaveCount(1);
+    expect(".o_list_footer .o_list_group_add").toHaveCount(0);
+});
+
+test.tags("desktop");
 test("SelectCreateDialog cascade x2many in create mode on desktop", async () => {
     expect.assertions(5);
 

--- a/addons/website/static/src/components/views/theme_preview_kanban.scss
+++ b/addons/website/static/src/components/views/theme_preview_kanban.scss
@@ -90,7 +90,7 @@
                 }
 
                 &:hover, &.show {
-                    .o_kanban_config {
+                    .o_group_config {
                         display: none;
                     }
                 }


### PR DESCRIPTION
First commit adds the functionnality to quick create groups in lists grouped by a many2one field. The button to do so is added to the footer when possible and behaves similarly to kanban's column quick create. It is possible to disable this feature with the group_create arch attribute (as is done in kanban).

Second commit enables users to configure groups in the list view, similar to the existing configuration menu available in kanban headers. To achieve this, the configuration menu logic was extracted from the KanbanHeader and moved to a new shared component (GroupConfigMenu), now used by both KanbanHeader and ListRenderer.
The fold action remains specific to kanban headers and is consistently displayed at the top of the configuration menu.

Third commit fixes a race condition between the useEffect in dropdown.js and the UI service's deactivateElement method.

The issue occurred when closing a dialog that triggered the mounting of new dropdowns underneath. In such cases, a dropdown could mistakenly register the modal element as its initial active element before it was deactivated by the UI service. As a result, the dropdown would fail to close on subsequent click-away events, since its registered active element no longer matched the current one (which had already been destroyed).

The fix ensures that the initial active element is only registered when the dropdown is actually opened, and it is cleared when the dropdown is closed.

Since this issue is difficult to reproduce and was only observed in a specific scenario (group configuration dropdowns in a list view within the web client introduced in second commit), the test focuses solely on that case.

task-4613135