### PR TITLE
[FIX] account_peppol: less smp calls send & print

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -512,15 +512,13 @@ class TestAccountMoveSendCommon(AccountTestInvoicingCommon):
             )
 
     def create_send_and_print(self, invoices, default=False, **kwargs):
-        wizard_model = 'account.move.send.wizard' if len(invoices) == 1 else 'account.move.send.batch.wizard'
-        if wizard_model == 'account.move.send.wizard' and not default and not kwargs.get('sending_methods'):
+        action_send_and_print = invoices.action_send_and_print()
+        if action_send_and_print['res_model'] == 'account.move.send.wizard' and not default and not kwargs.get('sending_methods'):
             # In most cases, for testing purpose you only want to try to generate the document, no need to send it.
             # Therefore by default we deactivate sending methods, unless default parameter is set to True,
             # or they are explicitly given.
             kwargs['sending_methods'] = []
-        return self.env[wizard_model]\
-            .with_context(active_model='account.move', active_ids=invoices.ids)\
-            .create(kwargs)
+        return self.env[action_send_and_print['res_model']].with_context(action_send_and_print['context']).create(kwargs)
 
     def _get_mail_message(self, move, limit=1):
         return self.env['mail.message'].search([('model', '=', move._name), ('res_id', '=', move.id)], limit=limit)

--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -23,6 +23,11 @@ class AccountMove(models.Model):
         copy=False,
     )
 
+    def action_send_and_print(self):
+        for move in self:
+            move.commercial_partner_id.button_account_peppol_check_partner_endpoint(company=move.company_id)
+        return super().action_send_and_print()
+
     def action_cancel_peppol_documents(self):
         # if the peppol_move_state is processing/done
         # then it means it has been already sent to peppol proxy and we can't cancel

--- a/addons/account_peppol/wizard/account_move_send_batch_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_batch_wizard.py
@@ -4,14 +4,6 @@ from odoo import api, models
 class AccountMoveSendBatchWizard(models.TransientModel):
     _inherit = 'account.move.send.batch.wizard'
 
-    def _compute_summary_data(self):
-        # EXTENDS 'account' - add checking of partner's validity
-        for wizard in self:
-            if peppol_moves := wizard.move_ids.filtered(lambda m: 'peppol' in wizard._get_default_sending_methods(m)):
-                for move in peppol_moves:
-                    move.commercial_partner_id.button_account_peppol_check_partner_endpoint(company=move.company_id)
-        super()._compute_summary_data()
-
     def action_send_and_print(self, force_synchronous=False, allow_fallback_pdf=False):
         # EXTENDS 'account'
         self.ensure_one()

--- a/addons/account_peppol/wizard/account_move_send_wizard.py
+++ b/addons/account_peppol/wizard/account_move_send_wizard.py
@@ -13,9 +13,6 @@ class AccountMoveSendWizard(models.TransientModel):
         """ EXTENDS 'account'
         If Customer is not valid on Peppol, we disable the checkbox. Also add the proxy mode if not in prod.
         """
-        for wizard in self:
-            peppol_partner = wizard.move_id.partner_id.commercial_partner_id.with_company(wizard.company_id)
-            peppol_partner.button_account_peppol_check_partner_endpoint(company=wizard.company_id)
         super()._compute_sending_method_checkboxes()
         for wizard in self:
             if peppol_checkbox := wizard.sending_method_checkboxes.get('peppol'):


### PR DESCRIPTION
Peppol send & print was performing lots of SMP calls for everything at every step, which didn't have that much value and to avoid overloading some SMPs, we prefer to limit the number of SMP calls the wizard does.

no-task