### PR TITLE
[FIX] calendar: fix mail activity schedule override

### DIFF
--- a/addons/calendar/wizard/mail_activity_schedule_views.xml
+++ b/addons/calendar/wizard/mail_activity_schedule_views.xml
@@ -18,7 +18,7 @@
             <xpath expr="//field[@name='note']" position="attributes">
                 <attribute name="invisible">activity_category == 'meeting'</attribute>
             </xpath>
-            <xpath expr="//group[@name='summary_group']" position="attributes">
+            <xpath expr="//group[@name='summary_group']|//field[@name='summary']" position="attributes">
                 <attribute name="invisible">activity_category == 'meeting'</attribute>
             </xpath>
             <xpath expr="//field[@name='note']" position="before">


### PR DESCRIPTION
Scheduler view in mail has been updated recently, trigerring an update of calendar view. However this may break installing new calendar override on old mail view. This happens if you have installed mail before the update, and install calendar after pulling updated code.

We therefore update the xpath of override in calendar to be more resilient.

Followup of odoo/odoo#210043
