### PR TITLE
[FIX] point_of_sale: auto-reconcile POS customer account move lines

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1133,7 +1133,7 @@ class PosSession(models.Model):
             vals.append(self._get_combine_receivable_vals(payment_method, amounts['amount'], amounts['amount_converted']))
         for payment, amounts in split_receivables_pay_later.items():
             vals.append(self._get_split_receivable_vals(payment, amounts['amount'], amounts['amount_converted']))
-        MoveLine.create(vals)
+        data['pay_later_move_lines'] = MoveLine.create(vals)
         return data
 
     def _create_combine_account_payment(self, payment_method, amounts, diff_amount):

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -523,7 +523,6 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
                 }
             )
             return (0, 0, {
-                **kwargs,
                 'id': randint(1, 1000000),
                 'pack_lot_ids': [],
                 'price_unit': price_unit,
@@ -531,7 +530,8 @@ class TestPoSCommon(ValuationReconciliationTestCommon):
                 'price_subtotal': tax_values['total_excluded'],
                 'price_subtotal_incl': tax_values['total_included'],
                 'qty': quantity,
-                'tax_ids': [(6, 0, tax_ids.ids)]
+                'tax_ids': [(6, 0, tax_ids.ids)],
+                **kwargs
             })
 
         def create_payment(payment_method, amount):


### PR DESCRIPTION
### Problem:
When paying a PoS order using customer account, an account move line debiting Account Receivable will be created. Settling this amount inside the PoS (by depositing money) will create another account move line crediting Account Receivable (represents the payment). The second move line is considered, by Odoo, as an outstanding amount, and this amount can be used to pay another invoice (sale order invoice). The moves affecting Account Receivable are still correct. However, unreconciling the two lines created from PoS will cause a confusion for clients who may use this amount to pay other invoices.

### How to reproduce:
    * Open a PoS session.
    * Create an order and pay using customer account.
    * Settle this customer's account (inside PoS).
    * Create a Sale Order and invoice it (or just an invoice).
    * The amount settled can be used as outstanding amount and can be used to pay the created invoice.
enterprise PR: https://github.com/odoo/enterprise/pull/86114

opw-4794793
