### PR TITLE
[FIX] l10n_it_edi: use date instead of invoice_date on self_invoices

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -124,7 +124,7 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento t-esc="document_type"/>
                 <Divisa t-esc="currency.name"/>
-                <Data t-esc="format_date(record.invoice_date)"/>
+                <Data t-esc="format_date(get_move_invoice_template_date(record))"/>
                 <Numero t-esc="format_alphanumeric(record.name[-20:])"/>
                 <DatiBollo t-if="record.l10n_it_stamp_duty">
                     <BolloVirtuale t-translation="off">SI</BolloVirtuale>
@@ -146,11 +146,11 @@
             </DatiConvenzione>
             <DatiFattureCollegate t-if="record.reversed_entry_id">
                 <IdDocumento t-out="format_alphanumeric(record.reversed_entry_id.name[-20:])"/>
-                <Data t-out="format_date(record.reversed_entry_id.invoice_date)"/>
+                <Data t-out="format_date(get_move_invoice_template_date(record.reversed_entry_id))"/>
             </DatiFattureCollegate>
             <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">
                 <IdDocumento t-out="format_alphanumeric(downpayment_move.name[-20:])"/>
-                <Data t-out="format_date(downpayment_move.invoice_date)"/>
+                <Data t-out="format_date(get_move_invoice_template_date(downpayment_move))"/>
             </DatiFattureCollegate>
             <DatiDDT t-if="record.l10n_it_ddt_id">
                 <NumeroDDT t-esc="format_alphanumeric(record.l10n_it_ddt_id.name[-20:])"/>

--- a/addons/l10n_it_edi/models/account_invoice.py
+++ b/addons/l10n_it_edi/models/account_invoice.py
@@ -214,6 +214,9 @@ class AccountMove(models.Model):
         def format_alphanumeric(text_to_convert):
             return text_to_convert.encode('latin-1', 'replace').decode('latin-1') if text_to_convert else False
 
+        def get_move_invoice_template_date(move):
+            return move.date if self.env['account.edi.format']._l10n_it_edi_is_self_invoice(move) else move.invoice_date
+
         def get_vat_values(partner):
             """ Generate the VAT and country code needed by l10n_it_edi XML export.
 
@@ -368,6 +371,7 @@ class AccountMove(models.Model):
             'conversion_rate': conversion_rate,
             'buyer_info': get_vat_values(buyer),
             'seller_info': get_vat_values(seller),
+            'get_move_invoice_template_date': get_move_invoice_template_date,
         }
         return template_values
 

--- a/addons/l10n_it_edi/tests/expected_xmls/reverse_charge_bill.xml
+++ b/addons/l10n_it_edi/tests/expected_xmls/reverse_charge_bill.xml
@@ -53,8 +53,8 @@
             <DatiGeneraliDocumento>
                 <TipoDocumento>TD18</TipoDocumento>
                 <Divisa>EUR</Divisa>
-                <Data>2022-03-24</Data>
-                <Numero>BILL/2022/03/0001</Numero>
+                <Data>2022-04-01</Data>
+                <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>1808.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
         </DatiGenerali>

--- a/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
+++ b/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
@@ -151,6 +151,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'move_type': 'in_invoice',
             'invoice_date': fields.Date.from_string('2022-03-24'),
             'invoice_date_due': fields.Date.from_string('2022-03-24'),
+            'date': fields.Date.from_string('2022-04-01'),
             'partner_id': cls.french_partner.id,
             'partner_bank_id': cls.test_bank.id,
             'invoice_line_ids': product_lines(
@@ -171,6 +172,7 @@ class TestItEdiReverseCharge(TestItEdi):
         cls.reverse_charge_bill_2 = cls.env['account.move'].with_company(cls.company).create(bill_data_2)
         cls.reverse_charge_refund = cls.reverse_charge_bill.with_company(cls.company)._reverse_moves([{
             'invoice_date': fields.Date.from_string('2022-03-24'),
+            'date': fields.Date.from_string('2022-04-01'),
         }])
 
         # Import bill San Marino
@@ -179,6 +181,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'move_type': 'in_invoice',
             'invoice_date': fields.Date.from_string('2022-03-24'),
             'invoice_date_due': fields.Date.from_string('2022-03-24'),
+            'date': fields.Date.from_string('2022-04-01'),
             'partner_id': cls.san_marino_partner.id,
             'partner_bank_id': cls.test_bank.id,
             'invoice_line_ids': product_lines(
@@ -266,13 +269,13 @@ class TestItEdiReverseCharge(TestItEdi):
                         <DatiGeneraliDocumento>
                             <TipoDocumento>TD18</TipoDocumento>
                             <Divisa>EUR</Divisa>
-                            <Data>2022-03-24</Data>
+                            <Data>2022-04-01</Data>
                             <Numero/>
                             <ImportoTotaleDocumento>-1808.91</ImportoTotaleDocumento>
                         </DatiGeneraliDocumento>
                         <DatiFattureCollegate>
                             <IdDocumento>{self.reverse_charge_bill.name}</IdDocumento>
-                            <Data>{self.reverse_charge_refund.invoice_date}</Data>
+                            <Data>{self.reverse_charge_refund.date}</Data>
                         </DatiFattureCollegate>
                     </DatiGenerali>
                 """,


### PR DESCRIPTION
Sending the self-invoice XML, it uses the wrong field "invoice_date" that is the invoice date of the supplier instead of accounting date. On self invoices the "date" field should be used because the Date must be in the month when the invoice is received
References:
https://www.agenziaentrate.gov.it/portale/documents/20143/451259/Guida_compilazione-FE-Esterometro-V_1.9_2024-03-05.pdf/67fe4c2d-1174-e8de-f1ee-cea77b7f5203 Page 14 https://www.fiscoetasse.com/approfondimenti/16247-reverse-charge-interno-e-reverse-charge-esterno.html at 5) concerns about the days

Backport of: https://github.com/odoo/odoo/pull/210342



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
