### PR TITLE
[FIX] point_of_sale: auto-reconcile POS customer account move lines

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1082,7 +1082,7 @@ class PosSession(models.Model):
             vals.append(self._get_combine_receivable_vals(payment_method, amounts['amount'], amounts['amount_converted']))
         for payment, amounts in split_receivables_pay_later.items():
             vals.append(self._get_split_receivable_vals(payment, amounts['amount'], amounts['amount_converted']))
-        MoveLine.create(vals)
+        data['pay_later_move_lines'] = MoveLine.create(vals)
         return data
 
     def _create_combine_account_payment(self, payment_method, amounts, diff_amount):
@@ -1292,7 +1292,6 @@ class PosSession(models.Model):
         stock_output_lines = data.get('stock_output_lines')
         payment_method_to_receivable_lines = data.get('payment_method_to_receivable_lines')
         payment_to_receivable_lines = data.get('payment_to_receivable_lines')
-
 
         all_lines = (
               split_cash_statement_lines


### PR DESCRIPTION
### Problem
When paying a PoS order using customer account, an account move line debiting Account Receivable will be created. Settling this amount inside the PoS (by depositing money) will create another account move line crediting Account Receivable (represents the payment). The second move line is considered, by Odoo, as an outstanding amount, and this amount can be used to pay another invoice (sale order invoice). The moves affecting Account Receivable are still correct. However, unreconciling the two lines created from PoS will cause a confusion for clients who may use this amount to pay other invoices.

This PR covers versions 18 & 18.1, as reconciliation logic differs in later versions.

### How to reproduce
    * Open a PoS session.
    * Create an order and pay using customer account.
    * Settle this customer's account (inside PoS).
    * Create a Sale Order and invoice it (or just an invoice).
    * The amount settled can be used as outstanding amount and can be used to pay the created invoice. 
    
enterprise PR: https://github.com/odoo/enterprise/pull/86174
18.2 PR: https://github.com/odoo/odoo/pull/210619
opw-4794793
