### PR TITLE
[FIX] base: compute object_write equation for each record


### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -684,6 +684,7 @@ class IrActionsServer(models.Model):
                     # run context dedicated to a particular active_id
                     run_self = action.with_context(active_ids=[active_id], active_id=active_id)
                     eval_context["env"].context = run_self._context
+                    eval_context['records'] = eval_context['record'] = records.browse(active_id)
                     res = runner(run_self, eval_context=eval_context)
             else:
                 _logger.warning(

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -176,6 +176,22 @@ class TestServerActions(TestServerActionsBase):
         self.assertEqual(len(partner), 1, 'ir_actions_server: TODO')
         self.assertEqual(partner.city, 'OrigCity', 'ir_actions_server: TODO')
 
+    def test_object_write_equation(self):
+        # Do: update partners city
+        self.action.write({
+            'state': 'object_write',
+            'fields_lines': [Command.create({
+                'col1': self.res_partner_city_field.id,
+                'evaluation_type': 'equation',
+                'value': 'record.id',
+            })],
+        })
+        partners = self.test_partner + self.test_partner.copy()
+        self.action.with_context(self.context, active_ids=partners.ids).run()
+        # Test: partners updated
+        self.assertEqual(partners[0].city, str(partners[0].id))
+        self.assertEqual(partners[1].city, str(partners[1].id))
+
     @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
     def test_40_multi(self):
         # Data: 2 server actions that will be nested


### PR DESCRIPTION
Scenario:
- create an object_write (Update the Record) action
- update a field with equation evaluation (Python expression) with an
  expression like "record.id"
- click on "Create contextual action"
- go to a list view of the model, execute the action for several records

Result: the value of the field of all records are computed based on the
first selected record.

Issue: we don't change the "record" in the evaluation context and just
keep the first record.

Fix: changing the record.

Note: without the fix, the added test fails because the city of the
second record is set to the value of the ID of the first record.

opw-4491099

__PR code note__:

I did the change in "run" but this could be done in `_run_action_object_write`, I chose run because we are already changing the action_id in it.

The "`if eval_context.get('record') is not None`" is to not change an hypothetical case where `self.model_id` doesn't match the `context.action_model`.

__PR note__:

If it was too risky, we could probably merge in an higher version, the ticket is in 17.0 and this is still happening in master.

I've not heard of this issue before so this must not be very frequent or urgent, but I guess this is because people either use a python constant or they just use a python action with a for loop in general.