### PR TITLE
[FIX] website_event: fix the filters on the events list page

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -38,7 +38,7 @@ class WebsiteEventController(http.Controller):
         SudoEventType = request.env['event.type'].sudo()
 
         searches.setdefault('search', '')
-        searches.setdefault('date', 'upcoming')
+        searches.setdefault('date', 'scheduled')
         searches.setdefault('tags', '')
         searches.setdefault('type', 'all')
         searches.setdefault('country', 'all')
@@ -60,7 +60,7 @@ class WebsiteEventController(http.Controller):
             'country': searches.get('country'),
         }
         order = 'date_begin'
-        if searches.get('date', 'upcoming') == 'old':
+        if searches.get('date', 'scheduled') == 'old':
             order = 'date_begin desc'
         order = 'is_published desc, ' + order + ', id desc'
         search = searches.get('search')
@@ -109,7 +109,7 @@ class WebsiteEventController(http.Controller):
         keep = QueryURL('/event', **{
             key: value for key, value in searches.items() if (
                 key == 'search' or
-                (value != 'upcoming' if key == 'date' else value != 'all'))
+                (value != 'scheduled' if key == 'date' else value != 'all'))
             })
 
         searches['search'] = fuzzy_search_term or search

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -450,12 +450,12 @@ class Event(models.Model):
 
     @api.model
     def _search_build_dates(self):
-        # To fetch events of the user's current day. The start and the end of the user's day must
+        now = fields.Datetime.now()
+        # To fetch the remaining events of the user's current day, the end of the user's day must
         # be localized and then converted in UTC, as it is the timezone used to record dates and
         # times in db.
         tz = timezone(self.env.user.tz or self.env.context.get('tz') or 'UTC')
         localized_today_begin = tz.localize(fields.Datetime.today())
-        utc_today_begin = localized_today_begin.astimezone(utc)
         utc_today_end = localized_today_begin.replace(hour=23, minute=59, second=59).astimezone(utc)
 
         def sd(date):
@@ -463,29 +463,24 @@ class Event(models.Model):
 
         def get_month_filter_domain(filter_name, months_delta):
             localized_month_begin = localized_today_begin.replace(day=1)
-            utc_month_begin = (localized_month_begin + relativedelta(months=months_delta)).astimezone(utc)
-            # As utc_month_begin may be the 30th day of the month, adding months may lead to miscalculation the
-            # last day of the interval since 31st day may be missing. Since localized_month_begin is always the
-            # first day of the month, it must be used to calculate the end of the interval and then the UTC
-            # conversion can be done.
             utc_months_delta_end = (localized_month_begin + relativedelta(months=months_delta + 1)).astimezone(utc)
             filter_string = _('This month') if months_delta == 0 \
                 else format_date(self.env, value=localized_today_begin + relativedelta(months=months_delta),
                     date_format='LLLL', lang_code=get_lang(self.env).code).capitalize()
             return [filter_name, filter_string, [
-                ("date_end", ">=", sd(utc_month_begin)),
+                ("date_end", ">=", sd(now)),
                 ("date_begin", "<", sd(utc_months_delta_end))],
                 0]
 
         return [
-            ['upcoming', _('Upcoming Events'), [("date_end", ">=", sd(utc_today_begin))], 0],
+            ['scheduled', _('Scheduled Events'), [("date_end", ">=", sd(now))], 0],
             ['today', _('Today'), [
-                ("date_end", ">", sd(utc_today_begin)),
+                ("date_end", ">", sd(now)),
                 ("date_begin", "<", sd(utc_today_end))],
                 0],
             get_month_filter_domain('month', 0),
             ['old', _('Past Events'), [
-                ("date_end", "<", sd(utc_today_begin))],
+                ("date_end", "<", sd(now))],
                 0],
             ['all', _('All Events'), [], 0]
         ]
@@ -536,7 +531,7 @@ class Event(models.Model):
             if date == date_details[0]:
                 domain.append(date_details[2])
                 no_country_domain.append(date_details[2])
-                if date_details[0] != 'upcoming':
+                if date_details[0] != 'scheduled':
                     current_date = date_details[1]
 
         search_fields = ['name']

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -450,33 +450,42 @@ class Event(models.Model):
 
     @api.model
     def _search_build_dates(self):
-        today = fields.Datetime.today()
-
-        def sdn(date):
-            return fields.Datetime.to_string(date.replace(hour=23, minute=59, second=59))
+        # To fetch events of the user's current day. The start and the end of the user's day must
+        # be localized and then converted in UTC, as it is the timezone used to record dates and
+        # times in db.
+        tz = timezone(self.env.user.tz or self.env.context.get('tz') or 'UTC')
+        localized_today_begin = tz.localize(fields.Datetime.today())
+        utc_today_begin = localized_today_begin.astimezone(utc)
+        utc_today_end = localized_today_begin.replace(hour=23, minute=59, second=59).astimezone(utc)
 
         def sd(date):
             return fields.Datetime.to_string(date)
 
         def get_month_filter_domain(filter_name, months_delta):
-            first_day_of_the_month = today.replace(day=1)
+            localized_month_begin = localized_today_begin.replace(day=1)
+            utc_month_begin = (localized_month_begin + relativedelta(months=months_delta)).astimezone(utc)
+            # As utc_month_begin may be the 30th day of the month, adding months may lead to miscalculation the
+            # last day of the interval since 31st day may be missing. Since localized_month_begin is always the
+            # first day of the month, it must be used to calculate the end of the interval and then the UTC
+            # conversion can be done.
+            utc_months_delta_end = (localized_month_begin + relativedelta(months=months_delta + 1)).astimezone(utc)
             filter_string = _('This month') if months_delta == 0 \
-                else format_date(self.env, value=today + relativedelta(months=months_delta),
+                else format_date(self.env, value=localized_today_begin + relativedelta(months=months_delta),
                     date_format='LLLL', lang_code=get_lang(self.env).code).capitalize()
             return [filter_name, filter_string, [
-                ("date_end", ">=", sd(first_day_of_the_month + relativedelta(months=months_delta))),
-                ("date_begin", "<", sd(first_day_of_the_month + relativedelta(months=months_delta+1)))],
+                ("date_end", ">=", sd(utc_month_begin)),
+                ("date_begin", "<", sd(utc_months_delta_end))],
                 0]
 
         return [
-            ['upcoming', _('Upcoming Events'), [("date_end", ">", sd(today))], 0],
+            ['upcoming', _('Upcoming Events'), [("date_end", ">=", sd(utc_today_begin))], 0],
             ['today', _('Today'), [
-                ("date_end", ">", sd(today)),
-                ("date_begin", "<", sdn(today))],
+                ("date_end", ">", sd(utc_today_begin)),
+                ("date_begin", "<", sd(utc_today_end))],
                 0],
             get_month_filter_domain('month', 0),
             ['old', _('Past Events'), [
-                ("date_end", "<", sd(today))],
+                ("date_end", "<", sd(utc_today_begin))],
                 0],
             ['all', _('All Events'), [], 0]
         ]

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -99,7 +99,7 @@
             <a href="#" role="button" class="btn dropdown-toggle" data-bs-toggle="dropdown">
                 <i class="fa fa-calendar"/>
                 <t t-if="current_date" t-out="current_date"/>
-                <t t-else="">Upcoming Events</t>
+                <t t-else="">Scheduled Events</t>
             </a>
             <div class="dropdown-menu">
                 <t t-foreach="dates" t-as="date">


### PR DESCRIPTION
This PR globally fixes bugs on the data filters on the events list page and it is split in two commits:

-Commit 1: the filters use today in UTC to fetch events in db. The commit fixes this by located today first and then converts it in UTC.
-Commit 2: some date filters do not use the current time to fetch events in db. This commit fixes that to display more relevant results.   

related odoo/odoo@bfd55de7c846a0d523e4de4b17020341d8fcfd23

task-4796181