### PR TITLE
[FIX] hr_expense: Expenses sheets journal_id not updated

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -269,7 +269,7 @@ class HrExpenseSheet(models.Model):
         for sheet in self:
             sheet.payment_method_line_id = sheet.selectable_payment_method_line_ids[:1]
 
-    @api.depends('employee_journal_id', 'payment_method_line_id')
+    @api.depends('employee_journal_id', 'payment_method_line_id', 'payment_mode')
     def _compute_journal_id(self):
         for sheet in self:
             if sheet.payment_mode == 'company_account':


### PR DESCRIPTION
Current behavior before PR:

1. Create an expense paid by company
2. Create an empty expense report (not through the expense form view)
3. Add the expense to the report (Updates the payment_method and payment_method_line_id but not the journal_id)
4. Try to move forward to create the move
5. Error (The selected payment method is not available for this payment, please select the payment method again.)

Desired behavior after PR is merged:

The right journal_id is set when adding an expense to an empty expense report.

task-4804970

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
