### PR TITLE
[FIX] mass_mailing: fix traces sent for mails with templates

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -1237,9 +1237,10 @@ class MailComposeMessage(models.TransientModel):
                     'model': self.model,
                     'res_id': res_id,
                 }
-                message_inmem = self.env['mail.message'].new({
-                    'body': mail_values['body'],
-                })
+                new_mail_message_values = {'body': mail_values['body']}
+                if self.template_id:
+                    new_mail_message_values['email_add_signature'] = False
+                message_inmem = self.env['mail.message'].new(new_mail_message_values)
                 for _lang, render_values, recipients_group_data in record._notify_get_classified_recipients_iterator(
                     message_inmem,
                     [{

--- a/addons/mass_mailing/wizard/mail_compose_message.py
+++ b/addons/mass_mailing/wizard/mail_compose_message.py
@@ -55,7 +55,7 @@ class MailComposeMessage(models.TransientModel):
                     mailing_sent_message=Markup(_(
                         'Received the mailing <b>{mailing_name}</b>',
                     )).format(
-                        mailing_name=self.mass_mailing_id.display_name
+                        mailing_name=self.mass_mailing_name or self.mass_mailing_id.display_name
                     ),
                     original_body=mail_values['body'],
                 )


### PR DESCRIPTION
This commit fixes an issue with the notifications sent when the user sends en masse emails with a template.

The issue is that the notification logged in the chatter uses the created mailing's display_name, which is computed on the subject of the mailing. This subject is set to a value that is an unrendered inline template.

To fix this, the value of the mailing_name in the body of the message is set to the rendered subject if there is a template linked to the composer. The subjects are rendered based on the list of res_ids notified.

task-4813503

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
