### PR TITLE
[IMP] website: adapt `snippets_all_drag_and_drop` tour after refactoring

### DIFF
--- a/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
+++ b/addons/website/static/tests/tours/snippets_all_drag_and_drop.js
@@ -3,91 +3,80 @@ import {
     insertSnippet,
     goBackToBlocks,
     clickOnSnippet,
-    changeOption,
+    changeOptionInPopover,
 } from "@website/js/tours/tour_utils";
-import { patch } from "@web/core/utils/patch";
-
-const patchWysiwygAdapter = () => {
-    const { WysiwygAdapterComponent } = odoo.loader.modules.get("@website/components/wysiwyg_adapter/wysiwyg_adapter");
-    return patch(WysiwygAdapterComponent.prototype, {
-        _trigger_up(ev) {
-            super._trigger_up(...arguments);
-            if (ev.name === 'snippet_removed') {
-                document.body.setAttribute("test-dd-snippet-removed", true);
-            }
-        }
-    });
-};
-
-let unpatchWysiwygAdapter = null;
-
 import { registry } from "@web/core/registry";
 
-let snippetsNames = (new URL(document.location.href)).searchParams.get('snippets_names') || '';
+const SUB_SNIPPET_TEMPLATES = {
+    s_masonry_block_default_template: "s_masonry_block",
+    s_masonry_block_reversed_template: "s_masonry_block",
+    s_masonry_block_images_template: "s_masonry_block",
+    s_masonry_block_mosaic_template: "s_masonry_block",
+    s_masonry_block_alternation_text_image_template: "s_masonry_block",
+    s_masonry_block_alternation_image_text_template: "s_masonry_block",
+};
+
+const DROP_IN_ONLY_SNIPPETS = {
+    "s_button": ".btn",
+    "s_video": ".media_iframe_video",
+};
+
+// Extract the snippets names from the URL parameters.
+let snippetsNames = (new URL(document.location.href)).searchParams.get("snippets_names") || "";
 // When this test is loaded in the backend, the search params aren't as easy to
 // read as before. Little trickery to make this test run.
-const searchParams = new URLSearchParams(window.location.search).get('path');
+const searchParams = new URLSearchParams(window.location.search).get("path");
 if (searchParams) {
-    snippetsNames = new URLSearchParams(searchParams.split('/')[1]).get('snippets_names') || '';
-    snippetsNames = snippetsNames.split(',');
+    snippetsNames = new URLSearchParams(searchParams.split("/")[1]).get("snippets_names") || "";
+    snippetsNames = snippetsNames.split(",");
 }
-const dropInOnlySnippets = {
-    's_button': '.btn',
-    's_video': '.media_iframe_video',
-};
+
+// Generate the tour steps for each snippet.
 let steps = [];
 let n = 0;
-const subSnippetTemplates = {
-    "s_masonry_block_default_template": "s_masonry_block",
-    "s_masonry_block_reversed_template": "s_masonry_block",
-    "s_masonry_block_images_template": "s_masonry_block",
-    "s_masonry_block_mosaic_template": "s_masonry_block",
-    "s_masonry_block_alternation_text_image_template": "s_masonry_block",
-    "s_masonry_block_alternation_image_text_template": "s_masonry_block",
-};
 for (let snippet of snippetsNames) {
     n++;
     snippet = {
-        name: snippet.split(':')[0],
-        group: snippet.split(':')[1],
+        name: snippet.split(":")[0],
+        group: snippet.split(":")[1],
     };
-    const isModal = ['s_popup', 's_newsletter_subscribe_popup'].includes(snippet.name);
-    const isDropInOnlySnippet = Object.keys(dropInOnlySnippets).includes(snippet.name);
+    const isModal = ["s_popup", "s_newsletter_subscribe_popup"].includes(snippet.name);
+    const isDropInOnlySnippet = Object.keys(DROP_IN_ONLY_SNIPPETS).includes(snippet.name);
+    const snippetKey = SUB_SNIPPET_TEMPLATES[snippet.name] || snippet.name;
 
     let draggableElSelector = "";
     if (snippet.group) {
-        draggableElSelector = `#oe_snippets .oe_snippet[data-snippet-group="${snippet.group}"] .oe_snippet_thumbnail`;
+        draggableElSelector = `.o_block_tab:not(.o_we_ongoing_insertion) #snippet_groups [data-snippet-group="${snippet.group}"] .o_snippet_thumbnail`;
     } else {
-        draggableElSelector = `#oe_snippets .oe_snippet:has( > [data-snippet="${snippet.name}"]) .oe_snippet_thumbnail`;
+        draggableElSelector = `.o_block_tab:not(.o_we_ongoing_insertion) #snippet_content [data-snippet="${snippet.name}"].o_snippet_thumbnail`;
     }
 
-    const snippetSteps = [{
-        content: `Drop ${snippet.group || snippet.name} ${snippet.group ? "group" : "snippet"} [${n}/${snippetsNames.length}]`,
-        trigger: draggableElSelector,
-        run: "drag_and_drop :iframe #wrap .oe_drop_zone",
-    }, {
-        content: `Edit ${snippet.name} snippet`,
-        trigger: `:iframe #wrap.o_editable [data-snippet='${subSnippetTemplates[snippet.name] || snippet.name}']${isModal ? ' .modal.show' : ''}`,
-        run: "click",
-    }, {
-        content: `check ${snippet.name} setting are loaded, wait panel is visible`,
-        trigger: ".o_we_customize_panel",
-    }, {
-        content: `Remove the ${snippet.name} snippet`, // Avoid bad perf if many snippets
-        trigger: "we-button.oe_snippet_remove:last",
-        run: "click",
-    },
-    {
-        trigger: "body[test-dd-snippet-removed]",
-    },
-    {
-        content: `click on 'BLOCKS' tab (${snippet.name})`,
-        trigger: ".o_we_add_snippet_btn",
-        async run (actions) {
-            document.body.removeAttribute("test-dd-snippet-removed");
-            await actions.click();
+    const snippetSteps = [
+        {
+            content: `Drop ${snippet.group || snippet.name} ${snippet.group ? "group" : "snippet"} [${n}/${snippetsNames.length}]`,
+            trigger: draggableElSelector,
+            run: "drag_and_drop :iframe #wrapwrap .oe_drop_zone",
         },
-    }];
+        {
+            content: "Wait for the drag and drop to be over", // TODO find a better way
+            trigger: ".o_block_tab:not(.o_we_ongoing_insertion)",
+        },
+        {
+            content: `Click on ${snippet.name} snippet`,
+            trigger: `:iframe #wrapwrap [data-snippet="${snippetKey}"]${isModal ? " .modal.show" : ""}`,
+            run: "click",
+        },
+        {
+            content: `Check ${snippet.name} settings are loaded, wait for panel to be visible`,
+            trigger: ".o_customize_tab",
+        },
+        {
+            content: `Remove the ${snippet.name} snippet`, // Avoid bad perf if many snippets
+            trigger: ".options-container .oe_snippet_remove:last",
+            run: "click",
+        },
+        goBackToBlocks(),
+    ];
 
     if (snippet.group) {
         snippetSteps.splice(1, 0, {
@@ -97,88 +86,69 @@ for (let snippet of snippetsNames) {
         });
     }
 
-    if (snippet === 's_google_map') {
-        snippetSteps.splice(2, 4, {
-            content: 'Close API Key popup',
+    if (snippet.name === "s_google_map") {
+        snippetSteps.splice(3, 3, {
+            content: "Close API Key popup",
             trigger: ":iframe .modal-footer .btn-secondary",
             run: "click",
         });
     } else if (isModal) {
-        snippetSteps.splice(
-            4,
-            3,
-            {
-                content: `Make sure ${snippet.name} is shown`,
-                trigger: ":iframe body.modal-open",
-            },
-            {
-                content: `Hide the ${snippet.name} popup`,
-                trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
-                run: "click",
-            }
-        );
+        snippetSteps.splice(5, 2, {
+            content: `Make sure ${snippet.name} is shown`,
+            trigger: ":iframe body.modal-open",
+        }, {
+            content: `Hide the ${snippet.name} popup`,
+            trigger: `:iframe [data-snippet='${snippet.name}'] .s_popup_close`,
+            run: "click",
+        });
     } else if (isDropInOnlySnippet) {
         // The 'drop in only' snippets have their 'data-snippet' attribute
-        // removed once they are dropped, so we need to use a different selector.
-        snippetSteps[1].trigger = `:iframe #wrap.o_editable ${dropInOnlySnippets[snippet.name]}`;
+        // removed once they are dropped, so we need to use a different
+        // selector.
+        snippetSteps[2].trigger = `:iframe #wrapwrap ${DROP_IN_ONLY_SNIPPETS[snippet.name]}`;
     }
     steps = steps.concat(snippetSteps);
 }
 
-registry.category("web_tour.tours").add("snippets_all_drag_and_drop", {
+registry.category("web_tour.tours").add("snippets_all_drag_and_drop", { steps: () => [
     // To run the tour locally, you need to insert the URL sent by the python
     // tour here. There is currently an issue with tours which don't have an URL
     // url: '/?enable_editor=1&snippets_names=s_process_steps:columns,s_website_form:,s_...',
-    steps: () => [
     ...clickOnEditAndWaitEditMode(),
     {
         content: "Ensure snippets are actually passed at the test.",
         trigger: "body",
         run: function () {
-            // safety check, otherwise the test might "break" one day and
+            // Safety check, otherwise the test might "break" one day and
             // receive no steps. The test would then not test anything anymore
             // without us noticing it.
             if (steps.length < 500) {
                 console.error(`This test is not behaving as it should, got only ${steps.length} steps.`);
             }
-            unpatchWysiwygAdapter = patchWysiwygAdapter();
         },
     },
-    // This first step is needed as it will be used later for inner snippets
+    // This first step is needed as it will be used later for inner snippets.
     // Without this, it will dropped inside the footer and will need an extra
     // selector.
-    ...insertSnippet({
-        id: "s_text_image",
-        name: "Text - Image",
-        groupName: "Content"
-    }),
+    ...insertSnippet({ id: "s_text_image", name: "Text - Image", groupName: "Content" }),
     {
-        content: "Edit s_text_image snippet",
+        content: "Click on s_text_image snippet",
         trigger: ":iframe #wrap.o_editable [data-snippet='s_text_image']",
         run: "click",
     },
     {
-        content: "check setting are loaded, wait panel is visible",
-        trigger: ".o_we_customize_panel",
-        run: "click",
+        content: "Check settings are loaded, wait for panel to be visible",
+        trigger: ".o_customize_tab [data-container-title='Text - Image']",
     },
     // We hide the header before starting to drop snippets. This prevents
     // situations where the header's drop zones overlap with those of the #wrap,
     // ensuring that a snippet is dropped in the #wrap as expected instead of
     // the header.
-    ...clickOnSnippet({id: "o_header_standard", name: "Header"}),
-    changeOption("TopMenuVisibility", "we-select:has([data-visibility]) we-toggler"),
-    changeOption("TopMenuVisibility", 'we-button[data-visibility="hidden"]'),
+    ...clickOnSnippet({ id: "o_header_standard", name: "Header" }),
+    ...changeOptionInPopover("Header", "Header Position", "Hidden"),
     goBackToBlocks(),
-].concat(steps).concat([
-    {
-        content: "Remove wysiwyg patch",
-        trigger: "body",
-        run: () => unpatchWysiwygAdapter(),
-    }
-            ])
-            .map((step) => {
-                delete step.noPrepend;
-                return step;
-            }),
+].concat(steps).map((step) => {
+        delete step.noPrepend;
+        return step;
+    }),
 });

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -27,8 +27,6 @@ class TestSnippets(HttpCase):
     def test_02_default_shape_gets_palette_colors(self):
         self.start_tour('/@/', 'default_shape_gets_palette_colors', login='admin')
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_03_snippets_all_drag_and_drop(self):
         with MockRequest(self.env, website=self.env['website'].browse(1)):
             snippets_template = self.env['ir.ui.view'].render_public_asset('website.snippets')


### PR DESCRIPTION
This commit adapts the `snippets_all_drag_and_drop` tour to make it work
with the new website code, following the refactoring [1]. It also takes
the opportunity to clean it a bit.

[1]: https://github.com/odoo-dev/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

task-4721040