### PR TITLE
[FIX] account: prevent traceback when accessing asset from a different company

### DIFF
--- a/addons/account/models/account_analytic_plan.py
+++ b/addons/account/models/account_analytic_plan.py
@@ -64,7 +64,7 @@ class AccountAnalyticApplicability(models.Model):
         account = self.env['account.account'].browse(kwargs.get('account'))
         if self.account_prefix:
             account_prefixes = tuple(prefix for prefix in re.split("[,;]", self.account_prefix.replace(" ", "")) if prefix)
-            if account and account.code.startswith(account_prefixes):
+            if account.code and account.code.startswith(account_prefixes):
                 score += 1
             else:
                 return -1

--- a/addons/account/tests/test_account_analytic.py
+++ b/addons/account/tests/test_account_analytic.py
@@ -505,3 +505,20 @@ class TestAccountAnalyticAccount(AccountTestInvoicingCommon, AnalyticCommon):
                 'analytic_distribution': {str(self.analytic_account_1.id): 100.00},
             },
         ])
+
+    def test_get_relevant_plans_in_multi_company(self):
+        """ Test the plans returned with applicability rules and options in multi-company """
+        self.analytic_plan_1.write({
+            'applicability_ids': [Command.create({
+                'business_domain': 'general',
+                'applicability': 'mandatory',
+                'account_prefix': '60, 61, 62',
+            })],
+        })
+        company_2 = self.company_data_2['company']
+        plans_json = self.env['account.analytic.plan'].sudo().with_company(company_2).get_relevant_plans(
+            business_domain='general',
+            account=self.company_data['default_account_assets'].id,
+            company=self.company.id,
+        )
+        self.assertTrue(plans_json)


### PR DESCRIPTION
**Steps to reproduce :**

1) Install Accounting and enable Analytic Accounting from the configuration. 
2) Create an analytic plan under Accounting > Configuration > Analytic Plans. 
3) Add a line with domain set to miscellaneous, applicability as mandatory and a prefix
4) Create an analytic account using the smart button on the plan. 
5) Create an asset record in one company in a multi-company setup. 
6) Switch to another company and try to access the asset created in the first company.

**Issue:**
A traceback occurs
```
AttributeError: 'bool' object has no attribute 'startswith'
```

**Cause:**

- When switching companies, all the chart of accounts records code for the previous company, will set as False.
- 
  When accessing an asset record expects a account code to call .startswith(), 
  but it fails when code is False. This leads to the above traceback.
https://github.com/odoo/odoo/blob/5a321b2327e36f3250b33c669bdb8bb344ab4cbd/addons/account/models/account_analytic_plan.py#L64-L67

**Solution:**
- Add a check to ensure that the account’s code exists before attempting to call .startswith().
  This makes the code more robust across multi-company environments.

opw-4745633