### PR TITLE
Master mysterious egg tours adaptation 7 shsa

### DIFF
--- a/addons/website/static/tests/tours/snippet_popup_and_animations.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_animations.js
@@ -2,12 +2,12 @@
 
 import { waitUntil } from "@odoo/hoot-dom";
 import {
-    changeOption,
     clickOnEditAndWaitEditMode,
     clickOnElement,
     clickOnSave,
     insertSnippet,
     registerWebsitePreviewTour,
+    changeOptionInPopover,
 } from "@website/js/tours/tour_utils";
 
 const snippets = [
@@ -30,10 +30,8 @@ const snippets = [
 
 const setOnScrollAnim = function () {
     return [
-        changeOption("WebsiteAnimate", 'we-select[data-is-animation-type-selection="true"] we-toggler'),
-        changeOption("WebsiteAnimate", 'we-button[data-animation-mode="onScroll"]'),
-        changeOption("WebsiteAnimate", 'we-select[data-name="animation_effect_opt"] we-toggler'),
-        changeOption("WebsiteAnimate", 'we-button[data-name="o_anim_slide_in_opt"]'),
+        ...changeOptionInPopover("Card", "Animation", "On Scroll"),
+        ...changeOptionInPopover("Card", "Effect", "Slide"),
     ];
 };
 
@@ -92,17 +90,17 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     ...insertSnippet(snippets[0]), // Popup
     ...insertSnippet(snippets[1]), // Media List
     {
-        trigger: ".o_website_preview.editor_enable.editor_has_snippets",
-    },
-    {
         content: "Drag the Columns snippet group and drop it at the bottom of the popup.",
-        trigger: ".o_block_tab:not(.o_we_ongoing_insertion) #oe_snippets .oe_snippet[name='Columns'] .oe_snippet_thumbnail",
+        trigger: ".o-snippets-menu .o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Columns'].o_draggable .o_snippet_thumbnail",
         run: "drag_and_drop :iframe #wrap .s_popup .modal-content.oe_structure .oe_drop_zone:last",
     },
     {
         content: "Click on the s_three_columns snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_three_columns"]',
+        trigger: ":iframe .o_add_snippets_preview [data-snippet-id='s_three_columns']",
         run: "click",
+    },
+    {
+        trigger: ":iframe:not(:has(.o_loading_screen))",
     },
     clickOnElement("3rd columns", ":iframe .s_popup .s_three_columns .row > :last-child"),
     ...setOnScrollAnim(),
@@ -143,11 +141,7 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:contains('Popup') i.fa-eye-slash",
     },
     clickOnElement("Last image of the 'Columns' snippet", ":iframe .s_three_columns .o_animate_on_scroll img"),
-    changeOption("WebsiteAnimate", 'we-toggler:contains("None")'),
-    changeOption("WebsiteAnimate", 'we-button[data-animation-mode="onHover"]'),
-    {
-        trigger: ".snippet-option-WebsiteAnimate we-row:contains('Animation') we-select[data-is-animation-type-selection] we-toggler:contains('On Hover')",
-    },
+    ...changeOptionInPopover("Image", "Animation", "On Hover"),
     {
         content: "Check that the hover effect animation has been applied on the image",
         trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='overlay']",
@@ -155,10 +149,9 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
     ...clickOnSave(),
     ...clickOnEditAndWaitEditMode(),
     clickOnElement("Image of the 'Columns' snippet with the overlay effect", ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='overlay']:not(:visible)"),
-    changeOption("WebsiteAnimate", 'we-toggler:contains("Overlay")'),
-    changeOption("WebsiteAnimate", 'we-button[data-select-data-attribute="outline"]'),
+    ...changeOptionInPopover("Image", "Effect", "Outline"),
     {
-        trigger: ".snippet-option-WebsiteAnimate we-select[data-attribute-name='hoverEffect'] we-toggler:contains('Outline')",
+        trigger: ".o_customize_tab .options-container[data-container-title='Image'] [data-label='Effect'] button:contains('Outline')",
     },
     {
         content: "Check that the outline effect has been applied on the image",
@@ -177,29 +170,34 @@ registerWebsitePreviewTour("snippet_popup_and_animations", {
         },
     },
     ...clickOnEditAndWaitEditMode(),
-    clickOnElement("Image of the 'Columns' snippet with the outline effect", ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)"),
-    changeOption("ImageTools", 'we-select:contains("Filter") we-toggler:contains("None")'),
-    changeOption("ImageTools", 'we-button:contains("Blur")'),
     {
-        trigger: ".snippet-option-ImageTools we-select:contains('Filter') we-toggler:contains('Blur')",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)",
+        run() {
+            this.anchor.scrollIntoView();
+            this.anchor.click();
+        },
+    },
+    ...changeOptionInPopover("Image", "Filter", "Blur"),
+    {
+        trigger: ".o_customize_tab .options-container[data-container-title='Image'] [data-label='Filter'] button:contains('Blur')",
     },
     {
         content: "Check that the Blur filter has been applied on the image",
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-gl-filter='blur']:not(:visible)",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-gl-filter='blur']",
     },
     {
         content: "Click on the 'undo' button",
-        trigger: ".o_we_external_history_buttons button.fa-undo",
+        trigger: ".o-snippets-top-actions button.fa-undo",
         run: "click",
     },
     {
         content: "Check that the Blur filter has been removed from the image",
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img:not([data-gl-filter='blur']):not(:visible)",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img:not([data-gl-filter='blur'])",
     },
     ...clickOnSave(),
     {
         content: "Check that the image src is not the raw data",
-        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']:not(:visible)",
+        trigger: ":iframe .s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']",
         run() {
             const imgEl = document.querySelector("iframe").contentDocument.querySelector(".s_three_columns .o_animate_on_scroll img[data-hover-effect='outline']");
             const src = imgEl.getAttribute("src");

--- a/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
+++ b/addons/website/static/tests/tours/snippet_popup_and_scrollbar.js
@@ -33,8 +33,8 @@ const checkScrollbar = function (hasScrollbar) {
     };
 };
 
-const toggleBackdrop = function () {
-    return changeOption('SnippetPopup', 'we-button[data-name="popup_backdrop_opt"] we-checkbox', 'backdrop');
+function toggleBackdrop(snippet) {
+    return changeOption(`${snippet}`, "[data-action-id='setBackdrop'] .form-check-input");
 };
 
 registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
@@ -49,33 +49,35 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
         trigger: ':iframe .s_popup .modal',
         run: "click",
     },
-    toggleBackdrop(), // hide Popup backdrop
+    toggleBackdrop("Popup"), // hide Popup backdrop
     checkScrollbar(true),
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it at the bottom of the popup.",
-        trigger: ".o_block_tab:not(.o_we_ongoing_insertion) #oe_snippets .oe_snippet[name='Content'] .oe_snippet_thumbnail",
+        trigger: ".o-snippets-menu .o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Content'].o_draggable .o_snippet_thumbnail",
         run: "drag_and_drop :iframe #wrap .s_popup .oe_drop_zone:last",
     },
     {
         content: "Click on the s_media_list snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_media_list"]',
+        trigger: ":iframe .o_add_snippets_preview [data-snippet='s_media_list']",
         run: "click",
     },
     checkScrollbar(false),
     {
+        trigger: ":iframe:not(:has(.o_loading_screen))",
+    },
+    {
         content: "Select the Media List snippet in the Popup.",
-        trigger: ":iframe #wrap .s_popup .modal-content .s_media_list",
+        trigger: ":iframe .s_popup .s_media_list",
         run: "click",
     },
     {
-        content: "Remove the Media List snippet in the Popup.",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+        content: "Remove the s_media_list snippet",
+        trigger: ".overlay .o_overlay_options .oe_snippet_remove",
         run: "click",
     },
     checkScrollbar(true),
-    toggleBackdrop(), // show Popup backdrop
-    checkScrollbar(false),
+    toggleBackdrop("Popup"), // show Popup backdrop
     {
         content: "Close the Popup that has now backdrop.",
         trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:first",
@@ -88,57 +90,57 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
         run: "click",
     },
     checkScrollbar(true),
-    toggleBackdrop(), // show Cookies Bar backdrop
-    checkScrollbar(false),
-    toggleBackdrop(), // hide Cookies Bar backdrop
+    toggleBackdrop("Cookies Bar"), // show Cookies Bar backdrop
+    toggleBackdrop("Cookies Bar"), // hide Cookies Bar backdrop
     checkScrollbar(true),
     {
         content: "Open the Popup that has backdrop.",
         trigger: ".o_we_invisible_el_panel .o_we_invisible_entry:first",
         run: "click",
     },
-    /* task-4185877
-    checkScrollbar(false),
-    */
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it at the bottom of the popup.",
-        trigger: ".o_block_tab:not(.o_we_ongoing_insertion) #oe_snippets .oe_snippet[name='Content'] .oe_snippet_thumbnail",
-        run: "drag_and_drop :iframe #wrap .s_popup .oe_drop_zone:last",
+        trigger: ".o-snippets-menu .o_snippet[name='Content'] .o_snippet_thumbnail:not(.o_we_ongoing_insertion)",
+        run: "drag_and_drop :iframe #wrap .s_popup .modal-content.oe_structure .oe_drop_zone:last",
     },
     {
         content: "Click on the s_media_list snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_media_list"]',
+        trigger: ":iframe .o_add_snippets_preview [data-snippet='s_media_list']",
         run: "click",
     },
-    /* task-4185877
-    checkScrollbar(true), // The popup backdrop is activated so there should be a scrollbar
-    */
     {
         content: 'Click on the s_popup snippet',
         trigger: ':iframe .s_popup .modal',
-        run: "click",
+        run() {
+            this.anchor.scrollIntoView();
+            this.anchor.click();
+        },
     },
     {
         content: "Remove the s_popup snippet",
-        trigger: ".o_we_customize_panel we-customizeblock-options:contains('Popup') we-button.oe_snippet_remove:first",
-        async run(helpers) {
-            await helpers.click();
-            // TODO: remove the below setTimeout. Without it, goBackToBlocks() not works.
-            await new Promise((r) => setTimeout(r, 1000));
-        }
+        trigger: ".overlay .o_overlay_options .oe_snippet_remove",
+        run: "click",
     },
     checkScrollbar(true),
+    {
+        content: "Open the Cookie Bar.",
+        trigger: ".o_we_invisible_el_panel .o_we_invisible_entry",
+        run: "click",
+    },
     goBackToBlocks(),
     {
         content: "Drag the Content snippet group and drop it in the Cookies Bar.",
-        trigger: ".o_block_tab:not(.o_we_ongoing_insertion) #oe_snippets .oe_snippet[name='Content'] .oe_snippet_thumbnail",
+        trigger: ".o-snippets-menu .o_snippet[name='Content'] .o_snippet_thumbnail:not(.o_we_ongoing_insertion)",
         run: "drag_and_drop :iframe #website_cookies_bar .modal-content.oe_structure",
     },
     {
         content: "Click on the s_media_list snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_media_list"]',
+        trigger: ":iframe .o_add_snippets_preview [data-snippet='s_media_list']",
         run: "click",
+    },
+    {
+        trigger: ":iframe:not(:has(.o_loading_screen))",
     },
     {
         content: "Select the Media List snippet in the Cookies Bar.",
@@ -147,21 +149,23 @@ registerWebsitePreviewTour("snippet_popup_and_scrollbar", {
     },
     {
         content: "Duplicate the Media List snippet",
-        trigger: ".o_we_customize_panel we-customizeblock-options:contains('Media List') we-button.oe_snippet_clone:first",
-        run() {
-            // TODO: use run: "click", instead
-            this.anchor.click();
-        }
+        trigger: ".o_customize_tab .options-container[data-container-title='Media List'] .oe_snippet_clone",
+        run: "click",
     },
     checkScrollbar(false),
     {
+        content: "Select the Media List snippet in the Cookies Bar.",
+        trigger: ":iframe #website_cookies_bar .modal-content .s_media_list",
+        run: "click",
+    },
+    {
         content: "Remove the first Media List snippet in the Cookies Bar.",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+        trigger: ".overlay .o_overlay_options .oe_snippet_remove",
         run: "click",
     },
     {
         content: "Remove the second Media List snippet in the Cookies Bar.",
-        trigger: ":iframe .oe_overlay.oe_active .oe_snippet_remove",
+        trigger: ".overlay .o_overlay_options .oe_snippet_remove",
         run: "click",
     },
     checkScrollbar(true),

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -7,7 +7,6 @@ from werkzeug.urls import url_encode
 from odoo.tests import HttpCase, tagged
 from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website.tools import create_image_attachment
-import unittest
 
 _logger = logging.getLogger(__name__)
 
@@ -112,8 +111,6 @@ class TestSnippets(HttpCase):
     def test_12_snippet_images_wall(self):
         self.start_tour('/', 'snippet_images_wall', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_snippet_popup_with_scrollbar_and_animations(self):
         website = self.env.ref('website.default_website')
         website.cookies_bar = True


### PR DESCRIPTION
This PR aligns tour steps with new DOM structure and re-enable related tests.

The `snippet_popup_and_scrollbar` tour was broken due to changes in DOM structure from the new website builder. This tour   disabled.

Split `test_snippet_popup_with_scrollbar_and_animations` into two separate tours: `snippet_popup_and_scrollbar` and snippet_popup_and_animation`. Note that animation behavior remains unfixed as `On Hover` option is missing.
