### PR TITLE
[PERF] point_of_sale: avoid loading pricelist record with items

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -205,7 +205,6 @@ class PosSession(models.Model):
         }
 
     def get_pos_ui_product_pricelist_item_by_product(self, product_tmpl_ids, product_ids, config_id):
-        pricelist_fields = self.env['product.pricelist']._load_pos_data_fields(config_id)
         pricelist_item_fields = self.env['product.pricelist.item']._load_pos_data_fields(config_id)
 
         pricelist_item_domain = [
@@ -218,12 +217,8 @@ class PosSession(models.Model):
         ]
 
         pricelist_item = self.env['product.pricelist.item'].search(pricelist_item_domain)
-        pricelist = pricelist_item.pricelist_id
 
-        return {
-            'product.pricelist.item': pricelist_item.read(pricelist_item_fields, load=False),
-            'product.pricelist': pricelist.read(pricelist_fields, load=False)
-        }
+        return {'product.pricelist.item': pricelist_item.read(pricelist_item_fields, load=False)}
 
     @api.depends('currency_id', 'company_id.currency_id')
     def _compute_is_in_company_currency(self):


### PR DESCRIPTION
Before this commit, loading missing pricelist items would also resend the entire pricelist record, even though pricelist records are already loaded at the beginning. This caused unnecessary data transfer and slower performance, especially when pricelists contained many items.

opw-4812031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
