### PR TITLE
[REM] l10n_in: remove the report title inherit

### DIFF
--- a/addons/l10n_in/i18n/l10n_in.pot
+++ b/addons/l10n_in/i18n/l10n_in.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~18.2\n"
+"Project-Id-Version: Odoo Server 18.4a1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-19 06:21+0000\n"
-"PO-Revision-Date: 2025-05-19 06:21+0000\n"
+"POT-Creation-Date: 2025-05-22 05:38+0000\n"
+"PO-Revision-Date: 2025-05-22 05:38+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -276,30 +276,6 @@ msgid "CGST (RC)"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled Credit Note"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled Invoice"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled Proforma Credit Note"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Cancelled Proforma Invoice"
-msgstr ""
-
-#. module: l10n_in
 #: model:ir.model.fields,field_description:l10n_in.field_res_company__l10n_in_gstin_status_feature
 #: model:ir.model.fields,field_description:l10n_in.field_res_config_settings__l10n_in_gstin_status_feature
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
@@ -407,12 +383,6 @@ msgid "Created on"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Credit Note"
-msgstr ""
-
-#. module: l10n_in
 #: model:iap.service,unit_name:l10n_in.iap_service_l10n_in_edi
 msgid "Credits"
 msgstr ""
@@ -474,30 +444,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_in.field_res_partner__display_pan_warning
 #: model:ir.model.fields,field_description:l10n_in.field_res_users__display_pan_warning
 msgid "Display pan warning"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft Credit Note"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft Invoice"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft Proforma Credit Note"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Draft Proforma Invoice"
 msgstr ""
 
 #. module: l10n_in
@@ -805,6 +751,11 @@ msgid "India"
 msgstr ""
 
 #. module: l10n_in
+#: model:res.country.group,name:l10n_in.inter_state_group
+msgid "India Inter-State Group"
+msgstr ""
+
+#. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_form_view
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_search_view
 #: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_port_code_tree_view
@@ -814,11 +765,6 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 msgid "India TDS Control:"
-msgstr ""
-
-#. module: l10n_in
-#: model:res.country.group,name:l10n_in.inter_state_group
-msgid "India inter-state group"
 msgstr ""
 
 #. module: l10n_in
@@ -917,8 +863,7 @@ msgid "Invalid sequence as per GST rule 46(b)"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "Invoice"
 msgstr ""
 
@@ -1326,12 +1271,6 @@ msgstr ""
 
 #. module: l10n_in
 #. odoo-python
-#: code:addons/l10n_in/models/res_config_settings.py:0
-msgid "Please enter a GST number in company."
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
 #: code:addons/l10n_in/models/res_partner.py:0
 msgid "Please enter the GSTIN"
 msgstr ""
@@ -1340,6 +1279,12 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in/wizard/l10n_in_withhold_wizard.py:0
 msgid "Please set a partner on the %s before creating a withhold."
+msgstr ""
+
+#. module: l10n_in
+#. odoo-python
+#: code:addons/l10n_in/models/res_config_settings.py:0
+msgid "Please set a valid GST number on company."
 msgstr ""
 
 #. module: l10n_in
@@ -1386,33 +1331,13 @@ msgid "Products"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Proforma Credit Note"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "Proforma Invoice"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "Proforma Tax Invoice"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Proforma Vendor Bill"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Proforma Vendor Credit Note"
 msgstr ""
 
 #. module: l10n_in
@@ -1981,8 +1906,7 @@ msgid "Tax"
 msgstr ""
 
 #. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
+#: model_terms:ir.ui.view,arch_db:l10n_in.l10n_in_report_invoice_document_inherit
 msgid "Tax Invoice"
 msgstr ""
 
@@ -2144,18 +2068,6 @@ msgstr ""
 #. module: l10n_in
 #: model_terms:ir.ui.view,arch_db:l10n_in.res_config_settings_view_form_inherit_l10n_in
 msgid "Use this if setup with Reseller(E-Commerce)."
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Vendor Bill"
-msgstr ""
-
-#. module: l10n_in
-#. odoo-python
-#: code:addons/l10n_in/models/account_invoice.py:0
-msgid "Vendor Credit Note"
 msgstr ""
 
 #. module: l10n_in

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -701,34 +701,3 @@ class AccountMove(models.Model):
             url,
             _("Buy Credits")
         )
-
-    def _get_l10n_in_customer_invoice_title(self, proforma=False):
-        """
-        Get the title to display in front of a customer invoice number.
-        The title is generated based on the state of the invoice and the `proforma` parameter.
-
-        :param proforma: Is the invoice a proforma one, defaults to False
-        :type proforma: bool, optional
-        :return: A customer invoice title
-        :rtype: str
-        """
-        self.ensure_one()
-        if self.move_type == 'out_invoice' and self.state == 'posted':
-            if self.invoice_line_ids.tax_ids:
-                return _("Tax Invoice") if not proforma else _("Proforma Tax Invoice")
-            else:
-                return _("Invoice") if not proforma else _("Proforma Invoice")
-        elif self.move_type == 'out_invoice' and self.state == 'draft':
-            return _("Draft Invoice") if not proforma else _("Draft Proforma Invoice")
-        elif self.move_type == 'out_invoice' and self.state == 'cancel':
-            return _("Cancelled Invoice") if not proforma else _("Cancelled Proforma Invoice")
-        elif self.move_type == 'out_refund' and self.state == 'posted':
-            return _("Credit Note") if not proforma else _("Proforma Credit Note")
-        elif self.move_type == 'out_refund' and self.state == 'draft':
-            return _("Draft Credit Note") if not proforma else _("Draft Proforma Credit Note")
-        elif self.move_type == 'out_refund' and self.state == 'cancel':
-            return _("Cancelled Credit Note") if not proforma else _("Cancelled Proforma Credit Note")
-        elif self.move_type == 'in_refund':
-            return _("Vendor Credit Note") if not proforma else _("Proforma Vendor Credit Note")
-        elif self.move_type == 'in_invoice':
-            return _("Vendor Bill") if not proforma else _("Proforma Vendor Bill")

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -60,22 +60,22 @@
         </xpath>
 
         <t name="invoice_title" position="replace">
-            <t name="invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
-        </t>
-        <t name="draft_invoice_title" position="replace">
-            <t name="draft_invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
-        </t>
-        <t name="cancelled_invoice_title" position="replace">
-            <t name="cancelled_invoice_title" t-out="o._get_l10n_in_customer_invoice_title()"/>
+            <t name="invoice_title">
+                <span t-if="o.invoice_line_ids.tax_ids">
+                    Tax Invoice
+                </span>
+                <span t-else="">
+                    Invoice
+                </span>
+            </t>
         </t>
         <t name="proforma_invoice_title" position="replace">
-            <t name="proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
-        </t>
-        <t name="draft_proforma_invoice_title" position="replace">
-            <t name="draft_proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
-        </t>
-        <t name="cancelled_proforma_invoice_title" position="replace">
-            <t name="cancelled_proforma_invoice_title" t-out="o._get_l10n_in_customer_invoice_title(proforma=True)"/>
+                <span t-if="o.invoice_line_ids.tax_ids">
+                   Proforma Tax Invoice
+                </span>
+                <span t-else="">
+                    Proforma Invoice
+                </span>
         </t>
 
         <xpath expr="//div[@id='payment_term']" position="after">


### PR DESCRIPTION
Follow up of commit https://github.com/odoo/odoo/commit/64c206744afc66b64571d7d125eb92914d69bf5b

In this commit-
we remove the method `_get_l10n_in_customer_invoice_title` because it is of no longer use and as mentioned above in the above commit it was historical mistake and now we only replace the invoice title becuase as per the government guidelines an invoice having tax would have title of `Tax Invoice`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
