### PR TITLE
[REM] stock: remove location positions

### DIFF
--- a/addons/stock/data/stock_data.xml
+++ b/addons/stock/data/stock_data.xml
@@ -28,13 +28,11 @@
         <record id="stock_location_locations_partner" model="stock.location">
             <field name="name">Partners</field>
             <field name="usage">view</field>
-            <field name="posz">1</field>
             <field name="company_id"></field>
         </record>
         <record id="stock_location_locations_virtual" model="stock.location">
             <field name="name">Virtual Locations</field>
             <field name="usage">view</field>
-            <field name="posz">1</field>
             <field name="company_id"></field>
         </record>
 

--- a/addons/stock/data/stock_demo_pre.xml
+++ b/addons/stock/data/stock_demo_pre.xml
@@ -3,14 +3,12 @@
     <data noupdate="1">
         <record id="stock_location_14" model="stock.location">
             <field name="name">Shelf 2</field>
-            <field name="posx">0</field>
             <field name="barcode">SHELF2</field>
             <field name="location_id" model="stock.location"
                 eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>
         </record>
         <record id="stock_location_components" model="stock.location">
             <field name="name">Shelf 1</field>
-            <field name="posx">0</field>
             <field name="barcode">SHELF1</field>
             <field name="location_id" model="stock.location"
                 eval="obj().env.ref('stock.warehouse0').lot_stock_id.id"/>

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -60,9 +60,6 @@ class StockLocation(models.Model):
         help='This location (if it\'s internal) and all its descendants filtered by type=Internal.'
     )
     comment = fields.Html('Additional Information')
-    posx = fields.Integer('Corridor (X)', default=0, help="Optional localization details, for information purpose only")
-    posy = fields.Integer('Shelves (Y)', default=0, help="Optional localization details, for information purpose only")
-    posz = fields.Integer('Height (Z)', default=0, help="Optional localization details, for information purpose only")
     parent_path = fields.Char(index=True)
     company_id = fields.Many2one(
         'res.company', 'Company',

--- a/addons/stock/tests/test_report.py
+++ b/addons/stock/tests/test_report.py
@@ -1360,7 +1360,6 @@ class TestReports(TestReportsCommon):
         stock_location = self.env.ref('stock.warehouse0').lot_stock_id
         sublocation = self.env['stock.location'].create({
             'name': 'Warehouse0 / Sublocation',
-            'posx': 0,
             'barcode': 'TEST_BARCODE_LOCATION',
             'location_id': stock_location.id
         })


### PR DESCRIPTION
These fields are completely unused, and even considering those as "purely informative", they were removed from the location form since [1].

[1] 9410e0c

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
