### PR TITLE
[IMP] website: adapt mysterious egg tours

### DIFF
--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -1,5 +1,5 @@
 import {
-    changeOption,
+    changeOptionInPopover,
     clickOnEditAndWaitEditMode,
     clickOnSave,
     clickOnSnippet,
@@ -15,14 +15,12 @@ registerWebsitePreviewTour("test_parallax", {
 }, () => [
     ...insertSnippet(coverSnippet),
     ...clickOnSnippet(coverSnippet),
-    changeOption("BackgroundOptimize", "we-toggler"),
-    changeOption("BackgroundOptimize", 'we-button[data-gl-filter="blur"]'),
+...changeOptionInPopover("Cover", "Filter", "Blur"),
 {
     content: "Check that the Cover snippet has the Blur filter on its background image",
     trigger: ":iframe .s_cover span[data-gl-filter='blur']",
 },
-    changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-set-parallax-type="none"]'),
+...changeOptionInPopover("Cover", "Parallax", "None"),
 {
     content: "Check that the data related to the filter have been transferred to the new target",
     trigger: ":iframe .s_cover[data-gl-filter='blur']",
@@ -31,8 +29,7 @@ registerWebsitePreviewTour("test_parallax", {
     content: "Check that the 'o_modified_image_to_save' class has been transferred to the new target",
     trigger: ":iframe .s_cover.o_modified_image_to_save",
 },
-    changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-set-parallax-type="fixed"]'),
+...changeOptionInPopover("Cover", "Parallax", "Fixed"),
 {
     content: "Check that the 'o_modified_image_to_save' class has been deleted from the old target",
     trigger: ":iframe .s_cover:not(.o_modified_image_to_save)",
@@ -45,14 +42,12 @@ registerWebsitePreviewTour("test_parallax", {
     content: "Check that the data related to the filter have been transferred to the new target",
     trigger: ":iframe span.s_parallax_bg[data-gl-filter='blur']",
 },
-    changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-set-parallax-type="top"]'),
+...changeOptionInPopover("Cover", "Parallax", "Parallax to Top"),
 {
     content: "Check that the option was correctly applied",
     trigger: ':iframe span.s_parallax_bg[style*=top][style*=bottom][style*=transform]',
 },
-    changeOption("Parallax", "we-toggler"),
-    changeOption("Parallax", 'we-button[data-set-parallax-type="zoom_in"]'),
+...changeOptionInPopover("Cover", "Parallax", "Zoom In"),
 {
     content: "Check that the option was correctly applied",
     trigger: ':iframe span.s_parallax_bg[style*="transform: scale("]',

--- a/addons/website/static/tests/tours/snippet_table_of_content.js
+++ b/addons/website/static/tests/tours/snippet_table_of_content.js
@@ -10,9 +10,9 @@ import {
 const scrollToHeading = function (position) {
     return {
         content: `Scroll to h2 number ${position}`,
-        trigger: `:iframe h2:eq(${position})`,
+        trigger: `:iframe .s_table_of_content h2:eq(${position})`,
         run: function () {
-            this.anchor.scrollIntoView(true);
+            this.anchor.scrollIntoView({ behavior: "smooth", block: "center" });
         },
     };
 };
@@ -30,24 +30,24 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     ...insertSnippet({id: "s_table_of_content", name: "Table of Content", groupName: "Text"}),
     {
         content: "Drag the Text snippet group and drop it.",
-        trigger: '#oe_snippets #snippet_groups .oe_snippet[name="Text"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
+        trigger: ".o-snippets-menu .o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Text'] .o_snippet_thumbnail",
         run: "drag_and_drop :iframe #wrap",
     },
     {
         content: "Click on the s_table_of_content snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_table_of_content"]',
+        trigger: ':iframe .o_add_snippets_preview [data-snippet="s_table_of_content"]',
         run: "click",
     },
     // To make sure that the public widgets of the two previous ones started.
     ...insertSnippet({id: "s_banner", name: "Banner", groupName: "Intro"}),
     {
         content: "Drag the Intro snippet group and drop it.",
-        trigger: '#oe_snippets .oe_snippet[name="Intro"] .oe_snippet_thumbnail:not(.o_we_ongoing_insertion)',
+        trigger: ".o-snippets-menu .o_block_tab:not(.o_we_ongoing_insertion) .o_snippet[name='Intro'] .o_snippet_thumbnail",
         run: "drag_and_drop :iframe #wrap",
     },
     {
         content: "Click on the s_banner snippet.",
-        trigger: ':iframe .o_snippet_preview_wrap[data-snippet-id="s_banner"]',
+        trigger: ':iframe .o_add_snippets_preview [data-snippet="s_banner"]',
         run: "click",
     },
     ...clickOnSave(),
@@ -59,7 +59,7 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     scrollToHeading(2),
     checkTOCNavBar(1, 0),
     scrollToHeading(3),
-    checkTOCNavBar(1, 1),
+    checkTOCNavBar(1, 0),
     ...clickOnEditAndWaitEditMode(),
     {
         content: "Click on the first TOC's title",
@@ -68,7 +68,7 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     },
     {
         content: "Hide the first TOC on mobile",
-        trigger: '[data-toggle-device-visibility="no_mobile"]',
+        trigger: '[data-action-param="no_mobile"]',
         run: "click",
     },
     // Go back to blocks tabs to avoid changing the first ToC options
@@ -80,7 +80,7 @@ registerWebsitePreviewTour('snippet_table_of_content', {
     },
     {
         content: "Hide the second TOC on desktop",
-        trigger: '[data-toggle-device-visibility="no_desktop"]',
+        trigger: '[data-action-param="no_desktop"]',
         run: "click",
     },
     ...clickOnSave(),

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -96,7 +96,6 @@ class TestSnippets(HttpCase):
         create_image_attachment(self.env, '/web/image/website.s_banner_default_image.jpg', 's_default_image2.jpg')
         self.start_tour("/", "snippet_image_gallery_remove", login='admin')
 
-    @unittest.skip
     def test_10_parallax(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'test_parallax', login='admin')
 

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -88,7 +88,6 @@ class TestSnippets(HttpCase):
     def test_07_image_gallery(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_image_gallery', login='admin')
 
-    @unittest.skip
     def test_08_table_of_content(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_table_of_content', login='admin')
 


### PR DESCRIPTION
The test_parallax, snippet_table_of_content was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This PR updates the tour steps to align with the new DOM and re-enables the associated test. 
