### PR TITLE
[FIX] mail: prevent badly generated message_id in tests

### DIFF
--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -201,7 +201,7 @@ class MockEmail(common.BaseCase, MockSmtplibCase):
                            with_user=None, **kwargs):
         self.assertFalse(self.env[target_model].search([(target_field, '=', subject)]))
         if not msg_id:
-            msg_id = "<%.7f-%5d-test@iron.sky>" % (time.time(), randint(0, 99998))
+            msg_id = "<%.7f-%05d-test@iron.sky>" % (time.time(), randint(0, 99998))
 
         if kwargs.pop('debug_log', False):
             _logger.info(


### PR DESCRIPTION
Steps to reproduce
==================

Run the test `/test_mail.test_message_process_references_multi_parent_notflat` a bunch of times. It will eventually fail.

Or simply change the random range from `randint(0, 99998)` to `randint(0, 98)`

Cause of the issue
==================

```py
"<%.7f-%05d-test@iron.sky>" % (time.time(), randint(0, 99998))
```

If randint returns a low enough value, the msg_id might look like
`'<1747742185.1234567-   42-test@iron.sky>'`

Solution
========

We can pad the random int with zeros.

runbot-110801