### PR TITLE
[IMP] purchase_requisition: remove has alternative column

### DIFF
--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -32,15 +32,6 @@ class PurchaseOrder(models.Model):
         domain="[('id', '!=', id), ('state', 'in', ['draft', 'sent', 'to approve'])]",
         string="Alternative POs", check_company=True,
         help="Other potential purchase orders for purchasing products")
-    has_alternatives = fields.Boolean(
-        "Has Alternatives", compute='_compute_has_alternatives',
-        help="Whether or not this purchase order is linked to another purchase order as an alternative.")
-
-    @api.depends('purchase_group_id')
-    def _compute_has_alternatives(self):
-        self.has_alternatives = False
-        if self.env.user.has_group('purchase_requisition.group_purchase_alternatives'):
-            self.filtered(lambda po: po.purchase_group_id).has_alternatives = True
 
     @api.onchange('requisition_id')
     def _onchange_requisition_id(self):

--- a/addons/purchase_requisition/views/purchase_views.xml
+++ b/addons/purchase_requisition/views/purchase_views.xml
@@ -61,11 +61,6 @@
         <field name="inherit_id" ref="purchase.purchase_order_tree"/>
         <field name="arch" type="xml">
             <field name="name" position="before">
-                <field name="has_alternatives" column_invisible="True"/>
-                <button class="fa fa-copy"
-                    title="Has Alternatives"
-                    disabled="1"
-                    invisible="not has_alternatives"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
- Linking an existing RFQ list is different than the PO list.

**Desired behavior after PR is merged:**
- Matching UI for Linking an Existing RFQ and the PO list by removing has_alternative column that was previously removed from the PO list to ensure consistency.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
