### PR TITLE
[FIX] website: add_page_dialog component may be destroyed while loading

### DIFF
--- a/addons/website/static/src/components/dialog/add_page_dialog.js
+++ b/addons/website/static/src/components/dialog/add_page_dialog.js
@@ -6,7 +6,7 @@ import { useAutofocus, useService } from '@web/core/utils/hooks';
 import { _t } from "@web/core/l10n/translation";
 import { WebsiteDialog } from '@website/components/dialog/dialog';
 import { Switch } from '@website/components/switch/switch';
-import { useRef, useState, useSubEnv, Component, onWillStart, onMounted } from "@odoo/owl";
+import { useRef, useState, useSubEnv, Component, onWillStart, onMounted, status } from "@odoo/owl";
 import wUtils from '@website/js/utils';
 
 const NO_OP = () => {};
@@ -303,6 +303,9 @@ export class AddPageTemplates extends Component {
         // Displaying the correct images in the previews also relies on the
         // website id having been forced.
         await this.env.getCssLinkEls();
+        if (status(this) === "destroyed") {
+            return new Promise(() => {});
+        }
 
         if (this.pages) {
             return this.pages;


### PR DESCRIPTION
Doing asynchronous things in the onWillStart can be tricky. Methods that come from services are usually protected against those, and hang up if the component was destroyed during the call, but other calls aren't protected.

This commit fixes a race condition where a protected call is done after a component is destroyed and crashes.

runbot-error-135245

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
