### PR TITLE
[FIX] l10n_es_edi_facturae: put ReceiverContractReference at the correct place

### DIFF
--- a/addons/l10n_es_edi_facturae/data/facturae_templates.xml
+++ b/addons/l10n_es_edi_facturae/data/facturae_templates.xml
@@ -104,9 +104,9 @@
         <!-- Sub-template used for every instance of InvoiceLineType -->
         <template id="invoice_line_type">
             <InvoiceLine>
+                <ReceiverContractReference t-out="line.get('ReceiverContractReference')"/>
                 <ReceiverTransactionReference t-out="line.get('ReceiverTransactionReference')"/>
                 <FileReference t-out="line.get('FileReference')"/>
-                <ReceiverContractReference t-out="line.get('ReceiverContractReference')"/>
                 <FileDate t-out="line.get('FileDate')"/>
                 <SequenceNumber t-out="line.get('SequenceNumber')"/>
                 <ItemDescription t-out="line['ItemDescription']"/>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -116,9 +116,9 @@
       </InvoiceTotals>
       <Items>
         <InvoiceLine>
+          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
           <FileReference>ABCD-2023-001</FileReference>
-          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>
@@ -140,9 +140,9 @@
           </TaxesOutputs>
         </InvoiceLine>
         <InvoiceLine>
+          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <ReceiverTransactionReference>ABCD-2023-001</ReceiverTransactionReference>
           <FileReference>ABCD-2023-001</FileReference>
-          <ReceiverContractReference>ABCD-2023-001</ReceiverContractReference>
           <FileDate>2023-01-01</FileDate>
           <ItemDescription>product_a</ItemDescription>
           <Quantity>1.0</Quantity>


### PR DESCRIPTION
**Steps to reproduce:**
- Install Accounting and l10n_es_edi_facturae
- Switch to a Spanish company (e.g. ES Company)
- Create or edit a Spanish customer and set "Facturae" as eInvoice format
- Create an invoice:
  * Customer: [the Spanish customer]
  * Product: [any]
  * Customer Reference: [anything]
- Confirm the invoice
- Generate Facturae edi file via "Send & Print" button
- Check the generated XML

**Issue:**
When submitting the XML to FACe service, the XML is rejected with the following error:
"Element 'ReceiverContractReference': This element is not expected. Expected is one of ( FileDate, SequenceNumber, DeliveryNotesReferences, ItemDescription )."
It is caused by "ReceiverContractReference" being set after "FileReference" in the invoice line section.
Apparently, the order defined in the documentation should be respected.
"ReceiverContractReference" should be set before "ReceiverTransactionReference".

The issue has been introduced by this other fix:
https://github.com/odoo/odoo/commit/ac1af565161d70d57f51d579d0530eb7766c0c76

opw-4579987



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
