### PR TITLE
[IMP] im_livechat, *: remove anonymous_name field

### DIFF
--- a/addons/crm_livechat/static/tests/message.test.js
+++ b/addons/crm_livechat/static/tests/message.test.js
@@ -18,7 +18,6 @@ test("Can open lead from internal link", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_1.xml
@@ -7,7 +7,6 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #234, Odoo</field>
-            <field name="anonymous_name">Visitor #234</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_1_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_2.xml
@@ -7,7 +7,6 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #235, Odoo</field>
-            <field name="anonymous_name">Visitor #235</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_2_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_chatbot_session_3.xml
@@ -7,7 +7,6 @@
             <field name="livechat_operator_id" ref="welcome_bot_operator_partner_demo"/>
             <field name="livechat_failure">no_agent</field>
             <field name="name">Visitor #236, Odoo</field>
-            <field name="anonymous_name">Visitor #235</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_chatbot_session_3_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_1.xml
@@ -8,7 +8,6 @@
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-0, minutes=5, seconds=25)"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Visitor #234, Mitchell Admin</field>
-            <field name="anonymous_name">Visitor #234</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1)"/>
         </record>
         <record id="livechat_channel_session_1_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_10.xml
@@ -10,7 +10,6 @@
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
             <field name="livechat_failure">no_failure</field>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
         <record id="im_livechat.livechat_channel_session_10_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_11.xml
@@ -9,7 +9,6 @@
             <field name="livechat_failure">no_failure</field>
             <field name="create_date" eval="datetime.now()"/>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visitor</field>
             <field name="country_id" ref="base.us"/>
         </record>
         <record id="im_livechat.livechat_channel_session_11_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_12.xml
@@ -9,7 +9,6 @@
             <field name="livechat_failure">no_answer</field>
             <field name="create_date" eval="datetime.now()"/>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visitor</field>
             <field name="country_id" ref="base.us"/>
         </record>
         <record id="im_livechat.livechat_channel_session_12_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_13.xml
@@ -10,7 +10,6 @@
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
             <field name="livechat_failure">no_answer</field>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
         <record id="im_livechat.livechat_channel_session_13_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_14.xml
@@ -9,7 +9,6 @@
             <field name="create_date" eval="datetime.now() - timedelta(minutes=1)"/>
             <field name="livechat_failure">no_failure</field>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visiteur</field>
             <field name="country_id" ref="base.be"/>
         </record>
         <record id="im_livechat.livechat_channel_session_14_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_15.xml
@@ -8,7 +8,6 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Mitchell Admin</field>
-            <field name="anonymous_name">Joel Willis</field>
         </record>
         <record id="im_livechat.livechat_channel_session_15_member_admin" model="discuss.channel.member">
             <field name="partner_id" ref="base.partner_admin"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_2.xml
@@ -8,7 +8,6 @@
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-1, minutes=11)"/>
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="name">Visitor #323, Marc Demo</field>
-            <field name="anonymous_name">Visitor #323</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-1)"/>
         </record>
         <record id="livechat_channel_session_2_history_member_demo" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_3.xml
@@ -8,7 +8,6 @@
             <field name="livechat_end_dt" eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=15)"/>
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="name">Joel Willis, Mitchell Admin</field>
-            <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-1, days=-2, minutes=12)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_3_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_4.xml
@@ -9,7 +9,6 @@
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Marc Demo</field>
-            <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-3)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_4_history_member_demo" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_5.xml
@@ -9,7 +9,6 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #532, Mitchell Admin</field>
-            <field name="anonymous_name">Visitor #532</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-2, days=-4)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_5_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_6.xml
@@ -9,7 +9,6 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #649, Mitchell Admin</field>
-            <field name="anonymous_name">Visitor #649</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-5)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_6_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_7.xml
@@ -9,7 +9,6 @@
             <field name="livechat_operator_id" ref="base.partner_admin"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Joel Willis, Mitchell Admin</field>
-            <field name="anonymous_name">Joel Willis</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-6)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_7_history_member_admin" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_8.xml
@@ -9,7 +9,6 @@
             <field name="livechat_operator_id" ref="base.partner_demo"/>
             <field name="livechat_failure">no_failure</field>
             <field name="name">Visitor #722, Marc Demo</field>
-            <field name="anonymous_name">Visitor #722</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(months=-3, days=-7)"/>
         </record>
         <record id="im_livechat.livechat_channel_session_8_history_member_demo" model="im_livechat.channel.member.history">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_session_9.xml
@@ -10,7 +10,6 @@
             <field name="livechat_failure">no_failure</field>
             <field name="create_date" eval="datetime.now() - timedelta(days=1)"/>
             <field name="channel_type">livechat</field>
-            <field name="anonymous_name">Visitor</field>
         </record>
         <record id="im_livechat.livechat_channel_session_9_history_member_admin" model="im_livechat.channel.member.history">
             <field name="channel_id" ref="livechat_channel_session_9"/>

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_1.xml
@@ -7,7 +7,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visiteur #301, Support</field>
-            <field name="anonymous_name">Visiteur #301</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=5)"/>
         </record>
         <record id="support_bot_session_1_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_2.xml
@@ -7,7 +7,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitatore #302, Support</field>
-            <field name="anonymous_name">Visitatore #302</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(weeks=-2)"/>
         </record>
         <record id="support_bot_session_2_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_3.xml
@@ -7,7 +7,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitatore #303, Support</field>
-            <field name="anonymous_name">Visitatore #303</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-10)"/>
         </record>
         <record id="support_bot_session_3_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_4.xml
@@ -7,7 +7,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitatore #304, Support</field>
-            <field name="anonymous_name">Visitatore #304</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=3)"/>
         </record>
         <record id="support_bot_session_4_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_5.xml
@@ -6,7 +6,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #305, Support</field>
-            <field name="anonymous_name">Visitor #305</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-5)"/>
         </record>
         <record id="support_bot_session_5_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_6.xml
@@ -6,7 +6,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #306, Support</field>
-            <field name="anonymous_name">Visitor #306</field>
             <field name="create_date" eval="datetime.now() - timedelta(minutes=6)"/>
         </record>
         <record id="support_bot_session_6_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
+++ b/addons/im_livechat/demo/im_livechat_channel/im_livechat_support_bot_session_7.xml
@@ -6,7 +6,6 @@
             <field name="livechat_channel_id" ref="support_bot_channel_demo"/>
             <field name="livechat_operator_id" ref="support_bot_operator_partner_demo"/>
             <field name="name">Visitor #307, Support</field>
-            <field name="anonymous_name">Visitor #307</field>
             <field name="create_date" eval="DateTime.today() + relativedelta(days=-6)"/>
         </record>
         <record id="support_bot_session_7_member_bot_demo" model="discuss.channel.member">

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -402,7 +402,7 @@ class ChatbotScriptStep(models.Model):
                         [
                             self.env.user.display_name
                             if not self.env.user._is_public()
-                            else discuss_channel.anonymous_name,
+                            else channel_sudo.self_member_id.guest_id.name,
                             human_operator.livechat_username
                             if human_operator.livechat_username
                             else human_operator.name,

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -25,7 +25,6 @@ class DiscussChannel(models.Model):
     _name = 'discuss.channel'
     _inherit = ['rating.mixin', 'discuss.channel']
 
-    anonymous_name = fields.Char('Anonymous Name')
     channel_type = fields.Selection(selection_add=[('livechat', 'Livechat Conversation')], ondelete={'livechat': 'cascade'})
     duration = fields.Float('Duration', compute='_compute_duration', help='Duration of the session in hours')
     livechat_lang_id = fields.Many2one("res.lang", string="Language", help="Lang of the visitor of the channel.")
@@ -332,7 +331,6 @@ class DiscussChannel(models.Model):
 
     def _to_store_defaults(self, target: Store.Target):
         fields = [
-            Store.Attr("anonymous_name", predicate=is_livechat_channel),
             "chatbot_current_step",
             Store.One("country_id", ["code", "name"], predicate=is_livechat_channel),
             Store.Attr("livechat_end_dt", predicate=is_livechat_channel),

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -314,7 +314,6 @@ class Im_LivechatChannel(models.Model):
             "livechat_failure": "no_answer" if agent else "no_failure",
             "livechat_status": "in_progress",
             'chatbot_current_step_id': chatbot_script._get_welcome_steps()[-1].id if chatbot_script else False,
-            "anonymous_name": visitor_user.display_name or guest.name,
             'channel_type': 'livechat',
             'name': name,
         }

--- a/addons/im_livechat/static/src/core/common/thread_model_patch.js
+++ b/addons/im_livechat/static/src/core/common/thread_model_patch.js
@@ -78,9 +78,6 @@ patch(Thread.prototype, {
         if (this.channel_type === "livechat" && persona.user_livechat_username) {
             return persona.user_livechat_username;
         }
-        if (persona.is_public && this.anonymous_name) {
-            return this.anonymous_name;
-        }
         return super.getPersonaName(persona);
     },
 });

--- a/addons/im_livechat/static/tests/call.test.js
+++ b/addons/im_livechat/static/tests/call.test.js
@@ -26,7 +26,6 @@ test("should display started a call message with operator livechat username", as
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/channel_invite.test.js
+++ b/addons/im_livechat/static/tests/channel_invite.test.js
@@ -32,7 +32,6 @@ test("Can invite a partner to a livechat channel", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 20",
         name: "Visitor 20",
         channel_member_ids: [
             Command.create({
@@ -84,7 +83,6 @@ test("Available operators come first", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #1" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #1",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -114,7 +112,6 @@ test("Partners invited most frequently by the current user come first", async ()
     });
     const guestId_1 = pyEnv["mail.guest"].create({ name: "Visitor #1" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #1",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({
@@ -132,7 +129,6 @@ test("Partners invited most frequently by the current user come first", async ()
     });
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor #2" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #2",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({
@@ -211,7 +207,6 @@ test("Operator invite shows livechat_username", async () => {
     });
     const guestId_1 = pyEnv["mail.guest"].create({ name: "Visitor #1" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #1",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({

--- a/addons/im_livechat/static/tests/channel_member_list.test.js
+++ b/addons/im_livechat/static/tests/channel_member_list.test.js
@@ -18,7 +18,6 @@ test("display country in channel member list", async () => {
         name: "Visitor #20",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/chat_window_patch.test.js
+++ b/addons/im_livechat/static/tests/chat_window_patch.test.js
@@ -94,7 +94,6 @@ test("Focus should not be stolen when a new livechat open", async () => {
     const channelIds = pyEnv["discuss.channel"].create([
         { name: "general" },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -155,7 +154,6 @@ test("Show livechats with new message in chat hub even when in discuss app)", as
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const [livechatId, channelId] = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({ partner_id: serverState.partnerId }),
                 Command.create({ guest_id: guestId }),

--- a/addons/im_livechat/static/tests/composer_patch.test.js
+++ b/addons/im_livechat/static/tests/composer_patch.test.js
@@ -26,7 +26,6 @@ test("Can execute help command on livechat channels", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -49,7 +48,6 @@ test('Receives visitor typing status "is typing"', async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/discuss_patch.test.js
+++ b/addons/im_livechat/static/tests/discuss_patch.test.js
@@ -28,7 +28,6 @@ test("add livechat in the sidebar on visitor sending first message", async () =>
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor (Belgium)",
         channel_member_ids: [
             Command.create({
                 unpin_dt: "2021-01-01 12:00:00",
@@ -70,7 +69,6 @@ test("invite button should be present on livechat", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -90,7 +88,6 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
     pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     last_interest_dt: "2021-01-01 10:00:00",
@@ -103,7 +100,6 @@ test("livechats are sorted by last activity time in the sidebar: most recent at 
             livechat_operator_id: serverState.partnerId,
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     last_interest_dt: "2021-02-01 10:00:00",
@@ -137,7 +133,6 @@ test("sidebar search finds livechats", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
@@ -28,7 +28,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
     const guestId_3 = pyEnv["mail.guest"].create({ name: "Visitor 13" });
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -41,7 +40,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
             name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -56,7 +54,6 @@ test("tab on discuss composer goes to oldest unread livechat", async () => {
             name: "Livechat 2",
         },
         {
-            anonymous_name: "Visitor 13",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -246,7 +243,6 @@ test("switching to folded chat window unfolds it", async () => {
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -259,7 +255,6 @@ test("switching to folded chat window unfolds it", async () => {
             name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -301,7 +296,6 @@ test("switching to hidden chat window unhides it", async () => {
     ]);
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -314,7 +308,6 @@ test("switching to hidden chat window unhides it", async () => {
             name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -358,7 +351,6 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -371,7 +363,6 @@ test("tab on composer doesn't switch thread if user is typing", async () => {
             name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -399,7 +390,6 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
     const channelIds = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor 11",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,
@@ -412,7 +402,6 @@ test("tab on composer doesn't switch thread if no unread thread", async () => {
             name: "Livechat 1",
         },
         {
-            anonymous_name: "Visitor 12",
             channel_member_ids: [
                 Command.create({
                     partner_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
+++ b/addons/im_livechat/static/tests/livechat_channel_info_list.test.js
@@ -25,7 +25,6 @@ test("livechat note is loaded when opening the channel info list", async () => {
         name: "Visitor #20",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -52,7 +51,6 @@ test("editing livechat note is synced between tabs", async () => {
         name: "Visitor #20",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -100,7 +98,6 @@ test("shows live chat status in discuss sidebar", async () => {
         name: "Visitor #20",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ guest_id: guestId }),
@@ -131,7 +128,6 @@ test("editing livechat status is synced between tabs", async () => {
         name: "Visitor #20",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ guest_id: guestId }),
@@ -183,7 +179,6 @@ test("Shows expertise", async () => {
         { name: "events" },
     ]);
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/messaging_menu_patch.test.js
@@ -10,7 +10,6 @@ test('livechats should be in "chat" filter', async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -32,7 +31,6 @@ test('livechats should be in "livechat" tab in mobile', async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
+++ b/addons/im_livechat/static/tests/mobile_messaging_menu_patch.test.js
@@ -25,7 +25,6 @@ test("Livechat button is present when there is at least one livechat thread", as
     patchUiSize({ size: SIZES.SM });
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({

--- a/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/discuss_channel.js
@@ -62,7 +62,6 @@ export class DiscussChannel extends mailModels.DiscussChannel {
         super._to_store(...arguments);
         for (const channel of this) {
             const channelInfo = {};
-            channelInfo["anonymous_name"] = channel.anonymous_name;
             const [country] = ResCountry.browse(channel.country_id);
             channelInfo["country_id"] = country
                 ? {

--- a/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
+++ b/addons/im_livechat/static/tests/mock_server/mock_models/im_livechat_channel.js
@@ -83,7 +83,6 @@ export class LivechatChannel extends models.ServerModel {
             livechat_operator_id: agent.partner_id,
             livechat_channel_id: id,
             livechat_status: "in_progress",
-            anonymous_name: visitorUser ? visitorUser.display_name : guest.name,
             channel_type: "livechat",
             name: membersName.join(" "),
         };

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -26,7 +26,6 @@ test("Unknown visitor", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -122,7 +121,6 @@ test("Smiley face avatar for livechat item linked to a guest", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -169,7 +167,6 @@ test("No counter if the category is unfolded and with unread messages", async ()
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
                 message_unread_counter: 10,
@@ -193,7 +190,6 @@ test("No counter if category is folded and without unread messages", async () =>
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -212,7 +208,6 @@ test("Counter should have correct value of unread threads if category is folded 
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
                 livechat_member_type: "agent",
@@ -240,7 +235,6 @@ test("Close manually by clicking the title", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -263,7 +257,6 @@ test("Open manually by clicking the title", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
                 partner_id: serverState.partnerId,
@@ -301,7 +294,6 @@ test("Category item should be invisible if the category is closed", async () => 
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -328,7 +320,6 @@ test("Active category item should be visible even if the category is closed", as
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
                 partner_id: serverState.partnerId,
@@ -355,7 +346,6 @@ test("Active category item should be visible even if the category is closed", as
 test("Clicking on leave button leaves the channel", async () => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({
@@ -381,7 +371,6 @@ test("Message unread counter", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
                 partner_id: serverState.partnerId,

--- a/addons/im_livechat/static/tests/suggestions.test.js
+++ b/addons/im_livechat/static/tests/suggestions.test.js
@@ -19,7 +19,6 @@ test("Suggestions are shown after delimiter was used in text (::)", async () => 
         substitution: "Hello dear customer, how may I help you?",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
@@ -43,7 +42,6 @@ test("Cannot mention other channels in a livechat", async () => {
     const pyEnv = await startServer();
     const [channelId] = pyEnv["discuss.channel"].create([
         {
-            anonymous_name: "Visitor",
             channel_type: "livechat",
             channel_member_ids: [
                 Command.create({

--- a/addons/im_livechat/static/tests/thread_icon_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_icon_patch.test.js
@@ -13,7 +13,6 @@ test("Public website visitor is typing", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/thread_model_patch.test.js
+++ b/addons/im_livechat/static/tests/thread_model_patch.test.js
@@ -26,7 +26,6 @@ test("Thread name unchanged when inviting new users", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -52,7 +51,6 @@ test("Can set a custom name to livechat conversation", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -77,7 +75,6 @@ test("Display livechat custom username if defined", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #20" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),
@@ -101,7 +98,6 @@ test("Display livechat custom name in typing status", async () => {
         user_livechat_username: "livechat custom username",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #20",
         channel_member_ids: [
             Command.create({ partner_id: partnerId, livechat_member_type: "agent" }),
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/transcript_sender.test.js
+++ b/addons/im_livechat/static/tests/transcript_sender.test.js
@@ -15,7 +15,6 @@ test("agent can send conversation after livechat ends", async () => {
         email: "awesome@example.com",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Awesome Partner",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ partner_id: demoPartnerId, livechat_member_type: "visitor" }),

--- a/addons/im_livechat/static/tests/translation.test.js
+++ b/addons/im_livechat/static/tests/translation.test.js
@@ -9,7 +9,6 @@ defineLivechatModels();
 test("message translation in livechat", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor",
         channel_type: "livechat",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -40,7 +40,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                 },
             )["store_data"]
         channel_info = data["discuss.channel"][0]
-        self.assertEqual(channel_info['anonymous_name'], "Visitor")
+        self.assertEqual(channel_info["name"], "Visitor Michel Operator")
         self.assertEqual(channel_info["country_id"], belgium.id)
         self.assertEqual(data["res.country"], [{"code": "BE", "id": belgium.id, "name": "Belgium"}])
 
@@ -102,7 +102,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             'channel_id': self.livechat_channel.id,
         })["store_data"]
         channel_info = data["discuss.channel"][0]
-        self.assertEqual(channel_info['anonymous_name'], "Roger")
+        self.assertEqual(channel_info["name"], "Roger Michel Operator")
         self.assertEqual(channel_info["country_id"], belgium.id)
         self.assertEqual(data["res.country"], [{"code": "BE", "id": belgium.id, "name": "Belgium"}])
         operator_member_domain = [
@@ -218,7 +218,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         ]
         operator_member = self.env['discuss.channel.member'].search(operator_member_domain)
         self.assertEqual(channel_info['livechat_operator_id'], operator.partner_id.id)
-        self.assertEqual(channel_info['anonymous_name'], "Michel")
+        self.assertEqual(channel_info["name"], "Michel Michel Operator")
         self.assertEqual(channel_info['country_id'], False)
         self.assertEqual(
             data["res.partner"],

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -855,7 +855,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1:
             return {
-                "anonymous_name": "test1",
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.in").id,
                 "create_uid": self.users[1].id,
@@ -883,7 +882,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2:
             return {
-                "anonymous_name": "Visitor",
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.be").id,
                 "create_uid": self.env.ref("base.public_user").id,

--- a/addons/website_livechat/controllers/chatbot.py
+++ b/addons/website_livechat/controllers/chatbot.py
@@ -39,7 +39,6 @@ class WebsiteLivechatChatbotScriptController(http.Controller):
             ],
             'livechat_operator_id': chatbot_script.operator_partner_id.id,
             'chatbot_current_step_id': chatbot_script._get_welcome_steps()[-1].id,
-            'anonymous_name': False,
             'channel_type': 'livechat',
             'name': chatbot_script.title,
         }

--- a/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
+++ b/addons/website_livechat/static/tests/livechat_channel_info_list_patch.test.js
@@ -19,7 +19,6 @@ test("shows recent page views", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: `Visitor #${visitorId}` });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: `Visitor #${visitorId}`,
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId, livechat_member_type: "agent" }),
             Command.create({ guest_id: guestId, livechat_member_type: "visitor" }),

--- a/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
+++ b/addons/website_livechat/static/tests/mock_server/mock_models/website_visitor.js
@@ -21,17 +21,20 @@ export class WebsiteVisitor extends websiteModels.WebsiteVisitor {
 
         const visitors = this.browse(ids);
         for (const visitor of visitors) {
+            const operator = this.env.user;
             const country = visitor.country_id ? ResCountry.browse(visitor.country_id) : undefined;
-            const visitor_name = `${visitor.display_name}${country ? `(${country.name})` : ""}`;
+            const visitor_name = `Visitor #${visitor.id}${country ? ` (${country.name})` : ""}`;
             const membersToAdd = [Command.create({ partner_id: serverState.partnerId })];
             if (visitor.partner_id) {
                 membersToAdd.push(Command.create({ partner_id: visitor.partner_id }));
             }
             const livechatId = DiscussChannel.create({
-                anonymous_name: visitor_name,
                 channel_member_ids: membersToAdd,
                 channel_type: "livechat",
                 livechat_operator_id: serverState.partnerId,
+                name: `${visitor_name}, ${
+                    operator.livechat_username ? operator.livechat_username : operator.name
+                }`,
             });
             if (!visitor.partner_id) {
                 const guestId = MailGuest.create({ name: `Visitor #${visitor.id}` });

--- a/addons/website_livechat/static/tests/thread_patch.test.js
+++ b/addons/website_livechat/static/tests/thread_patch.test.js
@@ -29,7 +29,6 @@ test("Rendering of visitor banner", async () => {
     });
     const guestId = pyEnv["mail.guest"].create({ name: `Visitor #${visitorId}` });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: `Visitor #${visitorId}`,
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ guest_id: guestId }),
@@ -71,7 +70,6 @@ test("Livechat with non-logged visitor should show visitor banner", async () => 
     });
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor #11" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ guest_id: guestId }),
@@ -118,7 +116,6 @@ test("Livechat without visitor should not show visitor banner", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Harry" });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ partner_id: partnerId }),
@@ -148,7 +145,6 @@ test("Can create a new record as livechat operator with a custom livechat userna
         user_livechat_username: "MitchellOp",
     });
     const channelId = pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor #11",
         channel_member_ids: [
             Command.create({ partner_id: serverState.partnerId }),
             Command.create({ partner_id: partnerId }),

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -194,7 +194,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             {
                 "discuss.channel": [
                     {
-                        "anonymous_name": f"Visitor #{self.visitor.id}",
                         "channel_type": "livechat",
                         "country_id": False,
                         "create_uid": self.user_public.id,
@@ -310,7 +309,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
             ).get_result()["discuss.channel"],
             [
                 {
-                    "anonymous_name": f"Visitor #{self.visitor.id}",
                     "channel_type": "livechat",
                     "country_id": False,
                     "create_uid": self.user_public.id,

--- a/addons/website_livechat/tests/test_livechat_request.py
+++ b/addons/website_livechat/tests/test_livechat_request.py
@@ -64,7 +64,7 @@ class TestLivechatRequestHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.assertEqual(len(channel), 1)
         self.assertEqual(channel.livechat_operator_id, self.operator.partner_id, "Michel Operator should be the operator of this channel.")
         self.assertEqual(len(channel.message_ids), 0)
-        self.assertEqual(channel.anonymous_name, f"Visitor #{self.visitor.id} ({self.visitor.country_id.name})")
+        self.assertEqual(channel.name, f"Visitor #{self.visitor.id} ({self.visitor.country_id.name}), {self.operator.livechat_username}")
 
         # Operator Sends message
         self._send_message(channel, self.operator.email, "Hello Again !", author_id=self.operator.partner_id.id)


### PR DESCRIPTION
*: crm_livechat, test_discuss_full, website_livechat

Now that we have guests in livechat, we almost always have a guest or user name.
 Over time, those values have replaced the usage of the anonymous_name field.
This change removes the use of this field from method params and demo files. If we address the channel naming in a few corner cases (e.g., using the name field for a deleted visitor or partner) in the next step, then we can remove  the anonymous_name field from the discuss channel model.

task-4675719

[Upgrade](https://github.com/odoo/upgrade/pull/8114)

