### PR TITLE
[ADD] orm: condition operator 'any!' to simplify joins in queries

### DIFF
--- a/addons/account/models/mail_message.py
+++ b/addons/account/models/mail_message.py
@@ -161,12 +161,12 @@ class MailMessage(models.Model):
             operator in ('in', 'not in') and any(isinstance(v, str) for v in value)
         ):
             res_id_domain = [('res_id', 'in', self.env[model]._search([('display_name', operator, value)]))]
-        elif operator in ('any', 'not any'):
+        elif operator in ('any', 'not any', 'any!', 'not any!'):
             if isinstance(value, Domain):
                 query = self.env[model]._search(value)
             else:
                 query = value
-            res_id_domain = [('res_id', 'in' if operator == 'any' else 'not in', query)]
+            res_id_domain = [('res_id', 'in' if operator in ('any', 'any!') else 'not in', query)]
         elif operator in ('in', 'not in'):
             res_id_domain = [('res_id', operator, value)]
         else:

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -358,10 +358,10 @@ class HrEmployee(models.Model):
         self.search([])._compute_current_version_id()
 
     def _search_version_id(self, operator, value):
-        if operator == 'any':
-            return [('current_version_id', operator, value)]
-        domain = [('id', operator, value)]
-        return [('id', 'in', self.env['hr.version']._search(domain).select('employee_id'))]
+        if operator in ('any', 'any!'):
+            return Domain('current_version_id', operator, value)
+        domain = Domain('id', operator, value)
+        return Domain('id', 'in', self.env['hr.version']._search(domain).select('employee_id'))
 
     def _field_to_sql(self, alias: str, field_expr: str, query: (Query | None) = None, flush: bool = True) -> SQL:
         """This is required to search for the related fields of version_id as version_id is not stored"""

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -428,9 +428,9 @@ class ProjectTask(models.Model):
         if Domain.is_negative_operator(operator):
             return NotImplemented
         field_name = 'display_name' if any(isinstance(v, str) for v in value) or value == '' else 'id'  # noqa: PLC1901
-        domain = [(field_name, operator, value), ('user_id', '=', self.env.uid)]
+        domain = Domain(field_name, operator, value) & Domain('user_id', '=', self.env.uid)
         personal_stages = self.env['project.task.stage.personal']._search(domain)
-        return [('id', 'in', personal_stages.subselect('task_id'))]
+        return Domain('id', 'in', personal_stages.subselect('task_id'))
 
     @api.model
     def _get_default_personal_stage_create_vals(self, user_id):

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -198,6 +198,8 @@ class IrActionsReport(models.Model):
             models = models.search(Domain('display_name', operator, value))
         elif isinstance(value, Domain):
             models = models.search(value)
+        elif operator == 'any!':
+            models = models.sudo().search(Domain('id', operator, value))
         elif operator == 'any' or isinstance(value, int):
             models = models.search(Domain('id', operator, value))
         elif operator == 'in':

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -6,6 +6,7 @@ from datetime import date
 from odoo import api, fields, models, tools
 from odoo.api import SUPERUSER_ID
 from odoo.exceptions import ValidationError
+from odoo.fields import Domain
 from odoo.tools import SQL
 
 
@@ -226,6 +227,6 @@ class IrDefault(models.Model):
         fallback = field.get_company_dependent_fallback(model)
         try:
             record = model.new({field_name: field.convert_to_write(fallback, model)})
-            return bool(record.filtered_domain([(field_expr, operator, value)]))
+            return bool(record.filtered_domain(Domain(field_expr, operator, value)))
         except ValueError:
             return None

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -473,7 +473,7 @@ class ResUsers(models.Model):
 
     @api.model
     def _search_res_users_settings_id(self, operator, operand):
-        return [('res_users_settings_ids', operator, operand)]
+        return Domain('res_users_settings_ids', operator, operand)
 
     @api.onchange('login')
     def on_change_login(self):

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -836,6 +836,14 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         with self.assertRaises(ValueError):
             Domain('foo', 'xxx', 'bar')
 
+        # special case for any! operators
+        for operator in ('any!', 'not any!'):
+            Domain('foo', operator, [])
+            with self.assertRaises(ValueError):
+                Domain([('foo', operator, [])])
+            dom = Domain([('foo', operator, [])], internal=True)
+            self.assertIsInstance(dom.value, Domain, "subdomain must be parsed")
+
         # &| operators create new instances
         and_domain_2 = and_domain
         and_domain_2 &= Domain('x', '>', 3)

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -452,6 +452,7 @@ class TestOrmRelated(models.Model):
     message_currency = fields.Many2one(related="message.author", string='Message Author')
 
     foo_id = fields.Many2one('test_orm.related_foo')
+    foo_ids = fields.Many2many('test_orm.related_foo', string='Foos')
 
     foo_name = fields.Char('foo_name', related='foo_id.name', related_sudo=False)
     foo_name_sudo = fields.Char('foo_name_sudo', related='foo_id.name', related_sudo=True)
@@ -474,6 +475,7 @@ class TestOrmRelated_Foo(models.Model):
 
     name = fields.Char()
     bar_id = fields.Many2one('test_orm.related_bar')
+    foo_ids = fields.One2many('test_orm.related', 'foo_id', string='Foos')
     bar_name = fields.Char('bar_name', related='bar_id.name', related_sudo=False)
     bar_alias = fields.Many2one(related='bar_id', string='bar_alias')
 

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -462,11 +462,23 @@ class TestOrmRelated(models.Model):
 
     foo_id_bar_name = fields.Char('foo_id_bar_name', related='foo_id.bar_name', related_sudo=False)
 
-    foo_bar_id = fields.Many2one(string='foo_bar_id', related='foo_id.bar_id', related_sudo=False)
-    foo_bar_id_name = fields.Char('foo_bar_id_name', related='foo_bar_id.name', related_sudo=False)
+    foo_bar_id = fields.Many2one(related='foo_id.bar_id', related_sudo=False, string='Bar')
+    foo_bar_id_name = fields.Char(related='foo_bar_id.name', related_sudo=False, string='Bar Name')
 
-    foo_bar_sudo_id = fields.Many2one(string='foo_bar_sudo_id', related='foo_id.bar_id', related_sudo=True)
-    foo_bar_sudo_id_name = fields.Char('foo_bar_sudo_id_name', related='foo_bar_sudo_id.name', related_sudo=False)
+    foo_bar_sudo_id = fields.Many2one(related='foo_id.bar_id', related_sudo=True, string='Bar Sudo')
+    foo_bar_sudo_id_name = fields.Char(related='foo_bar_sudo_id.name', related_sudo=False, string='Bar Sudo Name')
+
+    foo_bar_ids = fields.Many2many(related='foo_id.bar_ids', related_sudo=False)
+    foo_bar_sudo_ids = fields.Many2many(related='foo_id.bar_ids', related_sudo=True, string='Bars Sudo')
+
+    foo_foo_ids = fields.One2many(related='foo_id.foo_ids', related_sudo=False, string='Foo Foos')
+    foo_foo_sudo_ids = fields.One2many(related='foo_id.foo_ids', related_sudo=True, string='Foo Foos Sudo')
+
+    foo_binary_att = fields.Binary(related='foo_id.binary_att', related_sudo=False)
+    foo_binary_att_sudo = fields.Binary(related='foo_id.binary_att', related_sudo=True, string='Binary Att Sudo')
+
+    foo_binary_bin = fields.Binary(related='foo_id.binary_bin', related_sudo=False)
+    foo_binary_bin_sudo = fields.Binary(related='foo_id.binary_bin', related_sudo=True, string='Binary Bin Sudo')
 
 
 class TestOrmRelated_Foo(models.Model):
@@ -476,8 +488,17 @@ class TestOrmRelated_Foo(models.Model):
     name = fields.Char()
     bar_id = fields.Many2one('test_orm.related_bar')
     foo_ids = fields.One2many('test_orm.related', 'foo_id', string='Foos')
+    bar_ids = fields.Many2many('test_orm.related_bar', string='Bars')
+    binary_att = fields.Binary()
+    binary_bin = fields.Binary(attachment=False)
     bar_name = fields.Char('bar_name', related='bar_id.name', related_sudo=False)
     bar_alias = fields.Many2one(related='bar_id', string='bar_alias')
+
+    foo_names = fields.Char(related='foo_ids.name', related_sudo=False, string="Foo Names")
+    foo_names_sudo = fields.Char(related='foo_ids.name', related_sudo=True, string="Foo Names Sudo")
+
+    bar_names = fields.Char(related='bar_ids.name', related_sudo=False, string="Bar Names")
+    bar_names_sudo = fields.Char(related='bar_ids.name', related_sudo=True, string="Bar Names Sudo")
 
 
 class TestOrmRelated_Bar(models.Model):

--- a/odoo/addons/test_orm/tests/test_domain.py
+++ b/odoo/addons/test_orm/tests/test_domain.py
@@ -471,7 +471,7 @@ class TestDomainOptimize(TransactionCase):
     def test_condition_optimize_any(self):
         model = self.env['test_orm.mixed']
 
-        domain = Domain('currency_id', 'any', model.currency_id._search([]))
+        domain = Domain('currency_id', 'any!', model.currency_id._search([]))
         self.assertIs(domain.optimize(model), domain, "Idempotent with a Query value")
 
         self.assertEqual(
@@ -893,7 +893,7 @@ class TestDomainOptimize(TransactionCase):
                 query = model[field_name]._search([])
                 self.assertEqual(
                     (Domain(field_name, 'any', left) | Domain(field_name, 'any', query) | Domain(field_name, 'any', right)).optimize(model, full=True),
-                    Domain(field_name, 'any', left | right) | Domain(field_name, 'any', query),
+                    Domain(field_name, 'any', left | right) | Domain(field_name, 'any!', query),
                     "Don't merge query with domains",
                 )
                 self.assertEqual(

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -1053,7 +1053,8 @@ class DomainCondition(Domain):
         assert operator in STANDARD_CONDITION_OPERATORS, \
             f"Invalid operator {operator!r} for SQL in domain term {(field_expr, operator, value)!r}"
 
-        field = model._fields[parse_field_expr(field_expr)[0]]
+        field = self._field(model)
+        model._check_field_access(field, 'read')
         return field.condition_to_sql(field_expr, operator, value, model, alias, query)
 
 

--- a/odoo/orm/domains.py
+++ b/odoo/orm/domains.py
@@ -996,6 +996,17 @@ class DomainCondition(Domain):
             computed_domain = field.determine_domain(model, inversed_opeator, value)
             if computed_domain is not NotImplemented:
                 return ~Domain(computed_domain, internal=True)
+        # compatibility for any!
+        try:
+            if operator in ('any!', 'not any!'):
+                # Not strictly equivalent! If a search is executed, it will be done using sudo.
+                computed_domain = DomainCondition(self.field_expr, operator.rstrip('!'), value)
+                computed_domain = computed_domain._optimize_field_search_method(model.sudo())
+                _logger.warning("Field %s should implement any! operator", field)
+                return computed_domain
+        except (NotImplementedError, UserError) as e:
+            if original_exception is None:
+                original_exception = e
         # backward compatibility to implement only '=' or '!='
         try:
             if operator == 'in':

--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -1365,15 +1365,15 @@ class Field(typing.Generic[T]):
         # operator: any
         # Note: relational operators overwrite this function for a more specific
         # behaviour, here we check just the field against the subselect.
-        # Example usage: ('id', 'any', Query | SQL)
-        if operator in ('any', 'not any'):
+        # Example usage: ('id', 'any!', Query | SQL)
+        if operator in ('any!', 'not any!'):
             if isinstance(value, Query):
                 subselect = value.subselect()
             elif isinstance(value, SQL):
                 subselect = SQL("(%s)", value)
             else:
-                raise TypeError(f"condition_to_sql() operator 'any' accepts SQL or Query, got {value}")
-            sql_operator = SQL_OPERATORS["in" if operator == "any" else "not in"]
+                raise TypeError(f"condition_to_sql() operator 'any!' accepts SQL or Query, got {value}")
+            sql_operator = SQL_OPERATORS["in" if operator == "any!" else "not in"]
             return SQL("%s%s%s", sql_field, sql_operator, subselect)
 
         raise NotImplementedError(f"Invalid operator {operator!r} for SQL in domain term {(field_expr, operator, value)!r}")

--- a/odoo/orm/fields_binary.py
+++ b/odoo/orm/fields_binary.py
@@ -229,8 +229,6 @@ class Binary(Field):
     def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         if not self.attachment or field_expr != self.name:
             return super().condition_to_sql(field_expr, operator, value, model, alias, query)
-        # check permission
-        model._check_field_access(self, 'read')
         assert operator in ('in', 'not in') and set(value) == {False}, "Should have been done in Domain optimization"
         return SQL(
             "%s%s(SELECT res_id FROM ir_attachment WHERE res_model = %s AND res_field = %s)",

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -738,7 +738,6 @@ class _RelationalMulti(_Relational):
 
     def condition_to_sql(self, field_expr: str, operator: str, value, model: BaseModel, alias: str, query: Query) -> SQL:
         assert field_expr == self.name, "Supporting condition only to field"
-        model._check_field_access(self, 'read')
         comodel = model.env[self.comodel_name]
 
         # update the operator to 'any'


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The new operator bypasses access rights (including record rules) on the comodel.
Otherwise, it behaves just like the `any` operator.

This operator cannot be accepted through RPC, to avoid users bypassing security checks. The new operator is considered _internal_. When transforming `list` into `Domain`, we do not allow for internal operators. We still need to accept parsing a domain like this for return values of `_search` methods, though.

At this point, the new operator generates LEFT JOIN statements for many2one fields, which simplifies the implementation of related fields with `compute_sudo=True`. In the future, we will introduce further optimizations by injecting access rights into domains.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
