### PR TITLE
[FIX] account: fix a4 statement paper format

### DIFF
--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -59,13 +59,14 @@
             <field name="page_height">0</field>
             <field name="page_width">0</field>
             <field name="orientation">Portrait</field>
-            <field name="margin_top">20</field>
+            <field name="margin_top">52</field>
             <field name="margin_bottom">32</field>
-            <field name="margin_left">7</field>
-            <field name="margin_right">7</field>
+            <field name="margin_left">0</field>
+            <field name="margin_right">0</field>
             <field name="header_line" eval="False" />
-            <field name="header_spacing">15</field>
+            <field name="header_spacing">52</field>
             <field name="dpi">90</field>
+            <field name="css_margins" eval="True" />
         </record>
 
         <record id="action_report_account_statement" model="ir.actions.report">


### PR DESCRIPTION
Before this PR:
In A4 statement format reports, the folder layout was overwriting header information, causing important header details to be obscured in the printed output.

After this PR:
Fixed folder layout rendering to preserve header information in A4 statement format reports, ensuring all header details are properly displayed.

Solution:
Adapted the A4 statement format implementation to work with the new report margin approach that replaces paperformat spacing with $o-default-report-margins CSS variable, preventing layout conflicts that were causing header overwrites.

OPW-4741128
