### PR TITLE
[IMP] html_builder, website, website_payment: adapt and re-enable tours

### DIFF
--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.scss
@@ -38,3 +38,14 @@
         }
     }
 }
+.o_add_snippet_dialog_iframe_loader {
+    // This loader will appear after a 1s delay, ensuring it doesn't disrupt the
+    // experience for users with a good connection.
+    visibility: hidden;
+    animation: showLoader 0s 1s forwards;
+}
+@keyframes showLoader {
+    to {
+        visibility: visible;
+    }
+}

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.xml
@@ -35,9 +35,12 @@
                             <p class="h4">Take a look at the search bar, there might be a small typo!</p>
                         </div>
                     </t>
-                    <t t-else="">
-                        <div class="spinner-grow position-absolute top-50 start-50 translate-middle" role="status">
-                            <span class="visually-hidden">Loading...</span>
+                    <t t-elif="!state.showIframe">
+                        <div class="o_add_snippet_dialog_iframe_loader d-flex flex-column justify-content-center text-center h-100 p-4" role="status">
+                            <i class="fa fa-3x fa-circle-o-notch fa-spin"></i>
+                            <p class="h3 mt-3">
+                                Almost there! Snippets are incoming, grab a coffee and relax!
+                            </p>
                         </div>
                     </t>
                     <iframe class="border-0 fade bg-200 position-relative o_add_snippet_iframe" t-att-class="state.showIframe ? ' show' : '' " tabindex="-1" t-ref="iframe" src="about:blank" height="333%" width="333%" />

--- a/addons/website/static/tests/tours/add_snippet_dialog.js
+++ b/addons/website/static/tests/tours/add_snippet_dialog.js
@@ -9,7 +9,7 @@ registerWebsitePreviewTour(
     () => [
         {
             content: "Click on any snippet to open the 'Insert Snippet' dialog.",
-            trigger: ".o_panel_body div.oe_snippet",
+            trigger: ".o_snippets_container_body div.o_snippet button",
             run: "click",
         },
         {

--- a/addons/website/static/tests/tours/website_no_dirty_page.js
+++ b/addons/website/static/tests/tours/website_no_dirty_page.js
@@ -129,7 +129,7 @@ registerWebsitePreviewTour('website_no_dirty_lazy_image', {
         run: "click",
     },
     {
-        trigger: '.o_we_user_value_widget[data-replace-media="true"]',
+        trigger: "[data-action-id='replaceMedia']",
     },
     {
         content: "Check that there is no more than one dirty flag",

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -723,7 +723,6 @@ class TestUi(HttpCaseWithWebsiteUser):
         self.start_tour('/', 'website_powerbox_snippet', login='admin')
         self.start_tour('/', 'website_powerbox_keyword', login='admin')
 
-    @unittest.skip
     def test_website_no_dirty_lazy_image(self):
         website = self.env['website'].browse(1)
         # Enable multiple langs to reduce the chance of the test being silently
@@ -789,7 +788,6 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_website_seo_notification(self):
         self.start_tour(self.env['website'].get_client_action_url("/"), "website_seo_notification", login="admin")
 
-    @unittest.skip
     def test_website_add_snippet_dialog(self):
         self.start_tour("/", "website_add_snippet_dialog", login="admin")
 

--- a/addons/website_payment/static/tests/tours/donation.js
+++ b/addons/website_payment/static/tests/tours/donation.js
@@ -3,7 +3,7 @@ import {
     clickOnSave,
     registerWebsitePreviewTour,
     insertSnippet,
-    changeOption,
+    changeOptionInPopover,
 } from "@website/js/tours/tour_utils";
 
 registerWebsitePreviewTour(
@@ -127,8 +127,7 @@ registerWebsitePreviewTour(
             trigger: ":iframe .s_donation_donate_btn",
             run: "click",
         },
-        changeOption("Donation", "we-toggler"),
-        changeOption("Donation", '[data-name="slider_opt"]'),
+        ...changeOptionInPopover("Donation Button", "Custom Amount", "[data-action-param='slider']"),
         ...clickOnSave(),
     ],
 );

--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -1,13 +1,10 @@
 from odoo.tests.common import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-import unittest
 
 
 @tagged('post_install', '-at_install')
 class TestSnippets(HttpCaseWithUserPortal):
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_01_donation(self):
         payment_demo = self.env['ir.module.module']._get('payment_demo')
         if payment_demo.state != 'installed':


### PR DESCRIPTION
The `test_website_add_snippet_dialog`, `test_01_donation`, `test_website_no_dirty_lazy_image` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and re-enables the associated test.