### PR TITLE
[FIX] account: prevent scrollbar and ensure full-width terms in invoice

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -236,7 +236,7 @@
                                     <div class="oe_structure"/>
                                 </t>
                             </div>
-                            <div id="payment_term" class="clearfix overflow-auto">
+                            <div id="payment_term" class="clearfix overflow-hidden">
                                 <div class="justify-text">
                                     <p t-if="not is_html_empty(o.fiscal_position_id.note)" name="note" class="mb-2">
                                         <span t-field="o.fiscal_position_id.note"/>


### PR DESCRIPTION
<b>Steps to reproduce:</b>
1. Go to Invoices > Create new 
2.  Add a long string in Terms & Conditions > Click "Print"

<b>Issue:</b>
- In Invoices, a horizontal scrollbar appears in the Terms & Conditions section.
<b>Cause:</b>
- The class `overflow-auto` was applied to the container, which triggers scrollbar when content overflows.

<b>Solution:</b>
- Replace `overflow-auto` with `overflow-hidden` to avoid overflow.

<b>opw-4776919</b>

Image of issue:
![image](https://github.com/user-attachments/assets/41df69b1-4078-406b-a0ed-8edc2521bbbc)
![image](https://github.com/user-attachments/assets/ab41d900-ac39-4916-ac61-5046d5ff0959)
