### PR TITLE
[FIX] website_livechat: rename thread to channel_id

### DIFF
--- a/addons/website_livechat/static/src/web/channel_member_model_patch.js
+++ b/addons/website_livechat/static/src/web/channel_member_model_patch.js
@@ -4,8 +4,8 @@ import { patch } from "@web/core/utils/patch";
 /** @type {import("models").ChannelMember} */
 const channelMemberPatch = {
     getLangName() {
-        if (this.persona.is_public && this.thread.visitor?.langName) {
-            return this.thread.visitor.langName;
+        if (this.persona.is_public && this.channel_id.visitor?.langName) {
+            return this.channel_id.visitor.langName;
         }
         return super.getLangName();
     },


### PR DESCRIPTION
The rename was done by a [previous PR](https://github.com/odoo/odoo/pull/208544) and missed the website_livechat override.