### PR TITLE
[FIX] web: error dialog displayed on unloading page

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -45,7 +45,18 @@ export class UncaughtCorsError extends UncaughtError {
 
 export const errorService = {
     start(env) {
+        let isUnloadingPage = false;
+        window.addEventListener("beforeunload", () => {
+            isUnloadingPage = true;
+            // restore after 30 seconds
+            setTimeout(() => (isUnloadingPage = false), 30000);
+        });
+
         function handleError(uncaughtError, retry = true) {
+            if (isUnloadingPage) {
+                uncaughtError.event.preventDefault();
+                return;
+            }
             let originalError = uncaughtError;
             while (originalError instanceof Error && "cause" in originalError) {
                 originalError = originalError.cause;


### PR DESCRIPTION
When an iframe is removed from the DOM, it is unloaded, which can cause errors in some cases (e.g. fetch/loadJs).

This has not been a significant issue for the web client since it is designed with the assumption that users either keep the browser tab open or close it at some point. However, on the website, there are some iframes (e.g. when editing the website) and unloading these iframes appears to cause tracebacks to be logged in the console and a dialog is quickly display to the end user.

According to the Fetch specification, the user agent may terminate an ongoing fetch if that termination cannot be observed through script. In our case, however, the fetch cannot be terminated because the termination can be observed through the promise and a TypeError is thrown[1].

Here a sample to reproduce the errors with firefox on github:

```js
window.onbeforeunload = () => console.log("beforeunload");
fetch("https://github.com/").then(() => console.log("fetch"));
window.location = "https://github.com/";
```

Should log inside the Firefox console:

```log
beforeunload
Uncaught (in promise) TypeError: NetworkError when attempting to fetch resource.
```

Another errors can occur when we unload a page, if we manipulate the DOM when it's unload a DOMException can be trowed[2], we also handle these case inside this commit.

This commit prevents displaying these errors on dialog inside Odoo.

task-4457865

[1]: https://fetch.spec.whatwg.org/#http-network-fetch
[2]: https://webidl.spec.whatwg.org/#dom-domexception-abort_err


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
