### PR TITLE
[REM] mrp: remove consumption warning option, make warning default

### DIFF
--- a/addons/mrp/data/mrp_demo.xml
+++ b/addons/mrp/data/mrp_demo.xml
@@ -247,7 +247,6 @@
             <field name="product_tmpl_id" ref="product_product_computer_desk_product_template"/>
             <field name="product_uom_id" ref="uom.product_uom_unit"/>
             <field name="sequence">3</field>
-            <field name="consumption">flexible</field>
             <field name="days_to_prepare_mo">3</field>
         </record>
         <record id="mrp_routing_workcenter_5" model="mrp.routing.workcenter">

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -64,19 +64,6 @@ class MrpBom(models.Model):
     company_id = fields.Many2one(
         'res.company', 'Company', index=True,
         default=lambda self: self.env.company)
-    consumption = fields.Selection([
-        ('flexible', 'Allowed'),
-        ('warning', 'Allowed with warning'),
-        ('strict', 'Blocked')],
-        help="Defines if you can consume more or less components than the quantity defined on the BoM:\n"
-             "  * Allowed: allowed for all manufacturing users.\n"
-             "  * Allowed with warning: allowed for all manufacturing users with summary of consumption differences when closing the manufacturing order.\n"
-             "  Note that in the case of component Highlight Consumption, where consumption is registered manually exclusively, consumption warnings will still be issued when appropriate also.\n"
-             "  * Blocked: only a manager can close a manufacturing order when the BoM consumption is not respected.",
-        default='warning',
-        string='Flexible Consumption',
-        required=True
-    )
     possible_product_template_attribute_value_ids = fields.Many2many(
         'product.template.attribute.value',
         compute='_compute_possible_product_template_attribute_value_ids')

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -229,14 +229,6 @@ class MrpProduction(models.Model):
     production_location_id = fields.Many2one('stock.location', "Production Location", compute="_compute_production_location", store=True)
     picking_ids = fields.Many2many('stock.picking', compute='_compute_picking_ids', string='Picking associated to this manufacturing order')
     delivery_count = fields.Integer(string='Delivery Orders', compute='_compute_picking_ids')
-    consumption = fields.Selection([
-        ('flexible', 'Allowed'),
-        ('warning', 'Allowed with warning'),
-        ('strict', 'Blocked')],
-        required=True,
-        readonly=True,
-        default='flexible',
-    )
 
     mrp_production_child_count = fields.Integer("Number of generated MO", compute='_compute_mrp_production_child_count')
     mrp_production_source_count = fields.Integer("Number of source MO", compute='_compute_mrp_production_source_count')
@@ -1460,8 +1452,6 @@ class MrpProduction(models.Model):
         workorder_ids_to_confirm = set()
         for production in self:
             production_vals = {}
-            if production.bom_id:
-                production_vals.update({'consumption': production.bom_id.consumption})
             # In case of Serial number tracking, force the UoM to the UoM of product
             if production.product_tracking == 'serial' and production.product_uom_id != production.product_id.uom_id:
                 production_vals.update({
@@ -1605,7 +1595,7 @@ class MrpProduction(models.Model):
         if self.env.context.get('skip_consumption', False):
             return issues
         for order in self:
-            if order.consumption == 'flexible' or not order.bom_id or not order.bom_id.bom_line_ids:
+            if not order.bom_id or not order.bom_id.bom_line_ids:
                 continue
             expected_move_values = order._get_moves_raw_values()
             expected_qty_by_product = defaultdict(float)
@@ -1639,7 +1629,6 @@ class MrpProduction(models.Model):
             lines.append((0, 0, {
                 'mrp_production_id': order.id,
                 'product_id': product_id.id,
-                'consumption': order.consumption,
                 'product_uom_id': product_id.uom_id.id,
                 'product_consumed_qty_uom': consumed_qty,
                 'product_expected_qty_uom': expected_qty
@@ -1710,17 +1699,6 @@ class MrpProduction(models.Model):
                     continue
                 filtered_documents[(parent, responsible)] = rendering_context
             production._log_manufacture_exception(filtered_documents, cancel=True)
-
-        # In case of a flexible BOM, we don't know from the state of the moves if the MO should
-        # remain in progress or done. Indeed, if all moves are done/cancel but the quantity produced
-        # is lower than expected, it might mean:
-        # - we have used all components but we still want to produce the quantity expected
-        # - we have used all components and we won't be able to produce the last units
-        #
-        # However, if the user clicks on 'Cancel', it is expected that the MO is either done or
-        # canceled. If the MO is still in progress at this point, it means that the move raws
-        # are either all done or a mix of done / canceled => the MO should be done.
-        self.filtered(lambda p: p.state not in ['done', 'cancel'] and p.bom_id.consumption == 'flexible').write({'state': 'done'})
 
         return True
 

--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -128,7 +128,6 @@ class MrpWorkorder(models.Model):
     production_date = fields.Datetime('Production Date', compute='_compute_production_date', store=True)
     json_popover = fields.Char('Popover Data JSON', compute='_compute_json_popover')
     show_json_popover = fields.Boolean('Show Popover?', compute='_compute_json_popover')
-    consumption = fields.Selection(related='production_id.consumption')
     qty_reported_from_previous_wo = fields.Float('Carried Quantity', digits='Product Unit', copy=False,
         help="The quantity already produced awaiting allocation in the backorders chain.")
     is_planned = fields.Boolean(related='production_id.is_planned')

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -143,7 +143,6 @@
                             <group>
                                 <group>
                                     <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
-                                    <field name="consumption" invisible="type == 'phantom'" widget="radio"/>
                                     <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
                                 </group>
                                 <group>

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -213,7 +213,6 @@
                     <field name="qty_produced" invisible="1"/>
                     <field name="unreserve_visible" invisible="1"/>
                     <field name="reserve_visible" invisible="1"/>
-                    <field name="consumption" invisible="1"/>
                     <field name="is_planned" invisible="1"/>
                     <field name="show_allocation" invisible="1"/>
                     <field name="workorder_ids" invisible="1"/>

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -61,7 +61,6 @@
         <field name="priority" eval="100"/>
         <field name="arch" type="xml">
             <list>
-                <field name="consumption" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="is_produced" column_invisible="True"/>
                 <field name="is_user_working" column_invisible="True"/>

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -7,27 +7,17 @@ from odoo.exceptions import UserError
 
 class MrpConsumptionWarning(models.TransientModel):
     _name = 'mrp.consumption.warning'
-    _description = "Wizard in case of consumption in warning/strict and more component has been used for a MO (related to the bom)"
+    _description = "Warning wizard for when the consumed quantity doesn't match the required quantity relative to the BOM in an MO"
 
     mrp_production_ids = fields.Many2many('mrp.production')
     mrp_production_count = fields.Integer(compute="_compute_mrp_production_count")
 
-    consumption = fields.Selection([
-        ('flexible', 'Allowed'),
-        ('warning', 'Allowed with warning'),
-        ('strict', 'Blocked')], compute="_compute_consumption")
     mrp_consumption_warning_line_ids = fields.One2many('mrp.consumption.warning.line', 'mrp_consumption_warning_id')
 
     @api.depends("mrp_production_ids")
     def _compute_mrp_production_count(self):
         for wizard in self:
             wizard.mrp_production_count = len(wizard.mrp_production_ids)
-
-    @api.depends("mrp_consumption_warning_line_ids.consumption")
-    def _compute_consumption(self):
-        for wizard in self:
-            consumption_map = set(wizard.mrp_consumption_warning_line_ids.mapped("consumption"))
-            wizard.consumption = "strict" in consumption_map and "strict" or "warning" in consumption_map and "warning" or "flexible"
 
     def action_confirm(self):
         ctx = dict(self.env.context)
@@ -92,7 +82,6 @@ class MrpConsumptionWarningLine(models.TransientModel):
 
     mrp_consumption_warning_id = fields.Many2one('mrp.consumption.warning', "Parent Wizard", readonly=True, required=True, ondelete="cascade")
     mrp_production_id = fields.Many2one('mrp.production', "Manufacturing Order", readonly=True, required=True, ondelete="cascade")
-    consumption = fields.Selection(related="mrp_production_id.consumption")
 
     product_id = fields.Many2one('product.product', "Product", readonly=True, required=True)
     product_uom_id = fields.Many2one('uom.uom', "Unit", related="product_id.uom_id", readonly=True)

--- a/addons/mrp/wizard/mrp_consumption_warning_views.xml
+++ b/addons/mrp/wizard/mrp_consumption_warning_views.xml
@@ -9,14 +9,10 @@
             <field name="arch" type="xml">
                 <form string="Consumption Warning">
                     <field name="mrp_production_ids" invisible="1"/>
-                    <field name="consumption" invisible="1"/>
                     <field name="mrp_production_count" invisible="1"/>
                     <div class="m-2">
                         You consumed a different quantity than expected for the following products.
-                        <b invisible="consumption == 'strict'">
-                            Please confirm it has been done on purpose.
-                        </b>
-                        <b invisible="consumption != 'strict'">
+                        <b>
                             Please review your component consumption or ask a manager to validate
                             <span invisible="mrp_production_count != 1">this manufacturing order</span>
                             <span invisible="mrp_production_count == 1">these manufacturing orders</span>.
@@ -25,7 +21,6 @@
                     <field name="mrp_consumption_warning_line_ids" nolabel="1">
                         <list create="0" delete="0" editable="top">
                             <field name="mrp_production_id" column_invisible="parent.mrp_production_count == 1" force_save="1"/>
-                            <field name="consumption" column_invisible="True" force_save="1"/>
                             <field name="product_id" force_save="1"/>
                             <field name="product_uom_id" groups="uom.group_uom" force_save="1" widget="many2one_uom"/>
                             <field name="product_expected_qty_uom" force_save="1"/>
@@ -33,10 +28,7 @@
                         </list>
                     </field>
                     <footer>
-                        <button name="action_confirm" string="Force" data-hotkey="q"
-                            groups="mrp.group_mrp_manager" invisible="consumption != 'strict'"
-                            colspan="1" type="object" class="btn-primary"/>
-                        <button name="action_confirm" string="Confirm" invisible="consumption == 'strict'" data-hotkey="q"
+                        <button name="action_confirm" string="Confirm" data-hotkey="q"
                             colspan="1" type="object" class="btn-primary" barcode_trigger="NEXT"/>
                         <button name="action_set_qty" string="Set Quantities &amp; Validate" colspan="1" type="object" class="btn-secondary" invisible="'is_subcontracting_portal' in context"/>
                         <button name="action_cancel" string="Discard" data-hotkey="x"


### PR DESCRIPTION
There exists a setting to determine whether an MO can go ahead with production if its consumption doesn't match the values specified in the BoM, with the options 'flexible' for proceeding with the given values no questions asked, 'warning' for displaying a warning that shows the mismatched values before allowing the user to proceed, and 'strict' for outright blocking the user from performing such actions.

Here, we remove this setting and make the 'warning' option the default. The warning will be issued for mismatched consumption unconditionally.

Task ID: [4441090](https://www.odoo.com/odoo/project/966/tasks/4441090)