### PR TITLE
[FIX] mail: skip dark mode styles in email signature rendering

### DIFF
--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -1681,7 +1681,8 @@ function _getMatchedCSSRules(node, cssRules) {
         node.mozMatchesSelector ||
         node.msMatchesSelector ||
         node.oMatchesSelector;
-    const styles = cssRules.map((rule) => rule.style).filter(Boolean);
+
+    const styles = cssRules.map((rule) => removeBlacklistedStyles(rule, node)).filter(Boolean);
 
     // Add inline styles at the highest specificity.
     if (node.style.length) {
@@ -1918,4 +1919,28 @@ function _wrap(element, wrapperTag, wrapperClass, wrapperStyle) {
     element.parentElement.insertBefore(wrapper, element);
     wrapper.append(element);
     return wrapper;
+}
+
+function isBlacklistedStyle(node, selector, key) {
+    return (
+        node.matches("table, thead, tbody, tfoot, tr, td, th") &&
+        ["table", "thead", "tbody", "tfoot", "tr", "td", "th"].some((elName) =>
+            selector.includes(elName)
+        ) &&
+        key.includes("color")
+    );
+}
+
+function removeBlacklistedStyles(rule, node) {
+    if (!rule.style) {
+        return rule.style;
+    }
+    const styles = {};
+    for (const [key, value] of Object.entries(rule.style)) {
+        if (isBlacklistedStyle(node, rule.selector, key)) {
+            continue;
+        }
+        styles[key] = value;
+    }
+    return styles;
 }


### PR DESCRIPTION
Problem:
When in dark mode, additional styles are applied to improve display. However, these styles are inadvertently preserved during `convert_inline`, which processes HTML for email rendering.

This causes unwanted dark mode styles (e.g., `background-color`, `border-color`, and `color`) to persist even after switching back to light mode, especially in email signatures.

Solution:
Skip stylesheets that only affect `color`, `background-color`, or `border-color` on `table` elements. This avoids incorrect rendering in light mode without removing essential formatting styles.

Note:
Skipping all styles caused layout issues, so the fix targets only problematic styles.

Fixed in `web_editor`:
https://github.com/odoo/odoo/commit/d076dbcc273be5c8f337de9263effa82c9d9c0c8

Steps to reproduce:
1. Switch to dark mode.
2. Add an email signature in user preferences.
3. Switch back to light mode.
4. Open the mail composer. → The signature table shows a dark background.
5. Send the email. → The table in the mail thread still has a dark background.

opw-4713718

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
