### PR TITLE
[FIX] stock: fixed incorrect location in picking operations report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -141,7 +141,7 @@
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="from_col_exists" groups="stock.group_stock_multi_locations">
                                                 <div t-if="not move_has_multiple_lines">
-                                                    <span t-field="move.location_id.display_name">WH/Stock</span>
+                                                    <span t-field="move.move_line_ids[0].location_id.display_name">WH/Stock</span>
                                                     <t t-if="move.move_line_ids and move.move_line_ids[0].package_id">
                                                         <span t-field="move.move_line_ids[0].package_id">Package A</span>
                                                     </t>
@@ -150,7 +150,7 @@
                                             <!-- If a move contains only one move line, the move is summarized in the heading only -->
                                             <td class="text-start" t-if="to_col_exists" groups="stock.group_stock_multi_locations">
                                                 <div t-if="not move_has_multiple_lines">
-                                                    <span t-field="move.location_dest_id.display_name">WH/Outgoing</span>
+                                                    <span t-field="move.move_line_ids[0].location_dest_id.display_name">WH/Outgoing</span>
                                                     <t t-if="move.move_line_ids and move.move_line_ids[0].result_package_id">
                                                         <span t-field="move.move_line_ids[0].result_package_id">Package B</span>
                                                     </t>


### PR DESCRIPTION
**Steps to reproduce the issue:**
- Install stock, purchase
- Activate multi step routes setting
- Create a product with track inventory and putaway rule from loc1 to loc2
- Create a PO on that product and confirm it
- Print the picking operations report of the receipt picking

**Issue**
In 3816156, "To" column in the report shows the move's destination location instead of the actual destination location determined by the putaway rule.
https://github.com/odoo/odoo/blob/09efa08050c4e32d03b242be4098da999de9cdc3/addons/stock/report/report_stockpicking_operations.xml#L144

opw-4745361
opw-4715416

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
