### PR TITLE
Shipping weight decimal precision

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -677,7 +677,7 @@ class StockPicking(models.Model):
     weight_bulk = fields.Float(
         'Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
     shipping_weight = fields.Float(
-        "Weight for Shipping", compute='_compute_shipping_weight', readonly=False, store=True,
+        "Weight for Shipping", digits="Stock Weight", compute='_compute_shipping_weight', readonly=False, store=True,
         help="Total weight of packages and products not in a package. "
         "Packages with no shipping weight specified will default to their products' total weight. "
         "This is the weight used to compute the cost of the shipping.")

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -96,7 +96,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else '{:.2f}'.format(x)"/>
+                            <t t-set="format_number" t-value="lambda x: int(x) if x == int(x) else x"/>
                             <!-- In this step, we loop over every move of the picking and do the following
                                 1. We add the barcode column if any of the products has a barcode or if we have a tracked move
                                 2. We add From/To columns according to the type of the picking


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

- It is possible to define a decimal accuracy for stock weight but in some pdf reports it's not correct and some weights can be displayed with tons of decimals making it difficult to read.

**Desired behavior after PR is merged:**
- Shipping weight is consistent with the Stock weight decimal precision.
- Quantity in picking operations report is not consistent with the price unit.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
