### PR TITLE
[FIX] html_editor: support base btn-class

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -414,7 +414,7 @@ export class LinkPopover extends Component {
 
     get classes() {
         let classes = [...this.props.linkElement.classList]
-            .filter((value) => value != "btn" && !value.match(/btn-(sm|lg|fill)/))
+            .filter((value) => !value.match(/btn(-[a-z0-9]+)*/))
             .join(" ");
 
         if (this.state.type) {

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -682,6 +682,38 @@ describe("Link formatting in the popover", () => {
             '<p><a href="http://test.com/" class="btn btn-fill-primary">link2</a></p>'
         );
     });
+    test("after changing the link format, the link should be updated (2)", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="http://test.com/" class="btn btn-secondary">link2[]</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+
+        expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
+
+        await click('select[name="link_type"');
+        await select("primary");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.com/" class="btn btn-fill-primary">link2</a></p>'
+        );
+    });
+    test("after changing the link format, the link should be updated (3)", async () => {
+        const { el } = await setupEditor(
+            '<p><a href="http://test.com/" class="random-css-class btn btn-outline-secondary text-muted">link2[]</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        await click(".o_we_edit_link");
+        await animationFrame();
+
+        expect(queryOne('select[name="link_type"]').selectedIndex).toBe(2);
+
+        await click('select[name="link_type"');
+        await select("primary");
+        expect(cleanLinkArtifacts(getContent(el))).toBe(
+            '<p><a href="http://test.com/" class="random-css-class text-muted btn btn-fill-primary">link2</a></p>'
+        );
+    });
     test("after applying the link format, the link's format should be updated", async () => {
         const { el } = await setupEditor('<p><a href="http://test.com/">link2[]</a></p>');
         await waitFor(".o-we-linkpopover");


### PR DESCRIPTION
The popover was not removing correctly the btn class 
if the class was a basic `btn-primary` or `btn-secondary`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
