### PR TITLE
[FIX] website: adapt tours

### DIFF
--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -160,7 +160,6 @@ class TestUiHtmlEditor(HttpCaseWithUserDemo):
         self.start_tour(self.env['website'].get_client_action_url('/contactus'), 'test_html_editor_scss', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_html_editor_scss_2', login='demo')
 
-    @unittest.skip
     def test_media_dialog_undraw(self):
         BASE_URL = self.base_url()
         banner = '/website/static/src/img/snippets_demo/s_banner.jpg'


### PR DESCRIPTION
The ```website_media_dialog_undraw``` tour was previously broken due to
DOM structure changes introduced by the new website builder and was
consequently disabled.

This commit updates the tour steps to align with the new DOM and
re-enables the associated test.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
