### PR TITLE
[IMP] website_event{,_track}: prevent crawling of tag filter links

### DIFF
--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -43,6 +43,9 @@ class WebsiteEventController(http.Controller):
 
     @http.route(['/event', '/event/page/<int:page>', '/events', '/events/page/<int:page>'], type='http', auth="public", website=True, sitemap=sitemap_event)
     def events(self, page=1, **searches):
+        if searches.get('tags') and request.httprequest.method == 'GET' and not searches.get('prevent_redirect'):
+            return request.redirect('/event', code=301)
+
         Event = request.env['event.event']
         SudoEventType = request.env['event.type'].sudo()
 

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -58,8 +58,9 @@
                             <div class="dropdown-menu">
                                 <t t-foreach="category.tag_ids" t-as="tag">
                                     <a t-if="tag.color"
-                                        t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
-                                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
+                                        t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)"
+                                        t-attf-class="post_link dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}"
+                                        rel="nofollow">
                                         <t t-out="tag.name"/>
                                     </a>
                                 </t>
@@ -102,8 +103,8 @@
                                         <ul class="list-group list-group-flush">
                                             <t t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" t-foreach="category.tag_ids" t-as="tag">
                                                 <li t-if="tag.color" class="list-group-item border-0 px-0">
-                                                    <a t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
-                                                        class="text-reset" t-att-title="tag.name">
+                                                    <a t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)"
+                                                        class="post_link text-reset" t-att-title="tag.name" rel="nofollow">
                                                         <div class="form-check">
                                                             <input class="form-check-input pe-none" type="checkbox" t-attf-name="#{tag.color}" t-att-checked="tag in search_tags"/>
                                                             <label class="form-check-label" t-attf-for="#{tag.color}" t-out="tag.name"/>
@@ -129,7 +130,8 @@
         <t t-foreach="search_tags" t-as="tag">
             <span t-attf-class="d-inline-flex align-items-baseline rounded border ps-2 me-2 mb-2 #{'o_tag_color_%s' % tag.color if tag.color else ''}">
                 <t t-out="tag.display_name"/>
-                <a t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids))" class="btn border-0 py-1 text-white">&#215;</a>
+                <a t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids), prevent_redirect=True)"
+                    class="post_link btn border-0 py-1 text-white" rel="nofollow">&#215;</a>
             </span>
         </t>
     </div>

--- a/addons/website_event_track/controllers/event_track.py
+++ b/addons/website_event_track/controllers/event_track.py
@@ -15,6 +15,7 @@ import operator
 import pytz
 
 from odoo import exceptions, http, fields, tools, _
+from odoo.addons.http_routing.models.ir_http import slug
 from odoo.http import request
 from odoo.osv import expression
 from odoo.tools import is_html_empty, plaintext2html
@@ -69,6 +70,10 @@ class EventTrackController(http.Controller):
           * 'search': search string;
           * 'tags': list of tag IDs for filtering;
         """
+
+        if searches.get('tags') and request.httprequest.method == 'GET' and not searches.get('prevent_redirect'):
+            return request.redirect(f'/event/{slug(event)}/track', code=301)
+
         return request.render(
             "website_event_track.tracks_session",
             self._event_tracks_get_values(event, tag=tag, **searches)

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -126,12 +126,13 @@
                                 <ul class="list-group list-group-flush">
                                     <t t-if="tag_category.tag_ids and any(tag.color for tag in tag_category.tag_ids)" t-foreach="tag_category.tag_ids" t-as="tag">
                                         <li class="list-group-item border-0 px-0">
-                                                <a t-att-href="'/event/%s/track?%s' % (
+                                                <a t-att-data-post="'/event/%s/track?%s' % (
                                                         slug(event),
-                                                        keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
+                                                        keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
                                                     )"
                                                     t-if="tag.color"
-                                                    t-attf-class="d-flex align-items-center justify-content-between text-reset #{'active' if tag in search_tags else ''}">
+                                                    t-attf-class="post_link d-flex align-items-center justify-content-between text-reset #{'active' if tag in search_tags else ''}"
+                                                    rel="nofollow">
                                                     <t t-out="tag.name"/>
                                                 </a>
                                         </li>
@@ -160,12 +161,13 @@
                 </a>
                 <div class="dropdown-menu">
                     <t t-foreach="tag_category.tag_ids" t-as="tag">
-                        <a t-att-href="'/event/%s/track?%s' % (
+                        <a t-att-data-post="'/event/%s/track?%s' % (
                                 slug(event),
-                                keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
+                                keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
                             )"
                             t-if="tag.color"
-                            t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
+                            t-attf-class="post_link dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}"
+                            rel="nofollow">
                             <t t-out="tag.name"/>
                         </a>
                     </t>
@@ -441,8 +443,9 @@
             <span class="align-items-baseline border d-inline-flex rounded">
                 <i class="fa fa-tag mx-2 text-muted"/>
                 <t t-out="tag.display_name"/>
-                <a t-att-href="'/event/%s/track?%s' % (slug(event), keep_query('*', tags=str((search_tags - tag).ids)))"
-                    class="btn border-0 py-1">
+                <a t-att-data-post="'/event/%s/track?%s' % (slug(event), keep_query('*', tags=str((search_tags - tag).ids), prevent_redirect=True))"
+                    class="post_link btn border-0 py-1"
+                    rel="nofollow">
                     &#215;
                 </a>
             </span>
@@ -456,19 +459,21 @@
 
 <template id="track_tag_badge_link" name="Track: Tag Badge Link">
     <a t-if="search_tags"
-        t-att-href="'/event/%s/track?%s'% (
+        t-att-data-post="'/event/%s/track?%s'% (
             slug(event),
-            keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))
+            keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids),prevent_redirect=True)
         )"
-        t-att-class="'badge rounded-pill text-decoration-none %s' % ('text-bg-primary opacity-75-hover' if tag in search_tags else 'o_tag_color_hovered_0')"
-        t-out="tag.name"/>
+        t-att-class="'post_link badge rounded-pill text-decoration-none %s' % ('text-bg-primary opacity-75-hover' if tag in search_tags else 'o_tag_color_hovered_0')"
+        t-out="tag.name"
+        rel="nofollow"/>
     <a t-else=""
-        t-att-href="'/event/%s/track?%s'% (
+        t-att-data-post="'/event/%s/track?%s'% (
             slug(event),
-            keep_query('*', tags=str(tag.ids))
+            keep_query('*', tags=str(tag.ids), prevent_redirect=True)
         )"
-        t-att-class="'badge rounded-pill text-decoration-none o_tag_color_hovered_%s' % (tag.color)"
-        t-out="tag.name"/>
+        t-att-class="'post_link badge rounded-pill text-decoration-none o_tag_color_hovered_%s' % (tag.color)"
+        t-out="tag.name"
+        rel="nofollow"/>
 </template>
 
 <template id="track_tag_badge_info" name="Track: Tag Badge Info">


### PR DESCRIPTION
To avoid server performance issues caused by excessive crawling of numerous user-generated tag filter links (event tags, event track tags), these links are now rendered using the existing post_link widget.