### PR TITLE
[IMP] web: add target in argument for t-component

### DIFF
--- a/addons/web/static/src/public/colibri.js
+++ b/addons/web/static/src/public/colibri.js
@@ -159,12 +159,10 @@ export class Colibri {
         }
     }
 
-    mountComponent(nodes, C, props) {
-        for (const node of nodes) {
-            const root = this.core.prepareRoot(node, C, props);
-            root.mount();
-            this.cleanups.push(() => root.destroy());
-        }
+    mountComponent(node, C, props) {
+        const root = this.core.prepareRoot(node, C, props);
+        root.mount();
+        this.cleanups.push(() => root.destroy());
     }
 
     applyTOut(el, value, initialValue) {
@@ -292,9 +290,13 @@ export class Colibri {
                 } else if (directive === "t-component") {
                     const { Component } = odoo.loader.modules.get("@odoo/owl");
                     if (Object.prototype.isPrototypeOf.call(Component, value)) {
-                        this.mountComponent(nodes, value);
+                        for (const node of nodes) {
+                            this.mountComponent(node, value);
+                        }
                     } else {
-                        this.mountComponent(nodes, ...value());
+                        for (const node of nodes) {
+                            this.mountComponent(node, ...value(node));
+                        }
                     }
                 } else {
                     const suffix = directive.startsWith("t-") ? "" : " (should start with t-)";

--- a/addons/web/static/src/public/interaction.js
+++ b/addons/web/static/src/public/interaction.js
@@ -459,6 +459,6 @@ export class Interaction {
      * @param {Object|null} [props]
      */
     mountComponent(el, C, props = null) {
-        this.__colibri__.mountComponent([el], C, props);
+        this.__colibri__.mountComponent(el, C, props);
     }
 }

--- a/addons/web/static/tests/public/interaction.test.js
+++ b/addons/web/static/tests/public/interaction.test.js
@@ -1963,6 +1963,39 @@ describe("components", () => {
         expect(".test").toHaveOuterHTML(`<div class="test"></div>`);
     });
 
+    test("can receive the selected element with t-component", async () => {
+        let isCDestroyed = false;
+        class C extends Component {
+            static template = xml`<p>component<span t-out="props.prop"></span></p>`;
+            static props = {
+                prop: { optional: true, type: String },
+            };
+
+            setup() {
+                onWillDestroy(() => (isCDestroyed = true));
+            }
+        }
+
+        class Test extends Interaction {
+            static selector = ".test";
+            dynamicContent = {
+                _root: { "t-component": (el) => [C, { prop: el.className }] },
+            };
+        }
+        const { core } = await startInteraction(Test, `<div class="test"></div>`);
+        expect(".test").toHaveOuterHTML(
+            `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"></owl-component></div>`
+        );
+        await animationFrame();
+        expect(".test").toHaveOuterHTML(
+            `<div class="test"><owl-component contenteditable="false" data-oe-protected="true"><p>component<span>test</span></p></owl-component></div>`
+        );
+        expect(isCDestroyed).toBe(false);
+        core.stopInteractions();
+        expect(isCDestroyed).toBe(true);
+        expect(".test").toHaveOuterHTML(`<div class="test"></div>`);
+    });
+
     test("can insert a component with mountComponent", async () => {
         class C extends Component {
             static template = xml`component`;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In the dynamicContent of a an interaction, when mounting a component using t-component, is was not possible to get the selected element.

Current behavior before PR:
It is not possible to get the selected element.

Desired behavior after PR is merged:
The element selected can be received through the arguments.

linked to odoo/enterprise/pull/85471
task-4367641

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
