### PR TITLE
[FIX] html_editor: link popover test cases when url is empty

### DIFF
--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1248,3 +1248,44 @@ describe("apply button should be disabled when the URL is empty", () => {
         expect(".o_we_apply_link").toHaveAttribute("disabled");
     });
 });
+
+describe("link popover with empty URL", () => {
+    test("should not close the popover when pressing Enter with an empty URL", async () => {
+        const { editor } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "/link");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Link");
+        await click(".o-we-command-name:first");
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover").toHaveCount(1);
+        await contains(".o-we-linkpopover input.o_we_label_link").fill("label");
+        await click(".o-we-linkpopover input.o_we_href_input_link");
+        await press("Enter");
+        await animationFrame();
+        expect(".o-we-linkpopover").toHaveCount(1);
+    });
+    test("should close the popover and not create a link when clicking outside the popover when link URL is empty", async () => {
+        const { editor, el } = await setupEditor("<p>ab[]</p>");
+        await insertText(editor, "/link");
+        await animationFrame();
+        expect(".active .o-we-command-name").toHaveText("Link");
+        await click(".o-we-command-name:first");
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover").toHaveCount(1);
+        await contains(".o-we-linkpopover input.o_we_label_link").fill("label");
+        await click(el);
+        await animationFrame();
+        expect(".o-we-linkpopover").toHaveCount(0);
+        expect(getContent(el)).toBe("<p>[]ab</p>");
+    });
+    test("when edit a link URL to '', and clicking outside the link popover should remove the existing link", async () => {
+        const { el } = await setupEditor('<p>this is a <a href="http://test.com/">li[]nk</a></p>');
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await contains(".o-we-linkpopover input.o_we_href_input_link").clear();
+        await click(el);
+        await animationFrame();
+        expect(".o-we-linkpopover").toHaveCount(0);
+        expect(cleanLinkArtifacts(getContent(el))).toBe("<p>[]this is a link</p>");
+    });
+});


### PR DESCRIPTION
Added missing test cases not included in commit [1].

- Clicking outside the link popover should close the link popover without creating a link when URL is empty.
- After clearing the link URL, clicking outside the popover should remove the existing link.
- Pressing Enter inside the popover with an empty URL should not close the link popover.

[1]: https://github.com/odoo/odoo/commit/8c49168b0a19853b88078462f8d61863ddb8c979
