### PR TITLE
[IMP] l10n_in_ewaybill_stock: improve spacing in eWaybill report

### DIFF
--- a/addons/l10n_in_ewaybill_stock/report/ewaybill_report.xml
+++ b/addons/l10n_in_ewaybill_stock/report/ewaybill_report.xml
@@ -239,7 +239,8 @@
                                             </td>
                                             <td>
                                                 <t t-if="doc.vehicle_no" t-out="doc.vehicle_no"/>
-                                                <t t-else="" t-out="doc.transportation_doc_no"/><t t-out="doc.transportation_doc_date"/>
+                                                <t t-else="" t-out="doc.transportation_doc_no"/>
+                                                &amp; <t t-out="doc.transportation_doc_date"/>
                                             </td>
                                             <td>
                                                 <t t-out="generate_json['fromPlace']"/>


### PR DESCRIPTION
Before this commit:
- Vehicle number, document number, and date were rendered together without spacing, reducing readability.

After this commit:
- These fields are now separated by `&` for improved clarity in the vehicle details section.

task-4807692

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
