### PR TITLE
[FIX] mail: message bubble color in dark theme more readable

### DIFF
--- a/addons/hr_holidays/static/src/thread_patch.xml
+++ b/addons/hr_holidays/static/src/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//*[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.persona.outOfOfficeText" class="alert alert-primary py-0 rounded-0 mb-0 smaller fw-bold" t-esc="props.thread.correspondent.persona.outOfOfficeText" role="alert"/>
+            <div t-if="props.thread.model === 'discuss.channel' and props.thread.correspondent?.persona.outOfOfficeText" class="alert alert-primary mb-0 smaller fw-bolder o-rounded-bubble mx-1 o-mt-0_5 py-1 shadow-sm" t-esc="props.thread.correspondent.persona.outOfOfficeText" role="alert"/>
         </xpath>
     </t>
 </templates>

--- a/addons/im_livechat/static/src/core/common/thread_patch.xml
+++ b/addons/im_livechat/static/src/core/common/thread_patch.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Thread')]" position="before">
-            <div t-if="showVisitorDisconnected" class="o-livechat-VisitorDisconnected bg-secondary p-2 fw-bold">
+            <div t-if="showVisitorDisconnected" class="o-livechat-VisitorDisconnected bg-secondary p-1 fw-bold smaller o-rounded-bubble mx-1 o-mt-0_5 shadow-sm border border-secondary">
                 <i class="fa fa fa-circle-o text-700 mx-1"/><t t-esc="disconnectedText"/>
             </div>
         </xpath>

--- a/addons/mail/static/src/core/common/chat_bubble.js
+++ b/addons/mail/static/src/core/common/chat_bubble.js
@@ -6,6 +6,7 @@ import { useChildRef, useService } from "@web/core/utils/hooks";
 import { useHover, useMovable } from "@mail/utils/common/hooks";
 import { usePopover } from "@web/core/popover/popover_hook";
 import { CountryFlag } from "@mail/core/common/country_flag";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 class ChatBubblePreview extends Component {
     static props = ["chatWindow", "close"];
@@ -38,10 +39,12 @@ export class ChatBubble extends Component {
         super.setup();
         this.store = useService("mail.store");
         const popoverRef = useChildRef();
+        this.isMobileOS = isMobileOS();
         this.popover = usePopover(ChatBubblePreview, {
             animation: false,
             position: "left-middle",
-            popoverClass: "dropdown-menu bg-view border-0 p-0 overflow-visible rounded-3 mx-1",
+            popoverClass:
+                "dropdown-menu bg-view border-0 p-0 overflow-visible o-rounded-bubble mx-1",
             onClose: () => (this.state.showClose = false),
             ref: popoverRef,
         });

--- a/addons/mail/static/src/core/common/chat_bubble.xml
+++ b/addons/mail/static/src/core/common/chat_bubble.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.ChatBubble">
-        <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
-            <span class="o-mail-ChatBubble-unreadIndicator position-absolute" t-att-class="{ 'opacity-50': thread?.isUnread and !thread?.importantCounter, 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
+        <div class="o-mail-ChatBubble position-relative" t-att-name="props.chatWindow.displayName" t-att-class="{ 'o-bouncing': state.bouncing, 'position-fixed': env.embedLivechat, 'position-relative': !env.embedLivechat, 'o-active': popover.isOpen, 'o-mobile': isMobileOS }" t-att-style="env.embedLivechat ? `top: ${ position.top }; left: ${ position.left };` : ''" t-on-click="() => props.chatWindow.open({ focus: true })" t-on-animationend="() => state.bouncing = false" t-ref="root">
+            <span class="o-mail-ChatBubble-unreadIndicator position-absolute text-400" t-att-class="{ 'opacity-0': !thread?.isUnread or thread?.importantCounter }"><i class="fa fa-circle"/></span>
             <div t-if="thread?.importantCounter > 0" class="o-mail-ChatBubble-counter position-absolute badge rounded-pill fw-bold o-discuss-badge shadow" t-out="thread?.importantCounter"/>
-            <button t-if="state.showClose and !env.embedLivechat" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
-            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute o-mail-brighter'" member="thread.correspondent">
+            <button t-if="state.showClose and !env.embedLivechat and !isMobileOS" class="o-mail-ChatBubble-close position-absolute shadow rounded-circle fw-bold bg-view" title="Close Chat Bubble" t-on-click.stop="() => this.props.chatWindow.close()"><i class="oi oi-close"/></button>
+            <ImStatus t-if="thread?.correspondent?.persona?.im_status and thread?.correspondent?.persona?.im_status != 'offline'" className="'o-mail-ChatBubble-status position-absolute'" member="thread.correspondent">
                 <t t-set-slot="pre_icon">
-                    <i class="fa fa-circle position-absolute text-300" style="font-size: 18px; right: 1px; bottom: 0px; z-index: -1;"/>
+                    <i class="fa fa-circle position-absolute text-100" style="font-size: 18px; right: 1px; bottom: 0px; z-index: -1;"/>
                 </t>
             </ImStatus>
-            <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border'"/>
+            <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatBubble-country position-absolute bottom-0 border shadow-sm'"/>
             <button class="o-mail-ChatHub-bubbleBtn btn bg-view shadow">
                 <img class="o-mail-ChatBubble-avatar rounded-circle o_object_fit_cover" t-att-class="{ 'o-big': env.embedLivechat }" t-att-src="thread?.avatarUrl" alt="Thread image" draggable="false"/>
             </button>
@@ -18,7 +18,7 @@
     </t>
 
     <t t-name="mail.ChatBubblePreview">
-        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 rounded">
+        <div class="o-mail-ChatBubble-preview o-mail-ChatBubble-menu px-0 py-1 shadow-sm border border-secondary bg-100 o-rounded-bubble">
             <div class="text-truncate base-fs fw-bolder mb-0 mx-2 px-1" t-esc="props.chatWindow.displayName"/>
             <div t-if="previewContent" class="text-truncate small mx-2 px-1 text-muted">
                 <t t-call="mail.message_preview_prefix">

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -13,6 +13,11 @@
     &.o-mobile {
         margin-right: $o-mail-ChatHub-bubblesMargin + 5px;
         transform: translateY(-35px);
+
+        body:has(.o-mail-Discuss):not(:has(.o-mail-ChatWindow)) &, body:has(.o-mail-MessagingMenu):not(:has(.o-mail-ChatWindow)) &  {
+            transform: translateY(-65px);
+            z-index: $zindex-modal + 5;
+        }
     }
 }
 
@@ -93,11 +98,16 @@
     height: 30px !important;
     border: $border-width solid transparent !important;
 
-    &:hover, &.show {
-        background-color: mix($o-gray-200, $o-gray-300) !important;
-        opacity: 100% !important;
+    &.o-bubblesHover {
+        opacity: 50%;
+    }
+
+    &:hover {
+        border-color: $o-gray-300 !important;
+        opacity: 75%;
     }
     &.show {
+        opacity: 100% !important;
         border-color: mix($o-gray-300, $o-gray-400) !important;
     }
 }

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -14,7 +14,7 @@
                 </t>
                 <t t-else="">
                     <Dropdown t-if="(chatHub.opened.length + chatHub.folded.length) gt 0" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
-                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'text-500': bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
+                        <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn fa fa-ellipsis-h bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !options.isOpen and !isMobileOS, 'o-bubblesHover': bubblesHover.isHover and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                         <t t-set-slot="content">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -17,7 +17,7 @@
                 <div class="d-flex text-truncate">
                     <Dropdown position="ui.isSmall ? 'bottom-end' : 'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0 bg-100 border-secondary'">
                         <button
-                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center px-2 py-1 my-0 w-100 rounded-end-0"
+                            class="o-mail-ChatWindow-command o-actionsMenu btn rounded-0 d-flex align-items-center ps-2 pe-0 py-1 my-0 w-100 rounded-end-0"
                             t-att-class="{ 'rounded-top-3': !ui.isSmall, 'o-active': state.actionsMenuOpened, 'o-hover': actionsMenuButtonHover.isHover and !parentChannelHover.isHover }"
                             t-att-disabled="state.editingName or props.chatWindow.actionsDisabled"
                             t-att-title="actionsMenuTitleText"
@@ -74,10 +74,10 @@
             <t t-else="">
                 <t t-call="mail.ChatWindow.headerContent"/>
             </t>
-            <div class="flex-grow-1"/>
-            <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 badge rounded-pill fw-bold o-discuss-badge" t-ref="needactionCounter">
+            <div t-if="thread and thread.importantCounter > 0" class="o-mail-ChatWindow-counter mx-1 badge rounded-pill fw-bold o-discuss-badge shadow-sm" t-ref="needactionCounter">
                 <t t-out="thread.importantCounter"/>
             </div>
+            <div class="flex-grow-1"/>
             <div class="o-mail-ChatWindow-quickActions d-flex flex-shrink-0 o-gap-0_5" t-att-class="{ 'me-2': !ui.isSmall }">
                 <t t-foreach="partitionedActions.quick.slice(0, ui.isSmall ? 2 : 4).reverse()" t-as="action" t-key="action.id" t-call="mail.ChatWindow.quickAction">
                     <t t-if="action_last" t-set="itemClass" t-value="ui.isSmall ? 'mx-2' : ''"/>
@@ -108,7 +108,7 @@
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer t-if="thread.composer" composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>
@@ -116,7 +116,7 @@
 </t>
 
 <t t-name="mail.ChatWindow.quickAction">
-    <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center p-0 o-quick" style="aspect-ratio: 1;" t-att-class="{ 'border border-secondary rounded-circle o-small p-2 my-1': ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="props.chatWindow.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i class="fa-lg" t-attf-class="{{ action.icon }}"/></button>
+    <button class="o-mail-ChatWindow-command btn d-flex opacity-100-hover align-items-center p-0 o-quick rounded-3" style="aspect-ratio: 1;" t-att-class="{ 'o-small p-2 my-1': ui.isSmall }" t-attf-class="{{ itemClass }}" t-att-title="action.name" t-att-disabled="props.chatWindow.actionsDisabled" t-on-click.stop="() => action.onSelect()"><i class="fa-lg" t-attf-class="{{ action.icon }}"/></button>
 </t>
 
 <t t-name="mail.ChatWindow.dropdownAction">
@@ -141,7 +141,7 @@
         <i class="fa fa-chevron-right o-xsmaller ms-1 text-muted opacity-50"/>
     </t>
     <ThreadIcon t-if="thread?.channel_type === 'chat' and thread.correspondent" thread="thread"/>
-    <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatWindow-country border'"/>
+    <CountryFlag t-if="thread?.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-ChatWindow-country border shadow-sm'"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent mx-1 my-0 py-1" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="{ 'fs-4': ui.isSmall, 'fs-5': !ui.isSmall }"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -28,7 +28,7 @@
                     <button t-att-disabled="!state.active or areAllActionsDisabled" class="d-none" title="Attach files" aria-label="Attach files" t-ref="file-uploader"><i class="fa fa-fw fa-paperclip"/></button>
                 </t>
             </FileUploader>
-            <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0">
+            <div t-if="showComposerAvatar" class="o-mail-Composer-sidebarMain flex-shrink-0 d-flex">
                 <img class="o-mail-Composer-avatar mx-auto o_avatar rounded-3" t-att-src="store.self.avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
@@ -41,7 +41,7 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => props.messageToReplyTo.cancel()"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
-                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary rounded-3"
+                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary rounded-3 shadow-sm"
                     t-att-class="{
                         'o-iosPwa': isIosPwa,
                         'align-self-stretch' : extended,

--- a/addons/mail/static/src/core/common/composer_actions.js
+++ b/addons/mail/static/src/core/common/composer_actions.js
@@ -41,7 +41,7 @@ composerActionsRegistry
     .add("send-message", {
         btnClass: (component) => {
             if (component.sendMessageState.active) {
-                return "o-sendMessageActive o-text-white";
+                return "o-sendMessageActive o-text-white shadow-sm";
             }
             return "";
         },

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -83,6 +83,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     padding-bottom: map-get($spacers, 1) / 2;
 }
 
+.o-ps-1_5 {
+    padding-left: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
+}
+
 .o-py-1_5 {
     padding-top: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
     padding-bottom: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
@@ -97,27 +101,27 @@ $o-discuss-talkingColor: lighten($success, 10%);
 }
 
 .o-rounded-bubble {
-    border-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
 }
 
 .o-rounded-top-bubble {
-    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
-    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
+    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
 }
 
 .o-rounded-end-bubble {
-    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
-    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-top-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
+    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
 }
 
 .o-rounded-bottom-bubble {
-    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
-    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-bottom-right-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
+    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
 }
 
 .o-rounded-start-bubble {
-    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
-    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4);
+    border-bottom-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
+    border-top-left-radius: calc((#{$border-radius} + #{$border-radius-lg}) * 3 / 4) !important;
 }
 
 .o-text-white {

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -13,27 +13,27 @@
 
 .o-mail-Message-bubble {
     &.o-blue {
-        background-color: mix($gray-100, $info, 87.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black, 75%) !important;
+        background-color: mix($gray-100, darken($info, 10%), 85.5%) !important;
+        border-color: mix(lighten(mix($gray-100, darken($info, 10%), 85.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
-            background-color: darken(mix($gray-100, $info, 87.5%), 5%) !important;
+            background-color: darken(mix($gray-100, darken($info, 10%), 87.5%), 5%) !important;
         }
     }
     &.o-green {
-        background-color: mix($gray-100, $success, 87.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black, 75%) !important;
+        background-color: mix($gray-100, darken($success, 10%), 85.5%) !important;
+        border-color: mix(lighten(mix($gray-100, darken($success, 10%), 87.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
-            background-color: darken(mix($gray-100, $success, 87.5%), 5%) !important;
+            background-color: darken(mix($gray-100, darken($success, 10%), 87.5%), 5%) !important;
         }
     }
     &.o-orange {
-        background-color: mix($gray-100, $warning, 72.5%) !important;
-        border-color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black, 75%) !important;
+        background-color: mix($gray-100, darken($warning, 10%), 70.5%) !important;
+        border-color: mix(lighten(mix($gray-100, darken($warning, 10%), 72.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
-            background-color: darken(mix($gray-100, $warning, 72.5%), 10%) !important;
+            background-color: darken(mix($gray-100,  darken($warning, 10%), 72.5%), 10%) !important;
         }
     }
 }
@@ -41,26 +41,26 @@
 .o-mail-Message-bubbleTail {
      &.o-blue {
         .o-mail-Message-bubbleTailBg {
-            color:mix($gray-100, $info, 87.5%) !important;
+            color: mix($gray-100, darken($info, 10%), 85.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $info, 87.5%), 2.5%), black, 75%) !important;
+            color: mix(lighten(mix($gray-100, darken($info, 10%), 85.5%), 2.5%), black, 75%) !important;
         }
     }
     &.o-green {
         .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, $success, 87.5%) !important;
+            color: mix($gray-100, darken($success, 10%), 87.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $success, 87.5%), 2.5%), black, 75%) !important;
+            color: mix(lighten(mix($gray-100, darken($success, 10%), 87.5%), 2.5%), black, 75%) !important;
         }
     }
     &.o-orange {
         .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, $warning, 72.5%) !important;
+            color: mix($gray-100, darken($warning, 10%), 72.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, $warning, 72.5%), 2.5%), black, 75%) !important;
+            color: mix(lighten(mix($gray-100, darken($warning, 10%), 72.5%), 2.5%), black, 75%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -83,24 +83,24 @@
 
 .o-mail-Message-bubble {
     &.o-blue {
-        background-color: mix($o-view-background-color, $info, 87.5%) !important;
-        border-color: mix(darken(mix($o-view-background-color, $info, 87.5%), 10%), white, 75%) !important;
+        background-color: mix($o-view-background-color, lighten($info, 5%), 85.5%) !important;
+        border-color: mix(darken(mix($o-view-background-color, lighten($info, 5%), 85.5%), 10%), white, 92.5%) !important;
 
         &.o-muted {
-            background-color: mix($white, mix($o-view-background-color, $info, 87.5%)) !important;
+            background-color: mix($white, mix($o-view-background-color, lighten($info, 5%), 90.5%)) !important;
         }
     }
     &.o-green {
-        background-color: mix($o-view-background-color, $success, 87.5%) !important;
-        border-color: mix(darken(mix($o-view-background-color, $success, 87.5%), 10%), white, 75%) !important;
+        background-color: mix($o-view-background-color, lighten($success, 5%), 85.5%) !important;
+        border-color: mix(darken(mix($o-view-background-color, lighten($success, 5%), 85.5%), 10%), white, 92.5%) !important;
 
         &.o-muted {
-            background-color: mix($white, mix($o-view-background-color, $success, 87.5%)) !important;
+            background-color: mix($white, mix($o-view-background-color, lighten($success, 5%), 90.5%)) !important;
         }
     }
     &.o-orange {
-        background-color: mix($o-view-background-color, $warning, 75%) !important;
-        border-color: mix(darken(mix($o-view-background-color, $warning, 75%), 10%), white, 75%) !important;
+        background-color: mix($o-view-background-color, lighten($warning, 5%), 75%) !important;
+        border-color: mix(darken(mix($o-view-background-color, lighten($warning, 5%), 75%), 10%), white, 87.5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
@@ -116,26 +116,26 @@
 
     &.o-blue {
         .o-mail-Message-bubbleTailBg {
-            color: mix($o-view-background-color, $info, 87.5%) !important;
+            color: mix($o-view-background-color, lighten($info, 5%), 85.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(darken(mix($o-view-background-color, $info, 87.5%), 10%), white, 75%) !important;
+            color: mix(darken(mix($o-view-background-color, lighten($info, 5%), 85.5%), 10%), white, 92.5%) !important;
         }
     }
     &.o-green {
         .o-mail-Message-bubbleTailBg {
-            color: mix($o-view-background-color, $success, 87.5%) !important;
+            color: mix($o-view-background-color, lighten($success, 5%), 85.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(darken(mix($o-view-background-color, $success, 87.5%), 10%), white, 75%) !important;
+            color: mix(darken(mix($o-view-background-color, lighten($success, 5%), 85.5%), 10%), white, 92.5%) !important;
         }
     }
     &.o-orange {
         .o-mail-Message-bubbleTailBg {
-            color: mix($o-view-background-color, $warning, 75%) !important;
+            color: mix($o-view-background-color, lighten($warning, 5%), 75%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(darken(mix($o-view-background-color, $warning, 75%), 10%), white, 75%) !important;
+            color: mix(darken(mix($o-view-background-color, lighten($warning, 5%), 75%), 10%), white, 87.5%) !important;
         }
     }
 }
@@ -204,6 +204,7 @@
 
 .o-mail-Message-starred {
     color: $o-main-favorite-color;
+    filter: drop-shadow(1px 1px 0px #000000b0);
 }
 
 .o-mail-Message-translated {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -19,15 +19,19 @@
             >
                 <div t-if="props.asCard and isMobileOS" class="position-absolute end-0 z-1"><t t-call="mail.Message.actions"/></div>
                 <div class="o-mail-Message-core position-relative d-flex flex-shrink-0">
-                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0 justify-content-center" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
-                        <div t-if="!props.squashed" class="o-mail-Message-avatarContainer position-relative bg-view rounded-3" t-att-class="getAvatarContainerAttClass()">
-                            <img class="o-mail-Message-avatar w-100 h-100 rounded-3" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
-                        </div>
+                    <div class="o-mail-Message-sidebar d-flex flex-shrink-0 align-items-center flex-column" t-att-class="{ 'align-items-start': !isAlignedRight, 'o-inChatWindow': env.inChatWindow }">
+                        <t t-if="!props.squashed">
+                            <div class="o-mail-Message-avatarContainer position-relative bg-view rounded-3" t-att-class="getAvatarContainerAttClass()">
+                                <img class="o-mail-Message-avatar w-100 h-100 rounded-3" t-att-src="authorAvatarUrl" t-att-class="authorAvatarAttClass"/>
+                            </div>
+                            <t t-if="message.starred" t-call="mail.Message.sidebarStarred"/>
+                        </t>
                         <t t-elif="message.isPending" t-call="mail.Message.pendingStatus"/>
                         <t t-elif="!message.is_transient">
                             <small t-if="isActive and props.showDates" class="o-mail-Message-date o-xsmaller mt-2 text-center lh-1" t-att-title="message.datetimeShort">
                                 <t t-esc="message.dateSimple"/>
                             </small>
+                            <t t-elif="message.starred" t-call="mail.Message.sidebarStarred"/>
                         </t>
                     </div>
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
@@ -78,7 +82,14 @@
                                                     <path class="o-mail-Message-bubbleTailBg" fill="currentColor" d="M 2, 1 L 5, 7 V 1 z"/>
                                                 </svg>
                                             </div>
-                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{ 'w-100': state.isEditing }">
+                                            <div class="position-relative overflow-x-auto overflow-y-hidden d-inline-block text-body" t-att-class="{
+                                                'w-100': state.isEditing,
+                                                'shadow-sm': message.bubbleColor,
+                                                'o-rounded-bubble': message.bubbleColor and props.squashed,
+                                                'o-rounded-bottom-bubble': message.bubbleColor and !props.squashed,
+                                                'o-rounded-start-bubble': message.bubbleColor and !props.squashed and isAlignedRight,
+                                                'o-rounded-end-bubble': message.bubbleColor and !props.squashed and !isAlignedRight,
+                                            }">
                                                 <div t-if="message.bubbleColor" class="o-mail-Message-bubble position-absolute top-0 start-0 w-100 h-100 border" t-att-class="{
                                                     'o-rounded-bubble': props.squashed,
                                                     'o-rounded-bottom-bubble': !props.squashed,
@@ -146,7 +157,7 @@
 </t>
 
 <t t-name="mail.Message.actions">
-    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none"
+    <div t-if="props.hasActions and message.hasActions and !state.isEditing" class="o-mail-Message-actions d-print-none d-flex align-items-start"
         t-att-class="{
             'start-0': isAlignedRight,
             'mx-1': !isMobileOS,
@@ -156,10 +167,19 @@
             'o-expanded': optionsDropdown.isOpen
         }"
     >
-        <t t-if="isMobileOS and !mobileExpanded" t-call="mail.Message.expandAction"/>
+        <t t-if="isMobileOS">
+            <t t-if="isAlignedRight">
+                <t t-call="mail.Message.emptyQuickAction"/>
+                <t t-call="mail.Message.expandAction"/>
+            </t>
+            <t t-else="">
+                <t t-call="mail.Message.expandAction"/>
+                <t t-call="mail.Message.emptyQuickAction"/>
+            </t>
+        </t>
         <t t-else="">
             <t t-set="isReverse" t-value="env.inChatWindow and isAlignedRight"/>
-            <div class="d-flex rounded-1 overflow-hidden" t-att-class="{ 'flex-row-reverse': isReverse }">
+            <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
                 <t t-set="quickActions" t-value="messageActions.actions.slice(0, messageActions.actions.length gt quickActionCount ? quickActionCount - 1 : quickActionCount)"/>
                 <t t-foreach="quickActions" t-as="action" t-key="action.id">
                     <t t-set="isStart" t-value="(!isReverse and action.isFirst) or (isReverse and action.isLast)"/>
@@ -168,7 +188,7 @@
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }"/>
-                    <button t-else="" class="btn border-0 px-1 py-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
+                    <button t-else="" class="btn border-0 p-0 rounded-0" t-att-title="action.title" t-att-name="action.id" t-on-click.stop="action.onClick" t-att-class="{
                         'rounded-start-1': isStart,
                         'rounded-end-1': isEnd,
                     }">
@@ -192,9 +212,7 @@
                     </Dropdown>
                 </div>
                 <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
-                    <button class="btn border-0 px-1 py-0 rounded-0 opacity-0 pe-none">
-                        <i class="fa-lg fa fa-question"/>
-                    </button>
+                    <t t-call="mail.Message.emptyQuickAction"/>
                 </t>
             </div>
         </t>
@@ -203,16 +221,22 @@
 
 <t t-name="mail.Message.expandAction">
     <button class="btn border-0 rounded-0 o-mail-Message-expandBtn" t-att-title="expandText" t-on-click="openMobileActions" t-att-class="{
-        'o-mail-Message-openActionMobile p-2 rounded-circle user-select-none': isMobileOS and !mobileExpanded,
-        'me-n2': isMobileOS and !mobileExpanded and (isAlignedRight and !props.asCard or !isAlignedRight and props.asCard),
-        'ms-n2': isMobileOS and !mobileExpanded and (isAlignedRight and props.asCard or !isAlignedRight and !props.asCard),
+        'o-mail-Message-openActionMobile p-2 rounded-circle user-select-none': isMobileOS,
+        'me-n2': isMobileOS and (isAlignedRight and !props.asCard or !isAlignedRight and props.asCard),
+        'ms-n2': isMobileOS and (isAlignedRight and props.asCard or !isAlignedRight and !props.asCard),
         'mt-n3': isMobileOS and props.asCard,
         'mt-n1': isMobileOS and !props.asCard,
-        'px-2 py-0': !isMobileOS,
+        'px-1 py-0': !isMobileOS,
         'rounded-start-1': !isMobileOS and isReverse,
         'rounded-end-1': !isMobileOS and !isReverse,
     }">
         <i class="fa fa-lg fa-ellipsis-v" t-att-class="{ 'order-1': props.isInChatWindow, 'fa-fw': isMobileOS }" tabindex="1"/>
+    </button>
+</t>
+
+<t t-name="mail.Message.emptyQuickAction">
+    <button class="btn border-0 p-0 rounded-0 opacity-0 pe-none">
+        <i class="fa-lg fa fa-question"/>
     </button>
 </t>
 
@@ -242,6 +266,12 @@
 
 <t t-name="mail.Message.mentionedChannelIcon">
     <i t-att-class="icon"/>
+</t>
+
+<t t-name="mail.Message.sidebarStarred">
+    <small class="text-center lh-1 o-opacity-35" t-att-class="{ 'align-self-start ms-1': isAlignedRight, 'align-self-end me-1': !isAlignedRight, 'mt-2': props.squashed, 'mt-1': !props.squashed }">
+        <i class="fa fa-star o-mail-Message-starred"/>
+    </small>
 </t>
 
 </templates>

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -3,7 +3,7 @@
     <t t-name="mail.MessageCardList">
         <div class="o-mail-MessageCardList d-flex flex-column" t-att-class="{ 'justify-content-center flex-grow-1': props.messages.length === 0 }" t-ref="message-list">
             <div class="card mb-2 rounded-3 border-secondary" t-foreach="props.messages" t-as="message" t-key="message.id">
-                <div class="card-body ps-0 py-2 rounded-3">
+                <div class="card-body ps-0 py-2 rounded-3 shadow-sm">
                     <div class="position-absolute top-0 end-0 z-1 mx-2 my-1 d-flex align-items-center">
                         <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
                         <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0 opacity-25 opacity-100-hover" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">

--- a/addons/mail/static/src/core/common/message_in_reply.dark.scss
+++ b/addons/mail/static/src/core/common/message_in_reply.dark.scss
@@ -1,3 +1,7 @@
+.o-mail-MessageInReply-author {
+    opacity: 50%;
+}
+
 .o-mail-MessageInReply-core {
     background-color: rgba($gray-100, .35) !important;
 

--- a/addons/mail/static/src/core/common/message_in_reply.xml
+++ b/addons/mail/static/src/core/common/message_in_reply.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageInReply">
         <div class="o-mail-MessageInReply mx-2 mt-1 p-1 pb-0">
-            <small class="o-mail-MessageInReply-core o-mail-Message-bubble o-muted border position-relative d-flex px-2 py-1 rounded-3 rounded-start-0 d-inline-flex" t-att-class="{
+            <small class="o-mail-MessageInReply-core o-mail-Message-bubble o-muted border position-relative d-flex px-2 py-1 rounded-start-0 o-rounded-end-bubble d-inline-flex" t-att-class="{
                 'o-blue': props.message.parentMessage.bubbleColor === 'blue',
                 'o-green': props.message.parentMessage.bubbleColor === 'green',
                 'o-orange': props.message.parentMessage.bubbleColor === 'orange',
             }">
                 <span t-if="!props.message.parentMessage.isEmpty" class="d-inline-flex align-items-center text-muted opacity-75" t-att-class="{ 'cursor-pointer opacity-100-hover': props.onClick }" t-on-click="() => this.props.onClick?.()">
-                    <img class="o-mail-MessageInReply-avatar me-2 rounded-3 o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
+                    <img class="o-mail-MessageInReply-avatar me-2 o-rounded-bubble o_object_fit_cover" t-att-src="authorAvatarUrl" t-att-title="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from" alt="Avatar"/>
                     <span class="o-mail-MessageInReply-content overflow-hidden smaller">
-                        <b><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
+                        <b class="o-mail-MessageInReply-author"><t t-out="props.message.parentMessage.author?.name ?? props.message.parentMessage.email_from"/></b>:
                         <span class="o-mail-MessageInReply-message ms-1 text-break">
                             <t t-if="!props.message.parentMessage.isBodyEmpty">
                                 <t t-out="props.message.parentMessage.body"/>

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -10,7 +10,7 @@
     </t>
     
     <t t-name="mail.MessageReactionList.button">
-        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1 fs-5 px-1 gap-1 align-items-center" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border o-rounded-bubble mb-1 fs-5 px-1 gap-1 align-items-center shadow-sm" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-on-mouseenter="loadEmoji" t-ref="reactionButton" t-att-class="{
             'o-selfReacted border-primary text-primary fw-bold': hasSelfReacted(props.reaction),
             'bg-view border-secondary': !hasSelfReacted(props.reaction),
             'ms-1': env.inChatWindow and env.alignedRight,

--- a/addons/mail/static/src/core/common/quick_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/quick_reaction_menu.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="mail.QuickReactionMenu">
         <Dropdown state="dropdown" manual="true" menuClass="`o-mail-QuickReactionMenu-popover shadow-none`" position="'top-middle'" navigationOptions="navigationOptions">
-            <button class="btn border-0 px-1 py-0" t-att-class="attClass" t-att-title="props.action.title" t-att-aria-label="props.action.title" t-on-click="onClick">
+            <button class="btn border-0 p-0" t-att-class="attClass" t-att-title="props.action.title" t-att-aria-label="props.action.title" t-on-click="onClick">
                 <i class="fa-lg" t-att-class="props.action.icon"/>
             </button>
             <t t-set-slot="content">

--- a/addons/mail/static/src/core/common/search_message_input.xml
+++ b/addons/mail/static/src/core/common/search_message_input.xml
@@ -3,12 +3,12 @@
     <t t-name="mail.SearchMessageInput">
         <div class="o-mail-SearchMessageInput d-flex py-2">
             <div class="input-group">
-                <div class="o_searchview form-control d-flex align-items-center bg-view p-0" role="search" aria-autocomplete="list">
+                <div class="o_searchview form-control d-flex align-items-center bg-view p-0 shadow-sm" role="search" aria-autocomplete="list">
                     <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
                         <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0 rounded-start px-2 bg-view" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
                     </div>
                 </div>
-                <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
+                <button class="btn shadow-sm" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
                     <i t-if="!props.messageSearch.searching" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Messages" title="Search Messages"/>
                     <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                 </button>

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -12,8 +12,7 @@
 
     span {
         --bg-opacity: 90%;
-        font-size: 0.6rem;
-        clip-path: polygon(0% 50%, 15% 0%, 100% 0%, 100% 100%, 15% 100%);
+        clip-path: polygon(-1px 50%, 15% 0%, 100% 0%, 100% 100%, 15% 100%);
     }
 }
 
@@ -40,7 +39,7 @@
 
 .o-mail-Thread-banner {
     z-index: $o-mail-NavigableList-zIndex - 1;
-    --border-opacity: 0.25;
+    --border-opacity: 0.35;
 }
 
 .o-mail-Thread-bannerHover:hover {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -20,7 +20,7 @@
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
                     <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bold z-1 px-2">
-                        <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger opacity-100 shadow-sm"/><span class="ps-2 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm">New</span>
+                        <div class="o-mail-Thread-newMessageLine flex-grow-1 border border-danger rounded-start-3 opacity-100 shadow-sm"/><span class="o-ps-1_5 pe-1 bg-danger o-text-white rounded text-uppercase shadow-sm o-xxsmaller">New</span>
                     </div>
                     <Message
                         asCard="props.thread.model === 'mail.box'"

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -9,8 +9,8 @@
 }
 
 .o-mail-Discuss-selfAvatar {
-    height: $o-mail-Avatar-sizeSmall;
-    width: $o-mail-Avatar-sizeSmall;
+    height: 30px;
+    width: 30px;
 }
 
 .o-mail-Discuss-threadName {
@@ -51,6 +51,8 @@
 
 .o-mail-Discuss-headerActionsGroup {
     background-color: mix($gray-100, $gray-200, 65%);
+    outline: 1px solid $gray-200;
+    outline-offset: -1px;
 }
 
 .o-mail-Discuss-headerCountry {

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -21,7 +21,7 @@
                     <t t-else="">
                         <ThreadIcon className="'mx-2 align-self-center fs-2 my-2 opacity-75'" size="'large'" thread="thread"/>
                     </t>
-                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border'"/>
+                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-Discuss-headerCountry border shadow-sm'"/>
                     <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" className="'me-1'" member="thread.correspondent" />
                     <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                         <div t-if="thread.parent_channel_id" class="d-flex align-items-center gap-1 ms-1">
@@ -47,7 +47,7 @@
                         </t>
                     </div>
                     <div class="o-mail-Discuss-headerActions flex-shrink-0 d-flex align-items-center ms-1">
-                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3">
+                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
                             <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.quick" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -55,7 +55,7 @@
                         </span>
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
-                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3">
+                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
                          <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -64,7 +64,7 @@
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
                         <t t-foreach="partitionedActions.group.slice().reverse()" t-as="group" t-key="group_index">
-                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3">
+                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
                                 <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                     <t t-set="action" t-value="action"/>
                                 </t>
@@ -72,8 +72,8 @@
                             <span t-if="!group_last" class="text-muted align-self-stretch ms-2 me-1"/>
                         </t>
                         <div t-if="store.inPublicPage and !ui.isSmall" class="d-flex align-items-center">
-                            <img class="o-mail-Discuss-selfAvatar mx-1 rounded-3 o_object_fit_cover flex-shrink-0" alt="Avatar" t-att-src="store.self.avatarUrl"/>
-                            <div class="lead fw-bold flex-shrink-1 text-dark">
+                            <img class="o-mail-Discuss-selfAvatar ms-3 me-1 rounded-3 o_object_fit_cover flex-shrink-0 smaller" alt="Avatar" t-att-src="store.self.avatarUrl"/>
+                            <div class="fw-bold flex-shrink-1 text-dark">
                                 <t t-if="store.self.type === 'partner'" t-esc="store.self.name"/>
                                 <t t-else="">
                                     <AutoresizeInput
@@ -100,7 +100,7 @@
                                 <t t-component="threadActions.activeAction.component" thread="thread" t-props="threadActions.activeAction.componentProps"/>
                             </div>
                         </t>
-                        <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'main') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100 bg-view">
+                        <div t-elif="(!ui.isSmall or store.discuss.activeTab === 'main') and store.discuss.hasRestoredThread" class="d-flex flex-grow-1 align-items-center justify-content-center w-100">
                             <h4 class="text-muted"><b><i>No conversation selected.</i></b></h4>
                         </div>
                     </t>

--- a/addons/mail/static/src/core/public_web/discuss_sidebar.scss
+++ b/addons/mail/static/src/core/public_web/discuss_sidebar.scss
@@ -1,7 +1,7 @@
 .o-mail-DiscussSidebar {
     box-shadow: 1px 0px 6px -3px rgba(50, 50, 50, 0.15);
     width: 60px;
-    --border-opacity: 0;
+    --border-opacity: 0.25;
 
     &:not(.o-compact) {
         width: $o-mail-Discuss-inspector;
@@ -27,6 +27,7 @@
 
 .o-mail-DiscussSidebar-item {
     outline: 1px solid transparent !important;
+    outline-offset: -1px;
     padding-top: map-get($spacers, 1) / 2;
     padding-bottom: map-get($spacers, 1) / 2;
 
@@ -45,7 +46,7 @@
 
     &.o-active {
         background-color: var(--mail-DiscussSidebar-itemActiveBgColor, mix($o-view-background-color, $o-action, 90%)) !important;
-        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .15)) !important;
+        outline-color: var(--mail-DiscussSidebar-itemActiveOutlineColor, rgba($o-action, .05)) !important;
     }
 
     &.o-active, &:hover {

--- a/addons/mail/static/src/core/public_web/messaging_menu.xml
+++ b/addons/mail/static/src/core/public_web/messaging_menu.xml
@@ -36,7 +36,7 @@
                     </t>
                     <t t-set-slot="icon">
                         <ImStatus t-if="thread.channel_type === 'chat' and thread.correspondent" member="thread.correspondent" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
-                        <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border'"/>
+                        <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'o-mail-NotificationItem-country position-absolute border shadow-sm'"/>
                     </t>
                     <t t-if="message" t-set-slot="body-icon">
                         <t t-call="mail.message_preview_prefix">
@@ -57,8 +57,8 @@
             'pb-4': isIosPwa,
             'pb-2': !isIosPwa,
         }" t-on-click="() => this.onClickNavTab(tab.id)">
-            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
-            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id }"/>
+            <i t-attf-class="p-1 fs-2 {{ tab.icon }}" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id, 'opacity-50': store.discuss.activeTab !== tab.id }"/>
+            <span class="smaller" t-esc="tab.label" t-att-class="{ 'text-primary': store.discuss.activeTab === tab.id, 'opacity-50': store.discuss.activeTab !== tab.id }"/>
             <span t-if="tab.counter" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabCounter overflow-visible d-inline-block" t-esc="tab.counter"/>
             <span t-elif="tab.channelHasUnread" class="badge o-discuss-badge rounded-pill position-absolute o-mail-MessagingMenu-tabUnread overflow-visible d-inline-block ms-2"><i class="fa fa-circle"/></span>
         </button>

--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -3,8 +3,8 @@
     --mail-NotificationItem-bg: #{lighten(mix($gray-100, $gray-200, 65%), 1.5%)};
 
     &.o-important {
-        background-color: mix($o-gray-200, $o-info, 90%) !important;
-        border-color: lighten(mix($o-gray-200, $o-info, 90%), 5%) !important;
+        background-color: mix($gray-100, darken($info, 5%), 85.5%) !important;
+        border-color: lighten(mix($gray-100, darken($info, 5%), 85.5%), 5%) !important;
     }
     &:hover, &.o-active {
         background-color: mix($o-gray-200, $o-gray-300) !important;

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -4,8 +4,8 @@
     background-color: var(--mail-NotificationItem-bg, mix($gray-100, $o-view-background-color, 95%));
 
     &.o-important {
-        background-color: mix($o-gray-100, $o-info, 90%) !important;
-        border-color: darken(mix($o-gray-100, $o-info, 90%), 5%) !important;
+        background-color: mix($o-view-background-color, lighten($info, 5%), 87.5%);
+        border-color: darken(mix($o-view-background-color, lighten($info, 5%), 87.5%), 7.5%) !important;
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.NotificationItem">
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
-        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border rounded-3 o-py-1_5" t-on-click="onClick" t-ref="root" t-att-class="{
+        <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border o-rounded-bubble o-py-1_5 shadow-sm" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
             'text-muted border-transparent': props.muted === 1,
             'opacity-50 border-transparent': props.muted === 2,
@@ -23,8 +23,8 @@
                     </span>
                     <span class="flex-grow-1"/>
                     <div class="d-flex align-items-center">
-                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter"><t t-esc="props.counter"/></span>
-                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer" title="Mark As Read" t-ref="markAsRead"/>
+                        <span t-if="props.counter > 0 and !rootHover.isHover" t-attf-class="o-mail-NotificationItem-badge o-discuss-badge {{props.muted === 2 ? 'o-muted' : ''}} d-flex align-items-center justify-content-center m-0 badge rounded-pill fw-bold o-mail-NotificationItem-counter shadow-sm"><t t-esc="props.counter"/></span>
+                        <span t-if="props.hasMarkAsReadButton and rootHover.isHover" class="o-mail-NotificationItem-badge o-discuss-badgeShape text-success d-flex align-items-center justify-content-center m-0 rounded-3 fw-bold o-mail-NotificationItem-markAsRead fa fa-check text-600 opacity-75 opacity-100-hover cursor-pointer shadow-sm" title="Mark As Read" t-ref="markAsRead"/>
                     </div>
                 </div>
                 <div class="d-flex">

--- a/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar_mailboxes.xml
@@ -43,7 +43,7 @@
             </t>
             <t t-if="mailbox.counter > 0" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="mailbox.counter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebar-badge shadow-sm ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'mx-1')"/>
                 <t t-set="counterClass" t-value="(mailbox.id === 'starred' ? 'o-muted' : '')"/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -22,9 +22,9 @@
                 <t t-if="!ui.isSmall">
                     <MessagingMenuQuickSearch t-if="state.searchOpen" onClose.bind="toggleSearch"/>
                     <t t-else="">
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
-                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
+                        <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>

--- a/addons/mail/static/src/discuss/call/common/call_settings.xml
+++ b/addons/mail/static/src/discuss/call/common/call_settings.xml
@@ -15,7 +15,7 @@
                     Input device
                 </h5>
                 <div class="flex-grow-1"/>
-                <select name="inputDevice" class="form-select d-flex w-auto" t-on-change="onChangeSelectAudioInput">
+                <select name="inputDevice" class="form-select d-flex w-auto shadow-sm" t-on-change="onChangeSelectAudioInput">
                     <option value="">Browser default</option>
                     <t t-foreach="state.userDevices" t-as="device" t-key="device_index" device="device">
                         <option t-if="device.kind === 'audioinput'" t-att-selected="store.settings.audioInputDeviceId === device.deviceId" t-att-value="device.deviceId">

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_indicator.xml
@@ -4,7 +4,6 @@
         <div t-if="props.thread.rtcSessions.length > 0" title="Ongoing call" class="o-mail-DiscussSidebarCallIndicator fa-fw rounded-circle fa fa-volume-up" style="padding-top: 1px; padding-bottom: 1px;" t-att-class="{
             'o-discuss-inCallIconColor': props.thread.eq(rtc.channel),
             'opacity-50': !props.thread.eq(rtc.channel),
-            'me-2': !store.discuss.isSidebarCompact and props.thread.importantCounter === 0,
         }"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
+++ b/addons/mail/static/src/discuss/call/public_web/discuss_sidebar_call_participants.xml
@@ -19,7 +19,7 @@
     <t t-name="mail.DiscussSidebarCallParticipants.main">
         <div class="o-mail-DiscussSidebarCallParticipants d-flex py-1 bg-inherit" t-ref="root" t-att-class="{
             'justify-content-center': compact,
-            'ps-4 pe-2': props.compact === undefined and !compact,
+            'ps-3 pe-2': props.compact === undefined and !compact,
             'px-2': props.compact === false,
             'rounded-3': props.compact === undefined,
             'opacity-75': props.thread.notEq(rtc.channel) and compact,

--- a/addons/mail/static/src/discuss/core/common/channel_invitation.xml
+++ b/addons/mail/static/src/discuss/core/common/channel_invitation.xml
@@ -11,7 +11,7 @@
     <t t-name="discuss.ChannelInvitation.main">
         <div class="d-flex flex-column flex-grow-1 bg-inherit" t-att-class="{ 'o-mail-Discuss-threadActionPopover w-100': props.hasSizeConstraints, 'px-1': !props.thread }">
             <t t-if="store.self.type === 'partner'">
-                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
+                <input class="o-discuss-ChannelInvitation-search form-control lh-1 px-2 bg-view shadow-sm" t-att-value="searchStr" t-ref="input" t-att-placeholder="searchPlaceholder" t-on-input="onInput"/>
                 <ul class="d-flex flex-column mx-0 pt-1 pb-0 overflow-auto list-group border-0 flex-grow-1" t-att-class="{ 'align-items-center justify-content-center': selectablePartners.length === 0 }">
                     <div t-if="selectablePartners.length === 0" class="smaller text-muted mx-1 opacity-50">
                         <t t-if="props.thread">No user found that is not already a member of this channel.</t>
@@ -51,7 +51,7 @@
                         <t t-esc="invitationButtonText"/>
                     </button>
                 </t>
-                <div t-if="props.thread?.invitationLink" class="input-group">
+                <div t-if="props.thread?.invitationLink" class="input-group shadow-sm">
                     <input class="border border-secondary form-control lh-1 px-2 py-0 opacity-50 bg-view smaller" type="text" t-att-value="props.thread.invitationLink" readonly="" t-on-focus="onFocusInvitationLinkInput"/>
                     <button class="btn btn-primary px-2 o-py-0_5" t-on-click="onClickCopy">
                         <i class="fa fa-copy"/>

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.dark.scss
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.dark.scss
@@ -1,0 +1,3 @@
+.o-mail-MessageSeenIndicator {
+    --mail-MessageSeenIndicator-hasEveryoneSeenColor: #{lighten($primary, 15%)};
+}

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.scss
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.scss
@@ -1,8 +1,14 @@
-.o-mail-MessageSeenIndicator i {
-    // fa icons have a line height of 1 by default which breaks alignment
-    line-height: 1.5;
+.o-mail-MessageSeenIndicator {
+    &.o-hasEveryoneSeen {
+        color: var(--mail-MessageSeenIndicator-hasEveryoneSeenColor, lighten($primary, 20%));
+    }
 
-    &.o-second {
-        top: -3px;
+    i {
+        // fa icons have a line height of 1 by default which breaks alignment
+        line-height: 1.5;
+    
+        &.o-second {
+            top: -3px;
+        }
     }
 }

--- a/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/discuss/core/common/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'text-primary opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
+        <span class="o-mail-MessageSeenIndicator position-relative" t-att-class="{ 'opacity-25': !props.message.hasEveryoneSeen, 'o-hasEveryoneSeen opacity-75': props.message.hasEveryoneSeen, 'cursor-pointer': props.message.channelMemberHaveSeen.length }" t-att-title="summary" t-attf-class="{{ props.className }}" t-on-click="openDialog">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
                 <i t-if="props.message.hasSomeoneSeen" class="o-second start-0 fa fa-check position-absolute"/>

--- a/addons/mail/static/src/discuss/core/common/notification_settings.xml
+++ b/addons/mail/static/src/discuss/core/common/notification_settings.xml
@@ -40,7 +40,7 @@
                                 <span class="fw-bolder o-xsmaller ps-2 o-discuss-NotificationSettings-defaultValue"><t t-out="store.settings.NOTIFICATIONS.find((n) => n.label === store.settings.channel_notifications).name"/></span>
                             </div>
                             <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                            <input class="form-check-input" type="radio" t-att-checked="!props.thread.custom_notifications"/>
+                            <input class="form-check-input shadow-sm" type="radio" t-att-checked="!props.thread.custom_notifications"/>
                         </div>
                     </button>
                     <t t-foreach="store.settings.NOTIFICATIONS" t-as="notif" t-key="notif.label">
@@ -48,7 +48,7 @@
                             <div class="d-flex flex-grow-1 align-items-center px-2 py-1 rounded">
                                 <span class="fs-6 fw-normal text-wrap text-start text-break" t-esc="notif.name"/>
                                 <div class="o-discuss-NotificationSettings-separator flex-grow-1"/>
-                                <input class="form-check-input ms-2" type="radio" t-att-checked="props.thread.custom_notifications === notif.label"/>
+                                <input class="form-check-input ms-2 shadow-sm" type="radio" t-att-checked="props.thread.custom_notifications === notif.label"/>
                             </div>
                         </button>
                     </t>

--- a/addons/mail/static/src/discuss/core/common/thread_patch.xml
+++ b/addons/mail/static/src/discuss/core/common/thread_patch.xml
@@ -2,10 +2,10 @@
 <templates xml:space="preserve">
     <t t-inherit="mail.Thread" t-inherit-mode="extension">
         <xpath expr="//div[hasclass('o-mail-Thread')]" position="before">
-            <span t-if="!env.inChatter and props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller fw-bolder rounded-bottom-3 rounded-top-0">
-                <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover rounded-top-0 rounded-bottom-3 py-1'"/>
-                <span t-attf-class="{{ alertClass }} flex-grow-1" style="border-bottom-right-radius: 0 !important" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
-                <span t-attf-class="{{ alertClass }}" style="border-bottom-left-radius: 0 !important" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
+            <span t-if="!env.inChatter and props.thread.showUnreadBanner" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm smaller fw-bolder o-rounded-bubble border border-warning mx-1 o-mt-0_5">
+                <t t-set="alertClass" t-value="'alert alert-warning m-0 border-start-0 o-mail-Thread-bannerHover py-1'"/>
+                <span t-attf-class="{{ alertClass }} flex-grow-1 o-rounded-start-bubble rounded-end-0" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
+                <span t-attf-class="{{ alertClass }} o-rounded-end-bubble rounded-start-0" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
             </span>
         </xpath>
     </t>

--- a/addons/mail/static/src/discuss/core/public/welcome_page.xml
+++ b/addons/mail/static/src/discuss/core/public/welcome_page.xml
@@ -10,7 +10,7 @@
         <h2 class="m-5" t-esc="store.companyName"/>
         <div class="d-flex justify-content-center gap-5" t-att-class="{'flex-column': ui.isSmall}">
             <div t-if="this.store.discuss_public_thread.default_display_mode === 'video_full_screen'" class="position-relative d-flex justify-content-center" t-ref="root">
-                <video class="shadow rounded bg-dark" t-attf-height="{{ui.isSmall ? 240 : 480}}" t-attf-width="{{ui.isSmall ? 320 : 640}}" autoplay="" t-ref="video"/>
+                <video class="shadow rounded-3 bg-dark" t-attf-height="{{ui.isSmall ? 240 : 480}}" t-attf-width="{{ui.isSmall ? 320 : 640}}" autoplay="" t-ref="video"/>
                 <p t-if="hasRtcSupport and !state.videoStream" class="position-absolute bottom-50 text-light">
                     Camera is off
                 </p>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_command_palette.xml
@@ -19,7 +19,7 @@
             <span t-if="props.action?.searchValueSuffix" class="o-action fw-bold" t-esc="props.searchValue"/>
             <span class="flex-grow-1"/>
             <div t-if="props.counter > 0">
-                <span t-attf-class="badge rounded-pill o-discuss-badge ms-3 me-1 fw-bold" t-esc="props.counter"/>
+                <span t-attf-class="badge rounded-pill o-discuss-badge ms-3 me-1 fw-bold shadow-sm" t-esc="props.counter"/>
             </div>
         </div>
     </t>
@@ -28,7 +28,7 @@
         <Dialog size="'sm'" title.translate="New Channel">
             <div class="d-flex flex-column" t-on-keydown="onKeydown">
                 <span class="ms-1 text-uppercase text-muted o-xsmaller opacity-75"><i class="fa fa-hashtag"/> Channel name</span>
-                <input type="text" class="form-control lh-1" t-att-class="{ 'is-invalid': state.isInvalid }" placeholder="Channel name" t-model="state.name" tabindex="1"/>
+                <input type="text" class="form-control lh-1 shadow-sm" t-att-class="{ 'is-invalid': state.isInvalid }" placeholder="Channel name" t-model="state.name" tabindex="1"/>
                 <div class="invalid-feedback">Channel must have a name.</div>
             </div>
             <t t-set-slot="footer">

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar.dark.scss
@@ -1,4 +1,4 @@
 .o-mail-DiscussSidebar-item {
     --mail-DiscussSidebar-itemActiveBgColor: #{mix($gray-200, $gray-300)};
-    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .25)};
+    --mail-DiscussSidebar-itemActiveOutlineColor: #{rgba($gray-400, .15)};
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.dark.scss
@@ -2,10 +2,6 @@
     --mail-DiscussSidebarChannel-commandsHover: #{rgba($gray-400, .5)};
 }
 
-.o-mail-DiscussSidebar-unreadIndicator {
-    opacity: 75%;
-}
-
 .o-mail-DiscussSidebarChannel-container {
     --mail-DiscussSidebarChannel-borderOpacity: .125;
     ---mail-DiscussSidebarChannel-borderedBgColor: #{mix($gray-100, $gray-200, 75%)};

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.js
@@ -92,7 +92,7 @@ export class DiscussSidebarChannel extends Component {
 
     get attClassContainer() {
         return {
-            "border border-dark rounded-3 o-bordered": this.bordered,
+            "border border-dark o-rounded-bubble o-bordered": this.bordered,
             "o-compact": this.store.discuss.isSidebarCompact,
         };
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -69,7 +69,12 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 .o-mail-DiscussSidebar-unreadIndicator {
     font-size: 0.4rem;
     left: -3px;
-    opacity: 50%;
+
+    .o-mail-DiscussSidebarChannel-container.o-bordered & {
+        &.o-mail-DiscussSidebarChannel, &.o-compact {
+            filter: drop-shadow(1px 2px 0px $white) drop-shadow(-1px 1px 0px $white) drop-shadow(1px -1px 0px $white) drop-shadow(-1px -2px 0px $white);
+        }
+    }
 
     .o-mail-DiscussSidebarSubchannel &:not(.o-compact) {
         left: map-get($spacers, 2) + map-get($spacers, 1) / 2;

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -9,7 +9,7 @@
                 </div>
             </t>
         </Dropdown>
-        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded-3 mx-3 my-2 border border-secondary position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
+        <div t-else="" class="o-mail-DiscussSidebarCategories-search rounded-3 mx-3 my-2 border border-secondary shadow-sm position-relative d-flex align-items-center justify-content-center gap-1" t-on-click="onClickFindOrStartConversation">
             <input class="form-control rounded-3 border-0 bg-inherit" t-att-class="{ 'lh-1': !ui.isSmall }" disabled="true" placeholder="Find or start a conversation" tabindex="0"/>
             <div class="o-mail-DiscussSidebarCategories-searchClickable position-absolute z-1 opacity-0 cursor-pointer w-100 h-100"/>
         </div>
@@ -59,7 +59,7 @@
                 </t>
             </button>
             <t t-if="actions.length and !store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarCategory.actions"/>
-            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
+            <div t-if="!category.open and store.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold" t-att-class="{ 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact, 'me-1': !store.discuss.isSidebarCompact }">
                 <t t-esc="store.getDiscussSidebarCategoryCounter(category.id)"/>
             </div>
         </div>
@@ -70,7 +70,7 @@
             <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm ms-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                        <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
                             <i role="img" class="fa-fw fa-lg" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>
@@ -137,14 +137,14 @@
                 }" t-att-style="store.discuss.isSidebarCompact ? 'text-overflow: clip;' : ''"/>
                 <span class="flex-grow-1"/>
                 <t t-if="!store.discuss.isSidebarCompact" t-call="mail.DiscussSidebarChannel.commands"/>
-                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
+                <span t-if="thread.importantCounter > 0" t-attf-class="o-mail-DiscussSidebar-badge shadow-sm badge rounded-pill o-discuss-badge fw-bold top-0 {{thread.isMuted ? 'o-muted' : ''}}" t-att-class="{ 'mx-1': !store.discuss.isSidebarCompact, 'position-absolute top-0 o-compact': store.discuss.isSidebarCompact }" t-esc="thread.importantCounter"/>
             </button>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
         </li>
     </t>
 
     <t t-name="mail.DiscussSidebar.unreadIndicator">
-        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
+        <span class="o-mail-DiscussSidebar-unreadIndicator position-absolute text-400" t-att-class="{ 'o-compact': store.discuss.isSidebarCompact }" title="Thread has unread messages"><i class="fa fa-circle smaller"/></span>
     </t>
 
     <t t-name="mail.DiscussSidebarChannel.main">
@@ -157,27 +157,23 @@
                 <div class="bg-inherit position-relative d-flex flex-shrink-0 o-my-0_5 rounded-3" style="width:32px;height:32px;" t-att-class="{ 'ms-2': !store.discuss.isSidebarCompact }">
                     <img class="w-100 h-100 rounded-3 o_object_fit_cover shadow-sm" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                     <ThreadIcon t-if="thread.channel_type?.includes('chat') or (thread.channel_type === 'channel' and !thread.authorizedGroupFullName)" thread="thread" size="'small'" className="'o-mail-DiscussSidebarChannel-threadIcon position-absolute top-100 start-100 translate-middle mt-n1 ms-n1 d-flex align-items-center justify-content-center rounded-circle bg-inherit'"/>
-                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border'"/>
+                    <CountryFlag t-if="thread.showCorrespondentCountry" country="thread.correspondentCountry" class="'position-absolute o-mail-DiscussSidebarChannel-country border shadow-sm'"/>
                 </div>
                 <span t-if="!store.discuss.isSidebarCompact" class="o-mail-DiscussSidebarChannel-itemName mx-2 text-truncate" t-att-class="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted ? 'o-unread fw-bolder' : 'text-muted'">
                     <t t-esc="thread.displayName"/>
                 </span>
             </div>
+            <div t-if="indicators.length" class="position-absolute rounded-circle p-0 smaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
+                <t t-component="indicators[0]" t-props="{ thread }"/>
+            </div>
             <t t-if="!store.discuss.isSidebarCompact">
                 <div class="flex-grow-1"/>
                 <t t-call="mail.DiscussSidebarChannel.commands"/>
-                <t t-foreach="indicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
-                <i t-if="thread.isMuted" class="fa fa-fw fa-bell-slash me-1"/>
-            </t>
-            <t t-else="">
-                <div t-if="indicators.length" class="position-absolute rounded-circle p-0 smaller o-mail-DiscussSidebarChannel-indicatorCompact lh-1 bg-inherit" name="indicator-compact">
-                    <t t-component="indicators[0]" t-props="{ thread }"/>
-                </div>
             </t>
             <t t-if="thread.selfMember?.message_unread_counter > 0 and !thread.isMuted and thread.importantCounter === 0" t-call="mail.DiscussSidebar.unreadIndicator"/>
             <t t-if="thread.importantCounter > 0" t-call="mail.discuss_badge">
                 <t t-set="counter" t-value="thread.importantCounter"/>
-                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge flex-shrink-0 fw-bold ' + (thread.isMuted ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'ms-1 me-2')"/>
+                <t t-set="badgeClass" t-value="'o-mail-DiscussSidebarChannel-badge o-mail-DiscussSidebar-badge shadow-sm flex-shrink-0 fw-bold ' + (thread.isMuted ? 'o-muted' : '') + ' ' + (store.discuss.isSidebarCompact ? 'position-absolute top-0 o-compact' : 'ms-1 me-2')"/>
                 <t t-set="floating" t-value="store.discuss.isSidebarCompact"/>
             </t>
         </button>
@@ -191,7 +187,7 @@
         }">
             <div t-att-class="{ 'd-flex flex-column align-items-start ps-1 pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t t-foreach="sortedCommands" t-as="command" t-key="command_index">
-                    <button class="btn o-opacity-35 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
+                    <button class="btn o-opacity-35 opacity-100-hover" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-on-click.stop="() => command.onSelect()" t-att-title="store.discuss.isSidebarCompact ? '' : command.label">
                         <i role="img" class="fa-fw fa-lg" t-att-class="command.icon"/>
                         <span t-if="store.discuss.isSidebarCompact" t-esc="command.label"/>
                     </button>

--- a/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
+++ b/addons/mail/static/src/discuss/core/public_web/sub_channel_list.xml
@@ -7,14 +7,14 @@
                     <div class="input-group ms-2 my-2">
                         <div class="form-control d-flex align-items-center p-0 bg-view" role="search" aria-autocomplete="list">
                             <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1 h-100">
-                                <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2 bg-view" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>
+                                <input t-ref="search" t-model="state.searchTerm" type="text" class="o_searchview_input rounded flex-grow-1 w-auto border-0 px-2 bg-view shadow-sm" t-on-keydown="onKeydownSearch" placeholder="Search by name"/>
                             </div>
                         </div>
-                        <button class="btn btn-outline-secondary px-2 py-1" aria-label="Search button" t-on-click="search">
+                        <button class="btn btn-outline-secondary px-2 py-1 shadow-sm" aria-label="Search button" t-on-click="search">
                             <i t-if="!state.loading" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Sub Channels" title="Search Sub Channels"/>
                             <i t-else="" class="fa fa-circle-o-notch fa-spin" aria-label="Search in progress" title="Search in progress"/>
                         </button>
-                        <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
+                        <button t-if="store.self.isInternalUser" class="ms-1 btn btn-primary smaller shadow-sm" aria-label="Create Thread" t-on-click="onClickCreate">Create</button>
                     </div>
                 </div>
             </t>
@@ -28,7 +28,7 @@
                 <div class="d-flex flex-column flex-grow-1 gap-2">
                     <t t-foreach="state.subChannels" t-as="thread" t-key="thread.localId">
                         <t t-set="message" t-value="thread.newestPersistentOfAllMessage ?? thread.from_message_id"/>
-                        <button class="o-mail-SubChannelList-thread btn btn-light-subtle d-flex flex-column border border-secondary mx-1 px-2 py-1" t-on-click="() => this.onClickSubThread(thread)">
+                        <button class="o-mail-SubChannelList-thread btn btn-light-subtle d-flex flex-column border border-secondary mx-1 px-2 py-1 rounded-3 shadow-sm" t-on-click="() => this.onClickSubThread(thread)">
                             <div class="d-flex w-100">
                                 <span class="fw-bold text-truncate small" t-esc="thread.displayName"/>
                                 <span class="flex-grow-1"/>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -145,7 +145,7 @@ export function useHover(refNames, { onHover, onAway, stateObserver, onHovering 
                 awayTimeout = setTimeout(() => {
                     clearTimeout(hoveringTimeout);
                     onAway();
-                }, 200);
+                }, 100);
             }
         }
         wasHovering = hovering;

--- a/addons/mail/static/tests/discuss/core/common/message_seen_indicator.test.js
+++ b/addons/mail/static/tests/discuss/core/common/message_seen_indicator.test.js
@@ -48,7 +48,7 @@ test("rendering when just one has received the message", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator[title='Sent']");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen", { count: 0 });
 });
 
 test("rendering when everyone have received the message", async () => {
@@ -80,7 +80,7 @@ test("rendering when everyone have received the message", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator[title='Sent']");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 1 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen", { count: 0 });
 });
 
 test("rendering when just one has seen the message", async () => {
@@ -119,7 +119,7 @@ test("rendering when just one has seen the message", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator[title='Seen by Demo User']");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen", { count: 0 });
 });
 
 test("rendering when just one has seen & received the message", async () => {
@@ -154,7 +154,7 @@ test("rendering when just one has seen & received the message", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator[title='Seen by Demo User']");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 0 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen", { count: 0 });
 });
 
 test("rendering when just everyone has seen the message", async () => {
@@ -186,7 +186,7 @@ test("rendering when just everyone has seen the message", async () => {
     await contains(".o-mail-MessageSeenIndicator");
     await contains(".o-mail-MessageSeenIndicator[title='Seen by everyone']");
     await contains(".o-mail-MessageSeenIndicator .fa-check", { count: 2 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary", { count: 1 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen", { count: 1 });
 });
 
 test("'channel_fetch' notification received is correctly handled", async () => {
@@ -436,7 +436,7 @@ test("all seen indicator in chat displayed only once (chat created by correspond
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 2 });
-    await contains(".o-mail-MessageSeenIndicator.text-primary .fa-check", { count: 2 });
+    await contains(".o-mail-MessageSeenIndicator.o-hasEveryoneSeen .fa-check", { count: 2 });
 });
 
 test("no seen indicator in 'channel' channels (with is_typing)", async () => {


### PR DESCRIPTION
Message bubble color in dark theme were too light grey, which make text hard to read. Also the greyish tint makes discuss look sad. White theme color are not much saturated, but the light background makes it good enough in comparison.

This commit fixes the issue by darkening and adding more saturation to message bubble in dark theme. This gives them a more mature look with text more readable.

This commit makes similar improvement to important messaging menu items in dark theme.

White theme color has been slightly improved with a bit more color saturation on message bubble and notification item bg.

This PR also makes these other notable changes:
- shadow effects (message bubble, inputs, badges, etc.)
- message actions are horizontally more compact
- starred messages have starred icon in their sidebar
- useHover away timing is reduced to 100ms (down from 200ms), so that this feels snappier.
- chat bubble in mobile don't have close button: was too prone for accidental click with thumb
- thread banners have new style with floating rounded alerts
- chat window unread counter is next to name rather than always next to chat window quick actions.
- message bubbles in mobile do not go in the turf of bubbles in opposite alignment (i.e. more spacing at their end). Should make it easier to read conversation in mobile.