### PR TITLE
[FIX] project_todo: avoid horizontal scrolling on small screen

### DIFF
--- a/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.scss
+++ b/addons/project_todo/static/src/components/todo_chatter_panel/todo_chatter_panel.scss
@@ -1,12 +1,12 @@
 // Reduce horizontal spacing if the next sibling is an aside chatter
 .o_form_sheet_bg:has(+ .o_todo_chatter) {
-    @media screen and (max-width: 1920px) {
+    @media screen and (max-width: 1920px)  and (min-width: map-get($grid-breakpoints, md)) {
         --formView-sheetBg-padding-right: #{map-get($spacers, 2)};
     }
 }
 
 .o_FormRenderer_chatterContainer {
-    @media screen and (max-width: 1920px) {
+    @media screen and (max-width: 1920px)  and (min-width: map-get($grid-breakpoints, md)) {
         --ChatterAsideForm-padding-left: #{map-get($spacers, 2)};
     }
 }


### PR DESCRIPTION
This commit, avoid changing the padding on the form on small screen and so avoid having horizontal scrolling.

Step to reproduce:
* Open Odoo on small screen
* Open ToDo app
* Select or create a record
* TRy to scroll horizontally => Bug

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
