### PR TITLE
[FIX] stock: Determine inventory quantity as of a past date.

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -175,8 +175,8 @@ class Product(models.Model):
             # Calculate the moves that were done before now to calculate back in time (as most questions will be recent ones)
             domain_move_in_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_in_done
             domain_move_out_done = [('state', '=', 'done'), ('date', '>', to_date)] + domain_move_out_done
-            moves_in_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_in_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
-            moves_out_res_past = dict((item['product_id'][0], item['product_qty']) for item in Move._read_group(domain_move_out_done, ['product_id', 'product_qty'], ['product_id'], orderby='id'))
+            moves_in_res_past = dict((item['product_id'][0], item['quantity_done']) for item in Move._read_group(domain_move_in_done, ['product_id', 'quantity_done'], ['product_id'], orderby='id'))
+            moves_out_res_past = dict((item['product_id'][0], item['quantity_done']) for item in Move._read_group(domain_move_out_done, ['product_id', 'quantity_done'], ['product_id'], orderby='id'))
 
         res = dict()
         for product in self.with_context(prefetch_fields=False):


### PR DESCRIPTION
When determining inventory quantity in the past based on stock moves in the 'done' state, the calculation must use the completed quantity.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
