### PR TITLE
[IMP] web: calendar: do not read access rights for nothing

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -33,7 +33,9 @@ export class CalendarModel extends Model {
         this.data = {
             filters: {},
             filterSections: {},
-            hasCreateRight: null,
+            // Just keep hasCreateRight in stable for compatibility,
+            // Set it to its correct value though.
+            hasCreateRight: this.canCreate,
             range: null,
             records: {},
             unusualDays: [],
@@ -66,7 +68,7 @@ export class CalendarModel extends Model {
         return this.meta.date;
     }
     get canCreate() {
-        return this.meta.canCreate && this.data.hasCreateRight;
+        return this.meta.canCreate;
     }
     get canDelete() {
         return this.meta.canDelete;
@@ -320,9 +322,6 @@ export class CalendarModel extends Model {
      * @protected
      */
     async updateData(data) {
-        if (data.hasCreateRight === null) {
-            data.hasCreateRight = await user.checkAccessRight(this.meta.resModel, "create");
-        }
         data.range = this.computeRange();
         if (this.meta.showUnusualDays) {
             data.unusualDays = await this.loadUnusualDays(data);

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -2618,7 +2618,6 @@ test(`Add filters and specific color`, async () => {
     });
     expect.verifySteps([
         "get_views (event)",
-        "has_access (event)",
         "search_read (filter.partner) [partner_id]",
         "search_read (event) [display_name, start, stop, is_all_day, color, attendee_ids, type_id]",
     ]);


### PR DESCRIPTION
Before this commit, before loading the calendar view's data, we first checked whether the user had create and edit access rights (and we did that sequentially...).

However, this is completely useless. If the user doesn't have those rights, the view's postprocessing, in python, adds `edit` and/or `create` attributes on the arch root node, to indicate operations that aren't allowed.

This commit removes those 2 calls, thus speeding up a bit the loading of the calendar view.

task-4603194

Part-of: odoo/odoo#199276

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
