### PR TITLE
[FIX] web: properly reset record order in x2many lists

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -1016,7 +1016,7 @@ export class StaticList extends DataPoint {
                     if (orderBy[0].asc) {
                         orderBy[0] = { name: orderBy[0].name, asc: false };
                     } else {
-                        orderBy = [];
+                        orderBy = [{ name: "id", asc: true }];
                     }
                 }
             } else {

--- a/addons/web/static/tests/views/fields/one2many_field.test.js
+++ b/addons/web/static/tests/views/fields/one2many_field.test.js
@@ -11126,6 +11126,12 @@ test("x2many list sorted by many2one", async () => {
     expect(queryAllTexts(".o_data_row .o_list_number")).toEqual(["2", "1", "4"], {
         message: "should have correct order (DESC)",
     });
+
+    await contains(".o_list_renderer thead th:eq(1)").click();
+
+    expect(queryAllTexts(".o_data_row .o_list_number")).toEqual(["1", "2", "4"], {
+        message: "should fall back to initial order",
+    });
 });
 
 test("one2many with extra field from server not in (inline) form", async () => {


### PR DESCRIPTION
This commit fixes an issue introduced in https://github.com/odoo/odoo/pull/207227, where resetting the order of records in a x2many list field would lead to a traceback as long as it contained more than one record.

The issue stems from the compareRecords method in StaticList, which was not designed to handle an empty orderBy. To resolve this, the _sortBy method now falls back to using an ascending id order instead of emptying orderBy, effectively restoring the original order.

Skipping sorting in _sort would not suffice, as record order is cached and must be explicitly restored.
