### PR TITLE
[FIX] website: popup with scrollbar doesn't scroll


### DIFF
--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -220,6 +220,7 @@ const PopupWidget = publicWidget.Widget.extend(ObservingCookieWidgetMixin, {
         const previouslyFocusedEl = document.activeElement || document.body;
         if (tabableEls.length) {
             tabableEls[0].focus();
+            this.el.querySelector(".modal").scrollTop = 0;
         } else {
             this.el.focus();
         }

--- a/addons/website/static/tests/tours/snippet_popup_open_on_top.js
+++ b/addons/website/static/tests/tours/snippet_popup_open_on_top.js
@@ -1,0 +1,47 @@
+/** @odoo-module **/
+
+import { clickOnSave, insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+
+registerWebsitePreviewTour("snippet_popup_open_on_top", {
+    url: "/",
+    edition: true,
+}, () => [
+    ...insertSnippet({
+        name: "Popup",
+        id: "s_popup",
+        groupName: "Content",
+    }),
+    {
+        content: "Change content for long text.",
+        trigger: ":iframe .s_popup p.lead",
+        run: 'editor ' + ' hello world'.repeat(300),
+    },
+    {
+        content: "Set delay to 0 second",
+        trigger: '[data-attribute-name="showAfter"] input',
+        run: 'edit 0',
+    },
+    ...clickOnSave(),
+    {
+        content: 'Check that the modal is scrolled on top',
+        trigger: ":iframe .s_popup .modal:contains('hello world')",
+        run: function () {
+            const modalEl = this.anchor;
+            if (modalEl.scrollHeight <= modalEl.clientHeight) {
+                console.error('There is no scrollbar on the modal');
+            }
+            const activeEl = modalEl.ownerDocument.activeElement;
+            if (activeEl.parentElement.closest('.modal') !== modalEl) {
+                // Note: it might not be the best idea to still focus a button
+                // that is not in the viewport, but since this is a niche case
+                // this is the behavior right now. The important parts are:
+                // in the normal case, focus the button; in all cases, the modal
+                // should not be scrolled when opened.
+                console.error('The focus should be on an element inside the modal');
+            }
+            if (modalEl.scrollTop !== 0) {
+                console.error('The modal scrollbar is not scrolled at the top');
+            }
+        },
+    },
+]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -139,3 +139,6 @@ class TestSnippets(HttpCase):
 
     def test_custom_popup_snippet(self):
         self.start_tour(self.env["website"].get_client_action_url("/"), "custom_popup_snippet", login="admin")
+
+    def test_snippet_popup_open_on_top(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_open_on_top', login='admin')


### PR DESCRIPTION

Scenario: add a popup on a website page with enough text above the
button so the button is not visible on the page without scrolling.

Display the popup.

Result: the popup is opened scrolled at the bottom (depends on if we are
logged in or not), this usually works in incognito.

Issue: in 89e2513f577e9455d5bfd933d7e479b295d45a26 we focused on the
first tabbable element in the modal, but if that element is not in the
view, the browser automatically scrolls to it. So there is this side
effect that happen if the first tabbable element is hidden by the
scroll.

Fix: after we focus to the element, we reset the scrollTop to 0 to
ensure we stay at the top of the popup.

opw-4647172

X-original-commit: 3e8b9cb540674b12f496eb234cbb53a92233e27a
