### PR TITLE
[IMP] pos_self_order: kiosk UI/UX adaptations

### DIFF
--- a/addons/pos_self_order/static/src/app/components/kiosk_attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/kiosk_attribute_selection/attribute_selection.xml
@@ -11,11 +11,10 @@
                             <button
                                 t-on-click="() => this.selectAttribute(attribute, value)"
                                 role="button"
-                                class="o_kiosk_product_box btn btn-light d-flex flex-column align-items-center justify-content-center gap-2 border-transparent shadow-sm"
-                                t-attf-class="{{ valueSelected ? 'o_kiosk_box_selected text-bg-primary': '' }}">
+                                class="o_kiosk_product_box btn btn-light d-flex flex-column align-items-center justify-content-center gap-2 border border-4 shadow-sm"
+                                t-attf-class="{{ valueSelected ? 'border-primary': 'border-transparent' }}">
                                     <span t-esc="value.name" class="fs-4"/>
-                                    <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="fs-5 text-muted"
-                                    t-att-class="{ 'text-light opacity-75' : valueSelected }"  />
+                                    <span t-if="shouldShowPriceExtra(value)" t-esc="formatExtraPrice(value)" class="badge position-absolute top-0 end-0 m-1 px-2 py-1 rounded-3 text-bg-primary fw-bold"></span>
                             </button>
                         </div>
                     </div>

--- a/addons/pos_self_order/static/src/app/kiosk_style.js
+++ b/addons/pos_self_order/static/src/app/kiosk_style.js
@@ -1,51 +1,81 @@
-export function insertKioskStyle(primaryBgColor, primaryTextColor) {
+export function insertKioskStyle(primaryBgColor) {
     const style = document.createElement("style");
-    style.textContent = generateKioskCSS(primaryBgColor, primaryTextColor);
+    style.textContent = generateKioskCSS(primaryBgColor);
     document.head.appendChild(style);
 }
 
-function generateKioskCSS(primaryBg, primaryText = "#fff") {
-    if (!primaryBg || primaryBg === "#875A7B") {
-        primaryBg = "#714B67";
+function generateKioskCSS(companyPrimaryColor) {
+    let bgPrimary = companyPrimaryColor;
+    if (!bgPrimary || bgPrimary === "#875A7B") {
+        bgPrimary = "#714B67";
     }
-    const activeBG = shadeColor(primaryBg, 0.2);
-    const primaryRGB = hexToRgb(primaryBg);
-    const hoverFocusRGB = hexToRgb(mixColors(primaryText, primaryBg, 0.15));
-    const kioskBG = mixColors("#fff", primaryBg, 0.85);
+    const luminance = getLuminance(bgPrimary);
+    const isLightBackground = luminance > 0.55;
+    const shadedPrimary = shadeColor(bgPrimary, 0.6);
+
+    const textBgPrimary = isLightBackground
+        ? shadeColor(bgPrimary, 0.95)
+        : mixColors("#FFFFFF", bgPrimary, 0.95);
+    const primaryTextBorder = isLightBackground ? shadedPrimary : bgPrimary;
+
+    const buttonActiveColor = shadeColor(bgPrimary, 0.2);
 
     return `
-:root {
-  --primary-rgb: ${primaryRGB};
-  --primary: ${primaryBg};
-}
+        :root {
+            --primary-rgb: ${hexToRgb(bgPrimary)};
+            --primary: ${bgPrimary};
+        }
 
-.btn-primary {
-  --btn-color: ${primaryText};
-  --btn-bg: ${primaryBg};
-  --btn-border-color: ${primaryBg};
-  --btn-hover-color: ${primaryText};
-  --btn-hover-bg: ${primaryBg};
-  --btn-hover-border-color: ${primaryBg};
-  --btn-focus-shadow-rgb: ${hoverFocusRGB};
-  --btn-active-color: ${primaryText};
-  --btn-active-bg: ${activeBG};
-  --btn-active-border-color: ${activeBG};
-  --btn-active-shadow: 0;
-  --btn-disabled-color: ${primaryText};
-  --btn-disabled-bg: ${primaryBg};
-  --btn-disabled-border-color: ${primaryBg};
-}
+        .btn-primary {
+            --btn-color: ${textBgPrimary};
+            --btn-bg: ${bgPrimary};
+            --btn-border-color: ${bgPrimary};
+            --btn-hover-color: ${textBgPrimary};
+            --btn-hover-bg: ${bgPrimary};
+            --btn-hover-border-color: ${bgPrimary};
+            --btn-focus-shadow-rgb: ${hexToRgb(mixColors(textBgPrimary, bgPrimary, 0.15))};
+            --btn-active-color: ${textBgPrimary};
+            --btn-active-bg: ${buttonActiveColor};
+            --btn-active-border-color: ${buttonActiveColor};
+            --btn-active-shadow: 0;
+            --btn-disabled-color: ${textBgPrimary};
+            --btn-disabled-bg: ${bgPrimary};
+            --btn-disabled-border-color: ${bgPrimary};
+        }
 
-.text-primary {
-  --color: rgba(${primaryRGB}, var(--text-opacity, 1));
-}
+        .text-primary {
+            --color: rgba(${hexToRgb(primaryTextBorder)}, var(--text-opacity, 1));
+        }
 
-.o_kiosk_background {
-  background-color: ${kioskBG};
-}`;
+        .border-primary {
+            border-color: ${primaryTextBorder} !important;
+        }
+
+        .text-bg-primary :is(h1, h2, h3, h4, h5, h6) {
+            color: ${textBgPrimary};
+        }
+
+        .text-bg-primary .btn-link, .badge.text-bg-primary, .btn.text-bg-primary {
+            color: ${textBgPrimary} !important;
+        }
+
+        .text-bg-primary .btn-link:hover {
+            color: ${mixColors(textBgPrimary, bgPrimary, 0.85)} !important;
+        }
+
+        .o_kiosk_background {
+            background-color: ${mixColors("#ffffff", bgPrimary, 0.85)};
+        }
+    `;
 }
 
 // Utilities
+
+function getLuminance(hex) {
+    const fullHex = expandHex(hex);
+    const [r, g, b] = [0, 2, 4].map((i) => parseInt(fullHex.slice(i, i + 2), 16));
+    return (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+}
 
 function hexToRgb(hex) {
     const fullHex = expandHex(hex);
@@ -76,7 +106,6 @@ function mixColors(color1, color2, weight) {
     return result;
 }
 
-//  Mix a color with black
 function shadeColor(color, weight) {
     return mixColors("#000000", color, weight);
 }

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.js
@@ -1,12 +1,10 @@
 import { Component } from "@odoo/owl";
 import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { useService } from "@web/core/utils/hooks";
-import { KioskLanguageSelector } from "@pos_self_order/app/components/kiosk_language_selector/language_selector";
 
 export class EatingLocationPage extends Component {
     static template = "pos_self_order.EatingLocationPage";
     static props = {};
-    static components = { KioskLanguageSelector };
 
     setup() {
         this.selfOrder = useSelfOrder();

--- a/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/eating_location_page/eating_location_page.xml
@@ -28,12 +28,11 @@
                     </div>
                 </div>
 
-                <div class="d-flex justify-content-between align-items-center position-relative p-2 p-md-3">
+                <div class="p-2 p-md-3">
                     <button class="btn btn-lg btn-light btn-back border-light" t-on-click="()=>this.onClickBack()">
                         <i class="oi oi-chevron-left d-md-none" />
                         <span class="d-none d-md-inline">Back</span>
                     </button>
-                    <KioskLanguageSelector/>
                 </div>
             </div>
         </t>

--- a/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.js
@@ -3,10 +3,9 @@ import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { useService } from "@web/core/utils/hooks";
 import { _t } from "@web/core/l10n/translation";
 import { CancelPopup } from "@pos_self_order/app/components/cancel_popup/cancel_popup";
-import { KioskLanguageSelector } from "@pos_self_order/app/components/kiosk_language_selector/language_selector";
+
 export class KioskCategoryListPage extends Component {
     static template = "pos_self_order.KioskCategoryListPage";
-    static components = { KioskLanguageSelector };
     static props = {};
 
     setup() {

--- a/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_category_list_page/kiosk_category_list_page.xml
@@ -18,7 +18,7 @@
                 </div>
             </div>
 
-            <div class="d-flex justify-content-between align-items-center position-relative p-2 p-md-3">
+            <div class="p-2 p-md-3">
                 <t t-set="isBack" t-value="shouldGoBack()"/>
                 <button class="btn btn-lg btn-light btn-back border-light" t-att-class="{'btn-back' : isBack, 'btn-cancel': !isBack}" t-on-click="()=>this.onClickBack()">
                     <t t-if="isBack">
@@ -30,7 +30,6 @@
                         <i class="oi oi-close d-md-none"/><span class="d-none d-md-inline">Cancel</span>
                     </t>
                 </button>
-                <KioskLanguageSelector />
             </div>
         </div>
     </t>

--- a/addons/pos_self_order/static/src/app/pages/kiosk_combo_page/kiosk_combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_combo_page/kiosk_combo_page.xml
@@ -5,12 +5,12 @@
             <!-- Header -->
             <t t-set="productList" t-value="products"/>
             <div class="o_kiosk_combo_page_header p-3 text-bg-primary shadow-lg z-1">
-                <button class="btn btn-link btn-lg d-inline-flex align-items-center gap-2 p-2 text-reset" t-on-click="() => this.router.back()">
+                <button class="btn btn-link btn-lg d-inline-flex align-items-center gap-2 p-2" t-on-click="() => this.router.back()">
                     <i class="oi oi-close fa-fw" aria-hidden="true"/>
                     Discard
                 </button>
                 <div class="d-flex flex-column gap-4 align-items-center">
-                    <h1 class="mb-0 text-reset" t-esc="currentCombo.name"/>
+                    <h1 class="mb-0" t-esc="currentCombo.name"/>
                     <div class="o_kiosk_combo_image rounded-4">
                         <img height="384" width="384" t-attf-src="/web/image/product.template/{{ props.productTemplate.id }}/image_512?unique=#{props.productTemplate.write_date}" loading="lazy"/>
                     </div>
@@ -53,7 +53,7 @@
                                         <div class="h-100 w-100 ratio ratio-1x1">
                                             <img class="w-100 h-100 object-fit-cover" t-attf-src="/web/image/product.product/{{ product.id }}/image_512?unique=#{product.write_date}" loading="lazy"/>
                                         </div>
-                                        <span t-if="extraPrice" class="badge position-absolute top-0 end-0 m-2 p-2 rounded-4 text-bg-primary fs-5 fw-bold">
+                                        <span t-if="extraPrice" class="badge position-absolute top-0 end-0 m-1 px-2 py-1 rounded-3 text-bg-primary fw-bold">
                                         + <t t-out="selfOrder.formatMonetary(extraPrice)"/>
                                         </span>
                                         <div class="d-flex flex-column flex-grow-1 align-items-center justify-content-center py-2 text-center">

--- a/addons/pos_self_order/static/src/app/pages/kiosk_product_list_page/kiosk_product_list_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_product_list_page/kiosk_product_list_page.scss
@@ -1,6 +1,4 @@
 .o_kiosk_product_list_page {
-  --category-title-size: 5vh;
-
   .category_list {
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -8,20 +6,6 @@
 
   .category_list::-webkit-scrollbar {
     display: none;
-  }
-
-  .category-title {
-    font-size: var(--category-title-size);
-  }
-
-  .category-title-duplicate {
-    left: 30px;
-    margin-top: -30px;
-    background: linear-gradient(to top, rgba(0,0,0,0.15) 0%, transparent 70%);
-    background-clip: text;
-    -webkit-background-clip: text;
-    font-size: calc(var(--category-title-size) * 2);
-    color: transparent;
   }
 
   .sub_category_container{

--- a/addons/pos_self_order/static/src/app/pages/kiosk_product_page/kiosk_product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/kiosk_product_page/kiosk_product_page.xml
@@ -3,14 +3,14 @@
     <t t-name="pos_self_order.KioskProductPage">
         <div class="o_kiosk_product_page d-flex flex-column vh-100 overflow-hidden o_kiosk_background o_kiosk_fade">
             <!-- Header -->
-            <div class="o_kiosk_product_page_header p-3 text-bg-primary shadow-lg z-1">
+            <div class="o_kiosk_product_page_header p-3 text-bg-primary text-reset shadow-lg z-1">
                 <t t-set="product" t-value="productTemplate"/>
-                <button class="btn btn-link btn-lg d-inline-flex align-items-center gap-2 p-2 text-reset" t-on-click="() => this.router.back()">
+                <button class="btn btn-link btn-lg d-inline-flex align-items-center gap-2 p-2" t-on-click="() => this.router.back()">
                     <i class="oi oi-close fa-fw" aria-hidden="true"/>
                     Discard
                 </button>
                 <div class="d-flex flex-column gap-4 align-items-center">
-                    <h1 class="mb-0 text-reset" t-esc="product.name"/>
+                    <h1 class="mb-0" t-esc="product.name"/>
                     <div class="o_kiosk_product_image rounded-4">
                         <img height="384" width="384" t-attf-src="/web/image/product.template/{{ product.id }}/image_512?unique=#{product.write_date}" loading="lazy"/>
                     </div>

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -5,10 +5,12 @@ import { useSelfOrder } from "@pos_self_order/app/services/self_order_service";
 import { useService } from "@web/core/utils/hooks";
 import { LanguagePopup } from "@pos_self_order/app/components/language_popup/language_popup";
 import { session } from "@web/session";
+import { KioskLanguageSelector } from "@pos_self_order/app/components/kiosk_language_selector/language_selector";
 
 export class LandingPage extends Component {
     static template = "pos_self_order.LandingPage";
     static props = {};
+    static components = { KioskLanguageSelector };
 
     setup() {
         this.selfOrder = useSelfOrder();

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.scss
@@ -6,13 +6,3 @@
         aspect-ratio: 3/2;
     }
 }
-
-.o_pos_landing_footer {
-    @include o-so-portrait() {
-        flex-direction: column;
-    }
-
-    .gap-3 {
-        flex-direction: inherit;
-    }
-}

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.xml
@@ -18,32 +18,30 @@
             </div>
         </div>
         <div class="o_pos_landing_footer position-absolute bottom-0 end-0 d-flex w-100 gap-3 p-2 p-md-3">
-            <div class="d-flex gap-3" t-att-class="{'flex-grow-1 justify-content-around': !selfOrder.models['pos_self_order.custom_link'].length}">
-                <t t-if="showMyOrderBtn()">
-                    <a
-                        type="button"
-                        t-on-click="clickMyOrder"
-                        class="btn btn-lg btn-secondary"
-                        style="border-color: #714B67">
-                        <t t-if="draftOrder.length > 0">
-                            My Order
-                        </t>
-                        <t t-else="">
-                            My Orders
-                        </t>
-                    </a>
-                </t>
-            </div>
-            <div t-if="selfOrder.models['pos_self_order.custom_link'].length" class="d-flex gap-3 flex-grow-1">
+            <div t-if="selfOrder.models['pos_self_order.custom_link'].length" class="d-flex flex-column flex-lg-row flex-fill gap-3">
+                <a type="button"
+                    t-if="showMyOrderBtn()"
+                    t-on-click="clickMyOrder"
+                    class="btn btn-lg btn-secondary flex-fill">
+                    <t t-if="draftOrder.length > 0">
+                        My Order
+                    </t>
+                    <t t-else="">
+                        My Orders
+                    </t>
+                </a>
                 <t t-foreach="selfOrder.models['pos_self_order.custom_link'].getAll()" t-as="link" t-key="link.id">
                     <a type="button"
                         t-if="!hideBtn(link)"
                         t-on-click="(event) => this.clickCustomLink(link)"
-                        t-attf-class="btn btn-lg btn-{{link.style}}">
+                        t-attf-class="btn btn-lg btn-{{link.style}} flex-fill">
                         <t t-esc="link.name"/>
                     </a>
                 </t>
             </div>
+            <t t-if="selfOrder.kioskMode">
+                <KioskLanguageSelector />
+            </t>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
@@ -5,7 +5,7 @@
             <div class="kiosk_stand_page d-flex flex-column align-items-center flex-grow-1 o_kiosk_background overflow-y-auto text-center o_kiosk_fade"
             t-attf-style="background-image:#{selfOrder.kioskBackgroundImage};background-size: cover; background-position: center;">
                 <div class="d-flex flex-column my-auto overflow-y-auto">
-                    <h1 class="mb-4 m-0">Take a tracker and enter its number</h1>
+                    <h1 class="mb-4 m-0">Enter your tracker number</h1>
                     <div class="d-flex flex-column gap-4">
                         <div class="input-number form-control form-control-lg w-100 rounded-4 bg-white text-center oveflow-hidden text-nowrap text-truncate shadow-sm">
                             <span t-attf-class="display-1 fw-bolder {{ state.standNumber ? 'text-primary' : 'opacity-0' }}" t-esc="state.standNumber || '_ _'"/>
@@ -22,7 +22,7 @@
         <t t-else="">
             <div class="self_order_stand_number d-flex flex-column flex-grow-1 justify-content-between px-3 overflow-y-auto">
                 <div class="text-center pt-5">
-                    <h1>Take a tracker and enter its number</h1>
+                    <h1>Enter your tracker number</h1>
                     <div class="input-number form-contol w-100 form-control-lg text-center">
                         <span t-esc="state.standNumber || '_ _'" class="display-1"/>
                     </div>

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -121,11 +121,6 @@ li {
     }
 }
 
-.o_kiosk_background {
-    background-color: mix(white, $o-brand-primary, 85%);
-}
-
-
 .o_kiosk_container {
     grid-template-columns: repeat(2, 1fr);
 }

--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -139,10 +139,9 @@ registry.category("web_tour.tours").add("kiosk_order_price_null", {
 
 registry.category("web_tour.tours").add("self_order_language_changes", {
     steps: () => [
-        Utils.clickBtn("Order Now"),
-
         LandingPage.checkKioskLanguageSelected("English"),
         LandingPage.checkKioskCountryFlagShown("us"),
+        Utils.clickBtn("Order Now"),
 
         LandingPage.selectKioskLocation("Test-Takeout"),
         CategoryPage.clickKioskCategory("Test Category"),
@@ -150,9 +149,9 @@ registry.category("web_tour.tours").add("self_order_language_changes", {
         ProductPage.clickBack(),
         ...CategoryPage.clickCancel(),
 
-        Utils.clickBtn("Order Now"),
+        LandingPage.checkKioskLanguageSelected("English"),
+        LandingPage.checkKioskCountryFlagShown("us"),
         ...Utils.changeKioskLanguage("Français"),
-        Utils.clickBackBtn(),
 
         Utils.clickBtn("Commander maintenant"),
         LandingPage.selectKioskLocation("Test-Takeout"),


### PR DESCRIPTION
This commit introduces a few enhancements for the kiosk (self order):

Primary color readability: The primary color has recently been derived from the company settings, but the current logic sometimes led to readability issues (e.g., low contrast on headings or button links). Contrast handling has been improved for better accessibility, especially with company light primary colors.

Language selector: Removed from all screens except the welcome screen. It is now shown only next to the “Order now” button.

misc: copy refinements, remove unused classes.

task-4768698

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
