### PR TITLE
[REF] test_lint: Add check to detect file not used

### DIFF
--- a/addons/crm/__manifest__.py
+++ b/addons/crm/__manifest__.py
@@ -91,4 +91,7 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'views/assets.xml',
+    ],
 }

--- a/addons/hr_work_entry_contract/__manifest__.py
+++ b/addons/hr_work_entry_contract/__manifest__.py
@@ -27,4 +27,7 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/hr_work_entry_data.xml',
+    ],
 }

--- a/addons/l10n_cl/__manifest__.py
+++ b/addons/l10n_cl/__manifest__.py
@@ -47,4 +47,7 @@ Plan contable chileno e impuestos de acuerdo a disposiciones vigentes.
         'demo/demo_company.xml',
     ],
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'views/l10n_latam_document_type_view.xml',
+    ],
 }

--- a/addons/l10n_ec_sale/__manifest__.py
+++ b/addons/l10n_ec_sale/__manifest__.py
@@ -16,4 +16,7 @@
     'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/payment_method_data.xml',
+    ],
 }

--- a/addons/l10n_nz/__manifest__.py
+++ b/addons/l10n_nz/__manifest__.py
@@ -32,4 +32,7 @@ Also:
         'demo/demo_company.xml',
     ],
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'security/ir.model.access.csv',
+    ],
 }

--- a/addons/marketing_card/__manifest__.py
+++ b/addons/marketing_card/__manifest__.py
@@ -32,4 +32,7 @@
     'installable': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/utm_source_data.xml',
+    ],
 }

--- a/addons/partner_autocomplete/__manifest__.py
+++ b/addons/partner_autocomplete/__manifest__.py
@@ -34,4 +34,7 @@ Auto-complete partner companies' data
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/cron.xml',
+    ],
 }

--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -251,4 +251,8 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        # file loaded from load_onboarding_furniture_scenario method
+        'data/orders_demo.xml',
+    ],
 }

--- a/addons/sale_expense/__manifest__.py
+++ b/addons/sale_expense/__manifest__.py
@@ -24,4 +24,8 @@ This module allow to reinvoice employee expense, by setting the SO directly on t
     'auto_install': True,
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'security/ir.model.access.csv',
+        'security/sale_expense_security.xml',
+    ],
 }

--- a/addons/sale_pdf_quote_builder/__manifest__.py
+++ b/addons/sale_pdf_quote_builder/__manifest__.py
@@ -37,4 +37,7 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/ir_config_parameters.xml',
+    ],
 }

--- a/addons/test_event_full/__manifest__.py
+++ b/addons/test_event_full/__manifest__.py
@@ -40,4 +40,7 @@ automatic lead generation, full Online support, ...
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/event_type_data.xml',
+    ],
 }

--- a/addons/website_blog/__manifest__.py
+++ b/addons/website_blog/__manifest__.py
@@ -57,4 +57,7 @@
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'data/ir_asset.xml',
+    ],
 }

--- a/addons/website_event_sale/__manifest__.py
+++ b/addons/website_event_sale/__manifest__.py
@@ -27,4 +27,7 @@ Sell event tickets through eCommerce app.
     },
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        'views/assets.xml',
+    ],
 }

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -95,4 +95,12 @@ The kernel of Odoo, needed for all installation.
     'post_init_hook': 'post_init',
     'author': 'Odoo S.A.',
     'license': 'LGPL-3',
+    'not_used_exclude': [
+        # TODO: Delete files or use them (not referenced)
+        'report/custom_view.xml',
+        'report/corporate_sxw_header.xml',
+        'report/corporate_defaults.xml',
+        'report/corporate_odt_header.xml',
+        'report/custom_report.xml',
+    ],
 }


### PR DESCRIPTION
Check if there is a file created in the module
but not referenced from `__manifest__.py`

Inspired by https://github.com/OCA/odoo-pre-commit-hooks/pull/127

Related to https://github.com/odoo/enterprise/pull/86245

WIP fixing the current cases from:
- [x] https://github.com/odoo/odoo/pull/211150
- [x] https://github.com/odoo/enterprise/pull/86151
