### PR TITLE
[IMP] website: adapt tour

### DIFF
--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -16,6 +16,7 @@ import { PopupVisibilityPlugin } from "./plugins/popup_visibility_plugin";
 import { SaveTranslationPlugin } from "./plugins/save_translation_plugin";
 import { TranslationPlugin } from "./plugins/translation_plugin";
 import { WebsiteVisibilityPlugin } from "./plugins/website_visibility_plugin";
+import { EditInteractionPlugin } from "./plugins/edit_interaction_plugin";
 
 const TRANSLATION_PLUGINS = [
     BuilderOptionsPlugin,
@@ -29,6 +30,7 @@ const TRANSLATION_PLUGINS = [
     WebsiteVisibilityPlugin,
     HighlightPlugin,
     OperationPlugin,
+    EditInteractionPlugin,
 ];
 
 export class WebsiteBuilder extends Component {

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -10,7 +10,7 @@ registerWebsitePreviewTour('translate_menu_name', {
 }, () => [
     {
         content: "Open Edit dropdown",
-        trigger: '.o_edit_website_container button',
+        trigger: ".o_menu_systray button:contains('Edit')",
         run: "click",
     },
     {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -209,8 +209,6 @@ class TestUiTranslate(odoo.tests.HttpCase):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'rte_translator', login='admin', timeout=120)
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_translate_menu_name(self):
         lang_en = self.env.ref('base.lang_en')
         parseltongue = self.env['res.lang'].create({


### PR DESCRIPTION
The ```translate_menu_name``` tour was previously
broken due to DOM structure changes introduced by the new website
builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and
re-enables the associated test.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
