### PR TITLE
[FIX] purchase:  respect product UoM when selecting from catalog

### DIFF
--- a/addons/product/controllers/catalog.py
+++ b/addons/product/controllers/catalog.py
@@ -44,3 +44,19 @@ class ProductCatalogController(Controller):
         return order.with_company(order.company_id)._update_order_line_info(
             product_id, quantity, **kwargs,
         )
+
+    @route('/product/catalog/update_order_line_uom', auth='user', type='jsonrpc')
+    def product_catalog_update_order_line_uom(self, res_model, order_id, product_id, quantity=0, **kwargs):
+        """ Update order line information on a given order for a given product.
+
+        :param string res_model: The order model.
+        :param int order_id: The order id.
+        :param int product_id: The product, as a `product.product` id.
+        :return: The unit price price of the product, based on the pricelist of the order and
+                 the quantity selected.
+        :rtype: float
+        """
+        order = request.env[res_model].browse(order_id)
+        return order.with_company(order.company_id)._update_order_line_uom(
+            product_id, quantity, **kwargs,
+        )

--- a/addons/product/static/src/product_catalog/kanban_record.js
+++ b/addons/product/static/src/product_catalog/kanban_record.js
@@ -61,10 +61,18 @@ export class ProductCatalogKanbanRecord extends KanbanRecord {
     async _updateQuantity() {
         const price = await this._updateQuantityAndGetPrice();
         this.productCatalogData.price = parseFloat(price);
+        const uom = await this._updateQuantityAndGetUom();
+        this.productCatalogData.uom.id = uom.product_uom_id;
+        this.productCatalogData.uom.display_name = uom.display_uom;
+        
     }
 
     _updateQuantityAndGetPrice() {
         return rpc("/product/catalog/update_order_line_info", this._getUpdateQuantityAndGetPriceParams());
+    }
+
+    _updateQuantityAndGetUom() {
+        return rpc("/product/catalog/update_order_line_uom", this._getUpdateQuantityAndGetPriceParams());
     }
 
     _getUpdateQuantityAndGetPriceParams() {


### PR DESCRIPTION
Steps to reproduce the bug:
- Create a storable product “P1”:
    - UoM: unit
    - Purchase tab:
        - Vendor: Azure interior
        - UoM: Pack of 6

- Create a purchase order:
    - Vendor: Azure interior
    - Click the Catalog button:
        - Select 1 unit of P1 (note: UoM cannot be changed in the catalog)

Problem:
The purchase order line is created, but with 1 pack of 6 instead of 1 unit

Fix:
Ensure the selected product quantity and UoM from the catalog are correctly applied to the PO line.

Opw-4794362
