### PR TITLE
[FIX] fleet: update future_driver_id in batch

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -337,10 +337,14 @@ class FleetVehicle(models.Model):
             states = self.mapped('state_id').ids if 'state_id' not in vals else [vals['state_id']]
             if not state_waiting_list or state_waiting_list.id not in states:
                 future_driver = self.env['res.partner'].browse(vals['future_driver_id'])
-                if self.vehicle_type == 'bike':
-                    future_driver.sudo().write({'plan_to_change_bike': True})
-                if self.vehicle_type == 'car':
-                    future_driver.sudo().write({'plan_to_change_car': True})
+                future_driver_vals = {}
+                for vehicle in self:
+                    if vehicle.vehicle_type == 'bike':
+                        future_driver_vals['plan_to_change_bike'] = True
+                    elif vehicle.vehicle_type == 'car':
+                        future_driver_vals['plan_to_change_car'] = True
+                if future_driver_vals:
+                    future_driver.sudo().write(future_driver_vals)
 
         if 'active' in vals and not vals['active']:
             self.env['fleet.vehicle.log.contract'].search([('vehicle_id', 'in', self.ids)]).active = False

--- a/addons/fleet/tests/test_access_rights.py
+++ b/addons/fleet/tests/test_access_rights.py
@@ -4,20 +4,56 @@ from odoo.tests import common, new_test_user
 
 
 class TestFleet(common.TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.manager = new_test_user(cls.env, "test fleet manager", groups="fleet.fleet_group_manager,base.group_partner_manager")
+        cls.user = new_test_user(cls.env, "test base user", groups="base.group_user")
+        cls.car_brand, cls.bike_brand = cls.env["fleet.vehicle.model.brand"].create([
+            {"name": "Audi"},
+            {"name": "Nakamura"},
+        ])
+        cls.car_model, cls.bike_model = cls.env["fleet.vehicle.model"].create([
+            {
+                "brand_id": cls.car_brand.id,
+                "name": "A3",
+            },
+            {
+                "brand_id": cls.bike_brand.id,
+                "name": "Crossover xv",
+                "vehicle_type": "bike",
+            },
+        ])
 
     def test_manager_create_vehicle(self):
-        manager = new_test_user(self.env, "test fleet manager", groups="fleet.fleet_group_manager,base.group_partner_manager")
-        user = new_test_user(self.env, "test base user", groups="base.group_user")
-        brand = self.env["fleet.vehicle.model.brand"].create({
-            "name": "Audi",
-        })
-        model = self.env["fleet.vehicle.model"].create({
-            "brand_id": brand.id,
-            "name": "A3",
-        })
-        car = self.env["fleet.vehicle"].with_user(manager).create({
-            "model_id": model.id,
-            "driver_id": user.partner_id.id,
+        car = self.env["fleet.vehicle"].with_user(self.manager).create({
+            "model_id": self.car_model.id,
+            "driver_id": self.user.partner_id.id,
             "plan_to_change_car": False
         })
-        car.with_user(manager).plan_to_change_car = True
+        car.with_user(self.manager).plan_to_change_car = True
+
+    def test_change_future_driver(self):
+        car, bike = self.env["fleet.vehicle"].create([
+            {
+                "model_id": self.car_model.id,
+                "driver_id": self.user.partner_id.id,
+                "plan_to_change_car": False
+            },
+            {
+                "model_id": self.bike_model.id,
+                "driver_id": self.user.partner_id.id,
+                "plan_to_change_car": False,
+            }
+        ])
+        self.assertFalse(car.future_driver_id)
+        self.assertFalse(bike.future_driver_id)
+        self.assertFalse(self.manager.partner_id.plan_to_change_bike)
+        self.assertFalse(self.manager.partner_id.plan_to_change_car)
+
+        (car + bike).write({"future_driver_id": self.manager.partner_id.id})
+        self.assertEqual(car.future_driver_id, self.manager.partner_id)
+        self.assertEqual(bike.future_driver_id, self.manager.partner_id)
+        self.assertTrue(self.manager.partner_id.plan_to_change_bike)
+        self.assertTrue(self.manager.partner_id.plan_to_change_car)


### PR DESCRIPTION
Before this commit, it was not possible to update in batch the future driver of many vehicle because a check made during the update expects there is only one vehicle to update.

This commit fixes the issue to be able to alter the future driver on many vehicle at the same time.
