### PR TITLE
Fix hide and show invisible with history redo/undo

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -151,6 +151,31 @@
     }
 }
 
+%o_we_sublevel > div.o_title::before {
+    content: "└"; // TODO The size and look of this depends on the
+                  // browser default font, we should use a SVG instead.
+    display: inline-block;
+    margin-right: 0.4em;
+
+    .o_rtl & {
+        transform: scaleX(-1);
+    }
+}
+@for $level from 1 through 3 {
+    .o_we_sublevel_#{$level} {
+        --o-we-checkbox-color: #{$o-we-fg-light};
+
+        @extend %o_we_sublevel;
+        color: $o-we-fg-light;
+
+        @if $level > 1 {
+            > div.o_title {
+                padding-left: ($level - 1) * 0.6em;
+            }
+        }
+    }
+}
+
 // TODO: adjust the style of those elements
 .o_pager_container {
     overflow-y: scroll;

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -344,6 +344,7 @@ export class BuilderOptionsPlugin extends Plugin {
                 targetEl = nextTarget;
             }
             if (targetEl) {
+                this.dispatchTo("on_restore_containers_handlers", targetEl);
                 this.updateContainers(targetEl, { forceUpdate: true });
                 // Scroll to the target if not visible.
                 if (!isElementInViewport(targetEl)) {

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -16,6 +16,7 @@ export class VisibilityPlugin extends Plugin {
         system_classes: ["o_snippet_override_invisible"],
         clean_for_save_handlers: this.cleanForSaveVisibility.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
+        on_restore_containers_handlers: (newTargetEl) => this.makeTargetVisible(newTargetEl),
     };
 
     setup() {
@@ -33,6 +34,24 @@ export class VisibilityPlugin extends Plugin {
                 invisibleEl.removeAttribute("data-invisible");
             }
         });
+    }
+
+    /**
+     * Toggles the visibility of the given element and its ancestors if it was
+     * not visible.
+     *
+     * @param {HTMLElement} targetEl the element
+     */
+    makeTargetVisible(targetEl) {
+        let invisibleEl = targetEl.closest("[data-invisible='1']");
+        if (!invisibleEl) {
+            return;
+        }
+        while (invisibleEl) {
+            this.toggleTargetVisibility(invisibleEl, true);
+            invisibleEl = targetEl.closest("[data-invisible='1']");
+        }
+        this.config.updateInvisibleElementsPanel();
     }
 
     cleanForSaveVisibility({ root: rootEl }) {

--- a/addons/html_builder/static/src/core/visibility_plugin.js
+++ b/addons/html_builder/static/src/core/visibility_plugin.js
@@ -1,19 +1,21 @@
 import { Plugin } from "@html_editor/plugin";
-import { isMobileView } from "@html_builder/utils/utils";
+import { getElementsWithOption, isMobileView } from "@html_builder/utils/utils";
 import { withSequence } from "@html_editor/utils/resource";
+
+const invisibleElementsSelector =
+    ".o_snippet_invisible, .o_snippet_mobile_invisible, .o_snippet_desktop_invisible";
+const deviceInvisibleSelector = ".o_snippet_mobile_invisible, .o_snippet_desktop_invisible";
 
 export class VisibilityPlugin extends Plugin {
     static id = "visibility";
     static dependencies = ["builderOptions", "disableSnippets"];
-    static shared = [
-        "toggleTargetVisibility",
-        "cleanForSaveVisibility",
-        "onOptionVisibilityUpdate",
-    ];
+    static shared = ["toggleTargetVisibility", "onOptionVisibilityUpdate", "hideElement"];
     resources = {
         on_mobile_preview_clicked: withSequence(10, this.onMobilePreviewClicked.bind(this)),
         system_attributes: ["data-invisible"],
         system_classes: ["o_snippet_override_invisible"],
+        clean_for_save_handlers: this.cleanForSaveVisibility.bind(this),
+        on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
     };
 
     setup() {
@@ -22,58 +24,46 @@ export class VisibilityPlugin extends Plugin {
         // depending on if we are in mobile preview or not, so the DOM is
         // consistent.
         const isMobilePreview = isMobileView(this.editable);
-        this.editable
-            .querySelectorAll(".o_snippet_mobile_invisible, .o_snippet_desktop_invisible")
-            .forEach((invisibleEl) => {
-                const isMobileHidden = invisibleEl.matches(".o_snippet_mobile_invisible");
-                const isDesktopHidden = invisibleEl.matches(".o_snippet_desktop_invisible");
-                if ((isMobileHidden && isMobilePreview) || (isDesktopHidden && !isMobilePreview)) {
-                    invisibleEl.setAttribute("data-invisible", "1");
-                } else {
-                    invisibleEl.removeAttribute("data-invisible");
-                }
-            });
+        this.editable.querySelectorAll(deviceInvisibleSelector).forEach((invisibleEl) => {
+            const isMobileHidden = invisibleEl.matches(".o_snippet_mobile_invisible");
+            const isDesktopHidden = invisibleEl.matches(".o_snippet_desktop_invisible");
+            if ((isMobileHidden && isMobilePreview) || (isDesktopHidden && !isMobilePreview)) {
+                invisibleEl.setAttribute("data-invisible", "1");
+            } else {
+                invisibleEl.removeAttribute("data-invisible");
+            }
+        });
     }
 
-    cleanForSaveVisibility(editingEl) {
-        const show =
-            !editingEl.classList.contains("o_snippet_invisible") &&
-            !editingEl.classList.contains("o_snippet_mobile_invisible") &&
-            !editingEl.classList.contains("o_snippet_desktop_invisible");
-        this.toggleTargetVisibility(editingEl, show);
-        const overrideInvisibleEls = [
-            editingEl,
-            ...editingEl.querySelectorAll(".o_snippet_override_invisible"),
-        ];
-        for (const overrideInvisibleEl of overrideInvisibleEls) {
-            overrideInvisibleEl.classList.remove("o_snippet_override_invisible");
+    cleanForSaveVisibility({ root: rootEl }) {
+        const invisibleEls = getElementsWithOption(rootEl, invisibleElementsSelector);
+        for (const invisibleEl of invisibleEls) {
+            // Hide the invisible elements.
+            this.toggleTargetVisibility(invisibleEl, false, false, true);
+            // Remove the `data-invisible` attribute from conditionally hidden
+            // elements.
+            if (invisibleEl.matches("[data-visibility='conditional']")) {
+                invisibleEl.removeAttribute("data-invisible");
+            }
         }
+    }
 
-        // Remove data-invisible attribute from condtionally hidden elements.
-        // TODO do it for all invisible elements in general ?
-        const conditionalHiddenEls = [
-            ...editingEl.querySelectorAll("[data-visibility='conditional']"),
-        ];
-        if (editingEl.matches("[data-visibility='conditional']")) {
-            conditionalHiddenEls.unshift(editingEl);
+    onSnippetDropped({ snippetEl }) {
+        // Show the invisible elements.
+        const invisibleEls = getElementsWithOption(snippetEl, invisibleElementsSelector);
+        for (const invisibleEl of invisibleEls) {
+            this.toggleTargetVisibility(invisibleEl, true);
         }
-        conditionalHiddenEls.forEach((el) => el.removeAttribute("data-invisible"));
     }
 
     onMobilePreviewClicked() {
-        const invisibleOverrideEls = this.editable.querySelectorAll(
-            ".o_snippet_mobile_invisible, .o_snippet_desktop_invisible"
-        );
-        for (const invisibleOverrideEl of [...invisibleOverrideEls]) {
-            invisibleOverrideEl.classList.remove("o_snippet_override_invisible");
-            const show = this.toggleVisibilityStatus({
-                editingEl: invisibleOverrideEl,
-                considerDeviceVisibility: true,
-            });
-            if (
-                !show &&
-                invisibleOverrideEl.contains(this.dependencies["builderOptions"].getTarget())
-            ) {
+        const deviceInvisibleEls = this.editable.querySelectorAll(deviceInvisibleSelector);
+        const currentContainerTargetEl = this.dependencies["builderOptions"].getTarget();
+        for (const deviceInvisibleEl of [...deviceInvisibleEls]) {
+            deviceInvisibleEl.classList.remove("o_snippet_override_invisible");
+            const show = !isTargetVisible(deviceInvisibleEl);
+            const isShown = this.toggleVisibilityStatus(deviceInvisibleEl, show, true);
+            if (!isShown && deviceInvisibleEl.contains(currentContainerTargetEl)) {
                 this.dependencies["builderOptions"].deactivateContainers();
             }
         }
@@ -85,12 +75,14 @@ export class VisibilityPlugin extends Plugin {
      * @param {HTMLElement} editingEl
      * @param {Boolean} show true to show the element, false to hide it
      * @param {Boolean} considerDeviceVisibility
+     * @param {Boolean} [isCleaning=false] true if the function is called by the
+     * clean_for_save handler.
      * @returns {Boolean}
      */
-    toggleTargetVisibility(editingEl, show, considerDeviceVisibility) {
-        show = this.toggleVisibilityStatus({ editingEl, show, considerDeviceVisibility });
-        const dispatchName = show ? "target_show" : "target_hide";
-        this.dispatchTo(dispatchName, editingEl);
+    toggleTargetVisibility(editingEl, show, considerDeviceVisibility, isCleaning = false) {
+        show = this.toggleVisibilityStatus(editingEl, show, considerDeviceVisibility);
+        const resourceName = show ? "target_show" : "target_hide";
+        this.dispatchTo(resourceName, editingEl);
         return show;
     }
 
@@ -101,7 +93,7 @@ export class VisibilityPlugin extends Plugin {
      * @param {Boolean} show true/false if the element was shown/hidden
      */
     onOptionVisibilityUpdate(editingEl, show) {
-        const isShown = this.toggleVisibilityStatus({ editingEl, show });
+        const isShown = this.toggleVisibilityStatus(editingEl, show);
         if (!isShown) {
             this.dependencies.builderOptions.setNextTarget(false);
         }
@@ -118,7 +110,7 @@ export class VisibilityPlugin extends Plugin {
      * @param {Boolean} considerDeviceVisibility
      * @returns {Boolean}
      */
-    toggleVisibilityStatus({ editingEl, show, considerDeviceVisibility = false }) {
+    toggleVisibilityStatus(editingEl, show, considerDeviceVisibility = false) {
         if (
             considerDeviceVisibility &&
             editingEl.matches(".o_snippet_mobile_invisible, .o_snippet_desktop_invisible")
@@ -137,6 +129,22 @@ export class VisibilityPlugin extends Plugin {
             editingEl.dataset.invisible = "1";
         }
         return show;
+    }
+
+    /**
+     * Hides the given element and updates what needs to be.
+     * Note: to use only when hiding things without adding history steps:
+     * - if an action adding a history step hides the element, it should call
+     *   `onOptionVisibilityUpdate`
+     * - if it concerns the "Invisible Element" panel, refer to its component.
+     *
+     * @param {HTMLElement} toHideEl the element to hide.
+     */
+    hideElement(toHideEl) {
+        this.toggleTargetVisibility(toHideEl, false);
+        this.dependencies.builderOptions.deactivateContainers();
+        this.config.updateInvisibleElementsPanel();
+        this.dependencies.disableSnippets.disableUndroppableSnippets();
     }
 }
 

--- a/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
+++ b/addons/html_builder/static/src/sidebar/invisible_elements_panel.js
@@ -90,6 +90,7 @@ export class InvisibleElementsPanel extends Component {
             // Toggle the entry visibility to "Show".
             invisibleEntry.isVisible = true;
             this.shared.visibility.toggleTargetVisibility(snippetEl, true);
+            this.env.editor.dispatchTo("on_reveal_target_handlers", snippetEl);
             this.shared.builderOptions.updateContainers(snippetEl);
             // Scroll to the target if not visible.
             if (!isElementInViewport(snippetEl) && !snippetEl.matches(".s_popup")) {

--- a/addons/html_builder/static/src/sidebar/invisible_elements_panel.xml
+++ b/addons/html_builder/static/src/sidebar/invisible_elements_panel.xml
@@ -15,12 +15,12 @@
 
 <t t-name="html_builder.invisibleSnippetEntry">
     <div class="o_we_invisible_entry d-flex py-1 align-items-center justify-content-between"
-        t-att-class="{'o_we_invisible_root_parent pb-1': entry.isRootParent, 'o_we_sublevel': entry.isDescendant}"
+        t-att-class="{'o_we_invisible_root_parent': entry.isRootParent, 'o_we_sublevel_1': entry.isDescendant}"
         t-on-click="() => toggleElementVisibility(entry)">
-        <div t-out="entry.name"/>
+        <div class="o_title" t-out="entry.name"/>
         <i class="fa ms-2" t-att-class="entry.isVisible ? 'fa-eye' : 'fa-eye-slash'"></i>
     </div>
-    <ul t-if="entry.children.length > 0">
+    <ul t-if="entry.isVisible and entry.children.length > 0">
         <t t-foreach="entry.children" t-as="child" t-key="child_index">
             <li>
                 <t t-call="html_builder.invisibleSnippetEntry" t-call-context="{'entry': child, toggleElementVisibility}"/>

--- a/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/popup_option_plugin.js
@@ -1,7 +1,6 @@
 import { SNIPPET_SPECIFIC, SNIPPET_SPECIFIC_END } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { getElementsWithOption } from "@html_builder/utils/utils";
 import { withSequence } from "@html_editor/utils/resource";
 import { BuilderAction } from "@html_builder/core/builder_action";
 
@@ -56,17 +55,11 @@ class PopupOptionPlugin extends Plugin {
             this.assignUniqueID(snippetEl);
             this.dependencies.history.addCustomMutation({
                 apply: () => {
-                    this.dependencies.popupVisibilityPlugin.onTargetShow(snippetEl);
+                    this.dependencies.visibility.toggleTargetVisibility(snippetEl, true);
                 },
-                revert: () => {
-                    this.dependencies.popupVisibilityPlugin.onTargetHide(snippetEl);
-                },
+                revert: () => {},
             });
         }
-        const droppedEls = getElementsWithOption(snippetEl, ".s_popup");
-        droppedEls.forEach((droppedEl) =>
-            this.dependencies.visibility.toggleTargetVisibility(droppedEl, true, true)
-        );
     }
 
     assignUniqueID(editingElement) {

--- a/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/visibility_option_plugin.js
@@ -2,7 +2,6 @@ import { registry } from "@web/core/registry";
 import { Plugin } from "@html_editor/plugin";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { pyToJsLocale } from "@web/core/l10n/utils";
-import { getElementsWithOption } from "@html_builder/utils/utils";
 import { VisibilityOption } from "./visibility_option";
 import { withSequence } from "@html_editor/utils/resource";
 import { CONDITIONAL_VISIBILITY, DEVICE_VISIBILITY } from "@website/builder/option_sequence";
@@ -23,20 +22,17 @@ class VisibilityOptionPlugin extends Plugin {
                     websiteSession: this.dependencies.websiteSession.getSession(),
                 },
                 selector: VISIBILITY_OPTION_SELECTOR,
-                cleanForSave: this.dependencies.visibility.cleanForSaveVisibility,
             }),
             withSequence(DEVICE_VISIBILITY, {
                 template: "website.DeviceVisibilityOption",
                 selector: DEVICE_VISIBILITY_OPTION_SELECTOR,
                 exclude: ".s_col_no_resize.row > div, .s_masonry_block .s_col_no_resize",
-                cleanForSave: this.dependencies.visibility.cleanForSaveVisibility,
             }),
         ],
         builder_actions: {
             ForceVisibleAction,
             ToggleDeviceVisibilityAction,
         },
-        on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
         normalize_handlers: this.normalizeCSSSelectors.bind(this),
         visibility_selector_parameters: [
             {
@@ -106,14 +102,6 @@ class VisibilityOptionPlugin extends Plugin {
             return true;
         }
         return false;
-    }
-
-    onSnippetDropped({ snippetEl }) {
-        const selector = [VISIBILITY_OPTION_SELECTOR, DEVICE_VISIBILITY_OPTION_SELECTOR].join(", ");
-        const droppedEls = getElementsWithOption(snippetEl, selector);
-        droppedEls.forEach((droppedEl) =>
-            this.dependencies.visibility.toggleTargetVisibility(droppedEl, true, true)
-        );
     }
 
     normalizeCSSSelectors(rootEl) {

--- a/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
+++ b/addons/website/static/src/builder/plugins/popup_visibility_plugin.js
@@ -11,6 +11,8 @@ export class PopupVisibilityPlugin extends Plugin {
         target_show: this.onTargetShow.bind(this),
         target_hide: this.onTargetHide.bind(this),
         clean_for_save_handlers: this.cleanForSave.bind(this),
+        on_restore_containers_handlers: this.hidePopupsWithoutTarget.bind(this),
+        on_reveal_target_handlers: this.hidePopupsWithoutTarget.bind(this),
     };
 
     setup() {
@@ -72,6 +74,25 @@ export class PopupVisibilityPlugin extends Plugin {
             this.window.Modal.getOrCreateInstance(modalEl)._hideModal();
             this.window.Modal.getInstance(modalEl).dispose();
         }
+    }
+
+    /**
+     * Hides all the open popups that do not contain the given target element.
+     *
+     * @param {HTMLElement} targetEl the element
+     */
+    hidePopupsWithoutTarget(targetEl) {
+        const openPopupEls = this.editable.querySelectorAll(".s_popup:not([data-invisible='1']");
+        if (!openPopupEls.length) {
+            return;
+        }
+
+        for (const popupEl of openPopupEls) {
+            if (!popupEl.contains(targetEl)) {
+                this.dependencies.visibility.toggleTargetVisibility(popupEl, false);
+            }
+        }
+        this.config.updateInvisibleElementsPanel();
     }
 }
 

--- a/addons/website/static/tests/builder/invisible_elements.test.js
+++ b/addons/website/static/tests/builder/invisible_elements.test.js
@@ -121,6 +121,21 @@ test("mobile and desktop option container", async () => {
     expect(".options-container").not.toHaveCount();
 });
 
+test("desktop option undo after override", async () => {
+    const builder = await setupWebsiteBuilder(`
+        <section>test</section>
+    `);
+    await contains(":iframe section").click();
+    await contains(
+        "[data-action-id='toggleDeviceVisibility'][data-action-param='no_desktop']"
+    ).click();
+    expect(":iframe section").not.toHaveClass("o_snippet_override_invisible");
+    await contains(".o_we_invisible_entry .fa-eye-slash").click();
+    expect(":iframe section").toHaveClass("o_snippet_override_invisible");
+    builder.getEditor().shared.history.undo();
+    expect(":iframe section").not.toHaveClass("o_snippet_override_invisible");
+});
+
 test("keep the option container of a visible snippet even if there are hidden snippet on the page", async () => {
     await setupWebsiteBuilder(`
         <section id="my_el">

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -6,7 +6,6 @@ import {
     defineWebsiteModels,
     insertCategorySnippet,
     setupWebsiteBuilder,
-    waitForEndOfOperation,
 } from "../website_helpers";
 import { Plugin } from "@html_editor/plugin";
 import { insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
@@ -23,7 +22,6 @@ describe("Popup options: empty page before edit", () => {
     test("dropping the popup snippet automatically displays it", async () => {
         await insertCategorySnippet({ group: "content", snippet: "s_popup" });
         expect(".o_add_snippet_dialog").toHaveCount(0);
-        await waitForEndOfOperation();
         // Check if the popup is visible.
         expect(":iframe .s_popup .modal").toHaveClass("show");
         expect(":iframe .s_popup .modal").toHaveStyle({ display: "block" });
@@ -121,5 +119,17 @@ describe("Popup options: popup in page before edit", () => {
         await animationFrame();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         expect(":iframe .s_popup .modal").toBeVisible();
+    });
+
+    test("undoing something on a target outside s_popup closes it", async () => {
+        await insertCategorySnippet({ group: "intro", snippet: "s_cover" });
+        expect(".o_add_snippet_dialog").toHaveCount(0);
+        await contains(":iframe .s_cover").click();
+        await contains("button:contains(Grid)").click(); // arbitrary thing to undo
+        await contains(".o_we_invisible_entry .fa-eye-slash").click();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        undo(builder.getEditor());
+        await animationFrame();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
     });
 });

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { advanceTime, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
+    addPlugin,
     defineWebsiteModels,
     insertCategorySnippet,
     setupWebsiteBuilder,
     waitForEndOfOperation,
 } from "../website_helpers";
+import { Plugin } from "@html_editor/plugin";
 
 defineWebsiteModels();
 
@@ -26,9 +28,43 @@ describe("Popup options: empty page before edit", () => {
     });
 });
 describe("Popup options: popup in page before edit", () => {
+    let builder;
     // Done in `beforeEach` because frontend JS takes too much time to load.
     beforeEach(async () => {
-        await setupWebsiteBuilder(
+        addPlugin(
+            class extends Plugin {
+                static id = "ignore_d-none_on_s_popup";
+                resources = {
+                    // NOTE: this plugin is here as a workaround to make the
+                    // test pass, because (at the time of this commit):
+                    // - the website_edit service is removed for the tests, thus
+                    //   the patch that wraps interaction's functions in
+                    //   `ignoreDOMMutation` is not applied
+                    // - the interaction SharedPopup adds and removes `d-none`
+                    //   on `.s_popup` element to track the visibility of the
+                    //   modal
+                    // - one of the tests here plays with the visibility of the
+                    //   modal, and verifies that it did not add mutations
+                    // TODO: once the service website_edit runs during the
+                    // tests, this plugin should be removed
+                    savable_mutation_record_predicates: (record) => {
+                        if (
+                            record.target.matches?.(".s_popup") &&
+                            record.attributeName === "class"
+                        ) {
+                            const oldValue = new Set(record.oldValue.split(" "));
+                            const newValue = new Set(record.target.className.split(" "));
+                            const union = oldValue.union(newValue);
+                            const intersection = oldValue.intersection(newValue);
+                            const difference = union.difference(intersection);
+                            return !(difference.size === 1 && difference.has("d-none"));
+                        }
+                        return true;
+                    },
+                };
+            }
+        );
+        builder = await setupWebsiteBuilder(
             `<div class="s_popup o_snippet_invisible o_draggable" data-snippet="s_popup" data-name="Popup" id="sPopup" data-invisible="1">
                 <div class="modal fade s_popup_middle modal_shown" style="background-color: var(--black-50)  !important; display: none;" data-show-after="5000" data-display="afterDelay" data-consents-duration="7" data-bs-focus="false" data-bs-backdrop="false" tabindex="-1" aria-label="Popup" aria-hidden="true">
                     <div class="modal-dialog d-flex">
@@ -60,5 +96,8 @@ describe("Popup options: popup in page before edit", () => {
         await contains(":iframe .s_popup div.js_close_popup").click();
         expect(":iframe .s_popup").not.toBeVisible();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
+        // Ensure that no mutations were registered in the history.
+        // `addStep` return the created step, or false if there was no mutations
+        expect(builder.getEditor().shared.history.addStep()).toBe(false);
     });
 });

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -93,8 +93,10 @@ describe("Popup options: popup in page before edit", () => {
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
         // Sometimes bootstrap.js takes a bit of time to display the popup
         await waitFor(":iframe .s_popup div.js_close_popup", { timeout: 500, visible: true });
+        expect(":iframe .s_popup .modal").toBeVisible();
         await contains(":iframe .s_popup div.js_close_popup").click();
-        expect(":iframe .s_popup").not.toBeVisible();
+        expect(":iframe .s_popup .modal").not.toBeVisible();
+        await animationFrame();
         expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
         // Ensure that no mutations were registered in the history.
         // `addStep` return the created step, or false if there was no mutations

--- a/addons/website/static/tests/builder/website_builder/popup_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/popup_option.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { advanceTime, waitFor } from "@odoo/hoot-dom";
+import { advanceTime, animationFrame, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
     addPlugin,
@@ -9,6 +9,8 @@ import {
     waitForEndOfOperation,
 } from "../website_helpers";
 import { Plugin } from "@html_editor/plugin";
+import { insertText, undo } from "@html_editor/../tests/_helpers/user_actions";
+import { setSelection } from "@html_editor/../tests/_helpers/selection";
 
 defineWebsiteModels();
 
@@ -70,7 +72,7 @@ describe("Popup options: popup in page before edit", () => {
                     <div class="modal-dialog d-flex">
                         <div class="modal-content oe_structure">
                             <div class="s_popup_close js_close_popup o_we_no_overlay o_not_editable" aria-label="Close" contenteditable="false">×</div>
-                            <section>Popup content</section>
+                            <section><p>Popup content</p></section>
                         </div>
                     </div>
                 </div>
@@ -101,5 +103,23 @@ describe("Popup options: popup in page before edit", () => {
         // Ensure that no mutations were registered in the history.
         // `addStep` return the created step, or false if there was no mutations
         expect(builder.getEditor().shared.history.addStep()).toBe(false);
+    });
+
+    test("editing s_popup, then closing it, then undo show it again", async () => {
+        const editor = builder.getEditor();
+        await contains(".o_we_invisible_entry .fa-eye-slash").click();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        expect(":iframe .s_popup .modal").toBeVisible();
+        setSelection({ anchorNode: queryOne(":iframe .s_popup section p"), anchorOffset: 0 });
+        insertText(editor, "Other content");
+        await animationFrame();
+        await contains(":iframe .s_popup div.js_close_popup").click();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye-slash");
+        expect(":iframe .s_popup .modal").not.toBeVisible();
+        expect(editor.shared.history.canUndo()).toBe(true);
+        undo(editor);
+        await animationFrame();
+        expect(".o_we_invisible_entry .fa").toHaveClass("fa-eye");
+        expect(":iframe .s_popup .modal").toBeVisible();
     });
 });

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -495,6 +495,7 @@ export async function insertCategorySnippet({ group, snippet } = {}) {
         } .o_snippet_thumbnail .o_snippet_thumbnail_area`
     ).click();
     await confirmAddSnippet(snippet);
+    await waitForEndOfOperation();
 }
 
 export async function waitForSnippetDialog() {

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -233,8 +233,8 @@ registerWebsitePreviewTour("conditional_visibility_5", {
         run: "click",
     },
     {
-        content: "Check that the 'Text - Image' is the parent of 'Column' in the 'Invisible Elements' panel",
-        trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image') + ul .o_we_invisible_entry.o_we_sublevel:contains('Column')",
+        content: "Check that only the 'Text - Image' entry is in the 'Invisible Elements' panel",
+        trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image') + .o_we_invisible_entry:contains('Banner')",
     },
     {
         content: "Click on the 'Text - Image' entry on the 'Invisible Elements' panel",
@@ -244,6 +244,10 @@ registerWebsitePreviewTour("conditional_visibility_5", {
     {
         content: "Check that the snippet is visible on the website",
         trigger: ":iframe .s_text_image.o_snippet_desktop_invisible.o_snippet_override_invisible",
+    },
+    {
+        content: "Check that the 'Column' entry is in the 'Invisible Elements' panel",
+        trigger: ".o_we_invisible_el_panel ul .o_we_invisible_entry.o_we_sublevel_1:contains('Column')",
     },
     {
         content: "Change visibility of the 'Text - Image' snippet",
@@ -278,7 +282,16 @@ registerWebsitePreviewTour("conditional_visibility_5", {
         run: "click",
     },
     {
-        content: "Check that the 'Text - Image' is the parent of 'Column' in the 'Invisible Elements' panel",
-        trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image') + ul .o_we_invisible_entry.o_we_sublevel:contains('Column')",
+        content: "Check that only the 'Text - Image' entry is in the 'Invisible Elements' panel",
+        trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image') + .o_we_invisible_entry:contains('Banner')",
+    },
+    {
+        content: "Click on the 'Text - Image' entry on the 'Invisible Elements' panel",
+        trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image')",
+        run: "click",
+    },
+    {
+        content: "Check that the 'Column' entry is in the 'Invisible Elements' panel",
+        trigger: ".o_we_invisible_el_panel ul .o_we_invisible_entry.o_we_sublevel_1:contains('Column')",
     },
 ]);

--- a/addons/website/static/tests/tours/popup_visibility_option.js
+++ b/addons/website/static/tests/tours/popup_visibility_option.js
@@ -18,15 +18,18 @@ registerWebsitePreviewTour(
             run: "click",
         },
         {
-            content: "Click the 'No Desktop' visibility option.",
+            content: "Click the 'No Desktop' visibility option to hide the banner.",
             trigger:
                 `.options-container [data-label="Visibility"] button[data-action-param="no_desktop"]`,
             run: "click",
         },
         {
-            content: "Verify that the popup is visible and the column is invisible.",
-            trigger:
-                ".o_we_invisible_root_parent i.fa-eye, ul .o_we_invisible_entry i.fa-eye-slash",
+            content: "Check that the popup is visible.",
+            trigger: ".o_we_invisible_root_parent i.fa-eye",
+        },
+        {
+            content: "Check that the banner is invisible.",
+            trigger: "ul .o_we_invisible_entry i.fa-eye-slash",
         },
     ]
 );

--- a/addons/website/static/tests/tours/snippet_visibility_option.js
+++ b/addons/website/static/tests/tours/snippet_visibility_option.js
@@ -45,12 +45,12 @@ registerWebsitePreviewTour("snippet_visibility_option", {
         run: "click"
     },
     {
-        content: "Verify that both the banner and column are marked as invisible.",
+        content: "Check that only the banner is marked as invisible and the column entry does not appear in the panel.",
         trigger: ".o_we_invisible_root_parent",
         run: () => {
             const isBlockInvisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
-            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
-            if (!isBlockInvisible || !isColumnInvisible) {
+            const isColumnEntryDisplayed = document.querySelector("li li .o_we_invisible_entry");
+            if (!isBlockInvisible || !!isColumnEntryDisplayed) {
                 console.error("Visibility issue detected with the elements.");
             }
         }
@@ -58,59 +58,67 @@ registerWebsitePreviewTour("snippet_visibility_option", {
     ...clickOnSave(),
     ...clickOnEditAndWaitEditMode(),
     {
-        content: "Click on the banner snippet in the list of invisible elements.",
-        trigger: "li > .o_we_invisible_entry",
-        run: "click"
-    },
-    {
-        content: "Verify that the popup is visible and the column is still invisible.",
-        trigger: "li > .o_we_invisible_entry",
-        run: () => {
-            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
-            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
-            if (!isPopupVisible || !isColumnInvisible) {
-                console.error("Visibility issue detected with the elements.");
-            }
-        }
-    },
-    ...clickOnSave(),
-    ...clickOnEditAndWaitEditMode(),
-    {
-        content: "Click on the column snippet in the list of invisible elements.",
-        trigger: "li li .o_we_invisible_entry",
-        run: "click"
-    },
-    {
-        content: "Verify that both the popup and the banner are now visible.",
+        content: "Check that only the popup entry is displayed and that it is invisible.",
         trigger: ".o_we_invisible_root_parent",
         run: () => {
-            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
-            const isBlockVisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye");
-            if (!isPopupVisible || !isBlockVisible) {
+            const isSubentryDisplayed = document.querySelector("li .o_we_invisible_entry");
+            const isPopupInvisible = document.querySelector(".o_we_invisible_root_parent > i").classList.contains("fa-eye-slash");
+            if (!!isSubentryDisplayed || !isPopupInvisible) {
                 console.error("Visibility issue detected with the elements.");
             }
         }
     },
     {
-        content: "Click on the popup snippet to hide its descendant elements.",
+        content: "Click on the popup entry to show it.",
         trigger: ".o_we_invisible_root_parent",
+        run: "click"
+    },
+    {
+        content: "Click on the banner entry to show it.",
+        trigger: "li > .o_we_invisible_entry",
+        run: "click"
+    },
+    {
+        content: "Check that the popup and banner are visible and the column is still invisible.",
+        trigger: "li > .o_we_invisible_entry",
         run: () => {
-            setTimeout(() => {
-                document.querySelector(".o_we_invisible_root_parent").click();
-            }, 1000);
+            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
+            const isBannerVisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye");
+            const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            if (!isPopupVisible || !isBannerVisible || !isColumnInvisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
         }
     },
     {
-        content: "Make sure the parent snippet is invisible.",
-        trigger: ".o_we_invisible_root_parent i.fa-eye-slash",
+        content: "Click on the popup entry to hide it.",
+        trigger: ".o_we_invisible_root_parent",
+        run: "click",
     },
     {
-        content: "Verify that both the banner and column snippets are marked as invisible.",
+        content: "Check that only the popup entry is displayed and that it is invisible.",
         trigger: ".o_we_invisible_root_parent",
         run: () => {
-            const isBlockInvisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
+            const isSubentryDisplayed = document.querySelector("li .o_we_invisible_entry");
+            const isPopupInvisible = document.querySelector(".o_we_invisible_root_parent > i").classList.contains("fa-eye-slash");
+            if (!!isSubentryDisplayed || !isPopupInvisible) {
+                console.error("Visibility issue detected with the elements.");
+            }
+        }
+    },
+    {
+        content: "Click on the popup entry to show it.",
+        trigger: ".o_we_invisible_root_parent",
+        run: "click",
+    },
+    {
+        content: "Check that the popup and banner are visible and the column is still invisible.",
+        trigger: "li > .o_we_invisible_entry",
+        run: () => {
+            const isPopupVisible = document.querySelector(".o_we_invisible_root_parent i").classList.contains("fa-eye");
+            const isBannerVisible = document.querySelector("li .o_we_invisible_entry i").classList.contains("fa-eye");
             const isColumnInvisible = document.querySelector("li li .o_we_invisible_entry i").classList.contains("fa-eye-slash");
-            if (!isColumnInvisible || !isBlockInvisible) {
+            if (!isPopupVisible || !isBannerVisible || !isColumnInvisible) {
                 console.error("Visibility issue detected with the elements.");
             }
         }


### PR DESCRIPTION
> [FGE] add Popup section, play with visibility + undo/redo. Visibility eye is not update correctly

> [BLSE] Click on a section, hide it in desktop, click on the eye to make it visible, undo => the section still has the overlay to tell it is invisible (but with the icon for the phone)