### PR TITLE
[FIX] project: auto-subscribe recipients to project task on share and message

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -92,6 +92,7 @@ class ProjectTask(models.Model):
         'html.field.history.mixin',
     ]
     _mail_post_access = 'read'
+    _mail_thread_customer = True
     _order = "priority desc, sequence, date_deadline asc, id desc"
     _primary_email = 'email_from'
     _systray_view = 'activity'

--- a/addons/project/tests/test_project_mail_features.py
+++ b/addons/project/tests/test_project_mail_features.py
@@ -3,6 +3,7 @@ from odoo.addons.project.tests.test_project_base import TestProjectCommon
 from odoo.addons.test_mail.data.test_mail_data import MAIL_TEMPLATE
 from odoo.tests import tagged, users
 from odoo.tools import formataddr, mute_logger
+from odoo.fields import Command
 
 
 @tagged('post_install', '-at_install', 'mail_flow', 'mail_tools')
@@ -209,12 +210,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                 self.assertEqual(task.project_id, self.project_followers)
                 self.assertEqual(task.stage_id, self.project_followers.type_ids[0])
                 # followers: email cc is added in followers at creation time, aka only recognized partners
-                if not test_user:
-                    self.assertEqual(task.message_partner_ids, internal_followers + self.partner_1 + self.partner_2,
-                                    'Note that author is not added by mailgateway, as he is external'
-                                    'But project subscribe "current_partner" at create time.')
-                else:
-                    self.assertEqual(task.message_partner_ids, internal_followers + author + self.partner_1 + self.partner_2)
+                self.assertEqual(task.message_partner_ids, internal_followers + author + self.partner_1 + self.partner_2)
                 # messages
                 self.assertEqual(len(task.message_ids), 2)
                 # first message: incoming email: sent to email followers
@@ -349,10 +345,7 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                         subject=f'Re: {task.name}',
                         subtype_id=self.env.ref('mail.mt_comment').id,
                     )
-                if not test_user:
-                    self.assertEqual(task.message_partner_ids, internal_followers + self.partner_1 + self.partner_2)
-                else:
-                    self.assertEqual(task.message_partner_ids, internal_followers + author + self.partner_1 + self.partner_2)
+                self.assertEqual(task.message_partner_ids, internal_followers + author + self.partner_1 + self.partner_2)
 
                 external_partners = self.partner_1 + self.partner_2 + new_partner_cc + new_partner_customer
                 self.assertMailNotifications(
@@ -422,16 +415,10 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
                     '"Valid Poilvache" <valid.other@gmail.com>',
                     'Updated with new Cc')
                 self.assertEqual(len(task.message_ids), 4, 'Incoming email + acknowledgement + chatter reply + customer reply')
-                if not test_user:
-                    self.assertEqual(
-                        task.message_partner_ids,
-                        internal_followers + self.partner_1 + self.partner_2 + self.partner_3 + new_partner_cc + new_partner_customer,
-                        'Project adds recognized recipients as followers')
-                else:
-                    self.assertEqual(
-                        task.message_partner_ids,
-                        internal_followers + author + self.partner_1 + self.partner_2 + self.partner_3 + new_partner_cc + new_partner_customer,
-                        'Project adds recognized recipients as followers')
+                self.assertEqual(
+                    task.message_partner_ids,
+                    internal_followers + author + self.partner_1 + self.partner_2 + self.partner_3 + new_partner_cc + new_partner_customer,
+                    'Project adds recognized recipients as followers')
 
                 self.assertMailNotifications(
                     task.message_ids[0],
@@ -542,3 +529,28 @@ class TestProjectMailFeatures(TestProjectCommon, MailCommon):
             self.flush_tracking()
         # check that no mail was received for the assignee of the task
         self.assertNotSentEmail(self.user_projectuser.email_formatted)
+
+    def test_task_portal_share_adds_followers(self):
+        """ Test that sharing a task through the portal share wizard adds recipients as followers.
+
+            Test Cases:
+            ===========
+            1) Verify that the portal user is not a follower of the task.
+            2) Create and execute a portal share wizard to share the task with the portal user.
+            3) Verify that the portal user has been added as a follower after sharing.
+        """
+
+        self.assertNotIn(self.user_portal.partner_id, self.task_1.message_partner_ids,
+                        "Portal user's partner should not be a follower initially")
+
+        share_wizard = self.env['portal.share'].create({
+            'res_model': 'project.task',
+            'res_id': self.task_1.id,
+            'partner_ids': [Command.set(self.user_portal.partner_id.ids)]
+        })
+
+        with self.mock_mail_gateway():
+            share_wizard.action_send_mail()
+
+        self.assertIn(self.user_portal.partner_id, self.task_1.message_partner_ids,
+                    "Portal user's partner should be added as a follower after sharing")

--- a/addons/project/wizard/__init__.py
+++ b/addons/project/wizard/__init__.py
@@ -5,3 +5,4 @@ from . import project_project_stage_delete
 from . import project_task_type_delete
 from . import project_share_wizard
 from . import project_share_collaborator_wizard
+from . import portal_share

--- a/addons/project/wizard/portal_share.py
+++ b/addons/project/wizard/portal_share.py
@@ -1,0 +1,15 @@
+from odoo import models
+
+
+class PortalShare(models.TransientModel):
+    _inherit = 'portal.share'
+
+    def action_send_mail(self):
+        # Extend portal share to subscribe partners when sharing project tasks.
+        result = super().action_send_mail()
+
+        # Only subscribe partners if shared from project.task
+        if self.res_model == 'project.task':
+            self.resource_ref.message_subscribe(partner_ids=self.partner_ids.ids)
+
+        return result


### PR DESCRIPTION
Before this commit, when a task was shared through the share wizard or when a message was sent to a customer via the chatter, the recipients were not added as followers of the task. As a result, they couldn't see the task in the portal.

This commit ensures:
 - Recipients are now added as followers of the task when it is shared with them through the wizard.
 - A message to a customer in the chatter also adds them as a follower of the task.

task-4781259

