### PR TITLE
[FIX] website: allow defaut value for data-for form field


### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -22,16 +22,6 @@ odoo.define('website.s_website_form', function (require) {
          */
         start: function () {
             if (this.editableMode) {
-                // TODO: Improve this. Since the form behavior was handled using
-                // two separate public widgets, and the "data-for" values were
-                // removed (on destroy before saving), we still need to restore
-                // them in edit mode in the case of a simple widget refresh.
-                this.dataForValues = wUtils.getParsedDataFor(this.$target[0].id, this.$target[0].ownerDocument);
-                for (const fieldEl of this._getDataForFields()) {
-                    if (!fieldEl.getAttribute("value")) {
-                        fieldEl.setAttribute("value", this.dataForValues[fieldEl.name]);
-                    }
-                }
                 // We do not initialize the datetime picker in edit mode but want the dates to be formated
                 const dateTimeFormat = time.getLangDatetimeFormat();
                 const dateFormat = time.getLangDateFormat();
@@ -45,21 +35,7 @@ odoo.define('website.s_website_form', function (require) {
             }
             return this._super(...arguments);
         },
-        /**
-         * @override
-         */
-        destroy() {
-            if (this.editableMode) {
-                // The "data-for" values are always correctly added to the form
-                // on the form widget start. But if we make any change to it in
-                // "edit" mode, we need to be sure it will not be saved with
-                // the new values.
-                for (const fieldEl of this._getDataForFields()) {
-                    fieldEl.removeAttribute("value");
-                }
-            }
-            this._super(...arguments);
-        },
+        // Todo: remove in master
         /**
          * @private
          */

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1513,7 +1513,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             }
         }
         const newInputEl = this.$target[0].querySelector('input');
-        if (newInputEl) {
+        if (newInputEl && dataFillWith) {
             newInputEl.dataset.fillWith = dataFillWith;
         }
     },

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -84,11 +84,20 @@ odoo.define('website_hr_recruitment.tour', function(require) {
             document.querySelector('.o_iframe:not(.o_ignore_in_tour)').contentDocument.querySelector('input[name="job_id"]').value = 'FAKE_JOB_ID_DEFAULT_VAL';
         },
     }, {
-        content: 'Edit the form',
-        trigger: 'iframe input[type="file"]',
+        content: 'Make the department_id field visible',
+        trigger: "body",
+        run: () => {
+            const departmentEl = document.querySelector('.o_iframe:not(.o_ignore_in_tour)').contentDocument.querySelector('input[name="department_id"]');
+            departmentEl.type = 'text';
+            departmentEl.closest('.s_website_form_field').classList.remove('s_website_form_dnone');
+        },
     }, {
-        content: 'Add a new field',
-        trigger: 'we-button[data-add-field]',
+        content: 'Focus on department_id field',
+        trigger: 'iframe input[name="department_id"]',
+    }, {
+        content: 'Add a fake default value for the department_id field',
+        trigger: 'we-input[data-attribute-name="value"] input',
+        run: 'text FAKE_DEPARTMENT_ID_DEFAULT_VAL',
     }, {
         content: 'Save',
         trigger: 'button[data-action="save"]',
@@ -114,18 +123,35 @@ odoo.define('website_hr_recruitment.tour', function(require) {
                 console.error('The job_id field has a wrong value');
             }
         }
+    }, {
+        content: 'Check that a department_id has been loaded',
+        trigger: 'iframe input[name="department_id"][value="FAKE_DEPARTMENT_ID_DEFAULT_VAL"]',
+        run: function () {
+            if (this.$anchor.val() === "FAKE_DEPARTMENT_ID_DEFAULT_VAL") {
+                console.error('The department_id data-for should have been applied');
+            }
+        }
     },
     ...wTourUtils.clickOnEditAndWaitEditMode(),
     {
-        content: 'Verify that the job_id field has kept its default value',
+        content: 'Verify that the job_id hidden field has lost its default value',
         trigger: "body",
         run: () => {
             const doc = document.querySelector(".o_iframe:not(.o_ignore_in_tour)").contentDocument;
             const id = doc.querySelector('[data-oe-model="hr.job"]').dataset.oeId;
             if (!doc.querySelector(`input[name="job_id"][value="${id}"]`)) {
-                console.error('The job_id field has lost its default value');
+                console.error('The hidden field has kept its default value in edit mode instead of data-for');
             }
         }
+    },
+    {
+        content: 'Verify that the department_id shown field has kept its default value',
+        trigger: 'iframe input[name="department_id"][value="FAKE_DEPARTMENT_ID_DEFAULT_VAL"]',
+        run: function () {
+            if (this.$anchor.val() !== "FAKE_DEPARTMENT_ID_DEFAULT_VAL") {
+                console.error('The department_id field has lost its default value');
+            }
+        },
     },
 ]);
 

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -8,13 +8,16 @@ from odoo.tools import html2plaintext
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
     def test_tour(self):
+        department = self.env['hr.department'].create({'name': 'guru team'})
         job_guru = self.env['hr.job'].create({
             'name': 'Guru',
             'is_published': True,
+            'department_id': department.id,
         })
         job_intern = self.env['hr.job'].create({
             'name': 'Internship',
             'is_published': True,
+            'department_id': department.id,
         })
         self.start_tour(self.env['website'].get_client_action_url('/jobs'), 'website_hr_recruitment_tour_edit_form', login='admin')
 


### PR DESCRIPTION
Scenario:
- go to the /contactus page
- edit the subject field and set a default value then save

Result: the default value is not saved.

Reason: in 13.0, field default value had priority over data-for so an
issue was solved by b637a5e32f767b62736241042f88fa0cecf9f10b that if you
saved a form, the data-for would become the default for all the uses of
that form (so eg. a job position would be set for all job positions).

In 8d0a63f35519090a74fcefedf482fea5f6eedd97 the priority was changed so
data-for has higher priority than the default value, that made the
prior fix unnecessary (just a nice to have, to not save the data-for as
default that would be overridden by another data-for).

The fix was reintroduced by ca433f38dbfe379dc9e0b823c7862eaec1a7ed9d but
it removes default value if there is a data-for.

Fix: remove the filling and removing of value: the data-for is not shown
in the editor (allowing us to set default) but has the priority when
rendering the field in non-editable mode. This is mirroring what is
already done for data-fill-with.

Side note: this commit also remove useless data-fill-with="undefined"
attributes that are added when editing field. They shouldn't cause any
issue unless someone add a "undefined" field in the prefilled fields.

opw-4794903