### PR TITLE
[FIX] stock: allow to revoke write access on location

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1027,7 +1027,7 @@ class StockQuant(models.Model):
                                                      package_id=quant.package_id))
         moves = self.env['stock.move'].with_context(inventory_mode=False).create(move_vals)
         moves._action_done()
-        self.location_id.write({'last_inventory_date': fields.Date.today()})
+        self.location_id.sudo().write({'last_inventory_date': fields.Date.today()})
         date_by_location = {loc: loc._get_next_inventory_date() for loc in self.mapped('location_id')}
         for quant in self:
             quant.inventory_date = date_by_location[quant.location_id]


### PR DESCRIPTION
PR #210777 Fix the issue for master (18.4)

Currently the write access right is given to the inventory user. However some customer want to revoke this access in order to avoid user messing with their location configuration. But it's not possible since it will also raise an access error when validation an inventory adjustement.

opw-4782515