### PR TITLE
[FIX] mail: align margins of activity list in chatter

### DIFF
--- a/addons/mail/static/src/chatter/web/chatter.xml
+++ b/addons/mail/static/src/chatter/web/chatter.xml
@@ -127,7 +127,7 @@
 
 <t t-name="mail.ActivityList">
     <div class="o-mail-ActivityList">
-        <div class="d-flex pt-2 cursor-pointer fw-bolder" t-on-click="toggleActivities">
+        <div class="d-flex pt-2 px-2 cursor-pointer fw-bolder" t-on-click="toggleActivities">
             <hr class="flex-grow-1 fs-3"/>
             <div class="d-flex align-items-center px-3">
                 <i class="fa fa-fw" t-att-class="state.showActivities ? 'fa-caret-down' : 'fa-caret-right'"/>

--- a/addons/mail/static/src/core/web/activity.scss
+++ b/addons/mail/static/src/core/web/activity.scss
@@ -1,4 +1,9 @@
 .o-mail-Activity-sidebar {
+    flex-basis: $o-mail-Message-sidebarWidth;
+    max-width: $o-mail-Message-sidebarWidth;
+}
+
+.o-mail-Activity-avatarContainer {
     width: $o-mail-Avatar-size;
     height: $o-mail-Avatar-size;
 }

--- a/addons/mail/static/src/core/web/activity.xml
+++ b/addons/mail/static/src/core/web/activity.xml
@@ -3,22 +3,22 @@
 
 <t t-name="mail.Activity">
     <div class="o-mail-Activity d-flex py-1 mb-2" t-on-click="onClick">
-        <div class="o-mail-Activity-sidebar flex-shrink-0 position-relative">
-            <a role="button" t-on-click="onClickAvatar">
+        <div class="o-mail-Activity-sidebar d-flex flex-shrink-0 justify-content-center align-items-start">
+            <div class="o-mail-Activity-avatarContainer position-relative" role="button" t-on-click="onClickAvatar">
                 <img class="w-100 h-100 rounded o_object_fit_cover" t-att-src="props.activity.persona.avatarUrl" />
-            </a>
-            <div
-                class="o-mail-Activity-iconContainer position-absolute top-100 start-100 translate-middle d-flex align-items-center justify-content-center mt-n1 ms-n1 rounded-circle w-50 h-50"
-                t-att-class="{
-                       'text-bg-success': props.activity.state === 'planned',
-                       'text-bg-warning': props.activity.state === 'today',
-                       'text-bg-danger': props.activity.state === 'overdue',
-                       }"
-            >
-                <i class="fa small" t-attf-class="{{ props.activity.icon }}"/>
+                <div
+                    class="o-mail-Activity-iconContainer position-absolute top-100 start-100 translate-middle d-flex align-items-center justify-content-center mt-n1 ms-n1 rounded-circle w-50 h-50"
+                    t-att-class="{
+                        'text-bg-success': props.activity.state === 'planned',
+                        'text-bg-warning': props.activity.state === 'today',
+                        'text-bg-danger': props.activity.state === 'overdue',
+                        }"
+                >
+                    <i class="fa small" t-attf-class="{{ props.activity.icon }}"/>
+                </div>
             </div>
         </div>
-        <div class="flex-grow px-3">
+        <div class="flex-grow px-1">
             <div class="o-mail-Activity-info lh-1">
                 <span class="fw-bolder text-success" t-if="delay === 1">Tomorrow:</span>
                 <span class="fw-bolder text-success" t-elif="delay gt 0">Due in <t t-esc="delay"/> days:</span>


### PR DESCRIPTION
This commit changes the activity component sidebar structure to match the message sidebar's.
This is done to make sure the avatars in the chatter are all horizontally aligned.
This commit also adds padding to the Activities separator/dropdown to align with the messages date separator.

Before:
![Pasted image 20250523133336](https://github.com/user-attachments/assets/a1f4ef6b-c370-4b1e-83b5-fb3b3dc20eb4)
After:
![image](https://github.com/user-attachments/assets/c0145a05-6a3b-4be2-8504-446c8c590b0e)