### PR TITLE
[FIX] website: fix quotes carousel missing options

### DIFF
--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -220,6 +220,19 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
         const toFind = $html.find("we-fontfamilypicker[data-variable]").toArray();
         const fontVariables = toFind.map((el) => el.dataset.variable);
         FontFamilyPickerUserValueWidget.prototype.fontVariables = fontVariables;
+
+        // TODO: Remove in Master.
+        const snippetCarouselOptionEl =
+            html.querySelector("[data-js='Carousel'][data-target='> .carousel']");
+        if (snippetCarouselOptionEl) {
+            const oldExcludeSelector = snippetCarouselOptionEl.dataset.exclude;
+            snippetCarouselOptionEl.dataset.exclude =
+                oldExcludeSelector.replace(
+                    ".s_quotes_carousel_wrapper",
+                    ".s_quotes_carousel_wrapper:has(>.s_quotes_carousel_compact)"
+                );
+        }
+
         return super._computeSnippetTemplates(html);
     }
     /**


### PR DESCRIPTION
Steps to reproduce the issue:

- Enter Website Edit mode.
- Drag and drop a "Quotes" carousel snippet onto the page.
- Click the snippet.
- Bug: most of the expected options are missing, and clicking the "+" (add slide) button causes the page to freeze (infinite loading).

This bug has been occurring since commit [1], where a new snippet "s_quotes_carousel_compact" was introduced. While trying to exclude this snippet from the default options of "Carousel" snippets, we accidentally excluded the other "Quotes" snippets as well, which caused them to lose their options.

[1]: https://github.com/odoo/odoo/commit/826b2d5061699c915dba7e627aef6d8d87b4a81b

opw-4803058