### PR TITLE
[FIX] point_of_sale: cancelled KOT printing

### DIFF
--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -154,8 +154,9 @@ export const getOrderChanges = (order, skipped = false, orderPreparationCategori
     }
     const sittingMode = order.last_order_preparation_change.sittingMode;
     if (
-        (sittingMode !== "dine in" && !order.takeaway) ||
-        (sittingMode !== "takeaway" && order.takeaway)
+        Object.keys(order.last_order_preparation_change.lines).length &&
+        ((sittingMode !== "dine in" && !order.takeaway) ||
+            (sittingMode !== "takeaway" && order.takeaway))
     ) {
         result.modeUpdate = true;
     }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1626,24 +1626,25 @@ export class PosStore extends Reactive {
                     true,
                     diningModeUpdate
                 );
+                changes.new = [];
                 if (!printed) {
                     unsuccedPrints.push("Detailed Receipt");
                 }
-            } else {
-                // Print all receipts related to line changes
-                const toPrintArray = this.preparePrintingData(order, changes);
-                for (const [key, value] of Object.entries(toPrintArray)) {
-                    const printed = await this.printReceipts(order, printer, key, value, false);
-                    if (!printed) {
-                        unsuccedPrints.push(key);
-                    }
+            }
+
+            // Print all receipts related to line changes
+            const toPrintArray = this.preparePrintingData(order, changes);
+            for (const [key, value] of Object.entries(toPrintArray)) {
+                const printed = await this.printReceipts(order, printer, key, value, false);
+                if (!printed) {
+                    unsuccedPrints.push(key);
                 }
-                // Print Order Note if changed
-                if (orderChange.generalNote) {
-                    const printed = await this.printReceipts(order, printer, "Message", []);
-                    if (!printed) {
-                        unsuccedPrints.push("General Message");
-                    }
+            }
+            // Print Order Note if changed
+            if (orderChange.generalNote && anyChangesToPrint) {
+                const printed = await this.printReceipts(order, printer, "Message", []);
+                if (!printed) {
+                    unsuccedPrints.push("General Message");
                 }
             }
         }


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Install POS restaurant & configure a preparation printer.
- Open a session, order item A with some quantity from table X.
- Again open table X & remove some qty of item A and add some qty of item B.
- Order the changes.
- On the preparation printer the cancelled KOT for item A won't appear.

Issue:
--------
- No receipt printed for the items which are cancelled.

Cause:
---------
- We have conditioned the printing in a way that if we found something new or if mode is updated rest prints won't be printed.

Fix:
-----
- Now we will have 2 receipts one for the new ordered items and the another with cancelled items.

Task: 4805293