### PR TITLE
[FIX] sale_loyalty: calculate correct loyalty history for multi-reward

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -2,8 +2,8 @@
 
 import itertools
 import random
-
 from collections import defaultdict
+from functools import partial
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -79,13 +79,13 @@ class SaleOrder(models.Model):
 
     def _add_loyalty_history_lines(self):
         self.ensure_one()
-        points_per_coupon = defaultdict(dict)
+        points_per_coupon = defaultdict(partial(defaultdict, int))
         for coupon_point in self.coupon_point_ids:
             points_per_coupon[coupon_point.coupon_id]['issued'] = coupon_point.points
         for line in self.order_line:
             if not line.coupon_id:
                 continue
-            points_per_coupon[line.coupon_id]['cost'] = line.points_cost
+            points_per_coupon[line.coupon_id]['cost'] += line.points_cost
 
         create_values = []
         base_values = {


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Create a loyalty card program applying on future orders;
2. add 2 rewards: free shipping (100 points) & discount (200 points);
3. create a loyalty card for current user with 500 points;
4. apply both rewards on an eCommerce order & pay to confirm.

Issue
-----
In the back end, the sale order displays the loyalty points cost as 200 instead of 300. The same applies to the points history on the loyalty card view.

Cause
-----
The loyalty history model introduced by 17ef5c57a5c1 does not sum up the total cost of the points used on an order, instead it only saves the points used of the last reward line per coupon.

Solution
--------
Sum up the points per coupon.

opw-4783518