### PR TITLE
[IMP] account: Change all Many2One ir.attachment field to Binary field

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -54,12 +54,6 @@ REVERSED_COUNTRY_CODE = {v: k for k, v in COUNTRY_CODE_MAP.items()}
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    l10n_es_edi_facturae_xml_id = fields.Many2one(
-        comodel_name='ir.attachment',
-        string="Facturae Attachment",
-        compute=lambda self: self._compute_linked_attachment_id('l10n_es_edi_facturae_xml_id', 'l10n_es_edi_facturae_xml_file'),
-        depends=['l10n_es_edi_facturae_xml_file']
-    )
     l10n_es_edi_facturae_xml_file = fields.Binary(
         attachment=True,
         string="Facturae File",
@@ -124,7 +118,7 @@ class AccountMove(models.Model):
     def _l10n_es_edi_facturae_get_default_enable(self):
         self.ensure_one()
         return not self.invoice_pdf_report_id \
-            and not self.l10n_es_edi_facturae_xml_id \
+            and not self.l10n_es_edi_facturae_xml_file \
             and not self.l10n_es_is_simplified \
             and self.is_invoice(include_receipts=True) \
             and (self.partner_id.is_company or self.partner_id.vat) \

--- a/addons/l10n_es_edi_facturae/models/account_move_send.py
+++ b/addons/l10n_es_edi_facturae/models/account_move_send.py
@@ -15,7 +15,12 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, move):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(move) + move.l10n_es_edi_facturae_xml_id
+        l10n_es_edi_facturae_xml_id = self.env['ir.attachment'].search([
+            ('res_model', '=', move._name),
+            ('res_id', 'in', move.id),
+            ('res_field', '=', 'l10n_es_edi_facturae_xml_file')
+        ])
+        return super()._get_invoice_extra_attachments(move) + l10n_es_edi_facturae_xml_id
 
     def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
@@ -79,4 +84,4 @@ class AccountMoveSend(models.AbstractModel):
         if attachments_vals:
             attachments = self.env['ir.attachment'].with_user(SUPERUSER_ID).create(attachments_vals)
             res_ids = attachments.mapped('res_id')
-            self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['l10n_es_edi_facturae_xml_id', 'l10n_es_edi_facturae_xml_file'])
+            self.env['account.move'].browse(res_ids).invalidate_recordset(fnames=['l10n_es_edi_facturae_xml_file'])

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -202,7 +202,7 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
         invoice.action_post()
         wizard = self.create_send_and_print(invoice)
         wizard.action_send_and_print()
-        self.assertFalse(invoice.l10n_es_edi_facturae_xml_id)
+        self.assertFalse(invoice.l10n_es_edi_facturae_xml_file)
 
     def test_tax_withheld(self):
         with freeze_time(self.frozen_today), \

--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -103,7 +103,7 @@
                             <t t-set="seq_and_num" t-value="refunded_doc._get_tbai_sequence_and_number()"/>
                             <SerieFactura t-out="seq_and_num[0]"/>
                             <NumFactura t-out="seq_and_num[1]"/>
-                            <FechaExpedicionFactura t-out="format_date(refunded_doc.xml_attachment_id and refunded_doc._get_tbai_signature_and_date()[1] or refunded_doc_invoice_date)"/>
+                            <FechaExpedicionFactura t-out="format_date(refunded_doc._get_xml_attachment_id() and refunded_doc._get_tbai_signature_and_date()[1] or refunded_doc_invoice_date)"/>
                         </IDFacturaRectificadaSustituida>
                     </FacturasRectificadasSustituidas>
                 </t>

--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -47,19 +47,19 @@ class AccountMove(models.Model):
 
     l10n_es_tbai_post_file = fields.Binary(
         string="TicketBAI Post File",
-        related='l10n_es_tbai_post_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_post_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_post_file_name = fields.Char(
         string="TicketBAI Post Attachment Name",
-        related="l10n_es_tbai_post_document_id.xml_attachment_id.name",
+        related="l10n_es_tbai_post_document_id.xml_attachment_bin_filename",
     )
     l10n_es_tbai_cancel_file = fields.Binary(
         string="TicketBAI Cancel File",
-        related='l10n_es_tbai_cancel_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_cancel_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_cancel_file_name = fields.Char(
         string="TicketBAI Cancel File Name",
-        related='l10n_es_tbai_cancel_document_id.xml_attachment_id.name',
+        related='l10n_es_tbai_cancel_document_id.xml_attachment_bin_filename',
     )
 
     l10n_es_tbai_is_required = fields.Boolean(
@@ -170,7 +170,7 @@ class AccountMove(models.Model):
                 test_suffix=test_suffix,
                 message=message,
             ),
-            attachment_ids=[self.l10n_es_tbai_post_document_id.xml_attachment_id.id] if not cancel else [self.l10n_es_tbai_cancel_document_id.xml_attachment_id.id],
+            attachment_ids=[(self.l10n_es_tbai_post_document_id if not cancel else self.l10n_es_tbai_cancel_document_id)._get_xml_attachment_id().id]
         )
 
     def _l10n_es_tbai_lock_move(self):

--- a/addons/l10n_es_edi_tbai/models/account_move_send.py
+++ b/addons/l10n_es_edi_tbai/models/account_move_send.py
@@ -20,14 +20,14 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, move):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id.xml_attachment_id
+        return super()._get_invoice_extra_attachments(move) + move.l10n_es_tbai_post_document_id._get_xml_attachment_id()
 
     def _get_placeholder_mail_attachments_data(self, move, invoice_edi_format=None, extra_edis=None):
         # EXTENDS 'account'
         results = super()._get_placeholder_mail_attachments_data(move, invoice_edi_format=invoice_edi_format, extra_edis=extra_edis)
 
         if (
-            not move.l10n_es_tbai_post_document_id.xml_attachment_id
+            not move.l10n_es_tbai_post_document_id.xml_attachment_bin
             and 'es_tbai' in extra_edis
         ):
             filename = move._l10n_es_tbai_get_attachment_name()

--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -56,12 +56,13 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
         required=True,
         readonly=True,
     )
-    xml_attachment_id = fields.Many2one(
-        comodel_name='ir.attachment',
+    xml_attachment_bin = fields.Binary(
         string="XML Attachment",
         copy=False,
         readonly=True,
+        attachment=True,
     )
+    xml_attachment_bin_filename = fields.Char()
     company_id = fields.Many2one(
         'res.company',
         required=True,
@@ -94,6 +95,13 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
     # -------------------------------------------------------------------------
     # HELPER METHODS
     # -------------------------------------------------------------------------
+
+    def _get_xml_attachment_id(self):
+        return self.env['ir.attachment'].search([
+            ('res_model', '=', self._name),
+            ('res_id', 'in', self.id),
+            ('res_field', '=', 'xml_attachment_bin')
+        ])
 
     def _is_in_chain(self):
         """True iff the document has been posted to the chain and confirmed by govt."""
@@ -159,7 +167,7 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
         if error:
             return error
 
-        if not self.xml_attachment_id:
+        if not self.xml_attachment_bin:
             self._generate_xml(values)
 
         if (
@@ -229,7 +237,7 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             'url': get_key(self.company_id.l10n_es_tbai_tax_agency, 'cancel_url_' if self.is_cancel else 'post_url_', company.l10n_es_tbai_test_env),
             'headers': {"Content-Type": "application/xml; charset=utf-8"},
             'pkcs12_data': company.l10n_es_tbai_certificate_id,
-            'data': self.xml_attachment_id.raw,
+            'data': base64.b64decode(self.xml_attachment_bin),
         }
 
     @api.model
@@ -257,7 +265,7 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             xml_to_send = self._generate_final_xml_bi(freelancer=freelancer)
             lroe_str = etree.tostring(xml_to_send)
         else:
-            lroe_str = self.xml_attachment_id.raw
+            lroe_str = base64.b64decode(self.xml_attachment_bin)
 
         lroe_bytes = gzip.compress(lroe_str)
 
@@ -298,7 +306,7 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             'freelancer': freelancer,
             'epigrafe': self.env['ir.config_parameter'].sudo().get_param('l10n_es_edi_tbai.epigrafe', '')
         }
-        lroe_values.update({'tbai_b64_list': [base64.b64encode(self.xml_attachment_id.raw).decode()]})
+        lroe_values.update({'tbai_b64_list': [self.xml_attachment_bin.decode()]})
         lroe_str = self.env['ir.qweb']._render('l10n_es_edi_tbai.template_LROE_240_main', lroe_values)
         lroe_xml = cleanup_xml_node(lroe_str)
 
@@ -364,12 +372,16 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
             xml_doc = self._generate_purchase_document_xml_bi(values)
 
         if xml_doc is not None:
-            self.sudo().xml_attachment_id = self.env['ir.attachment'].create({
-                'name': values['attachment_name'],
-                'raw': etree.tostring(xml_doc, encoding='UTF-8'),
-                'type': 'binary',
-                'res_model': values['res_model'],
-                'res_id': values['res_id'],
+            # Generate XML
+            self.sudo().write({
+                'xml_attachment_bin': base64.b64encode(etree.tostring(xml_doc, encoding='UTF-8')),
+                'xml_attachment_bin_filename': values['attachment_name']
+            })
+
+            # Set name on newly-created attachment.
+            attachment = self._get_xml_attachment_id()
+            attachment.sudo().write({
+                'name': values['attachment_name']
             })
 
     @api.model
@@ -824,7 +836,19 @@ class L10n_Es_Edi_TbaiDocument(models.Model):
     def _get_xml(self):
         """Returns the XML object representing the document."""
         self.ensure_one()
-        doc = self.xml_attachment_id
+        doc = base64.b64decode(self.xml_attachment_bin)
         if not doc:
             return None
-        return etree.fromstring(doc.raw.decode('utf-8'))
+        return etree.fromstring(doc.decode('utf-8'))
+
+    # -------------------------------------------------------------------------
+    # CRUD METHODS
+    # -------------------------------------------------------------------------
+
+    def unlink(self):
+        for record in self:
+            self.env['ir.attachment'].search([
+                ('res_model', '=', self._name),
+                ('res_id', '=', record.id)
+            ]).unlink()
+        return super().unlink()

--- a/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_bill_bizkaia.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_bill_bizkaia.py
@@ -14,7 +14,7 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
 
         self.assertEqual(bill.l10n_es_tbai_state, 'to_send')
         self.assertFalse(bill.l10n_es_tbai_chain_index)
-        self.assertFalse(bill.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertFalse(bill.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         with patch(
             'odoo.addons.l10n_es_edi_tbai.models.l10n_es_edi_tbai_document.requests.Session.request',
@@ -25,10 +25,10 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
         self.assertEqual(bill.l10n_es_tbai_state, 'sent')
         # No chain index for vendor bills
         self.assertFalse(bill.l10n_es_tbai_chain_index)
-        self.assertTrue(bill.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(bill.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.assertEqual(bill.state, 'posted')
-        self.assertFalse(bill.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertFalse(bill.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         with patch(
             'odoo.addons.l10n_es_edi_tbai.models.l10n_es_edi_tbai_document.requests.Session.request',
@@ -38,7 +38,7 @@ class TestSendBillEdiBizkaia(TestEsEdiTbaiCommonBizkaia):
 
         self.assertEqual(bill.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(bill.state, 'cancel')
-        self.assertTrue(bill.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(bill.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
     def test_post_bill_tbai_failure(self):
         bill = self._create_posted_bill()

--- a/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_invoice.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_tbai_send_invoice.py
@@ -15,7 +15,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
         self.assertFalse(invoice.l10n_es_tbai_chain_index)
-        self.assertFalse(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertFalse(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         # Post with success
         with patch(
@@ -27,10 +27,10 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertTrue(invoice.l10n_es_tbai_chain_index)
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.assertEqual(invoice.state, 'posted')
-        self.assertFalse(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertFalse(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         # Cancel with success
         with patch(
@@ -41,7 +41,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         self.assertEqual(invoice.state, 'cancel')
 
@@ -64,7 +64,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
             self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
             self.assertFalse(invoice.l10n_es_tbai_chain_index)
             self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'rejected')
-            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         failed_document_id = invoice.l10n_es_tbai_post_document_id.id
 
@@ -80,7 +80,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertTrue(invoice.l10n_es_tbai_chain_index)
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
     def test_cancel_invoice_tbai_failure(self):
         invoice = self._create_posted_invoice()
@@ -105,7 +105,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         except UserError:
             self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
             self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'rejected')
-            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         failed_document_id = invoice.l10n_es_tbai_cancel_document_id.id
 
@@ -120,7 +120,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
     def test_post_invoice_tbai_request_error(self):
         invoice = self._create_posted_invoice()
@@ -139,7 +139,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
             self.assertEqual(invoice.l10n_es_tbai_state, 'to_send')
             self.assertTrue(invoice.l10n_es_tbai_chain_index)
             self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'to_send')
-            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         pending_document_id = invoice.l10n_es_tbai_post_document_id.id
         chain_index = invoice.l10n_es_tbai_chain_index
@@ -156,7 +156,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
         self.assertEqual(invoice.l10n_es_tbai_post_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
     def test_cancel_invoice_request_error(self):
         invoice = self._create_posted_invoice()
@@ -181,7 +181,7 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
         except UserError:
             self.assertEqual(invoice.l10n_es_tbai_state, 'sent')
             self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'to_send')
-            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+            self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)
 
         pending_document_id = invoice.l10n_es_tbai_cancel_document_id.id
 
@@ -196,4 +196,4 @@ class TestSendAndPrintEdiGipuzkoa(TestEsEdiTbaiCommonGipuzkoa):
 
         self.assertEqual(invoice.l10n_es_tbai_state, 'cancelled')
         self.assertEqual(invoice.l10n_es_tbai_cancel_document_id.state, 'accepted')
-        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_id)
+        self.assertTrue(invoice.l10n_es_tbai_cancel_document_id.xml_attachment_bin)

--- a/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_web_services.py
@@ -58,8 +58,8 @@ class TestEdiTbaiWebServices(TestEsEdiTbaiCommon):
 
         self._get_invoice_send_wizard(self.out_invoice).action_send_and_print()
         self.assertEqual(self.out_invoice.l10n_es_tbai_state, 'sent')
-        self.assertTrue(self.out_invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(self.out_invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)
 
         self.in_invoice.l10n_es_tbai_send_bill()
         self.assertEqual(self.in_invoice.l10n_es_tbai_state, 'sent')
-        self.assertTrue(self.in_invoice.l10n_es_tbai_post_document_id.xml_attachment_id)
+        self.assertTrue(self.in_invoice.l10n_es_tbai_post_document_id.xml_attachment_bin)

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -289,7 +289,7 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             'res_id': self.out_invoice.id,
             'res_field': 'xml_attachment_id',
         })
-        post_edi_document.xml_attachment_id = post_xml_attachment
+        post_edi_document.xml_attachment_bin = post_xml_attachment.datas
         self.out_invoice.l10n_es_tbai_post_document_id = post_edi_document
         cancel_edi_document = self.out_invoice._l10n_es_tbai_create_edi_document(cancel=True)
         cancel_edi_document._generate_xml(self.out_invoice._l10n_es_tbai_get_values(cancel=True))

--- a/addons/l10n_es_edi_tbai_pos/models/pos_order.py
+++ b/addons/l10n_es_edi_tbai_pos/models/pos_order.py
@@ -26,11 +26,11 @@ class PosOrder(models.Model):
 
     l10n_es_tbai_post_file = fields.Binary(
         string="TicketBAI Post File",
-        related='l10n_es_tbai_post_document_id.xml_attachment_id.datas',
+        related='l10n_es_tbai_post_document_id.xml_attachment_bin',
     )
     l10n_es_tbai_post_file_name = fields.Char(
         string="TicketBAI Post Attachment Name",
-        related="l10n_es_tbai_post_document_id.xml_attachment_id.name",
+        related="l10n_es_tbai_post_document_id.xml_attachment_bin_filename",
     )
 
     l10n_es_tbai_is_required = fields.Boolean(

--- a/addons/l10n_in_edi/models/account_move.py
+++ b/addons/l10n_in_edi/models/account_move.py
@@ -31,15 +31,6 @@ class AccountMove(models.Model):
         tracking=True,
         readonly=True,
     )
-    l10n_in_edi_attachment_id = fields.Many2one(
-        comodel_name='ir.attachment',
-        string="E-Invoice(IN) Attachment",
-        compute=lambda self: self._compute_linked_attachment_id(
-            'l10n_in_edi_attachment_id',
-            'l10n_in_edi_attachment_file'
-        ),
-        depends=['l10n_in_edi_attachment_file']
-    )
     l10n_in_edi_attachment_file = fields.Binary(
         string="E-Invoice(IN) File",
         attachment=True,
@@ -155,8 +146,8 @@ class AccountMove(models.Model):
 
     def _get_l10n_in_edi_response_json(self):
         self.ensure_one()
-        if self.l10n_in_edi_attachment_id:
-            return json.loads(self.l10n_in_edi_attachment_id.sudo().raw.decode("utf-8"))
+        if self.l10n_in_edi_attachment_file:
+            return json.loads(base64.b64decode(self.l10n_in_edi_attachment_file).decode("utf-8"))
         return {}
 
     def _l10n_in_lock_invoice(self):

--- a/addons/l10n_in_edi/models/account_move_send.py
+++ b/addons/l10n_in_edi/models/account_move_send.py
@@ -44,7 +44,15 @@ class AccountMoveSend(models.AbstractModel):
 
     def _get_invoice_extra_attachments(self, invoice):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(invoice) + invoice.l10n_in_edi_attachment_id
+        # Fetch all EDI attachments(eInvoice) related to the invoice.
+        attachemnt = self.env['ir.attachment'].search([
+            ('res_model', '=', invoice._name),
+            ('res_field', '=', 'l10n_in_edi_attachment_file'),
+            ('res_id', '=', invoice.id)
+        ])
+        # If the number of attachments is odd, return the first one (newest eInvoice file created).
+        # If even, return nothing (new eInvoice file not yet created).
+        return super()._get_invoice_extra_attachments(invoice) + (attachemnt[0] if len(attachemnt) % 2 == 1 else attachemnt.browse())
 
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'

--- a/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill/models/l10n_in_ewaybill.py
@@ -141,11 +141,6 @@ class L10nInEwaybill(models.Model):
     cancel_remarks = fields.Char("Cancel remarks", copy=False, tracking=True)
 
     # Attachment
-    attachment_id = fields.Many2one(
-        'ir.attachment',
-        compute=lambda self: self._compute_linked_attachment_id('attachment_id', 'attachment_file'),
-        depends=['attachment_file'],
-    )
     attachment_file = fields.Binary(copy=False, attachment=True)
 
     # ------------Generic compute methods to be overriden in l10n_in_ewaybill_stock module---------------
@@ -190,20 +185,6 @@ class L10nInEwaybill(models.Model):
         return self.account_move_id.is_outbound()
 
     # -------------- Compute Methods ----------------
-
-    def _compute_linked_attachment_id(self, attachment_field, binary_field):
-        """Helper to retreive Attachment from Binary fields
-        This is needed because fields.Many2one('ir.attachment') makes all
-        attachments available to the user.
-        """
-        attachments = self.env['ir.attachment'].search([
-            ('res_model', '=', self._name),
-            ('res_id', 'in', self.ids),
-            ('res_field', '=', binary_field)
-        ])
-        ewb_vals = {att.res_id: att for att in attachments}
-        for ewb in self:
-            ewb[attachment_field] = ewb_vals.get(ewb._origin.id, False)
 
     @api.depends(lambda self: self._get_ewaybill_dependencies())
     def _compute_ewaybill_document_details(self):
@@ -663,9 +644,9 @@ class L10nInEwaybill(models.Model):
         see https://github.com/odoo/upgrade/pull/6624 for futher information
         """
         self.ensure_one()
-        if self.attachment_id:
+        if self.attachment_file:
             try:
-                res_json = json.loads(self.attachment_id.raw.decode("utf-8"))
+                res_json = json.loads(base64.b64decode(self.attachment_file).decode("utf-8"))
             except ValueError:
                 return False
             ewb_name = res_json.get("ewayBillNo") or res_json.get("EwbNo")

--- a/addons/l10n_ro_edi/models/ciusro_document.py
+++ b/addons/l10n_ro_edi/models/ciusro_document.py
@@ -66,7 +66,7 @@ class L10n_Ro_EdiDocument(models.Model):
                 Error -> Sending error or validation error from the SPV.""",
     )
     datetime = fields.Datetime(default=fields.Datetime.now, required=True)
-    attachment_id = fields.Many2one(comodel_name='ir.attachment')
+    attachment_bin = fields.Binary(attachment=True)
     message = fields.Char()
     key_loading = fields.Char(string="E-Factura Index")  # To be used to fetch the status of previously sent XML
     key_signature = fields.Char()    # Received from a successful response: to be saved for government purposes
@@ -197,7 +197,26 @@ class L10n_Ro_EdiDocument(models.Model):
     def action_l10n_ro_edi_download_signature(self):
         """ Download the received successful signature XML file from E-Factura """
         self.ensure_one()
+        attachment = self.env['ir.attachment'].search([
+            ('res_model', '=', self._name),
+            ('res_id', 'in', self.id),
+            ('res_field', '=', 'attachment_bin')
+        ])
         return {
             'type': 'ir.actions.act_url',
-            'url': f'/web/content/{self.attachment_id.id}?download=true',
+            'url': f'/web/content/{attachment.id}?download=true',
         }
+
+    #########################################################################
+    # Helper Methods
+    #########################################################################
+
+    def _set_attachment_name(self,name):
+        attachment = self.env['ir.attachment'].sudo().search([
+            ('res_model', '=', self._name),
+            ('res_id', '=', self.id),
+            ('res_field', '=', 'attachment_bin'),
+        ])
+        attachment.sudo().write({
+            'name': name
+        })

--- a/addons/l10n_ro_edi/views/account_move_views.xml
+++ b/addons/l10n_ro_edi/views/account_move_views.xml
@@ -25,7 +25,7 @@
                               decoration-warning="state == 'invoice_sent'"
                               decoration-success="state == 'invoice_validated'">
                             <field name="message" column_invisible="1"/>
-                            <field name="attachment_id" column_invisible="1"/>
+                            <field name="attachment_bin" column_invisible="1"/>
                             <field name="datetime"/>
                             <field name="state" widget="account_document_state"/>
                             <field name="key_loading" optional="hide"/>
@@ -37,7 +37,7 @@
                             <button name="action_l10n_ro_edi_download_signature"
                                     type="object"
                                     string="Download"
-                                    invisible="not attachment_id"/>
+                                    invisible="not attachment_bin"/>
                         </list>
                     </field>
                 </page>

--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -1,5 +1,6 @@
 from typing import Literal
 
+import base64
 import markupsafe
 import requests
 
@@ -597,19 +598,6 @@ class Picking(models.Model):
 
         return documents_in_state and documents_in_state[0]
 
-    @api.model
-    def _l10n_ro_edi_stock_create_attachment(self, values: dict):
-        data = {
-            'name': f"etransport_{values['name'].replace('/', '_')}.xml",
-            'res_model': 'l10n_ro_edi.document',
-            'res_id': values['res_id'],
-            'raw': values['raw'],
-            'type': 'binary',
-            'mimetype': 'application/xml',
-        }
-
-        return self.env['ir.attachment'].sudo().create(data)
-
     def _l10n_ro_edi_stock_create_document_stock_sent(self, values: dict[str, object]):
         self.ensure_one()
         document = self.env['l10n_ro_edi.document'].create({
@@ -617,13 +605,9 @@ class Picking(models.Model):
             'state': 'stock_sent',
             'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
             'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+            'attachment_bin': base64.b64encode(values['raw_xml']),
         })
-
-        document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
-            'name': self.name,
-            'res_id': document.id,
-            'raw': values['raw_xml'],
-        })
+        document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -638,12 +622,8 @@ class Picking(models.Model):
         })
 
         if 'raw_xml' in values:
-            # when an error is thrown during data validation there will be no 'raw_xml'
-            document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
-                'name': self.name,
-                'res_id': document.id,
-                'raw': values['raw_xml'],
-            })
+            document.attachment_bin = base64.b64encode(values['raw_xml'])
+            document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -654,13 +634,9 @@ class Picking(models.Model):
             'state': 'stock_validated',
             'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
             'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+            'attachment_bin': base64.b64encode(values['raw_xml']),
         })
-
-        document.attachment_id = self._l10n_ro_edi_stock_create_attachment({
-            'name': self.name,
-            'res_id': document.id,
-            'raw': values['raw_xml'],
-        })
+        document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -707,7 +683,7 @@ class Picking(models.Model):
                 document_values |= {
                     'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': last_sent_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(last_sent_document.attachment_bin),
                 }
 
             self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
@@ -719,6 +695,7 @@ class Picking(models.Model):
         )
 
         result = ETransportAPI().upload_data(company_id=self.company_id, data=raw_xml)
+        raw_xml = str(raw_xml).encode()
 
         if 'error' in result:
             document_values = {'message': result['error'], 'raw_xml': raw_xml}
@@ -761,7 +738,7 @@ class Picking(models.Model):
                     'message': '\n'.join(errors),
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 })
                 continue
 
@@ -776,14 +753,14 @@ class Picking(models.Model):
                     'message': result['error'],
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 })
             else:
                 documents_to_delete |= picking._l10n_ro_edi_stock_get_all_documents(('stock_sent', 'stock_sending_failed'))
                 new_document_data = {
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 }
                 match state := result['content']['stare']:
                     case 'ok':

--- a/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
+++ b/addons/l10n_ro_edi_stock/tests/test_etransport_flows.py
@@ -1,3 +1,5 @@
+import base64
+
 from odoo.exceptions import UserError
 from odoo.tests import tagged
 from odoo.tools import misc
@@ -111,7 +113,7 @@ class TestETransportFlows(TestL10nRoEdiStockCommon):
                 tag.attrib['codTarifar'] = self.default_intrastat_code.code
 
         self.assertXmlTreeEqual(
-            self.get_xml_tree_from_string(document.attachment_id.raw),
+            self.get_xml_tree_from_string(base64.b64decode(document.attachment_bin)),
             expected_tree,
         )
 

--- a/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
+++ b/addons/l10n_ro_edi_stock/views/stock_picking_views.xml
@@ -89,7 +89,7 @@
                               decoration-warning="state == 'stock_sent'"
                               decoration-success="state == 'stock_validated'">
                             <field name="message" column_invisible="1"/>
-                            <field name="attachment_id" column_invisible="1"/>
+                            <field name="attachment_bin" column_invisible="1"/>
                             <field name="datetime"/>
                             <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
                             <field name="l10n_ro_edi_stock_uit" string="UIT"/>

--- a/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
+++ b/addons/l10n_ro_edi_stock_batch/models/stock_picking_batch.py
@@ -1,3 +1,4 @@
+import base64
 import markupsafe
 import requests
 
@@ -246,13 +247,9 @@ class StockPickingBatch(models.Model):
             'state': 'stock_sent',
             'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
             'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+            'attachment_bin': base64.b64encode(values['raw_xml']),
         })
-
-        document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
-            'name': self.name,
-            'res_id': document.id,
-            'raw': values['raw_xml'],
-        })
+        document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -267,12 +264,8 @@ class StockPickingBatch(models.Model):
         })
 
         if 'raw_xml' in values:
-            # when an error is thrown during data validation there will be no 'raw_xml'
-            document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
-                'name': self.name,
-                'res_id': document.id,
-                'raw': values['raw_xml'],
-            })
+            document.attachment_bin = base64.b64encode(values['raw_xml'])
+            document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -283,13 +276,9 @@ class StockPickingBatch(models.Model):
             'state': 'stock_validated',
             'l10n_ro_edi_stock_load_id': values['l10n_ro_edi_stock_load_id'],
             'l10n_ro_edi_stock_uit': values['l10n_ro_edi_stock_uit'],
+            'attachment_bin': base64.b64encode(values['raw_xml']),
         })
-
-        document.attachment_id = self.env['stock.picking']._l10n_ro_edi_stock_create_attachment({
-            'name': self.name,
-            'res_id': document.id,
-            'raw': values['raw_xml'],
-        })
+        document._set_attachment_name(f"etransport_{(self.name).replace('/', '_')}.xml")
 
         return document
 
@@ -337,7 +326,7 @@ class StockPickingBatch(models.Model):
                 document_values |= {
                     'l10n_ro_edi_stock_load_id': last_sent_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': last_sent_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': last_sent_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(last_sent_document.attachment_bin),
                 }
 
             self._l10n_ro_edi_stock_create_document_stock_sending_failed(document_values)
@@ -349,6 +338,7 @@ class StockPickingBatch(models.Model):
         )
 
         result = ETransportAPI().upload_data(company_id=self.company_id, data=raw_xml)
+        raw_xml = str(raw_xml).encode()
 
         if 'error' in result:
             self._l10n_ro_edi_stock_get_all_documents('stock_sending_failed').unlink()
@@ -372,7 +362,7 @@ class StockPickingBatch(models.Model):
             else:
                 last_validated = self._l10n_ro_edi_stock_get_last_document('stock_validated')
                 uit = last_validated.l10n_ro_edi_stock_uit
-                raw_xml = last_validated.attachment_id.raw
+                raw_xml = base64.b64decode(last_validated.attachment_bin)
 
             self._l10n_ro_edi_stock_create_document_stock_sent({
                 'l10n_ro_edi_stock_load_id': content['index_incarcare'],
@@ -394,7 +384,7 @@ class StockPickingBatch(models.Model):
                     'message': '\n'.join(errors),
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 })
                 continue
 
@@ -410,14 +400,14 @@ class StockPickingBatch(models.Model):
                     'message': result['error'],
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 })
             else:
                 documents_to_delete |= batch._l10n_ro_edi_stock_get_all_documents(('stock_sent', 'stock_sending_failed'))
                 new_document_data = {
                     'l10n_ro_edi_stock_load_id': current_sending_document.l10n_ro_edi_stock_load_id,
                     'l10n_ro_edi_stock_uit': current_sending_document.l10n_ro_edi_stock_uit,
-                    'raw_xml': current_sending_document.attachment_id.raw,
+                    'raw_xml': base64.b64decode(current_sending_document.attachment_bin),
                 }
                 match state := result['content']['stare']:
                     case 'ok':

--- a/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
+++ b/addons/l10n_ro_edi_stock_batch/views/stock_picking_batch_views.xml
@@ -86,7 +86,7 @@
                            decoration-warning="state == 'stock_sent'"
                            decoration-success="state == 'stock_validated'">
                          <field name="message" column_invisible="1"/>
-                         <field name="attachment_id" column_invisible="1"/>
+                         <field name="attachment_bin" column_invisible="1"/>
                          <field name="datetime"/>
                          <field name="state" string="Status" widget="l10n_ro_edi_stock_document_state"/>
                          <field name="l10n_ro_edi_stock_uit" string="UIT"/>


### PR DESCRIPTION
[IMP] account: Change all Many2One ir.attachment field to Binary field
This is part of a general change for all the many2one ir.attachment fields to
binary in order to avoid security issues as the former would allow access to all
ir.attachment records.

Before:
Attachments were stored using many2one fields pointing to the ir.attachment
model.

Now:
Attachments are stored directly in binary fields within the model, and all
related many2one fields to ir.attachment have been removed.

Module Affected:
l10n_es_edi_facturae
l10n_es_edi_tbai
l10n_ro_edi
l10n_in_ewaybill

task-4771679