### PR TITLE
[FIX] purchase_requisition: link alternative RFQs and SO in MTSO route

### DIFF
--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -96,5 +96,6 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'product_uom_id': order_line.product_uom_id.id,
             'display_type': order_line.display_type,
             'analytic_distribution': order_line.analytic_distribution,
+            'group_id': order_line.group_id.id,
             **({'name': order_line.name} if order_line.display_type in ('line_section', 'line_note') or not has_product_description else {}),
         }


### PR DESCRIPTION
### The issue before PR:
When ordering a product with MTSO (Take from stock, if unavailable, trigger another rule) route, 
and creating alternative RFQs, the link between RFQs and the SO disappears.

### After PR:
When ordering a product with MTSO (Take from stock, if unavailable, trigger another rule) route, and creating alternative RFQs, the link between the SO and each of the RFQs is preserved.

Task-4795007