### PR TITLE
[PERF] product: fix memory error in `name_get`

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -441,7 +441,8 @@ class ProductProduct(models.Model):
 
         # Prefetch the fields used by the `name_get`, so `browse` doesn't fetch other fields
         # Use `load=False` to not call `name_get` for the `product_tmpl_id`
-        self.sudo().read(['name', 'default_code', 'product_tmpl_id'], load=False)
+        # Use `prefetch_fields=False` to ensure that product.template fields are not prefetched
+        self.sudo().with_context(prefetch_fields=False).read(['name', 'default_code', 'product_tmpl_id'], load=False)
 
         product_template_ids = self.sudo().mapped('product_tmpl_id').ids
 


### PR DESCRIPTION
Issue -->
Evaluating name_get for a large number of products can lead to a memory error. An example is grouping by product on the sales report pivot view.

Fix -->
Disabling the prefetcher cuts down on field_cache usage and prevents memory errors.

Benchmark -->
Memory footprint for about 2.2k products after the read call, 
| Before | After |
|--------|--------|
| MemoryError | ~5 MB |

opw-4726184
