### PR TITLE
[FIX] account_payment: Display correct overdue amount to pay on portal

### DIFF
--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -87,10 +87,10 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
             'payment': {
                 'date': fields.Date.today(),
                 'reference': batch_name,
-                'amount': total_amount,
+                'amount': amount_residual,
                 'currency': currency,
             },
-            'amount': total_amount,
+            'amount': amount_residual,
         })
 
         common_view_values = self._get_common_page_view_values(

--- a/addons/account_payment/tests/test_payment_flows.py
+++ b/addons/account_payment/tests/test_payment_flows.py
@@ -227,3 +227,82 @@ class TestFlows(AccountPaymentCommon, PaymentHttpCommon):
         self.assertEqual(values['next_amount_to_pay'], 26.0)
         self.assertEqual(values['payment_state'], 'not_paid')
         self.assertTrue(values['payment'])
+
+    def test_partially_paid_invoice_overdue_payment_flow(self):
+        """
+        Test partially paid overdue payment of an invoice is correctly processed
+        with invoice residual amount.
+        """
+        partner = self.env['res.partner'].create({'name': 'Qung'})
+        self.env['res.users'].create({
+            'login': 'TestUser',
+            'password': 'Odoo@123',
+            'groups_id': [Command.set(self.env.ref('account.group_account_manager').ids)],
+            'partner_id': partner.id
+        })
+        # Create an invoice with invoice due date must be in past with payment status to be not paid
+        invoice = self.init_invoice(
+            "out_invoice", partner, amounts=[1000.0], currency=self.currency,
+        )
+        invoice.invoice_date_due = invoice.invoice_date - timedelta(days=10)
+
+        invoice.action_post()
+        self.assertEqual(invoice.payment_state, 'not_paid')
+
+        # Create a payment to partially pay the overdue invoice
+        payment = self.env['account.payment'].create({
+            'amount': invoice.amount_residual / 2,
+            'payment_type': 'inbound',
+            'partner_id': partner.id,
+            'partner_type': 'customer',
+            'invoice_ids': [invoice.id],
+        })
+        payment.action_post()
+        (payment.move_id.line_ids + invoice.line_ids).filtered(
+                lambda line: line.account_id == payment.destination_account_id
+                and not line.reconciled
+            ).reconcile()
+
+        self.assertEqual(invoice.payment_state, 'partial')
+
+        # Must be authenticated before making an http resqest
+        self.authenticate('TestUser', 'Odoo@123')
+        overdue_url = self._build_url('/my/invoices/overdue')
+        resp = self._make_http_get_request(overdue_url, {})
+
+        # Validate the response status code
+        self.assertEqual(resp.status_code, 200)
+
+        tx_context = self._get_payment_context(resp)
+
+        # Validate the transaction context amount and payment_reference
+        self.assertEqual(tx_context.get('amount'), invoice.amount_residual)
+        self.assertEqual(tx_context['payment_reference'], invoice.payment_reference)
+
+        # Prepare the transaction route values
+        tx_route_values = {
+            'provider_id': self.provider.id,
+            'payment_method_id': self.payment_method_id,
+            'token_id': None,
+            'amount': tx_context.get('amount'),
+            'flow': 'direct',
+            'tokenization_requested': False,
+            'landing_route': tx_context['landing_route'],
+            'payment_reference': tx_context['payment_reference'],
+        }
+        with mute_logger('odoo.addons.payment.models.payment_transaction'):
+            processing_values = self._get_processing_values(
+                tx_route=tx_context['transaction_route'], **tx_route_values
+            )
+        tx_sudo = self._get_tx(processing_values['reference'])
+        tx_sudo._set_done()
+
+        # Validate the transaction amount is equal to the invoice amount
+        self.assertEqual(tx_sudo.amount, invoice.amount_residual)
+
+        url = self._build_url('/payment/status/poll')
+        resp = self.make_jsonrpc_request(url, {})
+        self.assertTrue(tx_sudo.is_post_processed)
+
+        self.assertEqual(resp['state'], 'done')
+        self.assertTrue(invoice.payment_state == invoice._get_invoice_in_payment_state())


### PR DESCRIPTION
Issue:
When customer pays overdue amount from the portal, it shows the total amount of the overdue invoices. However, if overdue invoices are partially paid then the customer of the invoices would be overpaying.

Purpose of this PR:
We should display the residual amount of the overdue invoices so that when the transaction and payment records are created, they are created with the residual amounts of the overdue invoices and not the total amount of invoices.

Steps to Reproduce on Runbot:
create an invoice for Joel Willis that is overdue. partially pay for the invoice.
go to the portal view with Joel Willis logged in and click 'Pay Overdue' the amount shown at the top and the corresponding transaction and payment records will have the total amount of the invoice.

opw-4745031
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
