### PR TITLE
[FIX] *: search PO reference in descriptions

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5309,8 +5309,6 @@ class AccountMove(models.Model):
         for move in self.filtered(lambda m: m.move_type in self.get_purchase_types()):
             references = move.invoice_origin.split() if move.invoice_origin else []
             move._find_and_set_purchase_orders(references, move.partner_id.id, move.amount_total, timeout=timeout)
-            if not any(line.purchase_order_id for line in move.line_ids):
-                move.invoice_origin = False
         return self
 
     def _autopost_bill(self):

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -507,6 +507,9 @@ class AccountMove(models.Model):
                         'sequence': -1,
                     })]
 
+        if not any(line.purchase_order_id for line in self.line_ids):
+            self.invoice_origin = False
+
 
 class AccountMoveLine(models.Model):
     """ Override AccountInvoice_line to add the link to the purchase order line it is related to"""


### PR DESCRIPTION
[FIX] *: search PO reference in descriptions

modules: account, purchase, purchase_edi_ubl_bis3

Fix a bug introduced by fafb49b9957223fb253e6559f91fdc359cdf272f : a
reference to 'purchase.order' was done in the account module causing a
crash when the purchase module wasn't installed.

- Moved the part of the code from the account module to the purchase
module, that itself is depending on the account module.