### PR TITLE
[REF] web: make autocomplete use navigation hook

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -4,7 +4,15 @@ import { isScrollableY, scrollTo } from "@web/core/utils/scrolling";
 import { useDebounced } from "@web/core/utils/timing";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { usePosition } from "@web/core/position/position_hook";
-import { Component, onWillUpdateProps, useExternalListener, useRef, useState } from "@odoo/owl";
+import {
+    Component,
+    onWillUpdateProps,
+    useEffect,
+    useExternalListener,
+    useRef,
+    useState,
+} from "@odoo/owl";
+import { useNavigation } from "@web/core/navigation/navigation";
 import { mergeClasses } from "@web/core/utils/classname";
 
 export class AutoComplete extends Component {
@@ -105,7 +113,7 @@ export class AutoComplete extends Component {
 
         useExternalListener(window, "scroll", this.externalClose, true);
         useExternalListener(window, "pointerdown", this.externalClose, true);
-        useExternalListener(window, "mousemove", () => this.mouseSelectionActive = true, true);
+        useExternalListener(window, "mousemove", () => (this.mouseSelectionActive = true), true);
 
         this.hotkey = useService("hotkey");
         this.hotkeysToRemove = [];
@@ -127,6 +135,8 @@ export class AutoComplete extends Component {
         } else {
             this.open(false);
         }
+
+        this.setupNavigation();
     }
 
     get targetDropdown() {
@@ -219,7 +229,8 @@ export class AutoComplete extends Component {
         }
 
         await Promise.all(proms);
-        this.navigate(0);
+        this.navigator.update();
+        this.navigator.items[1]?.setActive();
         this.scroll();
     }
     get displayOptions() {
@@ -274,53 +285,85 @@ export class AutoComplete extends Component {
         this.close();
     }
 
-    navigate(direction) {
-        let step = Math.sign(direction);
-        if (!step) {
-            this.state.activeSourceOption = null;
-            step = 1;
-        } else {
+    setupNavigation() {
+        const onArrow = (navigator, action) => {
             this.state.navigationRev++;
-        }
-
-        do {
-            if (this.state.activeSourceOption) {
-                let [sourceIndex, optionIndex] = this.state.activeSourceOption;
-                let source = this.sources[sourceIndex];
-
-                optionIndex += step;
-                if (0 > optionIndex || optionIndex >= source.options.length) {
-                    sourceIndex += step;
-                    source = this.sources[sourceIndex];
-
-                    while (source && source.isLoading) {
-                        sourceIndex += step;
-                        source = this.sources[sourceIndex];
-                    }
-
-                    if (source) {
-                        optionIndex = step < 0 ? source.options.length - 1 : 0;
-                    }
-                }
-
-                this.state.activeSourceOption = source ? [sourceIndex, optionIndex] : null;
+            if (this.isOpened) {
+                navigator[action]();
             } else {
-                let sourceIndex = step < 0 ? this.sources.length - 1 : 0;
-                let source = this.sources[sourceIndex];
-
-                while (source && source.isLoading) {
-                    sourceIndex += step;
-                    source = this.sources[sourceIndex];
-                }
-
-                if (source) {
-                    const optionIndex = step < 0 ? source.options.length - 1 : 0;
-                    if (optionIndex < source.options.length) {
-                        this.state.activeSourceOption = [sourceIndex, optionIndex];
-                    }
-                }
+                this.open(true);
             }
-        } while (this.activeOption?.unselectable);
+        };
+
+        this.navigator = useNavigation(this.listRef, {
+            virtualFocus: true,
+            activeClass: "ui-state-active",
+            getItems: () => {
+                const items = [];
+                if (this.inputRef.el) {
+                    items.push(this.inputRef.el);
+                }
+                if (this.listRef.el) {
+                    items.push(
+                        ...this.listRef.el.querySelectorAll(
+                            ":scope .o-autocomplete--dropdown-item a[role=option]"
+                        )
+                    );
+                }
+                return items;
+            },
+            /**
+             * @param {import("@web/core/navigation/navigation").Navigator} navigator
+             */
+            onNavigated: (navigator) => {
+                const el = navigator.activeItem && navigator.activeItem.el;
+                if (el && el.hasAttributes("data-source") && el.hasAttribute("data-option")) {
+                    const sourceIndex = parseInt(el.dataset.source);
+                    const optionIndex = parseInt(el.dataset.option);
+                    this.state.activeSourceOption = [sourceIndex, optionIndex];
+                    this.inputRef.el.setAttribute(
+                        "aria-activedescendant",
+                        this.activeSourceOptionId
+                    );
+                } else {
+                    this.state.activeSourceOption = null;
+                    this.inputRef.el.removeAttribute("aria-activedescendant");
+                }
+            },
+            hotkeys: {
+                arrowup: {
+                    callback: (navigator) => onArrow(navigator, "previous"),
+                },
+                arrowdown: {
+                    callback: (navigator) => onArrow(navigator, "next"),
+                },
+                escape: {
+                    isAvailable: () => this.isOpened,
+                    callback: () => this.cancel(),
+                },
+                tab: {
+                    isAvailable: () => false,
+                    callback: () => {},
+                },
+                "shift+tab": {
+                    isAvailable: () => false,
+                    callback: () => {},
+                },
+                enter: {
+                    isAvailable: () => false,
+                    callback: () => {},
+                },
+            },
+        });
+
+        useEffect(
+            (listEl) => {
+                if (listEl) {
+                    this.navigator?.items[1]?.setActive();
+                }
+            },
+            () => [this.listRef.el]
+        );
     }
 
     onInputBlur() {
@@ -380,81 +423,52 @@ export class AutoComplete extends Component {
 
     async onInputKeydown(ev) {
         const hotkey = getActiveHotkey(ev);
-        const isSelectKey = hotkey === "enter" || hotkey === "tab";
+        const isSelectKey = ["enter", "tab"].includes(hotkey);
 
         if (this.loadingPromise && isSelectKey) {
             if (hotkey === "enter") {
                 ev.stopPropagation();
                 ev.preventDefault();
             }
-
             await this.loadingPromise;
         }
 
+        const trySelectActiveOption = () => {
+            if (this.activeOption) {
+                this.selectOption(this.activeOption);
+                return true;
+            } else {
+                const firstOption = this.sources[0]?.options[0];
+                if (firstOption) {
+                    this.selectOption(firstOption);
+                    return true;
+                }
+            }
+            return false;
+        };
+
         switch (hotkey) {
             case "enter":
-                if (!this.isOpened || !this.state.activeSourceOption) {
-                    return;
+                if (trySelectActiveOption()) {
+                    ev.stopPropagation();
+                    ev.preventDefault();
                 }
-                this.selectOption(this.activeOption);
-                break;
-            case "escape":
-                if (!this.isOpened) {
-                    return;
-                }
-                this.cancel();
                 break;
             case "tab":
             case "shift+tab":
-                if (!this.isOpened) {
-                    return;
-                }
                 if (
                     this.props.autoSelect &&
-                    this.state.activeSourceOption &&
                     (this.state.navigationRev > 0 || this.inputRef.el.value.length > 0)
                 ) {
-                    this.selectOption(this.activeOption);
+                    trySelectActiveOption();
                 }
                 this.close();
-                return;
-            case "arrowup":
-                this.navigate(-1);
-                if (!this.isOpened) {
-                    this.open(true);
-                }
-                this.scroll();
-                break;
-            case "arrowdown":
-                this.navigate(+1);
-                if (!this.isOpened) {
-                    this.open(true);
-                }
-                this.scroll();
                 break;
             default:
-                return;
-        }
-
-        ev.stopPropagation();
-        ev.preventDefault();
-    }
-
-    onOptionMouseEnter(indices) {
-        if (!this.mouseSelectionActive) {
-            return;
-        }
-
-        const [sourceIndex, optionIndex] = indices;
-        if (this.sources[sourceIndex].options[optionIndex]?.unselectable) {
-            this.state.activeSourceOption = null;
-        } else {
-            this.state.activeSourceOption = indices;
+                break;
         }
     }
-    onOptionMouseLeave() {
-        this.state.activeSourceOption = null;
-    }
+
     onOptionClick(option) {
         this.selectOption(option);
         this.inputRef.el.focus();

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -52,8 +52,6 @@
                                 <li
                                     class="o-autocomplete--dropdown-item ui-menu-item d-block"
                                     t-att-class="option.cssClass"
-                                    t-on-mouseenter="() => this.onOptionMouseEnter([source_index, option_index])"
-                                    t-on-mouseleave="() => this.onOptionMouseLeave([source_index, option_index])"
                                     t-on-click="() => this.onOptionClick(option)"
                                     t-on-pointerdown="(ev) => this.onOptionPointerDown(option, ev)"
                                 >
@@ -64,6 +62,8 @@
                                         t-att-href="!option.unselectable and '#'"
                                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
+                                        t-att-data-source="source_index"
+                                        t-att-data-option="option_index"
                                     >
                                         <t t-slot="{{ source.optionSlot }}" label="option.label" data="option.data">
                                             <t t-out="option.label"/>

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -19,7 +19,6 @@
                 t-on-click="onInputClick"
                 t-on-change="onInputChange"
                 t-on-input="onInput"
-                t-on-keydown="onInputKeydown"
                 t-on-focus="onInputFocus"
                 t-ref="input"
             />
@@ -28,7 +27,9 @@
                     role="menu"
                     class="o-autocomplete--dropdown-menu ui-widget show"
                     t-att-class="ulDropdownClass"
-                    t-ref="sourcesList">
+                    t-ref="sourcesList"
+                    t-on-mouseleave="onMouseLeave"
+                >
                     <t t-foreach="sources" t-as="source" t-key="source.id">
                         <t t-if="source.isLoading">
                             <li class="ui-menu-item"

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -70,8 +70,8 @@ class NavigationItem {
     setActive(focus = true) {
         scrollTo(this.target);
         this._navigator._setActiveItem(this.index);
-        this.target.classList.add(ACTIVE_ELEMENT_CLASS);
         this.target.ariaSelected = true;
+        this.target.classList.add(this._options.activeClass);
 
         if (focus && !this._options.virtualFocus) {
             throttledFocus.cancel();
@@ -80,7 +80,7 @@ class NavigationItem {
     }
 
     setInactive(blur = true) {
-        this.target.classList.remove(ACTIVE_ELEMENT_CLASS);
+        this.target.classList.remove(this._options.activeClass);
         this.target.ariaSelected = false;
         if (blur && !this._options.virtualFocus) {
             this.target.blur();
@@ -124,6 +124,7 @@ export class Navigator {
                 isNavigationAvailable: ({ target }) => this.contains(target),
                 shouldFocusChildInput: true,
                 virtualFocus: false,
+                activeClass: ACTIVE_ELEMENT_CLASS,
                 hotkeys: {
                     home: () => this.items[0]?.setActive(),
                     end: () => this.items.at(-1)?.setActive(),
@@ -282,6 +283,7 @@ export class Navigator {
         this.activeItem?.setInactive(false);
         this.activeItem = this.items[index];
         this.activeItemIndex = index;
+        this._options.onNavigated?.(this);
     }
 
     /**
@@ -307,6 +309,8 @@ export class Navigator {
  * focused so the actual focus can be kept on another input.
  * @property {Boolean} [shouldFocusChildInput=false] - If true, elements like inputs or buttons
  * inside of the items are focused instead of the items themselves.
+ * @property {string} activeClass - CSS class which is added on the currently
+ * active element.
  */
 
 /**

--- a/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
+++ b/addons/web/static/src/core/record_selectors/tag_navigation_hook.js
@@ -33,6 +33,10 @@ export function useTagNavigation(refName, options = {}) {
     };
 
     const canNavigateFromInput = (navigator, navNext) => {
+        if (!navigator.activeItem) {
+            return false;
+        }
+
         const el = navigator.activeItem.el;
         if (el.classList.contains("o-autocomplete--input")) {
             const menu = tagsContainerRef.el.querySelector(".o-autocomplete--dropdown-menu");

--- a/addons/web/static/tests/core/autocomplete.test.js
+++ b/addons/web/static/tests/core/autocomplete.test.js
@@ -1,8 +1,8 @@
 import { expect, test } from "@odoo/hoot";
 import {
-    hover,
     isInViewPort,
     isScrollable,
+    manuallyDispatchProgrammaticEvent,
     pointerDown,
     pointerUp,
     press,
@@ -673,8 +673,10 @@ test("autocomplete scrolls when moving with arrows", async () => {
     const msgNotInView = "item should not be in view within dropdown";
     await mountWithCleanup(Parent);
     expect(".o-autocomplete input").toHaveCount(1);
-    // Open with arrow key.
+    // Open with arrow key.s
     await contains(".o-autocomplete input").focus();
+    await animationFrame();
+    await runAllTimers();
     await press("ArrowDown");
     await animationFrame();
     expect(".o-autocomplete--dropdown-item").toHaveCount(5);
@@ -757,6 +759,7 @@ test("unselectable options are... not selectable", async () => {
 
     await mountWithCleanup(Parent);
     await contains(`.o-autocomplete input`).click();
+    await animationFrame();
     expect(`.o-autocomplete--input`).toHaveAttribute("aria-activedescendant", "autocomplete_0_1");
     expect(`.dropdown-item#autocomplete_0_1`).toHaveText("selectable");
     expect(`.dropdown-item#autocomplete_0_1`).toHaveAttribute("aria-selected", "true");

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -944,6 +944,7 @@ test("input and remove text without selecting any tag or option on desktop", asy
     await hover(".o-autocomplete--dropdown-item:eq(0)");
     await hover(".o_form_renderer");
     await press("Tab");
+    await runAllTimers();
 
     // ensure we're not adding any value
     expect(".modal").toHaveCount(0);


### PR DESCRIPTION
This commit makes it so the AutoComplete component uses the navigation hook.

This slightly simplifies the autocomplete code but is also done in preparation to make the component use the dropdowns system.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
