### PR TITLE
[FIX] website_sale: inherit website salesperson domain in settings

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -28,7 +28,9 @@ class Website(models.Model):
 
     enabled_portal_reorder_button = fields.Boolean(string="Re-order From Portal")
     salesperson_id = fields.Many2one(
-        string="Salesperson", comodel_name='res.users', domain="[('share', '=', False)]",
+        string="Salesperson",
+        comodel_name='res.users',
+        domain=[('share', '=', False)],
     )
     salesteam_id = fields.Many2one(
         string="Sales Team",


### PR DESCRIPTION
Versions
--------
- saas-17.4+

Steps
-----
1. Go to Website / Settings;
2. scroll to Shop - Checkout Process;
3. assign portal user as salesperson for online orders.

Issue
-----
Portal user shouldn't be allowed as a salesperson.

Cause
-----
The `salesperson_id` field of `res.config.settings` is set to be related to `website_id.salesperson_id`. The `salesperson_id` field for `website` does have a domain configured, but because the domain is a string, it does not get re-used for related fields[^1].

[^1]: https://github.com/odoo/odoo/blob/87381d316/odoo/fields.py#L3009-L3021

Issue was introduced by commit 2f8c20d7d2385, which moved the domain from the `res.config.settings` field to the `website` field it relates to.

Solution
--------
Provide the domain as a list.

opw-4801697