### PR TITLE
[FIX] core: don't send almost same Date header twice

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -17,6 +17,7 @@ import threading
 import time
 import unittest
 import contextlib
+from email.utils import parsedate_to_datetime
 from io import BytesIO
 from itertools import chain
 
@@ -160,6 +161,12 @@ class RequestHandler(werkzeug.serving.WSGIRequestHandler):
             elif self._sent_date_header == value:
                 return  # don't send the same header twice
             else:
+                sent_datetime = parsedate_to_datetime(self._sent_date_header)
+                new_datetime = parsedate_to_datetime(value)
+                if sent_datetime == new_datetime:
+                    return  # don't send the same date twice (differ in format)
+                if abs((sent_datetime - new_datetime).total_seconds()) <= 1:
+                    return  # don't send the same date twice (jitter of 1 second)
                 _logger.warning(
                     "sending two different Date response headers: %r vs %r",
                     self._sent_date_header, value)


### PR DESCRIPTION
The code proved unreliable, emitting warnings for genuine controllers because the two headers were milliseconds appart. Made the warning ignore some almost equal headers.