### PR TITLE
[FIX] stock: prevent redirect from stock to account on refresh

### DIFF
--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -626,6 +626,13 @@
             <field name="search_view_id" ref="stock_product_search_form_view"/>
         </record>
 
+        <record id="product_category_action_form_stock" model="ir.actions.act_window">
+            <field name="name">Categories</field>
+            <field name="res_model">product.category</field>
+            <field name="search_view_id" ref="product.product_category_search_view"/>
+            <field name="view_id" ref="product.product_category_list_view"/>
+        </record>
+
         <menuitem id="menu_product_variant_config_stock" name="Products" action="product_template_action_product"
             parent="stock.menu_stock_inventory_control" sequence="1"/>
         <menuitem id="product_product_menu" name="Product Variants" action="stock_product_normal_action"
@@ -633,6 +640,8 @@
         <menuitem id="menu_product_packagings" name="Product Packagings" parent="stock.menu_product_in_config_stock" action="product.action_packaging_view" groups="product.group_stock_packaging"/>
         <menuitem id="menu_product_stock" name="Stock" action="stock.action_product_stock_view"
         parent="stock.menu_warehouse_report" sequence="5"/>
+        <menuitem id="menu_product_category_config_stock" action="product_category_action_form_stock"
+            parent="stock.menu_product_in_config_stock" sequence="2"/>
 
     </data>
 </odoo>

--- a/addons/stock/views/stock_menu_views.xml
+++ b/addons/stock/views/stock_menu_views.xml
@@ -23,9 +23,6 @@
         sequence="5" groups="uom.group_uom"/>
 
     <menuitem
-        action="product.product_category_action_form" id="menu_product_category_config_stock"
-        parent="stock.menu_product_in_config_stock" sequence="2"/>
-    <menuitem
         action="product.attribute_action" id="menu_attribute_action"
         parent="stock.menu_product_in_config_stock" sequence="4" groups="product.group_product_variant"/>
 


### PR DESCRIPTION
Issue before this commit:
Refreshing the 'Product Categories' view from the Inventory > Configuration menu caused an unintended redirect to the Accounting module, if installed.

Steps to reproduce:
1. Install both the Stock and Account modules.
2. Navigate to Inventory > Configuration > Product Categories.
3. Refresh the browser tab. -> The page gets redirected to the Accounting module.

After this commit:
The 'Product Categories' view opened from the Inventory menu will remain in the stock module, even after refresh, preventing any unintended module switching.

Defined a stock-specific act_window for Product Categories to prevent fallback to the accounting action.
