### PR TITLE
[FIX] im_livechat, *: portal conflicting with embed live chat

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -4,6 +4,7 @@ import io
 import logging
 import zipfile
 
+from contextlib import suppress
 from werkzeug.exceptions import NotFound
 
 from odoo import _, http
@@ -93,11 +94,12 @@ class AttachmentController(http.Controller):
             [("attachment_ids", "in", attachment.ids)], limit=1)
         message = request.env["mail.message"].sudo(False)._get_with_access(attachment_message.id,
                                                                            "create", **kwargs)
-        if not request.env.user.share:
-            # Check through standard access rights/rules for internal users.
-            attachment._delete_and_notify(message)
-            return
-        # For non-internal users 2 cases are supported:
+        with suppress(AccessError):
+            if not request.env.user.share:
+                # Check through standard access rights/rules for internal users.
+                attachment._delete_and_notify(message)
+                return
+        # For non-internal users or internal users that didn't have access to the attachment (e.g. internal users accessing portal document with token), 2 cases are supported:
         #   - Either the attachment is linked to a message: verify the request is made by the author of the message (portal user or guest).
         #   - Either a valid access token is given: also verify the message is pending (because unfortunately in portal a token is also provided to guest for viewing others' attachments).
         # sudo: ir.attachment: access is validated below with membership of message or access token

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -75,7 +75,7 @@ export class Chatter extends Component {
             if (this.state.thread.messages.length === 0) {
                 this.state.thread.messages.push({
                     id: this.store.getNextTemporaryId(),
-                    author: this.store.self,
+                    author: this.state.thread.effectiveSelf,
                     body: _t("Creating a new record..."),
                     message_type: "notification",
                     thread: this.state.thread,

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -564,7 +564,7 @@ export class Composer extends Component {
         }
         default_body = this.formatDefaultBodyForFullComposer(
             default_body,
-            this.props.composer.emailAddSignature ? markup(this.store.self.signature) : ""
+            this.props.composer.emailAddSignature ? this.thread.effectiveSelf.signature : ""
         );
         const context = {
             default_attachment_ids: attachmentIds,

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -20,7 +20,7 @@
                     'o-discussApp': env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="showComposerAvatar">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="thread.effectiveSelf.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/mail/static/src/core/common/follower_model.js
+++ b/addons/mail/static/src/core/common/follower_model.js
@@ -23,7 +23,7 @@ export class Follower extends Record {
     /** @returns {boolean} */
     get isEditable() {
         const hasWriteAccess = this.thread ? this.thread.hasWriteAccess : false;
-        return this.partner.eq(this.store.self) ? this.thread.hasReadAccess : hasWriteAccess;
+        return this.partner.in(this.thread?.selves) ? this.thread.hasReadAccess : hasWriteAccess;
     }
 
     async remove() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -62,7 +62,7 @@ messageActionsRegistry
                         const reaction = component.props.message.reactions.find(
                             ({ content, personas }) =>
                                 content === emoji &&
-                                personas.find((persona) => persona.eq(component.store.self))
+                                component.props.thread.effectiveSelf.in(personas)
                         );
                         if (!reaction) {
                             component.props.message.react(emoji);

--- a/addons/mail/static/src/core/common/message_reaction_button.js
+++ b/addons/mail/static/src/core/common/message_reaction_button.js
@@ -19,7 +19,7 @@ export class MessageReactionButton extends Component {
             onSelect: (emoji) => {
                 const reaction = this.props.message.reactions.find(
                     ({ content, personas }) =>
-                        content === emoji && personas.find((persona) => persona.eq(this.store.self))
+                        content === emoji && this.props.message.effectiveSelf.in(personas)
                 );
                 if (!reaction) {
                     this.props.message.react(emoji);

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -80,7 +80,7 @@ export class MessageReactionList extends Component {
     }
 
     hasSelfReacted(reaction) {
-        return this.store.self.in(reaction.personas);
+        return this.props.message.effectiveSelf.in(reaction.personas);
     }
 
     onClickReaction(reaction) {

--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -18,7 +18,7 @@
                         <span class="d-flex flex-grow-1 align-items-center">
                             <span class="mx-2 text-truncate fs-6" t-esc="persona.name"/>
                             <div class="flex-grow-1"/>
-                            <button t-if="persona.eq(store.self)" class="btn btn-light fa fa-trash rounded-pill bg-inherit border-0" title="Remove" t-on-click.stop="() => state.reaction.remove()"/>
+                            <button t-if="props.message.effectiveSelf.eq(persona)" class="btn btn-light fa fa-trash rounded-pill bg-inherit border-0" title="Remove" t-on-click.stop="() => state.reaction.remove()"/>
                         </span>
                     </div>
                 </div>

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -18,7 +18,7 @@ export class MessageReactions extends Component {
             onSelect: (emoji) => {
                 const reaction = this.props.message.reactions.find(
                     ({ content, personas }) =>
-                        content === emoji && personas.find((persona) => persona.eq(this.store.self))
+                        content === emoji && this.props.message.effectiveSelf.in(personas)
                 );
                 if (!reaction) {
                     this.props.message.react(emoji);

--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -74,6 +74,7 @@ export class Persona extends Record {
         eager: true,
         inverse: "imStatusTrackedPersonas",
     });
+    signature = Record.attr("", { html: true });
     /** @type {'partner' | 'guest'} */
     type;
     /** @type {string} */

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -760,7 +760,7 @@ export const storeService = {
      */
     start(env, services) {
         const store = makeStore(env);
-        store.insert(session.storeData);
+        store.insert(session.storeData, { html: true });
         /**
          * Add defaults for `self` and `settings` because in livechat there could be no user and no
          * guest yet (both undefined at init), but some parts of the code that loosely depend on

--- a/addons/portal/models/mail_message.py
+++ b/addons/portal/models/mail_message.py
@@ -160,7 +160,7 @@ class MailMessage(models.Model):
 
     def _is_editable_in_portal(self, **kwargs):
         self.ensure_one()
-        if self.model and self.res_id and self.env.user._is_public():
+        if self.model and self.res_id:
             thread = request.env[self.model].browse(self.res_id)
             partner = get_portal_partner(
                 thread, kwargs.get("hash"), kwargs.get("pid"), kwargs.get("token")

--- a/addons/portal/static/src/chatter/frontend/message_model_patch.js
+++ b/addons/portal/static/src/chatter/frontend/message_model_patch.js
@@ -1,0 +1,12 @@
+import { patch } from "@web/core/utils/patch";
+import { Message } from "@mail/core/common/message_model";
+
+patch(Message.prototype, {
+    get canToggleStar() {
+        let result = super.canToggleStar;
+        if (this.thread && this.thread.model !== "discuss.channel") {
+            result = result && this.thread.hasReadAccess;
+        }
+        return result;
+    },
+});

--- a/addons/portal/static/src/chatter/frontend/thread_model_patch.js
+++ b/addons/portal/static/src/chatter/frontend/thread_model_patch.js
@@ -3,6 +3,24 @@ import { Thread } from "@mail/core/common/thread_model";
 import { patch } from "@web/core/utils/patch";
 
 patch(Thread.prototype, {
+    setup() {
+        super.setup(...arguments);
+        /** @type {boolean|undefined} */
+        this.hasReadAccess;
+    },
+    get effectiveSelf() {
+        if (this.portal_partner && this.store.self.type !== "partner") {
+            return this.portal_partner;
+        }
+        return super.effectiveSelf;
+    },
+    get selves() {
+        const result = super.selves;
+        if (this.portal_partner) {
+            result.push(this.portal_partner);
+        }
+        return result;
+    },
     get rpcParams() {
         return {
             ...super.rpcParams,

--- a/addons/test_discuss_full/__manifest__.py
+++ b/addons/test_discuss_full/__manifest__.py
@@ -23,6 +23,11 @@
         'website_livechat',
         'website_slides',
     ],
+    "assets": {
+        "web.assets_tests": [
+            "test_discuss_full/static/tests/tours/*",
+        ],
+    },
     'installable': True,
     'license': 'LGPL-3',
 }

--- a/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
+++ b/addons/test_discuss_full/static/tests/tours/chatbot_redirect_to_portal_tour.js
@@ -1,0 +1,26 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_mail_full.chatbot_redirect_to_portal", {
+    url: "/contactus",
+    steps: () => [
+        {
+            trigger: ".o-livechat-root:shadow .o-livechat-LivechatButton",
+            run: "click",
+        },
+        {
+            trigger:
+                ".o-livechat-root:shadow .o-mail-Message:contains(Hello, were do you want to go?)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow li:contains(Go to the portal page)",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message:contains('Go to the portal page')",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-Message:last:contains('Tadam')",
+        },
+    ],
+});

--- a/addons/test_discuss_full/tests/__init__.py
+++ b/addons/test_discuss_full/tests/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import test_im_livechat_portal
 from . import test_performance

--- a/addons/test_discuss_full/tests/test_im_livechat_portal.py
+++ b/addons/test_discuss_full/tests/test_im_livechat_portal.py
@@ -1,0 +1,49 @@
+from odoo import Command, tests
+from odoo.addons.test_mail_full.tests.test_portal import TestPortal
+from odoo.addons.website_livechat.tests.test_chatbot_ui import TestLivechatChatbotUI
+
+
+@tests.common.tagged("post_install", "-at_install")
+class TestImLivechatPortal(TestLivechatChatbotUI, TestPortal):
+    def test_chatbot_redirect_to_portal(self):
+        chatbot_redirect_script = self.env["chatbot.script"].create({"title": "Redirection Bot"})
+        question_step = self.env["chatbot.script.step"].create(
+            [
+                {
+                    "chatbot_script_id": chatbot_redirect_script.id,
+                    "message": "Hello, were do you want to go?",
+                    "step_type": "question_selection",
+                },
+                {
+                    "chatbot_script_id": chatbot_redirect_script.id,
+                    "message": "Tadam, we are on the page you asked for!",
+                    "step_type": "text",
+                },
+            ]
+        )[0]
+        self.env["chatbot.script.answer"].create(
+            [
+                {
+                    "name": "Go to the portal page",
+                    "redirect_link": f"/my/test_portal_records/{self.record_portal.id}",
+                    "script_step_id": question_step.id,
+                },
+            ]
+        )
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {
+                "name": "Redirection Channel",
+                "rule_ids": [
+                    Command.create(
+                        {
+                            "regex_url": "/",
+                            "chatbot_script_id": chatbot_redirect_script.id,
+                        }
+                    )
+                ],
+            }
+        )
+        default_website = self.env.ref("website.default_website")
+        default_website.channel_id = livechat_channel.id
+        self.env.ref("website.default_website").channel_id = livechat_channel.id
+        self.start_tour("/contactus", "test_mail_full.chatbot_redirect_to_portal")

--- a/addons/test_mail_full/tests/test_portal_attachment_controller.py
+++ b/addons/test_mail_full/tests/test_portal_attachment_controller.py
@@ -43,3 +43,21 @@ class TestPortalAttachmentController(TestAttachmentControllerCommon):
                 (self.user_admin, True, hash_pid_param),
             ),
         )
+
+    def test_delete_attachment_as_internal_with_token(self):
+        record = self.env["mail.test.portal"].create(
+            {"name": "Test", "partner_id": self.partner_portal.id}
+        )
+        token_param = {"token": record._portal_ensure_token()}
+        self._authenticate_user(self.user_portal)
+        attachment_id = self._upload_attachment(record.id, "mail.test.portal", token_param)
+        attachment = self.env["ir.attachment"].sudo().search([("id", "=", attachment_id)])
+        message = record.message_post(
+            body="hello!", author_id=self.partner_portal.id, attachment_ids=attachment.ids
+        )
+        self.assertTrue(message.attachment_ids)
+        self._authenticate_user(self.user_employee)
+        with self.assertRaises(odoo.tests.common.JsonRpcException) as exc:
+            self._delete_attachment(attachment, {})
+        self.assertEqual(exc.exception.args[0], "werkzeug.exceptions.NotFound")
+        self._delete_attachment(attachment, token_param)


### PR DESCRIPTION
*: portal, portal_rating, test_mail_full.

Before this commit, the chat bot could stop when redirecting to a page
where the portal is enabled.

Both the portal and live chat modules rely on the discuss store’s `self`
field which identifies the authenticated user. However, the portal also
supports authentication via a token in the URL, which temporarily identifies
the user on a specific thread.

Previously, the portal would overwrite the global `self` value, causing
inconsistencies for other users of the store such as messages appearing
as if sent by another user.

Since token authentication is specific to portal threads, it should only
affect actions on the granted thread without altering the global user
identity.

This fix prevents the portal from overwriting the global `self` value and
instead returns the thread-specific `portal_partner` field.

opw-4722466