### PR TITLE
[IMP] *: remove unsupported `fa-solid` utility class

### DIFF
--- a/addons/event/static/src/client_action/event_registration_summary_dialog.xml
+++ b/addons/event/static/src/client_action/event_registration_summary_dialog.xml
@@ -7,14 +7,14 @@
             <div class="row">
                 <div class="col-lg-10 w-100 fs-2">
                     <div t-if="['confirmed_registration', 'unconfirmed_registration'].includes(registrationStatus.value)" class="alert alert-success d-flex justify-content-center" role="alert">
-                        <i class="fa fa-solid fa-check-circle align-self-center me-2 ms-0 ms-sm-5"/>
+                        <i class="fa fa-check-circle align-self-center me-2 ms-0 ms-sm-5"/>
                         <span>Successfully registered!</span>
                         <button type="button" class="btn btn-link ms-3 ms-sm-5" t-on-click="undoRegistration">
                             Undo
                         </button>
                     </div>
                     <div t-else="" class="alert alert-warning d-flex justify-content-center" role="alert">
-                        <i class="fa fa-solid fa-exclamation-circle me-2 align-self-center ms-0 ms-sm-5"/>
+                        <i class="fa fa-exclamation-circle me-2 align-self-center ms-0 ms-sm-5"/>
                         <t t-if="registrationStatus.value === 'need_manual_confirmation'">
                             <span>This ticket is for another event!<br/>
                             Confirm attendance?</span>

--- a/addons/event/static/src/template_reference_field/field_event_mail_template_reference.xml
+++ b/addons/event/static/src/template_reference_field/field_event_mail_template_reference.xml
@@ -5,7 +5,7 @@
         <xpath expr="//t[@t-if='!props.readonly and !hideModelSelector']" position="after">
             <t t-elif="getValue()">
                 <div class="o_mail_template_reference_field_icon d-flex justify-content-center flex-grow-0 flex-shrink-0">
-                    <span class="event_template_reference_mail fa fa-solid fa-envelope" t-if="relation === 'mail.template'"/>
+                    <span class="event_template_reference_mail fa fa-envelope" t-if="relation === 'mail.template'"/>
                 </div>
             </t>
         </xpath>

--- a/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.xml
+++ b/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.xml
@@ -3,7 +3,7 @@
     <t t-inherit="event.mailTemplateReferenceField" t-inherit-mode="extension">
         <xpath expr="//span[hasclass('event_template_reference_mail')]" position="after">
             <div t-if="relation === 'sms.template'" class="event_template_reference_sms">
-                <span class="fa fa-lg fa-solid fa-mobile" role="icon"/>
+                <span class="fa fa-lg fa-mobile" role="icon"/>
                 <span role="text">SMS</span>
             </div>
         </xpath>

--- a/addons/hr_skills/views/hr_employee_cv_templates.xml
+++ b/addons/hr_skills/views/hr_employee_cv_templates.xml
@@ -43,15 +43,15 @@
             <div class="o_sidebar_section" t-if="show_contact">
                 <ul class="o_social">
                     <li class="email" t-if="o.company_id.email">
-                        <i class="fa fa-solid fa-envelope pe-2"/>
+                        <i class="fa fa-envelope pe-2"/>
                         <a t-attf-href="mailto: #{o.company_id.email}" t-field="o.company_id.email">demo@email.com</a>
                     </li>
                     <li class="phone" t-if="o.company_id.phone">
-                        <i class="fa fa-solid fa-phone pe-2"/>
+                        <i class="fa fa-phone pe-2"/>
                         <a t-attf-href="tel:#{o.company_id.phone}" t-field="o.company_id.phone">+1234567890</a>
                     </li>
                     <li class="website" t-if="o.company_id.website">
-                        <i class="fa fa-solid fa-globe pe-2"/>
+                        <i class="fa fa-globe pe-2"/>
                         <a t-attf-href="tel:#{o.company_id.website}" t-field="o.company_id.website">www.demo.com</a>
                     </li>
                 </ul>
@@ -67,7 +67,7 @@
                 <div class="o_main_panel_section">
                     <h2 class="o_main_panel_title mt-4" t-attf-style="color: #{color_secondary};">
                         <span class="o_main_panel_icon" t-attf-style="background: #{color_secondary};">
-                            <i class="fa fa-solid fa-briefcase"/>
+                            <i class="fa fa-briefcase"/>
                         </span>
                         <span t-out="line_type">Experience</span>
                     </h2>
@@ -97,7 +97,7 @@
             <div class="o_main_panel_section" t-if="skill_type_language">
                 <h2 class="o_main_panel_title" t-attf-style="color: #{color_secondary};">
                     <span class="o_main_panel_icon" t-attf-style="background: #{color_secondary};">
-                        <i class="fa fa-solid fa-language"/>
+                        <i class="fa fa-language"/>
                     </span>
                     Languages
                 </h2>
@@ -119,7 +119,7 @@
             <div class="o_main_panel_section">
                 <h2 class="o_main_panel_title" t-attf-style="color: #{color_secondary};">
                     <span class="o_main_panel_icon" t-attf-style="background: #{color_secondary};">
-                        <i class="fa fa-solid fa-rocket"/>
+                        <i class="fa fa-rocket"/>
                     </span>
                     Skills
                 </h2>


### PR DESCRIPTION
*: event, event_sms, hr_skills

This commit cleans the code by taking off a useless class in Font Awesome v4 such as `fa-solid`.

task-4793826

enterprise : https://github.com/odoo/enterprise/pull/85890

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
