### PR TITLE
[FIX] website: fix transparent body and fallback iframe

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -175,6 +175,13 @@ $-seen-urls: ();
         $custom-colors: append($custom-colors, $key);
     }
     @include print-variable('custom-colors', $custom-colors);
+
+    // A background color is set on <html> to prevent the fallback iframe used
+    // for navigation in the backend to be visible once the top iframe is loaded
+    // (see /website/iframefallback). Indeed, if the website <body> uses a
+    // transparent background color, the fallback iframe would be visible on
+    // some browsers (e.g. Chrome).
+    background-color: white;
 }
 
 @mixin body-image-bg-style() {


### PR DESCRIPTION
Steps to reproduce:

- Enter Website edit mode.
- Click on the Theme tab.
- Click the 4th colorpicker in the colors options to change the body
background color.
- Choose a transparent color.
- Save and exit edit mode.
- Navigate to the "Contact Us" page.
- Issue: The fallback iframe is visible beneath the website iframe.

To prevent this, this commit adds a white background to the website's
HTML element, so the fallback iframe will never be visible.

task-4816245