### PR TITLE
[FIX] html_editor: prevent undo pollution when editing link popover

### DIFF
--- a/addons/html_editor/static/src/core/input_plugin.js
+++ b/addons/html_editor/static/src/core/input_plugin.js
@@ -9,6 +9,11 @@ export class InputPlugin extends Plugin {
     }
 
     onBeforeInput(ev) {
+        const selection = this.document.getSelection();
+        if (!this.editable.contains(selection?.anchorNode)) {
+            ev.preventDefault();
+            return;
+        }
         this.dependencies.history.stageSelection();
         this.dispatchTo("beforeinput_handlers", ev);
     }


### PR DESCRIPTION
Problem:
In Chrome, when focused on the first input inside the link popover, pressing `Ctrl+Z` (undo) triggers `beforeinput` and `input` events on the editable element, even though the selection is within the popover input, not the editable area.

This leads to `addStep` being incorrectly triggered, adding DOM changes like the `a` tag to the history stack and resulting in unintended undo behavior.

Note: This issue doesn't occur in saas-18.2+ where the `a` tag is only added upon confirming the change, thus no mutation is pushed to history while editing.

Solution:
Intercept the `beforeinput` event on the editable and call `preventDefault()` if the selection is not currently within the editable, thereby stopping history pollution.

Steps to reproduce:
1. Type `/Link` and open the link popover.
2. Focus is automatically set on the first input.
3. Press `Ctrl+Z`.
4. Click on the editable area to close the popover.
5. Repeatedly press `Ctrl+Z` → the `a` tag is added/removed, corrupting undo history.

opw-4800278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
