### PR TITLE
[FIX] core,base_import: Handle NULL selection fields on import

### DIFF
--- a/addons/test_import_export/tests/test_properties.py
+++ b/addons/test_import_export/tests/test_properties.py
@@ -288,6 +288,12 @@ class TestPropertiesExportImport(HttpCase):
                 'One Text', 'selection_3', self.partners[1].display_name,
                 '', '', '',
             ],
+            # Record with NULL selection value
+            [
+                str(def_record_1.id),
+                'One Text', '', self.partners[1].display_name,
+                '', '', '',
+            ],
 
             # Record attached to the second definition record
             [
@@ -338,6 +344,7 @@ class TestPropertiesExportImport(HttpCase):
         self.assertEqual(records_created.mapped('properties'), [
             {'char_prop': 'One Text', 'selection_prop': 'selection_2', 'm2o_prop': self.partners[0].id},
             {'char_prop': 'One Text', 'selection_prop': 'selection_3', 'm2o_prop': self.partners[1].id},
+            {'char_prop': 'One Text', 'selection_prop': False, 'm2o_prop': self.partners[1].id},
             {'bool_prop': True, 'tags_prop': ['aa'], 'm2m_prop': self.partners[:2].ids},
             {'bool_prop': False, 'tags_prop': ['bb'], 'm2m_prop': False},
         ])
@@ -350,31 +357,36 @@ class TestPropertiesExportImport(HttpCase):
             [
                 "Id", "Record Definition Id",
                 # Field of the first definition
-                f"TextType ({def_record_1.display_name})", f"many2one ({def_record_1.display_name})",
+                f"TextType ({def_record_1.display_name})", f"many2one ({def_record_1.display_name})", f"One Selection ({def_record_1.display_name})",
                 # Field of the second definition
                 f"CheckBox ({def_record_2.display_name})", "properties.tags_prop", f"M2M ({def_record_2.display_name})",
             ],
             # Record attached to the first definition record
             [
                 external_ids[0], str(def_record_1.id),
-                'SSBIYXRlIHRoaXMgZmVhdHVyZQ==', str(self.partners[2].id),
+                'SSBIYXRlIHRoaXMgZmVhdHVyZQ==', str(self.partners[2].id), 'selection_2',
                 '', '', '',
             ],
-
+            # Record with NULL selection value
+            [
+                external_ids[2], str(def_record_1.id),
+                'One Text', str(self.partners[1].id), 'selection_1',
+                '', '', '',
+            ],
             # Record attached to the second definition record
             [
                 external_ids[1], str(def_record_2.id),  # record that changed its parent
-                '', '',
+                '', '', '',
                 'FaLse', 'AA', f'{self.partners[1].id}',
             ],
             [
-                external_ids[2], str(def_record_2.id),
-                '', '',
+                external_ids[4], str(def_record_2.id),
+                '', '', '',
                 'false', 'bb,CC', '',
             ],
             [
                 external_ids[3], str(def_record_2.id),
-                '', '',
+                '', '', '',
                 '1', 'BB', f'{self.partners[1].id},{self.partners[2].id}',
             ],
         ]
@@ -394,9 +406,10 @@ class TestPropertiesExportImport(HttpCase):
                 1: ['record_definition_id'],
                 2: ['properties.char_prop'],
                 3: ['properties.m2o_prop'],
-                4: ['properties.bool_prop'],
-                5: ['properties.tags_prop'],
-                6: ['properties.m2m_prop'],
+                4: ['properties.selection_prop'],
+                5: ['properties.bool_prop'],
+                6: ['properties.tags_prop'],
+                7: ['properties.m2m_prop'],
             },
         )
 
@@ -406,6 +419,7 @@ class TestPropertiesExportImport(HttpCase):
                 'record_definition_id',
                 'properties.char_prop',
                 'properties.m2o_prop/.id',
+                'properties.selection_prop',
                 'properties.bool_prop',
                 'properties.tags_prop',
                 'properties.m2m_prop/.id',
@@ -418,6 +432,7 @@ class TestPropertiesExportImport(HttpCase):
         self.assertEqual(records_created.mapped('properties'), [
             {'char_prop': 'SSBIYXRlIHRoaXMgZmVhdHVyZQ==', 'selection_prop': 'selection_2', 'm2o_prop': self.partners[2].id},
             {'bool_prop': False, 'tags_prop': ['aa'], 'm2m_prop': self.partners[1].ids},
-            {'bool_prop': False, 'tags_prop': ['bb', 'cc'], 'm2m_prop': False},
+            {'char_prop': 'One Text', 'selection_prop': 'selection_1', 'm2o_prop': self.partners[1].id},
             {'bool_prop': True, 'tags_prop': ['bb'], 'm2m_prop': self.partners[1:].ids},
+            {'bool_prop': False, 'tags_prop': ['bb', 'cc'], 'm2m_prop': False},
         ])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5399,7 +5399,7 @@ class BaseModel(metaclass=MetaModel):
             if fname not in self or self._fields[fname].type != 'properties':
                 continue
             field_converter = self._fields[fname].convert_to_cache
-            to_write[fname] = dict(self[fname], **field_converter(values.pop(fname), self))
+            to_write[fname] = dict(self[fname] or {}, **field_converter(values.pop(fname), self))
 
         self.write(values)
         if to_write:


### PR DESCRIPTION
If the selection property of a parent record is NULL, and the record is exported and then re-imported, a TypeError occurs.

This is resolved by returning an empty dictionary during import whenever the selection property's value is NULL in the parent record.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


opw-4670210

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
