### PR TITLE
[IMP] hr: Update User's form view when redirect from employee form

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -361,3 +361,17 @@ class ResUsers(models.Model):
             'res_model': 'res.partner',
             'view_mode': 'form',
         }
+
+    def get_formview_action(self, access_uid=None):
+        """ Override this method in order to redirect many2one towards the full user form view
+        incase the user is ERP manager and the request coming from employee form."""
+
+        res = super().get_formview_action(access_uid=access_uid)
+        user = self.env.user
+        if access_uid:
+            user = self.env['res.users'].browse(access_uid).sudo()
+
+        if self.env.context.get('default_create_employee_id') and user.has_group('base.group_erp_manager'):
+            res['views'] = [(self.env.ref('base.view_users_form').id, 'form')]
+
+        return res

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -295,17 +295,31 @@
                             <page name="hr_settings" string="Settings" groups="hr.group_hr_user">
                                 <group>
                                     <group string="User" name="user">
-                                        <field name="user_id" string="User" placeholder="Create User"
-                                        domain="[('company_ids', 'in', company_id), ('share', '=', False)]"
-                                        context="{
-                                            'default_create_employee_id': id,
-                                            'default_name': name,
-                                            'default_phone': work_phone,
-                                            'default_mobile': mobile_phone,
-                                            'default_login': work_email,
-                                            'default_partner_id': work_contact_id,
-                                        }"
-                                        widget="many2one_avatar_user"/>
+                                        <field name="user_id" string="User" placeholder="Not linked to an user"
+                                            domain="[('company_ids', 'in', company_id), ('share', '=', False)]"
+                                            context="{
+                                                'default_create_employee_id': id,
+                                                'default_name': name,
+                                                'default_phone': work_phone,
+                                                'default_mobile': mobile_phone,
+                                                'default_login': work_email,
+                                                'default_partner_id': work_contact_id,
+                                            }"
+                                            widget="many2one_avatar_user"
+                                            groups="base.group_erp_manager"/>
+                                        <field name="user_id" string="User" placeholder="Not linked to an user"
+                                            domain="[('company_ids', 'in', company_id), ('share', '=', False)]"
+                                            context="{
+                                                'default_create_employee_id': id,
+                                                'default_name': name,
+                                                'default_phone': work_phone,
+                                                'default_mobile': mobile_phone,
+                                                'default_login': work_email,
+                                                'default_partner_id': work_contact_id,
+                                            }"
+                                            widget="many2one_avatar_user"
+                                            groups="!base.group_erp_manager"
+                                            options="{'no_open': True}"/>
                                     </group>
                                 </group>
                                 <group>


### PR DESCRIPTION
In this PR, we changed the behavior of the user Many2one avatar internal link to redirect to the full user form instead of the simplified one, provided the user has sufficient access rights.

Task: 4805733


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
