### PR TITLE
[FIX] hr_holidays: Fix leave type configuration UI

### DIFF
--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -87,13 +87,13 @@
                             <field name="allocation_validation_type" string="Approval" widget="radio" invisible="not requires_allocation"/>
                         </group>
                     </group>
-                    <group>
+                    <group style="justify-content: unset;">
                         <group name="configuration" id="configuration" string="Configuration">
-                            <div class="d-flex flex-row" colspan="2">
+                            <div class="o_cell o_wrap_label text-break text-900 d-flex flex-row" colspan="2">
                                 <div class="d-flex flex-column gap-2">
-                                    <label for="include_public_holidays_in_duration" class="fw-bold me-4"/>
-                                    <label for="hide_on_dashboard" class="fw-bold me-4"/>
-                                    <label for="support_document" class="fw-bold me-4" string="Require Supporting Document"/>
+                                    <label for="include_public_holidays_in_duration" class="me-4"/>
+                                    <label for="hide_on_dashboard" class="me-4"/>
+                                    <label for="support_document" class="me-4" string="Require Supporting Document"/>
                                 </div>
                                 <div class="d-flex flex-column gap-1">
                                     <field name="include_public_holidays_in_duration" class="mb-2" nolabel="1"/>
@@ -102,18 +102,20 @@
                                 </div>
                             </div>
                         </group>
-                        <group name="negative_cap" id="negative_cap" string="Negative Cap"
-                            invisible="not requires_allocation">
-                            <div class="o_row" colspan="2">
-                                <label for="allows_negative" class="fw-bold me-4" readonly="0"/>
-                                <field name="allows_negative" nolabel="1"/>
-                                <div invisible="not allows_negative">
-                                    <span class="mx-2">up to</span>
-                                    <field name="max_allowed_negative" class="oe_inline"/>
-                                    <span class="mx-2" invisible="request_unit == 'hour'">days</span>
-                                    <span class="mx-2" invisible="request_unit != 'hour'">hours</span>
+                        <group>
+                            <group name="negative_cap" id="negative_cap" string="Negative Cap"
+                                invisible="not requires_allocation" colspan="2">
+                                <div class="o_row o_cell o_wrap_label text-break text-900" colspan="2">
+                                    <label for="allows_negative" class="me-4" readonly="0"/>
+                                    <field name="allows_negative" nolabel="1"/>
+                                    <div invisible="not allows_negative">
+                                        <span class="mx-2">up to</span>
+                                        <field name="max_allowed_negative" class="oe_inline"/>
+                                        <span class="mx-2" invisible="request_unit == 'hour'">days</span>
+                                        <span class="mx-2" invisible="request_unit != 'hour'">hours</span>
+                                    </div>
                                 </div>
-                            </div>
+                            </group>
                         </group>
                     </group>
                     <group name="visual" id="visual" string="Display Option" class="mw-100 col-lg-12">

--- a/addons/l10n_in_hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/l10n_in_hr_holidays/views/hr_leave_type_views.xml
@@ -6,9 +6,13 @@
         <field name="model">hr.leave.type</field>
         <field name="inherit_id" ref="hr_holidays.edit_holiday_status_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//group[@name='configuration']" position="inside">
-                <field name="l10n_in_is_sandwich_leave" invisible="country_code and country_code != 'IN'" nolabel="1"/>
-                <label for="l10n_in_is_sandwich_leave" string="Sandwich Leaves" invisible="country_code and country_code != 'IN'"/>
+            <xpath expr="//group[@name='configuration']/div/div[1]" position="inside">
+                <label for="l10n_in_is_sandwich_leave" class="me-4"
+                    string="Sandwich Leaves" invisible="country_code and country_code != 'IN'"/>
+            </xpath>
+            <xpath expr="//group[@name='configuration']/div/div[2]" position="inside">
+                <field name="l10n_in_is_sandwich_leave" class="mb-2" nolabel="1"
+                    invisible="country_code and country_code != 'IN'"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
* = l10n_in_hr_holidays, l10n_ae_hr_payroll, l10n_be_hr_payroll

Steps:
- Navigate to Time Off > Configuration > Time Off Types.
- Open any time off type form with localization or payroll-related options.

Issues:
- Configuration fields (including localization modules) appeared misaligned.
- The Payroll section was not utilizing space effectively in the layout.

Fix:
- Aligned all configuration fields in a consistent two-column layout, including localization and payroll-related options.,
- Repositioned the Payroll section below the Negative Cap section.

Task - 4759116