### PR TITLE
[FIX] account: Fix overdue filter to display bills with any overdue installment

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1611,7 +1611,7 @@
                     <filter name="in_payment" string="In payment" domain="[('state', '=', 'posted'), ('payment_state', '=', 'in_payment')]"/>
                     <!-- overdue -->
                     <filter name="late" string="Overdue" domain="[
-                        ('invoice_date_due', '&lt;', time.strftime('%Y-%m-%d')),
+                        ('next_payment_date', '&lt;', time.strftime('%Y-%m-%d')),
                         ('state', '=', 'posted'),
                         ('payment_state', 'in', ('not_paid', 'partial'))
                     ]" help="Overdue invoices, maturity date passed"/>


### PR DESCRIPTION
Issue
----
Invoice/Bills with multiple installments would only appear in the "Overdue" filter when all installments were past due, making it hard to track partially overdue bills.

Step to reproduce
----
Navigate to Accounting > Vendors > Bills.
Create a bill with `Payment terms` (e.g., "30% Now, Balance 60 Days").
Apply the `Overdue` filter in the Bills view.

Fix
----
The overdue filter now uses `next_payment_date`, which reflects the earliest due date of the remaining unpaid installments. As a result, a bill will be shown as overdue as soon as any of its installments are late.

----
opw-4661825
