### PR TITLE
[FIX] pos_sale: Clear sale orders from IndexedDB after payment process

### DIFF
--- a/addons/pos_sale/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_sale/static/src/overrides/components/payment_screen/payment_screen.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import { PaymentScreen } from "@point_of_sale/app/screens/payment_screen/payment_screen";
+import { patch } from "@web/core/utils/patch";
+
+patch(PaymentScreen.prototype, {
+    async afterOrderValidation() {
+        const lines = this.currentOrder.lines.filter(
+            (e) => e.sale_order_origin_id && e.down_payment_details
+        );
+        if (lines.length > 0) {
+            const orders = [...new Set(lines.map((e) => e.sale_order_origin_id))];
+            await this.pos.data.read(
+                "sale.order.line",
+                orders.flatMap((o) => o.order_line).map((ol) => ol.id)
+            );
+            this.pos.data.syncDataWithIndexedDB(this.pos.data.records);
+        }
+        await super.afterOrderValidation();
+    },
+});


### PR DESCRIPTION
## Issue:
Completing a flow from quotation to payment (down payment → settle) via Point of Sale does not properly update the sale order lines when settling.

## Reason:
During the down payment process, the PoS adds new lines to the sale order. These are added during the order validation stage. However, the updated order lines are not written back to IndexedDB.

If the user attempts to settle the order without reloading the session or clearing the cache, the PoS relies on stale data from IndexedDB. This causes Odoo to see outdated `order_lines`, usually only the original item(s), leading to incorrect behavior such as product quantities resetting to 0.

## Fix:
To ensure data consistency, we explicitly remove the affected sale orders from IndexedDB after the down payment is completed. This forces the PoS to re-fetch the updated order from the backend.

The re-fetch happens through the `missingRecursive` function, which will retrieve the complete and up-to-date sale order data, including the new order lines, ensuring accurate behavior during the settlement process.

## Steps to reproduce:
1. Create a service product with "Ordered quantities" as the invoicing policy.
2. Create a quotation using this product.
3. Open the PoS.
4. Click "Actions" → "Quotations" → select the quotation.
5. Choose the "Down Payment" option (any type) and set amount/percentage.
6. Pay the order.
7. Again, go to "Actions" → "Quotations" and select the same order.
8. Click "Settle the order".
9. At this point, Odoo will incorrectly reset product quantity to 0.


OPW-4811612

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
