### PR TITLE
[FIX] web_editor, website: fix replacing a social media icon

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6009,6 +6009,13 @@ registry.ReplaceMedia = SnippetOptionWidget.extend({
      * @see this.selectClass for parameters
      */
     async replaceMedia() {
+        const sel = this.ownerDocument.getSelection();
+        // Ensure the element is selected before opening the media dialog.
+        if (!sel.rangeCount) {
+            const range = this.ownerDocument.createRange();
+            range.selectNodeContents(this.$target[0]);
+            sel.addRange(range);
+        }
         // open mediaDialog and replace the media.
         await this.options.wysiwyg.openMediaDialog({ node:this.$target[0] });
     },

--- a/addons/website/static/tests/tours/snippet_social_media.js
+++ b/addons/website/static/tests/tours/snippet_social_media.js
@@ -172,14 +172,13 @@ wTourUtils.registerWebsitePreviewTour('snippet_social_media', {
     },
     ...wTourUtils.clickOnSave(),
     ...wTourUtils.clickOnEditAndWaitEditMode(),
-    wTourUtils.clickOnSnippet({
-        id: 's_social_media',
-        name: 'Social Media',
-    }),
     {
         content: "Check if we can still change custom icons",
         trigger: 'iframe .s_social_media a[href="https://whatever.it/1EdSw9X"] i.fa-pencil',
-        run: 'dblclick',
+    },
+    {
+        content: "Click on replace media",
+        trigger: "[data-replace-media='true']",
     },
     {
         content: "Select a new icon",


### PR DESCRIPTION
Steps to reproduce the issue:

- Enter website edit mode.
- Drag and drop a "Social Media" snippet into the footer.
- Click on it.
- In the options, click the "Add New Social Network" button.
- Save the page.
- Re-enter edit mode.
- Click the pencil icon of the newly added item.
- In the options, click the "Replace" button.
- Bug: the media dialog does not open.

The bug was introduced by commit [1], where the double-click on the icon, which was triggered when clicking the "Replace" button, was replaced with a direct call to the `openMediaDialog` function.

After this change, in the steps described above, the function is called when there is no selection on the page. As a result, `openMediaDialog` does not execute completely.

This commit fixes the issue by selecting the icon if no selection is already present.

[1]: https://github.com/odoo/odoo/commit/3c89439a16c41d553322893761a35592b73a5338

opw-4734855