### PR TITLE
[FIX] account: properly display outstanding credits widget in Spanish

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1268,10 +1268,12 @@
                                             <field name="invoice_payments_widget" colspan="2" nolabel="1" widget="payment"/>
                                             <field name="amount_residual" class="oe_subtotal_footer_separator" invisible="state == 'draft'"/>
                                         </group>
-                                        <field name="invoice_outstanding_credits_debits_widget"
-                                            class="oe_invoice_outstanding_credits_debits py-3"
-                                            colspan="2" nolabel="1" widget="payment"
-                                            invisible="state != 'posted' or not invoice_has_outstanding"/>
+                                        <group class="oe_subtotal_footer px-4">
+                                            <field name="invoice_outstanding_credits_debits_widget"
+                                                class="oe_invoice_outstanding_credits_debits py-3"
+                                                colspan="2" nolabel="1" widget="payment"
+                                                invisible="state != 'posted' or not invoice_has_outstanding"/>
+                                        </group>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
**Issue**
When viewing an invoice in Spanish, the "Outstanding credits" section may overflow or be cut off on the right side.

**Steps to Reproduce**
1. Install the Accounting module.
2. Switch the user language to Spanish.
3. Navigate to Contabilidad > Clientes > Facturas.
4. Open an invoice that has outstanding credits.
5. Set the browser zoom to 125%.
6. Observe that the outstanding credits widget content is truncated or overflows its container.

**Root Cause**
The field `invoice_outstanding_credits_debits_widget` was placed directly in the form without a layout container, causing it to misalign and overflow in cases where translated text or zoom scaling increased its width. The lack of a proper responsive layout prevented it from adapting gracefully.

**Fix**
Wrapped the field inside a `<group>` element with class `oe_subtotal_footer px-4` to ensure it inherits consistent padding and alignment with other form elements. This provides a flexible layout that handles longer text and browser zoom correctly, maintaining readability and visual consistency.

opw-4716266
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
