### PR TITLE
[FIX] web: prevent crash when using invalid args in name_search

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one.js
+++ b/addons/web/static/src/views/fields/many2one/many2one.js
@@ -294,7 +294,7 @@ export class Many2One extends Component {
     async processScannedBarcode(barcode) {
         const pairs = await this.orm.call(this.props.relation, "name_search", [], {
             name: barcode,
-            args: this.props.domain(),
+            domain: this.props.domain(),
             operator: "ilike",
             limit: 2, // If one result we set directly and if more than one we use normal flow so no need to search more
             context: this.props.context,


### PR DESCRIPTION
The system crashes with an error when attempting to scan a barcode. because `name_search` expects `domain` and it gives `args`.

**Error:-**
`TypeError: ProductProduct.name_search() got an unexpected keyword argument 'args'`

**Issue:-**
- The **args** keyword was used to pass the domain filter. However, this is deprecated and not supported by the **name_search** method anymore. The correct keyword is **domain**.
Reference:- https://github.com/odoo/odoo/pull/198154

- but this PR misses the line number 297:-https://github.com/odoo/odoo/blob/2f901dde76546baae2f13c978a37d42f7b33299c/addons/web/static/src/views/fields/many2one/many2one.js#L295-L301

**Sentry - 6388425767**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
