### PR TITLE
[FIX] pos_restaurant: improve translatability

### DIFF
--- a/addons/pos_restaurant/i18n/fr.po
+++ b/addons/pos_restaurant/i18n/fr.po
@@ -1155,12 +1155,23 @@ msgstr "Plats à emporter"
 #. odoo-javascript
 #: code:addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml:0
 #: code:addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml:0
-#: code:addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml:0
 #: code:addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js:0
 #: code:addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.xml:0
 #: model:ir.model.fields,field_description:pos_restaurant.field_pos_order__table_id
 msgid "Table"
 msgstr "Table"
+
+#. module: pos_restaurant
+#. odoo-javascript
+#: code:addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js:0
+msgid "Table %(number)s"
+msgstr "Table %(number)s"
+
+#. module: pos_restaurant
+#. odoo-javascript
+#: code:addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js:0
+msgid "Table %(number)s, Guests: %(count)s"
+msgstr "Table %(number)s, Couverts : %(count)s"
 
 #. module: pos_restaurant
 #: model:ir.model.fields,field_description:pos_restaurant.field_pos_config__module_pos_restaurant_appointment

--- a/addons/pos_restaurant/i18n/pos_restaurant.pot
+++ b/addons/pos_restaurant/i18n/pos_restaurant.pot
@@ -17,12 +17,6 @@ msgstr ""
 
 #. module: pos_restaurant
 #. odoo-javascript
-#: code:addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml:0
-msgid ", Guests:"
-msgstr ""
-
-#. module: pos_restaurant
-#. odoo-javascript
 #: code:addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.xml:0
 msgid "/ Guest"
 msgstr ""
@@ -1131,11 +1125,22 @@ msgstr ""
 #. odoo-javascript
 #: code:addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml:0
 #: code:addons/pos_restaurant/static/src/overrides/components/navbar/navbar.xml:0
-#: code:addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml:0
 #: code:addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js:0
 #: code:addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.xml:0
 #: model:ir.model.fields,field_description:pos_restaurant.field_pos_order__table_id
 msgid "Table"
+msgstr ""
+
+#. module: pos_restaurant
+#. odoo-javascript
+#: code:addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js:0
+msgid "Table %(number)s"
+msgstr ""
+
+#. module: pos_restaurant
+#. odoo-javascript
+#: code:addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js:0
+msgid "Table %(number)s, Guests: %(count)s"
 msgstr ""
 
 #. module: pos_restaurant

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_header_patch.js
@@ -1,0 +1,20 @@
+import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
+
+import { _t } from "@web/core/l10n/translation";
+import { patch } from "@web/core/utils/patch";
+
+patch(ReceiptHeader.prototype, {
+    /** @returns {string} */
+    get tableName() {
+        if (this.props.data.table && this.props.data.customer_count) {
+            return _t("Table %(number)s, Guests: %(count)s", {
+                number: this.props.data.table,
+                count: this.props.data.customer_count,
+            });
+        }
+        if (this.props.data.table) {
+            return _t("Table %(number)s", { number: this.props.data.table });
+        }
+        return "";
+    },
+});

--- a/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/receipt_screen/order_receipt/order_receipt.xml
@@ -37,8 +37,7 @@
     </t>
     <t t-name="pos_restaurant.ReceiptHeader" t-inherit="point_of_sale.ReceiptHeader" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('cashier')]" position="after">
-            <t t-if="props.data.table">Table <t t-esc="props.data.table" /></t>
-            <t t-if="props.data.table and props.data.customer_count">, Guests: <t t-esc="props.data.customer_count" /></t>
+            <t t-if="tableName" t-esc="tableName"/>
         </xpath>
     </t>
 


### PR DESCRIPTION
Do not use t-out/t-esc to build human-readable content. This is basically the same as string concatenation.

This commit wraps the entire string in a gettext call to prevent it from being split into several non-reorderable translations. As a lucky side effect, it also creates a separate translation for the word "table" (as in restaurant tables) which won't overlap with the translation for spreadsheet tables.

opw-4754410