### PR TITLE
[FIX] im_livechat: fix tour history back and forth

### DIFF
--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { delay } from "@web/core/utils/concurrency";
 
 registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour", {
     steps: () => [
@@ -36,23 +37,29 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
         },
         {
             trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
-            run() {
+            async run() {
+                await delay(0);
                 history.back();
             },
         },
         {
             trigger: ".o_data_cell:contains(Visitor operator)",
-            run() {
+            async run() {
+                await delay(0);
                 history.forward();
             },
         },
         {
             trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
-            run: "click",
+            async run(helpers) {
+                await delay(0)
+                await helpers.click();
+            },
         },
         {
             trigger: ".o-mail-DiscussSidebar-item:contains(Visitor).o-active",
-            run() {
+            async run() {
+                await delay(0);
                 history.back();
             },
         },


### PR DESCRIPTION
The tour fixed implicitly checks the browser's history. In Odoo, and history entry is pushed after a setTimeout(0) to allow multiple calls to be aggregated.

The fix aknowledges this by introducing delays before executing the action.

runbot-error-108129
runbot-error-223364

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
