### PR TITLE
[FIX] website: carousel navigation buttons in translation mode

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -281,7 +281,7 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
             });
         };
         for (const translationEl of $editable) {
-            if (translationEl.closest('.o_not_editable')) {
+            if (translationEl.closest(".o_not_editable:not([data-bs-slide])")) {
                 translationEl.addEventListener('click', (ev) => {
                     ev.stopPropagation();
                     ev.preventDefault();

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -163,8 +163,21 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const $editable = this.getEditableArea();
         const translationRegex = /<span [^>]*data-oe-translation-initial-sha="([^"]+)"[^>]*>([\s\S]*?)<\/span>/;
         let $edited = $();
+        const $savable = $(this.websiteService.pageDocument).find(savableSelector);
         attrs.forEach((attr) => {
-            const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-initial-sha="]').filter(':empty, input, select, textarea, img');
+            const attrSelector = "[" + attr + "*='data-oe-translation-initial-sha=']";
+            const attrEdit = $editable
+                .filter(attrSelector)
+                .filter(":empty, input, select, textarea, img");
+            const attrRestore = $savable.filter(attrSelector).not(attrEdit);
+            attrRestore.each(function () {
+                const $node = $(this);
+                const match = $node.attr(attr).match(translationRegex);
+                $node.attr(attr, match[2]);
+                if (attr === "value") {
+                    $node[0].value = match[2];
+                }
+            });
             attrEdit.each(function () {
                 var $node = $(this);
                 var translation = $node.data('translation') || {};


### PR DESCRIPTION
## 1. Prevent toast on carousel nav buttons in translation mode [Commit 1]
### Steps to reproduce:
1. Go to Website -> Configuration -> Install another language.
2. Add the language to a website.
3. Go to the website and drop a Carousel snippet.
4. Switch to the newly added language and enter Translate mode.
5. Click the carousel's "Next" or "Previous" arrow buttons.

### Issue:
Clicking the buttons triggers "This translation is not editable."

### Cause:
Carousel navigation buttons are wrapped in `<a>` tags with the `o_not_editable` class, which triggers the non-editable warning during translation mode.

### Solution:
Ignore `.carousel-control-prev` and `.carousel-control-next` from triggering the translation error warning.

## 2. Strip translation HTML from attributes [Commit 2]

When translating a website, attributes like `title`, `alt`, or
`placeholder` on complex elements (elements containing children) or
non-editable elements (e.g., carousel controls, search icons) display
raw translation metadata (HTML spans) instead of the clean text.

Steps to reproduce:
1. Install another language and add it to website.
3. Drop a Carousel snippet.
4. Switch to the new language and enter Translate mode.
5. Hover over the carousel arrows (next/previous).

Issue:
The tooltip displays raw HTML, `<span data-oe-translation-initial-sha=..
.>Next</span>`.

Cause:
This happens because attributes like `placeholder`, `title`, `alt`,
`value` receive translation spans and the attribute cleanup logic had a
strict filter (`:empty`, `input`...) that excluded elements containing
other tags (like an `<a>` containing an `<i>` icon), so the raw
translation HTML was never replaced with the clean value.

Solution:
This commit removes translation-specific HTML from the `title` attribute
and keeps only the plain text.

task:[4756921](https://www.odoo.com/odoo/project/974/tasks/4756921)