### PR TITLE
[FIX] hr: ensure departure wizard tracking values

### DIFF
--- a/addons/hr/wizard/hr_departure_wizard.py
+++ b/addons/hr/wizard/hr_departure_wizard.py
@@ -38,10 +38,11 @@ class HrDepartureWizard(models.TransientModel):
     )
 
     def action_register_departure(self):
+        employee_ids = self.employee_ids
         for employee in self.employee_ids.filtered(lambda emp: emp.active):
             if self.env.context.get('employee_termination', False):
                 employee.with_context(no_wizard=True).action_archive()
-        self.employee_ids.write({
+        employee_ids.write({
             'departure_reason_id': self.departure_reason_id,
             'departure_description': self.departure_description,
             'departure_date': self.departure_date,


### PR DESCRIPTION
When we archive an employee that is the time off responsible of another employee, the `_clean_leave_responsible_users` method will clear our cache before we set some departure related fields. This will cause us to have to recompute the relation for `employee_ids` and the domain that ensures the suggested employees in the wizard are not already archived will prevent us from finding the employee we were archiving.

To ensure these fields are written properly, we save the value of `employee_ids` before archiving the employee.

opw-4729600
