### PR TITLE
[FIX] hr_skills: Add button hidden on long description

### DIFF
--- a/addons/hr_skills/static/src/scss/hr_employee.scss
+++ b/addons/hr_skills/static/src/scss/hr_employee.scss
@@ -7,7 +7,7 @@
         padding-right: calc(var(--gutter-x) * .5)!important;
     }
     .o_list_renderer {
-        overflow-x: hidden!important;
+        overflow-x: auto!important;
     }
 }
 


### PR DESCRIPTION
**Steps to Reproduce :**

1. Install HR module.
2. Open an employee record.
3. Navigate to the Resume section.
4. Add an Experience entry.
5. Enter long description (using a table with multiple columns).
6. After that  "ADD" button becomes no longer visible or usable.

**Issue :**

When a long description is added (especially with table content), 
It pushes the "ADD" button out of view, making it inaccessible.

**Causes:**

The container does not handle overflow properly, so elements extend
beyond the visible area without scrollbars.

**Solution:**

Apply `overflow: auto !important;` to the affected container to allow 
scrolling when content overflows. This ensures the "ADD" button remains accessible.

opw-4778793

**Before fix:** 
![Add btn _before fix](https://github.com/user-attachments/assets/26da9e0c-cfe4-4378-b61e-dbb4abc2ac38)

**After fix:**
![Add_btn_after_fix](https://github.com/user-attachments/assets/70edd45a-b171-4cdc-bc1a-ed2180253508)
