### PR TITLE
[FIX] mrp: do not assign component moves without operation to last WO

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1528,11 +1528,6 @@ class MrpProduction(models.Model):
                 move.write({
                     'workorder_id': workorder_per_operation[move.operation_id].id if move.operation_id in workorder_per_operation else False
                 })
-            else:
-                bom = move.bom_line_id.bom_id if (move.bom_line_id and move.bom_line_id.bom_id in workorder_boms) else self.bom_id
-                move.write({
-                    'workorder_id': last_workorder_per_bom[bom].id
-                })
 
     def action_assign(self):
         for production in self:

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1720,6 +1720,7 @@ class TestBoM(TestMrpCommon):
             ],
         })
         bom.bom_line_ids[0].operation_id = bom.operation_ids[0].id
+        bom.bom_line_ids[1].operation_id = bom.operation_ids[1].id
         # Creates a MO and confirms it.
         mo_form = Form(self.env['mrp.production'])
         mo_form.bom_id = bom
@@ -1727,7 +1728,7 @@ class TestBoM(TestMrpCommon):
         mo_1.action_confirm()
         self.assertRecordValues(mo_1.move_raw_ids, [
             {'operation_id': bom.operation_ids[0].id, 'workorder_id': mo_1.workorder_ids[0].id},
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[1].id},
+            {'operation_id': bom.operation_ids[1].id, 'workorder_id': mo_1.workorder_ids[1].id},
         ])
 
         # Adds a new operation and links BoM's lines to other operations.
@@ -1761,8 +1762,8 @@ class TestBoM(TestMrpCommon):
         mo_1.action_update_bom()
         self.assertEqual(mo_1.is_outdated_bom, False)
         self.assertRecordValues(mo_1.move_raw_ids, [
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[2].id},
-            {'operation_id': False, 'workorder_id': mo_1.workorder_ids[2].id},
+            {'operation_id': False, 'workorder_id': False},
+            {'operation_id': False, 'workorder_id': False},
         ])
 
     def test_bom_updates_mo_with_pre_prod_picking(self):

--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -245,8 +245,6 @@
                         </list>
                     </field>
                 </page>
-                <page string="Work Instruction" name="workorder_page_work_instruction">
-                </page>
                 <field name="allow_workorder_dependencies" invisible="1"/>
                 <page string="Blocked By" name="dependencies" invisible="not allow_workorder_dependencies">
                     <field name="blocked_by_workorder_ids" nolabel="1" readonly="1">

--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -625,6 +625,7 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             'time_cycle': 5,
             'sequence': 1,
         })]
+        self.bom.bom_line_ids.operation_id = self.bom.operation_ids
         production = self.env['mrp.production'].create({
             'bom_id': self.bom.id,
             'product_qty': 1,
@@ -648,8 +649,8 @@ class TestMrpAccountMove(TestAccountMoveStockCommon):
             {'name': production.name + ' - Labour', 'debit': 20.0, 'credit': 0.0},
             {'name': production.name + ' - ' + self.product_A.name, 'debit': 0.0, 'credit': 10.0},
             {'name': production.name + ' - ' + self.product_A.name, 'debit': 10.0, 'credit': 0.0},
-            {'name': production.name + ' - ' + self.product_B.name, 'debit': 0.0, 'credit': 10.0},
-            {'name': production.name + ' - ' + self.product_B.name, 'debit': 10.0, 'credit': 0.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 0.0, 'credit': 20.0},
+            {'name': production.name + ' - ' + self.product_B.name, 'debit': 20.0, 'credit': 0.0},
         ])
 
     def test_labor_cost_balancing_with_cost_share(self):

--- a/addons/project_mrp_account/tests/test_analytic_account.py
+++ b/addons/project_mrp_account/tests/test_analytic_account.py
@@ -463,6 +463,7 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.env.user.group_ids += self.env.ref('mrp.group_mrp_routings')
 
         self.bom.project_id = self.project
+        self.bom.bom_line_ids.operation_id = self.bom.operation_ids
         mo_form = Form(self.env['mrp.production'])
         mo_form.product_id = self.product
         mo_form.bom_id = self.bom


### PR DESCRIPTION
To reproduce:
- Create MO for 1x drawer: Sec assembly
- Open shop floor, and mark as done the first two WOs of the created MO

Current behaviour:
- The component moves are shown on the last (third) WO of the MO

Expected behaviour:
- The component moves are never shown as they are not consumed in any operation

task-4760982

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
