### PR TITLE
[FIX] pos_sale: prevent error when first line is a section or note

### DIFF
--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1193,6 +1193,9 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
         sale_order = self.env['sale.order'].create({
             'partner_id': partner_test.id,
             'order_line': [(0, 0, {
+                'display_type': 'line_section',
+                'name': "Section 1",
+            }), (0, 0, {
                 'product_id': product.id,
                 'name': product.name,
                 'product_uom_qty': 2,


### PR DESCRIPTION
Before this commit, if the first line in a sale order was a Section or Note, it would not be included in the `read_converted` result. As a result, using the index to access the corresponding data and read `lot_names` could fail, leading to missing or incorrect `lot_names`.

opw-4816447

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
