### PR TITLE
[FIX] mrp{_account}: fix rounding issue when validating MO

### DIFF
--- a/addons/mrp/report/mrp_report_mo_overview.py
+++ b/addons/mrp/report/mrp_report_mo_overview.py
@@ -333,7 +333,7 @@ class ReportMoOverview(models.AbstractModel):
             })
             total_expected_time += workorder.duration_expected
             total_current_time += wo_duration if is_workorder_started else workorder.duration_expected
-            total_expected_cost += mo_cost
+            total_expected_cost += production.company_id.currency_id.round(mo_cost)
             total_bom_cost = self._sum_bom_cost(total_bom_cost, bom_cost)
             total_real_cost += real_cost
 

--- a/addons/mrp_account/models/mrp_production.py
+++ b/addons/mrp_account/models/mrp_production.py
@@ -79,7 +79,7 @@ class MrpProduction(models.Model):
             workorders = defaultdict(self.env['mrp.workorder'].browse)
             for wo in mo.workorder_ids:
                 account = wo.workcenter_id.expense_account_id or product_accounts['expense']
-                labour_amounts[account] += wo._cal_cost()
+                labour_amounts[account] += wo.company_id.currency_id.round(wo._cal_cost())
                 workorders[account] |= wo
             workcenter_cost = sum(labour_amounts.values())
 


### PR DESCRIPTION
Steps to reproduce:

- Create two work centers with different expense accounts:
    - First: hourly cost of 0.01
    - Second: hourly cost of 0.01
- Create an MO for a product with real-time valuation and 2 work orders
(one per work center).
    - Each work order has an expected duration of 30:02
- Attempt to click on "Produce All" button.

This leads to an unbalanced move error.
This fix rounds the values before summing them to prevent rounding issues
and unbalanced moves. It also corrects the displayed value in the
Manufacturing Order overview.

opw-4631409