### PR TITLE
[FIX] survey: Use subject from template in surveys

### DIFF
--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -139,6 +139,7 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
             set([self.customer.email]))
         self.assertEqual(answers.mapped('partner_id'), self.customer)
         self.assertEqual(set(answers.mapped('deadline')), set([deadline]))
+        self.assertEqual(invite.subject, self.env["mail.template"].browse(action["context"]["default_template_id"]).subject)
 
         with self.subTest('Warning when inviting an already invited partner'):
             action = self.survey.action_send_survey()

--- a/addons/survey/wizard/survey_invite.py
+++ b/addons/survey/wizard/survey_invite.py
@@ -154,9 +154,9 @@ class SurveyInvite(models.TransientModel):
 
     @api.depends('template_id', 'partner_ids')
     def _compute_subject(self):
-        for invite in self:
-            if invite.subject:
-                continue
+        for invite in self.filtered(lambda inv: not inv.subject):
+            if invite.template_id and invite.template_id.subject:
+                invite.subject = invite.template_id.subject
             else:
                 invite.subject = _("Participate to %(survey_name)s", survey_name=invite.survey_id.display_name)
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a user updates the subject on a template used for a survey, it does not pull the subject from the template. It uses the default subject that is used when computing the subject for a survey email that is sent out. This bug came as a part of [this commit](https://github.com/odoo/odoo/commit/220e0271bf43e914950b8ae0d4a1cca5f3ea6d9c).

I've used an elif condition over here as opposed to calling super which was being done before so that the default of Participate to X survey still becomes the default subject. 

opw-4654411

Steps to reproduce on runbot:
1. Go to mail templates and search for Survey
2. Open the Survey: Invite template
3. Update the subject on this template
4. Open the Surveys app and select any survey
5. Click on Share and then enable send by email
6. The subject here will default to "Participate to {Survey Name}"

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
