### PR TITLE
[FIX] l10n_it_edi: fix address error without vat

### DIFF
--- a/addons/l10n_it_edi/static/src/interactions/address.js
+++ b/addons/l10n_it_edi/static/src/interactions/address.js
@@ -13,18 +13,18 @@ patch(CustomerAddress.prototype, {
     },
 
     computeCodiceFiscale() {
-        const vatValue = this.el.querySelector('input[name="vat"]').value;
+        const vat = this.el.querySelector('input[name="vat"]');
         const countryValue = this.el.querySelector('select[name="country_id"]')
             .selectedOptions[0]?.getAttribute('code');
         const l10nItCodiceFiscaleInput = this.el.querySelector('input[name="l10n_it_codice_fiscale"]');
 
         if (
             l10nItCodiceFiscaleInput
-            && vatValue
-            && (vatValue.startsWith('IT') || countryValue === 'IT')
+            && vat
+            && (vat.value.startsWith('IT') || countryValue === 'IT')
         ) {
-            l10nItCodiceFiscaleInput.value = /^IT[0-9]{11}$/.test(vatValue)
-                ? vatValue.slice(2, 13) : vatValue;
+            l10nItCodiceFiscaleInput.value = /^IT[0-9]{11}$/.test(vat.value)
+                ? vat.value.slice(2, 13) : vat.value;
         }
     },
 });


### PR DESCRIPTION
When user decides to have separate address for delivery and payment, delivery address does not have vat field, which gives an error. This commit fixes the issue.

[runbot-223239](https://runbot.odoo.com/odoo/error/223239)