### PR TITLE
[FIX] stock: revoke default location write access.

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1006,7 +1006,7 @@ class StockQuant(models.Model):
                                                      package_id=quant.package_id))
         moves = self.env['stock.move'].with_context(inventory_mode=False).create(move_vals)
         moves._action_done()
-        self.location_id.write({'last_inventory_date': fields.Date.today()})
+        self.location_id.sudo().write({'last_inventory_date': fields.Date.today()})
         date_by_location = {loc: loc._get_next_inventory_date() for loc in self.mapped('location_id')}
         for quant in self:
             quant.inventory_date = date_by_location[quant.location_id]

--- a/addons/stock/security/ir.model.access.csv
+++ b/addons/stock/security/ir.model.access.csv
@@ -5,7 +5,6 @@ access_stock_warehouse_user,stock.warehouse.user,model_stock_warehouse,base.grou
 access_stock_location_partner_manager,stock.location.partner.manager,model_stock_location,base.group_partner_manager,1,0,0,0
 access_stock_location_manager,stock.location.manager,model_stock_location,stock.group_stock_manager,1,1,1,1
 access_stock_location_all_user,stock.location.all.user,model_stock_location,base.group_user,1,0,0,0
-access_stock_location_user,stock.location.user,model_stock_location,stock.group_stock_user,1,1,0,0
 access_stock_picking_user,stock.picking user,model_stock_picking,stock.group_stock_user,1,1,1,1
 access_stock_picking_manager,stock.picking manager,model_stock_picking,stock.group_stock_manager,1,1,1,1
 access_stock_picking_type_all,stock.picking.type all users,model_stock_picking_type,base.group_user,1,0,0,0


### PR DESCRIPTION
The inventory user have the right of write on stock.location object. However most company doesn't want the inventory user to edit their location configuration. It was introduced in commit 37d96f49ccc85fa651f092b6c32bab1af2c34f2d

Remove the acl and use a sudo to write the last inventory date during an inventory adjustement

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
