### PR TITLE
[FIX] payment_{asiapay,ogone,payulatam}: remove useless AccountTestInvoicingCommon subclassing

### DIFF
--- a/addons/payment_asiapay/tests/common.py
+++ b/addons/payment_asiapay/tests/common.py
@@ -3,14 +3,13 @@
 from odoo import Command
 
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
-class AsiaPayCommon(AccountTestInvoicingCommon, PaymentCommon):
+class AsiaPayCommon(PaymentCommon):
 
     @classmethod
-    def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref=chart_template_ref)
+    def setUpClass(cls):
+        super().setUpClass()
 
         cls.asiapay = cls._prepare_provider('asiapay', update_values={
             'asiapay_merchant_id': '123456789',

--- a/addons/payment_ogone/tests/common.py
+++ b/addons/payment_ogone/tests/common.py
@@ -1,13 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
-class OgoneCommon(AccountTestInvoicingCommon, PaymentCommon):
+
+class OgoneCommon(PaymentCommon):
 
     @classmethod
-    def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref=chart_template_ref)
+    def setUpClass(cls):
+        super().setUpClass()
 
         cls.ogone = cls._prepare_provider('ogone', update_values={
             'ogone_pspid': 'dummy',

--- a/addons/payment_payulatam/tests/common.py
+++ b/addons/payment_payulatam/tests/common.py
@@ -1,14 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.payment.tests.common import PaymentCommon
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
-class PayULatamCommon(AccountTestInvoicingCommon, PaymentCommon):
+class PayULatamCommon(PaymentCommon):
 
     @classmethod
-    def setUpClass(cls, chart_template_ref=None):
-        super().setUpClass(chart_template_ref=chart_template_ref)
+    def setUpClass(cls):
+        super().setUpClass()
 
         cls.payulatam = cls._prepare_provider('payulatam', update_values={
             'payulatam_account_id': 'dummy',


### PR DESCRIPTION
Some tests are failing when account isn't installed because they extend
AccountTestInvoicingCommon but they have no dependencies on account:

ValueError: External ID not found in the system: account.group_account_manager

Each addon contains a test
`test_reference_is_computed_based_on_document_name` that is already
skipped if account_payment is not installed.

Similar to https://github.com/odoo/odoo/commit/d844fef414fbd6f59089ce3f0dca34895badfa33

runbot-163120
runbot-163121
runbot-163122
runbot-163161
runbot-163162