### PR TITLE
[FIX] website_slides: fix broken share link

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -600,12 +600,13 @@ class SlideSlide(models.Model):
     def _compute_website_absolute_url(self):
         super()._compute_website_absolute_url()
 
-    @api.depends('website_absolute_url', 'is_published')
+    @api.depends('is_published')
     def _compute_website_share_url(self):
-        self.website_share_url = '#'
+        self.website_share_url = False
         for slide in self:
-            if slide.website_absolute_url != '#':
-                slide.website_share_url = f'{slide.website_absolute_url}/share'
+            if slide.id:  # ensure we can build the URL
+                base_url = slide.channel_id.get_base_url()
+                slide.website_share_url = '%s/slides/slide/%s/share' % (base_url, slide.id)
 
     @api.depends('channel_id.can_publish')
     def _compute_can_publish(self):

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -661,3 +661,26 @@ class TestAttendeeCase(HttpCaseWithUserPortal):
             self.env['slide.channel'].search([('is_visible', '=', True)]),
             self.env['slide.channel'].search([('is_visible', '!=', False)]),
         )
+
+    def test_slide_slide_notification_link(self):
+        """Check link shared in content notification mail redirect to appropriate content"""
+        self.authenticate("portal", "portal")
+
+        url = self.slide.website_share_url
+        response = self.url_open(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertURLEqual(
+            response.url,
+            f"/slides/{self.channel.id}?access_error=course_content&access_error_slide_id={self.slide.id}&access_error_slide_name=How+to+understand+membership",
+            "Unathorized user cannot access non published content",
+        )
+
+        # Adding attendee to the course
+        self.channel._action_add_members(self.user_portal.partner_id)
+        response = self.url_open(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertURLEqual(
+            response.url,
+            f"/slides/slide/{self.env['ir.http']._slug(self.slide)}",
+            "Should redirect to the slide page",
+        )


### PR DESCRIPTION
Steps to reproduce
===================
1. Add new content to the course and publish it.
2. A notification email is sent to the course attendees.
3. Click the 'View Content' button in the email.
It leads to a 404 error page.

With https://github.com/odoo/odoo/commit/074be1ed36891065361a3cf40f8e189ba5fccb15, we replaced the ID-based route with website_absolute_url,
which uses a slugified URL format, and we don't have a slugify route with `/share`.

This commit restores the previous ID-based route for share link generation
to resolve the issue.

Task-4797324