### PR TITLE
[FIX] website: hide "Switch Theme" button for non-admin


### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1609,7 +1609,7 @@
         </we-collapse>
     </div>
     <div data-js="OptionsTab" data-selector="website-settings" data-no-check="true">
-        <we-row string="Theme">
+        <we-row string="Theme" groups="base.group_system">
             <we-button data-switch-theme="" data-no-preview="true">Switch Theme</we-button>
         </we-row>
         <we-row string="Code Injection" title="Enter code that will be added into every page of your site">


### PR DESCRIPTION
Scenario:
- have "Editor and Designer" group and not "Administration/Settings"
- go to the website, open editor and click on "Theme" > "Switch Theme"
- click to install/update any theme

Issue: an error is raised because we don't have the group
"Administration/Settings" necessary to install a module.

Fix: don't show the switch theme button if we don't have access to
install it.

opw-4782294

__pr note:__ for me the current behavior is ok but not very user friendly, lebl on the ticket suggested that we could hide the "Switch Theme" button.

side note: in 18.0 we get a usual access error (no read access to ir.module.module.dependency), while in 16.0 we get a manual access check:

https://github.com/odoo/odoo/blob/097c9c928d88c10a01446131273fd2d10036f3dd/odoo/addons/base/models/ir_module.py#L70-L72