### PR TITLE
[IMP] mrp: consumption issues warning wizard revamp

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -250,7 +250,7 @@ class MrpProduction(models.Model):
         ('strict', 'Blocked')],
         required=True,
         readonly=True,
-        default='flexible',
+        default='warning',
     )
 
     mrp_production_child_count = fields.Integer("Number of generated MO", compute='_compute_mrp_production_child_count')

--- a/addons/mrp/security/ir.model.access.csv
+++ b/addons/mrp/security/ir.model.access.csv
@@ -43,7 +43,6 @@ access_stock_warn_insufficient_qty_unbuild,access.stock.warn.insufficient.qty.un
 access_mrp_production_backorder,access.mrp.production.backorder,model_mrp_production_backorder,mrp.group_mrp_user,1,1,1,0
 access_mrp_production_backorder_line,access.mrp.production.backorder.line,model_mrp_production_backorder_line,mrp.group_mrp_user,1,1,1,0
 access_mrp_consumption_warning,access.mrp.consumption.warning,model_mrp_consumption_warning,mrp.group_mrp_user,1,1,1,0
-access_mrp_consumption_warning_line,access.mrp.consumption.warning.line,model_mrp_consumption_warning_line,mrp.group_mrp_user,1,1,1,0
 access_mrp_workcenter_tag_group_user,access.mrp.workcenter.tag,model_mrp_workcenter_tag,mrp.group_mrp_user,1,0,0,0
 access_mrp_workcenter_tag_manager,access.mrp.workcenter.tag,model_mrp_workcenter_tag,mrp.group_mrp_manager,1,1,1,1
 access_mrp_production_split_multi,access.mrp.production.split.multi,model_mrp_production_split_multi,mrp.group_mrp_user,1,1,1,0

--- a/addons/mrp/tests/test_stock_report.py
+++ b/addons/mrp/tests/test_stock_report.py
@@ -136,6 +136,7 @@ class TestMrpStockReports(TestReportsCommon):
             'product_uom_id': product_apple_pie.uom_id.id,
             'product_qty': 1.0,
             'type': 'normal',
+            'consumption': 'flexible',
             'bom_line_ids': [
                 (0, 0, {'product_id': product_apple.id, 'product_qty': 5}),
             ],

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -168,7 +168,6 @@
                             <group>
                                 <group>
                                     <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
-                                    <field name="consumption" invisible="type == 'phantom'" widget="radio"/>
                                     <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
                                 </group>
                                 <group>

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -167,10 +167,6 @@
                         <page string="Miscellaneous" name="miscellaneous">
                             <group>
                                 <group>
-                                    <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
-                                    <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
-                                </group>
-                                <group>
                                     <field name="picking_type_id" invisible="type == 'phantom'" groups="stock.group_adv_location"/>
                                     <label for="produce_delay" string="Manuf. Lead Time"/>
                                     <div>
@@ -189,6 +185,10 @@
                                         <field name="batch_size" class="w-50" invisible="not enable_batch_size" decoration-danger="batch_size &lt;= 0.0"/>
                                         <field name="product_uom_id" groups="uom.group_uom" readonly="1" invisible="not enable_batch_size"/>
                                     </div>
+                                </group>
+                                <group>
+                                    <field name="ready_to_produce" invisible="type == 'phantom'" string="Manufacturing Readiness" widget="radio" groups="mrp.group_mrp_routings"/>
+                                    <field name="allow_operation_dependencies" groups="mrp.group_mrp_workorder_dependencies"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/mrp/wizard/mrp_consumption_warning.py
+++ b/addons/mrp/wizard/mrp_consumption_warning.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import _, fields, models, api
-from odoo.exceptions import UserError
+from odoo import api, fields, models
 
 
 class MrpConsumptionWarning(models.TransientModel):
@@ -16,17 +12,17 @@ class MrpConsumptionWarning(models.TransientModel):
         ('flexible', 'Allowed'),
         ('warning', 'Allowed with warning'),
         ('strict', 'Blocked')], compute="_compute_consumption")
-    mrp_consumption_warning_line_ids = fields.One2many('mrp.consumption.warning.line', 'mrp_consumption_warning_id')
+    inconsistent_move_ids = fields.Many2many('stock.move', readonly=True, required=True)
 
     @api.depends("mrp_production_ids")
     def _compute_mrp_production_count(self):
         for wizard in self:
             wizard.mrp_production_count = len(wizard.mrp_production_ids)
 
-    @api.depends("mrp_consumption_warning_line_ids.consumption")
+    @api.depends('inconsistent_move_ids.raw_material_production_id.consumption')
     def _compute_consumption(self):
         for wizard in self:
-            consumption_map = set(wizard.mrp_consumption_warning_line_ids.mapped("consumption"))
+            consumption_map = set(wizard.inconsistent_move_ids.raw_material_production_id.mapped('consumption'))
             wizard.consumption = "strict" in consumption_map and "strict" or "warning" in consumption_map and "warning" or "flexible"
 
     def action_confirm(self):
@@ -35,44 +31,11 @@ class MrpConsumptionWarning(models.TransientModel):
         return self.mrp_production_ids.with_context(ctx, skip_consumption=True).button_mark_done()
 
     def action_set_qty(self):
-        missing_move_vals = []
-        problem_tracked_products = self.env['product.product']
-        for production in self.mrp_production_ids:
-            for line in self.mrp_consumption_warning_line_ids:
-                if line.mrp_production_id != production:
-                    continue
-                for move in production.move_raw_ids:
-                    if line.product_id != move.product_id:
-                        continue
-                    qty_expected = line.product_uom_id._compute_quantity(line.product_expected_qty_uom, move.product_uom)
-                    qty_compare_result = move.product_uom.compare(qty_expected, move.quantity)
-                    if qty_compare_result != 0:
-                        move.quantity = qty_expected
-                    # move should be set to picked to correctly consume the product
+        for order in self.mrp_production_ids:
+            for move in self.inconsistent_move_ids:
+                if move.raw_material_production_id == order:
+                    move.quantity = move.expected_qty
                     move.picked = True
-                    # in case multiple lines with same product => set others to 0 since we have no way to know how to distribute the qty done
-                    line.product_expected_qty_uom = 0
-                # move was deleted before confirming MO or force deleted somehow
-                if not line.product_uom_id.is_zero(line.product_expected_qty_uom):
-                    missing_move_vals.append({
-                        'product_id': line.product_id.id,
-                        'product_uom': line.product_uom_id.id,
-                        'product_uom_qty': line.product_expected_qty_uom,
-                        'quantity': line.product_expected_qty_uom,
-                        'raw_material_production_id': line.mrp_production_id.id,
-                        'additional': True,
-                        'picked': True,
-                    })
-        if problem_tracked_products:
-            products_list = "".join(f"\n- {product_name}" for product_name in problem_tracked_products.mapped("name"))
-            raise UserError(
-                _(
-                    "Values cannot be set and validated because a Lot/Serial Number needs to be specified for a tracked product that is having its consumed amount increased:%(products)s",
-                    products=products_list,
-                ),
-            )
-        if missing_move_vals:
-            self.env['stock.move'].create(missing_move_vals)
         return self.action_confirm()
 
     def action_cancel(self):
@@ -84,17 +47,3 @@ class MrpConsumptionWarning(models.TransientModel):
                 'res_id': self.mrp_production_ids.id,
                 'target': 'main',
             }
-
-
-class MrpConsumptionWarningLine(models.TransientModel):
-    _name = 'mrp.consumption.warning.line'
-    _description = "Line of issue consumption"
-
-    mrp_consumption_warning_id = fields.Many2one('mrp.consumption.warning', "Parent Wizard", readonly=True, required=True, ondelete="cascade")
-    mrp_production_id = fields.Many2one('mrp.production', "Manufacturing Order", readonly=True, required=True, ondelete="cascade")
-    consumption = fields.Selection(related="mrp_production_id.consumption")
-
-    product_id = fields.Many2one('product.product', "Product", readonly=True, required=True)
-    product_uom_id = fields.Many2one('uom.uom', "Unit", related="product_id.uom_id", readonly=True)
-    product_consumed_qty_uom = fields.Float("Consumed", readonly=True)
-    product_expected_qty_uom = fields.Float("To Consume", readonly=True)

--- a/addons/mrp/wizard/mrp_consumption_warning_views.xml
+++ b/addons/mrp/wizard/mrp_consumption_warning_views.xml
@@ -12,7 +12,8 @@
                     <field name="consumption" invisible="1"/>
                     <field name="mrp_production_count" invisible="1"/>
                     <div class="m-2">
-                        You consumed a different quantity than expected for the following products.
+                        You consumed a different quantity than expected for the following products<span invisible="not mrp_production_ids.bom_id">
+                        or consumed a product that is not included in the bill of materials</span>.
                         <b invisible="consumption == 'strict'">
                             Please confirm it has been done on purpose.
                         </b>
@@ -22,14 +23,13 @@
                             <span invisible="mrp_production_count == 1">these manufacturing orders</span>.
                         </b>
                     </div>
-                    <field name="mrp_consumption_warning_line_ids" nolabel="1">
+                    <field name="inconsistent_move_ids" nolabel="1">
                         <list create="0" delete="0" editable="top">
-                            <field name="mrp_production_id" column_invisible="parent.mrp_production_count == 1" force_save="1"/>
-                            <field name="consumption" column_invisible="True" force_save="1"/>
-                            <field name="product_id" force_save="1"/>
-                            <field name="product_uom_id" groups="uom.group_uom" force_save="1" widget="many2one_uom"/>
-                            <field name="product_expected_qty_uom" force_save="1"/>
-                            <field name="product_consumed_qty_uom" force_save="1"/>
+                            <field name="raw_material_production_id" column_invisible="parent.mrp_production_count == 1"/>
+                            <field name="product_id"/>
+                            <field name="product_uom" groups="uom.group_uom" force_save="1" widget="many2one_uom"/>
+                            <field name="expected_qty" string="To Consume" force_save="1"/>
+                            <field name="quantity" string="Consumed" force_save="1"/>
                         </list>
                     </field>
                     <footer>

--- a/addons/mrp_subcontracting/security/ir.model.access.csv
+++ b/addons/mrp_subcontracting/security/ir.model.access.csv
@@ -10,7 +10,6 @@ access_subcontracting_portal_production,subcontracting.portal.production,mrp.mod
 access_subcontracting_portal_bom,subcontracting.portal.bom,mrp.model_mrp_bom,base.group_portal,1,0,0,0
 access_subcontracting_portal_bom_line,subcontracting.portal.bom.line,mrp.model_mrp_bom_line,base.group_portal,1,0,0,0
 access_subcontracting_portal_consumption_warning,subcontracting.portal.consumption.warning,mrp.model_mrp_consumption_warning,base.group_portal,1,1,1,0
-access_subcontracting_portal_consumption_warning_line,subcontracting.portal.consumption.warning.line,mrp.model_mrp_consumption_warning_line,base.group_portal,1,1,1,0
 access_subcontracting_portal_product,subcontracting.portal.product,product.model_product_product,base.group_portal,1,0,0,0
 access_subcontracting_portal_product_template,subcontracting.portal.product.template,product.model_product_template,base.group_portal,1,0,0,0
 access_subcontracting_portal_uom,subcontracting.portal.uom,uom.model_uom_uom,base.group_portal,1,0,0,0

--- a/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
+++ b/addons/mrp_subcontracting/security/mrp_subcontracting_security.xml
@@ -28,13 +28,6 @@
         <field name="domain_force">[('mrp_production_ids', 'in', user.partner_id.commercial_partner_id.production_ids.ids)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
     </record>
-
-    <record model="ir.rule" id="consumption_warning_line_subcontractor_rule">
-        <field name="name">MRP Consumption Warning Lines Subcontractor</field>
-        <field name="model_id" ref="mrp.model_mrp_consumption_warning_line"/>
-        <field name="domain_force">[('mrp_production_id', 'in', user.partner_id.commercial_partner_id.production_ids.ids)]</field>
-        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
-    </record>
     
     <record model="ir.rule" id="stock_move_subcontractor_rule">
         <field name="name">Stock Moves Subcontractor</field>

--- a/addons/mrp_subcontracting/tests/common.py
+++ b/addons/mrp_subcontracting/tests/common.py
@@ -44,6 +44,7 @@ class TestMrpSubcontractingCommon(TransactionCase):
             bom_line.product_id = cls.comp2
             bom_line.product_qty = 1
         cls.bom = bom_form.save()
+        cls.bom.consumption = 'strict'
 
         # Create a BoM for cls.comp2
         cls.comp2comp = cls.env['product.product'].create({

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -966,6 +966,7 @@ class TestSubcontractingTracking(TransactionCase):
             bom_line.product_id = cls.comp2
             bom_line.product_qty = 1
         cls.bom_tracked = bom_form.save()
+        cls.bom_tracked.consumption = 'strict'
 
     def test_flow_tracked_1(self):
         """ This test mimics test_flow_1 but with a BoM that has tracking included in it.

--- a/addons/mrp_subcontracting/views/mrp_bom_views.xml
+++ b/addons/mrp_subcontracting/views/mrp_bom_views.xml
@@ -8,9 +8,6 @@
             <xpath expr="//field[@name='type']" position="after">
                 <field name="subcontractor_ids" widget="many2many_tags" invisible="type != 'subcontract'" required="type == 'subcontract'"/>
             </xpath>
-            <xpath expr="//field[@name='consumption']" position="attributes">
-                <attribute name="invisible">type == 'phantom' or type == 'subcontract'</attribute>
-            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The wizard that warns the user about mismatches in the quantity predicted to be consumed and the actual quantity consumed has some problems.

1. The problematic move values are collected by products. If multiple components in the MO are the same product but with different UoMs, they still get lumped together in the same `mrp.consumption.warning.line​`s with the quantities summed. We would like to keep them separate.
2. The above can be solved by collecting them by BoM lines instead, but we want the wizard to trigger without BoMs as well. (Right now the wizard won't kick in if the MO doesn't have a BoM because it relies on BoM values instead of move values.)
3. The lines use `product_id.uom_id​` for the UoMs (so they ignore the UoMs set in the BoM/MO) instead of `move.bom_line_id.product_uom_id​` — or better yet, `move.product_uom`​ since we want to be BoM-agnostic as stated above. 
    * Additionally, the computes for `allowed_uom_ids`​ for the moves can potentially change in the future, in which case locking the UoMs to those specified in the BoM would repeat the above issue.

Thus, we're doing away with the `mrp.consumption.warning.line` model in favour of directly passing `stock.move`s to `mrp.consumption.warning`, since it contains everything we need already (save for a new computed field).

Finally, we're removing the `consumption` field from the MO view, delegating it to a technical field (which is necessary as many tests and internal calls rely on the value being `flexible` to bypass the warning. (`skip_consumption` context parameter is always an option as well). `warning` will be the default value from now on. (ie It will always trigger a warning for mismatched values instead of blocking.)

Task ID: [4603609](https://www.odoo.com/odoo/my-tasks/4603609), [4441090](https://www.odoo.com/odoo/my-tasks/4441090)

**Note:** There's some overlap between this new field `expected_qty` and the existing `should_consume_qty` field, the latter of which relies on BoM. It could be adapted to this use case so as to obviate the need for adding a new field, if it doesn't break other things.