### PR TITLE
Prevent tools that inserts html in plaintext

### DIFF
--- a/addons/html_builder/static/src/core/media_website_plugin.js
+++ b/addons/html_builder/static/src/core/media_website_plugin.js
@@ -3,6 +3,7 @@ import { MEDIA_SELECTOR, isProtected } from "@html_editor/utils/dom_info";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 import { _t } from "@web/core/l10n/translation";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class MediaWebsitePlugin extends Plugin {
     static id = "media_website";
@@ -21,6 +22,7 @@ export class MediaWebsitePlugin extends Plugin {
                     noIcons: true,
                     extraTabs: false,
                 }),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -15,6 +15,7 @@ import {
     getBaseContainerSelector,
 } from "@html_editor/utils/base_container";
 import { DIRECTIONS } from "../utils/position";
+import { isHtmlContentSupported } from "./selection_plugin";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -198,8 +199,7 @@ export class ClipboardPlugin extends Plugin {
      * @param {DataTransfer} clipboardData
      */
     handlePasteUnsupportedHtml(selection, clipboardData) {
-        const targetSupportsHtmlContent = isHtmlContentSupported(selection.anchorNode);
-        if (!targetSupportsHtmlContent) {
+        if (!isHtmlContentSupported(selection)) {
             const text = clipboardData.getData("text/plain");
             this.dependencies.dom.insert(text);
             return true;
@@ -560,10 +560,10 @@ export class ClipboardPlugin extends Plugin {
      */
     async onDrop(ev) {
         ev.preventDefault();
-        if (!isHtmlContentSupported(ev.target)) {
+        const selection = this.dependencies.selection.getEditableSelection();
+        if (!isHtmlContentSupported(selection)) {
             return;
         }
-        const selection = this.dependencies.selection.getEditableSelection();
         const nodeToSplit =
             selection.direction === DIRECTIONS.RIGHT ? selection.focusNode : selection.anchorNode;
         const offsetToSplit =
@@ -690,19 +690,6 @@ function getImageUrl(file) {
     });
 }
 
-// @phoenix @todo: move to Odoo plugin?
-/**
- * Returns true if the provided node can suport html content.
- *
- * @param {Node} node
- * @returns {boolean}
- */
-export function isHtmlContentSupported(node) {
-    return !closestElement(
-        node,
-        '[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]'
-    );
-}
 
 /**
  * Add origin to relative img src.

--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -39,6 +39,7 @@ import { FONT_SIZE_CLASSES, TEXT_STYLE_CLASSES } from "../utils/formatting";
 import { DIRECTIONS, childNodeIndex, nodeSize, rightPos } from "../utils/position";
 import { normalizeCursorPosition } from "@html_editor/utils/selection";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 /**
  * Get distinct connected parents of nodes
@@ -70,8 +71,16 @@ export class DomPlugin extends Plugin {
     static shared = ["insert", "copyAttributes", "setTag", "setTagName"];
     resources = {
         user_commands: [
-            { id: "insertFontAwesome", run: this.insertFontAwesome.bind(this) },
-            { id: "setTag", run: this.setTag.bind(this) },
+            {
+                id: "insertFontAwesome",
+                run: this.insertFontAwesome.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
+            {
+                id: "setTag",
+                run: this.setTag.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
         ],
         /** Handlers */
         clean_for_save_handlers: ({ root }) => {

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -27,6 +27,7 @@ import {
 } from "../utils/dom_traversal";
 import { formatsSpecs } from "../utils/formatting";
 import { boundariesIn, boundariesOut, DIRECTIONS, leftPos, rightPos } from "../utils/position";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const allWhitespaceRegex = /^[\s\u200b]*$/;
 
@@ -59,24 +60,28 @@ export class FormatPlugin extends Plugin {
                 description: _t("Toggle bold"),
                 icon: "fa-bold",
                 run: this.formatSelection.bind(this, "bold"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "formatItalic",
                 description: _t("Toggle italic"),
                 icon: "fa-italic",
                 run: this.formatSelection.bind(this, "italic"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "formatUnderline",
                 description: _t("Toggle underline"),
                 icon: "fa-underline",
                 run: this.formatSelection.bind(this, "underline"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "formatStrikethrough",
                 description: _t("Toggle strikethrough"),
                 icon: "fa-strikethrough",
                 run: this.formatSelection.bind(this, "strikeThrough"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "formatFontSize",
@@ -85,6 +90,7 @@ export class FormatPlugin extends Plugin {
                         applyStyle: true,
                         formatProps: { size },
                     }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "formatFontSizeClassName",
@@ -93,6 +99,7 @@ export class FormatPlugin extends Plugin {
                         applyStyle: true,
                         formatProps: { className },
                     }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "removeFormat",
@@ -102,6 +109,7 @@ export class FormatPlugin extends Plugin {
                         : _t("Selection has no format"),
                 icon: "fa-eraser",
                 run: this.removeFormat.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         shortcuts: [

--- a/addons/html_editor/static/src/core/format_plugin.js
+++ b/addons/html_editor/static/src/core/format_plugin.js
@@ -547,6 +547,12 @@ export class FormatPlugin extends Plugin {
     }
 
     onBeforeInput(ev) {
+        if (
+            ev.inputType.startsWith("format") &&
+            !isHtmlContentSupported(this.dependencies.selection.getEditableSelection())
+        ) {
+            ev.preventDefault();
+        }
         if (ev.inputType === "insertText") {
             const selection = this.dependencies.selection.getEditableSelection();
             if (!selection.isCollapsed) {

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -95,6 +95,13 @@ export function isNotAllowedContent(node) {
     return isArtificialVoidElement(node) || VOID_ELEMENT_NAMES.includes(node.nodeName);
 }
 
+export function isHtmlContentSupported(selection) {
+    return !closestElement(
+        selection.focusNode,
+        '[data-oe-model]:not([data-oe-type="html"]):not([data-oe-field="arch"]):not([data-oe-translation-source-sha])'
+    );
+}
+
 /**
  * @returns edge text nodes if they do not have content selected
  */

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -20,7 +20,7 @@ import { Plugin } from "../plugin";
 
 export class ShortCutPlugin extends Plugin {
     static id = "shortcut";
-    static dependencies = ["userCommand"];
+    static dependencies = ["userCommand", "selection"];
 
     setup() {
         const hotkeyService = this.services.hotkey;
@@ -32,17 +32,25 @@ export class ShortCutPlugin extends Plugin {
         }
         for (const shortcut of this.getResource("shortcuts")) {
             const command = this.dependencies.userCommand.getCommand(shortcut.commandId);
-            this.addShortcut(shortcut.hotkey, () => {
-                command.run(shortcut.commandParams);
-            });
+            this.addShortcut(
+                shortcut.hotkey,
+                () => {
+                    command.run(shortcut.commandParams);
+                },
+                { isAvailable: command.isAvailable }
+            );
         }
     }
 
-    addShortcut(hotkey, action) {
+    addShortcut(hotkey, action, { isAvailable }) {
         this.services.hotkey.add(hotkey, action, {
             area: () => this.editable,
             bypassEditableProtection: true,
             allowRepeat: true,
+            isAvailable: () =>
+                isAvailable
+                    ? isAvailable(this.dependencies.selection.getEditableSelection())
+                    : true,
         });
     }
 }

--- a/addons/html_editor/static/src/fields/html_field.js
+++ b/addons/html_editor/static/src/fields/html_field.js
@@ -26,6 +26,7 @@ import { HtmlViewer } from "@html_editor/components/html_viewer/html_viewer";
 import { EditorVersionPlugin } from "@html_editor/core/editor_version_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { fixInvalidHTML, instanceofMarkup } from "@html_editor/utils/sanitize";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 /**
  * Check whether the current value contains nodes that would break
@@ -277,6 +278,7 @@ export class HtmlField extends Component {
                         description: _t("Code view"),
                         icon: "fa-code",
                         run: this.toggleCodeView.bind(this),
+                        isAvailable: isHtmlContentSupported,
                     },
                 ],
                 toolbar_groups: withSequence(100, {

--- a/addons/html_editor/static/src/main/align/align_plugin.js
+++ b/addons/html_editor/static/src/main/align/align_plugin.js
@@ -4,6 +4,7 @@ import { isVisibleTextNode } from "@html_editor/utils/dom_info";
 import { _t } from "@web/core/l10n/translation";
 import { AlignSelector } from "./align_selector";
 import { reactive } from "@odoo/owl";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const alignmentItems = [
     { mode: "left" },
@@ -20,18 +21,22 @@ export class AlignPlugin extends Plugin {
             {
                 id: "alignLeft",
                 run: () => this.setAlignment("left"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "alignCenter",
                 run: () => this.setAlignment("center"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "alignRight",
                 run: () => this.setAlignment("right"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "justify",
                 run: () => this.setAlignment("justify"),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_items: [
@@ -47,6 +52,7 @@ export class AlignPlugin extends Plugin {
                         this.setAlignment(item.mode);
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             },
         ],
 

--- a/addons/html_editor/static/src/main/banner_plugin.js
+++ b/addons/html_editor/static/src/main/banner_plugin.js
@@ -7,9 +7,13 @@ import { htmlEscape } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { closestBlock } from "@html_editor/utils/blocks";
 import { isParagraphRelatedElement } from "../utils/dom_info";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 function isAvailable(selection) {
-    return !closestElement(selection.anchorNode, ".o_editor_banner");
+    return (
+        isHtmlContentSupported(selection) &&
+        !closestElement(selection.anchorNode, ".o_editor_banner")
+    );
 }
 export class BannerPlugin extends Plugin {
     static id = "banner";

--- a/addons/html_editor/static/src/main/column_plugin.js
+++ b/addons/html_editor/static/src/main/column_plugin.js
@@ -4,6 +4,7 @@ import { closestBlock } from "@html_editor/utils/blocks";
 import { unwrapContents } from "@html_editor/utils/dom";
 import { closestElement, firstLeaf } from "@html_editor/utils/dom_traversal";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const REGEX_BOOTSTRAP_COLUMN = /(?:^| )col(-[a-zA-Z]+)?(-\d+)?(?:$| )/;
 
@@ -39,6 +40,7 @@ export class ColumnPlugin extends Plugin {
                 description: _t("Convert into columns"),
                 icon: "fa-columns",
                 run: this.columnize.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -21,6 +21,7 @@ import { _t } from "@web/core/l10n/translation";
 import { isColorGradient, isCSSColor, RGBA_REGEX, rgbaToHex } from "@web/core/utils/colors";
 import { ColorSelector } from "./color_selector";
 import { backgroundImageCssToParts, backgroundImagePartsToCss } from "@html_editor/utils/image";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const RGBA_OPACITY = 0.6;
 const HEX_OPACITY = "99";
@@ -47,6 +48,7 @@ export class ColorPlugin extends Plugin {
             {
                 id: "applyColor",
                 run: this.applyColor.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_items: [
@@ -56,6 +58,7 @@ export class ColorPlugin extends Plugin {
                 description: _t("Apply Font Color"),
                 Component: ColorSelector,
                 props: this.getPropsForColorSelector("foreground"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "backcolor",
@@ -63,6 +66,7 @@ export class ColorPlugin extends Plugin {
                 description: _t("Apply Background Color"),
                 Component: ColorSelector,
                 props: this.getPropsForColorSelector("background"),
+                isAvailable: isHtmlContentSupported,
             },
         ],
 

--- a/addons/html_editor/static/src/main/font/font_family_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_family_plugin.js
@@ -4,6 +4,7 @@ import { FontFamilySelector } from "@html_editor/main/font/font_family_selector"
 import { reactive } from "@odoo/owl";
 import { closestElement } from "../../utils/dom_traversal";
 import { withSequence } from "@html_editor/utils/resource";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export const defaultFontFamily = {
     name: "Default system font",
@@ -49,6 +50,7 @@ export class FontFamilyPlugin extends Plugin {
                         this.fontFamily.displayName = item.nameShort;
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             }),
         ],
         /** Handlers */

--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -31,6 +31,7 @@ import { getBaseContainerSelector } from "@html_editor/utils/base_container";
 import { withSequence } from "@html_editor/utils/resource";
 import { reactive } from "@odoo/owl";
 import { FontSizeSelector } from "./font_size_selector";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export const fontItems = [
     {
@@ -124,6 +125,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Big section heading"),
                 icon: "fa-header",
                 run: () => this.dependencies.dom.setTag({ tagName: "H1" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setTagHeading2",
@@ -131,6 +133,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Medium section heading"),
                 icon: "fa-header",
                 run: () => this.dependencies.dom.setTag({ tagName: "H2" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setTagHeading3",
@@ -138,6 +141,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Small section heading"),
                 icon: "fa-header",
                 run: () => this.dependencies.dom.setTag({ tagName: "H3" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setTagParagraph",
@@ -149,6 +153,7 @@ export class FontPlugin extends Plugin {
                         tagName: this.dependencies.baseContainer.getDefaultNodeName(),
                     });
                 },
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setTagQuote",
@@ -156,6 +161,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Add a blockquote section"),
                 icon: "fa-quote-right",
                 run: () => this.dependencies.dom.setTag({ tagName: "blockquote" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setTagPre",
@@ -163,6 +169,7 @@ export class FontPlugin extends Plugin {
                 description: _t("Add a code section"),
                 icon: "fa-code",
                 run: () => this.dependencies.dom.setTag({ tagName: "pre" }),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_groups: [
@@ -188,6 +195,7 @@ export class FontPlugin extends Plugin {
                         this.updateFontSelectorParams();
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             }),
             withSequence(20, {
                 id: "font-size",
@@ -213,6 +221,7 @@ export class FontPlugin extends Plugin {
                         this.updateFontSizeSelectorParams();
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             }),
         ],
         powerbox_categories: withSequence(5, { id: "format", name: _t("Format") }),

--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -12,6 +12,7 @@ import { rpc } from "@web/core/network/rpc";
 import { memoize } from "@web/core/utils/functions";
 import { withSequence } from "@html_editor/utils/resource";
 import { isBlock, closestBlock } from "@html_editor/utils/blocks";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 /**
  * @typedef {import("@html_editor/core/selection_plugin").EditorSelection} EditorSelection
@@ -150,7 +151,7 @@ export class LinkPlugin extends Plugin {
                     const linkEl = findInSelection(selection, "a");
                     return linkEl
                         ? this.getResource("link_popovers").some((p) => p.isAvailable(linkEl))
-                        : true;
+                        : isHtmlContentSupported(selection);
                 },
             },
             {
@@ -160,7 +161,11 @@ export class LinkPlugin extends Plugin {
                 icon: "fa-unlink",
                 isAvailable: (selection) => {
                     const linkEl = findInSelection(selection, "a");
-                    return !!linkEl && !this.isLinkImmutable(linkEl);
+                    return (
+                        !!linkEl &&
+                        !this.isLinkImmutable(linkEl) &&
+                        isHtmlContentSupported(selection)
+                    );
                 },
                 run: this.removeLinkFromSelection.bind(this),
             },
@@ -297,8 +302,13 @@ export class LinkPlugin extends Plugin {
             {
                 hotkey: "control+k",
                 category: "shortcut_conflict",
-                isAvailable: () =>
-                    this.dependencies.selection.getSelectionData().documentSelectionIsInEditable,
+                isAvailable: () => {
+                    const selectionData = this.dependencies.selection.getSelectionData();
+                    return (
+                        selectionData.documentSelectionIsInEditable &&
+                        isHtmlContentSupported(selectionData.editableSelection)
+                    );
+                },
             }
         );
         this.ignoredClasses = new Set(this.getResource("system_classes"));
@@ -1002,7 +1012,7 @@ export class LinkPlugin extends Plugin {
     handleAutomaticLinkInsertion() {
         let selection = this.dependencies.selection.getEditableSelection();
         if (
-            isHtmlContentSupported(selection.anchorNode) &&
+            isHtmlContentSupported(selection) &&
             !closestElement(selection.anchorNode, "a") &&
             selection.anchorNode.nodeType === Node.TEXT_NODE
         ) {
@@ -1123,19 +1133,4 @@ export class LinkPlugin extends Plugin {
     isLinkImmutable(linkEl) {
         return this.getResource("immutable_link_selectors").some((s) => linkEl.matches(s));
     }
-}
-
-// @phoenix @todo: duplicate from the clipboard plugin, should be moved to a shared location
-/**
- * Returns true if the provided node can suport html content.
- *
- * @param {Node} node
- * @returns {boolean}
- */
-export function isHtmlContentSupported(node) {
-    return !closestElement(
-        node,
-        '[data-oe-model]:not([data-oe-field="arch"]):not([data-oe-type="html"]),[data-oe-translation-id]',
-        true
-    );
 }

--- a/addons/html_editor/static/src/main/list/list_plugin.js
+++ b/addons/html_editor/static/src/main/list/list_plugin.js
@@ -32,6 +32,7 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { ListSelector } from "./list_selector";
 import { reactive } from "@odoo/owl";
 import { composeToolbarButton } from "../toolbar/toolbar";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const listSelectorItems = [
     {
@@ -73,6 +74,7 @@ export class ListPlugin extends Plugin {
                 description: _t("Create a simple bulleted list"),
                 icon: "fa-list-ul",
                 run: () => this.toggleListCommand({ mode: "UL" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "toggleListOL",
@@ -80,6 +82,7 @@ export class ListPlugin extends Plugin {
                 description: _t("Create a list with numbering"),
                 icon: "fa-list-ol",
                 run: () => this.toggleListCommand({ mode: "OL" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "toggleListCL",
@@ -87,6 +90,7 @@ export class ListPlugin extends Plugin {
                 description: _t("Track tasks with a checklist"),
                 icon: "fa-check-square-o",
                 run: () => this.toggleListCommand({ mode: "CL" }),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         shortcuts: [
@@ -105,6 +109,7 @@ export class ListPlugin extends Plugin {
                     getListMode: this.getListMode.bind(this),
                     key: this.toolbarListSelectorKey,
                 },
+                isAvailable: isHtmlContentSupported,
             }),
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -5,6 +5,7 @@ import {
 import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { unwrapContents } from "@html_editor/utils/dom";
 
 export class FilePlugin extends Plugin {
@@ -20,7 +21,8 @@ export class FilePlugin extends Plugin {
             description: _t("Add a download box"),
             icon: "fa-upload",
             run: this.uploadAndInsertFiles.bind(this),
-            isAvailable: this.isUploadCommandAvailable.bind(this),
+            isAvailable: (selection) =>
+                this.isUploadCommandAvailable(selection) && isHtmlContentSupported(selection),
         },
         powerbox_items: {
             categoryId: "media",

--- a/addons/html_editor/static/src/main/media/icon_plugin.js
+++ b/addons/html_editor/static/src/main/media/icon_plugin.js
@@ -3,6 +3,7 @@ import { Plugin } from "../../plugin";
 import { _t } from "@web/core/l10n/translation";
 import { MediaDialog } from "./media_dialog/media_dialog";
 import { ColorSelector } from "../font/color_selector";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class IconPlugin extends Plugin {
     static id = "icon";
@@ -13,37 +14,44 @@ export class IconPlugin extends Plugin {
                 id: "resizeIcon1",
                 description: _t("Resize icon 1x"),
                 run: () => this.resizeIcon({ size: "1" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "resizeIcon2",
                 description: _t("Resize icon 2x"),
                 run: () => this.resizeIcon({ size: "2" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "resizeIcon3",
                 description: _t("Resize icon 3x"),
                 run: () => this.resizeIcon({ size: "3" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "resizeIcon4",
                 description: _t("Resize icon 4x"),
                 run: () => this.resizeIcon({ size: "4" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "resizeIcon5",
                 description: _t("Resize icon 5x"),
                 run: () => this.resizeIcon({ size: "5" }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "toggleSpinIcon",
                 description: _t("Toggle icon spin"),
                 icon: "fa-play",
                 run: this.toggleSpinIcon.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "replaceIcon",
                 description: _t("Replace icon"),
                 run: this.openIconDialog.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_namespaces: [
@@ -72,6 +80,7 @@ export class IconPlugin extends Plugin {
                 description: _t("Select Font Color"),
                 Component: ColorSelector,
                 props: this.dependencies.color.getPropsForColorSelector("foreground"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "icon_backcolor",
@@ -79,6 +88,7 @@ export class IconPlugin extends Plugin {
                 description: _t("Select Background Color"),
                 Component: ColorSelector,
                 props: this.dependencies.color.getPropsForColorSelector("background"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "icon_size_1",

--- a/addons/html_editor/static/src/main/media/image_crop_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_crop_plugin.js
@@ -2,6 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { Plugin } from "../../plugin";
 import { ImageCrop } from "./image_crop";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class ImageCropPlugin extends Plugin {
     static id = "imageCrop";
@@ -14,6 +15,7 @@ export class ImageCropPlugin extends Plugin {
                 run: this.openCropImage.bind(this),
                 description: _t("Crop image"),
                 icon: "fa-crop",
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_items: [

--- a/addons/html_editor/static/src/main/media/image_plugin.js
+++ b/addons/html_editor/static/src/main/media/image_plugin.js
@@ -4,6 +4,7 @@ import { isImageUrl } from "@html_editor/utils/url";
 import { ImageDescription } from "./image_description";
 import { ImageToolbarDropdown } from "./image_toolbar_dropdown";
 import { createFileViewer } from "@web/core/file_viewer/file_viewer_hook";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { boundariesOut } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { ImageTransformButton } from "./image_transform_button";
@@ -46,39 +47,53 @@ export class ImagePlugin extends Plugin {
                 description: _t("Remove (DELETE) image"),
                 icon: "fa-trash text-danger",
                 run: this.deleteImage.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "previewImage",
                 description: _t("Preview image"),
                 icon: "fa-search-plus",
                 run: this.previewImage.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setImageShapeRounded",
                 description: _t("Set shape: Rounded"),
                 icon: "fa-square",
                 run: () => this.setImageShape("rounded", { excludeClasses: ["rounded-circle"] }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setImageShapeCircle",
                 description: _t("Set shape: Circle"),
                 icon: "fa-circle-o",
                 run: () => this.setImageShape("rounded-circle", { excludeClasses: ["rounded"] }),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setImageShapeShadow",
                 description: _t("Set shape: Shadow"),
                 icon: "fa-sun-o",
                 run: () => this.setImageShape("shadow"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "setImageShapeThumbnail",
                 description: _t("Set shape: Thumbnail"),
                 icon: "fa-picture-o",
                 run: () => this.setImageShape("img-thumbnail"),
+                isAvailable: isHtmlContentSupported,
             },
-            { id: "resizeImage", run: this.resizeImage.bind(this) },
-            { id: "transformImage", run: this.handleImageTransformation.bind(this) },
+            {
+                id: "resizeImage",
+                run: this.resizeImage.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
+            {
+                id: "transformImage",
+                run: this.handleImageTransformation.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
         ],
         toolbar_namespaces: [
             {
@@ -115,6 +130,7 @@ export class ImagePlugin extends Plugin {
                     getTooltip: () => this.getImageAttribute("title"),
                     updateImageDescription: this.updateImageDescription.bind(this),
                 },
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "shape_rounded",
@@ -153,6 +169,7 @@ export class ImagePlugin extends Plugin {
                         this.setImagePadding({ size: item.value });
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "image_size",
@@ -168,6 +185,7 @@ export class ImagePlugin extends Plugin {
                         this.updateImageParams();
                     },
                 },
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "image_transform",
@@ -175,6 +193,7 @@ export class ImagePlugin extends Plugin {
                 description: _t("Transform the picture (click twice to reset transformation)"),
                 Component: ImageTransformButton,
                 props: this.getImageTransformProps(),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "image_delete",

--- a/addons/html_editor/static/src/main/media/media_plugin.js
+++ b/addons/html_editor/static/src/main/media/media_plugin.js
@@ -16,6 +16,7 @@ import {
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { MediaDialog } from "./media_dialog/media_dialog";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { rightPos } from "@html_editor/utils/position";
 import { withSequence } from "@html_editor/utils/resource";
 import { closestElement } from "@html_editor/utils/dom_traversal";
@@ -41,6 +42,7 @@ export class MediaPlugin extends Plugin {
                 description: _t("Replace media"),
                 icon: "fa-exchange",
                 run: this.replaceImage.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "insertMedia",
@@ -49,6 +51,7 @@ export class MediaPlugin extends Plugin {
                 keywords: [_t("Image"), _t("Icon")],
                 icon: "fa-file-image-o",
                 run: this.openMediaDialog.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_groups: withSequence(31, { id: "replace_image", namespaces: ["image"] }),

--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -69,9 +69,13 @@ export class PowerButtonsPlugin extends Plugin {
         const composePowerButton = (/**@type {PowerButton} */ item) => {
             const command = this.dependencies.userCommand.getCommand(item.commandId);
             return {
-                ...pick(command, "description", "icon", "isAvailable"),
+                ...pick(command, "description", "icon"),
                 ...omit(item, "commandId", "commandParams"),
                 run: () => command.run(item.commandParams),
+                isAvailable: (selection) =>
+                    [command.isAvailable, item.isAvailable]
+                        .filter(Boolean)
+                        .every((predicate) => predicate(selection)),
             };
         };
         const renderButton = ({ description, icon, text, run }) => {
@@ -134,7 +138,7 @@ export class PowerButtonsPlugin extends Plugin {
             this.powerButtonsContainer.setAttribute("dir", direction);
             // Hide/show buttons based on their availability.
             for (const [{ isAvailable }, buttonElement] of this.descriptionToElementMap.entries()) {
-                const shouldHide = Boolean(isAvailable && !isAvailable(editableSelection));
+                const shouldHide = Boolean(!isAvailable(editableSelection));
                 buttonElement.classList.toggle("d-none", shouldHide); // 2nd arg must be a boolean
             }
             this.setPowerButtonsPosition(block, blockRect, direction);

--- a/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
+++ b/addons/html_editor/static/src/main/powerbox/powerbox_plugin.js
@@ -73,7 +73,7 @@ import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
  * @property {string} icon
  * @property {Function} run
  * @property {TranslatedString[]} [keywords]
- * @property { (selection: EditorSelection) => boolean  } [isAvailable]
+ * @property { (selection: EditorSelection) => boolean } isAvailable
  */
 
 /**
@@ -140,9 +140,7 @@ export class PowerboxPlugin extends Plugin {
      */
     getAvailablePowerboxCommands() {
         const selection = this.dependencies.selection.getEditableSelection();
-        return this.powerboxCommands.filter(
-            (cmd) => cmd.isAvailable === undefined || cmd.isAvailable(selection)
-        );
+        return this.powerboxCommands.filter((cmd) => cmd.isAvailable(selection));
     }
 
     /**
@@ -159,10 +157,14 @@ export class PowerboxPlugin extends Plugin {
         return powerboxItems.map((/** @type {PowerboxItem} */ item) => {
             const command = this.dependencies.userCommand.getCommand(item.commandId);
             return {
-                ...pick(command, "title", "description", "icon", "isAvailable"),
+                ...pick(command, "title", "description", "icon"),
                 ...omit(item, "commandId", "commandParams"),
                 categoryName: categoryDict[item.categoryId].name,
                 run: () => command.run(item.commandParams),
+                isAvailable: (selection) =>
+                    [command.isAvailable, item.isAvailable]
+                        .filter(Boolean)
+                        .every((predicate) => predicate(selection)),
             };
         });
     }

--- a/addons/html_editor/static/src/main/separator_plugin.js
+++ b/addons/html_editor/static/src/main/separator_plugin.js
@@ -7,6 +7,7 @@ import {
     isListItemElement,
     paragraphRelatedElementsSelector,
 } from "../utils/dom_info";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { removeClass } from "@html_editor/utils/dom";
 import { withSequence } from "@html_editor/utils/resource";
 import { fillEmpty } from "../utils/dom";
@@ -22,6 +23,7 @@ export class SeparatorPlugin extends Plugin {
                 description: _t("Insert a horizontal rule separator"),
                 icon: "fa-minus",
                 run: this.insertSeparator.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: withSequence(1, {

--- a/addons/html_editor/static/src/main/signature_plugin.js
+++ b/addons/html_editor/static/src/main/signature_plugin.js
@@ -6,6 +6,7 @@ import { withSequence } from "@html_editor/utils/resource";
 import { renderToString } from "@web/core/utils/render";
 import { markup } from "@odoo/owl";
 import { isEmptyBlock, paragraphRelatedElementsSelector } from "@html_editor/utils/dom_info";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export const SIGNATURE_CLASS = "o-signature-container";
 
@@ -21,6 +22,7 @@ export class SignaturePlugin extends Plugin {
                 description: _t("Insert your signature"),
                 icon: "fa-pencil-square-o",
                 run: this.insertSignature.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_categories: withSequence(100, { id: "basic_block", name: _t("Basic Bloc") }),

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -1,6 +1,7 @@
 import { Plugin } from "@html_editor/plugin";
 import { parseHTML } from "@html_editor/utils/html";
 import { _t } from "@web/core/l10n/translation";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class StarPlugin extends Plugin {
     static id = "star";
@@ -13,6 +14,7 @@ export class StarPlugin extends Plugin {
                 description: _t("Insert a rating"),
                 icon: "fa-star",
                 run: this.addStars.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -31,6 +31,7 @@ import { findInSelection } from "@html_editor/utils/selection";
 import { getColumnIndex, getRowIndex, getTableCells } from "@html_editor/utils/table";
 import { isBrowserFirefox } from "@web/core/browser/feature_detection";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export const BORDER_SENSITIVITY = 5;
 
@@ -97,6 +98,7 @@ export class TablePlugin extends Plugin {
                 run: (params) => {
                     this.insertTable(params);
                 },
+                isAvailable: isHtmlContentSupported,
             },
         ],
 

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -4,6 +4,7 @@ import { reactive } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { TableMenu } from "./table_menu";
 import { TablePicker } from "./table_picker";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 /**
  * This plugin only contains the table ui feature (table picker, menus, ...).
@@ -20,6 +21,7 @@ export class TableUIPlugin extends Plugin {
                 description: _t("Insert a table"),
                 icon: "fa-table",
                 run: this.openPickerOrInsertTable.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/main/tabulation_plugin.js
+++ b/addons/html_editor/static/src/main/tabulation_plugin.js
@@ -10,6 +10,7 @@ import {
 } from "@html_editor/utils/dom_traversal";
 import { parseHTML } from "@html_editor/utils/html";
 import { DIRECTIONS, childNodeIndex } from "@html_editor/utils/position";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 const tabHtml = '<span class="oe-tabs" contenteditable="false">\u0009</span>\u200B';
 const GRID_COLUMN_WIDTH = 40; //@todo Configurable?
@@ -39,8 +40,16 @@ export class TabulationPlugin extends Plugin {
     static shared = ["indentBlocks", "outdentBlocks"];
     resources = {
         user_commands: [
-            { id: "tab", run: this.handleTab.bind(this) },
-            { id: "shiftTab", run: this.handleShiftTab.bind(this) },
+            {
+                id: "tab",
+                run: this.handleTab.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
+            {
+                id: "shiftTab",
+                run: this.handleShiftTab.bind(this),
+                isAvailable: isHtmlContentSupported,
+            },
         ],
         shortcuts: [
             { hotkey: "tab", commandId: "tab" },

--- a/addons/html_editor/static/src/main/text_direction_plugin.js
+++ b/addons/html_editor/static/src/main/text_direction_plugin.js
@@ -3,6 +3,7 @@ import { Plugin } from "../plugin";
 import { closestBlock } from "../utils/blocks";
 import { closestElement } from "../utils/dom_traversal";
 import { isContentEditable, isTextNode } from "@html_editor/utils/dom_info";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class TextDirectionPlugin extends Plugin {
     static id = "textDirection";
@@ -15,6 +16,7 @@ export class TextDirectionPlugin extends Plugin {
                 description: _t("Switch the text's direction"),
                 icon: "fa-exchange",
                 run: this.switchDirection.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/main/toolbar/toolbar.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar.js
@@ -110,8 +110,12 @@ export const toolbarButtonProps = {
  */
 export function composeToolbarButton(userCommand, toolbarItem) {
     return {
-        ...pick(userCommand, "description", "icon", "isAvailable"),
+        ...pick(userCommand, "description", "icon"),
         ...omit(toolbarItem, "commandId", "commandParams"),
         run: () => userCommand.run(toolbarItem.commandParams),
+        isAvailable: (selection) =>
+            [userCommand.isAvailable, toolbarItem.isAvailable]
+                .filter(Boolean)
+                .every((predicate) => predicate(selection)),
     };
 }

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -111,7 +111,7 @@ import { _t } from "@web/core/l10n/translation";
  * @property {Function} run
  * @property {string} [icon]
  * @property {string} [text]
- * @property {(selection: EditorSelection) => boolean} [isAvailable]
+ * @property {(selection: EditorSelection) => boolean} isAvailable
  * @property {(selection: EditorSelection, nodes: Node[]) => boolean} [isActive]
  * @property {(selection: EditorSelection, nodes: Node[]) => boolean} [isDisabled]
  *
@@ -268,7 +268,9 @@ export class ToolbarPlugin extends Plugin {
             return composeToolbarButton(command, item);
         };
 
-        return toolbarItems.map((item) => ("Component" in item ? item : commandItemToButton(item)));
+        return toolbarItems.map((item) =>
+            "Component" in item ? { isAvailable: () => true, ...item } : commandItemToButton(item)
+        );
     }
 
     getButtonGroups() {
@@ -400,8 +402,7 @@ export class ToolbarPlugin extends Plugin {
                 }
                 this.state.buttonsActiveState[button.id] = button.isActive?.(selection, nodes);
                 this.state.buttonsDisabledState[button.id] = button.isDisabled?.(selection, nodes);
-                this.state.buttonsAvailableState[button.id] =
-                    button.isAvailable === undefined || button.isAvailable(selection);
+                this.state.buttonsAvailableState[button.id] = button.isAvailable(selection);
                 this.state.buttonsTitleState[button.id] =
                     button.description instanceof Function
                         ? button.description(selection, nodes)

--- a/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { DynamicPlaceholderPopover } from "@web/views/fields/dynamic_placeholder_popover";
 import { withSequence } from "@html_editor/utils/resource";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 /**
  * @typedef {Object} DynamicPlaceholderShared
@@ -20,6 +21,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
                 description: _t("Insert a field"),
                 icon: "fa-hashtag",
                 run: (params = {}) => this.open(params.resModel || this.defaultResModel),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_categories: withSequence(60, {

--- a/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/caption_plugin/caption_plugin.js
@@ -7,6 +7,7 @@ import { closestElement } from "@html_editor/utils/dom_traversal";
 import { EDITABLE_MEDIA_CLASS } from "@html_editor/utils/dom_info";
 import { boundariesOut, rightPos } from "@html_editor/utils/position";
 import { findInSelection } from "@html_editor/utils/selection";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class CaptionPlugin extends Plugin {
     static id = "caption";
@@ -24,6 +25,7 @@ export class CaptionPlugin extends Plugin {
                 id: "toggleImageCaption",
                 title: _t("Add/remove a caption"),
                 run: this.toggleImageCaption.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         toolbar_items: [

--- a/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/table_of_content_plugin/table_of_content_plugin.js
@@ -5,6 +5,7 @@ import {
     HEADINGS,
     TableOfContentManager,
 } from "@html_editor/others/embedded_components/core/table_of_content/table_of_content_manager";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class TableOfContentPlugin extends Plugin {
     static id = "tableOfContent";
@@ -17,6 +18,7 @@ export class TableOfContentPlugin extends Plugin {
                 description: _t("Highlight the structure (headings)"),
                 icon: "fa-bookmark",
                 run: this.insertTableOfContent.bind(this),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -1,5 +1,6 @@
 import { getEmbeddedProps } from "@html_editor/others/embedded_component_utils";
 import { Plugin } from "@html_editor/plugin";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { baseContainerGlobalSelector } from "@html_editor/utils/base_container";
 import { closestBlock } from "@html_editor/utils/blocks";
 import { isEmptyBlock, isParagraphRelatedElement } from "@html_editor/utils/dom_info";
@@ -64,6 +65,7 @@ export class ToggleBlockPlugin extends Plugin {
                 description: _t("Hide Text under foldable toggles"),
                 icon: "fa-caret-square-o-right",
                 isAvailable: (selection) =>
+                    isHtmlContentSupported(selection) &&
                     !closestElement(selection.anchorNode, `${toggleSelector} ${titleSelector}`),
                 run: () => {
                     this.insertToggleBlock();

--- a/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/toggle_block_plugin/toggle_block_plugin.js
@@ -63,7 +63,8 @@ export class ToggleBlockPlugin extends Plugin {
                 title: _t("Toggle list"),
                 description: _t("Hide Text under foldable toggles"),
                 icon: "fa-caret-square-o-right",
-                isAvailable: (node) => !closestElement(node, `${toggleSelector} ${titleSelector}`),
+                isAvailable: (selection) =>
+                    !closestElement(selection.anchorNode, `${toggleSelector} ${titleSelector}`),
                 run: () => {
                     this.insertToggleBlock();
                 },

--- a/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/video_plugin/video_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { VideoSelectorDialog } from "@html_editor/others/embedded_components/plugins/video_plugin/video_selector_dialog/video_selector_dialog";
 import { renderToElement } from "@web/core/utils/render";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 export class VideoPlugin extends Plugin {
     static id = "video";
@@ -18,6 +19,7 @@ export class VideoPlugin extends Plugin {
                         this.insertVideo(media);
                     });
                 },
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_items: [

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -12,6 +12,7 @@ import { removeClass, removeStyle } from "@html_editor/utils/dom";
 import { isTextNode } from "@html_editor/utils/dom_info";
 import { getCurrentTextHighlight } from "@website/js/highlight_utils";
 import { isCSSColor, rgbaToHex } from "@web/core/utils/colors";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { nodeSize } from "@html_editor/utils/position";
 
 export class HighlightPlugin extends Plugin {
@@ -39,6 +40,7 @@ export class HighlightPlugin extends Plugin {
                     },
                     onClick: this.completeHighlightSelection.bind(this),
                 },
+                isAvailable: isHtmlContentSupported,
             },
         ],
         clean_for_save_handlers: ({ root }) => {

--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -6,6 +6,7 @@ import { AnimateOption } from "./animate_option";
 import { ANIMATE } from "@website/builder/option_sequence";
 import { _t } from "@web/core/l10n/translation";
 import { AnimateText } from "./animate_text";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { ancestors, closestElement, findFurthest } from "@html_editor/utils/dom_traversal";
 import { childNodeIndex, DIRECTIONS, nodeSize } from "@html_editor/utils/position";
 import { BuilderAction } from "@html_builder/core/builder_action";
@@ -44,6 +45,7 @@ class AnimateOptionPlugin extends Plugin {
                     isDisabled: this.isAnimatedTextDisabled.bind(this),
                     animateOptionProps: { ...this.animateOptionProps, requireAnimation: true },
                 },
+                isAvailable: isHtmlContentSupported,
             },
         ],
         system_classes: ["o_animating"],

--- a/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
+++ b/addons/website/static/src/builder/plugins/snippets_powerbox_plugin.js
@@ -2,6 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { _t } from "@web/core/l10n/translation";
 import { withSequence } from "@html_editor/utils/resource";
 import { registry } from "@web/core/registry";
+import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 
 class SnippetsPowerboxPlugin extends Plugin {
     static id = "alert";
@@ -14,6 +15,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert an alert snippet"),
                 icon: "fa-info",
                 run: this.insertSnippet.bind(this, "s_alert"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_rating",
@@ -21,6 +23,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a rating snippet"),
                 icon: "fa-star-half-o",
                 run: this.insertSnippet.bind(this, "s_rating"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_card",
@@ -28,6 +31,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a card snippet"),
                 icon: "fa-sticky-note",
                 run: this.insertSnippet.bind(this, "s_card"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_share",
@@ -35,6 +39,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a share snippet"),
                 icon: "fa-share-square-o",
                 run: this.insertSnippet.bind(this, "s_share"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_text_highlight",
@@ -42,6 +47,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a text highlight snippet"),
                 icon: "fa-sticky-note",
                 run: this.insertSnippet.bind(this, "s_text_highlight"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_chart",
@@ -49,6 +55,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a chart snippet"),
                 icon: "fa-bar-chart",
                 run: this.insertSnippet.bind(this, "s_chart"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_progress_bar",
@@ -56,6 +63,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a progress bar snippet"),
                 icon: "fa-spinner",
                 run: this.insertSnippet.bind(this, "s_progress_bar"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_badge",
@@ -63,6 +71,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a badge snippet"),
                 icon: "fa-tags",
                 run: this.insertSnippet.bind(this, "s_badge"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_blockquote",
@@ -70,6 +79,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a blockquote snippet"),
                 icon: "fa-quote-left",
                 run: this.insertSnippet.bind(this, "s_blockquote"),
+                isAvailable: isHtmlContentSupported,
             },
             {
                 id: "s_hr",
@@ -77,6 +87,7 @@ class SnippetsPowerboxPlugin extends Plugin {
                 description: _t("Insert a horizontal separator snippet"),
                 icon: "fa-minus",
                 run: this.insertSnippet.bind(this, "s_hr"),
+                isAvailable: isHtmlContentSupported,
             },
         ],
         powerbox_categories: withSequence(110, {


### PR DESCRIPTION
> [LEBL] on /blog, edit mode, no overlay while we are able to change description and title + don't display link popover in that case (same in other modules like forum, etc.) (Just edit text content so remove toolbar)