### PR TITLE
[FIX] l10n_fr: Fiscal Positions VAT required

### DIFF
--- a/addons/l10n_fr_account/data/template/account.fiscal.position-fr.csv
+++ b/addons/l10n_fr_account/data/template/account.fiscal.position-fr.csv
@@ -1,6 +1,6 @@
 "id","sequence","name","auto_apply","vat_required","country_id","country_group_id","name@fr"
-"fiscal_position_template_domestic","1","Domestic - France","1","","base.fr","","Domestique - France"
-"fiscal_position_template_domestic_mc","1","Domestic - Monaco","1","","base.mc","","Domestique - Monaco"
+"fiscal_position_template_domestic","1","Domestic - France","1","1","base.fr","","Domestique - France"
+"fiscal_position_template_domestic_mc","1","Domestic - Monaco","1","1","base.mc","","Domestique - Monaco"
 "fiscal_position_template_intraeub2c","2","EU private","1","","","account.europe_vat","EU privé"
 "fiscal_position_template_intraeub2b","3","Intra-EU B2B","1","1","","account.europe_vat","Intra-EU B2B"
 "fiscal_position_template_import_export","50","Import/Export Outside Europe + DOM-TOM","1","","","","Import/Export Hors Europe + DOM-TOM"


### PR DESCRIPTION
When fixing the domestic fiscal positions - we inadvertently lost the vat required value. So...we bring it back.
Why it matters - VAT required fiscal positions have a higher priority, so, for B2C partners, the EU B2B Fiscal position was applying instead of Domestic.

No task - verbal report