### PR TITLE
[FIX] mrp_account: enable decrease qty on component stock move from u…

### DIFF
--- a/addons/mrp_account/models/stock_move.py
+++ b/addons/mrp_account/models/stock_move.py
@@ -46,7 +46,8 @@ class StockMove(models.Model):
         # 'real cost' of finished product moves @ build time
         price_unit_map = {
             move.id: (
-                move.unbuild_id.mo_id.move_finished_ids.stock_valuation_layer_ids.filtered(
+                (move.unbuild_id.mo_id.move_finished_ids |
+                move.unbuild_id.mo_id.move_raw_ids).stock_valuation_layer_ids.filtered(
                     lambda svl: svl.product_id == move.product_id
                 )[0].unit_cost,
                 move.company_id.currency_id.round,


### PR DESCRIPTION
…nbuild

**Problem:**
When decreaseing the quantity of the stock move created for the component of the bom when unbuilding, it triggers an error message

**Steps to reproduce:**
- create a product tracked by quantity (the "component product")
- in the category field select an avco category
- set an on hand quantity of 1
- create another product tracked by quantity (the "final product")
- create a bom for this product and select your first product as the component
- create a manufacture order for the final product
- confirm and produce all
- unbuild it and click on the "Unbuilds" smart button
- select the line of the manufacture order
- click on "product moves"
- select the line of the component product
- set the quantity to 0

**Current behavior:**
an error message appears

**Expected behavior:**
a stock valuation layer should be created with
the unit cost of the component product at the
time of the manufacture order

**Cause of the issue:**
price_unit_map is created to make sure that when unbuilding a non standard final product,
the outgoing stock valuation layer created for the final product has the same value as in the MO (the current standard_price could have changed due to POs since the MO happened for instance) https://github.com/odoo/odoo/blob/05cff3b7d866f6bc95c4b32f343ae14a4da946f2/addons/mrp_account/models/stock_move.py#L47-L56

when reducing the quantity of the stock move linked to the component of the unbuild an outgoing stock valuation layer is created and _get_out_svl_vals is triggered,
those 2 conditions are true
https://github.com/odoo/odoo/blob/05cff3b7d866f6bc95c4b32f343ae14a4da946f2/addons/mrp_account/models/stock_move.py#L55-L56 but the product is not the same as the one of move_finished_ids of the MO (this product is final product of the MO) so the filter result in an empty record set and
[0] creates an index out of range error
https://github.com/odoo/odoo/blob/05cff3b7d866f6bc95c4b32f343ae14a4da946f2/addons/mrp_account/models/stock_move.py#L49-L51

**Fix:**
the unit_cost of the stock valuation layer for the component product created from unbuild is the same as :
the unit_cost from the stock valuation layer created from the MO for the component (even if the standard_price changed inbetween).
https://github.com/odoo/odoo/blob/4fd9ae6ccd96ac13475e7e5aa9805e6f529cd609/addons/stock_account/models/stock_move.py#L516-L517
https://github.com/odoo/odoo/blob/4fd9ae6ccd96ac13475e7e5aa9805e6f529cd609/addons/stock_account/models/stock_move.py#L51

So to be consistent an ajustement to the the stock move created from the unbuild should create a stock valuation layer which also has the same unit cost

opw-4747920