### PR TITLE
[FIX] l10_din5008: fix different font size for addresses

### DIFF
--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -47,9 +47,7 @@
                 .colored_address {
                     color: $o-default-report-secondary-color;
                 }
-                > span {
-                    font-size: 0.8em;
-                }
+                font-size: 0.8em;
             }
             .information_block, .invoice_address {
                 width: 75mm;


### PR DESCRIPTION
### Steps to reproduce:
- Install "l10n_din5008"
- In Settings > Layout, select DIN5008 as the report layout
- Create a quotation, print it
- The address of the partner and the sipping address have different font size

### Cause:
Since this [commit](https://github.com/odoo/odoo/commit/92e4c3cb3bec0b3d5537a50fd441a22fa6509ed1) the partner address is a span which is applied a [`font-size: 0.8em;`](https://github.com/odoo/odoo/blob/f77b40bba0c92a9a225eb7ade694e79cb804f7bf/addons/l10n_din5008/static/src/scss/report_din5008.scss#L51). But not the shipping address.

### Solution:
Remove the restriction of `span` to apply the font-size. This way all text in address should have the same font-size.

Before: 
![image](https://github.com/user-attachments/assets/86862ffd-4b62-474f-9af5-3c51a0e6f5e7)


After:
![image](https://github.com/user-attachments/assets/31d1697c-59b2-4527-95b4-83fa6019760e)


opw-4725169