### PR TITLE
[FIX] account: allows autobalance with default account

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1429,6 +1429,8 @@ class AccountMoveLine(models.Model):
             defaults['account_id'] = quick_encode_suggestion['account_id']
             defaults['price_unit'] = quick_encode_suggestion['price_unit']
             defaults['tax_ids'] = [Command.set(quick_encode_suggestion['tax_ids'])]
+        elif (journal := self.env['account.journal'].browse(self.env.context.get('journal_id'))) and journal.default_account_id:
+            defaults['account_id'] = journal.default_account_id
         return defaults
 
     def _sanitize_vals(self, vals):

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -762,7 +762,7 @@ class TestAccountMove(AccountTestInvoicingCommon):
         tax_line.unlink()
 
         # But creating unbalanced misc entry shouldn't be allowed otherwise
-        with self.assertRaisesRegex(UserError, r"The move \(.*\) is not balanced\."):
+        with self.assertRaisesRegex(UserError, r"The entry is not balanced."):
             self.env["account.move"].create({
                 "move_type": "entry",
                 "line_ids": [


### PR DESCRIPTION
Problems:
The error message for unbalanced journal entries in the "Miscellaneous Operations" journal was unnecessarily complex and misleading. It suggested setting a default account on the journal to automatically balance entries, but this auto-balancing was intended only for lines with taxes.

Furthermore, the method _get_automatic_balancing_account in account.move was ignoring any default account set on the journal itself when auto-balancing because of taxes. It was instead always taking the company suspense account.

How to reproduce the issue:

- Add a default account to the miscellaneous journal.
- Create a journal entry manually, and add a line with any account of 100 debit.
- Attempt to save.

Finally, this commit also set the account_id of new account move lines to the default account id of the journal if it exists when creating a journal entry.

enterprise pr: https://github.com/odoo/enterprise/pull/86987

opw-4751270



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
