### PR TITLE
[FIX] website_slides: update share dialog message

### DIFF
--- a/addons/website_slides/static/src/js/public/components/slide_share_dialog/email_sharing_input.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_share_dialog/email_sharing_input.xml
@@ -13,7 +13,7 @@
             </div>
             <div t-if="this.state.isDone or this.isWebsiteUser" class="alert alert-info" role="alert">
                 <span t-if="this.state.isDone">
-                    <strong>Sharing is caring!</strong> Email(s) sent.
+                    <strong>Sharing is caring!</strong> Your email(s) will arrive shortly.
                 </span>
                 <span t-if="this.isWebsiteUser">
                     Please <a t-attf-href="/odoo?redirect={{ window.location.href }}" class="fw-bold"> login </a>

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -51,7 +51,7 @@
                 </button>
             </div>
             <div class="alert alert-info d-none" role="alert">
-                <strong>Sharing is caring!</strong> Email(s) sent.
+                <strong>Sharing is caring!</strong> Your email(s) will arrive shortly.
             </div>
             <div class="alert alert-warning d-none" role="alert">Please enter valid email(s)</div>
         </div>


### PR DESCRIPTION
This PR updates the share dialog message shown when a slide is shared via email. Since emails are queued and sent later in batches, the previous message could be misleading and prompt users to send multiple emails unnecessarily.

Task-4797324
