### PR TITLE
[FIX] core: comply to PDF/A with pypdf2.2

### DIFF
--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -27,9 +27,9 @@ except ImportError:
 # might be a good case for exception groups
 error = None
 # keep pypdf2 2.x first so noble uses that rather than pypdf 4.0
-for submod in ['._pypdf2_2', '._pypdf', '._pypdf2_1']:
+for SUBMOD in ['._pypdf2_2', '._pypdf', '._pypdf2_1']:
     try:
-        pypdf = importlib.import_module(submod, __spec__.name)
+        pypdf = importlib.import_module(SUBMOD, __spec__.name)
         break
     except ImportError as e:
         if error is None:
@@ -315,24 +315,36 @@ class OdooPdfFileWriter(PdfFileWriter):
         self._reader = None
         self.is_pdfa = False
 
+    def format_subtype(self, subtype):
+        """
+        Apply the correct format to the subtype.
+        It should take the form of "/xxx#2Fxxx". E.g. for "text/xml": "/text#2Fxml"
+        :param subtype: The mime-type of the attachement.
+        """
+        if not subtype:
+            return subtype
+
+        adapted_subtype = subtype
+        if REGEX_SUBTYPE_UNFORMATED.match(subtype):
+            # _pypdf2_2 does the formating when creating a NameObject
+            if SUBMOD == '._pypdf2_2':
+                return '/' + subtype
+            adapted_subtype = '/' + subtype.replace('/', '#2F')
+
+        if not REGEX_SUBTYPE_FORMATED.match(adapted_subtype):
+            # The subtype still does not match the correct format, so we will not add it to the document
+            _logger.warning("Attempt to add an attachment with the incorrect subtype '%s'. The subtype will be ignored.", subtype)
+            adapted_subtype = ''
+        return adapted_subtype
+
     def add_attachment(self, name, data, subtype=None):
         """
         Add an attachment to the pdf. Supports adding multiple attachment, while respecting PDF/A rules.
         :param name: The name of the attachement
         :param data: The data of the attachement
         :param subtype: The mime-type of the attachement. This is required by PDF/A, but not essential otherwise.
-        It should take the form of "/xxx#2Fxxx". E.g. for "text/xml": "/text#2Fxml"
         """
-        adapted_subtype = subtype
-        if subtype:
-            # If we receive the subtype in an 'unformated' (mimetype) format, we'll try to convert it to a pdf-valid one
-            if REGEX_SUBTYPE_UNFORMATED.match(subtype):
-                adapted_subtype = '/' + subtype.replace('/', '#2F')
-
-            if not REGEX_SUBTYPE_FORMATED.match(adapted_subtype):
-                # The subtype still does not match the correct format, so we will not add it to the document
-                _logger.warning("Attempt to add an attachment with the incorrect subtype '%s'. The subtype will be ignored.", subtype)
-                adapted_subtype = ''
+        adapted_subtype = self.format_subtype(subtype)
 
         attachment = self._create_attachment_object({
             'filename': name,
@@ -396,7 +408,7 @@ class OdooPdfFileWriter(PdfFileWriter):
                 # only need this if running on 1.x
                 #
                 # incidentally that means the heuristic above is completely broken
-                if submod == '._pypdf2_1':
+                if SUBMOD == '._pypdf2_1':
                     self._header += second_line
         # clone_reader_document_root clones reader._ID since 3.2 (py-pdf/pypdf#1520)
         if not hasattr(self, '_ID'):
@@ -424,8 +436,10 @@ class OdooPdfFileWriter(PdfFileWriter):
         # where 'n' is a single digit number between 0 (30h) and 7 (37h) "
         # " The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four
         # bytes, each of whose encoded byte values shall have a decimal value greater than 127 "
-        self._header = b"%PDF-1.7\n"
-        if submod == '._pypdf2_1':
+        self._header = b"%PDF-1.7"
+        if SUBMOD != '._pypdf2_2':
+            self._header += b"\n"
+        if SUBMOD == '._pypdf2_1':
             self._header += b"%\xDE\xAD\xBE\xEF"
 
         # Add a document ID to the trailer. This is only needed when using encryption with regular PDF, but is required


### PR DESCRIPTION
### Steps to reproduce:
- On a contact, add the "Factur-X" E-Invoicing method under the "Accounting" tab
- Create an invoice with this contact as the customer
- Send the invoice, download the PDF
- Verify the PDF. For example with https://demo.verapdf.org/
- `The aforementioned EOL marker shall be immediately followed by a % (25h) character followed by at least four bytes, each of whose encoded byte values shall have a decimal value greater than 127`
- `The MIME type of an embedded file, or a subset of a file, shall be specified using the Subtype key of the file specification dictionary. If the MIME type is not known, the "application/octet-stream" shall be used`

### Cause:
- 1
Pypdf 2.2 is [adding the necessary binary](https://github.com/py-pdf/pypdf/commit/036789a4664e3f572292bc7dceec10f08b7dbf62) like Odoo [does](https://github.com/odoo/odoo/blob/c1679123c9c6f7184293befb399de1e79a6205a9/odoo/tools/pdf/__init__.py#L471) for Pypdf2.1 because it is mandatory for PDF/A.

The issue comes from two line break following each others:
Pypdf2.2 adds one at the beginning of the [file](https://github.com/py-pdf/pypdf/blob/036789a4664e3f572292bc7dceec10f08b7dbf62/PyPDF2/pdf.py#L487): 
`\n % E2 E3 CF D3`
Then Odoo [adds the header `%PDF-1.7\n` before](https://github.com/odoo/odoo/blob/c1679123c9c6f7184293befb399de1e79a6205a9/odoo/tools/pdf/__init__.py#L469) resulting in :
`b"%PDF-1.7" \n \n % E2 E3 CF D3`
PDF/A expects to have `% E2 E3 CF D3` on the second line right after the header but there is nothing on this line.

- 2
The Subtype is badly formatted: from `text/xml` to `/text#232Fxml` instead of `/text#2Fxml`

This occurs as Odoo [replace `/` by `#2F`](https://github.com/odoo/odoo/blob/2e43bee546d5c14729d654386209b539d8aa71d7/odoo/tools/pdf/__init__.py#L369-L377).
But then when [adding the subtype](https://github.com/odoo/odoo/blob/2e43bee546d5c14729d654386209b539d8aa71d7/odoo/tools/pdf/__init__.py#L595C17-L595C74) to the attachment, we call `NameObject` from PyPdf. This object will [format](https://github.com/py-pdf/pypdf/blob/1c4173a12cd21b91dff6d6596ed0bbf1999f2d10/PyPDF2/generic/_base.py#L548) the text again replacing the `#` by `#23`. 

### Solution:
- Don't add a `\n` after `%PDF-1.7` when using `_pypdf2_2`.

- As PyPdf2.2 is doing the formatting itself, we don't format on our side if `submod == ._pypdf2_2`. 
We still need to add the `/`.

opw-4748600