### PR TITLE
[FIX] account: prevent crash on invalid chart template code

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -172,7 +172,14 @@ class AccountChartTemplate(models.AbstractModel):
         if not self.env.is_system():
             raise AccessError(_("Only administrators can install chart templates"))
 
-        chart_template_mapping = self._get_chart_template_mapping()[template_code]
+        template_info = self._get_chart_template_mapping()
+        if template_code not in template_info:
+            raise UserError(_(
+                "The chart template code '%s' is not available. "
+                "Please ensure the correct localization module is installed."
+            ) % template_code)
+
+        chart_template_mapping = template_info[template_code]
         if not company.country_id:
             company.country_id = chart_template_mapping.get('country_id')
 


### PR DESCRIPTION
The system would crash with a KeyError when attempting to load a chart of accounts using a template code that does not exist in the chart template mapping. This happened during the setup of a new company or while installing localization modules.

**Steps to Produce:-**

1. Install the `Accounting` module.
2. Navigate to `Settings > Users & Companies > Companies`.
3. Create a new company, but do not select a country for it.
4. Switch to the newly created company.
5. Go to `Accounting > Configuration > Settings and set Iraq as the Fiscal Localization`.
6. Attempt to save the changes.

**Error:-**
`KeyError: 'iq'`

**Solution:-**
- Check if `template_code` exists in the chart template mapping.
- Raise a proper `UserError` with a clear message if it doesn't, guiding the user to verify the correct localization module is installed.

**Sentry - 6613287121, 6613283263, 6712436024**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
