### PR TITLE
[FIX] account: do not overwrite origin PO when extending bill

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3224,7 +3224,8 @@ class AccountMove(models.Model):
                         success = decoder(invoice, file_data, new)
 
                         if success or file_data['attachment'].mimetype in ALLOWED_MIMETYPES:
-                            invoice._link_bill_origin_to_purchase_orders(timeout=4)
+                            if not extend_with_existing_lines:
+                                invoice._link_bill_origin_to_purchase_orders(timeout=4)
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)


### PR DESCRIPTION
Currently in MX localization we allow updating existing bills when users upload a CFDI XML [1]
However, we might change the bill source PO with a wrong one in case we have similar records

Steps to reproduce:
- With an MX Company setup
- Create a PO [PO1] with [Partner] and a line and confirm it
- Create an identical PO [PO2], confirm it, receive and create bill (Note: the bill is currently associated with PO2)
- In the bill upload the corresponding xml bill

Issue: After uploading the document, the bill will be associated to PO1

This occurs because in case of CFDI xml bills we process the attachment and update the bill even if some lines already exists. The system tries to find a PO not yet invoiced to associate with the bill, and finds PO1 which is identical to PO2 but not invoiced yet

A solution would be to avoid changing the source purchase order when we want to just extend the bill with an attachment

[1] https://github.com/odoo/odoo/commit/e05457c51e7a03115ba37a196e88a199b7682501

opw-4521106