### PR TITLE
[IMP] l10n_in_ewaybill_stock: remove transporter gst validation

### DIFF
--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -290,6 +290,12 @@ class AccountEdiFormat(models.Model):
                 "TransMode": invoice.l10n_in_mode,
                 "VehNo": invoice.l10n_in_vehicle_no,
                 "VehType": invoice.l10n_in_vehicle_type,
+                **{
+                    k: v for k, v in {
+                        "TransId": invoice.l10n_in_transporter_id.vat,
+                        "TransName": invoice.l10n_in_transporter_id.name,
+                    }.items() if v
+                },
             })
         elif invoice.l10n_in_mode in ("2", "3", "4"):
             doc_date = invoice.l10n_in_transportation_doc_date
@@ -504,6 +510,12 @@ class AccountEdiFormat(models.Model):
                 "transMode": invoices.l10n_in_mode,
                 "vehicleNo": invoices.l10n_in_vehicle_no or "",
                 "vehicleType": invoices.l10n_in_vehicle_type or "",
+                **{
+                    k: v for k, v in {
+                        "transporterId": invoices.l10n_in_transporter_id.vat,
+                        "transporterName": invoices.l10n_in_transporter_id.name,
+                    }.items() if v
+                },
             })
         return json_payload
 

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -150,3 +150,97 @@ class TestEdiEwaybillJson(TestEdiJson):
             "totInvValue": 0.0
         })
         self.assertDictEqual(json_value, expected, "Indian EDI with 0(zero) quantity sent json value is not matched")
+
+    def test_edi_ewaybill_transporter_gst(self):
+        self.partner_b.write({
+            "vat": False,
+            "street": "Block no. 401",
+            "street2": "Street 2",
+            "city": "City 2",
+            "zip": "500001",
+            "state_id": self.env.ref("base.state_in_ts").id,
+            "country_id": self.env.ref("base.in").id,
+            "l10n_in_gst_treatment": "unregistered",
+        })
+        self.invoice.write({
+            "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"),
+            "l10n_in_distance": 20,
+            "l10n_in_mode": "1",
+            "l10n_in_vehicle_no": "GJ11AA1234",
+            "l10n_in_vehicle_type": "R",
+            "l10n_in_transporter_id": self.partner_b.id,
+        })
+        expected = {
+            "supplyType": "O",
+            "docType": "INV",
+            "subSupplyType": "1",
+            "transactionType": 1,
+            "transDistance": "20",
+            "docNo": "INV/2019/00001",
+            "docDate": "01/01/2019",
+            "fromGstin": "36AABCT1332L011",
+            "fromTrdName": "company_1_data",
+            "fromAddr1": "Block no. 401",
+            "fromAddr2": "Street 2",
+            "fromPlace": "City 1",
+            "fromPincode": 500001,
+            "fromStateCode": 36,
+            "actFromStateCode": 36,
+            "toGstin": "36BBBFF5679L8ZR",
+            "toTrdName": "partner_a",
+            "toAddr1": "Block no. 401",
+            "toAddr2": "Street 2",
+            "toPlace": "City 2",
+            "toPincode": 500001,
+            "actToStateCode": 36,
+            "toStateCode": 36,
+            "itemList": [
+            {
+              "productName": "product_a",
+              "hsnCode": "01111",
+              "productDesc": "product_a",
+              "quantity": 1.0,
+              "qtyUnit": "UNT",
+              "taxableAmount": 900.0,
+              "cgstRate": 2.5,
+              "sgstRate": 2.5
+            },
+            {
+              "productName": "product_with_cess",
+              "hsnCode": "02222",
+              "productDesc": "product_with_cess",
+              "quantity": 1.0,
+              "qtyUnit": "UNT",
+              "taxableAmount": 900.0,
+              "cgstRate": 6.0,
+              "sgstRate": 6.0,
+              "cessRate": 5.0
+            }
+            ],
+            "totalValue": 1800.0,
+            "cgstValue": 76.5,
+            "sgstValue": 76.5,
+            "igstValue": 0.0,
+            "cessValue": 45.0,
+            "cessNonAdvolValue": 1.59,
+            "otherValue": 0.0,
+            "totInvValue": 1999.59,
+            "transMode": "1",
+            "vehicleNo": "GJ11AA1234",
+            "vehicleType": "R",
+            "transporterName": self.partner_b.name,
+        }
+        json_value = self.env["account.edi.format"]._l10n_in_edi_ewaybill_generate_json(self.invoice)
+        self.assertDictEqual(json_value, expected, "Indian EDI Ewaybill without transporter GST sent json value is not matched")
+
+        # =================================== Ewaybill Through IRN =============================================
+        json_value = self.env["account.edi.format"]._l10n_in_edi_irn_ewaybill_generate_json(self.invoice)
+        expected = {
+            "Irn": None,
+            "Distance": 20,
+            "TransMode": "1",
+            "TransName": self.partner_b.name,
+            "VehType": "R",
+            "VehNo": "GJ11AA1234"
+        }
+        self.assertDictEqual(json_value, expected, "Indian EDI Ewaybill through IRN without transporter GST sent json value is not matched")

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -37,6 +37,9 @@
                                 domain="[('vat','not in', ['', False]), ('country_id.code','=','IN')]"
                                 invisible="l10n_in_mode != '0'"
                                 required="l10n_in_mode == '0'"/>
+                            <field name="l10n_in_transporter_id"
+                                domain="[('country_id.code','=','IN')]"
+                                invisible="l10n_in_mode != '1'"/>
                             <field name="l10n_in_transportation_doc_no" 
                                 invisible="l10n_in_mode not in ('2', '3', '4')"
                                 required="l10n_in_mode in ('2', '3', '4')"

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -306,7 +306,7 @@ class Ewaybill(models.Model):
 
     def _check_transporter(self):
         error_message = []
-        if self.transporter_id and not self.transporter_id.vat:
+        if self.transporter_id and not self.transporter_id.vat and (self.mode != "1" or not self.vehicle_no):
             error_message.append(_("- Transporter %s does not have a GST Number", self.transporter_id.name))
         if self.mode == "4" and self.vehicle_no and self.vehicle_type == "R":
             error_message.append(_("- Vehicle type can not be regular when the transportation mode is ship"))

--- a/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
+++ b/addons/l10n_in_ewaybill_stock/tests/test_ewaybill_stock.py
@@ -30,6 +30,13 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
             'country_id': cls.env.ref('base.in').id,
             'zip': '431122'
         })
+        cls.partner_b.write({
+            'vat': False,
+            'l10n_in_gst_treatment': 'unregistered',
+            'state_id': cls.env.ref("base.state_in_mh").id,
+            'country_id': cls.env.ref('base.in').id,
+            'zip': '431122'
+        })
 
     def _create_stock_picking(self):
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)])
@@ -218,3 +225,93 @@ class TestStockEwaybill(AccountTestInvoicingCommon):
             }
             ewaybill._l10n_in_ewaybill_stock_handle_zero_distance_alert_if_present(response)
             self.assertEqual(ewaybill.distance, expected_distance)
+
+    @freeze_time('2025-05-22')
+    def test_ewaybill_stock_transporter_with_vehicle_no(self):
+        """
+        Ewaybill Transporter GST validation when Vehicle Number is present
+        and mode of transportation is by road
+        """
+        delivery_picking = self._create_stock_picking()
+        transportation_detail = self.env['l10n.in.ewaybill'].create({
+            'type_id': self.env.ref('l10n_in_ewaybill_stock.type_delivery_challan_sub_others').id,
+            'picking_id': delivery_picking.id,
+            'type_description': 'Other reasons',
+            'transporter_id': self.partner_b.id,
+            'transportation_doc_date': '2025-05-22',
+            'mode': '1',
+            'distance': 0,
+            'vehicle_no': 'GJ11AA1001',
+            'vehicle_type': 'R',
+        })
+        expected_json = {
+            'supplyType': 'O',
+            'subSupplyType': '8',
+            'docType': 'CHL',
+            'transactionType': 1,
+            'transDistance': '0',
+            'docNo': 'compa/OUT/00004',
+            'docDate': '22/05/2025',
+            'fromGstin': 'URP',
+            'toGstin': '27DJMPM8965E1ZE',
+            'fromTrdName': 'company_1_data',
+            'toTrdName': 'partner_a',
+            'fromStateCode': 24,
+            'toStateCode': 27,
+            'fromAddr1': '',
+            'toAddr1': '',
+            'fromAddr2': '',
+            'toAddr2': '',
+            'fromPlace': '',
+            'toPlace': '',
+            'fromPincode': 380004,
+            'toPincode': 431122,
+            'actToStateCode': 27,
+            'actFromStateCode': 24,
+            'subSupplyDesc': 'Other reasons',
+            'transporterName': 'partner_b',
+            'transMode': '1',
+            'transDocDate': '22/05/2025',
+            'vehicleNo': 'GJ11AA1001',
+            'vehicleType': 'R',
+            'itemList': [{
+                'productName': 'product_a',
+                'hsnCode': '01111',
+                'productDesc': 'product_a',
+                'quantity': 5.0,
+                'qtyUnit': 'UNT',
+                'taxableAmount': 2500.0,
+                'igstRate': 5.0
+            }],
+            'totalValue': 2500.0,
+            'cgstValue': 0.0,
+            'sgstValue': 0.0,
+            'igstValue': 125.0,
+            'cessValue': 0.0,
+            'cessNonAdvolValue': 0.0,
+            'otherValue': 0.0,
+            'totInvValue': 2625.0
+        }
+        self.assertEqual(transportation_detail._check_transporter(), [])
+        self.assertDictEqual(transportation_detail._ewaybill_generate_direct_json(), expected_json)
+
+    @freeze_time('2025-05-22')
+    def test_ewaybill_stock_transporter_without_vehicle_no(self):
+        """
+        Ewaybill Transporter GST validation when Vehicle Number is not present
+        but have transportation document no and mode of transportation is by road
+        """
+        delivery_picking = self._create_stock_picking()
+        transportation_detail = self.env['l10n.in.ewaybill'].create({
+            'type_id': self.env.ref('l10n_in_ewaybill_stock.type_delivery_challan_sub_others').id,
+            'type_description': 'Other reasons',
+            'picking_id': delivery_picking.id,
+            'transporter_id': self.partner_b.id,
+            'transportation_doc_date': '2025-05-22',
+            'transportation_doc_no': '123456789',
+            'mode': '1',
+            'distance': 0,
+            'vehicle_type': 'R',
+        })
+        expected_msg = _('- Transporter %s does not have a GST Number', self.partner_b.name)
+        self.assertEqual(transportation_detail._check_transporter(), [expected_msg])

--- a/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
+++ b/addons/l10n_in_ewaybill_stock/views/l10n_in_ewaybill_views.xml
@@ -85,7 +85,7 @@
                                    readonly="state != 'pending'"/>
                             <field name="vehicle_no"
                                    invisible="mode not in ('1','4')"
-                                   required="mode == '1'"
+                                   required="mode == '1' and not transportation_doc_no"
                                    readonly="state != 'pending'"/>
                             <label for="distance" readonly="state != 'pending'"/>
                             <div class="o_row" name="distance">


### PR DESCRIPTION
After this PR

- transporter gst number is not required while submitting ewaybill 
  if vehicle number is present and mode of transportation is by road
- vehicle number can be left empty if transportation document no is set 
  however transporter gst is required for that case

task-4807693
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
