### PR TITLE
[IMP] mail: limit activity display to active companies

### DIFF
--- a/addons/mail/security/mail_security.xml
+++ b/addons/mail/security/mail_security.xml
@@ -248,6 +248,13 @@
             <field name="perm_unlink" eval="True"/>
         </record>
 
+        <record id="mail_activity_rule_company" model="ir.rule">
+            <field name="name">Mail activity multi company rule</field>
+            <field name="model_id" ref="model_mail_activity"/>
+            <!-- <field eval="True" name="global"/> -->
+            <field name="domain_force">[('company_id', 'in', company_ids + [ False ])]</field>
+        </record>
+
         <record id="mail_activity_plan_rule_admin" model="ir.rule">
             <field name="name">Administrators can access all activity plans.</field>
             <field name="model_id" ref="model_mail_activity_plan"/>


### PR DESCRIPTION
Currently, the views "All Activities" and "My Activities" will display
every activity belonging to a user, even if they belong to record tied
to companies on which the user has no access.

This commit adds a company_id fields to activities, which will bind
them to the company which own their record, if any.

task-4800833