### PR TITLE
[FIX] hr_expense: Prevent sending unnecessary email notifications to manager

### DIFF
--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Expenses',
-    'version': '2.0',
+    'version': '2.1',
     'category': 'Human Resources/Expenses',
     'sequence': 70,
     'summary': 'Submit, validate and reinvoice employee expenses',
@@ -38,6 +38,7 @@ This module also uses analytic accounting and is compatible with the invoice on 
         'data/hr_expense_sequence.xml',
         'data/hr_expense_data.xml',
         'data/hr_expense_tour.xml',
+        'data/hr_expense_cron.xml',
         'wizard/hr_expense_refuse_reason_views.xml',
         'wizard/hr_expense_approve_duplicate_views.xml',
         'wizard/hr_expense_split_wizard_views.xml',

--- a/addons/hr_expense/data/hr_expense_cron.xml
+++ b/addons/hr_expense/data/hr_expense_cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="ir_cron_send_submitted_expenses_mail" model="ir.cron">
+            <field name="name">HR Expense: Send Submitted Expenses Mail</field>
+            <field name="model_id" ref="model_hr_expense"/>
+            <field name="state">code</field>
+            <field name="code">model._cron_send_submitted_expenses_mail()</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/hr_expense/data/mail_message_subtype_data.xml
+++ b/addons/hr_expense/data/mail_message_subtype_data.xml
@@ -5,14 +5,14 @@
         <record id="mt_expense_approved" model="mail.message.subtype">
             <field name="name">Approved</field>
             <field name="res_model">hr.expense</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Expense approved</field>
         </record>
 
         <record id="mt_expense_refused" model="mail.message.subtype">
             <field name="name">Refused</field>
             <field name="res_model">hr.expense</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Expense refused</field>
         </record>
 
@@ -20,27 +20,27 @@
             <field name="name">Paid</field>
             <field name="res_model">hr.expense</field>
             <field name="description">Expense paid</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
         </record>
 
         <record id="mt_expense_reset" model="mail.message.subtype">
             <field name="name">Draft</field>
             <field name="res_model">hr.expense</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Expense reset to Draft</field>
         </record>
 
         <record id="mt_expense_entry_delete" model="mail.message.subtype">
             <field name="name">Journal Entry Deleted</field>
             <field name="res_model">hr.expense</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Journal entry deleted</field>
         </record>
 
         <record id="mt_expense_entry_draft" model="mail.message.subtype">
             <field name="name">Journal Entry Reset to Draft</field>
             <field name="res_model">hr.expense</field>
-            <field name="default" eval="True"/>
+            <field name="default" eval="False"/>
             <field name="description">Journal entry reset to draft</field>
         </record>
     </data>

--- a/addons/hr_expense/data/mail_templates.xml
+++ b/addons/hr_expense/data/mail_templates.xml
@@ -33,12 +33,37 @@
         </template>
 
         <template id="hr_expense_template_submitted_expenses">
-            <p>Dear <t t-out="manager_name"/>,</p>
-            <p>
-                New expenses are awaiting your approval.
-                You can review them by following this link
-            </p>
-            <a t-att-href="'/odoo/expenses-to-process'" class="o_expense_button_mail">View expenses</a>
+            <div style="background:#F0F0F0;color:#515166;padding:10px 0px;font-family:Arial,Helvetica,sans-serif;font-size:14px;">
+                <table style="width:600px;margin:5px auto;background:white;border:1px solid #e1e1e1;">
+                    <tbody><tr>
+                        <td style="padding:15px 20px 10px 20px;">
+                            <p style="font-size:20px;font-weight:bold;color:#515166;">Expenses approval</p>
+                            <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                            <p>Dear <t t-out="manager_name"/>,</p>
+                            <p>New expenses are waiting for your approval. You can Review them by following this link.</p>
+                            <br/>
+                            <a t-att-href="url" style="padding: 8px 12px; font-size: 12px; color: #FFFFFF; text-decoration: none !important; font-weight: 400; background-color: #875A7B; border: 0px solid #875A7B; border-radius:3px">View expenses</a>
+                            <br/><br/>
+                            <hr style="background-color:rgb(204,204,204);border:medium none;clear:both;display:block;font-size:0px;min-height:1px;line-height:0; margin: 16px 0px 16px 0px;"/>
+                            <table style="width: 100%;">
+                                <tbody><tr>
+                                    <td align="center" style="min-width: 590px; padding: 0 8px 0 8px; font-size:11px;">
+                                        <b t-out="company.name"/><br/>
+                                        <div style="color: #999999;">
+                                            <t t-out="company.phone"/>
+                                            <t t-if="company.email"> | <a t-att-href="'mailto:%s' % company.email" style="text-decoration:none; color: #999999;"><t t-out="company.email"/></a></t>
+                                            <t t-if="company.website"> | <a t-att-href="company.website" style="text-decoration:none; color: #999999;"><t t-out="company.website"/></a></t>
+                                        </div>
+                                    </td>
+                                </tr></tbody>
+                            </table>
+                        </td>
+                    </tr></tbody>
+                </table>
+                <p style="text-align: center;font-size: 13px;">
+                    Powered by <a target="_blank" href="https://www.odoo.com?utm_source=db&amp;utm_medium=expense" style="color: #9E588B;">Odoo</a>.
+                </p>
+            </div>
         </template>
 
         <template id="hr_expense_template_register_no_user">

--- a/addons/hr_expense/migrations/2.1/pre-migrate.py
+++ b/addons/hr_expense/migrations/2.1/pre-migrate.py
@@ -1,0 +1,27 @@
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    xml_ids = [
+        'hr_expense.mt_expense_approved',
+        'hr_expense.mt_expense_refused',
+        'hr_expense.mt_expense_paid',
+        'hr_expense.mt_expense_reset',
+        'hr_expense.mt_expense_entry_delete',
+        'hr_expense.mt_expense_entry_draft',
+    ]
+
+    subtype_ids = []
+    for xml_id in xml_ids:
+        record = env.ref(xml_id, raise_if_not_found=False)
+        if record:
+            subtype_ids.append(record.id)
+
+    if subtype_ids:
+        cr.execute("""
+            UPDATE mail_message_subtype
+               SET "default" = false
+             WHERE id in %s
+        """,
+        (tuple(subtype_ids),))

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -8,7 +8,7 @@ import werkzeug
 
 from odoo import api, fields, Command, models, _
 from odoo.exceptions import RedirectWarning, UserError, ValidationError
-from odoo.tools import clean_context, email_normalize, float_repr, float_round, is_html_empty
+from odoo.tools import clean_context, email_normalize, float_repr, float_round, is_html_empty, parse_version
 
 
 _logger = logging.getLogger(__name__)
@@ -987,7 +987,7 @@ class HrExpense(models.Model):
         expenses_submitted_to_review = self.env['hr.expense']
         for expense in self:
             if expense.state == 'submitted':
-                expense.activity_schedule(
+                expense.with_context(mail_activity_quick_update=True).activity_schedule(
                     'hr_expense.mail_act_expense_approval',
                     user_id=expense.manager_id.id or
                     expense.sudo()._get_default_responsible_for_approval().id or
@@ -1004,40 +1004,53 @@ class HrExpense(models.Model):
             expenses_activity_done.activity_feedback(['hr_expense.mail_act_expense_approval'])
         if expenses_activity_unlink:
             expenses_activity_unlink.activity_unlink(['hr_expense.mail_act_expense_approval'])
-        # Avoid sending yourself mails
-        expenses_submitted_to_review = expenses_submitted_to_review.filtered(lambda expense: expense.manager_id != self.env.user)
+
+        # TODO: Remove in master
+        # Note: field latest_version of model ir.module.module is the installed version
+        installed_module_version = self.sudo().env.ref('base.module_hr_expense').latest_version
+        if expenses_submitted_to_review and parse_version(installed_module_version)[2:] < parse_version('2.1'):
+            self._send_submitted_expenses_mail()
+
+    @api.model
+    def _cron_send_submitted_expenses_mail(self):
+        expenses_submitted_to_review = self.search([('state', '=', 'submitted')])
         if expenses_submitted_to_review:
-            new_mails = []
-            for company, expenses_submitted_per_company in expenses_submitted_to_review.grouped('company_id').items():
-                parent_company_mails = company.parent_ids[::-1].mapped('email_formatted')
-                mail_from = (
-                        self.env.user.email
-                        or company.email_formatted
-                        or (parent_company_mails and parent_company_mails[0])
-                )
+            expenses_submitted_to_review._send_submitted_expenses_mail()
 
-                if not mail_from:  # We can't send a mail without sender
-                    _logger.warning(_("Failed to send mails for submitted expenses. No valid email was found for the company"))
+    def _send_submitted_expenses_mail(self):
+        new_mails = []
+        for company, expenses_submitted_per_company in self.grouped('company_id').items():
+            parent_company_mails = company.parent_ids[::-1].mapped('email_formatted')
+            mail_from = (
+                    self.env.user.email
+                    or company.email_formatted
+                    or (parent_company_mails and parent_company_mails[0])
+            )
+
+            if not mail_from:  # We can't send a mail without sender
+                _logger.warning(_("Failed to send mails for submitted expenses. No valid email was found for the company"))
+                continue
+
+            for manager, expenses_submitted in expenses_submitted_per_company.grouped('manager_id').items():
+                if not manager:
                     continue
-
-                for manager, expenses_submitted in expenses_submitted_per_company.grouped('manager_id').items():
-                    manager_langs = tuple(lang for lang in manager.partner_id.mapped('lang') if lang)
-                    mail_lang = (manager_langs and manager_langs[0]) or self.env.lang or 'en_US'
-                    body = self.env['ir.qweb']._render(
-                        template='hr_expense.hr_expense_template_submitted_expenses',
-                        values={'manager_name': manager.name, 'url': '/expenses-to-approve'},
-                        lang=mail_lang,
-                    )
-                    new_mails.append({
-                        'author_id': self.env.user.partner_id.id,
-                        'auto_delete': True,
-                        'body_html': body,
-                        'email_from': mail_from,
-                        'email_to': manager.employee_id.work_email or manager.email,
-                        'subject': _("New expenses waiting for your approval"),
-                    })
-                if new_mails:
-                    self.env['mail.mail'].sudo().create(new_mails).send()
+                manager_langs = tuple(lang for lang in manager.partner_id.mapped('lang') if lang)
+                mail_lang = (manager_langs and manager_langs[0]) or self.env.lang or 'en_US'
+                body = self.env['ir.qweb']._render(
+                    template='hr_expense.hr_expense_template_submitted_expenses',
+                    values={'manager_name': manager.name, 'url': '/expenses-to-approve'},
+                    lang=mail_lang,
+                )
+                new_mails.append({
+                    'author_id': self.env.user.partner_id.id,
+                    'auto_delete': True,
+                    'body_html': body,
+                    'email_from': mail_from,
+                    'email_to': manager.employee_id.work_email or manager.email,
+                    'subject': _("New expenses waiting for your approval"),
+                })
+            if new_mails:
+                self.env['mail.mail'].sudo().create(new_mails).send()
 
     @api.model
     def get_empty_list_help(self, help_message):

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1038,7 +1038,7 @@ class HrExpense(models.Model):
                 mail_lang = (manager_langs and manager_langs[0]) or self.env.lang or 'en_US'
                 body = self.env['ir.qweb']._render(
                     template='hr_expense.hr_expense_template_submitted_expenses',
-                    values={'manager_name': manager.name, 'url': '/expenses-to-approve'},
+                    values={'manager_name': manager.name, 'url': '/odoo/expenses-to-process', 'company': company},
                     lang=mail_lang,
                 )
                 new_mails.append({

--- a/addons/hr_expense/tests/test_expenses_states.py
+++ b/addons/hr_expense/tests/test_expenses_states.py
@@ -1,12 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.mail.tests.common import MailCase
 from odoo import fields
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.tests import tagged
 
 
 @tagged('-at_install', 'post_install')
-class TestExpensesStates(TestExpenseCommon):
+class TestExpensesStates(TestExpenseCommon, MailCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -195,8 +196,19 @@ class TestExpensesStates(TestExpenseCommon):
         self.assertSequenceEqual(['approved', 'approved'], self.expenses_all.mapped('state'))
 
     def test_expense_next_activity(self):
-        """ Test the auto-validation flow skips 'submitted' state when there is no manager"""
+        """ Test next activity is assigned to the right manager, no notification is sent, but validation email is sent"""
         self.expenses_employee.manager_id = self.expense_user_manager_2
-        self.expenses_all.action_submit()
+        with self.mock_mail_gateway():
+            self.expenses_employee.action_submit()
+            self.env['hr.expense']._cron_send_submitted_expenses_mail()
         mail_activity = self.env['mail.activity'].search([('res_model', '=', 'hr.expense'), ('res_id', '=', self.expenses_employee.id)])
         self.assertEqual(mail_activity.user_id.id, self.expense_user_manager_2.id)
+        # No notification should be sent
+        notification_message = self.env['mail.message'].search([('partner_ids', 'in', self.expense_user_manager_2.partner_id.ids), ('display_name', '=', mail_activity.res_name)])
+        self.assertFalse(notification_message)
+        # Expenses submitted email is sent via cron
+        expenses_submitted = self.env['mail.mail'].search(
+            [('email_to', '=', self.expense_user_manager_2.email),
+            ('subject', '=', "New expenses waiting for your approval")]
+            )
+        self.assertEqual(len(expenses_submitted), 1)


### PR DESCRIPTION
When an employee submits an expense and assigns a manager, an approval activity is scheduled.
However, email notifications are now disabled to avoid spamming the assigned managers.

* Prevent notifying the expense manager when expense state changes.

* Email 'Next expense is waiting your approval' is scheduled to be sent
  to the manager once a week if the manager has any expenses left to
approve.

task-4676396

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
