### PR TITLE
[FIX] Stock: column insertion issue in Studio

### DIFF
--- a/addons/product_expiry/report/report_deliveryslip.xml
+++ b/addons/product_expiry/report/report_deliveryslip.xml
@@ -13,7 +13,7 @@
     </template>
 
     <template id="stock_report_delivery_has_serial_move_line_inherit_product_expiry" inherit_id="stock.stock_report_delivery_has_serial_move_line">
-        <xpath expr="//t[@name='move_line_lot']" position="after">
+        <xpath expr="//td[@name='move_line_lot']" position="after">
             <t t-if="has_expiry_date">
                 <td><span t-field="move_line.lot_id.expiration_date"/></td>
             </t>

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -98,8 +98,12 @@
                         <thead>
                             <tr>
                                 <th name="th_sml_product">Product</th>
-                                <th name="th_sml_qty_ordered" class="text-center" t-if="not has_serial_number">Ordered</th>
-                                <th name="lot_serial" t-else="">Lot/Serial Number</th>
+                                <t t-if="has_serial_number">
+                                    <th name="lot_serial">Lot/Serial Number</th>
+                                </t>
+                                <t t-else="">
+                                    <th name="th_sml_qty_ordered" class="text-center">Ordered</th>
+                                </t>
                                 <th name="th_sml_quantity" class="text-center">Delivered</th>
                             </tr>
                         </thead>
@@ -225,8 +229,20 @@
                 <span t-esc="description"/>
             </p>
         </td>
-        <t t-if="has_serial_number" name="move_line_lot">
-            <td><span t-field="move_line.lot_id.name"/></td>
+        <t t-if="has_serial_number">
+            <td name="move_line_lot">
+                <span t-field="move_line.lot_id.name"/>
+            </td>
+        </t>
+        <t t-else="">
+            <td class="text-center" name="move_line_quantity">
+                <span t-field="move.product_uom_qty"/>
+                <span t-field="move.product_uom" groups="uom.group_uom"/>
+                <span t-if="move.product_packaging_id">
+                    (<span t-field="move.product_packaging_qty" t-options='{"widget": "integer"}'/>
+                    <span t-field="move.product_packaging_id"/>)
+                </span>
+            </td>
         </t>
         <td class="text-center" name="move_line_lot_quantity">
             <span t-field="move_line.quantity"/>


### PR DESCRIPTION
__Steps to reproduce:__

- Open a delivery slip report using Studio
- Insert a new column in table `state=='done'` 
  after "Delivered" or  "Ordered"
- Only the header or body is inserted, not both

__Description of the issue:__

The `<th>` elements used `t-if` / `t-else` for
conditional rendering, but the corresponding
`<td>` elements were missing an explicit `t-else`.
This caused a mismatch between header and body
columns, preventing the editor from aligning them
correctly when inserting a new column.

__Description of the solution:__

Refactored the table header and body to render
full `<th>` and `<td>` elements within conditional
`<t>` blocks, ensuring structural consistency.

- opw-4766132

