### PR TITLE
[IMP] sale_project, sale_timesheet: return SO and SOL based on partner in SO

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -43,7 +43,7 @@ class ProjectProject(models.Model):
     partner_id = fields.Many2one(compute="_compute_partner_id", store=True, readonly=False)
     display_sales_stat_buttons = fields.Boolean(compute='_compute_display_sales_stat_buttons', export_string_translation=False)
     sale_order_state = fields.Selection(related='sale_order_id.state', export_string_translation=False)
-    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', copy=False, domain="[('partner_id', '=', partner_id)]", index='btree_not_null',
+    reinvoiced_sale_order_id = fields.Many2one('sale.order', string='Sales Order', groups='sales_team.group_sale_salesman', copy=False, domain="['|', ('partner_id', '=', partner_id), ('partner_id.commercial_partner_id.id', 'parent_of', partner_id)]", index='btree_not_null',
         help="Products added to stock pickings, whose operation type is configured to generate analytic costs, will be re-invoiced in this sales order if they are set up for it.",
     )
     actual_margin = fields.Monetary(compute='_compute_actual_margin', export_string_translation=False)

--- a/addons/sale_timesheet/models/project_sale_line_employee_map.py
+++ b/addons/sale_timesheet/models/project_sale_line_employee_map.py
@@ -14,6 +14,8 @@ class ProjectSaleLineEmployeeMap(models.Model):
             self.env['sale.order.line']._sellable_lines_domain(),
             self.env['sale.order.line']._domain_sale_line_service(),
             [
+            '|',
+                ('order_partner_id.commercial_partner_id.id', 'parent_of', unquote('partner_id if partner_id else []')),
                 ('order_partner_id', '=?', unquote('partner_id')),
             ],
         ])

--- a/addons/sale_timesheet/tests/test_project.py
+++ b/addons/sale_timesheet/tests/test_project.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
+
 from odoo import Command
 from .common import TestCommonSaleTimesheet
 from odoo.tests import tagged, Form
+from odoo.tools.safe_eval import expr_eval
 
 
 @tagged('post_install', '-at_install')
@@ -230,3 +233,53 @@ class TestProject(TestCommonSaleTimesheet):
         new_project = wizard._create_project_from_template()
 
         self.assertEqual(new_project.company_id, self.partner_b.company_id)
+
+    def test_sale_lines_returned_for_parent_and_child_partner(self):
+        """
+        Test that sale order lines are correctly retrieved when the parent or child partner is set on the project.
+        Steps:
+        1. Set a child partner as a delivery contact under a parent partner
+        2. Create a sale order for each partner with a service product.
+        3. Confirm both sale orders.
+        4. Assign the parent partner to the project.
+        5. Verify that child partner's sale order lines are returned.
+        6. Assign the child partner to the project.
+        7. Verify parent partner's sale order lines are returned.
+        """
+        self.partner.write({
+            'type': 'delivery',
+            'parent_id': self.partner_b.id
+        })
+        sale_orders = sale_order_1, sale_order_2 = self.env['sale.order'].create([
+            {
+                'partner_id': self.partner_b.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product_order_timesheet1.id,
+                        'product_uom_qty': 10,
+                    })
+                ]
+            },
+            {
+                'partner_id': self.partner.id,
+                'order_line': [
+                    Command.create({
+                        'product_id': self.product_order_timesheet2.id,
+                        'product_uom_qty': 5,
+                    })
+                ]
+            }
+        ])
+        sale_orders.action_confirm()
+
+        self.project_global.partner_id = self.partner_b.id
+        domain = self.project_global.sale_line_employee_ids._domain_sale_line_id()
+        evaluated_domain = expr_eval(re.sub(r'\bpartner_id\b', str(self.project_global.partner_id.id), repr(domain)))
+        sale_order_lines = self.env['sale.order.line'].search(evaluated_domain)
+        self.assertIn(sale_order_2.order_line, sale_order_lines, "Expected sale order lines of child partner")
+
+        self.project_global.partner_id = self.partner.id
+        domain = self.project_global.sale_line_employee_ids._domain_sale_line_id()
+        evaluated_domain = expr_eval(re.sub(r'\bpartner_id\b', str(self.project_global.partner_id.id), repr(domain)))
+        sale_order_lines = self.env['sale.order.line'].search(evaluated_domain)
+        self.assertIn(sale_order_1.order_line, sale_order_lines, "Expected sale order lines of parent partner")


### PR DESCRIPTION
Before this commit:
- Sales order lines linked to the sale orders of child and parent partners do not return in the invoicing notebook.
- Sale orders linked to child or parent partners do not return to the project.

After this commit:
- Sales order lines linked to the sale orders of child and parent partners now return correctly in the invoicing notebook.
- Sale orders linked to child or parent partners now return correctly to the project.

task-4764834