### PR TITLE
[FIX] crm: fix recurring revenue fields visibility

### DIFF
--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -479,7 +479,7 @@
                                 <field name="priority" class="oe_inline mb-0" nolabel="1" widget="priority"/>
                             </div>
                         </div>
-                        <div class="d-flex align-items-center" colspan="2">
+                        <div class="d-flex align-items-center" colspan="2" groups="crm.group_use_recurring_revenues">
                             <i class="fa fa-refresh" title="Recurring Revenue"/>
                             <div class="o_row">
                                 <field name="recurring_revenue" class="oe_inline mb-0 o_field_highlight" widget="monetary" options="{'currency_field': 'company_currency'}"/>


### PR DESCRIPTION
Fix the recurring revenue fields that were visible in the quick create form even though the recurring revenue option wasn't activated.

The group was missing after a quick create form improvement.

related: odoo/odoo#206314

Task-4796880


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
