### PR TITLE
[FIX] account: allow custom Untaxed Amount translation on reports

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -15225,7 +15225,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #: code:addons/account/models/account_move.py:0
-#: code:addons/account/models/account_tax.py:0
 #: model:ir.model.fields,field_description:account.field_account_bank_statement_line__amount_untaxed
 #: model:ir.model.fields,field_description:account.field_account_move__amount_untaxed
 #: model:ir.model.fields,field_description:account.field_account_payment__amount_untaxed

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -1536,7 +1536,8 @@ class AccountTax(models.Model):
         for tax_group_vals in tax_group_vals_list:
             tax_group = tax_group_vals['tax_group']
 
-            subtotal_title = tax_group.preceding_subtotal or _("Untaxed Amount")
+            subtotal_title = tax_group.preceding_subtotal \
+                or self.env['account.move']._fields['amount_untaxed'].get_description(self.env)['string']
             sequence = tax_group.sequence
 
             subtotal_order[subtotal_title] = min(subtotal_order.get(subtotal_title, float('inf')), sequence)


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Enable a second language;
2. enable developer mode;
3. go to Settings / Technical / User Interface / Views;
4. look for "document_tax_totals_template"
5. attempt to change the translation for "Untaxed Amount";
6. print a sale order or invoice for a customer using the 2nd language.

Issue
-----
Neither customizing the translation in the template, nor importing a custom translation file is able to change the translation.

Cause
-----
Because the "Untaxed Amount" token used isn't associated with any templates, records, or fields, the translation will be fetched from file instead of the database.

Solution
--------
Retrieve the string from the `account.move.amount_untaxed` field. This way, customizing the translation on the field will also update the translation in the document.

opw-4747710