### PR TITLE
[FIX] {sale_,}purchase_stock: ensure correct picking partner

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -325,6 +325,11 @@ class StockRule(models.Model):
                 ('date_order', '<=', datetime.combine(procurement_date + relativedelta(days=delta_days), datetime.max.time())),
                 ('date_order', '>=', datetime.combine(procurement_date - relativedelta(days=delta_days), datetime.min.time()))
             )
+        strict_partner_dest = self.env['ir.config_parameter'].sudo().get_param('purchase_stock.split_po')
+        if strict_partner_dest:
+            domain += (
+                ('dest_address_id', '=', values.get('partner_id', False)),
+            )
         if group:
             domain += (('group_id', '=', group.id),)
         return domain


### PR DESCRIPTION
When mixing cross-dock (XD), MTO and MTS products, it may lead to
incorrect partners on the pickings.

To reproduce the issue:
1. Enable Multi-Routes
2. Edit the warehouse: 2-steps reception, 2-steps delivery
3. Unarchive MTO route
4. Setup 3 products:
   - Storable
   - Routes:
     - All with buy
     - One MTO
     - One XD
   - Same supplier
5. Create and confirm one SO for each product (starting with XD one),
   each one with a different customer
6. Validate the generated replenish
7. Confirm the PO
8. Process the receipts

Error: The internal pickings have the same defined partner, the
customer of the XD product.

There are two issues:
- The destination address of a purchase is defined on the PO level,
not the POL one
- When looking for a PO, the `_run_buy` mechanism doesn't filter on
the destination address

This explains why:
- All purchases are gathered on the same PO
- On the internal pickings, we will find the first destination address

Even though the first point is convenient, since the destination
address is defined on the PO level, it leads to incorrect results.
However, changing this on stable is too risky. The only (and sad)
thing we can do so far is the creation of an ICP that would split
all PO based on their destination address. On master, this address
will be defined on POL level.

OPW-4552316