### PR TITLE
[FIX] website_event: ensure edit mode is exited before continuing tour

### DIFF
--- a/addons/website_event/static/tests/tours/website_event.js
+++ b/addons/website_event/static/tests/tours/website_event.js
@@ -50,19 +50,8 @@ function websiteCreateEventTourSteps() {
             id: "s_image_text",
             name: "Image - Text",
             groupName: "Content",
-        }), {
-            // Wait until the drag and drop is resolved (causing a history step)
-            // before clicking save.
-            trigger: ".o_we_external_history_buttons button.fa-undo:not([disabled])",
-        }, {
-            trigger: "button[data-action=save]",
-            content: "Once you click on save, your event is updated.",
-            tooltipPosition: "bottom",
-            run: "click",
-        },
-        {
-            trigger: ":iframe body:not(.editor_enable)",
-        },
+        }),
+        ...clickOnSave(),
         {
             trigger: ".o_menu_systray_item.o_website_publish_container a",
             content: "Click to publish your event.",


### PR DESCRIPTION
The test `test_website_event_tour_admin` fails randomly depending on the
processing speed available.
When clicking on `a[title='Back to All Events']`, if the website
happens to still be in edit mode, the click will be prevented: 
https://github.com/odoo/odoo/blob/18.0/addons/website/static/src/client_actions/website_preview/website_preview.js#L424-L438
We can use the clickOnSave function made specifically for this.
It ensures exiting edit mode before continuing.

---

runbot-223022