### PR TITLE
[FIX] account: reports: properly rename tax tags instead of creating them when modifying an expression's formula

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -536,16 +536,21 @@ class AccountReportExpression(models.Model):
 
         self._strip_formula(vals)
 
+        tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
+
         if vals.get('engine') == 'tax_tags':
-            tag_name = vals.get('formula') or self.formula
-            country = self.report_line_id.report_id.country_id
-            self._create_tax_tags(tag_name, country)
-            return super().write(vals)
+            # We already generate the tags for the expressions receiving a new engine, but keeping the same formula
+            tags_create_vals = []
+            for expression_with_new_engine in self - tax_tags_expressions:
+                tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
+                    vals.get('formula') or expression_with_new_engine.formula,
+                    expression_with_new_engine.report_line_id.report_id.country_id.id,
+                )
+            self.env['account.account.tag'].create(tags_create_vals)
 
         if 'formula' not in vals:
             return super().write(vals)
 
-        tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
         former_formulas_by_country = defaultdict(lambda: [])
         for expr in tax_tags_expressions:
             former_formulas_by_country[expr.report_line_id.report_id.country_id].append(expr.formula)

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -253,3 +253,41 @@ class TaxReportTest(AccountTestInvoicingCommon):
         tags_after = self._get_tax_tags(self.test_country_1, tag_name=tag_name, active_test=False)
         self.assertEqual(len(tags_after), 2, "When creating a tax report line with an archived tag and it's complement doesn't exist, it should be re-created.")
         self.assertEqual(tags_after.mapped('name'), ['+' + tag_name, '-' + tag_name], "After creating a tax report line with an archived tag and when its complement doesn't exist, both a negative and a positive tag should be created.")
+
+    def test_change_engine_without_formula(self):
+        aggregation_line = self.env['account.report.line'].create({
+            'name': "Je ne mange pas de graines !!!",
+            'report_id': self.tax_report_1.id,
+            'expression_ids': [
+                Command.create({
+                    'label': 'balance',
+                    'engine': 'aggregation',
+                    'formula': 'Dudu',
+                }),
+            ],
+        })
+
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='Dudu')
+        self.assertFalse(tags_before, "The tags shouldn't exist yet")
+
+        aggregation_line.expression_ids.engine = 'tax_tags'
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Dudu')
+        self.assertEqual(len(tags_after), 2, "Changing the engine should have created tags")
+        self.assertEqual(tags_after.mapped('name'), ['-Dudu', '+Dudu'])
+
+    def test_change_formula_multiple_fields(self):
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='Buny')
+        self.assertFalse(tags_before, "The tags shouldn't exist yet")
+
+        tags_to_rename = self._get_tax_tags(self.test_country_1, tag_name='55')
+
+        self.tax_report_line_1_55.expression_ids.write({
+            'engine': 'tax_tags',  # Same value as before
+            'formula': 'Buny',
+        })
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='Buny')
+        self.assertEqual(len(tags_after), 2, "Changing the formula should have renamed the tags")
+        self.assertEqual(tags_after.mapped('name'), ['-Buny', '+Buny'])
+        self.assertEqual(tags_after, tags_to_rename, "Changing the formula should have renamed the tags")


### PR DESCRIPTION
When writing a new formula on a tax_tags expression, but also providing the 'engine' key with 'tax_tags' value, this condition https://github.com/odoo/odoo/blob/16.0/addons/account/models/account_report.py#L539 triggered and the return at the end of it caused the tag to be recreated instead of renamed.

This case can happen when changing the name of a tag in a data file, then updating the module. We saw it while working on an cleaned version of a localized report for master.
