### PR TITLE
[FIX] website_sale: abandoned cart crashing website

### DIFF
--- a/addons/website_sale/models/website.py
+++ b/addons/website_sale/models/website.py
@@ -430,6 +430,7 @@ class Website(models.Model):
         SaleOrderSudo = self.env['sale.order'].sudo()
 
         sale_order_sudo = SaleOrderSudo
+        partner_sudo = self.env.user.partner_id
         if CART_SESSION_CACHE_KEY in request.session:
             sale_order_sudo = SaleOrderSudo.browse(request.session[CART_SESSION_CACHE_KEY])
             if sale_order_sudo and (
@@ -448,13 +449,22 @@ class Website(models.Model):
             if (
                 sale_order_sudo
                 and not self.env.user._is_public()
-                and self.env.user.partner_id.id != sale_order_sudo.partner_id.id
+                and partner_sudo.id != sale_order_sudo.partner_id.id
                 and not request.env.cr.readonly
             ):
-                sale_order_sudo._update_address(self.env.user.partner_id.id, ['partner_id'])
-        elif self.env.user and not self.env.user._is_public():  # Search for abandonned cart.
+                sale_order_sudo._update_address(partner_sudo.id, ['partner_id'])
+        elif (
+            self.env.user
+            and not self.env.user._is_public()
+            # If the company of the partner doesn't allow them to buy from this website, updating
+            # the cart customer would raise because of multi-company checks.
+            # No abandoned cart should be returned in this situation.
+            and partner_sudo.filtered_domain(
+                self.env['res.partner']._check_company_domain(self.company_id.id)
+            )
+        ):  # Search for abandonned cart.
             abandonned_cart_sudo = SaleOrderSudo.search([
-                ('partner_id', '=', self.env.user.partner_id.id),
+                ('partner_id', '=', partner_sudo.id),
                 ('website_id', '=', self.id),
                 ('state', '=', 'draft'),
             ], limit=1)
@@ -462,7 +472,7 @@ class Website(models.Model):
                 if not request.env.cr.readonly:
                     # Force the recomputation of the pricelist and fiscal position when resurrecting
                     # an abandonned cart
-                    abandonned_cart_sudo._update_address(self.env.user.partner_id.id, ['partner_id'])
+                    abandonned_cart_sudo._update_address(partner_sudo.id, ['partner_id'])
                     abandonned_cart_sudo._verify_cart()
                 sale_order_sudo = abandonned_cart_sudo
 


### PR DESCRIPTION
Prior to this commit, if you had been testing out adding a product to your cart on your website, and then later decided to change your default company, you would no longer be able to access your website. This was due to an access rights error when reading the sale order representing the cart, to load in the top navbar.

This commit fixes this by canceling any abandoned carts when switching default companies. The choice to cancel the order outright was recommended by the PO, BOJE. However, RDE believes that there is a deeper problem in `website_sale` if this one is showing up like this. 

Before 18.2, we could change the default company on a user after adding a product to our cart and then still access our website, making use of the existing cart. Again, per BOJE's request, we are handling this issue by canceling the cart outright as this is a _very_ niche case.

This massive commit e3a3c58 to 18.2 changed a lot of `website_sale` code and could be worth a deeper look by the e-commerce team.