### PR TITLE
[FIX] portal_rating, website_slides: resolve button label issue

### DIFF
--- a/addons/portal_rating/static/src/js/portal_rating_composer.js
+++ b/addons/portal_rating/static/src/js/portal_rating_composer.js
@@ -36,7 +36,6 @@ const RatingPopupComposer = publicWidget.Widget.extend({
             'csrf_token': odoo.csrf_token,
             'user_id': user.userId,
         }, options, {});
-        this.options.send_button_label = this.options.default_message_id ? _t("Update review") : _t("Post review");
 
         return def;
     },
@@ -83,6 +82,8 @@ const RatingPopupComposer = publicWidget.Widget.extend({
             this._composer.destroy();
         }
 
+        // Change the text of send button
+        this.options.send_button_label = this.options.default_message_id ? _t("Update review") : _t("Post review");
         // Instantiate the "Portal Composer" widget and insert it into the modal
         this._composer = new PortalComposer(this, this.options);
         return this._composer.appendTo(this.$('.o_rating_popup_composer_modal .o_portal_chatter_composer')).then(() => {

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -50,7 +50,12 @@ registry.category("web_tour.tours").add("course_reviews", {
         },
         {
             trigger: ".modal.modal_shown.show button.o_portal_chatter_composer_btn",
-            run: "click",
+            run() {
+                if (this.anchor.textContent !== "Update review") {
+                    throw Error("Button text should be 'Update review'.")
+                }
+                this.anchor.click();
+            },
         },
         {
             content: "Reload page (fetch message)",


### PR DESCRIPTION
**Before this PR:**
The button label in the popup does not update when a user tries to edit a review.

**Technical**- The button label updates only during the widget initialization, as it is handled in the willStart function.
https://tinyurl.com/2derk498

**After this PR:**
The button label in the popup correctly updates to 'Update Review' when a user edits a review.

**Task**-4677251