### PR TITLE
[FIX] purchase: can't delete sections and notes even editable

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -226,7 +226,7 @@ class PurchaseOrderLine(models.Model):
     @api.ondelete(at_uninstall=False)
     def _unlink_except_purchase_or_done(self):
         for line in self:
-            if line.order_id.state in ['purchase', 'done']:
+            if line.order_id.state in ['purchase', 'done'] and line.display_type not in ['line_note', 'line_section']:
                 state_description = {state_desc[0]: state_desc[1] for state_desc in self._fields['state']._description_selection(self.env)}
                 raise UserError(_('Cannot delete a purchase order line which is in state “%s”.', state_description.get(line.state)))
 


### PR DESCRIPTION
This is a continuation of [this fix](https://github.com/odoo/odoo/commit/291518a7e7708690d183b9d1ca53c84d0c56ad90) following a feedback on its working state.

---

Description of the issue this commit addresses:

On purchase orders, it was decided that sections and notes would still be editable after the order has been confirmed so it would seem logic to be able to delete them too but at the moment, doing so raises an error.

---

Desired behavior after this commit is merged:

It is possible to delete a section or note line on a confirmed purchase order.

---

opw-4744367

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr