### PR TITLE
[FIX] website: bind `s_blockquote` options on parent handler

### DIFF
--- a/addons/html_builder/static/src/core/save_snippet_plugin.js
+++ b/addons/html_builder/static/src/core/save_snippet_plugin.js
@@ -3,8 +3,9 @@ import { Plugin } from "@html_editor/plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { markup } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
+import { BLOCKQUOTE_PARENT_HANDLERS } from "@html_builder/core/utils";
 
-const savableSelector = "[data-snippet], a.btn";
+const savableSelector = `[data-snippet], a.btn, ${BLOCKQUOTE_PARENT_HANDLERS}`;
 // TODO `so_submit_button_selector` ?
 const savableExclude = ".o_no_save, .s_donation_donate_btn, .s_website_form_send";
 
@@ -60,6 +61,13 @@ export class SaveSnippetPlugin extends Plugin {
     }
 
     async saveSnippet(el) {
+        // When saving a parent handler, save the child snippet instead
+        if (el.matches(BLOCKQUOTE_PARENT_HANDLERS)) {
+            const childBlockquote = el.querySelector(".s_blockquote");
+            if (childBlockquote) {
+                el = childBlockquote;
+            }
+        }
         const cleanForSaveHandlers = [
             ...this.getResource("clean_for_save_handlers"),
             ({ root }) => escapeTextNodes(root),

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -18,6 +18,12 @@ import { useBus } from "@web/core/utils/hooks";
 import { effect } from "@web/core/utils/reactive";
 import { useDebounced } from "@web/core/utils/timing";
 
+// Selectors for special cases where snippet options are bound to parent
+// containers instead of the snippet itself.
+export const BLOCKQUOTE_PARENT_HANDLERS = ".s_reviews_wall .row > div";
+export const BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO = ":scope > .s_blockquote";
+export const SPECIAL_BLOCKQUOTE_SELECTOR = `${BLOCKQUOTE_PARENT_HANDLERS} > .s_blockquote`;
+
 /**
  * @typedef { import("../../../../html_editor/static/src/editor").EditorContext } EditorContext
  */

--- a/addons/html_builder/static/src/plugins/block_alignment_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/block_alignment_option_plugin.js
@@ -13,7 +13,7 @@ class BlockAlignmentOptionPlugin extends Plugin {
 
 export class BlockAlignmentOption extends BaseOptionComponent {
     static template = "html_builder.BlockAlignmentOption";
-    static selector = ".s_alert, .s_blockquote, .s_text_highlight";
+    static selector = ".s_alert, .s_text_highlight";
 }
 
 registry.category("builder-plugins").add(BlockAlignmentOptionPlugin.id, BlockAlignmentOptionPlugin);

--- a/addons/html_builder/static/src/plugins/width_option_plugin.js
+++ b/addons/html_builder/static/src/plugins/width_option_plugin.js
@@ -13,7 +13,7 @@ class WidthOptionPlugin extends Plugin {
 
 export class WidthOption extends BaseOptionComponent {
     static template = "html_builder.WidthOption";
-    static selector = ".s_alert, .s_blockquote, .s_text_highlight";
+    static selector = ".s_alert, .s_text_highlight";
     static name = "widthOption";
 }
 registry.category("builder-plugins").add(WidthOptionPlugin.id, WidthOptionPlugin);

--- a/addons/website/static/src/builder/plugins/options/animate_option.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option.js
@@ -1,12 +1,16 @@
-import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import {
+    BaseOptionComponent,
+    useDomState,
+    SPECIAL_BLOCKQUOTE_SELECTOR,
+} from "@html_builder/core/utils";
+
 import { isImageSupportedForStyle } from "@html_builder/plugins/image/replace_media_option";
 
 export class AnimateOption extends BaseOptionComponent {
     static template = "website.AnimateOption";
     static dependencies = ["animateOption"];
     static selector = ".o_animable, section .row > div, img, .fa, .btn";
-    static exclude =
-        "[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_social_media i.fa, .s_share i.fa";
+    static exclude = `[data-oe-xpath], .o_not-animable, .s_col_no_resize.row > div, .s_col_no_resize, .s_social_media i.fa, .s_share i.fa, ${SPECIAL_BLOCKQUOTE_SELECTOR}`;
     static props = {
         requireAnimation: { type: Boolean, optional: true },
         slots: { type: Object, optional: true },

--- a/addons/website/static/src/builder/plugins/options/blockquote_option.js
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option.js
@@ -1,0 +1,42 @@
+import {
+    BaseOptionComponent,
+    useGetItemValue,
+    BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO,
+    BLOCKQUOTE_PARENT_HANDLERS,
+    SPECIAL_BLOCKQUOTE_SELECTOR,
+} from "@html_builder/core/utils";
+import { BaseWebsiteBackgroundOption } from "@website/builder/plugins/options/background_option";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import { ShadowOption } from "@html_builder/plugins/shadow_option";
+
+export class BaseBlockquoteOption extends BaseOptionComponent {
+    static template = "website.BlockquoteOption";
+    static components = {
+        BaseWebsiteBackgroundOption,
+        BorderConfigurator,
+        ShadowOption,
+    };
+    static props = {
+        disableWidth: { type: Boolean, optional: true },
+    };
+    static defaultProps = {
+        disableWidth: false,
+    };
+    setup() {
+        super.setup();
+        this.getItemValue = useGetItemValue();
+    }
+}
+
+export class BlockquoteOption extends BaseBlockquoteOption {
+    static selector = ".s_blockquote";
+    static exclude = SPECIAL_BLOCKQUOTE_SELECTOR;
+}
+
+export class BlockquoteWithoutWidthOption extends BaseBlockquoteOption {
+    static selector = BLOCKQUOTE_PARENT_HANDLERS;
+    static applyTo = BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO;
+    static defaultProps = {
+        disableWidth: true,
+    };
+}

--- a/addons/website/static/src/builder/plugins/options/blockquote_option.xml
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option.xml
@@ -2,6 +2,29 @@
 <templates xml:space="preserve">
 
 <t t-name="website.BlockquoteOption">
+    <t t-if="!this.props.disableWidth">
+        <BaseWebsiteBackgroundOption
+            withColors="true"
+            withImages="true"
+            withShapes="true"
+            withColorCombinations="true"
+        />
+        <BuilderRow label.translate="Width">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'w-25'">25%</BuilderSelectItem>
+                <BuilderSelectItem classAction="'w-50'">50%</BuilderSelectItem>
+                <BuilderSelectItem classAction="'w-75'">75%</BuilderSelectItem>
+                <BuilderSelectItem classAction="'w-100'" id="'so_width_100'">100%</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+        <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')" level="1">
+            <BuilderButtonGroup>
+                <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"/>
+                <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"/>
+                <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"/>
+            </BuilderButtonGroup>
+        </BuilderRow>
+    </t>
     <!-- Layout -->
     <BuilderRow label.translate="Edge Spacing">
         <BuilderRange action="'setClassRange'" actionParam="['p-1','p-2','p-3','p-4','p-5']" max="4"/>
@@ -19,13 +42,18 @@
         <BuilderColorPicker styleAction="'background-color'" enabledTabs="['solid', 'custom', 'gradient']"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Author Alignment" applyTo="'.s_blockquote_infos'">
-        <BuilderSelect>
-            <BuilderSelectItem classAction="'flex-row align-items-start justify-content-start text-start'">Left</BuilderSelectItem>
-            <BuilderSelectItem classAction="'flex-column align-items-center text-center'">Center</BuilderSelectItem>
-            <BuilderSelectItem classAction="'flex-row-reverse align-items-start justify-content-start text-end'">Right</BuilderSelectItem>
-        </BuilderSelect>
-    </BuilderRow>
+    <BuilderContext applyTo="'.s_blockquote_infos'">
+        <BuilderRow label.translate="Show Author">
+            <BuilderCheckbox id="'blockquote_show_author_opt'" classAction="'d-flex'"/>
+        </BuilderRow>
+        <BuilderRow t-if="this.isActiveItem('blockquote_show_author_opt')" label.translate="Author Alignment" level="1">
+            <BuilderSelect>
+                <BuilderSelectItem classAction="'flex-row align-items-start justify-content-start text-start'">Left</BuilderSelectItem>
+                <BuilderSelectItem classAction="'flex-column align-items-center text-center'">Center</BuilderSelectItem>
+                <BuilderSelectItem classAction="'flex-row-reverse align-items-start justify-content-start text-end'">Right</BuilderSelectItem>
+            </BuilderSelect>
+        </BuilderRow>
+    </BuilderContext>
 
     <BorderConfigurator label.translate="Border"/>
     <ShadowOption/>

--- a/addons/website/static/src/builder/plugins/options/blockquote_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option_plugin.js
@@ -1,20 +1,17 @@
-import { after, ANIMATE, END } from "@html_builder/utils/option_sequence";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
-import { withSequence } from "@html_editor/utils/resource";
+import {
+    BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO,
+    BLOCKQUOTE_PARENT_HANDLERS,
+} from "@html_builder/core/utils";
 import { BaseWebsiteBackgroundOption } from "@website/builder/plugins/options/background_option";
-import { BaseOptionComponent } from "@html_builder/core/utils";
-import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
-import { ShadowOption } from "@html_builder/plugins/shadow_option";
-
-export class BlockquoteOption extends BaseOptionComponent {
-    static template = "website.BlockquoteOption";
-    static selector = ".s_blockquote";
-    static components = { BorderConfigurator, ShadowOption };
-}
+import { BlockquoteOption, BlockquoteWithoutWidthOption } from "./blockquote_option";
+import { withSequence } from "@html_editor/utils/resource";
+import { SNIPPET_SPECIFIC_BEFORE } from "@html_builder/utils/option_sequence";
 
 export class WebsiteBackgroundBlockquoteOption extends BaseWebsiteBackgroundOption {
-    static selector = ".s_blockquote";
+    static selector = BLOCKQUOTE_PARENT_HANDLERS;
+    static applyTo = BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO;
     static defaultProps = {
         withColors: true,
         withImages: true,
@@ -26,10 +23,14 @@ export class WebsiteBackgroundBlockquoteOption extends BaseWebsiteBackgroundOpti
 class BlockquoteOptionPlugin extends Plugin {
     static id = "blockquoteOption";
     resources = {
-        mark_color_level_selector_params: [{ selector: ".s_blockquote" }],
+        mark_color_level_selector_params: [
+            { selector: BlockquoteOption.selector, exclude: BlockquoteOption.exclude },
+            { selector: BLOCKQUOTE_PARENT_HANDLERS, applyTo: BLOCKQUOTE_DISABLE_WIDTH_APPLY_TO },
+        ],
         builder_options: [
-            withSequence(after(ANIMATE), WebsiteBackgroundBlockquoteOption),
-            withSequence(END, BlockquoteOption),
+            withSequence(SNIPPET_SPECIFIC_BEFORE, WebsiteBackgroundBlockquoteOption),
+            BlockquoteOption,
+            BlockquoteWithoutWidthOption,
         ],
     };
 }

--- a/addons/website/static/src/builder/plugins/options/border_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/border_option_plugin.js
@@ -1,16 +1,16 @@
 import { CARD_PARENT_HANDLERS } from "@website/builder/plugins/options/utils";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
+import { BaseOptionComponent, BLOCKQUOTE_PARENT_HANDLERS } from "@html_builder/core/utils";
 import { withSequence } from "@html_editor/utils/resource";
 import { BOX_BORDER_SHADOW } from "@website/builder/option_sequence";
-import { BaseOptionComponent } from "@html_builder/core/utils";
 import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
 import { ShadowOption } from "@html_builder/plugins/shadow_option";
 
 export class BorderOption extends BaseOptionComponent {
     static template = "website.BorderOption";
     static selector = "section .row > div, section:has(.s_carousel_cards)";
-    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_text_cover .row > .o_not_editable, ${CARD_PARENT_HANDLERS}`;
+    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_image_gallery .row > div, .s_masonry_block .s_col_no_resize, .s_text_cover .row > .o_not_editable, ${CARD_PARENT_HANDLERS}, ${BLOCKQUOTE_PARENT_HANDLERS}`;
     static components = {
         BorderConfigurator,
         ShadowOption,

--- a/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/website_background_option_plugin.js
@@ -2,6 +2,7 @@ import { BaseWebsiteBackgroundOption } from "@website/builder/plugins/options/ba
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
 import { CARD_PARENT_HANDLERS, BASE_ONLY_BG_IMAGE_SELECTOR } from "./utils";
+import { BLOCKQUOTE_PARENT_HANDLERS } from "@html_builder/core/utils";
 import { withSequence } from "@html_editor/utils/resource";
 import { SNIPPET_SPECIFIC_BEFORE } from "@html_builder/utils/option_sequence";
 import { WEBSITE_BACKGROUND_OPTIONS } from "@website/builder/option_sequence";
@@ -33,7 +34,7 @@ export class WebsiteBackgroundBGColorImageOption extends BaseWebsiteBackgroundOp
 export class WebsiteBackgroundBGColorOption extends BaseWebsiteBackgroundOption {
     static selector =
         "section .row > div, .s_text_highlight, .s_mega_menu_thumbnails_footer, .s_hr, .s_cta_badge";
-    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div`;
+    static exclude = `.s_col_no_bgcolor, .s_col_no_bgcolor.row > div, .s_masonry_block .row > div, .s_color_blocks_2 .row > div, .s_image_gallery .row > div, .s_text_cover .row > .o_not_editable, [data-snippet] :not(.oe_structure) > .s_hr, ${CARD_PARENT_HANDLERS}, .s_website_form_cover .row > .o_not_editable, .s_bento_grid .row > div, .s_banner_categories .row > div, ${BLOCKQUOTE_PARENT_HANDLERS}`;
     static defaultProps = {
         withColors: true,
         withImages: false,


### PR DESCRIPTION
This PR restores the ability to bind the `s_blockquote` options to the parent handlers instead of the `s_blockquote` snippet itself, allowing us to achieve more interesting layout and provide more flexibility.

This feature was previously implemented in Commit[^1], which was reverted with the merge of Commit[^2] since it did not take the change made to the `s_blockquote` into account.

[^1]: https://github.com/odoo/odoo/commit/b3083dad6cb641901afb36c1b0cc892d9f17589a
[^2]: https://github.com/odoo/odoo/pull/187419/commits/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
