### PR TITLE
[FIX] point_of_sale: prevent creation of rounding from POS settings

### DIFF
--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -67,7 +67,7 @@
                                 <div class="content-group mt16" invisible="not pos_cash_rounding">
                                     <div class="row mt16">
                                         <label string="Rounding Method" for="pos_rounding_method" class="col-lg-3 o_light_label" />
-                                        <field name="pos_rounding_method" required="pos_cash_rounding" readonly="pos_has_active_session"/>
+                                        <field name="pos_rounding_method" required="pos_cash_rounding" readonly="pos_has_active_session" options="{'no_quick_create': True}" />
                                     </div>
                                     <div class="row mt16">
                                         <div class="col">


### PR DESCRIPTION
Added `no_create` option to the `pos_rounding_method` field to enforce use of predefined `cash.rounding.method` form, avoiding bypass of required Profit & Loss accounts setup (which cause some issue when trying to cash in/out in POS or when trying to close the session).

task-id: 4805617



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
