### PR TITLE
[IMP] pos_hr,*: prevent browser from saving password on splash screen

### DIFF
--- a/addons/pos_hr/static/src/app/screens/login_screen/login_screen.js
+++ b/addons/pos_hr/static/src/app/screens/login_screen/login_screen.js
@@ -68,4 +68,13 @@ patch(LoginScreen.prototype, {
     get backBtnName() {
         return this.pos.login && this.pos.config.module_pos_hr ? _t("Discard") : super.backBtnName;
     },
+    maskedInput(ev) {
+        ev.preventDefault();
+        const input = ev.target;
+        const pin = this.state.pin || "";
+        const maskedLen = input.value.length;
+        this.state.pin = maskedLen < pin.length ? pin.slice(0, maskedLen) : pin + (ev.data || "");
+
+        input.value = "•".repeat(this.state.pin.length);
+    },
 });

--- a/addons/pos_hr/static/src/app/screens/login_screen/login_screen.xml
+++ b/addons/pos_hr/static/src/app/screens/login_screen/login_screen.xml
@@ -7,9 +7,10 @@
         <xpath expr="//div[hasclass('screen-login')]" position="after">
             <div t-if="this.pos.config.module_pos_hr and this.pos.login" class="screen-login flex-grow-1 d-flex align-items-center justify-content-center">
                 <div class="d-flex bg-white p-3 gap-2 rounded">
-                    <input t-model="this.state.pin"
+                    <input
                         t-ref="autofocus"
-                        type="password"
+                        type="text"
+                        t-on-input="maskedInput"
                         class="form-control form-control-lg rounded flex-grow-1"
                         placeholder="Enter your PIN" />
                     <button class="select-cashier btn btn-secondary px-4" t-on-click="() => this.selectCashier(false, true)">


### PR DESCRIPTION
*=point_of_sale

Following this commit:
====
- Replaced 'password' input type with masked 'text' input to prevent browsers from offering to save or autofill credentials on the splash screen.
- This improves security in shared device environments, especially when multiple employees access the system on the same device.

task-4800745
