### PR TITLE
[FIX] html_editor: prevent traceback when pressing TAB inside `th`

### DIFF
--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -481,12 +481,12 @@ export class TablePlugin extends Plugin {
      */
     shiftCursorToTableCell(shiftIndex) {
         const sel = this.dependencies.selection.getEditableSelection();
-        const currentTd = closestElement(sel.anchorNode, "td");
+        const currentTd = closestElement(sel.anchorNode, "td, th");
         const closestTable = closestElement(currentTd, "table");
         if (!currentTd || !closestTable) {
             return false;
         }
-        const tds = [...closestTable.querySelectorAll("td")];
+        const tds = [...closestTable.querySelectorAll("td, th")];
         const cursorDestination = tds[tds.findIndex((td) => currentTd === td) + shiftIndex];
         if (!cursorDestination) {
             return false;

--- a/addons/html_editor/static/tests/table/tabulation.test.js
+++ b/addons/html_editor/static/tests/table/tabulation.test.js
@@ -5,6 +5,60 @@ import { unformat } from "../_helpers/format";
 
 describe("move selection with tab/shift+tab", () => {
     describe("tab", () => {
+        test("should move cursor to the next th", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>[]ab</th>
+                                <th>cd</th>
+                                <th>ef</th>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("Tab"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>ab</th>
+                                <th>cd[]</th>
+                                <th>ef</th>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should move cursor to the next td", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>[]ab</th>
+                                <td>cd</td>
+                                <td>ef</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: async () => press("Tab"),
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th>ab</th>
+                                <td>cd[]</td>
+                                <td>ef</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
         test("should move cursor to the end of next cell", async () => {
             await testEditor({
                 contentBefore: unformat(`


### PR DESCRIPTION
Problem:
`shiftCursorToTableCell` is not considering being inside `th` which causes traceback as `currentTd` will be null.

Solution:
Include `th` in the selector alongside `td` to ensure proper detection and navigation.

Steps to reproduce:
- Copy and paste in the editor any table that has `th`.
- Put selection inside a `th` element.
- Press "TAB". → Traceback occurs.

opw-4808751

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
