### PR TITLE
[FIX] website: include only final 2XX targets in sitemap.xml

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -98,7 +98,7 @@ class EventEvent(models.Model):
         """Fall back on the website_url to share the event."""
         for event in self:
             event.event_share_url = event.event_url or werkzeug.urls.url_join(event.get_base_url(), event.website_url)
- 
+
     @api.depends('registration_ids')
     @api.depends_context('uid')
     def _compute_is_participating(self):


### PR DESCRIPTION
Fix sitemap to exclude redirected URLs and include only final 2XX URLs

Before this PR:
- Sitemap included URLs with redirect rules (301/302).
- This caused issues for search engines trying to index valid URLs.

---

After this PR:
- Sitemap now includes only URLs that return a 2XX status.
- If a user-defined redirect rule exists, the sitemap includes only the final target URL.

task-4655590