### PR TITLE
[FIX] web: list column widths: detect escaped parts

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -106,13 +106,16 @@ function computeOptimalDateWidths() {
     const dates = [];
     const datetimes = [];
     const { dateFormat, timeFormat } = localization;
+    const escapedPartsRegex = /('[^']*')/g;
+    const dateFormatWoEscParts = dateFormat.replaceAll(escapedPartsRegex, "");
     // generate a date for each month if date format contains MMMM or MMM (full or abbrev. month)
-    for (let month = 1; month <= (/(?<!')MMM/.test(dateFormat) ? 12 : 1); month++) {
+    for (let month = 1; month <= (/MMM/.test(dateFormatWoEscParts) ? 12 : 1); month++) {
         // generate a date for each day if date format contains cccc or ccc (full or abbrev. day)
-        for (let day = 1; day <= (/(?<!')ccc/.test(dateFormat) ? 7 : 1); day++) {
+        for (let day = 1; day <= (/ccc/.test(dateFormatWoEscParts) ? 7 : 1); day++) {
             dates.push(formatDate(luxon.DateTime.local(2017, month, day)));
             datetimes.push(formatDateTime(luxon.DateTime.local(2017, month, day, 8, 0, 0)));
-            if (/(?<!')a/.test(timeFormat)) {
+            const timeFormatWoEscParts = timeFormat.replaceAll(escapedPartsRegex, "");
+            if (/a/.test(timeFormatWoEscParts)) {
                 // generate a date in the afternoon if time is displayed with AM/PM or equivalent
                 datetimes.push(formatDateTime(luxon.DateTime.local(2017, month, day, 20, 0, 0)));
             }

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -484,6 +484,39 @@ test(`width computation: date and datetime with fancy formats`, async () => {
     expect(getColumnWidths()).toEqual([40, 325, 170, 265]);
 });
 
+test(`width computation: date and datetime with fancy formats (2)`, async () => {
+    // Those formats contains static parts ("a" not prefixed by "%") which will be escaped when
+    // converted into the luxon format (wrapped into single quotes). The regex that detects patterns
+    // like "MMM" (abrev. month, in letters) must properly ignore those escaped parts. This test
+    // ensures it.
+    defineParams({
+        lang_parameters: {
+            date_format: "%Ya%ba%d",
+            time_format: "%H%M%Sa%p",
+        },
+    });
+    resetDateFieldWidths();
+    after(resetDateFieldWidths);
+
+    await mountView({
+        type: "list",
+        resModel: "foo",
+        arch: `
+            <list>
+                <field name="foo"/>
+                <field name="date"/>
+                <field name="datetime"/>
+            </list>`,
+    });
+
+    expect(queryAllTexts(".o_data_row:eq(0) .o_data_cell")).toEqual([
+        "yop",
+        "2017aJana25",
+        "2016aDeca12 115505aAM",
+    ]);
+    expect(getColumnWidths()).toEqual([40, 470, 99, 191]);
+});
+
 test(`width computation: width attribute in arch and overflowing table`, async () => {
     Foo._records[0].text =
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +


### PR DESCRIPTION
This commit is a followup of odoo/odoo#210300 where we didn't correctly detect escaped parts (wrapped in single quotes) in date and time formats. This commit ensures that we first remove from the formats all escaped parts, before analysing those formats to detect patterns.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
