### PR TITLE
[FIX] web_unsplash: prevented error during photo retrieval on connection failure

### DIFF
--- a/addons/web_unsplash/controllers/main.py
+++ b/addons/web_unsplash/controllers/main.py
@@ -133,13 +133,16 @@ class Web_Unsplash(http.Controller):
                 return {'error': 'no_access'}
             return {'error': 'key_not_found'}
         post['client_id'] = access_key
-        response = requests.get('https://api.unsplash.com/search/photos/', params=url_encode(post))
-        if response.status_code == requests.codes.ok:
-            return response.json()
-        else:
-            if not request.env.user._can_manage_unsplash_settings():
-                return {'error': 'no_access'}
-            return {'error': response.status_code}
+        try:
+            response = requests.get('https://api.unsplash.com/search/photos/', params=url_encode(post))
+            if response.status_code == requests.codes.ok:
+                return response.json()
+            else:
+                if not request.env.user._can_manage_unsplash_settings():
+                    return {'error': 'no_access'}
+                return {'error': response.status_code}
+        except requests.exceptions.RequestException as e:
+            return {'error': 'Request failed: ' + str(e)}
 
     @http.route("/web_unsplash/get_app_id", type='json', auth="public")
     def get_unsplash_app_id(self, **post):


### PR DESCRIPTION
The system generates an error when the photo loading likely fails due to a temporary DNS resolution error that prevented api.unsplash.com from being resolved to an IP address.

**Error:-**
`ConnectionError: HTTPSConnectionPool(host='api.unsplash.com', port=443):
 Max retries exceeded with url: /search/photos/?query=cow&page=1&per_page=30
 &client_id=f01a0029f1057eb8c2e7540997df64b5052ff8b1c5d908a92168a6c30b2765b0
 (Caused by NameResolutionError(< urllib3. connection.HTTPSConnection object
 at 0x72156cdaef30>: Failed to resolve 'api.unsplash.com' ([Errno -2] Name
 or service not known)))`

**Solution:-**
- Added a try-except block to prevent crashes during HTTP requests and handle exceptions properly.

**Sentry - 6557160164**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
