### PR TITLE
[FIX] l10n_my_edi: add safeguard on dictionary read

### DIFF
--- a/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
+++ b/addons/l10n_my_edi/models/account_edi_xml_ubl_my.py
@@ -125,7 +125,7 @@ class AccountEdiXmlUBLMyInvoisMY(models.AbstractModel):
         })
         # We ensure that the customer does not have their ttx set (it could be on the record if they're also supplier)
         customer_identification_vals = [
-            vals for vals in vals['vals']['accounting_customer_party_vals']['party_vals']['party_identification_vals'] if vals['id_attrs'] != {'schemeID': 'TTX'}
+            vals for vals in vals['vals']['accounting_customer_party_vals']['party_vals']['party_identification_vals'] if vals.get('id_attrs', {}) != {'schemeID': 'TTX'}
         ]
         vals['vals']['accounting_customer_party_vals']['party_vals']['party_identification_vals'] = customer_identification_vals
 

--- a/addons/l10n_my_edi/tests/test_file_generation.py
+++ b/addons/l10n_my_edi/tests/test_file_generation.py
@@ -52,6 +52,7 @@ class L10nMyEDITestFileGeneration(AccountTestInvoicingCommon):
             'street': 'that other street, 3',
             'city': 'Main city',
             'phone': '+60123456786',
+            'ref': "MY-REF",
         })
         cls.partner_b.write({
             'vat': 'EI00000000020',

--- a/addons/l10n_my_edi/tests/test_submissions.py
+++ b/addons/l10n_my_edi/tests/test_submissions.py
@@ -44,6 +44,7 @@ class L10nMyEDITestSubmission(TestAccountMoveSendCommon):
             'street': 'that other street, 3',
             'city': 'Main city',
             'phone': '+60123456786',
+            'ref': "MY-REF",
         })
         cls.product_a.l10n_my_edi_classification_code = "001"
 


### PR DESCRIPTION
*Behavior before this PR*
When sending an Invoice to MyInvois, tracebacks could be raised if the `party_identification_vals` dictionary held values other than `id_attrs`. This was the case for the Customer Reference (`ref`), added in PR #206655

*Behavior after this PR*
Invoices can be properly submitted to MyInvois, even with Customer References.

opw-4807559

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
