### PR TITLE
[FIX] web: Odd rows on stripped lists are not highlighted

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -499,6 +499,7 @@
                 $-focus-bg: rgba(var(--#{$variable-prefix}emphasis-color-rgb), #{$table-hover-bg-factor * 2});
 
                 --#{$variable-prefix}table-accent-bg: #{$-focus-bg};
+                --#{$variable-prefix}table-striped-bg: #{$-focus-bg};
             }
         }
 


### PR DESCRIPTION
Current behavior before PR:

When selecting an even row by clicking on it (if it's not opening a record) or by selecting the checkbox and then unchecking it, it will highlight this row. This is only working on even rows but not on odd rows.

Desired behavior after PR is merged:

This fix aims to make even and odd rows work correctly by being highlighted.

task-4809597

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
