### PR TITLE
[FIX] html_editor,web_editor: wait for selectionchange handlers in tests

### DIFF
--- a/addons/html_editor/static/tests/_helpers/editor.js
+++ b/addons/html_editor/static/tests/_helpers/editor.js
@@ -4,7 +4,7 @@ import { queryOne } from "@odoo/hoot-dom";
 import { Component, xml } from "@odoo/owl";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { getContent, getSelection, setContent } from "./selection";
-import { animationFrame } from "@odoo/hoot-mock";
+import { animationFrame, tick } from "@odoo/hoot-mock";
 import { dispatchCleanForSave } from "./dispatch";
 import { fixInvalidHTML } from "@html_editor/utils/sanitize";
 
@@ -182,7 +182,7 @@ export async function testEditor(config) {
     }
 
     // Wait for selectionchange handlers to react before any actual testing.
-    await Promise.resolve();
+    await tick();
 
     if (contentBeforeEdit) {
         // we should do something before (sanitize)

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
@@ -332,7 +332,7 @@ export async function testEditor(Editor = OdooEditor, spec, options = {}) {
         }
 
         // Wait for selectionchange handlers to react before any actual testing.
-        await Promise.resolve();
+        await nextTick();
 
         if (spec.stepFunction) {
             try {


### PR DESCRIPTION
It looks like in some cases awaiting for a microtask tick is not enough for the selectionchange handlers to be called. This commit waits for a full tick instead. This is a stronger version of the original fix at https://github.com/odoo/odoo/pull/210022.