### PR TITLE
[FIX] html_editor: allow double click link edit

### DIFF
--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -201,7 +201,9 @@ export class SelectionPlugin extends Plugin {
             }
         });
         this.addDomListener(this.editable, "mousedown", (ev) => {
-            if (ev.detail >= 3) {
+            if (ev.detail === 2) {
+                this.correctDoubleClick = true;
+            } else if (ev.detail >= 3) {
                 this.correctTripleClick = true;
             }
             this.handleEmptySelection();
@@ -277,6 +279,31 @@ export class SelectionPlugin extends Plugin {
                 if (focusOffset === 0 && anchorNode !== focusNode) {
                     [focusNode, focusOffset] = endPos(previousLeaf(focusNode));
                     return this.setSelection({ anchorNode, anchorOffset, focusNode, focusOffset });
+                }
+            }
+            if (this.correctDoubleClick) {
+                this.correctDoubleClick = false;
+                const { anchorNode, anchorOffset, focusNode } = this.activeSelection;
+                const anchorElement = closestElement(anchorNode);
+                // Allow editing the text of a link after "double click" on the last word of said link.
+                // This is done by correcting the selection focus inside of the link
+                if (
+                    anchorElement.tagName === "A" &&
+                    anchorNode !== focusNode &&
+                    focusNode.previousSibling === anchorElement
+                ) {
+                    const anchorElementLength = anchorElement.childNodes.length;
+
+                    // Due to the ZWS added around links we can always expect
+                    // the last childNode to be a ZWS in its own textNode.
+                    // therefore we can safely set the selection focus before last node.
+                    const newSelection = {
+                        anchorNode: anchorNode,
+                        anchorOffset: anchorOffset,
+                        focusNode: anchorElement,
+                        focusOffset: anchorElementLength - 1,
+                    };
+                    return this.setSelection(newSelection);
                 }
             }
 

--- a/addons/html_editor/static/tests/_helpers/selection.js
+++ b/addons/html_editor/static/tests/_helpers/selection.js
@@ -1,3 +1,5 @@
+import { manuallyDispatchProgrammaticEvent, animationFrame } from "@odoo/hoot-dom";
+
 /**
  * @param {Node} node
  * @param {Object} options
@@ -213,4 +215,43 @@ function visitAndSetRange(target, ref, configSelection) {
             }
         }
     }
+}
+
+export async function firstClick(target) {
+    manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 1 });
+    setSelection({ anchorNode: target, anchorOffset: 0 });
+    await animationFrame(); // selectionChange
+    manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 1 });
+    manuallyDispatchProgrammaticEvent(target, "click", { detail: 1 });
+    await animationFrame();
+}
+
+export async function secondClick(target) {
+    manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 2 });
+    const document = target.ownerDocument;
+    document.getSelection().modify("extend", "forward", "word");
+    await animationFrame(); // selectionChange
+    manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 2 });
+    manuallyDispatchProgrammaticEvent(target, "click", { detail: 2 });
+    await animationFrame();
+}
+
+export async function thirdClick(target) {
+    manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 3 });
+    const document = target.ownerDocument;
+    document.getSelection().modify("extend", "forward", "paragraphboundary");
+    await animationFrame(); // selectionChange
+    manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 3 });
+    manuallyDispatchProgrammaticEvent(target, "click", { detail: 3 });
+    await animationFrame();
+}
+
+export async function simulateDoubleClickSelect(target) {
+    await firstClick(target);
+    await secondClick(target);
+}
+export async function simulateTripleClickSelect(target) {
+    await firstClick(target);
+    await secondClick(target);
+    await thirdClick(target);
 }

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -33,6 +33,11 @@ import {
     moveSelectionOutsideEditor,
     setContent,
     setSelection,
+    simulateDoubleClickSelect,
+    simulateTripleClickSelect,
+    firstClick,
+    secondClick,
+    thirdClick,
 } from "./_helpers/selection";
 import { strong } from "./_helpers/tags";
 import { delay } from "@web/core/utils/concurrency";
@@ -625,9 +630,7 @@ test("toolbar correctly show namespace button group and stop showing when namesp
             toolbar_namespaces: [
                 {
                     id: "aNamespace",
-                    isApplied: (nodeList) => {
-                        return !!nodeList.find((node) => node.tagName === "DIV");
-                    },
+                    isApplied: (nodeList) => !!nodeList.find((node) => node.tagName === "DIV"),
                 },
             ],
             user_commands: { id: "test_cmd", run: () => null },
@@ -840,13 +843,11 @@ test("close the toolbar if the selection contains any nodes (traverseNode = [], 
 
 test.tags("desktop");
 test("should not close image cropper while loading media", async () => {
-    onRpc("/html_editor/get_image_info", () => {
-        return {
-            original: {
-                image_src: "#",
-            },
-        };
-    });
+    onRpc("/html_editor/get_image_info", () => ({
+        original: {
+            image_src: "#",
+        },
+    }));
     onRpc("/web/image/__odoo__unknown__src__/", async () => {
         await delay(50);
         return {};
@@ -969,42 +970,11 @@ describe("toolbar open and close on user interaction", () => {
             expect(".o-we-toolbar").toHaveCount(0);
         });
 
-        const firstClick = async (target) => {
-            manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 1 });
-            setSelection({ anchorNode: target, anchorOffset: 0 });
-            await tick(); // selectionChange
-            manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 1 });
-            manuallyDispatchProgrammaticEvent(target, "click", { detail: 1 });
-            await tick();
-        };
-
-        const secondClick = async (target) => {
-            manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 2 });
-            const document = target.ownerDocument;
-            document.getSelection().modify("extend", "forward", "word");
-            await tick(); // selectionChange
-            manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 2 });
-            manuallyDispatchProgrammaticEvent(target, "click", { detail: 2 });
-            await tick();
-        };
-
-        const thirdClick = async (target) => {
-            manuallyDispatchProgrammaticEvent(target, "mousedown", { detail: 3 });
-            const document = target.ownerDocument;
-            document.getSelection().modify("extend", "forward", "paragraphboundary");
-            await tick(); // selectionChange
-            manuallyDispatchProgrammaticEvent(target, "mouseup", { detail: 3 });
-            manuallyDispatchProgrammaticEvent(target, "click", { detail: 3 });
-            await tick();
-        };
-
         test("toolbar should open on double click", async () => {
             const { el } = await setupEditor("<p>test</p>");
             const p = el.firstElementChild;
 
-            // Double click
-            await firstClick(p);
-            await secondClick(p);
+            await simulateDoubleClickSelect(p);
             expect(getContent(el)).toBe("<p>[test]</p>");
             // toolbar open after double click is debounced
             await advanceTime(500);
@@ -1015,10 +985,7 @@ describe("toolbar open and close on user interaction", () => {
             const { el } = await setupEditor("<p>test text</p>");
             const p = el.firstElementChild;
 
-            // Triple click
-            await firstClick(p);
-            await secondClick(p);
-            await thirdClick(p);
+            await simulateTripleClickSelect(p);
             expect(getContent(el)).toBe("<p>[test text]</p>");
             // toolbar open after triple click is debounced
             await advanceTime(500);
@@ -1048,8 +1015,7 @@ describe("toolbar open and close on user interaction", () => {
             const { el } = await setupEditor("<p>test text</p>");
             const p = el.firstElementChild;
 
-            await firstClick(p);
-            await secondClick(p);
+            await simulateDoubleClickSelect(p);
             await pointerDown(p);
             manuallyDispatchProgrammaticEvent(p, "mousedown", { detail: 3 });
             setSelection({ anchorNode: p, anchorOffset: 0, focusOffset: 1 });


### PR DESCRIPTION
Correct the double click selection at the end of a link to allow the new text input to be inside the link.

task-4801000


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
