### PR TITLE
[FIX] account: prevent error when importing product records with tax values

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -253,7 +253,7 @@ class AccountTax(models.Model):
     @api.model
     @api.readonly
     def name_search(self, name='', domain=None, operator='ilike', limit=100):
-        domain = Domain(domain)
+        domain = Domain(domain or Domain.TRUE)
         if 'search_default_domestictax' in self.env.context:
             domain &= Domain('fiscal_position_ids', '=', False) | Domain('fiscal_position_ids.is_domestic', '=', True)
         if fp_id := self.env.context.get('dynamic_fiscal_position_id'):


### PR DESCRIPTION
Currently an error occurs when the user import the product record.

Steps to Reproduce (to avoid step just try to import this [File](https://github.com/user-attachments/files/20360727/Product.product.template.1.xlsx)) :

 - Install the `account` module.
 - Go to Products > switch to `List View`, select a `product`, and click `Export` under the Actions.
 - In the Available Fields, search for `Sales Taxes` or `Purchase Taxes`, select either one, and then click `Export`.
 - In the Products, click Actions > Import Records, and upload the file that was recently exported.
 - Click import.

`TypeError: Domain() invalid argument type for domain: None`

This error occurs when a user imports a product template record and the system calls name_search to resolve tax_id values. When no domain is passed, it defaults to None, causing a TypeError.

This commit ensures that when the system calls name_search to resolve tax_id values without a domain, an empty domain ([(1, '=', 1)]) is used instead to prevent the error.

sentry-6616172972


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
