### PR TITLE
[FIX] mail: add partner_ids in mass mailing messages after creation

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -430,7 +430,7 @@ class MailComposer(models.TransientModel):
                     mail_values['reply_to'] = mail_values['email_from']
                 # mail_mail values: body -> body_html, partner_ids -> recipient_ids
                 mail_values['body_html'] = mail_values.get('body', '')
-                mail_values['recipient_ids'] = [Command.link(id) for id in mail_values.pop('partner_ids', [])]
+                mail_values['recipient_ids'] = [Command.link(id) for id in mail_values.get('partner_ids', [])]
 
                 # process attachments: should not be encoded before being processed by message_post / mail_mail create
                 mail_values['attachments'] = [(name, base64.b64decode(enc_cont)) for name, enc_cont in email_dict.pop('attachments', list())]

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -1755,7 +1755,8 @@ class TestComposerResultsMass(TestMailComposer):
             self.assertEqual(message.author_id, self.user_employee.partner_id)
             # post-related fields are void
             self.assertFalse(message.subtype_id)
-            self.assertFalse(message.partner_ids)
+            # recipients should be added to the mail messages
+            self.assertEqual(message.partner_ids, record.customer_id)
 
     @users('employee')
     @mute_logger('odoo.models.unlink', 'odoo.addons.mail.models.mail_mail')

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -427,7 +427,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             }).create({})
             composer._onchange_template_id_wrapper()
 
-        with self.assertQueryCount(admin=157, employee=160), self.mock_mail_gateway():
+        with self.assertQueryCount(admin=167, employee=169), self.mock_mail_gateway():
             composer._action_send_mail()
 
         self.assertEqual(len(self._new_mails), 10)
@@ -1088,7 +1088,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         rec1 = rec.with_context(active_test=False)      # to see inactive records
         self.assertEqual(rec1.message_partner_ids, self.partners | self.env.user.partner_id | self.user_portal.partner_id)
 
-        with self.assertQueryCount(admin=31, employee=31):
+        with self.assertQueryCount(admin=32, employee=32):
             rec.write({
                 'name': 'Test2',
                 'customer_id': customer_id,


### PR DESCRIPTION
**Steps to reproduce:**
- Install Invoicing app
- Select several invoices
- Press Action > Send & Print
- Mails are sent but
recipients are missing in the corresponding messages

**Issue:**
When using mass mailing (`wizard.composition_mode == 'mass_mail'`),
`partner_ids` are replaced by `recipient_ids` for the `mail.mail` model
in `mail.compose.message`.

`mail_values['recipient_ids'] = [Command.link(id) for id in mail_values.pop('partner_ids', [])]`

The mails are created properly but the class inherit `mail.message` which
uses `partner_ids` directly for the recipients :

`_inherits = {'mail.message': 'mail_message_id'}`

There was also a check made for the refactoring of the mail composer
in a `test_mail_composer_wtpl` which needed to be modified:
`self.assertFalse(message.partner_ids)`

**Fix:**
Kept the `partner_ids` in `mail.compose.message` when extracting the values
for the `mail.mail` so that they can be used for the creation of the
inherited `mail.message` instances when mass_mailing is used.

Fixed in 16.2 with
https://github.com/odoo/odoo/commit/e9e90811aeee46989a83b21f9b59071a9c7bc362
Composer test was added here to prepare for the refactoring
https://github.com/odoo/odoo/commit/94ab6963cf00bbd788bc11d261deae1d9fb96791

opw-4782029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
