### PR TITLE
[IMP] web: add a hover effect on `o_priority` class

### DIFF
--- a/addons/web/static/src/views/fields/priority/priority_field.xml
+++ b/addons/web/static/src/views/fields/priority/priority_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PriorityField">
-        <div class="o_priority" role="radiogroup" name="priority" aria-label="Priority">
+        <div class="o_priority opacity-trigger-hover" role="radiogroup" name="priority" aria-label="Priority">
             <t t-foreach="options" t-as="value" t-key="value">
                 <t t-if="!value_first">
                     <t t-if="props.readonly">
@@ -21,7 +21,7 @@
                             href="#"
                             class="o_priority_star fa"
                             role="radio"
-                            t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o'"
+                            t-att-class="value_index lte index ? 'fa-star' : 'fa-star-o opacity-25 opacity-100-hover'"
                             tabindex="0"
                             t-att-data-tooltip="getTooltip(value[1])"
                             t-att-aria-checked="value_index === index ? 'true' : 'false'"


### PR DESCRIPTION
Before this PR, the unchecked star were too emphasized, the goal of this commit is to display their 100% opacity on hover, and de-emphazise them when not hovering.

task-4806002
| Before | After |
|--------|--------|
| ![Screenshot 2025-05-21 at 13 34 37](https://github.com/user-attachments/assets/135808f2-9345-4c41-8b01-56c635dd4e56) | ![Screenshot 2025-05-21 at 13 34 49](https://github.com/user-attachments/assets/9ba96b3d-da2d-4719-8516-7f378e0a54c3) |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
