### PR TITLE
[FIX] mail: message quick add reaction usable in mobile

### DIFF
--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -3,6 +3,7 @@ import { Component, useRef } from "@odoo/owl";
 import { MessageReactionList } from "@mail/core/common/message_reaction_list";
 import { useService } from "@web/core/utils/hooks";
 import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 export class MessageReactions extends Component {
     static props = ["message", "openReactionMenu"];
@@ -14,6 +15,7 @@ export class MessageReactions extends Component {
         this.store = useService("mail.store");
         this.ui = useService("ui");
         this.addRef = useRef("add");
+        this.isMobileOS = isMobileOS();
         this.emojiPicker = useEmojiPicker(this.addRef, {
             onSelect: (emoji) => {
                 const reaction = this.props.message.reactions.find(

--- a/addons/mail/static/src/core/common/message_reactions.scss
+++ b/addons/mail/static/src/core/common/message_reactions.scss
@@ -1,4 +1,4 @@
-.o-mail-MessageReactions:not(.o-emojiPickerOpen):not(:hover) .o-mail-MessageReactions-add {
+.o-mail-MessageReactions:not(.o-emojiPickerOpen):not(:hover) .o-mail-MessageReactions-add:not(.o-mobile) {
     visibility: hidden;
 }
 

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -10,7 +10,7 @@
         <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
             <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
         </t>
-        <button t-if="props.message.canAddReaction()" class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-75 opacity-100-hover" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
+        <button t-if="props.message.canAddReaction()" class="o-mail-MessageReactions-add btn bg-inherit d-flex px-1 py-0 border-0 rounded-0 mb-1 align-items-center fs-5 opacity-25 opacity-100-hover" t-att-class="{ 'o-mobile': isMobileOS }" title="Add Reaction" t-ref="add"><i class="oi fa-fw oi-smile-add"/></button>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/tests/mobile/mobile.test.js
+++ b/addons/mail/static/tests/mobile/mobile.test.js
@@ -78,3 +78,27 @@ test("enter key should create a newline in composer", async () => {
     await click(".fa-paper-plane-o");
     await contains(".o-mail-Message-body:has(br)", { textContent: "TestOther" });
 });
+
+// FIXME: test doesn't work on runbot, somehow it runs there as if isMobileOS() is false
+test.skip("can add message reaction (mobile)", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message", { text: "Hello world" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".modal button:contains('Add a Reaction')");
+    await click(".modal .o-EmojiPicker .o-Emoji:contains('😀')");
+    await contains(".o-mail-MessageReaction:contains('😀')");
+    // Can quickly add new reactions
+    await click(".o-mail-MessageReactions button[title='Add Reaction']");
+    await click(".modal .o-EmojiPicker .o-Emoji:contains('🤣')");
+    await contains(".o-mail-MessageReaction:contains('🤣')");
+    await contains(".o-mail-MessageReaction:contains('😀')");
+});

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -534,7 +534,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
      * @param {import("@web/core/utils/hooks").Ref} ref
      */
     function add(ref, onSelect, { show = false } = {}) {
-        const toggler = () => toggle(ref, onSelect);
+        const toggler = () => toggle(isMobileOS() ? undefined : ref, onSelect);
         targets.push([ref, toggler]);
         if (!ref.el) {
             return;
@@ -559,7 +559,7 @@ export function usePicker(PickerComponent, ref, props, options = {}) {
                     return res;
                 },
             };
-            if (ref.el) {
+            if (ref?.el) {
                 pickerMobileProps.close = () => remove();
                 const app = new App(PickerMobile, {
                     name: "Popout",


### PR DESCRIPTION
Before this commit, when a message has at least 1 reaction, using the quick reaction button in mobile displayed the emoji picker that shared the viewport of message list.

This makes it hardly practical.

This happens because the `useEmojiPicker()` in message reactions provide a ref, and this ref in mobile is used as a target to mount the emoji picker. This feature is useful for discuss composer to place emoji picker nicely under the composer input. In desktop the ref is used for click target of popover.

In practice the passing of ref in mobile is niche use-case: most of the time it should open in bottom screen as a dialog in a similar fashion as popover.

This commit fixes the issue by making 1st param of `useEmojiPicker` only act as the toggler part . In mobile to provide the container of emoji picker, one need to call `open(ref)` explicitly.

Task-4800688

From click there:
![Screenshot 2025-05-20 at 13 17 11](https://github.com/user-attachments/assets/40daf28b-bfe0-4c62-9385-b12d2d3264a0)

Before
![Screenshot 2025-05-20 at 13 16 43](https://github.com/user-attachments/assets/7719ef22-9aae-4fdd-90fb-89d19514125e)

After
![Screenshot 2025-05-20 at 13 15 56](https://github.com/user-attachments/assets/ee5bb01c-35f3-485d-987f-38add201dee1)

