### PR TITLE
[FIX] pos_restaurant_loyalty: fix runbot test error

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -443,7 +443,7 @@ patch(PosOrder.prototype, {
             return false;
         });
         for (const line of this.get_orderlines()) {
-            if (line.is_reward_line && line.coupon_id.id === coupon_id) {
+            if (line.is_reward_line && line.coupon_id?.id === coupon_id) {
                 points -= line.points_cost;
             }
         }

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -1,5 +1,6 @@
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
 import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/tours/utils/chrome_util";
 import { registry } from "@web/core/registry";
@@ -11,11 +12,11 @@ registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
             Dialog.confirm("Open Register"),
             FloorScreen.clickTable("5"),
             ProductScreen.clickDisplayedProduct("Water"),
-            ProductScreen.totalAmountIs("1.98"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
             Chrome.clickPlanButton(),
             Chrome.clickBtn("second floor"),
             Chrome.clickBtn("main floor"),
             FloorScreen.clickTable("5"),
-            ProductScreen.totalAmountIs("1.98"),
+            PosLoyalty.hasRewardLine("10% on your order", "-0.22", "1"),
         ].flat(),
 });

--- a/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
+++ b/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
@@ -34,3 +34,5 @@ class TestPoSRestaurantLoyalty(TestFrontend):
             "PosRestaurantRewardStay",
             login="pos_admin",
         )
+        order = self.env['pos.order'].search([])
+        self.assertEqual(order.currency_id.round(order.amount_total), 1.98)


### PR DESCRIPTION
Steps are triggered too quick on the runbot.
1- It was trying to render the reward button while computation was still ocurring, thus `coupon_id` wasn't set.
> Use of the ? to avoid the traceback

2- It was trying to check for the price while the reward hadn't loaded yet.
> Instead we check that the reward is there, we'll check the price
at the end.

runbot: 163072