### PR TITLE
[FIX] website_slides: avoid horizontal scroll on small screen

### DIFF
--- a/addons/website_slides/views/slide_channel_views.xml
+++ b/addons/website_slides/views/slide_channel_views.xml
@@ -286,7 +286,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div name="card_content" class="row mt-auto">
+                            <div name="card_content" class="row g-0 mt-auto">
                                 <a name="action_redirect_to_invited_members" type="object" class="d-flex flex-column align-items-center col-3 border-end">
                                     <field name="members_invited_count" class="fw-bold"/>
                                     <span class="text-muted text-truncate mw-100" title="Invited">Invited</span>


### PR DESCRIPTION
In the kanban template there is a `row` container that is not wrapped into a `container` DIV, so it has negative margin and produce an overflow (horizontal scroll).

This commit adds the `g-0` class on the `row` container.

Steps to reproduce:
* On Odoo on small screen
* Go to the app "eLearning"
* Try to scroll horizontally => BUG

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
