### PR TITLE
[IMP] hr_recruitment_survey: expire survey links

### DIFF
--- a/addons/hr_recruitment_survey/controllers/main.py
+++ b/addons/hr_recruitment_survey/controllers/main.py
@@ -10,3 +10,20 @@ class ApplicantSurvey(main.Survey):
             result["applicant_id"] = answer.applicant_id.id
 
         return result
+
+    def _check_validity(
+        self,
+        survey_sudo,
+        answer_sudo,
+        answer_token,
+        ensure_token=True,
+        check_partner=True,
+    ):
+        validity_code = super()._check_validity(
+            survey_sudo, answer_sudo, answer_token, ensure_token, check_partner
+        )
+        if validity_code is not True:
+            return validity_code  # survey is invalid already
+        if answer_sudo.state == 'cancelled':
+            return "survey_closed"
+        return True

--- a/addons/hr_recruitment_survey/models/__init__.py
+++ b/addons/hr_recruitment_survey/models/__init__.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import applicant_refuse_reason
 from . import hr_job
 from . import hr_applicant
 from . import survey_survey
 from . import survey_user_input
+from . import survey_invite

--- a/addons/hr_recruitment_survey/models/applicant_refuse_reason.py
+++ b/addons/hr_recruitment_survey/models/applicant_refuse_reason.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class ApplicantGetRefuseReason(models.TransientModel):
+    _inherit = 'applicant.get.refuse.reason'
+
+    def action_refuse_reason_apply(self):
+        # when refusing applicants, we want to cancel all their surveys
+        refused_applications = self.applicant_ids
+        if self.duplicates:
+            refused_applications |= self.duplicate_applicant_ids
+        refused_applications._cancel_survey_user_inputs()
+        return super().action_refuse_reason_apply()

--- a/addons/hr_recruitment_survey/models/hr_applicant.py
+++ b/addons/hr_recruitment_survey/models/hr_applicant.py
@@ -1,8 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import timedelta
-from odoo import fields, models
+
+from odoo import api, fields, models
 from odoo.exceptions import UserError
+from odoo.fields import Domain
 
 
 class HrApplicant(models.Model):
@@ -10,6 +12,21 @@ class HrApplicant(models.Model):
 
     survey_id = fields.Many2one('survey.survey', related='job_id.survey_id', string="Survey", readonly=True)
     response_ids = fields.One2many('survey.user_input', 'applicant_id', string="Responses")
+
+    def _cancel_survey_user_inputs(self) -> None:
+        """Cancels all open surveys for the applicant(s)"""
+        surveys_to_cancel_domain = Domain.AND([
+            Domain('partner_id', 'in', self.partner_id.ids),
+            Domain('state', 'in', ['new', 'in_progress']),
+        ])
+        self.env['survey.user_input'].search(surveys_to_cancel_domain).write(
+            {'state': 'cancelled'},
+        )
+
+    def action_archive(self):
+        res = super().action_archive()
+        self._cancel_survey_user_inputs()
+        return res
 
     def action_print_survey(self):
         """ If response is available then print this response otherwise print survey form (print template of the survey) """
@@ -72,3 +89,13 @@ class HrApplicant(models.Model):
             'target': 'new',
             'context': local_context,
         }
+
+    def write(self, vals):
+        stage = self.env['hr.recruitment.stage'].browse(vals.get('stage_id'))
+        if stage.hired_stage:
+            self._cancel_survey_user_inputs()
+        return super().write(vals)
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_cancel_user_inputs(self) -> None:
+        self._cancel_survey_user_inputs()

--- a/addons/hr_recruitment_survey/models/survey_invite.py
+++ b/addons/hr_recruitment_survey/models/survey_invite.py
@@ -1,0 +1,10 @@
+from odoo import models
+
+
+class SurveyInvite(models.TransientModel):
+    _inherit = "survey.invite"
+
+    def _get_survey_inputs(self):
+        return self.survey_id.user_input_ids.filtered(
+            lambda s: s.state != 'cancelled',
+        )

--- a/addons/hr_recruitment_survey/models/survey_user_input.py
+++ b/addons/hr_recruitment_survey/models/survey_user_input.py
@@ -8,6 +8,8 @@ class SurveyUser_Input(models.Model):
 
     applicant_id = fields.Many2one('hr.applicant', string='Applicant', index='btree_not_null')
 
+    state = fields.Selection(selection_add=[('cancelled', 'Cancelled')])
+
     def _mark_done(self):
         odoobot = self.env.ref('base.partner_root')
         for user_input in self:

--- a/addons/hr_recruitment_survey/tests/__init__.py
+++ b/addons/hr_recruitment_survey/tests/__init__.py
@@ -1,4 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import test_recruitment_survey
+from . import (
+    survey_link_common,
+    test_recruitment_survey,
+    test_survey_expiration,
+    test_survey_link,
+)

--- a/addons/hr_recruitment_survey/tests/survey_link_common.py
+++ b/addons/hr_recruitment_survey/tests/survey_link_common.py
@@ -1,0 +1,79 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields
+from odoo.tests import tagged
+from odoo.tests.common import HttpCase
+
+
+@tagged('-at_install', 'post_install')
+class SurveyLinkCommon(HttpCase):
+    """Utilities to create and test surveys sent by email to partners/users"""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.certification_survey = cls.env['survey.survey'].create(
+            {
+                'title': 'Flight Certification',
+                'survey_type': 'recruitment',
+                'access_mode': 'token',
+                'certification_mail_template_id': cls.env.ref(
+                    'hr_recruitment_survey.mail_template_applicant_interview_invite',
+                ).id,
+            },
+        )
+        cls.env['survey.question'].create(
+            {
+                'title': 'Can you fly?',
+                'survey_id': cls.certification_survey.id,
+                'sequence': 2,
+                'question_type': 'text_box',
+            },
+        )
+        stage_new, cls.stage_hired = cls.env['hr.recruitment.stage'].create(
+            [
+                {
+                    'name': 'New',
+                    'sequence': 0,
+                    'hired_stage': False,
+                },
+                {
+                    'name': 'Hired',
+                    'sequence': 1,
+                    'hired_stage': True,
+                },
+            ],
+        )
+        job = cls.env['hr.job'].create(
+            {
+                'name': 'Sheep Burner',
+                'no_of_recruitment': 1,
+                'survey_id': cls.certification_survey.id,
+            },
+        )
+        cls.test_applicant = cls.env['hr.applicant'].create(
+            {
+                'partner_name': 'Spyro the Dragon',
+                'email_from': 'spyro@the.dragon',
+                'job_id': job.id,
+                'stage_id': stage_new.id,
+            },
+        )
+
+    def _send_new_survey_and_get_url(self) -> str:
+        send_survey_action = self.test_applicant.action_send_survey()
+        context = send_survey_action['context']
+        wizard = self.env['survey.invite'].with_context(context).create({
+            'survey_id': self.certification_survey.id,
+        })
+        wizard.action_invite()
+
+        user_input = self.env['survey.user_input'].search(
+            [
+                ('partner_id', '=', self.test_applicant.partner_id.id),
+                ('deadline', '>', fields.Datetime.now()),
+            ],
+            order='id desc',
+            limit=1,
+        )
+        return user_input.get_start_url()

--- a/addons/hr_recruitment_survey/tests/test_survey_expiration.py
+++ b/addons/hr_recruitment_survey/tests/test_survey_expiration.py
@@ -1,0 +1,77 @@
+from odoo.tests import tagged
+
+from odoo.addons.hr_recruitment_survey.tests.survey_link_common import (
+    SurveyLinkCommon,
+)
+
+
+@tagged('-at_install', 'post_install')
+class TestSurveyExpiration(SurveyLinkCommon):
+    """
+    Links to surveys should expire, and not be accessible anymore in some
+    specific cases.
+    This suite tests all the cases where surveys should be marked as "cancelled"
+    automatically.
+    """
+
+    def _is_survey_closed(self, survey_url: str) -> bool:
+        survey_closed_text = (
+            "This survey is now closed. Thank you for your interest!"
+        )
+        res = self.url_open(survey_url)
+        self.assertEqual(
+            res.status_code,
+            200,
+            f"url_open did not succeed for survey url at {survey_url}",
+        )
+        return survey_closed_text in res.content.decode('utf-8')
+
+    def test_refuse_expires_survey(self) -> None:
+        survey_url = self._send_new_survey_and_get_url()
+        refuse_reason = self.env['hr.applicant.refuse.reason'].create(
+            [{'name': 'Fired'}],
+        )
+        applicant_get_refuse_reason = self.env[
+            'applicant.get.refuse.reason'
+        ].create(
+            [
+                {
+                    'refuse_reason_id': refuse_reason.id,
+                    'applicant_ids': [self.test_applicant.id],
+                    'duplicates': True,
+                },
+            ],
+        )
+        self.assertFalse(self._is_survey_closed(survey_url))
+        applicant_get_refuse_reason.action_refuse_reason_apply()
+        self.assertTrue(
+            self._is_survey_closed(survey_url),
+            "Refusing an applicant should expire its surveys",
+        )
+
+    def test_archive_expires_survey(self) -> None:
+        survey_url = self._send_new_survey_and_get_url()
+        self.assertFalse(self._is_survey_closed(survey_url))
+        self.test_applicant.action_archive()
+        self.assertTrue(
+            self._is_survey_closed(survey_url),
+            "Archiving an applicant should expire its surveys",
+        )
+
+    def test_hire_applicant_expires_survey(self) -> None:
+        survey_url = self._send_new_survey_and_get_url()
+        self.assertFalse(self._is_survey_closed(survey_url))
+        self.test_applicant.write({'stage_id': self.stage_hired.id})
+        self.assertTrue(
+            self._is_survey_closed(survey_url),
+            "Hiring an applicant should expire its surveys",
+        )
+
+    def test_unlink_expires_survey(self) -> None:
+        survey_url = self._send_new_survey_and_get_url()
+        self.assertFalse(self._is_survey_closed(survey_url))
+        self.test_applicant.unlink()
+        self.assertTrue(
+            self._is_survey_closed(survey_url),
+            "Deleting an applicant should expire its surveys",
+        )

--- a/addons/hr_recruitment_survey/tests/test_survey_link.py
+++ b/addons/hr_recruitment_survey/tests/test_survey_link.py
@@ -1,0 +1,98 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from urllib.parse import urlparse
+from uuid import uuid4
+
+from odoo.tests import tagged
+
+from odoo.addons.hr_recruitment_survey.tests.survey_link_common import (
+    SurveyLinkCommon,
+)
+
+
+@tagged('-at_install', 'post_install')
+class TestSurveyLink(SurveyLinkCommon):
+    """
+    This test suite ensures that survey url permissions behave correctly
+    depending of the url used to access it
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_cynder = cls.env['res.users'].create(
+            {
+                'name': 'Cynder the Dragon',
+                'login': 'cynder',
+                'email': 'cynder@the.dragon',
+            },
+        )
+        cls.closed_survey_txt = (
+            "This survey is now closed. Thank you for your interest!"
+        )
+        cls.survey_access_error_txt = "Survey Access Error"
+
+    def test_unrelated_user_valid_answer_token(self):
+        """
+        A survey with a valid answer_token in its url should be accessible, even
+        if you're logged into an unrelated user.
+        """
+        survey_url = self._send_new_survey_and_get_url()
+        self.authenticate(self.user_cynder.login, self.user_cynder.login)
+        response = self.url_open(survey_url)
+        status_code = response.status_code
+        content = response.content.decode('utf-8')
+        self.assertEqual(
+            status_code,
+            200,
+            f"url_open did not succeed for survey_url at {survey_url}",
+        )
+        self.assertNotIn(
+            self.closed_survey_txt,
+            content,
+            "Survey should not be closed.",
+        )
+        self.assertNotIn(
+            self.survey_access_error_txt,
+            content,
+            "Any user should be able to access the survey if the url contains the correct answer_token",
+        )
+
+    def test_unrelated_user_invalid_answer_token(self):
+        """
+        A survey with an invalid answer_token in its url should display an
+        access error.
+        """
+        survey_url = urlparse(self._send_new_survey_and_get_url())
+        fake_answer_token = uuid4()
+        is_query_answer_token_only = (
+            len(survey_url.query) == len(f'answer_token={fake_answer_token}')
+            and survey_url.query[: len('answer_token=')] == 'answer_token='
+        )
+        self.assertTrue(
+            is_query_answer_token_only,
+            "survey_url should only have a valid answer_token query string parameter",
+        )
+        survey_url = survey_url._replace(
+            query=f'answer_token={fake_answer_token}',
+        )
+        self.authenticate(self.user_cynder.login, self.user_cynder.login)
+        response = self.url_open(survey_url.geturl())
+        status_code = response.status_code
+        content = response.content.decode('utf-8')
+        # the page shows an error, but the HTTP Code is still 200(OK)
+        self.assertEqual(
+            status_code,
+            200,
+            f"url_open did not succeed for survey_url at {survey_url}",
+        )
+        self.assertNotIn(
+            self.closed_survey_txt,
+            content,
+            "Survey should not be closed.",
+        )
+        self.assertIn(
+            self.survey_access_error_txt,
+            content,
+            "Accessing a survey with a wrong answer_token should show an error",
+        )

--- a/addons/hr_recruitment_survey/wizard/__init__.py
+++ b/addons/hr_recruitment_survey/wizard/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import hr_recruitment_survey_invite
+from . import survey_invite

--- a/addons/hr_recruitment_survey/wizard/survey_invite.py
+++ b/addons/hr_recruitment_survey/wizard/survey_invite.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import models
+from odoo.fields import Domain
+
+
+class SurveyInvite(models.TransientModel):
+    _inherit = "survey.invite"
+
+    def _get_existing_answers_domain(self, partners, emails):
+        return Domain.AND([
+            Domain('state', '!=', 'cancelled'),
+            super()._get_existing_answers_domain(partners, emails),
+        ])

--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -87,8 +87,10 @@ class Survey(http.Controller):
         if answer_sudo and answer_sudo.deadline and answer_sudo.deadline < datetime.now():
             return 'answer_deadline'
 
-        if answer_sudo and check_partner:
-            if request.env.user._is_public() and answer_sudo.partner_id and not answer_token:
+        # if there is an answer token (from the url or cookie), then we don't
+        # have to check whether the user doing the request is the correct one.
+        if answer_sudo and check_partner and not answer_token:
+            if request.env.user._is_public() and answer_sudo.partner_id:
                 # answers from public user should not have any partner_id; this indicates probably a cookie issue
                 return 'answer_wrong_user'
             if not request.env.user._is_public() and answer_sudo.partner_id != request.env.user.partner_id:


### PR DESCRIPTION
[IMP] hr_recruitment_survey: expire survey links

There is no need to be able to access survey links when the applicant is
hired, deleted, archived or refused.
To do so, a new "cancelled" state had to be added to the survey
model (survey.user.input), and I used this state to mark the surveys
when doing the aforementioned actions on the applicant.

I made so that a new invite would be always regenerated / sent when
sending it via the wizard, to avoid confusion with the same invite being
resent sometimes.

Survey links would always refuse logged in users that were not the
intended recipient, even if the answer token was correct. Although
opening the url in a private window would allow us to access the survey.
This commit fixes that, allowing anyone to access the survey IF the
answer_token is valid in the URL.

task-4784231