### PR TITLE
[FIX] sale_loyalty: prevent double deduction of points after so confirmation

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -571,11 +571,12 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         points = coupon.points
-        if coupon.program_id.applies_on != 'future' and self.state not in ('sale', 'done'):
-            # Points that will be given by the order upon confirming the order
-            points += self.coupon_point_ids.filtered(lambda p: p.coupon_id == coupon).points
-        # Points already used by rewards
-        points -= sum(self.order_line.filtered(lambda l: l.coupon_id == coupon).mapped('points_cost'))
+        if self.state not in ('sale', 'done'):
+            if coupon.program_id.applies_on != 'future':
+                # Points that will be given by the order upon confirming the order
+                points += self.coupon_point_ids.filtered(lambda p: p.coupon_id == coupon).points
+            # Points already used by rewards
+            points -= sum(self.order_line.filtered(lambda l: l.coupon_id == coupon).mapped('points_cost'))
         points = coupon.currency_id.round(points)
         return points
 

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -376,6 +376,57 @@ class TestLoyalty(TestSaleCouponCommon):
         order.action_confirm()
         self.assertEqual(loyalty_card.points, 90)
 
+    def test_multiple_rewards_after_confirm(self):
+        """
+        Check that multiple rewards from a loyalty promotion program are correctly applied to a SO
+        after its confirmation by asserting that:
+            - Both rewards are applied to the order lines.
+            - The total points cost matches the rule's requirement.
+            - The coupon's points are fully consumed after applying the rewards.
+        """
+        promo_program = self.immediate_promotion_program
+        promo_program.write({
+            'active': True,
+            'rule_ids': [
+                Command.clear(),
+                Command.create({
+                    'minimum_qty': 1,
+                    'minimum_amount': 0.00,
+                    'reward_point_amount': 2,
+                })
+            ],
+            'reward_ids': [
+                Command.clear(),
+                Command.create({
+                    'discount': 10,
+                    'discount_applicability': 'specific',
+                    'discount_product_ids': [self.product_A.id],
+                }),
+                Command.create({
+                    'discount': 15,
+                    'discount_applicability': 'specific',
+                    'discount_product_ids': [self.product_B.id],
+                })
+            ],
+        })
+
+        order = self.empty_order
+        order.order_line = [
+            Command.create({'product_id': self.product_A.id, 'product_uom_qty': 1}),
+            Command.create({'product_id': self.product_B.id, 'product_uom_qty': 1}),
+        ]
+        order.action_confirm()
+
+        order._update_programs_and_rewards()
+        coupon = order.coupon_point_ids.coupon_id
+        reward1, reward2 = rewards = promo_program.reward_ids
+        order._apply_program_reward(reward1, coupon)
+        order._apply_program_reward(reward2, coupon)
+
+        self.assertEqual(order.order_line.reward_id, rewards, "All rewards should be applied")
+        self.assertEqual(sum(order.order_line.mapped('points_cost')), 2)
+        self.assertEqual(coupon.points, 0)
+
     def test_points_awarded_discount_code_no_domain_program(self):
         """
         Check the calculation for points awarded when there is a discount coupon applied and the


### PR DESCRIPTION
## Versions:
16.0+

## Issue:
After confirming a Sales Order (SO), loyalty points are incorrectly calculated when applying additional promotions. This causes only one reward to be applied instead of all eligible ones.

## Cause:
When the SO is confirmed, the cost in points for each line is retrieved and deducted to compute remaining available points. However, when promotions are re-applied, the system re-evaluates the total cost of the SO and deducts the points again, effectively double-counting the same lines.

## Steps to reproduce:
- Set up a `Discount & Loyalty` promotion program:
  - 2 points granted per purchase (minimum $0).
  - Rewards:
    - 5% discount on "Simple Pen" (costs 1 point).
    - 10% discount on "Whiteboard Pen" (costs 1 point).
  - Create a Quotation with "Simple Pen" and "Whiteboard Pen".
  - Confirm the Quotation into a Sales Order.
  - Apply promotions:
    - The first reward applies correctly
    - The second reward does not apply

opw-4753472
