### PR TITLE
[IMP] mail: add email template version history

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -59,7 +59,7 @@ For more specific needs, you may also assign custom-defined actions
 (technically: Server Actions) to be triggered for each incoming mail.
     """,
     'website': 'https://www.odoo.com/app/discuss',
-    'depends': ['base', 'base_setup', 'bus', 'web_tour', 'html_editor'],
+    'depends': ['base', 'base_setup', 'bus', 'web_tour', 'html_editor', 'web_editor'],
     'data': [
         'data/mail_groups.xml',
         'wizard/mail_activity_schedule_views.xml',

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -17,11 +17,14 @@ _logger = logging.getLogger(__name__)
 class MailTemplate(models.Model):
     "Templates for sending email"
     _name = 'mail.template'
-    _inherit = ['mail.render.mixin', 'template.reset.mixin']
+    _inherit = ['mail.render.mixin', 'template.reset.mixin', 'html.field.history.mixin']
     _description = 'Email Templates'
     _order = 'user_id, name, id'
 
     _unrestricted_rendering = True
+
+    def _get_versioned_fields(self):
+        return [MailTemplate.body_html.name]
 
     @api.model
     def default_get(self, fields):

--- a/addons/mail/static/src/views/web/form/email_template_form_controller.js
+++ b/addons/mail/static/src/views/web/form/email_template_form_controller.js
@@ -1,0 +1,72 @@
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { escape } from "@web/core/utils/strings";
+import { FormController } from "@web/views/form/form_controller";
+import { HistoryDialog } from "@html_editor/components/history_dialog/history_dialog";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+import { markup } from "@odoo/owl";
+
+export class EmailTemplateFormController extends FormController {
+    setup() {
+        super.setup();
+        this.notifications = useService("notification");
+    }
+
+    /**
+     * @override
+     */
+    getStaticActionMenuItems() {
+        return {
+            ...super.getStaticActionMenuItems(),
+            openHistoryDialog: {
+                sequence: 15,
+                icon: "fa fa-history",
+                description: _t("Version History"),
+                callback: this.openHistoryDialog.bind(this),
+            },
+        };
+    }
+
+    async openHistoryDialog() {
+        const record = this.model.root;
+        const versionedFieldName = "body_html";
+        const historyMetadata = record.data["html_field_history_metadata"]?.[versionedFieldName];
+        if (!historyMetadata) {
+            this.notifications.add(
+                escape(
+                    _t(
+                        "The template body lacks any past content that could be restored at the moment."
+                    )
+                )
+            );
+            return;
+        }
+
+        this.dialogService.add(HistoryDialog, {
+            title: _t("Email Template History"),
+            noContentHelper: markup(
+                `<span class='text-muted fst-italic'>${escape(
+                    _t("The template body was empty at the time.")
+                )}</span>`
+            ),
+            recordId: record.resId,
+            recordModel: this.props.resModel,
+            versionedFieldName,
+            historyMetadata,
+            restoreRequested: (html, close) => {
+                this.dialogService.add(ConfirmationDialog, {
+                    title: _t("Are you sure you want to restore this version ?"),
+                    body: _t(
+                        "Restoring will replace the current content with the selected version. Any unsaved changes will be lost."
+                    ),
+                    confirm: () => {
+                        record.update({ [versionedFieldName]: html });
+                        close();
+                    },
+                    confirmLabel: _t("Restore"),
+                });
+            },
+        });
+    }
+}

--- a/addons/mail/static/src/views/web/form/email_template_form_view.js
+++ b/addons/mail/static/src/views/web/form/email_template_form_view.js
@@ -1,0 +1,10 @@
+import { EmailTemplateFormController } from "@mail/views/web/form/email_template_form_controller";
+import { formView } from "@web/views/form/form_view";
+import { registry } from "@web/core/registry";
+
+export const EmailTemplateFormView = {
+    ...formView,
+    Controller: EmailTemplateFormController,
+};
+
+registry.category("views").add("email_template_form_view", EmailTemplateFormView);

--- a/addons/mail/static/tests/tours/mail_template_history_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_history_tour.js
@@ -1,0 +1,150 @@
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+const baseDescriptionContent = "Test history version";
+function changeDescriptionContentAndSave(newContent) {
+    const newText = `${baseDescriptionContent} ${newContent}`;
+    return [
+        {
+            // force focus on editable so editor will create initial p (if not yet done)
+            trigger: "div.note-editable.odoo-editor-editable",
+            run: "click",
+        },
+        {
+            trigger: `div.note-editable[spellcheck='true'].odoo-editor-editable`,
+            run: `editor ${newText}`,
+        },
+        ...stepUtils.saveForm(),
+    ];
+}
+
+/**
+ * Mail Template history tour.
+ * Features tested:
+ * - Create / edit a template body and ensure revisions are created on write
+ * - Open the history dialog and check that the revisions are correctly shown
+ * - Select a revision and check that the content / comparison are correct
+ * - Click the restore button and check that the content is correctly restored
+ */
+registry.category("web_tour.tours").add("mail_template_history_tour", {
+    test: true,
+    url: "/odoo",
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            content: 'Go into the Settings "app"',
+            trigger: '.o_app[data-menu-xmlid="base.menu_administration"]',
+            run: "click",
+        },
+        {
+            content: "Open email templates",
+            trigger: 'button[name="open_mail_templates"]',
+            run: "click",
+        },
+        {
+            content: "Create a new email template",
+            trigger: "button.o_list_button_add",
+            run: "click",
+        },
+        {
+            content: "Add a template name",
+            trigger: "div[name=name] input",
+            run: "edit History Template",
+        },
+        {
+            content: 'Type "Contact" model',
+            trigger: 'div[name="model_id"] input[type="text"]',
+            run: "edit Contact",
+        },
+        {
+            content: 'Select "Contact" model',
+            trigger: 'a.dropdown-item:contains("Contact")',
+            run: "click",
+        },
+        // edit the template body 3 times and save after each edit
+        ...changeDescriptionContentAndSave("0"),
+        ...changeDescriptionContentAndSave("1"),
+        ...changeDescriptionContentAndSave("2"),
+        ...changeDescriptionContentAndSave("3"),
+        {
+            trigger: "div.note-editable.odoo-editor-editable",
+            content: "Wait for the changes to be saved",
+            timeout: 3000,
+        },
+        {
+            content: "Open History Dialog",
+            trigger: ".o_form_view .o_cp_action_menus i.fa-cog",
+            run: "click",
+        },
+        {
+            trigger: ".dropdown-menu",
+        },
+        {
+            content: "Open History Dialog",
+            trigger: ".o_menu_item i.fa-history",
+            run: "click",
+        },
+        {
+            content: "Verify that 3 revisions are displayed (3 edits)",
+            trigger: ".modal .html-history-dialog .revision-list .btn",
+            run: function () {
+                const items = document.querySelectorAll(".revision-list .btn");
+                if (items.length !== 3) {
+                    console.error("Expect 3 Revisions in the history dialog, got " + items.length);
+                }
+            },
+        },
+        {
+            content: "Verify that the active revision (revision 3) is related to the second edit",
+            trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 2")`,
+            run: "click",
+        },
+        {
+            content: "Go to the second revision related to the first edit",
+            trigger: ".modal .html-history-dialog .revision-list .btn:nth-child(2)",
+            run: "click",
+        },
+        {
+            content: "Verify that the active revision is the one clicked in the previous step",
+            trigger: `.modal .history-container .tab-pane:contains("${baseDescriptionContent} 1")`,
+            run: "click",
+        },
+        {
+            content: "Go to comparison tab",
+            trigger: ".modal .history-container .nav-item:contains(Comparison) a",
+            run: "click",
+        },
+        {
+            content: "Verify comparaison text",
+            trigger: ".modal .history-container .tab-pane",
+            run: function () {
+                const comparaisonHtml = this.anchor.innerHTML;
+                const correctHtml = `<added>${baseDescriptionContent} 1</added><removed>${baseDescriptionContent} 3</removed>`;
+                if (!comparaisonHtml.includes(correctHtml)) {
+                    console.error(`Expect comparison to be ${correctHtml}, got ${comparaisonHtml}`);
+                }
+            },
+        },
+        {
+            content: "Click on Restore History btn to get back to the selected revision",
+            trigger: ".modal button.btn-primary:contains(/^Restore history$/)",
+            run: "click",
+        },
+        {
+            content: "Verify the confirmation dialog is opened",
+            trigger: ".modal button.btn-primary:contains(/^Restore$/)",
+            run: "click",
+        },
+        {
+            content: "Verify that the body contains the right text after the restore",
+            trigger: `div.note-editable.odoo-editor-editable`,
+            run: function () {
+                const p = this.anchor?.innerText;
+                const expected = `${baseDescriptionContent} 1`;
+                if (p !== expected) {
+                    console.error(`Expect body to be ${expected}, got ${p}`);
+                }
+            },
+        },
+    ],
+});

--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -472,6 +472,10 @@ class TestMailTemplateUI(HttpCase):
     def test_mail_template_dynamic_placeholder_tour(self):
         self.start_tour("/odoo", 'mail_template_dynamic_placeholder_tour', login="admin")
 
+    def test_mail_template_history(self):
+        """This tour will check that the history works properly."""
+        self.start_tour('/odoo', 'mail_template_history_tour', login='admin')
+
 
 @tagged("mail_template", "-at_install", "post_install")
 class TestTemplateConfigRestrictEditor(MailCommon):

--- a/addons/mail/views/mail_template_views.xml
+++ b/addons/mail/views/mail_template_views.xml
@@ -5,8 +5,9 @@
             <field name="name">email.template.form</field>
             <field name="model">mail.template</field>
             <field name="arch" type="xml">
-                <form string="Templates">
+                <form string="Templates" js_class="email_template_form_view">
                     <header>
+                        <field name="html_field_history_metadata" invisible="1"/>
                         <field name="ref_ir_act_window" invisible="1"/>
                         <field name="template_fs" invisible="1"/>
                         <field name="is_template_editor" invisible="1"/>


### PR DESCRIPTION
Add a "Version History" menu for the email templates to allow users to rollback a change without having to lose all their work with a factory reset.

Task-4812601


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
