### PR TITLE
[FIX] spreadsheet: correct sorted measure id

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -395,14 +395,19 @@ function migrate12to13(data) {
             if (!pivot.sortedColumn) {
                 continue;
             }
+            const measure = pivot.measures.find(
+                (measure) => measure.fieldName === pivot.sortedColumn.measure
+            );
             // We're missing some information to convert the sortedColumn (fieldType), so we'll drop the sorted columns
             // that are not on the total column
-            if (pivot.sortedColumn.groupId[1]?.length) {
+            // Also, a previous bug allowed to have a sortedColumn measure that is not in the measures,
+            // in this case we also drop the sortedColumn because we can't sort a measure that is not there
+            if (pivot.sortedColumn.groupId[1]?.length || !measure) {
                 pivot.sortedColumn = undefined;
                 continue;
             }
             pivot.sortedColumn = {
-                measure: pivot.sortedColumn.measure,
+                measure: measure.id,
                 order: pivot.sortedColumn.order,
                 domain: [],
             };

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -516,12 +516,20 @@ test("Pivot sorted columns are migrated (12 to 13)", () => {
                 sortedColumn: { groupId: [[], []], measure: "testMeasure", order: "desc" },
                 columns: [],
                 rows: [],
-                measures: [],
+                measures: [{ id: "testMeasure:sum", fieldName: "testMeasure", aggregator: "sum" }],
             },
             2: {
                 name: "test2",
                 sortedColumn: { groupId: [[], [1]], measure: "testMeasure", order: "desc" },
                 columns: [{ fieldName: "product_id" }],
+                rows: [],
+                measures: [{ id: "testMeasure:sum", fieldName: "testMeasure", aggregator: "sum" }],
+            },
+            3: {
+                name: "test",
+                // sortedColumn is not in the measures
+                sortedColumn: { groupId: [[], []], measure: "testMeasure", order: "desc" },
+                columns: [],
                 rows: [],
                 measures: [],
             },
@@ -530,10 +538,11 @@ test("Pivot sorted columns are migrated (12 to 13)", () => {
     const migratedData = load(data);
     expect(migratedData.pivots["1"].sortedColumn).toEqual({
         domain: [],
-        measure: "testMeasure",
+        measure: "testMeasure:sum",
         order: "desc",
     });
     expect(migratedData.pivots["2"].sortedColumn).toBe(undefined);
+    expect(migratedData.pivots["3"].sortedColumn).toBe(undefined);
 });
 
 test("Odoo version is exported", () => {


### PR DESCRIPTION
Commit 88473425583e31269ec892fbc3a491050b9b8e80
changed `sortedColumn.measure` that was the field name `'expected_revenue'` to the fully qualified measure id `'expected_revenue:sum'`

However, the spreadsheet client-side upgrade forgot to change that. As a consequence, the sorting was just ignored.

Task: 4818107


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
