### PR TITLE
[FIX] stock_dropshipping: remove internal note from delivery slip

### DIFF
--- a/addons/stock_dropshipping/models/__init__.py
+++ b/addons/stock_dropshipping/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import product
 from . import purchase
 from . import res_company
 from . import sale

--- a/addons/stock_dropshipping/models/product.py
+++ b/addons/stock_dropshipping/models/product.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class ProductProduct(models.Model):
+    _inherit = "product.product"
+
+    def _get_description(self, picking_type_id):
+        if picking_type_id.code == 'dropship':
+            return self.description_pickingout or self.name
+        else:
+            return super()._get_description(picking_type_id)

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -89,6 +89,8 @@ class TestDropship(common.TransactionCase):
 
     def test_00_dropship(self):
         self.dropship_product.description_purchase = "description_purchase"
+        self.dropship_product.description = "internal note"
+        self.dropship_product.description_pickingout = "description_out"
         # Required for `route_id` to be visible in the view
         self.env.user.groups_id += self.env.ref('stock.group_adv_location')
 
@@ -136,6 +138,10 @@ class TestDropship(common.TransactionCase):
             ('location_dest_id', '=', self.env.ref('stock.stock_location_customers').id),
             ('product_id', '=', self.dropship_product.id)])
         self.assertEqual(len(move_line.ids), 1, 'There should be exactly one move line')
+
+        # Check description is not the internal note
+        self.assertNotEqual(move_line.move_id.description_picking, self.dropship_product.description)
+        self.assertEqual(move_line.move_id.description_picking, self.dropship_product.description_pickingout)
 
     def test_sale_order_picking_partner(self):
         """ Test that the partner is correctly set on the picking and the move when the product is dropshipped or not."""


### PR DESCRIPTION
In a dropshipping context, the internal note of a product with displayed on the delivery slip of the operation.

Steps to reproduce:
-------------------
* Create (or use) a product with an internal note
* Enable Buy and Dropship Routes, add a Vendor
* Create and Confirn a Sale Order with that product
* Click on Purchase smart button and Confirm Order
* Click on Dropship smart button
* Print the Delivery Slip
> Observation:
The internal note was displayed under the name of the product

Why the fix:
------------
When used with picking_code == 'dropship', `_get_description()` returns the product's description (internal note). We don't want that description to be visible on a report that's used outside of the company.

opw-4791064



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
