### PR TITLE
[IMP] account*,l10n*:  Schedule the print & send invoice

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -78,6 +78,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/account_menuitem.xml',
         'wizard/account_secure_entries_wizard.xml',
         'views/mail_message_views.xml',
+        'views/mail_scheduled_message_views.xml',
         'wizard/accrued_orders.xml',
         'views/bill_preview_template.xml',
         'data/account_reports_data.xml',

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -43,6 +43,7 @@ from . import ir_actions_report
 from . import ir_http
 from . import ir_module
 from . import mail_message
+from . import mail_scheduled_message
 from . import mail_template
 from . import mail_tracking_value
 from . import merge_partner_automatic

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5862,6 +5862,12 @@ class AccountMove(models.Model):
         self._check_draftable()
         # We remove all the analytics entries for this journal
         self.line_ids.analytic_line_ids.with_context(skip_analytic_sync=True).unlink()
+        # We delete scheduled messages from account_move_send_wizard related to the sending of this invoice
+        self.env['mail.scheduled.message'].search([
+            ('model', '=', 'account.move'),
+            ('res_id', 'in', self.ids),
+            ('from_account_move_send', '=', True),
+        ]).unlink()
         self.state = 'draft'
         self.sending_data = False
 

--- a/addons/account/models/mail_scheduled_message.py
+++ b/addons/account/models/mail_scheduled_message.py
@@ -1,0 +1,199 @@
+import json
+
+from markupsafe import Markup
+
+from odoo import _, api, fields, models
+
+
+class MailScheduledMessage(models.Model):
+    _inherit = 'mail.scheduled.message'
+
+    from_account_move_send = fields.Boolean(compute='_compute_from_account_move_send', store=True)
+
+    # ------------------------------------------------------
+    # Compute Methods
+    # ------------------------------------------------------
+
+    @api.depends('notification_parameters')
+    def _compute_from_account_move_send(self):
+        for scheduled_message in self:
+            notification_parameters = json.loads(scheduled_message.notification_parameters or '{}')
+            scheduled_message.from_account_move_send = notification_parameters.get('from_account_move_send')
+
+    # ------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------
+
+    def _post_message(self, raise_exception=True):
+        # OVERRIDE mail
+        # To handle scheduled messages from account.move.send.wizard specifically
+        account_scheduled_messages = self.filtered(lambda s: (
+            s.model == 'account.move' and
+            s.from_account_move_send and
+            json.loads(s.notification_parameters or '{}').get('scheduled_move_data')
+        ))
+        remained_scheduled_messages = self - account_scheduled_messages
+
+        for scheduled_message in account_scheduled_messages:
+            scheduled_move_data = json.loads(scheduled_message.notification_parameters or '{}').get('scheduled_move_data')
+            move_id = self.env['account.move'].browse(scheduled_message.res_id)
+
+            sending_settings = {
+                **{k: v for k, v in scheduled_move_data.items() if k in self._account_get_scheduled_move_data_whitelist()},
+                'pdf_report': self.env['ir.actions.report'].browse(scheduled_move_data.get('pdf_report')),
+                'author_partner_id': scheduled_message.author_id.id,
+            }
+            if 'email' in sending_settings['sending_methods']:
+                # Add manual attachments from scheduled message to mail_attachments_widget if any,
+                # except the attachments which are already in scheduled_move_data from account_move_send_wizard
+                move_data_attachments_widget = sending_settings.get('mail_attachments_widget', [])
+                attachment_names_from_move_data = [d.get('name') for d in move_data_attachments_widget]
+                manual_attachments_widget_data = [
+                    {
+                        'id': attachment.id,
+                        'name': attachment.name,
+                        'mimetype': attachment.mimetype,
+                        'placeholder': False,
+                        'manual': True,
+                    }
+                    for attachment in scheduled_message.attachment_ids
+                    if attachment.name not in attachment_names_from_move_data
+                ]
+                sending_settings = {
+                    **sending_settings,
+                    'mail_partner_ids': scheduled_message.partner_ids.ids,
+                    'mail_subject': scheduled_message.subject,
+                    'mail_body': scheduled_message.body,
+                    'mail_template': self.env['mail.template'].browse(sending_settings.get('mail_template')),
+                    'mail_attachments_widget': move_data_attachments_widget + manual_attachments_widget_data,
+                }
+
+            # The generate and send invoice logic (including any EDI sending methods) with extra manual attachment if any
+            attachments = self.env['account.move.send']._generate_and_send_invoices(
+                moves=move_id,
+                allow_raising=raise_exception,
+                **sending_settings,
+            )
+
+            if attachments and scheduled_message.from_account_move_send and scheduled_message.is_note:
+                move_id._message_log(
+                    subject=scheduled_message.subject,
+                    body=scheduled_message._account_get_log_note_body(event='sending'),
+                )
+            scheduled_message.unlink()
+
+        if remained_scheduled_messages:
+            super(MailScheduledMessage, remained_scheduled_messages)._post_message(raise_exception)
+
+    # ------------------------------------------------------
+    # Business Methods
+    # ------------------------------------------------------
+
+    @api.model
+    def _account_get_scheduled_move_data_whitelist(self):
+        """ Account specific scheduled_move_data parameters which are used when generating and sending invoices.
+        """
+        return {
+            'allow_fallback_pdf',
+            'author_user_id',
+            'extra_edis',
+            'invoice_edi_format',
+            'mail_attachments_widget',
+            'mail_lang',
+            'mail_partner_ids',
+            'mail_template',
+            'pdf_report',
+            'sending_methods',
+        }
+
+    @api.model
+    def _account_get_sending_method_and_edi_data_from_scheduled_messages(self, move):
+        """ To get the sending methods and edis data from scheduled messages of move
+            :return: A dict with the following keys:
+                - sending_methods: A set of invoice sending methods for which the message is already scheduled
+                - extra_edis:      A set of invoice EDI methods for which the message is already scheduled
+        """
+        moves_data = []
+        sending_methods = set()
+        extra_edis = set()
+
+        scheduled_messages = self.env['mail.scheduled.message'].search([
+            ('from_account_move_send', '=', True),
+            ('notification_parameters', '!=', False),
+            ('res_id', '=', move.id)
+        ])
+        for scheduled_message in scheduled_messages:
+            if scheduled_move_data := json.loads(scheduled_message.notification_parameters or '{}').get('scheduled_move_data'):
+                moves_data.append(scheduled_move_data)
+
+        for move_data in moves_data:
+            # Exclude 'email' as it is necessary to allow scheduling multiple emails at once
+            sending_methods.update(sending_method for sending_method in move_data.get('sending_methods', []) if sending_method != 'email')
+            extra_edis.update(move_data.get('extra_edis', []))
+
+        return {
+            'sending_methods': sending_methods,
+            'extra_edis': extra_edis,
+        }
+
+    def _account_get_log_note_body(self, event):
+        """ To get the body of the log note to post on the move for the scheduled message with EDI or other sending methods,
+            based on the event
+        """
+        self.ensure_one()
+        scheduled_move_data = json.loads(self.notification_parameters or '{}').get('scheduled_move_data')
+        body = self.body
+        user_name = self.env.user.name
+        if edi_methods := scheduled_move_data.get('extra_edis', []):
+            all_extra_edis = self.env['account.move.send']._get_all_extra_edis()
+            edi_labels = ", ".join(
+                all_extra_edis.get(extra_edi, {}).get('label')
+                for extra_edi in edi_methods
+                if extra_edi in all_extra_edis and 'label' in all_extra_edis[extra_edi]
+            )
+            if event == 'sending':
+                body = Markup("<p>%s</p>") % (_(
+                        'The scheduled request for %s is sent.',
+                        Markup("<strong>{}</strong>").format(edi_labels),
+                    ))
+            elif event == 'cancellation':
+                body = Markup("<p>%s</p>") % _(
+                    'The scheduled request for %(edi)s is cancelled by %(user)s.',
+                    edi=Markup("<strong>{}</strong>").format(edi_labels),
+                    user=user_name,
+                )
+        if other_sending_methods := set(scheduled_move_data.get('sending_methods', [])) - {'email'}:
+            methods = dict(self.env['ir.model.fields'].get_field_selection('res.partner', 'invoice_sending_method'))
+            methods_labels = ", ".join(
+                methods.get(sending_method, '')
+                for sending_method in other_sending_methods
+                if sending_method in methods
+            )
+            if event == 'sending':
+                body = Markup("<p>%s</p>") % (_(
+                    'The scheduled %s method is sent.',
+                    Markup("<strong>{}</strong>").format(methods_labels),
+                ))
+            elif event == 'cancellation':
+                body = Markup("<p>%s</p>") % _(
+                    'The scheduled %(other)s method is cancelled by %(user)s.',
+                    other=Markup("<strong>{}</strong>").format(methods_labels),
+                    user=user_name,
+                )
+        return body
+
+    def account_log_cancellation(self):
+        """ Post a log note on the move when the scheduled messages with EDI or other sending methods are cancelled by user.
+        """
+        moves = self.env['account.move'].browse(self.filtered(
+            lambda s: (s.model == 'account.move')).mapped('res_id')
+        )
+        for scheduled_message in self.filtered(lambda s: (
+            s.model == 'account.move' and
+            s.from_account_move_send and
+            s.is_note
+        )):
+            self.env['account.move'].with_prefetch(moves).browse(scheduled_message.res_id)._message_log(
+                author_id=scheduled_message.author_id.id,
+                body=scheduled_message._account_get_log_note_body(event='cancellation'),
+            )

--- a/addons/account/static/src/components/account_mail_scheduled_message/mail_scheduled_message_model.js
+++ b/addons/account/static/src/components/account_mail_scheduled_message/mail_scheduled_message_model.js
@@ -1,11 +1,26 @@
-import { ScheduledMessage } from "@mail/chatter/web/scheduled_message_model";
 import { patch } from "@web/core/utils/patch";
+import { RPCError } from "@web/core/network/rpc";
+import { ScheduledMessage } from "@mail/chatter/web/scheduled_message_model";
 
+// account specific modifications
 patch(ScheduledMessage.prototype, {
     async cancel() {
         await this.store.env.services.orm.call("mail.scheduled.message", "account_log_cancellation", [
             this.id,
         ]);
         await super.cancel();
+    },
+    // patching this method, cause parent method catches all the errors
+    async send() {
+        try {
+            await this.store.env.services.orm.call("mail.scheduled.message", "post_message", [
+                this.id,
+            ]);
+        } catch(error) {
+            if (error instanceof RPCError) {
+                throw error;  // re-raise errors only from server-side
+            }
+            return;
+        }
     }
 })

--- a/addons/account/static/src/components/account_mail_scheduled_message/mail_scheduled_message_model.js
+++ b/addons/account/static/src/components/account_mail_scheduled_message/mail_scheduled_message_model.js
@@ -1,0 +1,11 @@
+import { ScheduledMessage } from "@mail/chatter/web/scheduled_message_model";
+import { patch } from "@web/core/utils/patch";
+
+patch(ScheduledMessage.prototype, {
+    async cancel() {
+        await this.store.env.services.orm.call("mail.scheduled.message", "account_log_cancellation", [
+            this.id,
+        ]);
+        await super.cancel();
+    }
+})

--- a/addons/account/static/tests/tours/account_move_send_tests.js
+++ b/addons/account/static/tests/tours/account_move_send_tests.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_account_log_cancellation", {
+    steps: () => [
+        {
+            content: "Click Cancel Button",
+            trigger: ".o-mail-Scheduled-Message-buttons .fa-times",
+            run: "click",
+        },
+        {
+            content: "Click confirm button",
+            trigger: ".modal-footer .btn-primary",
+            run: "click",
+        },
+    ],
+});

--- a/addons/account/views/mail_scheduled_message_views.xml
+++ b/addons/account/views/mail_scheduled_message_views.xml
@@ -1,0 +1,23 @@
+<odoo>
+    <data>
+        <record id="mail_scheduled_message_form_account" model="ir.ui.view">
+            <field name="name">mail.scheduled.message.view.form.account</field>
+            <field name="model">mail.scheduled.message</field>
+            <field name="inherit_id" ref="mail.mail_scheduled_message_view_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='subject']" position="attributes">
+                    <attribute name="readonly">is_note and from_account_move_send</attribute>
+                </xpath>
+                <xpath expr="//field[@name='body']" position="attributes">
+                    <attribute name="readonly">is_note and from_account_move_send</attribute>
+                </xpath>
+                <xpath expr="//field[@name='attachment_ids' and @widget='mail_composer_attachment_list']" position="attributes">
+                    <attribute name="invisible">is_note and from_account_move_send</attribute>
+                </xpath>
+                <xpath expr="//field[@name='attachment_ids' and @widget='mail_composer_attachment_selector']" position="attributes">
+                    <attribute name="invisible">is_note and from_account_move_send</attribute>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/addons/account/wizard/account_move_send_wizard.py
+++ b/addons/account/wizard/account_move_send_wizard.py
@@ -597,6 +597,16 @@ class AccountMoveSendWizard(models.TransientModel):
                 **self._get_default_sending_settings(self.move_id, **sending_settings, allow_fallback_pdf=allow_fallback_pdf),
             }
         }
+
+        # Collect validation errors before scheduling the invoice.
+        move = self.move_id
+        self._hook_invoice_validation_errors(move, move_data.get(move, {}))
+
+        # Manage collected validation errors.
+        errors = {move: move_data for move, move_data in move_data.items() if move_data.get('error')}
+        if errors:
+            self._hook_if_errors(errors, allow_raising=not allow_fallback_pdf)
+
         # generating invoice pdf to show in the scheduled message.
         attachment_to_create = []
         if self.sending_methods and 'email' in self.sending_methods:

--- a/addons/account/wizard/account_move_send_wizard.xml
+++ b/addons/account/wizard/account_move_send_wizard.xml
@@ -63,13 +63,19 @@
                             name="action_send_and_print"
                             type="object"
                             class="btn-primary"
-                            invisible="not sending_methods"/>
+                            invisible="not sending_methods or scheduled_date"/>
                     <button string="Generate"
                             data-hotkey="q"
                             name="action_send_and_print"
                             type="object"
                             class="btn-primary"
-                            invisible="sending_methods"/>
+                            invisible="sending_methods or scheduled_date"/>
+                    <button string="Schedule"
+                            data-hotkey="q"
+                            name="action_schedule_message"
+                            type="object"
+                            class="btn-primary"
+                            invisible="not scheduled_date"/>
                     <button string="Discard"
                             data-hotkey="x"
                             special="cancel"
@@ -77,6 +83,7 @@
 
                     <field name="mail_attachments_widget" widget="mail_attachments_selector" invisible="'email' not in sending_methods"/>
                     <field name="template_id" widget="mail_composer_template_selector"/>
+                    <field name="scheduled_date" widget="text_scheduled_date" invisible="not sending_methods and not extra_edis"/>
                 </footer>
             </form>
         </field>

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -118,3 +118,11 @@ class AccountMoveSend(models.AbstractModel):
             attachments = self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachments_vals)
             res_ids = attachments.mapped('res_id')
             self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['l10n_es_edi_facturae_xml_id', 'l10n_es_edi_facturae_xml_file'])
+
+    def _generate_and_send_invoices(self, moves, from_cron=False, allow_raising=True, allow_fallback_pdf=False, **custom_settings):
+        attachments = super()._generate_and_send_invoices(moves, from_cron, allow_raising, allow_fallback_pdf, **custom_settings)
+        if 'es_facturae' in custom_settings.get('extra_edis', []):
+            # Set partner's invoice_edi_format to 'es_facturae' after sending
+            partner = moves.commercial_partner_id
+            partner.invoice_edi_format = 'es_facturae'
+        return attachments

--- a/addons/l10n_es_edi_facturae/wizard/account_move_send_wizard.py
+++ b/addons/l10n_es_edi_facturae/wizard/account_move_send_wizard.py
@@ -11,12 +11,3 @@ class AccountMoveSendWizard(models.TransientModel):
             if 'es_facturae' in checkboxes:
                 # Set 'checked' status for the 'es_facturae' checkbox
                 checkboxes['es_facturae']['checked'] = wizard.move_id._l10n_es_edi_facturae_get_default_enable()
-
-    def action_send_and_print(self, allow_fallback_pdf=False):
-        action = super().action_send_and_print(allow_fallback_pdf)
-        checkboxes = self.extra_edi_checkboxes or {}
-        if 'es_facturae' in checkboxes and checkboxes['es_facturae']['checked']:
-            # Set partner's invoice_edi_format to 'es_facturae' after sending
-            partner = self.move_id.commercial_partner_id
-            partner.invoice_edi_format = 'es_facturae'
-        return action

--- a/addons/l10n_gr_edi/models/account_move_send.py
+++ b/addons/l10n_gr_edi/models/account_move_send.py
@@ -39,6 +39,17 @@ class AccountMoveSend(models.AbstractModel):
     # SENDING METHODS
     # -------------------------------------------------------------------------
 
+    def _hook_invoice_validation_errors(self, invoice, invoice_data):
+        # EXTENDS 'account'
+        super()._hook_invoice_validation_errors(invoice, invoice_data)
+        if 'gr_edi' in invoice_data['extra_edis']:
+            if errors := invoice._l10n_gr_edi_get_pre_error_dict():
+                for error in errors.values():
+                    invoice_data['error'] = {
+                        'error_title': _("Error while validating invoice for myDATA"),
+                        'errors': [error.get('message', '')],
+                    }
+
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
         super()._call_web_service_before_invoice_pdf_render(invoices_data)

--- a/addons/l10n_in_edi/models/account_move_send.py
+++ b/addons/l10n_in_edi/models/account_move_send.py
@@ -46,6 +46,19 @@ class AccountMoveSend(models.AbstractModel):
         # EXTENDS 'account'
         return super()._get_invoice_extra_attachments(invoice) + invoice.l10n_in_edi_attachment_id
 
+    def _hook_invoice_validation_errors(self, invoice, invoice_data):
+        # EXTENDS 'account'
+        super()._hook_invoice_validation_errors(invoice, invoice_data)
+        if 'in_edi_send' in invoice_data['extra_edis']:
+            partners = set(invoice._get_l10n_in_seller_buyer_party().values())
+            if error := invoice._l10n_in_edi_partner_field_validation(partners):
+                invoice_data['error'] = {
+                    'error_title': self.env._(
+                        "Error while validating the e-invoice:"
+                    ),
+                    'errors': [error] if not isinstance(error, list) else error,
+                }
+
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
         super()._call_web_service_before_invoice_pdf_render(invoices_data)

--- a/addons/l10n_it_edi/models/account_move_send.py
+++ b/addons/l10n_it_edi/models/account_move_send.py
@@ -60,9 +60,9 @@ class AccountMoveSend(models.AbstractModel):
             ('res_id', 'in', invoice.ids),
         ])
 
-    def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
+    def _hook_invoice_validation_errors(self, invoice, invoice_data):
         # EXTENDS 'account'
-        super()._hook_invoice_document_before_pdf_report_render(invoice, invoice_data)
+        super()._hook_invoice_validation_errors(invoice, invoice_data)
         if (
                 ('it_edi_send' in invoice_data['extra_edis'] and not invoice.l10n_it_edi_attachment_file)
                 or (invoice_data['invoice_edi_format'] == 'it_edi_xml' and invoice._l10n_it_edi_ready_for_xml_export())

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -321,7 +321,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         if not self.env['res.company']._with_locked_records(records=self, allow_raising=False):
             return
-        if error_message := self._l10n_jo_validate_config() or self._l10n_jo_validate_fields() or self._submit_to_jofotara():
+        if error_message := self._submit_to_jofotara():
             self.l10n_jo_edi_error = error_message
             return error_message
         else:

--- a/addons/l10n_jo_edi/models/account_move_send.py
+++ b/addons/l10n_jo_edi/models/account_move_send.py
@@ -65,6 +65,16 @@ class AccountMoveSend(models.AbstractModel):
     # SENDING METHODS
     # -------------------------------------------------------------------------
 
+    def _hook_invoice_validation_errors(self, invoice, invoice_data):
+        # EXTENDS 'account'
+        super()._hook_invoice_validation_errors(invoice, invoice_data)
+        if 'jo_edi' in invoice_data['extra_edis']:
+            if error_message := invoice._l10n_jo_validate_config() or invoice._l10n_jo_validate_fields():
+                invoice_data["error"] = {
+                    "error_title": _("Errors while validating the JoFotara e-invoice:"),
+                    "errors": [error_message],
+                }
+
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
         super()._call_web_service_before_invoice_pdf_render(invoices_data)

--- a/addons/l10n_ke_edi_tremol/wizard/account_move_send_wizard.py
+++ b/addons/l10n_ke_edi_tremol/wizard/account_move_send_wizard.py
@@ -12,3 +12,11 @@ class AccountMoveSendWizard(models.TransientModel):
             if warning_moves := self._get_l10n_ke_edi_tremol_warning_moves(self.move_id):
                 raise UserError(self._get_l10n_ke_edi_tremol_warning_message(warning_moves))
         return super().action_send_and_print(allow_fallback_pdf=allow_fallback_pdf)
+
+    def action_schedule_message(self, allow_fallback_pdf=False):
+        # EXTENDS account - prevent scheduling the Send & Print if KE invoices aren't validated and no fallback is allowed.
+        self.ensure_one()
+        if not allow_fallback_pdf:
+            if warning_moves := self._get_l10n_ke_edi_tremol_warning_moves(self.move_id):
+                raise UserError(self._get_l10n_ke_edi_tremol_warning_message(warning_moves))
+        return super().action_schedule_message(allow_fallback_pdf)

--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -82,16 +82,14 @@ class AccountMove(models.Model):
     # Send Logics
     ################################################################################
 
-    def _l10n_ro_edi_get_pre_send_errors(self, xml_data):
-        """ Compute all possible common errors before sending the XML to the SPV """
+    def _l10n_ro_edi_invoice_validation_errors(self):
+        """ Compute all possible validation errors before sending/scheduling the invoice for SPV """
         self.ensure_one()
         errors = []
         if self.state != 'posted':
             errors.append(_('Only posted entries can be sent to SPV.'))
         if not self.company_id.l10n_ro_edi_access_token:
             errors.append(_('Romanian access token not found. Please generate or fill it in the settings.'))
-        if not xml_data:
-            errors.append(_('CIUS-RO XML attachment not found.'))
         if self.l10n_ro_edi_document_ids:
             errors.append(_('The invoice has already been sent to the SPV.'))
         return errors
@@ -109,7 +107,9 @@ class AccountMove(models.Model):
         :return: the `list` of errors that occured during the sending and processing of data, if any
         """
         self.ensure_one()
-        if errors := self._l10n_ro_edi_get_pre_send_errors(xml_data):
+        if errors := self._l10n_ro_edi_invoice_validation_errors():
+            if not xml_data:
+                errors.append(_('CIUS-RO XML attachment not found.'))
             self.message_post(body=_("The invoice is not ready to be sent: %s", ", ".join(errors)))
             return errors
 

--- a/addons/mail/static/src/chatter/web/scheduled_message.js
+++ b/addons/mail/static/src/chatter/web/scheduled_message.js
@@ -74,12 +74,21 @@ export class ScheduledMessage extends Component {
     }
 
     onClickCancel() {
-        this.dialogService.add(ConfirmationDialog, {
-            body: _t("Are you sure you want to cancel the scheduled message?"),
-            cancel: () => {},
+        const { is_note } = this.props.scheduledMessage;
+        const dialogConfig = {
+            body: is_note
+                ? _t("Are you sure you want to cancel the scheduled log?")
+                : _t("Are you sure you want to cancel the scheduled message?"),
+            confirmLabel: is_note ? _t("Cancel Log") : _t("Cancel Message"),
             cancelLabel: _t("Close"),
+        };
+
+        this.dialogService.add(ConfirmationDialog, {
+            body: dialogConfig.body,
+            cancelLabel: dialogConfig.cancelLabel,
+            cancel: () => {},
             confirm: this.cancel.bind(this),
-            confirmLabel: _t("Cancel Message"),
+            confirmLabel: dialogConfig.confirmLabel,
         });
     }
 

--- a/addons/mail/views/mail_scheduled_message_views.xml
+++ b/addons/mail/views/mail_scheduled_message_views.xml
@@ -8,6 +8,8 @@
                 <form string="Scheduled Message">
                     <sheet>
                         <group>
+                            <field name="res_id" invisible="1"/>
+                            <field name="model" invisible="1"/>
                             <field name="composition_comment_option" invisible="1"/>
                             <label for="partner_ids" string="To" invisible="is_note"/>
                             <div invisible="is_note" class="d-flex gap-3">


### PR DESCRIPTION
PURPOSE

- The purpose of this commit is to allow users to schedule the execution of the
  Invoice and EDI sending in the future from the account move send wizard.
- Users have control to schedule the e-mail, EDIs, and other sending methods on
  different dates and times, as there will be separate scheduled messages for
  all these sending methods and EDI requests.

TECHNICAL DETAILS

- Introduced basic scheduling functionalities similar to the mail compose
  message wizard into the account move send wizard.
- Categorising the selected checkboxes into 3 categories of scheduled messages:
  1. For email sending method
  2. For all the selected extra EDIs
  3. For all the other selected sending methods (snailmail, peppol, ...)
- Classifying the calculated `invoice_data` based on the selected checkboxes and
  preparing the invoice_data for individual scheduled messages.
- Preserving this invoice_data in the `notification_parameter` of the scheduled 
  message to retrieve it later when posting the scheduled messages and calling
  the actual `_generate_and_send_invoices` process.
- Manually added attachments in the scheduled message will also be added to the
  `mail_attachments_widget` in invoice_data to consider it for the email sending
  method.

Related Enterprise PR: https://github.com/odoo/enterprise/pull/92857

Task: 4677423