### PR TITLE
[FIX] l10n_es_edi_sii: tax rounding in multi-company

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -129,7 +129,7 @@ class AccountEdiFormat(models.Model):
                     tax_info = {
                         'TipoImpositivo': tax_values['applied_tax_amount'],
                         'BaseImponible': round(base_amount, 2),
-                        'CuotaRepercutida': round(math.copysign(tax_values['tax_amount'], base_amount), 2),
+                        'CuotaRepercutida': round(math.copysign(tax_values['tax_amount_currency'], base_amount), 2),
                     }
 
                     recargo = recargo_tax_details.get(tax_values['group_tax_details'][0]['tax_repartition_line'].tax_id)


### PR DESCRIPTION
CuotaRepercutida was incorrectly using `tax_amount`, which may be wrong in multi-company contexts when rounding differs.

Steps to reproduce:
- Create two companies: one in Spain (EUR) and one in the US (USD)
- Set USD rounding to 1 (no decimals)
- Set US company tax rounding method to "round globally"
- Create an invoice in the Spanish company
- Switch to US company (while keeping the spain company selected)
- Post the invoice and attempt SII submission

Issue: CuotaRepercutida was incorrectly rounded due to USD settings.

Fix: use `tax_amount_currency` to avoid incorrect rounding.

opw-4724945