### PR TITLE
[FIX] account: prevent tax group name overflow in invoice PDF

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -337,8 +337,8 @@
                 <t t-foreach="subtotal['tax_groups']" t-as="tax_group">
                     <tr class="o_taxes">
                         <t t-if="same_tax_base or tax_group['display_base_amount_currency'] is None">
-                            <td>
-                                <span class="text-nowrap" t-out="tax_group['group_name']">Tax 15%</span>
+                            <td style="max-width: 200px;">
+                                <span t-out="tax_group['group_name']">Tax 15%</span>
                             </td>
                             <td class="text-end o_price_total">
                                 <span class="text-nowrap"


### PR DESCRIPTION
**Issue**
When the tax group name is too long, it pushes the total amount off the page in the invoice PDF, making the amount unreadable.

**Steps to Reproduce**
1. Install the Accounting module.
2. Go to Taxes.
3. Select a tax and open Advanced Options.
4. Set a very long name for the tax group.
5. Go to Accounting > Customers > Invoices.
6. Create and confirm an invoice using the tax with the long group name.
7. Print the invoice PDF and observe the layout issue.

**Root Cause**
The text-nowrap CSS class prevents the tax group name from wrapping, causing it to expand the table cell width and push the amount outside the page boundary.

**Fix**
Remove the text-nowrap class and apply a maximum width to the <td> element, allowing the tax group name to wrap or truncate properly without overlapping or pushing the total amount off the page.

Opw-4795941
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
