### PR TITLE
[FIX] test_sale_product_configurators: ensure test customer 'Azure' exists

### DIFF
--- a/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
+++ b/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
@@ -252,6 +252,10 @@ class TestProductConfiguratorUi(HttpCase, TestProductConfiguratorCommon):
                 }),
             ],
         })
+        self.env['res.partner'].create({
+            'name': "Azure",
+            'email': "azure@example.com",
+        })
 
         self.start_tour("/odoo", 'product_attribute_multi_type', login="salesman")
 


### PR DESCRIPTION
The test test_product_attribute_multi_type was failing due to the UI tour expecting a partner named "Azure" to appear in an autocomplete dropdown. However, this customer was not created as part of the test setup, causing the selector ul.ui-autocomplete > li > a:contains("Azure") to timeout.

This change introduces the creation of the "Azure" partner in the test environment before running the tour, ensuring the step that selects the customer can succeed.

build_error-161723