### PR TITLE
[FIX] account_edi_ubl_cii: prevent small discount calculation from rounding when importing invoice

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -654,8 +654,9 @@ class AccountEdiCommon(models.AbstractModel):
         discount = 0
         amount_fixed_taxes = sum(d['tax_amount'] * billed_qty for d in fixed_taxes_list)
         if billed_qty * price_unit != 0 and price_subtotal is not None:
-            inferred_discount = 100 * (1 - (price_subtotal - amount_fixed_taxes) / (billed_qty * price_unit))
-            discount = inferred_discount if not float_is_zero(inferred_discount, 2) else 0.0
+            currency = invoice_line.currency_id or self.env.company.currency_id
+            inferred_discount = 100 * (1 - (price_subtotal - amount_fixed_taxes) / currency.round(billed_qty * price_unit))
+            discount = inferred_discount if not float_is_zero(inferred_discount, currency.decimal_places) else 0.0
 
         # Sometimes, the xml received is very bad; e.g.:
         #   * unit price = 0, qty = 0, but price_subtotal = -200

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -377,15 +377,23 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         invoice = self.env['account.move'].create({
             'partner_id': self.partner_a.id,
             'move_type': 'out_invoice',
-            'invoice_line_ids': [Command.create({
-                'product_id': self.product_a.id,
-                'quantity': 3,
-                'price_unit': 11.34,
-            })],
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 3,
+                    'price_unit': 11.34,
+                }),
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 1.65,
+                    'price_unit': 29.9,
+                }),
+            ],
         })
         xml_attachment = self.env['ir.attachment'].create({
             'raw': self.env['account.edi.xml.cii']._export_invoice(invoice)[0],
             'name': 'test_invoice.xml',
         })
         imported_invoice = self.import_attachment(xml_attachment, self.company_data["default_journal_sale"])
-        self.assertFalse(imported_invoice.invoice_line_ids.discount)  # if slight rounding error won't be falsy
+        for line in imported_invoice.invoice_line_ids:
+            self.assertFalse(line.discount, "A discount on the imported lines signals a rounding error in the discount computation")


### PR DESCRIPTION
When calculating line discounts, extra decimal places are being used when computing the total in intermediate steps. This discrepancy is interpreted as a small discount, that shouldn't be there. We should instead use the current currency's precision.

Example:
```
qty: 1.65
unit_price: 29.9
total: 1.65 * 29.9 = 49.335, rounded to 49.34
discount = 0.005 * 100 / 49.335 = 0.010
```

Steps:
- Create an invoice with a product
- Set quantity to 1.65, price to 29.9
- Confirm & get the invoice PDF
- Upload the PDF in accounting app
- Check the "discount" value

Slight improvement to odoo/odoo#206107

opw-4776391