### PR TITLE
[FIX] website_mass_mailing: remove number on the mailing list selection

### DIFF
--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -29,6 +29,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
             'website_mass_mailing/static/src/js/mass_mailing_form_editor.js',
             'website_mass_mailing/static/src/scss/website_mass_mailing_edit_mode.scss',
             'website_mass_mailing/static/src/snippets/s_popup/options.js',
+            'website_mass_mailing/static/src/snippets/s_website_form/options.js',
         ],
         'web.assets_tests': [
             'website_mass_mailing/static/tests/**/*',

--- a/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
+++ b/addons/website_mass_mailing/static/src/js/mass_mailing_form_editor.js
@@ -22,6 +22,5 @@ FormEditorRegistry.add('create_mailing_contact', {
         modelRequired: true,
         string: _t('Subscribe to'),
         type: 'many2many',
-        fieldName: "name",
     }],
 });

--- a/addons/website_mass_mailing/static/src/snippets/s_website_form/options.js
+++ b/addons/website_mass_mailing/static/src/snippets/s_website_form/options.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { patch } from '@web/core/utils/patch';
+import options from '@web_editor/js/editor/snippets.options';
+
+const websiteMassMailingFetchFieldRecords = {
+    /**
+    * Adds fieldName as "name" so the "name" field gets fetched instead
+    * of the "display_name" field to avoid seeing (number of contacts) in
+    * the "Subscribe to Newsletter" form editor.
+    */
+    async _fetchFieldRecords(field) {
+        if (field.name === 'list_ids' && field.relation === 'mailing.list') {
+            field.fieldName = 'name';
+        }
+        return super._fetchFieldRecords(...arguments);
+    }
+};
+
+patch(options.registry.WebsiteFormEditor.prototype, websiteMassMailingFetchFieldRecords);
+patch(options.registry.WebsiteFieldEditor.prototype, websiteMassMailingFetchFieldRecords);


### PR DESCRIPTION
In the "Subscribe to newsletter" form, "Add new Checkbox" on the web editor for "Subscribe to" field lists mailing list with number. This commit removes the number by fetching the records from mailing list via "name" and not "display_name".

Steps to Reproduce:
1. Add a form
2. Change action to "Subscribe to Newsletter"
3. Click on "Subscribe to" field
4. Click on "Add new Checkbox" and you see the numbers on the list.

opw-4730089