### PR TITLE
[IMP] html_editor, website: adapt and re-enable tours

### DIFF
--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -5,6 +5,7 @@ import {
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
+import { unwrapContents } from "@html_editor/utils/dom";
 
 export class FilePlugin extends Plugin {
     static id = "file";
@@ -40,6 +41,16 @@ export class FilePlugin extends Plugin {
             },
         }),
         selectors_for_feff_providers: () => ".o_file_box",
+        normalize_handlers: (node) => {
+            // If an image is wrapped in an <a> tag, remove the link on
+            // replacing it with a document. This ensures the document is not
+            // unnecessarily wrapped in a clickable link.
+            const fileElement = node.querySelector(".o_file_box");
+            const parentEl = fileElement?.parentElement;
+            if (parentEl?.tagName === "A" && parentEl.children.length === 1) {
+                unwrapContents(parentEl);
+            }
+        },
     };
 
     get recordInfo() {

--- a/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/video_selector.js
@@ -119,6 +119,9 @@ export class VideoSelector extends Component {
                     "";
                 if (src) {
                     this.state.urlInput = src;
+                    if (!src.includes("https:") && !src.includes("http:")) {
+                        this.state.urlInput = "https:" + this.state.urlInput;
+                    }
                     await this.updateVideo();
 
                     this.state.options = this.state.options.map((option) => {

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -19,6 +19,7 @@ import { MediaDialog } from "./media_dialog/media_dialog";
 import { rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { closestElement } from "@html_editor/utils/dom_traversal";
+import { unwrapContents } from "@html_editor/utils/dom";
 
 /**
  * @typedef { Object } MediaShared
@@ -104,6 +105,15 @@ export class MediaPlugin extends Plugin {
             mediaElements.push(node);
         }
         for (const el of mediaElements) {
+            if (el.classList.contains("media_iframe_video")) {
+                // If an image is wrapped in an <a> tag, remove the link on
+                // replacing it with a video. This ensures the video is not
+                // unnecessarily wrapped in a clickable link.
+                const parentEl = el?.parentElement;
+                if (parentEl?.tagName === "A" && parentEl.children.length === 1) {
+                    unwrapContents(parentEl);
+                }
+            }
             if (isProtected(el) || isProtecting(el)) {
                 continue;
             }

--- a/addons/website/static/src/builder/plugins/image/replace_media_option.js
+++ b/addons/website/static/src/builder/plugins/image/replace_media_option.js
@@ -13,7 +13,8 @@ export class ReplaceMediaOption extends BaseOptionComponent {
     canSetLink(editingElement) {
         return (
             isImageSupportedForStyle(editingElement) &&
-            !searchSupportedParentLinkEl(editingElement).matches("a[data-oe-xpath]")
+            !searchSupportedParentLinkEl(editingElement).matches("a[data-oe-xpath]") &&
+            !editingElement.classList.contains("media_iframe_video")
         );
     }
     hasHref(editingElement) {

--- a/addons/website/static/tests/tours/media_iframe_video.js
+++ b/addons/website/static/tests/tours/media_iframe_video.js
@@ -11,12 +11,13 @@ registerWebsitePreviewTour("website_media_iframe_video", {
         }),
         {
             content: "Select the image",
-            trigger: ":iframe #wrap .s_text_image img",
+            trigger:
+                ":iframe #wrap .s_text_image img, :iframe #wrap .s_text_image img:not(:visible)",
             run: "click",
         },
         {
             content: "Open image link options",
-            trigger: "[data-name='media_link_opt']",
+            trigger: "[data-action-id='setLink']",
             run: "click",
         },
         {
@@ -26,7 +27,7 @@ registerWebsitePreviewTour("website_media_iframe_video", {
         },
         {
             content: "Click on replace media",
-            trigger: "[data-replace-media='true']",
+            trigger: "[data-action-id='replaceMedia']",
             run: "click",
         },
         {
@@ -50,7 +51,7 @@ registerWebsitePreviewTour("website_media_iframe_video", {
         },
         {
             content: "Click on replace media",
-            trigger: "[data-replace-media='true']",
+            trigger: "[data-action-id='replaceMedia']",
             run: "click",
         },
         {

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -710,7 +710,6 @@ class TestUi(HttpCaseWithWebsiteUser):
     def test_snippet_carousel_autoplay(self):
         self.start_tour("/", "snippet_carousel_autoplay", login="admin")
 
-    @unittest.skip
     def test_media_iframe_video(self):
         self.start_tour("/", "website_media_iframe_video", login="admin")
 


### PR DESCRIPTION
The `test_media_iframe_video` tour was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test.
