### PR TITLE
[IMP] mail: improve system internal-note entry

### DIFF
--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -10,11 +10,11 @@
                         </p>
                     </t>
                     <t t-if="message.trackingValues.length">
-                        <ul class="mb-0 ps-4">
+                        <ul t-attf-class="mb-0 {{ message.trackingValues.length > 1 ? 'ps-4' : 'list-unstyled' }}">
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
-                                    <span class="o-mail-Message-trackingOld me-1 px-1 text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.oldValue)"/>
-                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-1 text-600"/>
+                                    <span class="o-mail-Message-trackingOld text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.oldValue)"/>
+                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
                                     <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldType, trackingValue.newValue)"/>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.changedField"/>)</span>
                                 </li>


### PR DESCRIPTION
This PR removes the bullet when there is only one entry in the system's internal note change messages and gives a more balanced space around the arrow because before there was more space on the left.

task-4798292

| Before | After |
|--------|--------|
| <img width="383" alt="journal-entry-before" src="https://github.com/user-attachments/assets/e0cbcd8e-65b6-4760-8692-e32a2931aaf0" /> | <img width="258" alt="journal-entry-after" src="https://github.com/user-attachments/assets/d58b357c-3d82-4334-87cb-5948d36a6455" /> | 

---



I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
