### PR TITLE
[IMP] account: fiscal position map to many

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -113,10 +113,10 @@ class AccountTax(models.Model):
         string="Replaces",
         domain="""[
             ('type_tax_use', '=', type_tax_use),
-            ('id', '!=', id),
             ('is_domestic', '=', True),
         ]""",
         ondelete='cascade',
+        help="List of taxes to replace when applying any of the stipulated fiscal positions.",
     )
     display_alternative_taxes_field = fields.Boolean(compute='_compute_display_alternative_taxes_field')
     is_domestic = fields.Boolean(compute='_compute_is_domestic', store=True, precompute=True)


### PR DESCRIPTION
countries like spain use the fiscal position feature to add a withholding tax to the product's domestic tax. in order to do that, the domestic tax needs to replace itself (as was done in the old tax mapping) The UI domain was restricting this (even though the data files do that).
