### PR TITLE
[FIX] website_sale: disable embedded components sale description


### DIFF
--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -190,6 +190,7 @@
                         colspan="2"
                         name="description_ecommerce"
                         nolabel="1"
+                        options="{'embedded_components': false}"
                         placeholder="A detailed,formatted description to promote your product on
                                      this page. Use '/' to discover more features."
                     />


### PR DESCRIPTION
Scenario:

- go in backend of a product > "Sales" tab > "Ecommerce Description"
- type "/" and select "Toggle List" style
- enter a shown line, and a toggle-able line
- go to the website view of this product

Result: the "Toggle List" widget code is not working and we see both
line without the toggling possible.

Issue: the "Toggle List" feature was meant to only be added to knowledge
and backend field that are not mailing or website and the toggle list is
already disabled in frontend website.

Fix: in the backend, disable embedded_components for the given field.

opw-4793768

__PR note:__ a similar fix was done in e9b372f04726e800f9f7427aac697f12a2e2a01f and 289517e7ca38dcd7e84c4fc4bc6118429f2a25d0
