### PR TITLE
[FIX] *: mapped('id')

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -263,6 +263,7 @@ class StockMove(models.Model):
         for bom in self.bom_line_id.bom_id:
             if bom.type != 'phantom':
                 continue
+            # mapped('id') to keep NewId
             line_ids = self.bom_line_id.filtered(lambda line: line.bom_id == bom).mapped('id')
             total = len(line_ids)
             for i, line_id in enumerate(line_ids):

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -31,7 +31,7 @@ class HrEmployee(models.Model):
         fields = self._load_pos_data_fields(data['pos.config'][0]['id'])
 
         employees = self.search(domain)
-        manager_ids = employees.filtered(lambda emp: data['pos.config'][0]['group_pos_manager_id'] in emp.user_id.groups_id.ids).mapped('id')
+        manager_ids = employees.filtered(lambda emp: data['pos.config'][0]['group_pos_manager_id'] in emp.user_id.groups_id.ids).ids
 
         employees_barcode_pin = employees.get_barcodes_and_pin_hashed()
         bp_per_employee_id = {bp_e['id']: bp_e for bp_e in employees_barcode_pin}

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -196,13 +196,13 @@ class PosOrder(models.Model):
                                                                                   p.pos_report_print_id)
         if gift_card_programs:
             gift_cards = self.env['loyalty.card'].search([('source_pos_order_id', '=', self.id),
-                                                          ('program_id', 'in', gift_card_programs.mapped('id'))])
+                                                          ('program_id', 'in', gift_card_programs.ids)])
             if gift_cards:
                 for program in gift_card_programs:
                     filtered_gift_cards = gift_cards.filtered(lambda gc: gc.program_id == program)
                     if filtered_gift_cards:
                         action_report = program.pos_report_print_id
-                        report = action_report._render_qweb_pdf(action_report.report_name, filtered_gift_cards.mapped('id'))
+                        report = action_report._render_qweb_pdf(action_report.report_name, filtered_gift_cards.ids)
                         filename = name + '.pdf'
                         gift_card_pdf = self.env['ir.attachment'].create({
                             'name': filename,

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -696,7 +696,7 @@ class StockQuant(models.Model):
                 if pkg[0] is None:
                     # Lazily retrieve ids for single items
                     if not single_item_ids:
-                        single_item_ids = self.search(expression.AND([[('package_id', '=', None)], domain])).mapped('id')
+                        single_item_ids = self.search(expression.AND([[('package_id', '=', None)], domain])).ids
                     selected_single_items.append(single_item_ids.pop())
 
             expr = [('package_id', 'in', [elem[0] for elem in node.taken_packages if elem[0] is not None])]

--- a/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/tests/test_stock_valuation_layer_revaluation.py
@@ -263,7 +263,7 @@ class TestStockValuationLayerRevaluation(TestStockValuationCommon):
         # Adjusting layers for multiple products at once: raise
         with self.assertRaises(UserError):
             Form(self.env['stock.valuation.layer.revaluation'].with_context({
-                'active_ids': self.env['stock.valuation.layer'].search([]).mapped("id"),
+                'active_ids': self.env['stock.valuation.layer'].search([]).ids,
                 'active_model': 'stock.valuation.layer'
             })).save()
 

--- a/addons/test_mass_mailing/tests/test_mailing.py
+++ b/addons/test_mass_mailing/tests/test_mailing.py
@@ -517,7 +517,7 @@ class TestMassMailing(TestMassMailCommon):
 
         with self.mock_mail_gateway():
             for i in range(0, 20, BATCH_SIZE):
-                mailing.action_send_mail(records[i:i + BATCH_SIZE].mapped('id'))
+                mailing.action_send_mail(records[i:i + BATCH_SIZE].ids)
             self.assertEqual(len(self._mails), BATCH_SIZE)
             self.assertEqual(mailing.canceled, 15)
             mails_sent = [email_normalize(mail['email_to'][0]) for mail in self._mails]

--- a/addons/website_crm_partner_assign/models/crm_lead.py
+++ b/addons/website_crm_partner_assign/models/crm_lead.py
@@ -131,7 +131,7 @@ class CrmLead(models.Model):
                     ('partner_latitude', '>', latitude - 2), ('partner_latitude', '<', latitude + 2),
                     ('partner_longitude', '>', longitude - 1.5), ('partner_longitude', '<', longitude + 1.5),
                     ('country_id', '=', lead.country_id.id),
-                    ('id', 'not in', lead.partner_declined_ids.mapped('id')),
+                    ('id', 'not in', lead.partner_declined_ids.ids),
                 ])
 
                 # 2. second way: in the same country, big area
@@ -141,7 +141,7 @@ class CrmLead(models.Model):
                         ('partner_latitude', '>', latitude - 4), ('partner_latitude', '<', latitude + 4),
                         ('partner_longitude', '>', longitude - 3), ('partner_longitude', '<', longitude + 3),
                         ('country_id', '=', lead.country_id.id),
-                        ('id', 'not in', lead.partner_declined_ids.mapped('id')),
+                        ('id', 'not in', lead.partner_declined_ids.ids),
                     ])
 
                 # 3. third way: in the same country, extra large area
@@ -151,7 +151,7 @@ class CrmLead(models.Model):
                         ('partner_latitude', '>', latitude - 8), ('partner_latitude', '<', latitude + 8),
                         ('partner_longitude', '>', longitude - 8), ('partner_longitude', '<', longitude + 8),
                         ('country_id', '=', lead.country_id.id),
-                        ('id', 'not in', lead.partner_declined_ids.mapped('id')),
+                        ('id', 'not in', lead.partner_declined_ids.ids),
                     ])
 
                 # 5. fifth way: anywhere in same country
@@ -160,7 +160,7 @@ class CrmLead(models.Model):
                     partner_ids = Partner.search([
                         ('partner_weight', '>', 0),
                         ('country_id', '=', lead.country_id.id),
-                        ('id', 'not in', lead.partner_declined_ids.mapped('id')),
+                        ('id', 'not in', lead.partner_declined_ids.ids),
                     ])
 
                 # 6. sixth way: closest partner whatsoever, just to have at least one result


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Replace all usages of `mapped('id')` by `ids`.
The former is slower and does not work in domains because NewId is not a valid value for psycopg.

Current behavior before PR:
The `mapped` call returns `.id` for each record, which on new records returns a NewId. That value is not supported in domains or as SQL parameters. (impacted modules: at least l10n_uk*)

Desired behavior after PR is merged:
Simply use `.ids`.

odoo/enterprise#86275


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
