### PR TITLE
[FIX] account: move report name should match report

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -38,6 +38,7 @@ from odoo.tools import (
 )
 from odoo.tools.mail import email_re, email_split, is_html_empty, generate_tracking_message_id
 from odoo.tools.misc import StackMap
+from odoo.tools.safe_eval import safe_eval, time
 
 
 _logger = logging.getLogger(__name__)
@@ -5865,6 +5866,9 @@ class AccountMove(models.Model):
     def _get_invoice_report_filename(self, extension='pdf'):
         """ Get the filename of the generated invoice report with extension file. """
         self.ensure_one()
+        report = self.env['ir.actions.report']._get_report('account.account_invoices')
+        if report.print_report_name:
+            return f"{safe_eval(report.print_report_name, {'object': self, 'time': time}).replace('/', '_')}.{extension}"
         return f"{self.name.replace('/', '_')}.{extension}"
 
     def _get_invoice_proforma_pdf_report_filename(self):


### PR DESCRIPTION
Default pdf report name should match the "print report name" set on the action report

Task 4646733