### PR TITLE
[FIX] point_of_sale: exclude default_code from exact match

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -264,7 +264,6 @@ export class ProductTemplate extends Base {
         const fields = ["barcode"];
         const variantMatch = this.product_variant_ids.some(
             (variant) =>
-                (variant.default_code && variant.default_code.toLowerCase() == searchWord) ||
                 (variant.barcode && variant.barcode.toLowerCase() == searchWord) ||
                 variant.product_template_variant_value_ids.some((vv) =>
                     vv.name.toLowerCase().includes(searchWord)


### PR DESCRIPTION
Before this commit, if the search term was included in a product's internal reference (default_code), the search results would only return products with an exact match on default_code, and would exclude other products that matched the search term in their name. This was due to default_code being included in the exact match logic.

opw-4778729


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
