### PR TITLE
[IMP] im_livechat: fix chat bot restart error

### DIFF
--- a/addons/im_livechat/static/src/core/common/chatbot_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_model.js
@@ -81,7 +81,7 @@ export class Chatbot extends Record {
             chatbot_script_id: this.script.id,
         });
         this.store.insert(store_data);
-        this.thread.messages.push(this.store["mail.message"].get(message_id));
+        this.thread.messages.add(message_id);
         if (this.currentStep) {
             this.currentStep.isLast = false;
             this.thread.livechat_active = true;


### PR DESCRIPTION
Before this commit, an error would occur if the "/chatbot/restart" rpc came after the bus notification related to the restart message.

It occurs because the chat bot model pushes the restart message into the channel's message without checking if it was already done by the new message notification handler.

Since the thread template sets the message id as a `t-key`, we cannot have the same message twice. This would lead to the chat bot flow tour failing silently on runbot when this happens.

This commit ensures the restart message will only be added to the thread's message once.

fixes runbot-181545

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
