### PR TITLE
[FIX] mail: message actions in mobile aligned correctly (non-mailbox)

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -203,9 +203,11 @@
 
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile p-2 mt-n3 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
-        'ms-n2': isMobileOS and !mobileExpanded and isAlignedRight,
-        'me-n2': isMobileOS and !mobileExpanded and !isAlignedRight,
+        'o-mail-Message-openActionMobile p-2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
+        'me-n2': isMobileOS and !mobileExpanded and (isAlignedRight and !props.asCard or !isAlignedRight and props.asCard),
+        'ms-n2': isMobileOS and !mobileExpanded and (isAlignedRight and props.asCard or !isAlignedRight and !props.asCard),
+        'mt-n3': isMobileOS and props.asCard,
+        'mt-n1': isMobileOS and !props.asCard,
         'px-2 py-0': !isMobileOS,
         'rounded-start-1': !isMobileOS and isReverse,
         'rounded-end-1': !isMobileOS and !isReverse,


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/210304

PR above improve message actions placement in mobile in card layout, such as in Inbox. However it makes a regression in placement of other message actions.

This commit fixes the issue by keeping the card visual of message actions as the fix for card layout and same visual as before the fix for non-card messages.

Before / After in mailboxes (unchanged)
![before2](https://github.com/user-attachments/assets/c79dd8ec-62dd-42be-9043-87e97fc3cba5) ![after2](https://github.com/user-attachments/assets/0cd3cda0-42d7-449d-82b5-02e4a2b48540)

Before / After in conversation (fixed)
![before1](https://github.com/user-attachments/assets/f3822656-9552-4ab2-88ca-69fa5e7bba09) ![after1](https://github.com/user-attachments/assets/198ffbf0-4741-4615-bd50-995af96d43b0)
