### PR TITLE
[IMP] website_sale: adapt product_configurator_strikethrough_price

### DIFF
--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import unittest
-
 from datetime import datetime
 
 from odoo.fields import Command
@@ -399,8 +397,6 @@ class TestWebsiteSaleProductConfigurator(HttpCase, WebsiteSaleCommon):
         })
         self.start_tour('/', 'website_sale_product_configurator_zero_priced')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_product_configurator_strikethrough_price(self):
         """ Test that the product configurator displays the strikethrough price correctly. """
         self.env['res.config.settings'].create({


### PR DESCRIPTION
`product_configurator_strikethrough_price` test was disabled after the new website builder changes. This PR re-enables this test.