### PR TITLE
[FIX] website_blog: align blog tour aligns with python test expectations

### DIFF
--- a/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
+++ b/addons/website_blog/static/tests/tours/blog_sidebar_with_date_and_tag.js
@@ -14,14 +14,14 @@ wTourUtils.registerWebsitePreviewTour(
             trigger: "iframe b:contains('Nature')",
         },
         {
-            content: "Check if the archive dropdown contains exactly 1 option: January.",
+            content: "Check if the archive dropdown contains exactly 1 option: February.",
             trigger: "iframe select[name=archive]",
             run: function () {
                 const optionEls = this.$anchor[0].querySelectorAll("optgroup option");
                 const length = optionEls.length;
                 const monthName = optionEls[0].textContent;
-                if (length !== 1 && !monthName.includes("January")) {
-                    throw new Error("There should be 1 option in the select");
+                if (length !== 1 || !monthName.includes("February")) {
+                    throw new Error("Expected 1 option in the select with February");
                 }
             },
         },
@@ -30,14 +30,14 @@ wTourUtils.registerWebsitePreviewTour(
             trigger: "iframe b:contains('Space')",
         },
         {
-            content: "Verify that the archive dropdown now contains only 1 option: February.",
+            content: "Verify that the archive dropdown now contains only 1 option: January.",
             trigger: "iframe select[name=archive]",
             run: function () {
                 const optionEls = this.$anchor[0].querySelectorAll("optgroup option");
                 const length = optionEls.length;
                 const monthName = optionEls[0].textContent;
-                if (length !== 1 && !monthName.includes("February")) {
-                    throw new Error("There should be 1 option in the select");
+                if (length !== 1 || !monthName.includes("January")) {
+                    throw new Error("Expected 1 option in the select with January");
                 }
             },
         },

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -78,7 +78,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         Post.create({
             'name': 'First Blog Post',
             'blog_id': Blog1.id,
-            'author_id': self.user_public.id,
+            'author_id': self.env.user.id,
             'is_published': True,
             'published_date': datetime(2025, 2, 10, 12, 0, 0),
         })
@@ -87,7 +87,7 @@ class TestWebsiteBlogUi(odoo.tests.HttpCase, TestWebsiteBlogCommon):
         Post.create({
             'name': 'Second Blog Post',
             'blog_id': Blog2.id,
-            'author_id': self.user_public.id,
+            'author_id': self.env.user.id,
             'is_published': True,
             'published_date': datetime(2025, 1, 15, 14, 30, 0),
         })


### PR DESCRIPTION
This PR updates the blog tour configuration to match what the Python test expects. The tour was designed in a way that avoids checking the actual month name, so even if the blog's publish month and the tour's month were different, the test wouldn’t fail.

To make sure the test behaves correctly, we needed to update the tour so it fully aligns with the Python test case.

Related PR: [#197172](https://github.com/odoo/odoo/pull/197172)

task-4546888
