### PR TITLE
[IMP] l10n_sa, l10n_sa_edi: Restrict PDF deletion on posted invoices

### DIFF
--- a/addons/l10n_sa/i18n_extra/ar.po
+++ b/addons/l10n_sa/i18n_extra/ar.po
@@ -4,16 +4,17 @@
 #
 msgid ""
 msgstr ""
-
-#. module: l10n_sa
-#: model:account.tax.report,name:l10n_sa.tax_report_vat_filing
-msgid "VAT Filing Report"
-msgstr "الإقرار الضريبي"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
-msgid "VAT on Sales and all other Outputs (Base)"
-msgstr "ضريبة القيمة المضافة على المبيعات (أساسي)"
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-10 09:11+0000\n"
+"PO-Revision-Date: 2025-06-10 09:11+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
@@ -21,54 +22,9 @@ msgid "1. Standard Rated 15% (Base)"
 msgstr "1. المبيعات الخاضعة لنسبة أساسية (أساسي)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
-msgid "2. Special Sales to Locals (Base)"
-msgstr ""
-"2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
-msgid "3. Local Sales Subject to 0% (Base)"
-msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
-msgid "4. Export Sales (Base)"
-msgstr "4. الصادرات (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
-msgid "5. Exempt Sales (Base)"
-msgstr "5. المبيعات معفاة من الضريبة (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
-msgid "6. Net Sales (Base)"
-msgstr "6. إجمالي المبيعات (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
-msgid "VAT on Expenses and all other Inputs (Base)"
-msgstr "ضريبة القيمة المضافة على المشتريات (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
-msgid "7. Standard rated 15% Purchases (Base)"
-msgstr "7. ضريبة القيمة المضافة على المشتريات (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
-msgid "8. Taxable Imports 15% Paid to Customs (Base)"
-msgstr ""
-"8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في"
-" الجمارك 15 % (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
-msgid "9. Imports subject to reverse charge mechanism (Base)"
-msgstr ""
-"9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب "
-"العكس (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
+msgid "1. Standard Rated 15% (Tax)"
+msgstr "1. المبيعات الخاضعة لنسبة أساسية (ضريبة)"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
@@ -76,79 +32,14 @@ msgid "10. Zero Rated Purchases (Base)"
 msgstr "10. المشتريات الخاضعة للنسبة الصفرية (أساسي)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
-msgid "11. Exempt Purchases (Base)"
-msgstr "11. المشتريات معفاة من الضريبة (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
-msgid "12. Net Purchases (Base)"
-msgstr "12. إجمالي المشتريات (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
-msgid "VAT on Sales and all other Outputs (Tax)"
-msgstr "ضريبة القيمة المضافة على المبيعات (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_tax
-msgid "1. Standard Rated 15% (Tax)"
-msgstr "1. المبيعات الخاضعة لنسبة أساسية (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
-msgid "2. Special Sales to Locals (Tax)"
-msgstr ""
-"2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
-msgid "3. Local Sales Subject to 0% (Tax)"
-msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
-msgid "4. Export Sales (Tax)"
-msgstr "4. الصادرات (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
-msgid "5. Exempt Sales (Tax)"
-msgstr "5. المبيعات معفاة من الضريبة (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
-msgid "6. Net Sales (Tax)"
-msgstr "6. إجمالي المبيعات (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
-msgid "VAT on Expenses and all other Inputs (Tax)"
-msgstr "ضريبة القيمة المضافة على المشتريات (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
-msgid "7. Standard rated 15% Purchases (Tax)"
-msgstr "7. ضريبة القيمة المضافة على المشتريات (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
-msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
-msgstr ""
-"8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في"
-" الجمارك 15 % (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
-msgid "9. Imports subject to reverse charge mechanism (Tax)"
-msgstr ""
-"9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب "
-"العكس (ضريبة)"
-
-#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_tax
 msgid "10. Zero Rated Purchases (Tax)"
 msgstr "10. المشتريات الخاضعة للنسبة الصفرية (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
+msgid "11. Exempt Purchases (Base)"
+msgstr "11. المشتريات معفاة من الضريبة (أساسي)"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
@@ -156,9 +47,201 @@ msgid "11. Exempt Purchases (Tax)"
 msgstr "11. المشتريات معفاة من الضريبة (ضريبة)"
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
+msgid "12. Net Purchases (Base)"
+msgstr "12. إجمالي المشتريات (أساسي)"
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_tax
 msgid "12. Net Purchases (Tax)"
 msgstr "12. إجمالي المشتريات (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
+msgid "2. Special Sales to Locals (Base)"
+msgstr "2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
+msgid "2. Special Sales to Locals (Tax)"
+msgstr "2. المبيعات للمواطنين (الخدمات الصحية  الخاصة/التعليم الأهلي الخاص) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
+msgid "3. Local Sales Subject to 0% (Base)"
+msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
+msgid "3. Local Sales Subject to 0% (Tax)"
+msgstr "3. المبيعات المحلية الخاضعة للنسبة الصفرية (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
+msgid "4. Export Sales (Base)"
+msgstr "4. الصادرات (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
+msgid "4. Export Sales (Tax)"
+msgstr "4. الصادرات (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
+msgid "5. Exempt Sales (Base)"
+msgstr "5. المبيعات معفاة من الضريبة (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
+msgid "5. Exempt Sales (Tax)"
+msgstr "5. المبيعات معفاة من الضريبة (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
+msgid "6. Net Sales (Base)"
+msgstr "6. إجمالي المبيعات (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
+msgid "6. Net Sales (Tax)"
+msgstr "6. إجمالي المبيعات (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
+msgid "7. Standard rated 15% Purchases (Base)"
+msgstr "7. ضريبة القيمة المضافة على المشتريات (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
+msgid "7. Standard rated 15% Purchases (Tax)"
+msgstr "7. ضريبة القيمة المضافة على المشتريات (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
+msgid "8. Taxable Imports 15% Paid to Customs (Base)"
+msgstr "8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك 15 % (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
+msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
+msgstr "8. الاستيرادات الخاضعة لضريبة القيمة المضافة بالنسبة الأساسية و التي تدفع في الجمارك 15 % (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
+msgid "9. Imports subject to reverse charge mechanism (Base)"
+msgstr "9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكس (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
+msgid "9. Imports subject to reverse charge mechanism (Tax)"
+msgstr "9. الاستيرادات الخاضعة لضريبة القيمة المضافة التي تُطبق عليها آلية الاحتساب العكس (ضريبة)"
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                Subtotal<br/>(exclusive of VAT)\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                Subtotal<br/>(inclusive of VAT)\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                المجموع الفرعي بدون الضريبة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                المجموع شامل ضريبة القيمة المضافة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                نسبة الضريبة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid "<strong class=\"d-block mt-3\">Shipping Address:</strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong style=\"white-space:nowrap\">:\n"
+"                        تاريخ التوصيل\n"
+"                    </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong style=\"white-space:nowrap\">Delivery Date:\n"
+"                    </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong>\n"
+"                Invoice Taxable Amount\n"
+"                /<br/>\n"
+"                المبلغ الخاضع للضريبة غير شامل ضريبة القيمة المضافة\n"
+"            </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong>\n"
+"                Invoice Total (inclusive of VAT)\n"
+"                /\n"
+"                إجمالي قيمة الفاتورة شامل ضريبة القيمة المضافة\n"
+"            </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.column,name:l10n_sa.tax_report_vat_filing_balance
+#: model:account.report.column,name:l10n_sa.tax_report_withholding_tax_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+msgid "Confirmation Date"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_account_move
+msgid "Journal Entry"
+msgstr ""
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due
@@ -166,79 +249,44 @@ msgid "Net VAT Due"
 msgstr "صافي الضريبة المستحق"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
-msgid "Total value of due tax for the period"
-msgstr "إجمالي ضريبة القيمة المستحقة للفترة الحالية"
-
-#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due_or_reclaimed_for_the_period
 msgid "Net VAT due (or reclaimed) for the period"
 msgstr "ضرريبة القيمة المضافة التي تم ترحيلها من الفترة / الفترات السابقة"
 
 #. module: l10n_sa
-#: model:account.tax.report,name:l10n_sa.tax_report_withholding_tax
-msgid "Withholding Tax Report"
-msgstr "تقرير استقطاع الضريبة"
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
+msgid "Total value of due tax for the period"
+msgstr "إجمالي ضريبة القيمة المستحقة للفترة الحالية"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
-msgid "Withholding Tax on Purchased Services (Base)"
-msgstr "استقطاع الضريبة على الخدمات المشتراة (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_recoverable_tax_for_the_period
+msgid "Total value of recoverable tax for the period"
+msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
-msgid "Withholding Tax 5% (Rental) (Base)"
-msgstr " استقطاع الضريبة 5 % (إيجار) (أساسي)"
+#: model:account.report,name:l10n_sa.tax_report_vat_filing
+msgid "VAT Filing Report"
+msgstr "الإقرار الضريبي"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
-msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
-msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
+msgid "VAT on Expenses and all other Inputs (Base)"
+msgstr "ضريبة القيمة المضافة على المشتريات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
-msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
-msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
+msgid "VAT on Expenses and all other Inputs (Tax)"
+msgstr "ضريبة القيمة المضافة على المشتريات (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
-msgid "Withholding Tax 5% (International Telecommunication)(Base)"
-msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
+msgid "VAT on Sales and all other Outputs (Base)"
+msgstr "ضريبة القيمة المضافة على المبيعات (أساسي)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
-msgid "Withholding Tax 5% (Distributed Profits) (Base)"
-msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
-msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
-msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
-msgid "Withholding Tax 5% (Return from Loans) (Base)"
-msgstr " استقطاع الضريبة 5 % (عوائد قروض) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
-msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
-msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
-msgid "Withholding Tax 15% (Royalties)(Base)"
-msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
-msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
-msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة للمركز الرئيسي) (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
-msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
-msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة لشركة مرتبطة) (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
+msgid "VAT on Sales and all other Outputs (Tax)"
+msgstr "ضريبة القيمة المضافة على المبيعات (ضريبة)"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_base
@@ -246,64 +294,14 @@ msgid "Withholding Tax 15% (Others)(Base)"
 msgstr " استقطاع الضريبة 15 % (لأي دفعات أخرى) (أساسي)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
-msgid "Withholding Tax 20% (Managerial)(Base)"
-msgstr " استقطاع الضريبة 20 % (أتعاب إدارة) (أساسي)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
+msgid "Withholding Tax 15% (Others)(Tax)"
+msgstr " استقطاع الضريبة 15 % (لأي دفعات أخرى) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
-msgid "Withholding Tax Total (Base)"
-msgstr "إجمالي استقطاع الضريبة (أساسي)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
-msgid "Withholding Tax on Purchased Services (Tax)"
-msgstr "استقطاع الضريبة على الخدمات المشتراة (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
-msgid "Withholding Tax 5% (Rental) (Tax)"
-msgstr " استقطاع الضريبة 5 % (إيجار) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
-msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
-msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
-msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
-msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
-msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
-msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
-msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
-msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
-msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
-msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
-msgid "Withholding Tax 5% (Return from Loans) (Tax)"
-msgstr " استقطاع الضريبة 5 % (عوائد قروض) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
-msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
-msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (ضريبة)"
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
-msgid "Withholding Tax 15% (Royalties)(Tax)"
-msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (ضريبة)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
+msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
+msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة للمركز الرئيسي) (أساسي)"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_tax
@@ -311,14 +309,29 @@ msgid "Withholding Tax 15% (Paid Services from Main Branch)(Tax)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة للمركز الرئيسي) (ضريبة)"
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
+msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
+msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة لشركة مرتبطة) (أساسي)"
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
 msgid "Withholding Tax 15% (Paid Services from another branch)(Tax)"
 msgstr " استقطاع الضريبة 15 % (خدمات مدفوعة لشركة مرتبطة) (ضريبة)"
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
-msgid "Withholding Tax 15% (Others)(Tax)"
-msgstr " استقطاع الضريبة 15 % (لأي دفعات أخرى) (ضريبة)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
+msgid "Withholding Tax 15% (Royalties)(Base)"
+msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
+msgid "Withholding Tax 15% (Royalties)(Tax)"
+msgstr " استقطاع الضريبة 15 % (أتاوة أو ريع) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
+msgid "Withholding Tax 20% (Managerial)(Base)"
+msgstr " استقطاع الضريبة 20 % (أتعاب إدارة) (أساسي)"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_tax
@@ -326,19 +339,109 @@ msgid "Withholding Tax 20% (Managerial)(Tax)"
 msgstr " استقطاع الضريبة 20 % (أتعاب إدارة) (ضريبة)"
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
+msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
+msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
+msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
+msgstr " استقطاع الضريبة 5 % (خدمات فنية أو استشارية) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
+msgid "Withholding Tax 5% (Distributed Profits) (Base)"
+msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
+msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
+msgstr " استقطاع الضريبة 5 % (أرباح موزعة) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
+msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
+msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
+msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
+msgstr " استقطاع الضريبة 5 % (قسط تأمين أو إعادة تأمين) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
+msgid "Withholding Tax 5% (International Telecommunication)(Base)"
+msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
+msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
+msgstr " استقطاع الضريبة 5 % (خدمات اتصاالت هاتفية دولية) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
+msgid "Withholding Tax 5% (Rental) (Base)"
+msgstr " استقطاع الضريبة 5 % (إيجار) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
+msgid "Withholding Tax 5% (Rental) (Tax)"
+msgstr " استقطاع الضريبة 5 % (إيجار) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
+msgid "Withholding Tax 5% (Return from Loans) (Base)"
+msgstr " استقطاع الضريبة 5 % (عوائد قروض) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
+msgid "Withholding Tax 5% (Return from Loans) (Tax)"
+msgstr " استقطاع الضريبة 5 % (عوائد قروض) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
+msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
+msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
+msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
+msgstr " استقطاع الضريبة 5 % (تذاكر طيران أو شحن جوي) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
+msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
+msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (أساسي)"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
+msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
+msgstr " استقطاع الضريبة 5 % (تذاكر أو شحن بحري) (ضريبة)"
+
+#. module: l10n_sa
+#: model:account.report,name:l10n_sa.tax_report_withholding_tax
+msgid "Withholding Tax Report"
+msgstr "تقرير استقطاع الضريبة"
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
+msgid "Withholding Tax Total (Base)"
+msgstr "إجمالي استقطاع الضريبة (أساسي)"
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
 msgid "Withholding Tax Total (Tax)"
 msgstr "إجمالي استقطاع الضريبة (ضريبة)"
 
 #. module: l10n_sa
-#: model:res.country,vat_label:base.sa
-msgid "VAT Number"
-msgstr "رقم تسجيل ضريبة القيمة المضافة"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
+msgid "Withholding Tax on Purchased Services (Base)"
+msgstr "استقطاع الضريبة على الخدمات المشتراة (أساسي)"
 
 #. module: l10n_sa
-#: model:res.currency,currency_unit_label:base.SAR
-msgid "Riyal"
-msgstr "ريال"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
+msgid "Withholding Tax on Purchased Services (Tax)"
+msgstr "استقطاع الضريبة على الخدمات المشتراة (ضريبة)"
 
 #. module: l10n_sa
 #: model:res.currency,currency_subunit_label:base.SAR

--- a/addons/l10n_sa/i18n_extra/l10n_sa.pot
+++ b/addons/l10n_sa/i18n_extra/l10n_sa.pot
@@ -4,85 +4,20 @@
 #
 msgid ""
 msgstr ""
-
-#. module: l10n_sa
-#: model:account.tax.report,name:l10n_sa.tax_report_vat_filing
-msgid "VAT Filing Report"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
-msgid "VAT on Sales and all other Outputs (Base)"
-msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-10 09:11+0000\n"
+"PO-Revision-Date: 2025-06-10 09:11+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_base
 msgid "1. Standard Rated 15% (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
-msgid "2. Special Sales to Locals (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
-msgid "3. Local Sales Subject to 0% (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
-msgid "4. Export Sales (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
-msgid "5. Exempt Sales (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
-msgid "6. Net Sales (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
-msgid "VAT on Expenses and all other Inputs (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
-msgid "7. Standard rated 15% Purchases (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
-msgid "8. Taxable Imports 15% Paid to Customs (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
-msgid "9. Imports subject to reverse charge mechanism (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
-msgid "10. Zero Rated Purchases (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
-msgid "11. Exempt Purchases (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
-msgid "12. Net Purchases (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
-msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
@@ -91,48 +26,8 @@ msgid "1. Standard Rated 15% (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
-msgid "2. Special Sales to Locals (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
-msgid "3. Local Sales Subject to 0% (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
-msgid "4. Export Sales (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
-msgid "5. Exempt Sales (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
-msgid "6. Net Sales (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
-msgid "VAT on Expenses and all other Inputs (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
-msgid "7. Standard rated 15% Purchases (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
-msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
-msgid "9. Imports subject to reverse charge mechanism (Tax)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_zero_rated_purchases_base
+msgid "10. Zero Rated Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
@@ -141,8 +36,18 @@ msgid "10. Zero Rated Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_base
+msgid "11. Exempt Purchases (Base)"
+msgstr ""
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_exempt_purchases_tax
 msgid "11. Exempt Purchases (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_purchases_base
+msgid "12. Net Purchases (Base)"
 msgstr ""
 
 #. module: l10n_sa
@@ -151,13 +56,195 @@ msgid "12. Net Purchases (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due
-msgid "Net VAT Due"
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_base
+msgid "2. Special Sales to Locals (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
-msgid "Total value of due tax for the period"
+#: model:account.report.line,name:l10n_sa.tax_report_line_special_sales_to_locals_tax
+msgid "2. Special Sales to Locals (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_base
+msgid "3. Local Sales Subject to 0% (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_local_sales_subject_to_0_tax
+msgid "3. Local Sales Subject to 0% (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_base
+msgid "4. Export Sales (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_export_sales_tax
+msgid "4. Export Sales (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_base
+msgid "5. Exempt Sales (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_exempt_sales_tax
+msgid "5. Exempt Sales (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_base
+msgid "6. Net Sales (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_sales_tax
+msgid "6. Net Sales (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_base
+msgid "7. Standard rated 15% Purchases (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_standard_rated_15_purchases_tax
+msgid "7. Standard rated 15% Purchases (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_base
+msgid "8. Taxable Imports 15% Paid to Customs (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_taxable_imports_15_paid_to_customs_tax
+msgid "8. Taxable Imports 15% Paid to Customs (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_base
+msgid "9. Imports subject to reverse charge mechanism (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_imports_subject_tp_reverse_charge_mechanism_tax
+msgid "9. Imports subject to reverse charge mechanism (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                Subtotal<br/>(exclusive of VAT)\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                Subtotal<br/>(inclusive of VAT)\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                المجموع الفرعي بدون الضريبة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                المجموع شامل ضريبة القيمة المضافة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<span>\n"
+"                نسبة الضريبة\n"
+"            </span>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid "<strong class=\"d-block mt-3\">Shipping Address:</strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong style=\"white-space:nowrap\">:\n"
+"                        تاريخ التوصيل\n"
+"                    </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong style=\"white-space:nowrap\">Delivery Date:\n"
+"                    </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong>\n"
+"                Invoice Taxable Amount\n"
+"                /<br/>\n"
+"                المبلغ الخاضع للضريبة غير شامل ضريبة القيمة المضافة\n"
+"            </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model_terms:ir.ui.view,arch_db:l10n_sa.arabic_english_invoice
+msgid ""
+"<strong>\n"
+"                Invoice Total (inclusive of VAT)\n"
+"                /\n"
+"                إجمالي قيمة الفاتورة شامل ضريبة القيمة المضافة\n"
+"            </strong>"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.column,name:l10n_sa.tax_report_vat_filing_balance
+#: model:account.report.column,name:l10n_sa.tax_report_withholding_tax_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_confirmation_datetime
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_confirmation_datetime
+msgid "Confirmation Date"
+msgstr ""
+
+#. module: l10n_sa
+#: model:ir.model,name:l10n_sa.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_net_vat_due
+msgid "Net VAT Due"
 msgstr ""
 
 #. module: l10n_sa
@@ -166,68 +253,38 @@ msgid "Net VAT due (or reclaimed) for the period"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.tax.report,name:l10n_sa.tax_report_withholding_tax
-msgid "Withholding Tax Report"
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_due_tax_for_the_period
+msgid "Total value of due tax for the period"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
-msgid "Withholding Tax on Purchased Services (Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_total_value_of_recoverable_tax_for_the_period
+msgid "Total value of recoverable tax for the period"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
-msgid "Withholding Tax 5% (Rental) (Base)"
+#: model:account.report,name:l10n_sa.tax_report_vat_filing
+msgid "VAT Filing Report"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
-msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_base
+msgid "VAT on Expenses and all other Inputs (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
-msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_expenses_tax
+msgid "VAT on Expenses and all other Inputs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
-msgid "Withholding Tax 5% (International Telecommunication)(Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_base
+msgid "VAT on Sales and all other Outputs (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
-msgid "Withholding Tax 5% (Distributed Profits) (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
-msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
-msgid "Withholding Tax 5% (Return from Loans) (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
-msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
-msgid "Withholding Tax 15% (Royalties)(Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
-msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
-msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_vat_all_sales_tax
+msgid "VAT on Sales and all other Outputs (Tax)"
 msgstr ""
 
 #. module: l10n_sa
@@ -236,63 +293,13 @@ msgid "Withholding Tax 15% (Others)(Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
-msgid "Withholding Tax 20% (Managerial)(Base)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
+msgid "Withholding Tax 15% (Others)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
-msgid "Withholding Tax Total (Base)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
-msgid "Withholding Tax on Purchased Services (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
-msgid "Withholding Tax 5% (Rental) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
-msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
-msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
-msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
-msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
-msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
-msgid "Withholding Tax 5% (Return from Loans) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
-msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
-msgid "Withholding Tax 15% (Royalties)(Tax)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_main_branch_base
+msgid "Withholding Tax 15% (Paid Services from Main Branch)(Base)"
 msgstr ""
 
 #. module: l10n_sa
@@ -301,13 +308,28 @@ msgid "Withholding Tax 15% (Paid Services from Main Branch)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_base
+msgid "Withholding Tax 15% (Paid Services from another branch)(Base)"
+msgstr ""
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_paid_services_from_another_branch_tax
 msgid "Withholding Tax 15% (Paid Services from another branch)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_others_tax
-msgid "Withholding Tax 15% (Others)(Tax)"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_base
+msgid "Withholding Tax 15% (Royalties)(Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_15_royalties_tax
+msgid "Withholding Tax 15% (Royalties)(Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_20_managerial_base
+msgid "Withholding Tax 20% (Managerial)(Base)"
 msgstr ""
 
 #. module: l10n_sa
@@ -316,28 +338,114 @@ msgid "Withholding Tax 20% (Managerial)(Tax)"
 msgstr ""
 
 #. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_base
+msgid "Withholding Tax 5% (Consulting and Technical) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_consulting_and_technical_tax
+msgid "Withholding Tax 5% (Consulting and Technical) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_base
+msgid "Withholding Tax 5% (Distributed Profits) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_distributed_profits_tax
+msgid "Withholding Tax 5% (Distributed Profits) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_base
+msgid "Withholding Tax 5% (Insurance & Reinsurance) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_insurance_and_reinsurance_tax
+msgid "Withholding Tax 5% (Insurance & Reinsurance) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_base
+msgid "Withholding Tax 5% (International Telecommunication)(Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_international_telecommunication_tax
+msgid "Withholding Tax 5% (International Telecommunication)(Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_base
+msgid "Withholding Tax 5% (Rental) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_rental_tax
+msgid "Withholding Tax 5% (Rental) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_base
+msgid "Withholding Tax 5% (Return from Loans) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_return_from_loans_tax
+msgid "Withholding Tax 5% (Return from Loans) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_base
+msgid "Withholding Tax 5% (Tickets or Air Freight) (Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_air_freight_tax
+msgid "Withholding Tax 5% (Tickets or Air Freight) (Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_base
+msgid "Withholding Tax 5% (Tickets or Sea Freight)(Base)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_5_tickets_or_sea_freight_tax
+msgid "Withholding Tax 5% (Tickets or Sea Freight)(Tax)"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report,name:l10n_sa.tax_report_withholding_tax
+msgid "Withholding Tax Report"
+msgstr ""
+
+#. module: l10n_sa
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_base
+msgid "Withholding Tax Total (Base)"
+msgstr ""
+
+#. module: l10n_sa
 #: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_total_tax
 msgid "Withholding Tax Total (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:res.country,vat_label:base.sa
-msgid "VAT Number"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_base
+msgid "Withholding Tax on Purchased Services (Base)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:res.currency,currency_unit_label:base.SAR
-msgid "Riyal"
+#: model:account.report.line,name:l10n_sa.tax_report_line_withholding_tax_on_purchased_services_tax
+msgid "Withholding Tax on Purchased Services (Tax)"
 msgstr ""
 
 #. module: l10n_sa
-#: model:res.currency,currency_subunit_label:base.SAR
-msgid "Halala"
-msgstr ""
-
-#. module: l10n_sa
-#: model:account.tax.group,name:l10n_sa.sa_tax_group_taxes_15
-msgid "VAT Taxes"
+#: model:ir.model.fields,field_description:l10n_sa.field_account_bank_statement_line__l10n_sa_qr_code_str
+#: model:ir.model.fields,field_description:l10n_sa.field_account_move__l10n_sa_qr_code_str
+msgid "Zatka QR Code"
 msgstr ""
 
 #. module: l10n_sa

--- a/addons/l10n_sa/models/__init__.py
+++ b/addons/l10n_sa/models/__init__.py
@@ -1,3 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_sa
 from . import account_move
+from . import ir_attachment

--- a/addons/l10n_sa/models/ir_attachment.py
+++ b/addons/l10n_sa/models/ir_attachment.py
@@ -1,0 +1,21 @@
+from odoo import _, api, models
+from odoo.exceptions import UserError
+
+
+class IrAttachment(models.Model):
+    _inherit = "ir.attachment"
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_posted_pdf_invoices(self):
+        '''
+        Prevents unlinking of invoice pdfs linked to an invoice that is posted.
+        '''
+        restricted_moves = self._get_posted_pdf_moves_to_check().filtered(lambda move: move.country_code == 'SA' and move.state == 'posted')
+        if restricted_moves:
+            raise UserError(_("The Invoice PDF(s) cannot be deleted according to ZATCA rules: %s", ', '.join(restricted_moves.mapped('invoice_pdf_report_id.name'))))
+
+    def _get_posted_pdf_moves_to_check(self):
+        '''
+        Returns the moves to check whether they can be unlinked.
+        '''
+        return self.env['account.move'].browse(self.filtered(lambda rec: rec.res_model == 'account.move' and rec.res_field == 'invoice_pdf_report_file').mapped('res_id'))

--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -860,6 +860,15 @@ msgid "Server returned an unexpected error: %(error)s"
 msgstr "حدث خطأ غير متوقع في الخادم: %(error)s "
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid ""
+"Set a Serial Number for your device\n"
+"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_serial_number\"/>"
+msgstr ""
+"قم بتعيين رقم تسلسلي لجهازك\n"
+"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_serial_number\"/>"
+
+#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid "Set whether the system should use the Production API"
 msgstr "قم بإعداد ما إذا كان على النظام استخدام الواجهة البرمجية للإنتاج أم لا"

--- a/addons/l10n_sa_edi/models/account_move_send.py
+++ b/addons/l10n_sa_edi/models/account_move_send.py
@@ -1,4 +1,4 @@
-from odoo import api, models, _
+from odoo import _, api, models
 
 
 class AccountMoveSend(models.AbstractModel):

--- a/addons/l10n_sa_edi/models/ir_attachment.py
+++ b/addons/l10n_sa_edi/models/ir_attachment.py
@@ -1,4 +1,4 @@
-from odoo import api, models, _
+from odoo import _, api, models
 from odoo.exceptions import UserError
 
 
@@ -15,3 +15,32 @@ class IrAttachment(models.Model):
             move = self.env['account.move'].browse(attach.res_id)
             if move.country_code == "SA":
                 raise UserError(_("You can't unlink an attachment being an EDI document refused by the government."))
+
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_validated_pdf_invoices(self):
+        '''
+        Prevents unlinking of invoice pdfs linked to an invoice
+        where the pdf attachment was created after or at the same time as the edi_documents last write date.
+        '''
+        attachments_to_check = self.filtered(
+            lambda attachment: attachment.res_model == "account.move"
+            and attachment.res_field == "invoice_pdf_report_file"
+        )
+        res = self.env["account.edi.document"]._read_group(
+            domain=[("move_id", "in", attachments_to_check.mapped("res_id")), ("state", "=", "sent"), ("edi_format_id.code", "=", "sa_zatca")],
+            aggregates=["write_date:min"],
+            groupby=["move_id"],
+        )
+        edi_documents = {doc[0].id: doc[1] for doc in res}
+        restricted_attachments = self.env["ir.attachment"]
+        for attachment in attachments_to_check:
+            if (document_date := edi_documents.get(attachment.res_id)) and attachment.create_date >= document_date:
+                restricted_attachments += attachment
+        if restricted_attachments:
+            raise UserError(_(
+                "Oops! The invoice PDF(s) are linked to a validated EDI document and cannot be deleted according to ZATCA rules: %s",
+                ", ".join(restricted_attachments.mapped("name"))))
+
+    def _get_posted_pdf_moves_to_check(self):
+        # Extends l10n_sa: to bypass the unlink check in l10n_sa for posted moves
+        return super()._get_posted_pdf_moves_to_check().filtered(lambda rec: not rec.edi_state)


### PR DESCRIPTION
Task ID: 4730762
Description of the issue/feature this PR addresses:
- As per ZATCA's auditability principles (clause 3 sub-heading C, paragraph 2): The Compliant E-Invoice solution must be able to protect the generated Electronic Invoices and Electronic Notes from alteration or deletion.
- This PR aims to restrict the deletion of valid invoice PDFs once the invoice has been generated & sent to ZATCA.


Current Behavior before PR:
- Invoice PDF attachments were allowed to be deleted in l10n_sa, even when the invoice is posted.
- For l10n_sa_edi, if and invoice PDF is generated during a rejected state, it is kept there unless you reset to draft.

Desired behavior after PR is merged:
- in l10n_sa, deleting an attached invoice PDF raises a user error (reset to draft is required to detach the invoice first)
- For l10n_sa_edi, if the invoice PDF is generated during a rejected state, but the invoice is resubmtited to ZATCA and accepted.
The creation & write dates of the attachment linked & edi_documents respectively are compared and the deletion of the pdf attachment is allowed to be deleted in the case where the creation date was less than the write date.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr