### PR TITLE
[IMP] l10n_in_ewaybill_stock: store PDF on eWaybill generation

### DIFF
--- a/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
+++ b/addons/l10n_in_ewaybill_stock/i18n/l10n_in_ewaybill_stock.pot
@@ -1,0 +1,1134 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_in_ewaybill_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-23 09:39+0000\n"
+"PO-Revision-Date: 2025-05-23 09:39+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "%s has been generated"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "&amp;"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.actions.report,print_report_name:l10n_in_ewaybill_stock.action_report_ewaybill
+msgid "'Ewaybill - %s' % (object.document_number)"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "(Vehicle Type is"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- Country is required"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- State is required"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- TIN number not set in state %s"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- Transporter %s does not have a GST Number"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- Vehicle type can not be regular when the transportation mode is ship"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "- Zip code required and should be 6 digits"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid ""
+"<br/>\n"
+"                                            <br/>\n"
+"                                            ::Dispatch From:: <br/><br/>"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid ""
+"<br/>\n"
+"                                            <br/>\n"
+"                                            ::Ship To:: <br/><br/>"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_picking_form_inherit_ewaybill
+msgid "<span class=\"o_stat_text\">e-Waybill / Challan</span>"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "<span>km</span>"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__access_warning
+msgid "Access warning"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Address Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__mode__3
+msgid "Air"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Airway Bill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Airway Bill Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Approx Distance"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Approx Distance:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Barcode"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__partner_bill_from_id
+msgid "Bill From"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Bill From - Dispatch From"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__partner_bill_to_id
+msgid "Bill To"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Bill To - Ship To"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Bill of lading Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Bill of lading No"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__blocking_level
+msgid "Blocking Level"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__mode__1
+msgid "By Road"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "CESS Amount"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "CESS Non.Advol Amt"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "CGST Amount"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#: model:ir.model,name:l10n_in_ewaybill_stock.model_l10n_in_ewaybill_cancel
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_ewaybill_cancel_form
+#, python-format
+msgid "Cancel Ewaybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__cancel_reason
+msgid "Cancel Reason"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__cancel_remarks
+msgid "Cancel Remarks"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Cancel details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Cancel e-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__cancel_reason
+msgid "Cancel reason"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__cancel_remarks
+msgid "Cancel remarks"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__challan
+#, python-format
+msgid "Challan"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Combination of 2 and 3"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__company_id
+msgid "Company"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Company Logo"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__content
+msgid "Content"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_picking_form_inherit_ewaybill
+msgid "Create e-Waybill / Challan"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__create_uid
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__create_date
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__company_currency_id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_stock_move__company_currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__access_url
+msgid "Customer Portal URL"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__cancel_reason__2
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill_cancel__cancel_reason__2
+msgid "Data Entry Mistake"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__document_date
+msgid "Date at which the transfer has been processed or cancelled."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Delivery Challan"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__type_description
+msgid "Description"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.view_ewaybill_cancel_form
+msgid "Discard"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__partner_ship_from_id
+msgid "Dispatch From"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__display_name
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__distance
+msgid "Distance"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__document_number
+msgid "Document"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__document_date
+msgid "Document Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Document Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Document Details:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Document No.:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__type_id
+msgid "Document Type"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "Document number should be set and not more than 16 characters"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Download JSON"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__cancel_reason__1
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill_cancel__cancel_reason__1
+msgid "Duplicate"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "E-WAY BILL Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "E-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Entered By"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Entered Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__blocking_level__error
+#, python-format
+msgid "Error"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__error_message
+msgid "Error Message"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__l10n_in_ewaybill_id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_stock_move__l10n_in_ewaybill_id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_stock_picking__l10n_in_ewaybill_id
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Ewaybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.actions.report,name:l10n_in_ewaybill_stock.action_report_ewaybill
+msgid "Ewaybill / Delivery Challan"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_stock_move__ewaybill_price_unit
+msgid "Ewaybill Price Unit"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/stock_picking.py:0
+#, python-format
+msgid "Ewaybill already created for this picking."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__fiscal_position_id
+msgid "Fiscal Position"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "From"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "GSTIN:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Generate e-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__generated
+msgid "Generated"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Generated By:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Generated Date:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Goods Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "HSN Code"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "HSN code is not set in product %s"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__id
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__id
+msgid "ID"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "IGST Amount"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_error
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "Invalid HSN Code (%s) in product %s"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__supply_type__i
+msgid "Inward"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__is_bill_from_editable
+msgid "Is Bill From Editable"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__is_bill_to_editable
+msgid "Is Bill To Editable"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__is_ship_from_editable
+msgid "Is Ship From Editable"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__is_ship_to_editable
+msgid "Is Ship To Editable"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Item Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Km"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__write_uid
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__write_date
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill_cancel__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Mode"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Mode:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "Only Delivery Challan and Cancelled E-waybill can be reset to pending."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__cancel_reason__3
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill_cancel__cancel_reason__3
+msgid "Order Cancelled"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Other Amt"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__cancel_reason__4
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill_cancel__cancel_reason__4
+msgid "Others"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__supply_type__o
+msgid "Outward"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__vehicle_type__o
+msgid "Over Dimensional Cargo"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#: code:addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py:0
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__state__pending
+#, python-format
+msgid "Pending"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid ""
+"Please generate the E-Waybill or mark the document as a Challan to print it."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/stock_picking.py:0
+#, python-format
+msgid ""
+"Please set HSN code in below products: \n"
+"%s"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__access_url
+msgid "Portal Access URL"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Print"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Product Description"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Quantity"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "RR Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "RR No"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__mode__2
+msgid "Rail"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__vehicle_type__r
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Regular"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Reset to Pending"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "SGST Amount"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__access_token
+msgid "Security Token"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "Set GST Treatment for in %s"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__partner_ship_to_id
+msgid "Ship To"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__mode__4
+msgid "Ship or Ship Cum Road/Rail"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+#, python-format
+msgid ""
+"Somehow this E-waybill has been %s in the government portal before. You can "
+"verify by checking the details into the government "
+"(https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__state
+msgid "Status"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model,name:l10n_in_ewaybill_stock.model_stock_move
+msgid "Stock Move Ewaybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__move_ids
+msgid "Stock Moves"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__picking_id
+msgid "Stock Transfer"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__sub_type_code
+msgid "Sub-type Code"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__supply_type
+msgid "Supply Type"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Tax Rate (C+S+I+Cess+Cess Non Advol)"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Taxable Amount Rs."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_stock_move__ewaybill_tax_ids
+msgid "Taxes"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "The challan can only be generated in the Pending state."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid "This document is being sent by another process already."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "To"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Total Inv. Amt"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Total Taxable Amount"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Transaction Type:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model,name:l10n_in_ewaybill_stock.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Transportation Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Transportation Details (Part B)"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__mode
+msgid "Transportation Mode"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__transporter_id
+msgid "Transporter"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Transporter Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__transportation_doc_date
+msgid "Transporter Doc Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__transportation_doc_no
+msgid "Transporter Doc No"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Transporter Doc and Date:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Transporter ID and Name:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__picking_type_code
+msgid "Type of Operation"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Type:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+#, python-format
+msgid ""
+"Unable to connect to the E-WayBill service.The web service may be temporary "
+"down. Please try again in a moment."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+#, python-format
+msgid ""
+"Unable to send E-waybill.Create an API user in NIC portal, and set it using "
+"the top menu: Configuration > Settings."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Unit Price"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_view
+msgid "Use as Challan"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Valid Upto:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Vehicle / Trans <br/>Doc No &amp; Dt."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "Vehicle Details"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__vehicle_no
+msgid "Vehicle Number"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__vehicle_type
+msgid "Vehicle Type"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields.selection,name:l10n_in_ewaybill_stock.selection__l10n_in_ewaybill__blocking_level__warning
+msgid "Warning"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/tools/ewaybill_api.py:0
+#, python-format
+msgid ""
+"We don't know the error message for this error code. Please contact support."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,help:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#. odoo-python
+#: code:addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py:0
+#, python-format
+msgid ""
+"You cannot delete a generated E-waybill. Instead, you should cancel it."
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "e-Way Bill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.actions.act_window,name:l10n_in_ewaybill_stock.l10n_in_ewaybill_form_action
+#: model:ir.model,name:l10n_in_ewaybill_stock.model_l10n_in_ewaybill
+msgid "e-Waybill"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__ewaybill_date
+msgid "e-Waybill Date"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__name
+msgid "e-Waybill Number"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model:ir.model.fields,field_description:l10n_in_ewaybill_stock.field_l10n_in_ewaybill__ewaybill_expiry_date
+msgid "e-Waybill Valid Upto"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "eway Bill No:"
+msgstr ""
+
+#. module: l10n_in_ewaybill_stock
+#: model_terms:ir.ui.view,arch_db:l10n_in_ewaybill_stock.report_ewaybill
+msgid "km"
+msgstr ""

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -263,6 +263,30 @@ class Ewaybill(models.Model):
             'state': 'challan',
         })
 
+    def action_print(self):
+        self.ensure_one()
+        if self.state in ['pending', 'cancel']:
+            raise UserError(_("Please generate the E-Waybill or mark the document as a Challan to print it."))
+
+        doc_label = _("Challan") if self.state == 'challan' else _("E-Waybill")
+        body = _("%s has been generated", doc_label)
+        filename = "%s - %s.pdf" % (doc_label, self.document_number)
+        pdf_content = self.env['ir.actions.report']._render_qweb_pdf(
+            'l10n_in_ewaybill_stock.action_report_ewaybill', res_ids=[self.id])[0]
+        attachment = self.env['ir.attachment'].create({
+            'name': filename,
+            'type': 'binary',
+            'datas': base64.b64encode(pdf_content),
+            'res_model': 'l10n.in.ewaybill',
+            'res_id': self.id,
+            'mimetype': 'application/pdf',
+        })
+        self.message_post(body=body, attachment_ids=[attachment.id])
+        return {
+            'type': 'ir.actions.act_url',
+            'url': f'/web/content/{attachment.id}?download=true',
+        }
+
     def _is_overseas(self):
         self.ensure_one()
         return self._get_gst_treatment()[1] in ('overseas', 'special_economic_zone')

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -11,6 +11,7 @@
                     <button name="reset_to_pending" string="Reset to Pending" type="object" invisible="not state in ['cancel', 'challan']" data-hotkey="r"/>
                     <button name="action_set_to_challan" string="Use as Challan" type="object" invisible="state != 'pending'" data-hotkey="d"/>
                     <button name="action_export_json" string="Download JSON" class="oe_highlight" type="object" invisible="not error_message" groups="base.group_no_one"/>
+                    <button name="action_print" string="Print" class="oe_highlight" type="object" invisible="not state in ['challan', 'generated']" data-hotkey="f"/>
                     <field name="state" widget="statusbar" statusbar_visible="pending,generated" invisible="state == 'challan'"/>
                 </header>
                 <field name="blocking_level" invisible="1"/>


### PR DESCRIPTION
In this PR:
- A `Print` button allows users to generate the E-Waybill or Challan PDF.
- The PDF is attached to the chatter and gets downloaded.
- Applies only when the document is marked as an E-Waybill or Challan.

Task-4807694

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
