### PR TITLE
[PERF] test_lint: skip visited docstrings

### DIFF
--- a/odoo/addons/test_lint/tests/test_docstring.py
+++ b/odoo/addons/test_lint/tests/test_docstring.py
@@ -185,7 +185,7 @@ class TestDocstring(BaseCase):
                     continue
                 if method_name in seen_methods:
                     continue
-                seen_methods.add((model_name, method_name))
+                seen_methods.add(method_name)
 
                 # We don't care of the docstring in overrides, find the
                 # class that introduced the method.


### PR DESCRIPTION
**[PERF] test_lint: compute docutils settings once**

Using `setting_override` makes docutils parse the override at every call
using its extensible argparse machinery. Changes the code to produce the
settings only once, to skip the argparse machinery.

Running the linter with crm and stock installed went fror taking 90s to
taking 60s.

---

**[PERF] test_lint: skip visited docstrings**

The methods coming with BaseModel don't have any model attached, this
made the linter re-lint every single BaseModel's method's docstring on
every model.

Running the linter with crm and stock installed went from taking 60s to
taking 3s.

