### PR TITLE
[FIX] website_event_exhibitor: sponsor link work with multi domain


### DIFF
--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -278,7 +278,7 @@
             </div>
         </div>
         <div class="o_wesponsor_connect_button"
-            t-att-data-sponsor-url="sponsor.website_absolute_url"
+            t-att-data-sponsor-url="sponsor.website_url"
             t-att-data-is-participating="event.is_participating"
             t-att-data-sponsor-id="sponsor.id"
             t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"


### PR DESCRIPTION

Scenario:
- have two domains for a website (eg. example.odoo.com and example.com)
- add an exhibitor to an event
- go to the website with domain that is not web.base.url
- click on "More Info" / "Connect" on an exhibitor from the list

Result: a traceback with error "Can't redirect to another origin"
happens.

Reason: to change page, we are using redirect method that prevent
changing domain. But since 074be1ed36891065361a3cf40f8e189ba5fccb15
we are using the absolute URL (with web.base.url domain) instead of a
relative URL, so the redirection to the other domain is prevented.

Fix: use the relative URL again.

opw-4799163
