### PR TITLE
[FIX] account: correct expression syntax for field invisibility

### DIFF
--- a/addons/account/views/ir_actions_views.xml
+++ b/addons/account/views/ir_actions_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="base.act_report_xml_view"/>
         <field name="arch" type="xml">
             <field name="paperformat_id" position="after">
-                <field name="is_invoice_report" invisible="'model' != 'account.move'"/>
+                <field name="is_invoice_report" invisible="model != 'account.move'"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Currently, the `Invoice report` is hidden when the user tries to select the invoice report for 'account.move'.

With PR [1], we added the invisible attribute to the `is_invoice_report` field to hide it when the model is not 'account.move'. However, due to mistake, we used `'model'` instead of `model`, which caused the field to always be hidden.

This commit fixes the above issue by using `model` instead of `'model'`, so the is_invoice_report field is visible only when the model is 'account.move'.

[1] https://github.com/odoo/odoo/pull/207635


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
