### PR TITLE
[REM] l10n_cl/l10n_latam_invoice_document: remove unnecessary invisible fields

### DIFF
--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -1,16 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="view_move_form_inherit_l10n_cl" model="ir.ui.view">
-        <field name="name">account.move.form.inherit.l10n.cl</field>
-        <field name="model">account.move</field>
-        <field name="inherit_id" ref="account.view_move_form"/>
-        <field name="arch" type="xml">
-            <form>
-                <field name="l10n_latam_internal_type" invisible="1"/>
-            </form>
-        </field>
-    </record>
-
     <record id="view_latam_form_inherit_l10n_cl" model="ir.ui.view">
         <field name="name">account.move.latam.form.inherit.l10n.cl</field>
         <field name="model">account.move</field>
@@ -44,7 +33,6 @@
                 <field name="amount_tax_signed" string="Tax" sum="Total" optional="show"/>
                 <field name="amount_total_signed" string="Total" sum="Total" optional="show"/>
                 <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="show"/>
-                <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/>
                 <field name="company_currency_id" column_invisible="True"/>
                 <field name="state" optional="show"/>
                 <field name="payment_state" optional="hide"/>

--- a/addons/l10n_cl/views/res_bank_view.xml
+++ b/addons/l10n_cl/views/res_bank_view.xml
@@ -8,7 +8,6 @@
             <field name="inherit_id" ref="base.view_res_bank_form" />
             <field name="arch" type="xml">
                 <field name="name" position="before">
-                    <field name="fiscal_country_codes" invisible="1"/>
                     <field name="l10n_cl_sbif_code" invisible="'CL' not in fiscal_country_codes"/>
                 </field>
             </field>

--- a/addons/l10n_latam_invoice_document/views/account_journal_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_journal_view.xml
@@ -7,7 +7,6 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <form>
-                <field name="country_code" invisible="1"/>
                 <field name="l10n_latam_company_use_documents" invisible="1"/>
             </form>
             <field name="type" position="after">

--- a/addons/l10n_latam_invoice_document/views/account_move_view.xml
+++ b/addons/l10n_latam_invoice_document/views/account_move_view.xml
@@ -35,9 +35,7 @@
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
             <form>
-                <field name="l10n_latam_available_document_type_ids" invisible="1"/>
                 <field name="l10n_latam_use_documents" invisible="1"/>
-                <field name="l10n_latam_manual_document_number" invisible="1"/>
             </form>
 
             <xpath expr="//div[@name='journal_div']" position="after">

--- a/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
+++ b/addons/l10n_latam_invoice_document/wizards/account_move_reversal_view.xml
@@ -7,11 +7,9 @@
         <field name="inherit_id" ref="account.view_account_move_reversal"/>
         <field name="arch" type="xml">
             <form>
-                <field name="l10n_latam_use_documents" invisible="1"/>
                 <field name="l10n_latam_manual_document_number" invisible="1"/>
             </form>
             <field name="date" position="before">
-                <field name="l10n_latam_available_document_type_ids" invisible="1"/>
                 <field name="l10n_latam_document_type_id" invisible="not l10n_latam_use_documents" required="l10n_latam_use_documents" options="{'no_open': True, 'no_create': True}"/>
                 <field name="l10n_latam_document_number" invisible="not l10n_latam_use_documents or not l10n_latam_manual_document_number" required="l10n_latam_manual_document_number and l10n_latam_use_documents"/>
             </field>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

Starting in 18.0, it is no longer mandatory to define invisible fields
in views so that other expressions (domains, modifiers) can work correctly,
as they are now added automatically to views.

However, their presence in the codebase causes issues when building
development branches in Odoo SH, which is why this commit removes
the reported fields that are throwing warnings.

```
Please indicate why the always invisible fields are present in the view, or remove the field tag.

Addon: 'l10n_cl'
    View: view_move_form_inherit_l10n_cl
    Fields:
        <field name="l10n_latam_internal_type" invisible="1"/>

    View: view_complete_invoice_refund_tree
    Fields:
        <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/>

    View: view_res_bank_form
    Fields:
        <field name="fiscal_country_codes" invisible="1"/>

Addon: 'l10n_latam_invoice_document'
    View: view_account_journal_form
    Fields:
        <field name="country_code" invisible="1"/>

    View: view_move_form
    Fields:
        <field name="l10n_latam_available_document_type_ids" invisible="1"/>
        <field name="l10n_latam_manual_document_number" invisible="1"/>

    View: view_account_move_reversal
    Fields:
        <field name="l10n_latam_use_documents" invisible="1"/>
        <field name="l10n_latam_available_document_type_ids" invisible="1"/>
```

In the case of the view "l10n_cl.view_move_form_inherit_l10n_cl,"
since it only contains one field, the entire view will be removed.
No other views inherit from it.

Related enterprise PR: https://github.com/odoo/enterprise/pull/85904

## Current behavior before PR:

SH branches throw a warning because invisible fields are present in views, which is no longer needed after linked commit.

## Desired behavior after PR is merged:

SH branches won't become red or warn about invisible fields present in views because they have been added automatically to the view.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
