### PR TITLE
[FIX] hr_holidays: remove period filter on balance report

### DIFF
--- a/addons/hr_holidays/report/hr_leave_employee_type_report.py
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.py
@@ -133,7 +133,6 @@ class LeaveReport(models.Model):
             'search_view_id': [self.env.ref('hr_holidays.view_search_hr_holidays_employee_type_report').id],
             'domain': domain,
             'context': {
-                'search_default_year': True,
                 'search_default_company': True,
                 'search_default_employee': True,
                 'group_expand': True,

--- a/addons/hr_holidays/report/hr_leave_employee_type_report.xml
+++ b/addons/hr_holidays/report/hr_leave_employee_type_report.xml
@@ -7,7 +7,7 @@
             <search string="Search Time Off">
                 <field name="employee_id"/>
                 <field name="date_from"/>
-                <filter name="year" date="date_from" default_period="year" string="Period"/>
+                <filter invisible="1" name="year" date="date_from" default_period="year" string="Period"/>  <!-- TODO: remove in master, period filter for this report isn't supported -->
                 <filter string="Company" name="company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>
                 <filter string="Employee" name="employee" context="{'group_by':'employee_id'}"/>
             </search>


### PR DESCRIPTION
**Issue**
In the "Balance" report, the number of days/hours left is incorrect
when a period filter is applied.

**Cause**
The report groups all allocations for a certain time off type and
returns a single `hr.leave.employee.type.report` which uses the
start date of the record with the lowest id.
The "Period" filter, using the start date of the records, will
therefore not make sense.

**Change**
Remove the default period filter as trying to display a balance
by period introduces too many complications.

**Steps to reproduce**
- Have an employee with 0 allocations.
- Create an allocationfor this employee with a start and end date
in the previous year for a certain time off type.
- Create another allocation for this employee with a start and end
date in the current year for the same time off type.
- Time Off > Reporting > Balance
- Bug: with the default filter (Period: current year), the "Number of
days" and "Number of hours" left for that time off type shows nothing.
However, when applying a filter for the previous year, both allocations
are counted.

opw-4715547