### PR TITLE
[FIX] im_livechat: call gc before checking availability

### DIFF
--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -310,14 +310,14 @@ class Im_LivechatChannel(models.Model):
         :rtype : res.users
         """
         self.ensure_one()
+        # FIXME: remove inactive call sessions so operators no longer in call are available
+        # sudo: required to use garbage collecting function.
+        self.env["discuss.channel.rtc.session"].sudo()._gc_inactive_sessions()
         users = users if users is not None else self.available_operator_ids
         if not users:
             return self.env["res.users"]
         if expertises is None:
             expertises = self.env["im_livechat.expertise"]
-        # FIXME: remove inactive call sessions so operators no longer in call are available
-        # sudo: required to use garbage collecting function.
-        self.env["discuss.channel.rtc.session"].sudo()._gc_inactive_sessions()
         self.env.cr.execute("""
             WITH operator_rtc_session AS (
                 SELECT COUNT(DISTINCT s.id) as nbr, member.partner_id as partner_id


### PR DESCRIPTION
Follow up of https://github.com/odoo/odoo/pull/193597

Starting from 18.1, the unavailable operators (due to being in call in particular) are excluded from available_operator_ids, rather than filtered afterwards.

This means the gc will not be called if all operators are in call, even though the goal was to remove potentially obsolete calls.