### PR TITLE
[IMP] mail, *: subscribe to presence with token

### DIFF
--- a/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
+++ b/addons/cloud_storage_azure/tests/test_cloud_storage_azure_attachment_controller.py
@@ -4,7 +4,7 @@ from requests import Response
 from unittest.mock import patch
 
 import odoo
-from odoo.tools.misc import file_open, limited_field_access_token
+from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_azure.tests.test_cloud_storage_azure import TestCloudStorageAzureCommon
 
@@ -65,9 +65,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                     "id": attachment.id,
                                     "mimetype": "text/x-python",
                                     "name": "__init__.py",
-                                    "raw_access_token": limited_field_access_token(
-                                        attachment, "raw"
-                                    ),
+                                    "raw_access_token": attachment._get_raw_access_token(),
                                     "res_name": False,
                                     "thread": False,
                                     "voice": False,

--- a/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
+++ b/addons/cloud_storage_google/tests/test_cloud_storage_google_attachment_controller.py
@@ -2,7 +2,7 @@ import json
 import re
 
 import odoo
-from odoo.tools.misc import file_open, limited_field_access_token
+from odoo.tools.misc import file_open
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.cloud_storage_google.tests.test_cloud_storage_google import TestCloudStorageGoogleCommon
 
@@ -50,7 +50,7 @@ class TestCloudStorageAttachmentController(HttpCaseWithUserDemo, TestCloudStorag
                                 "id": attachment.id,
                                 "mimetype": "text/x-python",
                                 "name": "__init__.py",
-                                "raw_access_token": limited_field_access_token(attachment, "raw"),
+                                "raw_access_token": attachment._get_raw_access_token(),
                                 "res_name": False,
                                 "thread": False,
                                 "voice": False,

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -6,7 +6,7 @@ import json
 from odoo import Command, fields
 from odoo.addons.im_livechat.tests import chatbot_common
 from odoo.tests.common import JsonRpcException, new_test_user, tagged
-from odoo.tools.misc import limited_field_access_token, mute_logger
+from odoo.tools.misc import mute_logger
 from odoo.addons.bus.models.bus import json_dump
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -232,16 +232,17 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                 0,
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.chatbot_script.operator_partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.chatbot_script.operator_partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": self.chatbot_script.operator_partner_id.id,
                     "im_status": "im_partner",
+                    "im_status_access_token": self.chatbot_script.operator_partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "name": "Testing Bot",
                     "user_livechat_username": False,
-                    "write_date": fields.Datetime.to_string(self.chatbot_script.operator_partner_id.write_date),
+                    "write_date": fields.Datetime.to_string(
+                        self.chatbot_script.operator_partner_id.write_date
+                    ),
                 },
             )
             channel_data = Store(discuss_channel).get_result()
@@ -330,12 +331,11 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.partner_employee, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
                                     "country_id": self.env.ref("base.be").id,
                                     "id": self.partner_employee.id,
                                     "im_status": "offline",
+                                    "im_status_access_token": self.partner_employee._get_im_status_access_token(),
                                     "is_public": False,
                                     "name": "Ernest Employee",
                                     "user_livechat_username": False,
@@ -392,9 +392,7 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                             ],
                             "res.partner": self._filter_partners_fields(
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.partner_employee, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
                                     "id": self.partner_employee.id,
                                     "name": "Ernest Employee",
                                     "user_livechat_username": False,

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -5,7 +5,6 @@ from freezegun import freeze_time
 from unittest.mock import patch, PropertyMock
 
 from odoo import fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests import new_test_user, tagged
@@ -53,10 +52,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data["mail.guest"],
             [
                 {
-                    "avatar_128_access_token": limited_field_access_token(guest, "avatar_128"),
+                    "avatar_128_access_token": guest._get_avatar_128_access_token(),
                     "country_id": belgium.id,
                     "id": guest.id,
                     "im_status": "offline",
+                    "im_status_access_token": guest._get_im_status_access_token(),
                     "name": "Visitor",
                     "offline_since": False,
                     "write_date": fields.Datetime.to_string(guest.write_date),
@@ -68,11 +68,10 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
               {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -82,12 +81,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
@@ -121,12 +119,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -136,12 +133,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        test_user.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": test_user.partner_id._get_avatar_128_access_token(),
                     "country_id": belgium.id,
                     "id": test_user.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": test_user.partner_id._get_im_status_access_token(),
                     "isAdmin": False,
                     "isInternalUser": True,
                     "is_public": False,
@@ -155,12 +151,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "user_livechat_username": "Michel Operator",
                     "write_date": fields.Datetime.to_string(operator.write_date),
@@ -222,12 +217,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.partner_root, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.partner_root._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.partner_root._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -237,12 +231,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        operator.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "isAdmin": False,
                     "isInternalUser": True,
                     "is_public": False,

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -5,7 +5,6 @@ from markupsafe import Markup
 
 from odoo import Command, fields
 from odoo.exceptions import AccessError
-from odoo.tools.misc import limited_field_access_token
 from odoo.tests.common import users, tagged
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -210,9 +209,9 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                 ],
                 "res.partner": self._filter_partners_fields(
                     {
-                        "avatar_128_access_token": limited_field_access_token(
-                            self.users[1].partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": self.users[
+                            1
+                        ].partner_id._get_avatar_128_access_token(),
                         "id": self.users[1].partner_id.id,
                         "is_company": False,
                         "isInternalUser": True,
@@ -322,9 +321,7 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
                                 ],
                                 "res.partner": self._filter_partners_fields(
                                     {
-                                        "avatar_128_access_token": limited_field_access_token(
-                                            self.env.user.partner_id, "avatar_128"
-                                        ),
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                         "id": self.env.user.partner_id.id,
                                         "isInternalUser": False,
                                         "is_company": False,

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -1,6 +1,5 @@
 from odoo import fields
 from odoo.tests.common import tagged
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
@@ -52,9 +51,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
         self.assertEqual(
             data["res.partner"][0],
             {
-                "avatar_128_access_token": limited_field_access_token(
-                    john.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": john.partner_id._get_avatar_128_access_token(),
                 "id": john.partner_id.id,
                 "user_livechat_username": "ELOPERADOR",
                 "write_date": fields.Datetime.to_string(john.partner_id.write_date),

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -5,7 +5,6 @@ import contextlib
 from odoo import _, models, SUPERUSER_ID
 from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.tools import consteq
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tools.discuss import Store
 
 
@@ -84,7 +83,7 @@ class IrAttachment(models.Model):
             "file_size",
             "mimetype",
             "name",
-            Store.Attr("raw_access_token", lambda a: limited_field_access_token(a, "raw")),
+            Store.Attr("raw_access_token", lambda a: a._get_raw_access_token()),
             "res_name",
             Store.One("thread", [], as_thread=True),
             "type",

--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -232,13 +232,25 @@ class ResPartner(models.Model):
     # DISCUSS
     # ------------------------------------------------------------
 
+    def _get_im_status_access_token(self):
+        """Return a scoped access token for the `im_status` field. The token is used in
+        `ir_websocket._prepare_subscribe_data` to grant access to presence channels.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "im_status", scope="mail.presence")
+
     def _field_store_repr(self, field_name):
         if field_name == "avatar_128":
             return [
-                Store.Attr(
-                    "avatar_128_access_token", lambda p: limited_field_access_token(p, "avatar_128")
-                ),
+                Store.Attr("avatar_128_access_token", lambda p: p._get_avatar_128_access_token()),
                 "write_date",
+            ]
+        if field_name == "im_status":
+            return [
+                "im_status",
+                Store.Attr("im_status_access_token", lambda p: p._get_im_status_access_token()),
             ]
         return [field_name]
 

--- a/addons/mail/static/src/core/common/im_status_service.js
+++ b/addons/mail/static/src/core/common/im_status_service.js
@@ -8,9 +8,13 @@ export const AWAY_DELAY = 30 * 60 * 1000; // 30 minutes
  * connection to the server is established, the user's presence is updated. If
  * another device or browser updates the user's presence, the presence is sent to
  * the server if relevant (e.g., another device is away or offline, but this one
- * is online). To receive updates through the bus, subscribe to presence channels
- * (e.g., subscribe to `odoo-presence-res.partner_3` to receive updates about
- * this partner).
+ * is online).
+ *
+ * To receive updates through the bus, subscribe to presence channels
+ * (e.g., subscribe to `odoo-presence-res.partner_3-token` to receive updates about
+ * this partner). Token is optional and can be used to grant access to the presence
+ * channel if the user is not allowed to read the partner's presence.
+ * See `_get_im_status_access_token`.
  */
 export const imStatusService = {
     dependencies: ["bus_service", "presence"],

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -85,9 +85,6 @@ export class Store extends BaseStore {
     mt_note = fields.One("mail.message.subtype");
     /** @type {boolean} */
     hasMessageTranslationFeature;
-    imStatusTrackedPersonas = fields.Many("Persona", {
-        inverse: "storeAsTrackedImStatus",
-    });
     hasLinkPreviewFeature = true;
     // messaging menu
     menu = { counter: 0 };
@@ -355,10 +352,9 @@ export class Store extends BaseStore {
                 if (thread) {
                     thread.open({ focus: true });
                 } else {
-                    this.env.services.notification.add(
-                        _t("This thread is no longer available."),
-                        { type: "danger" }
-                    );
+                    this.env.services.notification.add(_t("This thread is no longer available."), {
+                        type: "danger",
+                    });
                 }
             });
             return true;

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -17,15 +17,6 @@ export class DiscussCoreCommon {
     }
 
     setup() {
-        this.busService.addEventListener(
-            "connect",
-            () =>
-                this.store.imStatusTrackedPersonas.forEach((p) => {
-                    const model = p.type === "partner" ? "res.partner" : "mail.guest";
-                    this.busService.addChannel(`odoo-presence-${model}_${p.id}`);
-                }),
-            { once: true }
-        );
         this.busService.subscribe("discuss.channel/delete", (payload, metadata) => {
             const thread = this.store.Thread.insert({
                 id: payload.id,

--- a/addons/mail/static/tests/discuss/core/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss.test.js
@@ -8,9 +8,10 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
-import { describe, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
+import { tick } from "@odoo/hoot-dom";
 import { mockDate } from "@odoo/hoot-mock";
-import { asyncStep, Command, serverState, waitForSteps } from "@web/../tests/web_test_helpers";
+import { asyncStep, makeMockEnv, waitForSteps } from "@web/../tests/web_test_helpers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -26,28 +27,31 @@ test("Member list and Pinned Messages Panel menu are exclusive", async () => {
     await contains(".o-discuss-ChannelMemberList", { count: 0 });
 });
 
-test("subscribe to known partner presences", async () => {
-    onWebsocketEvent("subscribe", (data) => asyncStep(`subscribe - [${data.channels}]`));
-    const pyEnv = await startServer();
-    const bobPartnerId = pyEnv["res.partner"].create({
-        name: "Bob",
-        user_ids: [Command.create({ name: "bob" })],
-    });
-    const later = luxon.DateTime.now().plus({ seconds: 2 });
-    mockDate(
-        `${later.year}-${later.month}-${later.day} ${later.hour}:${later.minute}:${later.second}`
-    );
-    await start();
-    await openDiscuss();
-    const expectedPresences = [
-        `odoo-presence-res.partner_${serverState.partnerId}`,
-        `odoo-presence-res.partner_${serverState.odoobotId}`,
-    ];
-    await waitForSteps([`subscribe - [${expectedPresences.join(",")}]`]);
-    await click("[placeholder='Find or start a conversation']");
-    await click(".o-mail-DiscussCommand", { text: "Bob" });
-    expectedPresences.push(`odoo-presence-res.partner_${bobPartnerId}`);
-    await waitForSteps([`subscribe - [${expectedPresences.join(",")}]`]);
+test("subscribe to presence channels according to store data", async () => {
+    const env = await makeMockEnv();
+    const store = env.services["mail.store"];
+    onWebsocketEvent("subscribe", (data) => expect.step(`subscribe - [${data.channels}]`));
+    expect(env.services.bus_service.isActive).toBe(false);
+    // Should not subscribe to presences as bus service is not started.
+    store["Persona"].insert({ id: 1, type: "partner", name: "Partner 1" });
+    store["Persona"].insert({ id: 2, type: "partner", name: "Partner 2" });
+    await tick();
+    expect.waitForSteps([]);
+    // Starting the bus should subscribe to known presence channels.
+    env.services.bus_service.start();
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
+    // Discovering new presence channels should refresh the subscription.
+    store["Persona"].insert({ id: 1, type: "guest" });
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-mail.guest_1,odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
+    // Updating "im_status_access_token" should refresh the subscription.
+    store["Persona"].insert({ id: 1, type: "guest", im_status_access_token: "token" });
+    await expect.waitForSteps([
+        "subscribe - [odoo-presence-mail.guest_1-token,odoo-presence-res.partner_1,odoo-presence-res.partner_2]",
+    ]);
 });
 
 test("bus subscription is refreshed when channel is joined", async () => {

--- a/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
+++ b/addons/mail/static/tests/discuss_app/bus_connection_alert.test.js
@@ -20,7 +20,9 @@ test("show warning when bus connection encounters issues", async () => {
     const unlockWebsocket = lockWebsocketConnect();
     MockServer.env["bus.bus"]._simulateDisconnection(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
     await waitForSteps(["reconnecting"]);
-    expect(await waitFor(".o-bus-ConnectionAlert")).toHaveText("Real-time connection lost...");
+    expect(await waitFor(".o-bus-ConnectionAlert", { timeout: 2500 })).toHaveText(
+        "Real-time connection lost..."
+    );
     await runAllTimers();
     await animationFrame();
     expect(".o-bus-ConnectionAlert").toHaveText("Real-time connection lost...");

--- a/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_guest.js
@@ -28,6 +28,9 @@ export class MailGuest extends models.ServerModel {
                 data.avatar_128_access_token = guest.id;
                 data.write_date = guest.write_date;
             }
+            if (fields.includes("im_status")) {
+                data.im_status_access_token = guest.id;
+            }
             store.add(this.browse(guest.id), data);
         }
     }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -270,6 +270,7 @@ export class ResPartner extends webModels.ResPartner {
             }
             if (fields.includes("im_status")) {
                 data.im_status = this.compute_im_status(partner);
+                data.im_status_access_token = partner.id;
             }
             if (fields.includes("user")) {
                 const users = ResUsers.browse(partner.user_ids);

--- a/addons/mail/tests/discuss/test_avatar_acl.py
+++ b/addons/mail/tests/discuss/test_avatar_acl.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, Command
-from odoo.tools.misc import limited_field_access_token
 from odoo.tests import HttpCase
 from odoo.tests.common import tagged
 
@@ -11,7 +10,7 @@ class TestAvatarAcl(HttpCase):
     def get_avatar_url(self, record, add_token=False):
         access_token = ""
         if add_token:
-            access_token = f"&access_token={limited_field_access_token(record, 'avatar_128')}"
+            access_token = f"&access_token={record._get_avatar_128_access_token()}"
         return f"/web/image?field=avatar_128&id={record.id}&model={record._name}&unique={fields.Datetime.to_string(record.write_date)}{access_token}"
 
     def test_partner_open_guest_avatar(self):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 from markupsafe import Markup
 
 from odoo import Command, fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.models.discuss.discuss_channel import channel_avatar, group_avatar
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail.tests.common import MailCommon
@@ -138,9 +137,7 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 ),
                                 "res.partner": self._filter_partners_fields(
                                     {
-                                        "avatar_128_access_token": limited_field_access_token(
-                                            self.env.user.partner_id, "avatar_128"
-                                        ),
+                                        "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                         "id": self.env.user.partner_id.id,
                                         "isInternalUser": True,
                                         "is_company": False,
@@ -171,12 +168,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.test_partner, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",
+                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
                                     "isInternalUser": False,
                                     "is_company": False,
                                     "name": "Test Partner",
@@ -218,12 +214,11 @@ class TestChannelInternals(MailCommon, HttpCase):
                             "res.partner": self._filter_partners_fields(
                                 {
                                     "active": True,
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.test_partner, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.test_partner._get_avatar_128_access_token(),
                                     "email": "test_customer@example.com",
                                     "id": self.test_partner.id,
                                     "im_status": "im_partner",
+                                    "im_status_access_token": self.test_partner._get_im_status_access_token(),
                                     "isInternalUser": False,
                                     "is_company": False,
                                     "name": "Test Partner",
@@ -453,11 +448,10 @@ class TestChannelInternals(MailCommon, HttpCase):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    self.user_admin.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": self.user_admin.partner_id._get_avatar_128_access_token(),
                                 "id": self.user_admin.partner_id.id,
                                 "im_status": self.user_admin.im_status,
+                                "im_status_access_token": self.user_admin.partner_id._get_im_status_access_token(),
                                 "name": self.user_admin.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     self.user_admin.partner_id.write_date

--- a/addons/mail/tests/discuss/test_discuss_mail_presence.py
+++ b/addons/mail/tests/discuss/test_discuss_mail_presence.py
@@ -7,6 +7,8 @@ try:
 except ImportError:
     ws = None
 
+from itertools import product
+
 from odoo.tests import tagged, new_test_user
 from odoo.addons.bus.tests.common import WebsocketCase
 from odoo.addons.mail.tests.common import MailCommon
@@ -15,86 +17,59 @@ from odoo.addons.bus.models.bus import channel_with_db, json_dump
 
 @tagged("post_install", "-at_install")
 class TestMailPresence(WebsocketCase, MailCommon):
-    def _receive_presence(self, sender, recipient):
-        self._reset_bus()
-        sent_from_user = isinstance(sender, self.env.registry["res.users"])
-        receive_to_user = isinstance(recipient, self.env.registry["res.users"])
-        if receive_to_user:
-            session = self.authenticate(recipient.login, recipient.login)
+    def _receive_presence(self, requested_by, target, has_token=False):
+        self.env["mail.presence"].search([]).unlink()
+        target_user = isinstance(target, self.env.registry["res.users"])
+        if isinstance(requested_by, self.env.registry["res.users"]):
+            session = self.authenticate(requested_by.login, requested_by.login)
             auth_cookie = f"session_id={session.sid};"
         else:
             self.authenticate(None, None)
-            auth_cookie = f"{recipient._cookie_name}={recipient._format_auth_cookie()};"
+            auth_cookie = f"{requested_by._cookie_name}={requested_by._format_auth_cookie()};"
         websocket = self.websocket_connect(cookie=auth_cookie)
-        sender_bus_target = sender.partner_id if sent_from_user else sender
-        self.subscribe(
-            websocket,
-            [f"odoo-presence-{sender_bus_target._name}_{sender_bus_target.id}"],
-            self.env["bus.bus"]._bus_last_id(),
-        )
-        self.env["mail.presence"]._update_presence(sender)
-        self.trigger_notification_dispatching([(sender_bus_target, "presence")])
+        target_channel = target.partner_id if target_user else target
+        channel_parts = ["odoo-presence", f"{target_channel._name}_{target_channel.id}"]
+        if has_token:
+            channel_parts.append(target_channel._get_im_status_access_token())
+        self.subscribe(websocket, ["-".join(channel_parts)], self.env["bus.bus"]._bus_last_id())
+        self.env["mail.presence"]._update_presence(target)
+        self.trigger_notification_dispatching([(target_channel, "presence")])
         notifications = json.loads(websocket.recv())
         self._close_websockets()
         bus_record = self.env["bus.bus"].search([("id", "=", int(notifications[0]["id"]))])
         self.assertEqual(
             bus_record.channel,
-            json_dump(channel_with_db(self.env.cr.dbname, (sender_bus_target, "presence"))),
+            json_dump(channel_with_db(self.env.cr.dbname, (target_channel, "presence"))),
         )
         self.assertEqual(notifications[0]["message"]["type"], "bus.bus/im_status_updated")
         self.assertEqual(notifications[0]["message"]["payload"]["im_status"], "online")
         self.assertEqual(notifications[0]["message"]["payload"]["presence_status"], "online")
         self.assertEqual(
-            notifications[0]["message"]["payload"]["partner_id" if sent_from_user else "guest_id"],
-            sender_bus_target.id,
+            notifications[0]["message"]["payload"]["partner_id" if target_user else "guest_id"],
+            target_channel.id,
         )
 
-    def test_receive_presences_as_guest(self):
-        guest = self.env["mail.guest"].create({"name": "Guest"})
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        # Guest should not receive users's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=bob, recipient=guest)
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
-        channel._add_members(guests=guest, users=bob)
-        # Now that they share a channel, guest should receive users's presence.
-        self._receive_presence(sender=bob, recipient=guest)
-
-        other_guest = self.env["mail.guest"].create({"name": "OtherGuest"})
-        # Guest should not receive guest's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=other_guest, recipient=guest)
-        channel._add_members(guests=other_guest)
-        # Now that they share a channel, guest should receive guest's presence.
-        self._receive_presence(sender=other_guest, recipient=guest)
-        self.assertEqual(other_guest.im_status, "online")
-
-    def test_receive_presences_as_portal(self):
-        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        # Portal should not receive users's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=bob, recipient=portal)
-        channel = self.env["discuss.channel"]._create_channel(group_id=None, name="General")
-        channel._add_members(users=portal | bob)
-        # Now that they share a channel, portal should receive users's presence.
-        self._receive_presence(sender=bob, recipient=portal)
-
-        guest = self.env["mail.guest"].create({"name": "Guest"})
-        # Portal should not receive guest's presence: no common channel.
-        with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
-            self._receive_presence(sender=guest, recipient=portal)
-        channel._add_members(guests=guest)
-        # Now that they share a channel, portal should receive guest's presence.
-        self._receive_presence(sender=guest, recipient=portal)
-        self.assertEqual(guest.im_status, "online")
-
-    def test_receive_presences_as_internal(self):
+    def test_presence_access(self):
         internal = new_test_user(self.env, login="internal_user", groups="base.group_user")
+        other_internal = new_test_user(
+            self.env, login="other_internal_user", groups="base.group_user"
+        )
+        portal = new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        other_portal = new_test_user(
+            self.env, login="other_portal_user", groups="base.group_portal"
+        )
         guest = self.env["mail.guest"].create({"name": "Guest"})
-        # Internal can access guest's presence regardless of their channels.
-        self._receive_presence(sender=guest, recipient=internal)
-        # Internal can access users's presence regardless of their channels.
-        bob = new_test_user(self.env, login="bob_user", groups="base.group_user")
-        self._receive_presence(sender=bob, recipient=internal)
-        self.assertEqual(bob.im_status, "online")
+        other_guest = self.env["mail.guest"].create({"name": "Other Guest"})
+        for requested_by, target, has_token, allowed in [
+            *product([internal], [guest, other_internal, portal], [True, False], [True]),
+            *product([guest, portal], [internal, other_guest, other_portal], [False], [False]),
+            *product([guest, portal], [internal, other_guest, other_portal], [True], [True]),
+        ]:
+            with self.subTest(
+                f"test presence access, requested_by={requested_by.name}, target={target.name}, has_token={has_token}, allowed={allowed}"
+            ):
+                if allowed:
+                    self._receive_presence(requested_by, target, has_token=has_token)
+                else:
+                    with self.assertRaises(ws._exceptions.WebSocketTimeoutException):
+                        self._receive_presence(requested_by, target, has_token=has_token)

--- a/addons/mail/tests/discuss/test_message_controller.py
+++ b/addons/mail/tests/discuss/test_message_controller.py
@@ -5,7 +5,6 @@ import json
 import odoo
 from odoo.tests import tagged, users
 from odoo.tools import mute_logger
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.base.tests.common import HttpCase, HttpCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon, mail_new_test_user
 from odoo.http import STATIC_CACHE_LONG
@@ -106,7 +105,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -164,7 +163,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -178,7 +177,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[1].id,
                     "name": "File 2",
-                    "raw_access_token": limited_field_access_token(self.attachments[1], "raw"),
+                    "raw_access_token": self.attachments[1]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -214,7 +213,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[0].id,
                     "name": "File 1",
-                    "raw_access_token": limited_field_access_token(self.attachments[0], "raw"),
+                    "raw_access_token": self.attachments[0]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},
@@ -228,7 +227,7 @@ class TestMessageController(HttpCaseWithUserDemo):
                     "file_size": 0,
                     "id": self.attachments[1].id,
                     "name": "File 2",
-                    "raw_access_token": limited_field_access_token(self.attachments[1], "raw"),
+                    "raw_access_token": self.attachments[1]._get_raw_access_token(),
                     "res_name": "Test channel",
                     "mimetype": "application/octet-stream",
                     "thread": {"id": self.channel.id, "model": "discuss.channel"},

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -8,7 +8,7 @@ from odoo import fields
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import tagged, users
-from odoo.tools.misc import limited_field_access_token, mute_logger
+from odoo.tools.misc import mute_logger
 
 
 @tagged("RTC", "post_install", "-at_install")
@@ -86,11 +86,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -152,11 +151,10 @@ class TestChannelRTC(MailCommon):
                 ],
                 "res.partner": self._filter_partners_fields(
                     {
-                        "avatar_128_access_token": limited_field_access_token(
-                            channel_member.partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                         "id": channel_member.partner_id.id,
                         "im_status": channel_member.partner_id.im_status,
+                        "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                         "name": channel_member.partner_id.name,
                         "write_date": fields.Datetime.to_string(
                             channel_member.partner_id.write_date
@@ -230,11 +228,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -267,11 +264,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -350,11 +346,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token":  channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -390,11 +385,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -443,11 +437,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -456,11 +449,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -527,11 +519,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -570,11 +561,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -629,11 +619,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -648,7 +637,9 @@ class TestChannelRTC(MailCommon):
                         "discuss.channel": [
                             {
                                 "id": channel.id,
-                                "rtc_session_ids": [("ADD", [channel_member.rtc_session_ids.id + 2])],
+                                "rtc_session_ids": [
+                                    ("ADD", [channel_member.rtc_session_ids.id + 2])
+                                ],
                             },
                         ],
                         "discuss.channel.member": [
@@ -672,11 +663,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -739,11 +729,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -796,11 +785,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -898,11 +886,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -911,11 +898,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date
@@ -1018,11 +1004,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -1062,11 +1047,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member.partner_id.id,
                                 "im_status": channel_member.partner_id.im_status,
+                                "im_status_access_token": channel_member.partner_id._get_im_status_access_token(),
                                 "name": channel_member.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member.partner_id.write_date
@@ -1115,11 +1099,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "mail.guest": [
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_guest.guest_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_guest.guest_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_guest.guest_id.id,
                                 "im_status": channel_member_test_guest.guest_id.im_status,
+                                "im_status_access_token": channel_member_test_guest.guest_id._get_im_status_access_token(),
                                 "name": channel_member_test_guest.guest_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_guest.guest_id.write_date
@@ -1128,11 +1111,10 @@ class TestChannelRTC(MailCommon):
                         ],
                         "res.partner": self._filter_partners_fields(
                             {
-                                "avatar_128_access_token": limited_field_access_token(
-                                    channel_member_test_user.partner_id, "avatar_128"
-                                ),
+                                "avatar_128_access_token": channel_member_test_user.partner_id._get_avatar_128_access_token(),
                                 "id": channel_member_test_user.partner_id.id,
                                 "im_status": channel_member_test_user.partner_id.im_status,
+                                "im_status_access_token": channel_member_test_user.partner_id._get_im_status_access_token(),
                                 "name": channel_member_test_user.partner_id.name,
                                 "write_date": fields.Datetime.to_string(
                                     channel_member_test_user.partner_id.write_date

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -3,7 +3,6 @@
 from odoo import models
 from odoo.http import request
 from odoo.tools import format_datetime, groupby
-from odoo.tools.misc import limited_field_access_token
 
 
 class MailMessage(models.Model):
@@ -80,7 +79,7 @@ class MailMessage(models.Model):
             related_attachments = {
                 att_read_values["id"]: {
                     **att_read_values,
-                    "raw_access_token": limited_field_access_token(att, "raw"),
+                    "raw_access_token": att._get_raw_access_token(),
                 }
                 for att, att_read_values in zip(
                     attachments_sudo,

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -6,7 +6,6 @@ from unittest.mock import patch, PropertyMock
 
 from odoo import Command, fields
 from odoo.fields import Domain
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
 from odoo.tests.common import users, tagged, HttpCase, warmup
@@ -377,16 +376,16 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         The point of having a separate getter is to allow it to be overriden.
         """
         xmlid_to_res_id = self.env["ir.model.data"]._xmlid_to_res_id
+        partner_0 = self.users[0].partner_id
         return {
             "res.partner": self._filter_partners_fields(
                 {
                     "active": False,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.user_root.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": self.user_root.partner_id._get_avatar_128_access_token(),
                     "email": "odoobot@example.com",
                     "id": self.user_root.partner_id.id,
                     "im_status": "bot",
+                    "im_status_access_token": self.user_root.partner_id._get_im_status_access_token(),
                     "isInternalUser": True,
                     "is_company": False,
                     "name": "OdooBot",
@@ -396,9 +395,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 },
                 {
                     "active": True,
-                    "avatar_128_access_token": limited_field_access_token(
-                        self.users[0].partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": partner_0._get_avatar_128_access_token(),
                     "id": self.users[0].partner_id.id,
                     "isAdmin": False,
                     "isInternalUser": True,
@@ -1616,12 +1613,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[0]:
             res = {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": "e.e@example.com",
                 "id": user.partner_id.id,
                 "im_status": "online",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "Ernest Employee",
@@ -1643,12 +1639,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[1]:
             res = {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "country_id": self.env.ref("base.in").id,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "isInternalUser": True,
                 "is_company": False,
                 "is_public": False,
@@ -1663,22 +1658,20 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[2]:
             if only_inviting:
                 return {
-                    "avatar_128_access_token": limited_field_access_token(
-                        user.partner_id, "avatar_128"
-                    ),
+                    "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                     "id": user.partner_id.id,
                     "im_status": "offline",
+                    "im_status_access_token": user.partner_id._get_im_status_access_token(),
                     "name": "test2",
                     "write_date": fields.Datetime.to_string(user.partner_id.write_date),
                 }
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": "test2@example.com",
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test2",
@@ -1689,12 +1682,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[3]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test3",
@@ -1705,12 +1697,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[12]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test12",
@@ -1721,12 +1712,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[14]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test14",
@@ -1737,12 +1727,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if user == self.users[15]:
             return {
                 "active": True,
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "email": False,
                 "id": user.partner_id.id,
                 "im_status": "offline",
+                "im_status_access_token": user.partner_id._get_im_status_access_token(),
                 "is_company": False,
                 "isInternalUser": True,
                 "name": "test15",
@@ -1752,9 +1741,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if user == self.user_root:
             return {
-                "avatar_128_access_token": limited_field_access_token(
-                    user.partner_id, "avatar_128"
-                ),
+                "avatar_128_access_token": user.partner_id._get_avatar_128_access_token(),
                 "id": user.partner_id.id,
                 "isInternalUser": True,
                 "is_company": False,
@@ -1764,10 +1751,11 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if guest:
             return {
-                "avatar_128_access_token": limited_field_access_token(self.guest, "avatar_128"),
+                "avatar_128_access_token": self.guest._get_avatar_128_access_token(),
                 "country_id": self.guest.country_id.id,
                 "id": self.guest.id,
                 "im_status": "offline",
+                "im_status_access_token": self.guest._get_im_status_access_token(),
                 "name": "Visitor",
                 "offline_since": False,
                 "write_date": fields.Datetime.to_string(self.guest.write_date),

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -4,7 +4,6 @@ from markupsafe import Markup
 from unittest.mock import patch
 
 from odoo import Command, fields
-from odoo.tools.misc import limited_field_access_token
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.addons.mail.tools.discuss import Store
@@ -1565,9 +1564,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "Jeannette Testouille",
                                 },
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.env.user.partner_id, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                     "id": self.env.user.partner_id.id,
                                     "isInternalUser": True,
                                     "is_company": False,
@@ -1679,9 +1676,7 @@ class TestMessageToStorePerformance(BaseMailPerformance):
                                     "name": "Jeannette Testouille",
                                 },
                                 {
-                                    "avatar_128_access_token": limited_field_access_token(
-                                        self.env.user.partner_id, "avatar_128"
-                                    ),
+                                    "avatar_128_access_token": self.env.user.partner_id._get_avatar_128_access_token(),
                                     "id": self.env.user.partner_id.id,
                                     "isInternalUser": True,
                                     "is_company": False,

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -9,7 +9,6 @@ from odoo.addons.test_mail.tests.test_performance import BaseMailPerformance
 from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo.tools import mute_logger
-from odoo.tools.misc import limited_field_access_token
 
 
 @tagged('mail_performance', 'post_install', '-at_install')
@@ -260,9 +259,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'id': message.attachment_ids[0].id,
                         'mimetype': 'application/octet-stream',
                         'name': 'Test file 1',
-                        'raw_access_token': limited_field_access_token(
-                            message.attachment_ids[0], 'raw'
-                        ),
+                        'raw_access_token': message.attachment_ids[0]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
                     }, {
@@ -272,9 +269,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
                         'id': message.attachment_ids[1].id,
                         'mimetype': 'application/octet-stream',
                         'name': 'Test file 0',
-                        'raw_access_token': limited_field_access_token(
-                            message.attachment_ids[1], 'raw'
-                        ),
+                        'raw_access_token': message.attachment_ids[1]._get_raw_access_token(),
                         'res_id': record.id,
                         'res_model': record._name,
                     }

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -7,7 +7,6 @@ from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.mail.tools.discuss import Store
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
 from odoo.tests.common import new_test_user
-from odoo.tools.misc import limited_field_access_token
 
 
 @tests.tagged('post_install', '-at_install')
@@ -243,10 +242,11 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 ],
                 "mail.guest": [
                     {
-                        "avatar_128_access_token": limited_field_access_token(guest, "avatar_128"),
+                        "avatar_128_access_token": guest._get_avatar_128_access_token(),
                         "country_id": False,
                         "id": guest.id,
                         "im_status": "offline",
+                        "im_status_access_token": guest._get_im_status_access_token(),
                         "name": f"Visitor #{self.visitor.id}",
                         "offline_since": False,
                         "write_date": fields.Datetime.to_string(guest.write_date),
@@ -258,12 +258,11 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                 "res.partner": self._filter_partners_fields(
                     {
                         "active": True,
-                        "avatar_128_access_token": limited_field_access_token(
-                            self.operator.partner_id, "avatar_128"
-                        ),
+                        "avatar_128_access_token": self.operator.partner_id._get_avatar_128_access_token(),
                         "country_id": False,
                         "id": self.operator.partner_id.id,
                         "im_status": "online",
+                        "im_status_access_token": self.operator.partner_id._get_im_status_access_token(),
                         "is_public": False,
                         "user_livechat_username": "El Deboulonnator",
                         "write_date": fields.Datetime.to_string(

--- a/odoo/addons/base/models/avatar_mixin.py
+++ b/odoo/addons/base/models/avatar_mixin.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from hashlib import sha512
 from odoo import models, fields, api
 from odoo.tools import html_escape, file_open
+from odoo.tools.misc import limited_field_access_token
 
 
 def get_hsl_from_seed(seed):
@@ -77,3 +78,12 @@ class AvatarMixin(models.AbstractModel):
 
     def _avatar_get_placeholder(self):
         return file_open(self._avatar_get_placeholder_path(), 'rb').read()
+
+    def _get_avatar_128_access_token(self):
+        """Return a scoped access token for the `avatar_128` field. The token can be
+        used with `ir_binary._find_record` to bypass access rights.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "avatar_128", scope="binary")

--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -20,6 +20,7 @@ from odoo.fields import Domain
 from odoo.http import Stream, root, request
 from odoo.tools import config, consteq, human_size, image, split_every, str2bool
 from odoo.tools.mimetypes import guess_mimetype, fix_filename_extension
+from odoo.tools.misc import limited_field_access_token
 
 _logger = logging.getLogger(__name__)
 
@@ -673,6 +674,15 @@ class IrAttachment(models.Model):
             attachment.write({'access_token': access_token})
             tokens.append(access_token)
         return tokens
+
+    def _get_raw_access_token(self):
+        """Return a scoped access token for the `raw` field. The token can be
+        used with `ir_binary._find_record` to bypass access rights.
+
+        :rtype: str
+        """
+        self.ensure_one()
+        return limited_field_access_token(self, "raw", scope="binary")
 
     @api.model
     def create_unique(self, values_list):

--- a/odoo/addons/base/models/ir_binary.py
+++ b/odoo/addons/base/models/ir_binary.py
@@ -47,7 +47,7 @@ class IrBinary(models.AbstractModel):
             record = self.env[res_model].browse(res_id).exists()
         if not record:
             raise MissingError(f"No record found for xmlid={xmlid}, res_model={res_model}, id={res_id}")  # pylint: disable=missing-gettext
-        if access_token and verify_limited_field_access_token(record, field, access_token):
+        if access_token and verify_limited_field_access_token(record, field, access_token, scope="binary"):
             return record.sudo()
         if record._can_return_content(field, access_token):
             return record.sudo()


### PR DESCRIPTION
*: im_livechat, test_discuss_full, test_mail, website_livechat.

Currently, complex queries and overrides are used to validate access to presences. This commit replaces those by a simple access token.

task-4676556

enterprise: https://github.com/odoo/enterprise/pull/85963