### PR TITLE
[FIX] website_sale: added conditional check for item rendering in cart

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2264,6 +2264,7 @@
             <t t-foreach="website_sale_order.website_order_line" t-as="line">
                 <t t-set="is_combo" t-value="line.product_type == 'combo'"/>
                 <div
+                    t-if='line.name'
                     class="o_cart_product d-flex gap-3 pb-4"
                     t-attf-data-product-id="#{line.product_id and line.product_id.id}"
                 >


### PR DESCRIPTION
Currently, an error occurs when the user attempts to go to cart on website with a Promotions program enabled with no discount item attached to it.

Steps to replicate:
- Install `Sales` and `Ecommerce`, turn on Discounts and Loyalty from settings.
- Go to `Sales > Products > Discounts & Loyalty` and create new with `Program type` as `Promotions`.
- Make sure `Reward type` is  selected as `Discount` and save.
- Now click on rewards and then remove the `Discount Product`.
- Now go to Website and add any product with Price > 50 in your cart and go to your cart, you will get your error.

Error:
`QWebException: Error while render the template
AttributeError: 'bool' object has no attribute 'splitlines'`

The error occurs because line **[1]** attempts to call `splitlines()` on a `False` value instead of a string, which happens because the product is removed from the `Discount Product` field.

This commit resolves the issue by adding a check before rendering an item to prevent it from being passed as empty.

[1]-https://github.com/odoo/odoo/blob/35221b9529333410d9a011049788bd6d46635a70/addons/website_sale/models/sale_order_line.py#L26

sentry-6612266221
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
