### PR TITLE
[IMP] project: show create date of tasks in list view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -498,6 +498,7 @@
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="create_date" optional="hide"/>
                                     <field name="stage_id" optional="hide" context="{'default_project_id': project_id}"/>
                                 </list>
                             </field>
@@ -544,6 +545,7 @@
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
+                                    <field name="create_date" optional="hide"/>
                                     <field name="stage_id" optional="hide"/>
                                 </list>
                             </field>
@@ -743,6 +745,7 @@
                     <field name="date_deadline" optional="hide" widget="remaining_days" invisible="state in ['1_done', '1_canceled']"/>
                     <field name="priority" widget="priority" optional="show" width="70px"/>
                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="show" context="{'project_id': project_id}"/>
+                    <field name="create_date" optional="hide"/>
                     <field name="date_last_stage_update" optional="hide" column_invisible="context.get('default_is_template', False)"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" options="{'is_toggle_mode': false}"/>
                     <field name="stage_id_color" column_invisible="1"/>


### PR DESCRIPTION
Before this commit, the task list views do not have the Creation Date field available as a column. This makes it difficult to  sort tasks by creation date, especially when trying to find the newest or oldest tasks. Relying on the ID field can be confusing and does not provide clear insight into when tasks were created.

This commit adds the creation date of tasks in the list views.

task-4793632
