### PR TITLE
[FIX] web_editor: support `row` and `col` in `o_text_columns` container

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -171,7 +171,7 @@ function bootstrapToTable(editable) {
         masonryRow.parentElement.style.setProperty('height', '100%');
     }
 
-    const containers = editable.querySelectorAll('.container, .container-fluid, .o_fake_table');
+    const containers = editable.querySelectorAll('.container, .container-fluid, .o_fake_table, .o_text_columns');
     // Capture the widths of the containers before manipulating it.
     for (const container of containers) {
         container.setAttribute('o-temp-width', _getWidth(container));


### PR DESCRIPTION
Problem:
Bootstrap grid classes like `row` and `col` are not handled properly when placed inside an `o_text_columns` container. During processing (e.g., for email rendering), rows are expected to be converted to tables — but since `o_text_columns` is not included in the selector query, the transformation is skipped.

As a result, when rendering the email, columns are not preserved and fall back to stacked layout.

Solution:
Update the container selection logic to include `o_text_columns` when querying Bootstrap-based containers that need to be transformed into tables.

Steps to reproduce:
1. Go to Email Marketing.
2. Create a new email.
3. Add a Text snippet.
4. Type `/col` and choose "2 Columns".
5. Add text to both columns.
6. Save and send the email. → In the received email, the two columns appear stacked
   vertically instead of side by side.

opw-4675310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
