### PR TITLE
[FIX] website_sale: don't assume product grid presence

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.editor.js
+++ b/addons/website_sale/static/src/js/website_sale.editor.js
@@ -12,12 +12,28 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
     /**
      * @override
      */
-    start: function () {
+    start: async function () {
+        const _super = this._super.bind(this);
+
         const gridEl = this.$target[0].querySelector('#o_wsale_products_grid');
-        this.ppg = parseInt(gridEl.dataset.ppg);
-        this.ppr = parseInt(gridEl.dataset.ppr);
-        this.gap = this.$target[0].style.getPropertyValue('--o-wsale-products-grid-gap');
-        this.default_sort = gridEl.dataset.defaultSort;
+        if (gridEl) {
+            this.ppg = parseInt(gridEl.dataset.ppg);
+            this.ppr = parseInt(gridEl.dataset.ppr);
+            this.gap = this.$target[0].style.getPropertyValue('--o-wsale-products-grid-gap');
+            this.default_sort = gridEl.dataset.defaultSort;
+        } else {
+            const { data_res_model, data_res_id } = this.options.recordInfo;
+            [{
+                shop_ppg: this.ppg,
+                shop_ppr: this.ppr,
+                shop_gap: this.gap,
+                shop_default_sort: this.default_sort,
+            }] = await this.orm.read(
+                data_res_model,
+                [data_res_id],
+                ['shop_ppg', 'shop_ppr', 'shop_gap', 'shop_default_sort'],
+            );
+        }
 
         // Activate HTML previews when necessary only
         // See 'website_sale.editor_previews' XML template
@@ -25,7 +41,7 @@ options.registry.WebsiteSaleGridLayout = options.Class.extend({
             this._handlePreviews();
         }
 
-        return this._super.apply(this, arguments);
+        return _super(...arguments);
     },
     /**
      * @override


### PR DESCRIPTION
Versions
--------
- saas-18.3+

Steps
-----
1. Have no products listed in eCommerce;
2. go to `/shop`;
3. open editor;
4. add a Columns element.

Issue
-----
> Uncaught Promise > Cannot read properties of null (reading 'dataset')

Cause
-----
Commit 328c241fa5897 changed the `/shop` page edition, but didn't factor in that the product grid element is only added when there are products.

Before this commit, the product grid numbers were initialized as `NaN` due to the element being undefined.

Solution
--------
As we still want the shop page to be editable, retrieve the relevant values via RPC if we cannot get them from the grid element.

opw-4793447