### PR TITLE
[IMP]l10n_sa_edi: Allow retry all

### DIFF
--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -364,15 +364,13 @@ class AccountMove(models.Model):
         docs = self.edi_document_ids.filtered(lambda d: d.state in ('to_send', 'to_cancel') and d.blocking_level != 'error')
         docs._process_documents_web_services(with_commit=with_commit)
 
-    def _retry_edi_documents_error_hook(self):
-        ''' Hook called when edi_documents are retried. For example, when it's needed to clean a field.
-        TO OVERRIDE
+    def _retry_edi_documents_error(self):
+        '''Called when edi_documents need to be retried.
         '''
-        return
+        self.edi_document_ids.write({'error': False, 'blocking_level': False})
 
     def action_retry_edi_documents_error(self):
-        self._retry_edi_documents_error_hook()
-        self.edi_document_ids.write({'error': False, 'blocking_level': False})
+        self._retry_edi_documents_error()
         self.action_process_edi_web_services()
 
     ####################################################

--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.5alpha1\n"
+"Project-Id-Version: Odoo Server 18.4a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-28 13:33+0000\n"
-"PO-Revision-Date: 2025-05-28 17:41+0400\n"
+"POT-Creation-Date: 2025-06-20 12:27+0000\n"
+"PO-Revision-Date: 2025-06-20 17:35+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -407,6 +407,12 @@ msgstr "UUID الخاص بالمستند (المملكة العربية السع
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_format
 msgid "EDI format"
 msgstr "صيغة EDI "
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Error: This invoice is blocked due to %s. Please check it."
+msgstr "خطأ: هذه الفاتورة محظورة بسبب %s. يرجى التحقق من ذلك."
 
 #. module: l10n_sa_edi
 #. odoo-python

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.4a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-28 13:33+0000\n"
-"PO-Revision-Date: 2025-05-28 13:33+0000\n"
+"POT-Creation-Date: 2025-06-20 12:24+0000\n"
+"PO-Revision-Date: 2025-06-20 12:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -414,6 +414,12 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_format
 msgid "EDI format"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Error: This invoice is blocked due to %s. Please check it."
 msgstr ""
 
 #. module: l10n_sa_edi

--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -320,8 +320,9 @@ class AccountEdiFormat(models.Model):
         # to the taxpayer for clarifications
         chain_head = invoice.journal_id._l10n_sa_get_last_posted_invoice()
         if chain_head and chain_head != invoice and not chain_head._l10n_sa_is_in_chain():
+            invoice.l10n_sa_edi_chain_head_id = chain_head
             return {invoice: {
-                'error': f"ZATCA: Cannot post invoice while chain head ({chain_head.name}) has not been posted",
+                'error': _("Error: This invoice is blocked due to %s. Please check it.", chain_head.name),
                 'blocking_level': 'error',
                 'response': None,
             }}
@@ -365,6 +366,7 @@ class AccountEdiFormat(models.Model):
 
         # Save the submitted/returned invoice XML content once the submission has been completed successfully
         invoice._l10n_sa_log_results(cleared_xml.encode(), response_data)
+        invoice.journal_id._l10n_sa_reset_chain_head_error()
         return {
             invoice: {
                 'success': True,

--- a/addons/l10n_sa_edi/models/account_journal.py
+++ b/addons/l10n_sa_edi/models/account_journal.py
@@ -85,6 +85,17 @@ class AccountJournal(models.Model):
     l10n_sa_latest_submission_hash = fields.Char("Latest Submission Hash", copy=False,
                                                  help="Hash of the latest submitted invoice to be used as the Previous Invoice Hash (KSA-13)")
 
+    def _l10n_sa_reset_chain_head_error(self):
+        """
+            Reset the chain head error from the journal's stuck invoices
+        """
+        stuck_invoices = self.env['account.move'].search([
+            ('l10n_sa_edi_chain_head_id', '!=', False),
+            ('journal_id', 'in', self.ids),
+        ])
+        # We only need to remove blocking errors, so webservices do not need to be triggered
+        stuck_invoices._retry_edi_documents_error()
+
     # ====== Utility Functions =======
 
     def _l10n_sa_ready_to_submit_einvoices(self):

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -92,5 +92,19 @@
             </field>
         </record>
 
+        <record id="view_account_form_inherit" model="ir.ui.view">
+            <field name="name">account.move.form.inherit</field>
+            <field name="model">account.move</field>
+            <field name="inherit_id" ref="account.view_move_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='action_retry_edi_documents_error']" position="attributes">
+                    <attribute name="invisible">l10n_sa_edi_chain_head_id</attribute>
+                </xpath>
+                <xpath expr="//button[@name='action_retry_edi_documents_error']" position="after">
+                    <!-- when invoice is stuck due to chain head, retry action does not make sense (there are no issues with the current invoice), and instead, we redirect them to the affected invoice -->
+                    <button name="action_show_chain_head" type="object" class="oe_link py-0 text-danger" string="Blocking Invoice" invisible="not l10n_sa_edi_chain_head_id"/>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
    
    ZATCA enforces invoices to be sent in a chain, (check implementation ICV for more info), sometimes, documents timeout in transit.
    Since we do not know if the invoice was successfuly received by zatca, that invoice has to be re-sent, and blocks the EDI.
task-4728978

Current behavior before PR:
  EDI documents are blocked until the chain head is cleared
Desired behavior after PR is merged:
 Edi documents are unblocked automatically as the chain head is cleared




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
