### PR TITLE
[FIX] html_editor: convert empty signature container to base container

### DIFF
--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -30,9 +30,12 @@ export class SignaturePlugin extends Plugin {
                 commandId: "insertSignature",
             },
         ],
+
+        /**Predicates */
         is_empty_predicates: this.isEmpty.bind(this),
         unsplittable_node_predicates: (host) =>
             host.nodeType === Node.ELEMENT_NODE && host.matches(`.${SIGNATURE_CLASS}`),
+        empty_base_container_candidates_predicates: (node) => node.matches(`.${SIGNATURE_CLASS}`),
     };
 
     cleanSignatures({ rootClone }) {

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -502,6 +502,15 @@ describe("Selection collapsed", () => {
                 contentAfter: `<p>a[]</p>`,
             });
         });
+
+        test("should transform empty signature container into base container", async () => {
+            await testEditor({
+                contentBefore: `<div class="o-signature-container"><span data-oe-zws-empty-inline="">[]\u200B</span></div>`,
+                stepFunction: deleteBackward,
+                contentAfter: `<div>[]<br></div>`,
+                config: { baseContainer: "DIV" },
+            });
+        });
     });
 
     describe("Line breaks", () => {


### PR DESCRIPTION
### Steps to Reproduce:

- Insert a signature (e.g., using /signature).
- Press Ctrl + A, then press Backspace — signature content is removed.
- Press Backspace again — o-signature-container div remains.
- Any new content is inserted inside the empty o-signature-container.

### Description of the issue/feature this PR addresses:

- Empty signature containers were not converted to base containers on backspace.

### Desired behavior after PR is merged:

- A predicate was added that checks for empty blocks of types: pre, heading, blockquote, and signature.  This ensures empty signature containers are also converted to base containers on backspace.

task-4793734

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
