### PR TITLE
[FIX] pos_online_payment_self_order: typo in query parameter

### DIFF
--- a/addons/pos_online_payment_self_order/models/pos_order.py
+++ b/addons/pos_online_payment_self_order/models/pos_order.py
@@ -14,7 +14,7 @@ class PosOrder(models.Model):
         self.ensure_one()
 
         # Lock the line
-        self.env.cr.execute("SELECT id FROM pos_order WHERE id = %s FOR UPDATE NOWAIT", (self.id))
+        self.env.cr.execute("SELECT id FROM pos_order WHERE id = %s FOR UPDATE NOWAIT", (self.id,))
 
         if self.nb_print > 0:
             raise ValueError("This order has already been printed automatically.")


### PR DESCRIPTION
There is a typo in the SQL query parameter, id is passed instead of
tuple, list or dict.
This issue was introduced in this commit: https://github.com/odoo/odoo/commit/1b853d6b526a502e8b60c514962ead683195f07a

Steps to reproduce the error:
- Install ``pos_online_payment_self_order`` module
- Go to Point of sale > Load Restaurant
- Go to settings > Self Ordering: QR menu + Ordering > Save
- Activate Demo payment Provider
- Create Payment method for restaurant > Online Payment: True > 
  Allowed Providers: Demo
- Open Register > Add any product > Payment > Select Online Payment > Validate
  Scan the QR > Pay

Traceback:
```
File "/home/odoo/src/odoo/addons/pos_online_payment_self_order/models/pos_order.py", line 17, in get_order_to_print
    self.env.cr.execute("SELECT id FROM pos_order WHERE id = %s FOR UPDATE NOWAIT", (self.id))
  File "/home/odoo/src/odoo/odoo/sql_db.py", line 418, in execute
    raise ValueError("SQL query parameters should be a tuple, list or dict; got %r" % (params,))
ValueError: SQL query parameters should be a tuple, list or dict; got 5
```

https://github.com/odoo/odoo/blob/6ef8565053352e4f679d26032e5485474fda62ce/addons/pos_online_payment_self_order/models/pos_order.py#L17
here, ``(self.id)`` is used which is evaluated as an integer,
So, It will lead to the above traceback.

sentry-6605659445

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
