### PR TITLE
[FIX] iot_base: stop suppressing action errors

### DIFF
--- a/addons/iot_base/static/src/network_utils/longpolling.js
+++ b/addons/iot_base/static/src/network_utils/longpolling.js
@@ -86,16 +86,7 @@ export class IoTLongpolling {
             device_identifier: device_identifier,
             data: JSON.stringify(data),
         };
-        return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback).then(
-            (result) => {
-                return result
-            },
-            (e) => {
-                if (e.name === "TimeoutError") {
-                    this._onError();
-                }
-            }
-        );
+        return this._rpcIoT(iot_ip, route || this.actionRoute, body, undefined, fallback);
     }
 
     /**


### PR DESCRIPTION
In https://github.com/odoo/odoo/pull/210149, changes were made to the IoT longpolling methods
to eliminate multiple error notifications when the IoT box couldn't be
reached. However, these changes went a bit too far as it also broke
error messages in the PoS, since they relied on the `action` method
throwing an error when something went wrong. Instead, it currently fails
silently.

This commit reverts the change only for the `action` method (the polling
method will still not throw errors).

Enterprise PR: https://github.com/odoo/enterprise/pull/86166

task-4787494

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
