### PR TITLE
[IMP] web: list_view: incremental update in multi edit

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -176,7 +176,6 @@
             'barcodes/static/src/js/barcode_parser.js',
             'barcodes_gs1_nomenclature/static/src/js/barcode_parser.js',
             'barcodes_gs1_nomenclature/static/src/js/barcode_service.js',
-            'web/static/src/views/fields/parsers.js',
             # report download utils
             'web/static/src/webclient/actions/reports/utils.js',
             # PoS files

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -75,6 +75,7 @@
             "web/static/src/core/utils/render.js",
             "pos_self_order/static/src/app/store/order_change_receipt_template.xml",
             "account/static/src/helpers/*.js",
+            'web/static/src/model/relational_model/operation.js',
             "web/static/src/views/fields/parsers.js",
 
             # Related models from point_of_sale

--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -92,6 +92,15 @@ class Base(models.AbstractModel):
             self = self.browse(next_id)
         return self.with_context(bin_size=True).web_read(specification)
 
+    def web_save_multi(self, vals_list: list[dict], specification: dict[str, dict]) -> list[dict]:
+        if len(self) != len(vals_list):
+            raise ValueError("Each record must have a corresponding vals entry.")
+
+        for record, val in zip(self, vals_list):
+            record.write(val)
+
+        return self.with_context(bin_size=True).web_read(specification)
+
     @api.readonly
     def web_read(self, specification: dict[str, dict]) -> list[dict]:
         fields_to_read = list(specification) or ['id']

--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -90,6 +90,7 @@ export const UPDATE_METHODS = [
     "create",
     "write",
     "web_save",
+    "web_save_multi",
     "action_archive",
     "action_unarchive",
 ];
@@ -361,6 +362,24 @@ export class ORM {
         validatePrimitiveList("ids", "number", ids);
         validateObject("data", data);
         return this.call(model, "web_save", [ids, data], kwargs);
+    }
+
+    /**
+     * @param {string} model
+     * @param {number[]} ids
+     * @param {Object[]} data
+     * @param {Object} [kwargs={}]
+     * @param {Object} [kwargs.specification]
+     * @param {Object} [kwargs.context]
+     * @returns {Promise<any[]>}
+     */
+    async webSaveMulti(model, ids, data, kwargs = {}) {
+        validatePrimitiveList("ids", "number", ids);
+        validateArray("data", data);
+        data.forEach((d) => {
+            validateObject("data item", d);
+        });
+        return this.call(model, "web_save_multi", [ids, data], kwargs);
     }
 }
 

--- a/addons/web/static/src/model/relational_model/operation.js
+++ b/addons/web/static/src/model/relational_model/operation.js
@@ -1,0 +1,21 @@
+export class Operation {
+    constructor(operator, operand) {
+        this.operator = operator;
+        this.operand = operand;
+    }
+
+    compute(value) {
+        switch (this.operator) {
+            case "+":
+                return value + this.operand;
+            case "-":
+                return value - this.operand;
+            case "*":
+                return value * this.operand;
+            case "/":
+                return value / this.operand;
+            default:
+                throw new Error(`Unsupported operator: ${this.operator}`);
+        }
+    }
+}

--- a/addons/web/static/src/views/fields/float/float_field.js
+++ b/addons/web/static/src/views/fields/float/float_field.js
@@ -49,7 +49,9 @@ export class FloatField extends Component {
     }
 
     parse(value) {
-        return this.props.inputType === "number" ? Number(value) : parseFloat(value);
+        return this.props.inputType === "number"
+            ? Number(value)
+            : parseFloat(value, { allowOperation: true });
     }
 
     get formattedValue() {

--- a/addons/web/static/src/views/fields/integer/integer_field.js
+++ b/addons/web/static/src/views/fields/integer/integer_field.js
@@ -32,7 +32,7 @@ export class IntegerField extends Component {
         useInputField({
             getValue: () => this.formattedValue,
             refName: "numpadDecimal",
-            parse: (v) => parseInteger(v),
+            parse: (v) => parseInteger(v, { allowOperation: true }),
         });
         useNumpadDecimal();
     }

--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -42,7 +42,7 @@ export class MonetaryField extends Component {
         return {
             getValue: () => this.formattedValue,
             refName: "numpadDecimal",
-            parse: parseMonetary,
+            parse: (v) => parseMonetary(v, { allowOperation: true }),
         };
     }
 

--- a/addons/web/static/src/views/list/list_confirmation_dialog.js
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.js
@@ -1,7 +1,8 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
-import { Field, fieldVisualFeedback } from "@web/views/fields/field";
 import { useAutofocus } from "@web/core/utils/hooks";
+import { Operation } from "@web/model/relational_model/operation";
+import { Field, fieldVisualFeedback } from "@web/views/fields/field";
 
 import { Component } from "@odoo/owl";
 
@@ -11,12 +12,9 @@ export class ListConfirmationDialog extends Component {
     static props = {
         close: Function,
         title: {
-            validate: (m) => {
-                return (
-                    typeof m === "string" ||
-                    (typeof m === "object" && typeof m.toString === "function")
-                );
-            },
+            validate: (m) =>
+                typeof m === "string" ||
+                (typeof m === "object" && typeof m.toString === "function"),
             optional: true,
         },
         confirm: { type: Function, optional: true },
@@ -26,6 +24,7 @@ export class ListConfirmationDialog extends Component {
         nbRecords: Number,
         nbValidRecords: Number,
         record: Object,
+        changes: Object,
     };
     static defaultProps = {
         title: _t("Confirmation"),
@@ -51,6 +50,12 @@ export class ListConfirmationDialog extends Component {
         });
     }
 
+    get showTip() {
+        return this.props.fields.some((field) =>
+            ["monetary", "integer", "float"].includes(field.fieldNode?.type)
+        );
+    }
+
     _cancel() {
         if (this.props.cancel) {
             this.props.cancel();
@@ -74,5 +79,9 @@ export class ListConfirmationDialog extends Component {
             ...field.fieldNode,
             readonly: true,
         }).empty;
+    }
+
+    isValueOperation(field) {
+        return this.props.changes[field.name] instanceof Operation;
     }
 }

--- a/addons/web/static/src/views/list/list_confirmation_dialog.xml
+++ b/addons/web/static/src/views/list/list_confirmation_dialog.xml
@@ -24,12 +24,22 @@
                                     <td>Update to:</td>
                                     <td style="pointer-events: none;">
                                         <span t-if="isValueEmpty(field)">None</span>
+                                        <span t-elif="isValueOperation(field)" t-att-name="field.name">
+                                            <t t-out="field.label + ' ' + props.changes[field.name].operator + ' ' + props.changes[field.name].operand"></t>
+                                        </span>
                                         <Field t-else="" name="field.name" record="props.record" type="field.widget" readonly="true" fieldInfo="field.fieldNode"/>
                                     </td>
                                 </tr>
                             </t>
                         </tbody>
                     </table>
+                    <div t-if="showTip" class="alert alert-info d-flex align-items-center mt-3">
+                        <i class="fa fa-lightbulb-o fa-lg me-4"></i>
+                        <div class="text-muted">
+                            <div>Use the operators "+=", "-=", "*=" and "/=" to update the current value.</div>
+                            <div>For example, if the value is "1" and you enter "+=2", it will be updated to "3".</div>
+                        </div>
+                    </div>
                 </div>
             </main>
             <t t-set-slot="footer">

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -505,7 +505,7 @@ export class ListController extends Component {
 
     onWillSaveMulti(editedRecord, changes, validSelectedRecords) {
         if (this.hasMousedownDiscard) {
-            this.nextActionAfterMouseup = () => this.model.root.multiSave(editedRecord);
+            this.nextActionAfterMouseup = () => this.model.root.multiSave(editedRecord, changes);
             return false;
         }
         if (validSelectedRecords.length > 1) {
@@ -534,6 +534,7 @@ export class ListController extends Component {
                             widget: fieldNode && fieldNode.widget,
                         };
                     }),
+                    changes,
                     nbRecords: selection.length,
                     nbValidRecords: validSelectedRecords.length,
                     record: editedRecord,

--- a/addons/web/static/tests/_framework/mock_server/mock_model.js
+++ b/addons/web/static/tests/_framework/mock_server/mock_model.js
@@ -2918,6 +2918,36 @@ export class Model extends Array {
     }
 
     /**
+     * @param {number[]} ids - List of record IDs to update
+     * @param {Partial<ModelRecord>[]} values - List of value dicts (same length/order as `ids`)
+     * @param {Record<string, any>} specification - Fields to return after save
+     * @returns {any[]} - List of saved records
+     */
+    web_save_multi(ids, values, specification) {
+        const kwargs = getKwArgs(arguments, "ids", "values", "specification");
+        ({ ids, values, specification } = kwargs);
+
+        if (!Array.isArray(ids) || !Array.isArray(values) || ids.length !== values.length) {
+            throw new Error("web_save_multi requires `ids` and `values` of the same length.");
+        }
+
+        const results = [];
+
+        for (let i = 0; i < ids.length; i++) {
+            const id = ids[i];
+            const val = values[i];
+            const res = this.web_save([id], val, specification);
+            if (Array.isArray(res)) {
+                results.push(...res);
+            } else {
+                results.push(res);
+            }
+        }
+
+        return results;
+    }
+
+    /**
      * @param {DomainListRepr} domain
      * @param {Record<string, any>} specification
      * @param {number} [offset]

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -27,3 +27,4 @@ from . import test_perf_load_menu
 from . import test_pivot_export
 from . import test_res_partner_properties
 from . import test_action
+from . import test_web_save_multi

--- a/addons/web/tests/test_web_save_multi.py
+++ b/addons/web/tests/test_web_save_multi.py
@@ -1,0 +1,34 @@
+from odoo.tests.common import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWebSaveMulti(HttpCase):
+
+    def test_web_save_multi(self):
+        partner1 = self.env['res.partner'].create({'name': 'Test Partner 1', 'credit_limit': 100.0, 'customer_rank': 0})
+        partner2 = self.env['res.partner'].create({'name': 'Test Partner 2', 'credit_limit': 200.0, 'customer_rank': 0})
+
+        self.authenticate('admin', 'admin')
+
+        partners = self.env['res.partner'].browse([partner1.id, partner2.id])
+
+        vals = [
+            {"name": "Updated Partner 1", "credit_limit": 150.0, "customer_rank": 1},
+            {"credit_limit": 250.0, "customer_rank": 1},
+        ]
+
+        specification = {
+            "name": {"type": "char"},
+            "credit_limit": {"type": "float"},
+        }
+
+        result = partners.web_save_multi(vals, specification)
+
+        names = [rec["name"] for rec in result]
+        credit_limits = {rec["name"]: rec["credit_limit"] for rec in result}
+
+        self.assertIn("Updated Partner 1", names)
+        self.assertIn("Test Partner 2", names)
+
+        self.assertEqual(credit_limits["Updated Partner 1"], 150.0)
+        self.assertEqual(credit_limits["Test Partner 2"], 250.0)


### PR DESCRIPTION
In this commit, we're adding a new feature. In the list view,
in the multi-edit mode, we're adding the ability to update all
selected records by applying one of the following operations to
the modified field:
*=, /=, +=, -=

1. Select the records in the list view
2. Modify one of the records with one of the above operations
3. The confirmation window summarizes the modification
4. Confirm
5. An RPC is sent on a custom route to apply the operation to all
records

task-id~3880707