### PR TITLE
[FIX] point_of_sale: swap obsolete `partner.mobile` for `partner.phone`

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -24,7 +24,7 @@ export class ReceiptScreen extends Component {
         const email = partner?.invoice_emails || partner?.email || "";
         this.state = useState({
             email: email,
-            phone: partner?.mobile || "",
+            phone: partner?.phone || "",
         });
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
         this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());


### PR DESCRIPTION
Steps to reproduce:
-------------------
1. Install `whatsapp_pos`
2. In a PoS shop, select a partner with a valid phone, select a product, and invoice it.

Observation:
------------
on the receipt screen, we can't send the receipt via whatsapp, since the phone input is empty, and hence, the send via whatsapp button is disabled.

Reason:
-------
Commit a4b8a589c4007cd0385b253a58b1b87baf3905b8 removed the `mobile` field from `res.partner` for simplicity, however, we have forgot to update the usage of the `moblie` field in `point_of_sale`.

Fix:
----
Swap `mobile` for `phone`.

opw-4792841