### PR TITLE
[FIX] pos_self_order: fill email field on self order delivery

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -119,7 +119,7 @@ class PosSelfOrderController(http.Controller):
                 lst_price = 0
 
     @http.route('/pos-self-order/validate-partner', auth='public', type='jsonrpc', website=True)
-    def validate_partner(self, access_token, name, phone, street, zip, city, country_id, state_id=None, partner_id=None):
+    def validate_partner(self, access_token, name, phone, street, zip, city, country_id, state_id=None, partner_id=None, email=None):
         pos_config = self._verify_pos_config(access_token)
         existing_partner = pos_config.env['res.partner'].sudo().browse(int(partner_id)) if partner_id else False
 
@@ -132,6 +132,7 @@ class PosSelfOrderController(http.Controller):
         country_id = pos_config.env['res.country'].browse(int(country_id))
         partner_sudo = request.env['res.partner'].sudo().create({
             'name': name,
+            'email': email,
             'phone': phone,
             'street': street,
             'zip': zip,

--- a/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
+++ b/addons/pos_self_order/static/src/app/components/preset_info_popup/preset_info_popup.js
@@ -35,6 +35,7 @@ export class PresetInfoPopup extends Component {
                 access_token: this.selfOrder.access_token,
                 partner_id: this.state.selectedPartnerId,
                 name: this.state.name,
+                email: this.state.email,
                 phone: this.state.phone,
                 street: this.state.street,
                 city: this.state.city,
@@ -61,6 +62,7 @@ export class PresetInfoPopup extends Component {
     selectExistingPartner(event) {
         const partner = this.selfOrder.models["res.partner"].get(event.target.value);
         this.state.name = partner?.name || "";
+        this.state.email = partner?.email || "";
         this.state.phone = partner?.phone || "";
         this.state.street = partner?.street || "";
         this.state.city = partner?.city || "";

--- a/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_preset_tour.js
@@ -43,6 +43,7 @@ registry.category("web_tour.tours").add("self_order_preset_delivery_tour", {
         CartPage.checkProduct("Free", "0", "1"),
         Utils.clickBtn("Pay"),
         CartPage.fillInput("Name", "Dr Dre"),
+        CartPage.fillInput("Email", "dre@dr.com"),
         CartPage.fillInput("Phone", "0490 90 43 90"),
         CartPage.fillInput("Street and Number", "Rue du Bronx 90"),
         CartPage.fillInput("Zip", "9999"),

--- a/addons/pos_self_order/tests/test_self_order_preset.py
+++ b/addons/pos_self_order/tests/test_self_order_preset.py
@@ -51,6 +51,7 @@ class TestSelfOrderPreset(SelfOrderCommonTest):
 
         last_order = self.env["pos.order"].search([], limit=1, order="id desc")
         self.assertEqual(last_order.partner_id.name, 'Dr Dre')
+        self.assertEqual(last_order.partner_id.email, 'dre@dr.com')
         self.assertEqual(last_order.partner_id.street, 'Rue du Bronx 90')
         self.assertEqual(last_order.partner_id.zip, '9999')
         self.assertEqual(last_order.partner_id.city, 'New York')


### PR DESCRIPTION
**Problem:**
When ordering a delivery with the self order, you have to fill in your informations. For the second order, you can automatically add those informations that were saved. When doing this second order, the email was not automatically filled in, and it was impossible to manually fill it in, as the field was locked.

**Steps to reproduce:**
- Go to your self order and make an order.
- Fill your informations in.
- Pay or cancel it, to be able to make another order.
- Make another order and select "Select your address" for it to fill your informations in.
- The email is not present and it is not possible to do it manually afterwards.

**Why the fix:**
The email was never accounted for, we retrieved every other data to create a new res partner, except for the email. It is now given for the creation of this res partner, and is displayed accordingly, allowing to go to the next step, and the email is sent as it should.

opw-4795481