### PR TITLE
[FIX] html_editor: avoid `nbsp` on pasting plain text in code blocks

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -334,17 +334,23 @@ export class ClipboardPlugin extends Plugin {
      */
     pasteText(selection, text) {
         const textFragments = text.split(/\r?\n/);
+        const preEl = closestElement(selection.anchorNode, "PRE");
         let textIndex = 1;
         for (const textFragment of textFragments) {
-            // Replace consecutive spaces by alternating nbsp.
-            const modifiedTextFragment = textFragment.replace(/( {2,})/g, (match) => {
-                let alertnateValue = false;
-                return match.replace(/ /g, () => {
-                    alertnateValue = !alertnateValue;
-                    const replaceContent = alertnateValue ? "\u00A0" : " ";
-                    return replaceContent;
+            let modifiedTextFragment = textFragment;
+
+            // <pre> preserves whitespace by default, so no need for &nbsp.
+            if (!preEl) {
+                // Replace consecutive spaces by alternating nbsp.
+                modifiedTextFragment = textFragment.replace(/( {2,})/g, (match) => {
+                    let alternateValue = false;
+                    return match.replace(/ /g, () => {
+                        alternateValue = !alternateValue;
+                        const replaceContent = alternateValue ? "\u00A0" : " ";
+                        return replaceContent;
+                    });
                 });
-            });
+            }
             this.dependencies.dom.insert(modifiedTextFragment);
             // The selection must be updated after calling insert, as the insertion
             // process modifies the selection.

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -261,6 +261,20 @@ describe("Simple text", () => {
                 contentAfter: "<pre>a<br>b<br>c[]</pre>",
             });
         });
+
+        test("should preserve spaces and not add nbsp when pasting plain text inside <pre>", async () => {
+            await testEditor({
+                contentBefore: "<pre>[]<br></pre>",
+                stepFunction: async (editor) => {
+                    pasteText(
+                        editor,
+                        "function example() {\n    console.log('Hello,    world!');\n    // Indented    comment\n}"
+                    );
+                },
+                contentAfter:
+                    "<pre>function example() {<br>    console.log('Hello,    world!');<br>    // Indented    comment<br>}[]</pre>",
+            });
+        });
     });
 
     describe("range not collapsed", () => {


### PR DESCRIPTION
### Rationale for omitting `nbsp` in code blocks:

- Code blocks, usually rendered within `<pre>` tags, inherently preserve whitespace & indentation through browser’s white-space: pre CSS behavior. Thus, inserting `nbsp` to maintain space visibility is redundant & may introduce hidden characters.

### Description of the issue/feature this PR addresses:

- Indentation pasted as plain text inside code blocks was replaced by `nbsp`.

### Desired behavior after PR is merged:

- Pasting plain text inside code blocks preserves indentation using normal spaces, avoiding insertion of `nbsp`.

task-4815939

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
