### PR TITLE
[FIX] l10n_es_edi_tbai:  Set correct regime code '19' for REAGYP taxes

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -650,7 +650,7 @@ class AccountEdiFormat(models.Model):
         if intracom:
             values['regime_key'] = ['09']
         elif reagyp:
-            values['regime_key'] = ['02']
+            values['regime_key'] = ['19']
         else:
             values['regime_key'] = ['01']
         # Credit notes (factura rectificativa)


### PR DESCRIPTION
- Vendor bills with taxes of l10n_es_type == 'sujeto_agricultura' (REAGYP) must be reported with regime code '19', as per TicketBAI specifications.
- This fix ensures that such invoices include '19' in `regime_key`, avoiding schema validation errors and ensuring legal compliance.

https://www.batuz.eus/fitxategiak/batuz/ticketbai/ticketbaiv1-2-2.xsd

OPW-4532600