### PR TITLE
[FIX] website: fix toggle invisible footer and header

### DIFF
--- a/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
+++ b/addons/website/static/src/builder/plugins/options/website_page_config_option.xml
@@ -21,7 +21,7 @@
 
 <t t-name="html_builder.HideFooterOption">
     <BuilderRow label.translate="Page Visibility">
-        <BuilderCheckbox classAction="'d-none o_snippet_invisible'" action="'setPageWebsiteDirty'" inverseAction="true"/>
+        <BuilderCheckbox action="'setWebsiteFooterVisible'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/tests/builder/options/top_menu_visibility_option.test.js
+++ b/addons/website/static/tests/builder/options/top_menu_visibility_option.test.js
@@ -137,6 +137,7 @@ test("regular -> hidden -> regular", async () => {
     const precedentWrapwrap = queryOne(":iframe #wrapwrap").outerHTML;
     await contains("[data-label='Header Position'] .dropdown").click();
     await contains(".o-overlay-container [data-action-value='hidden']").click();
+    await contains(":iframe #wrapwrap > header").click();
     await contains("[data-label='Header Position'] .dropdown").click();
     await contains(".o-overlay-container [data-action-value='regular']").click();
     const modifiedWrapwrap = queryOne(":iframe #wrapwrap");


### PR DESCRIPTION
When hiding a footer or a header in the builder, it was listed in the "invisible elements" but the toggle was not working (the state did not match the visibility, and clicking it did not changed it).
