### PR TITLE
[FIX] stock: display quant_ids on scrap orders

### DIFF
--- a/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
+++ b/addons/stock/wizard/stock_warn_insufficient_qty_views.xml
@@ -5,6 +5,7 @@
         <field name="model">stock.warn.insufficient.qty</field>
         <field name="arch" type="xml">
             <form>
+                <field name="product_id" invisible="True"/>
                 <div>
                     The product is not available in sufficient quantity
                     <span class="oe_inline" groups="stock.group_stock_multi_locations"> in


### PR DESCRIPTION
Prior to this commit, when validating a Scrap Order for a product with
insuficient quantity, a wizard was shown to confirm the order as you
would end up with a negative quantity in your warehouse. However,
the view did not properly displayed quant_ids which allows seeing the
current quantity for this product on the current warehouse as this
compute field was not triggered during the first onchange call.
When confirming the popup, the quant_ids could barely be seen
before closing.
The idea is to make so that quand_ids can be seen as expected before
any confirmation/cancelation.