### PR TITLE
[IMP] sale_stock, *: align shipping policy label and behavior

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -179,7 +179,7 @@ class PosConfig(models.Model):
     warehouse_id = fields.Many2one('stock.warehouse', default=_default_warehouse_id, ondelete='restrict')
     route_id = fields.Many2one('stock.route', string="Spefic route for products delivered later.")
     picking_policy = fields.Selection([
-        ('direct', 'As soon as possible'),
+        ('direct', 'As soon as possible, with back orders'),
         ('one', 'When all products are ready')],
         string='Shipping Policy', required=True, default='direct',
         help="If you deliver all products at once, the delivery order will be scheduled based on the greatest "

--- a/addons/sale_stock/models/res_config_settings.py
+++ b/addons/sale_stock/models/res_config_settings.py
@@ -12,10 +12,6 @@ class ResConfigSettings(models.TransientModel):
         string="Security Lead Time for Sales",
         config_parameter='sale_stock.use_security_lead',
         help="Margin of error for dates promised to customers. Products will be scheduled for delivery that many days earlier than the actual promised date, to cope with unexpected delays in the supply chain.")
-    default_picking_policy = fields.Selection([
-        ('direct', 'Ship products as soon as available, with back orders'),
-        ('one', 'Ship all products at once')
-        ], "Picking Policy", default='direct', default_model="sale.order", required=True)
 
     @api.onchange('use_security_lead')
     def _onchange_use_security_lead(self):

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -19,11 +19,9 @@ class SaleOrder(models.Model):
         help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
     incoterm_location = fields.Char(string='Incoterm Location')
     picking_policy = fields.Selection([
-        ('direct', 'As soon as possible'),
-        ('one', 'When all products are ready')],
-        string='Shipping Policy', required=True, default='direct',
-        help="If you deliver all products at once, the delivery order will be scheduled based on the greatest "
-        "product lead time. Otherwise, it will be based on the shortest.")
+        ('direct', 'As soon as possible, with back orders'), ('one', 'When all products are ready')],
+        string='Shipping Policy', required=True, default=lambda self: self.env.company.picking_policy,
+        help="It specifies goods to be deliver partially or all at once")
     warehouse_id = fields.Many2one(
         'stock.warehouse', string='Warehouse',
         compute='_compute_warehouse_id', store=True, readonly=False, precompute=True,

--- a/addons/sale_stock/views/res_config_settings_views.xml
+++ b/addons/sale_stock/views/res_config_settings_views.xml
@@ -6,11 +6,6 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="stock.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <setting id="warning_info" position="after">
-                <setting help="When to start shipping">
-                    <field name="default_picking_policy" class="o_light_label w-auto" widget="selection"/>
-                </setting>
-            </setting>
             <div id="sale_security_lead" position="replace">
                 <setting company_dependent="1" help="Schedule deliveries earlier to avoid delays" documentation="/applications/inventory_and_mrp/inventory/management/planning/scheduled_dates.html" title="Margin of error for dates promised to customers. Products will be scheduled for procurement and delivery that many days earlier than the actual promised date, to cope with unexpected delays in the supply chain.">
                     <field name="use_security_lead"/>

--- a/addons/stock/models/res_company.py
+++ b/addons/stock/models/res_company.py
@@ -49,6 +49,10 @@ class ResCompany(models.Model):
     # used for sending stock text confirmation
     stock_text_confirmation = fields.Boolean("Stock Text Confirmation")
     stock_confirmation_type = fields.Selection([('sms', 'SMS')], default='sms')
+    picking_policy = fields.Selection([
+        ('direct', 'As soon as possible, with back orders'),
+        ('one', 'When all products are ready')
+    ], default='direct', required=True)
 
     def _create_transit_location(self):
         '''Create a transit location with company_id being the given company_id. This is needed

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -150,8 +150,8 @@ class StockPickingType(models.Model):
     )
     kanban_dashboard_graph = fields.Text(compute='_compute_kanban_dashboard_graph')
     move_type = fields.Selection([
-        ('direct', 'As soon as possible'), ('one', 'When all products are ready')],
-        'Shipping Policy', default='direct', required=True,
+        ('direct', 'As soon as possible, with back orders'), ('one', 'When all products are ready')], 'Shipping Policy',
+        default=lambda self: self.env.company.picking_policy, required=True,
         help="It specifies goods to be transferred partially or all at once")
 
     @api.model_create_multi
@@ -566,7 +566,7 @@ class StockPicking(models.Model):
     return_count = fields.Integer('# Returns', compute='_compute_return_count', compute_sudo=False)
 
     move_type = fields.Selection([
-        ('direct', 'As soon as possible'), ('one', 'When all products are ready')], 'Shipping Policy',
+        ('direct', 'As soon as possible, with back orders'), ('one', 'When all products are ready')], 'Shipping Policy',
         compute='_compute_move_type', store=True, required=True, readonly=False, precompute=True,
         help="It specifies goods to be deliver partially or all at once")
     state = fields.Selection([

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -20,6 +20,9 @@
                             <setting id="warning_info" string="Partner-Specific Instructions" help="Display instructions tailored to the customer or vendor on stock operations.">
                                 <field name="group_warning_stock"/>
                             </setting>
+                            <setting help="When to start shipping">
+                                <field name="picking_policy" string="Shipping Policy" class="o_light_label w-auto" widget="selection"/>
+                            </setting>
                             <setting id="quality_control" help="Add quality checks to your transfer operations"
                                      documentation="/applications/inventory_and_mrp/manufacturing/management/quality_control.html">
                                 <field name="module_quality_control" widget="upgrade_boolean"/>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -104,7 +104,7 @@
                                     <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                     <field invisible="code not in ['incoming', 'outgoing', 'internal']" name="return_picking_type_id" string="Returns Type"/>
                                     <field name="create_backorder"/>
-                                    <field name="move_type" help="Unless previously specified by the source document, this will be the default picking policy for this operation type." invisible="code != 'internal'"/>
+                                    <field name="move_type" help="Unless previously specified by the source document, this will be the default shipping policy for this operation type." invisible="code != 'internal'"/>
                                 </group>
                             </group>
                             <group name="second">


### PR DESCRIPTION
*: stock, point_of_sale


- Currently, users see the same delivery setting displayed as 'Picking Policy'
  in Configuration and 'Shipping Policy' in Sales Orders and Transfers, even though
  both control the same functionality. This inconsistent naming, along with different
  option labels and tooltips make it difficult for users to understand that these
  labels refer to the same shipping behaviour.

- Also, when the Picking Policy is changed in Settings, it is only applied to the
  Sales Order and is not reflected in the related Operation Type. As a result,
  both newly created and existing Operation Types continue to use the
  previous default value instead of the updated policy. Breaking consistency across Sales Orders,
  Transfers, and Operation Types.

- Additionally, users are not able to define different Picking policy
  per company in Configuration, even though each company may require
  its own specific policy, making it difficult to handle company-specific
  logistics behaviour in a multi-company environment.

These changes provide consistent terminology by aligning the label names and
tooltips, eliminate user confusion, and ensure that shipping behaviour across
all to follow the configured company-specific defaults.

TaskId: 4791665