### PR TITLE
[FIX] website_event: bring back missing event page options

### DIFF
--- a/addons/website_event/static/src/website_builder/event_page_option.xml
+++ b/addons/website_event/static/src/website_builder/event_page_option.xml
@@ -7,7 +7,6 @@
     </BuilderRow>
 </t>
 
-
 <t t-name="website_event.EventMainPageOption">
     <BuilderRow label.translate="Cover Position">
         <BuilderSelect action="'websiteConfig'">
@@ -16,6 +15,31 @@
             <BuilderSelectItem actionParam="{views: ['website_event.opt_event_description_cover_hidden']}">Hidden (visitor only)</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
+
+    <BuilderRow label.translate="Fixed Sidebar">
+        <BuilderCheckbox action="'websiteConfig'" actionParam="{views: ['website_event.opt_event_fixed_sidebar']}"/>
+    </BuilderRow>
+
+    <BuilderRow label.translate="Sidebar Blocks"> </BuilderRow>
+    <BuilderContext action="'websiteConfig'">
+        <BuilderRow label.translate="Registration" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_registration_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Dates" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_dates_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Calendar links" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_calendar_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Location" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_location_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Organizer" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_organizer_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Share" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_share_block']}"/>
+        </BuilderRow>
+    </BuilderContext>
 </t>
 </templates>
-

--- a/addons/website_event/static/src/website_builder/event_page_option_plugin.js
+++ b/addons/website_event/static/src/website_builder/event_page_option_plugin.js
@@ -20,7 +20,7 @@ class EventPageOption extends Plugin {
                 template: "website_event.EventMainPageOption",
                 selector: "main:has(#o_wevent_event_main)",
                 editableOnly: false,
-                title: _t("Event Cover Position"),
+                title: _t("Event Page"),
                 groups: ["website.group_website_designer"],
             }),
         ],

--- a/addons/website_event/static/src/website_builder/option_sequence.js
+++ b/addons/website_event/static/src/website_builder/option_sequence.js
@@ -1,7 +1,7 @@
 import { DEFAULT, END, splitBetween } from "@html_builder/utils/option_sequence";
 
 const EVENT_PAGE = DEFAULT;
-const [EXHIBITOR_FILTER, SPONSOR, TRACK, EVENT_PAGE_MAIN, ...__DETECT_ERROR_1__] = splitBetween(
+const [EXHIBITOR_FILTER, EVENT_PAGE_MAIN, SPONSOR, TRACK, ...__DETECT_ERROR_1__] = splitBetween(
     EVENT_PAGE,
     END,
     4


### PR DESCRIPTION
Some option for the selector `main:has(#o_wevent_event_main)` were missed during the initial website builder refactoring
