### PR TITLE
[FIX] html_editor: replace non-empty <div> with baseContainer on paste

### DIFF
--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -42,6 +42,7 @@ describe("Html Paste cleaning - whitelist", () => {
                         pasteHtml(editor, `a<${tagDescription}>b</${tagName}>c`);
                     },
                     contentAfter: "<p>123" + html + "[]4</p>",
+                    config: { baseContainer: "DIV" },
                 });
             }
         }
@@ -773,6 +774,17 @@ describe("Simple html elements containing <br>", () => {
                     pasteHtml(editor, "<div>abc<br>def</div>");
                 },
                 contentAfter: `<div>abc</div><div>def[]</div>`,
+                config: { baseContainer: "DIV" },
+            });
+        });
+
+        test("should split div with <br> (2)", async () => {
+            await testEditor({
+                contentBefore: "<p>[]<br></p>",
+                stepFunction: async (editor) => {
+                    pasteHtml(editor, "<div>abc<br>def</div>");
+                },
+                contentAfter: `<p>abc</p><p>def[]</p>`,
             });
         });
     });
@@ -1914,6 +1926,39 @@ describe("Complex html div", () => {
                 pasteHtml(editor, complexHtmlData);
             },
             contentAfter: `<div>abcdef</div><div dir="rtl">ghijkl</div><div>jklmno[]</div>`,
+            config: { baseContainer: "DIV" },
+        });
+    });
+
+    test("should convert div to a baseContainer (2)", async () => {
+        await testEditor({
+            contentBefore: "<p>[]<br></p>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, complexHtmlData);
+            },
+            contentAfter: `<p>abcdef</p><p dir="rtl">ghijkl</p><p>jklmno[]</p>`,
+        });
+    });
+
+    const copiedHtmlData = `<ol><li><div>abc</div><div></div></li><li><div></div><div style="white-space: break-spaces;"><span>def\nghi</span><br><span>jkl</span></div></li></ol>`;
+    test("should remove empty <div> elements from pasted content", async () => {
+        await testEditor({
+            contentBefore: "<p>12[]3</p>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, copiedHtmlData);
+            },
+            contentAfter: `<p>12</p><ol><li><div>abc</div></li><li><div>def</div><div>ghi</div><div>jkl[]</div></li></ol><p>3</p>`,
+            config: { baseContainer: "DIV" },
+        });
+    });
+
+    test("should remove empty <div> elements from pasted content (2)", async () => {
+        await testEditor({
+            contentBefore: "<p>12[]3</p>",
+            stepFunction: async (editor) => {
+                pasteHtml(editor, copiedHtmlData);
+            },
+            contentAfter: `<p>12</p><ol><li><p>abc</p></li><li><p>def</p><p>ghi</p><p>jkl[]</p></li></ol><p>3</p>`,
         });
     });
 });


### PR DESCRIPTION
Steps to Reproduce : 
- Open the Discord app
- Copy the text written in multiple lines
- Paste it in the Odoo Editor
- Click below any line or empty space
- You will notice that the placeholder "Type '/' for commands" is getting destroyed.

Description of the issue this PR addresses:
- The issue was caused by visually empty `<div>` elements included in pasted content and not converted into baseContainer.
- This regression was introduced in commit [#196481](https://github.com/odoo/odoo/pull/196481/files?diff=split&w=0#diff-1b8ed5b7d66a870806b1e7400a0d6cb9ba8810327824244eca868be9583b7fd9L467-L477), which stopped replacing blacklisted tags like `<div>` with `<p>`. 
- As a result, cleanForPaste no longer strips inline styles from `<div>` elements.

Current behavior before PR:
- Pasted content includes non-visible `<div>` elements.
- These empty blocks occupy space without contributing visual content.
- Inline styles from copied content remain intact.
- `<div>` elements are not replaced with valid block tags.
- Placeholder rendering is broken in these ghost spaces.

Desired behavior after PR is merged:
- Non-empty `<div>` elements are replaced with a baseContainer element.
- Empty `<div>` elements are automatically removed from pasted content.
- This restores the expected cleaning behavior, removes unwanted styles, and preserves line breaks.

task-4805536

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
