### PR TITLE
[FIX] hr_holidays: added back the default filters removed in promenade

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -81,7 +81,8 @@
         <field name="view_mode">calendar</field>
         <field name="search_view_id" ref="hr_leave_report_calendar_view_search"/>
         <field name="domain">[('employee_id.active','=',True)]</field>
-        <field name="context">{'hide_employee_name': 1, 'search_default_my_team': 1, 'search_default_current_year': 1}</field>
+        <field name="context">{'hide_employee_name': 1, 'search_default_my_team': 1, 'search_default_current_year': 1,
+            'search_default_validate': 1, 'search_default_approve': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Nobody here ? All of the people you're looking for will be working at that time.


### PR DESCRIPTION
- `hr_holidays` promenade removed the default filters added in [task-4672501](https://www.odoo.com/odoo/project.task/4672501)
- this PR adds them back in.

task: 4815435