### PR TITLE
[FIX] calendar: add resource_ids through booking lines calendar events

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -577,6 +577,16 @@ class Meeting(models.Model):
                 values['activity_ids'] = [(0, 0, activity_vals)]
         self._set_videocall_location(vals_list)
 
+        # Set the resource_ids field from the booking_line_ids
+        for vals in vals_list:
+            resource_ids = [
+                cmd[2]['appointment_resource_id']
+                for cmd in vals.get('booking_line_ids', [])
+                if cmd[0] == 0 and 'appointment_resource_id' in cmd[2]
+            ]
+            if resource_ids:
+                vals['resource_ids'] = [(6, 0, resource_ids)]
+
         # Add commands to create attendees from partners (if present) if no attendee command
         # is already given (coming from Google event for example).
         # Automatically add the current partner when creating an event if there is none (happens when we quickcreate an event)


### PR DESCRIPTION
**Steps to reproduce:**
1. Create or use a calendar event with a resource.
2. Now go to the calendar view of that event.
3. Click to make an appointment and go to More Options.
4. Add a booking line and select a resource.
5. Save the event.

**Issue:**
When creating a calendar event with booking lines, the `resource_ids` field is not correctly populated. This is due to the fact that the compute method relying on `booking_line_ids` does not work at creation time, as the One2many lines have not yet been created in the database when the compute runs.

As a result, events created this way appear without any linked resources, even though the user selected them through the booking lines.

**Fix:**
To avoid relying on the computed field during record creation, we explicitly extract `appointment_resource_id` values from the inline booking lines in the incoming `vals_list` and assign them directly to `resource_ids`.

This ensures that resource information is preserved at creation time, without relying on deferred compute logic that cannot access the booking lines yet.

opw-4565161
