### PR TITLE
[IMP] survey, hr_recruitment_survey: survey invite wizard rewamp

### DIFF
--- a/addons/hr_recruitment_survey/models/hr_applicant.py
+++ b/addons/hr_recruitment_survey/models/hr_applicant.py
@@ -60,7 +60,9 @@ class HrApplicant(models.Model):
             default_partner_ids=applicant_partner_ids.ids,
             default_use_template=bool(template),
             default_template_id=template and template.id or False,
-            default_deadline=fields.Datetime.now() + timedelta(days=15)
+            default_deadline=fields.Datetime.now() + timedelta(days=15),
+            hide_mail_template_management_options=True,
+            dialog_size='large',
         )
 
         return {

--- a/addons/hr_recruitment_survey/wizard/hr_recruitment_survey_invite.py
+++ b/addons/hr_recruitment_survey/wizard/hr_recruitment_survey_invite.py
@@ -221,7 +221,8 @@ class HrRecruitmentSurveyInvite(models.TransientModel):
         if answer.applicant_id:
             sanitized_html = html_sanitize(mail.body_html)
             answer.applicant_id.message_post(body=sanitized_html)
-            mail.send()
+            if not self.scheduled_date or self.scheduled_date < fields.Datetime.now():
+                mail.send()
         return mail
 
     # Security

--- a/addons/hr_recruitment_survey/wizard/survey_invite_views.xml
+++ b/addons/hr_recruitment_survey/wizard/survey_invite_views.xml
@@ -16,7 +16,7 @@
         </xpath>
 
         <xpath expr="//field[@name='emails']" position="attributes">
-            <attribute name="invisible">has_many_applicants or not send_email</attribute>
+            <attribute name="invisible">1</attribute>
         </xpath>
       </field>
     </record>

--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -30,7 +30,7 @@ export class MailComposerAttachmentSelector extends Component {
                 : this.props.record.context.active_ids;
         }
         const thread = await this.mailStore["mail.thread"].insert({
-            model: this.props.record.data.model,
+            model: this.props.record.data.model || this.props.record.context.active_model,
             id: resIds[0],
         });
         const file = new File([dataUrlToBlob(data, type)], name, { type });

--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -1066,6 +1066,7 @@ class SurveySurvey(models.Model):
             default_survey_id=self.id,
             default_template_id=template and template.id or False,
             default_send_email=(self.access_mode != 'public'),
+            hide_mail_template_management_options=True,
         )
         return {
             'type': 'ir.actions.act_window',

--- a/addons/survey/static/src/views/form/survey_invite_form_controller.js
+++ b/addons/survey/static/src/views/form/survey_invite_form_controller.js
@@ -1,0 +1,22 @@
+import { registry } from "@web/core/registry";
+import { formView } from "@web/views/form/form_view";
+import { EventBus, useSubEnv } from "@odoo/owl";
+
+export class SurveyInviteController extends formView.Controller {
+    static props = {
+        ...formView.Controller.props,
+        fullComposerBus: { type: EventBus, optional: true },
+    };
+    static defaultProps = { fullComposerBus: new EventBus() };
+    setup() {
+        super.setup();
+        useSubEnv({
+            fullComposerBus: this.props.fullComposerBus,
+        });
+    }
+}
+
+registry.category("views").add("survey_invite_form", {
+    ...formView,
+    Controller: SurveyInviteController,
+});

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -6,7 +6,7 @@ import re
 import werkzeug
 
 from odoo import api, fields, models, tools, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.mail import email_split_and_format, email_normalize
 
 _logger = logging.getLogger(__name__)
@@ -61,6 +61,17 @@ class SurveyInvite(models.TransientModel):
     deadline = fields.Datetime(string="Answer deadline")
     send_email = fields.Boolean(compute="_compute_send_email",
                                 inverse="_inverse_send_email")
+    scheduled_date = fields.Datetime('Scheduled Date',
+        help="send emails after that date. This date is considered as being in UTC timezone."
+    )
+
+    @api.constrains('scheduled_date', 'deadline')
+    def _check_deadline_after_schedule(self):
+        for invite in self:
+            if invite.scheduled_date and invite.deadline and invite.scheduled_date > invite.deadline:
+                raise ValidationError(
+                    self.env._("The answer deadline should be after the email schedule date.")
+                )
 
     @api.depends('survey_access_mode')
     def _compute_send_email(self):
@@ -245,6 +256,7 @@ class SurveyInvite(models.TransientModel):
             'model': None,
             'res_id': None,
             'subject': subject,
+            'scheduled_date': self.scheduled_date,
         }
         if answer.partner_id:
             mail_values['recipient_ids'] = [(4, answer.partner_id.id)]

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -5,7 +5,7 @@
             <field name="name">survey.invite.view.form</field>
             <field name="model">survey.invite</field>
             <field name="arch" type="xml">
-                <form string="Compose Email" class="o_mail_composer_form">
+                <form string="Compose Email" class="o_mail_composer_form" js_class="survey_invite_form">
                     <group col="1">
                         <group col="2">
                             <field name="author_id" invisible="1"/>
@@ -24,6 +24,7 @@
                             <field string="Send by Email" name="send_email" widget="boolean_toggle" options="{'autosave': False}"
                                    invisible="survey_access_mode != 'public'"/>
                             <field name="partner_ids"
+                                string="To"
                                 widget="many2many_tags_email"
                                 placeholder="Add existing contacts..." options="{'no_quick_create': True}"
                                 context="{'show_email': True, 'form_view_ref': 'base.view_partner_simple_form'}"
@@ -35,40 +36,45 @@
                         </group>
                         <field name="existing_partner_ids" invisible="1"/>
                         <field name="existing_emails" invisible="1"/>
-                        <div col="2" class="alert alert-warning" role="alert"
+                        <div col="2" class="alert alert-warning pb-0" role="alert"
                             invisible="survey_access_mode == 'public' or not existing_text">
                             <field name="existing_text"/>
                             <group col="2">
                                 <label for="existing_mode" string="Handle existing"/>
                                 <div>
                                     <field name="existing_mode" nolabel="1"/>
-                                    <p invisible="existing_mode != 'resend'">Customers will receive the same token.</p>
-                                    <p invisible="existing_mode != 'new'">Customers will receive a new token and be able to completely retake the survey.</p>
+                                    <p class="mb-0" invisible="existing_mode != 'resend'">Customers will receive the same token.</p>
+                                    <p class="mb-0" invisible="existing_mode != 'new'">Customers will receive a new token and be able to completely retake the survey.</p>
                                 </div>
                             </group>
                         </div>
                         <group col="2">
-                            <field name="subject" invisible="not send_email" placeholder="Subject..."/>
+                            <field name="subject" invisible="not send_email" placeholder="Subject..." widget="char_emojis"/>
                         </group>
+                        <hr/>
                         <field name="can_edit_body" invisible="1"/>
-                        <field name="body" class="oe-bordered-editor border border-1 m-3 p-0 flex-fill"
+                        <field name="body" class="oe-bordered-editor"
                             widget="html_mail"
-                            options="{'height': 380}"
+                            options="{'height': 300}"
                             invisible="not send_email"
                             readonly="not can_edit_body" force_save="1"/>
+                        <hr/>
                         <group invisible="not send_email">
-                            <group>
-                                <field name="attachment_ids" widget="many2many_binary"/>
-                            </group>
-                            <group>
-                                <field name="deadline"/>
-                                <field name="template_id" label="Use template"/>
-                            </group>
+                            <field name="deadline" string="Deadline"
+                                placeholder="The interview link will expire after the deadline."/>
+                        </group>
+                        <hr colspan="2" invisible="not attachment_ids"/>
+                        <group invisible="not send_email">
+                            <field name="attachment_ids" widget="mail_composer_attachment_list"
+                                invisible="not attachment_ids" nolabel="1" colspan="2"/>
                         </group>
                     </group>
                     <footer>
                         <button string="Send" invisible="not send_email" name="action_invite" type="object" class="btn-primary" data-hotkey="q"/>
                         <button string="Close" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                        <field name="attachment_ids" widget="mail_composer_attachment_selector" invisible="not send_email" data-hotkey="a"/>
+                        <field name="template_id" widget="mail_composer_template_selector" invisible="not send_email"/>
+                        <field name="scheduled_date" widget="datetime_scheduled_date" invisible="not send_email"/>
                     </footer>
                 </form>
             </field>


### PR DESCRIPTION
- add attachment, template and schedule date buttons to the survey
invite wizard footer.
- change ux of survey invite wizard
- users can now schedule email sending dates via the schedule date button
in the wizard footer.
- add emojis to the subject field
- hide the 'additional emails' field in the recruitment send interview wizard.
- mail_composer_attachment_selector widget cannot find the model field,
updated the js if no model found use active_model instead of adding a
model field

task-4735348