### PR TITLE
[FIX] account_payment: exclude cancelled invoices from reconciliation

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -204,6 +204,7 @@ class PaymentTransaction(models.Model):
             invoices = self.source_transaction_id.invoice_ids
         else:
             invoices = self.invoice_ids
+        invoices = invoices.filtered(lambda inv: inv.state != 'cancel')
         if invoices:
             invoices.filtered(lambda inv: inv.state == 'draft').action_post()
 

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -296,3 +296,28 @@ class TestAccountPayment(AccountPaymentCommon):
 
         self.assertNotEqual(self.partner.property_account_receivable_id, payment.destination_account_id)
         self.assertEqual(payment.destination_account_id, invoice.line_ids[-1].account_id)
+
+    def test_post_process_does_not_fail_on_cancelled_invoice(self):
+        """ If the payment state is 'pending' and the invoice gets cancelled, and later the payment is confirmed,
+            ensure that the _post_process() method does not raise an error.
+        """
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'test line',
+                    'price_unit': 100.0,
+                }),
+            ],
+        })
+        tx = self._create_transaction(
+            flow='direct',
+            state='pending',
+            invoice_ids=[invoice.id],
+        )
+        invoice.button_cancel()
+        tx._set_done()
+        # _post_process() shouldn't raise an error even though the invoice is cancelled
+        tx._post_process()
+        self.assertEqual(tx.payment_id.state, 'in_process')


### PR DESCRIPTION
Steps to reproduce:
1. Create an invoice.
2. Register a payment in the 'pending' state.
3. Cancel the invoice.
4. Confirm the payment (set payment state to 'done').
5. Run the post_process cron job and check the logs.
   → Error occurs during reconciliation due to the cancelled invoice.

Issue:
cancelled invoices were being considered during the reconciliation process,
leading to errors.

Solution:
This fix ensures that only posted invoices are considered during the
reconciliation process, thereby preventing such issues.