### PR TITLE
[FIX] html_editor: traceback when removing color from cells

### DIFF
--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -177,7 +177,12 @@ export class ColorPlugin extends Plugin {
                 const hasAnySelectedNodeColor = (mode) => {
                     const nodes = this.dependencies.selection
                         .getTraversedNodes()
-                        .filter((n) => isTextNode(n) || n.classList.contains("o_selected_td"));
+                        .filter(
+                            (n) =>
+                                isTextNode(n) ||
+                                (mode === "backgroundColor" &&
+                                    n.classList.contains("o_selected_td"))
+                        );
                     return hasAnyNodesColor(nodes, mode);
                 };
                 while (hasAnySelectedNodeColor(mode) && max > 0) {

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -5,6 +5,7 @@ import { click, queryAll, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
 import { expectElementCount } from "../_helpers/ui_expectations";
+import { unformat } from "../_helpers/format";
 
 test("should do nothing if no format is set", async () => {
     await testEditor({
@@ -662,6 +663,48 @@ test("should remove font size and color styles", async () => {
         contentBefore: `<p><span style="font-size: 10px;"><font style="background-image: linear-gradient(135deg, rgb(214, 255, 127) 0%, rgb(0, 179, 204) 100%);">[abcdefg]</font></span></p>`,
         stepFunction: (editor) => execCommand(editor, "removeFormat"),
         contentAfter: `<p>[abcdefg]</p>`,
+    });
+});
+
+test("should remove backgroundColor from selected cells using removeFormat", async () => {
+    const defaultTextColor = "color: rgb(1, 10, 100);";
+    const styleContent = `* {${defaultTextColor}}`;
+    await testEditor({
+        contentBefore: unformat(`
+            <table class="table table-bordered o_table"><tbody>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}"><p>[ab</p></td></tr>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}"><p>cd]</p></td></tr>
+            </tbody></table>
+        `),
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: unformat(`
+            <table class="table table-bordered o_table"><tbody>
+                <tr><td><p>[ab</p></td></tr>
+                <tr><td><p>cd]</p></td></tr>
+            </tbody></table>
+        `),
+        styleContent,
+    });
+});
+
+test("should remove backgroundColor from selected cells using removeFormat (2)", async () => {
+    const defaultTextColor = "color: rgb(1, 10, 100);";
+    const styleContent = `* {${defaultTextColor}}`;
+    await testEditor({
+        contentBefore: unformat(`
+            <table class="table table-bordered o_table"><tbody>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}"><p>[<br></p></td></tr>
+                <tr><td style="background-color: rgb(255, 0, 0); ${defaultTextColor}"><p>]<br></p></td></tr>
+            </tbody></table>
+        `),
+        stepFunction: (editor) => execCommand(editor, "removeFormat"),
+        contentAfter: unformat(`
+            <table class="table table-bordered o_table"><tbody>
+                <tr><td><p>[\u200b</p></td></tr>
+                <tr><td><p>]\u200b</p></td></tr>
+            </tbody></table>
+        `),
+        styleContent,
     });
 });
 


### PR DESCRIPTION
**Current behavior before PR:**

Steps to reproduce:

- Create a table.
- Select some cells, apply background color on them.
- Try to remove format using removeFormat button.

Trying to remove format from the colored cells leads to traceback `Infinite Loop in removeAllColor()`. The issue happens because after merging commit [1], when applying background-color on cells, text-color will also get applied along with background-color. When trying to remove color using removeFormat button, `applyTableColor` method fails to remove text-color from cells despite having color on them, leading to infinite loop error.

**Desired behavior after PR:**

Now, background-color is removed from cells without any traceback.

[1]: https://github.com/odoo/odoo/commit/616413c3272429ec48a6ac238c899b31d0751546

task-4805468



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
