### PR TITLE
[FIX] mrp: prevent error when clicking on Prepare MO

### DIFF
--- a/addons/mrp/tests/test_smp.py
+++ b/addons/mrp/tests/test_smp.py
@@ -351,3 +351,14 @@ class TestMrpSerialMassProduce(TestMrpCommon):
         mo.action_assign()
         action = mo.action_mass_produce()
         self.assertEqual(action, None)
+
+    def test_mass_produce_without_component_separator(self):
+        mo = self.generate_mo(tracking_final='serial', tracking_base_1='serial', qty_final=3, qty_base_1=1, qty_base_2=1)[0]
+        mo.action_confirm()
+        action = mo.button_mark_done()
+        with self.debug_mode():
+            wizard = Form(self.env['mrp.batch.produce'].with_context(**action['context']))
+        wizard.component_separator = False
+        self.assertEqual(wizard.production_text_help, 'Write one line per finished product to produce, with serial numbers as follows:\nYoung TomBotox')
+        wizard.component_separator = ','
+        self.assertEqual(wizard.production_text_help, 'Write one line per finished product to produce, with serial numbers as follows:\nYoung Tom,Botox')

--- a/addons/mrp/wizard/mrp_batch_produce.py
+++ b/addons/mrp/wizard/mrp_batch_produce.py
@@ -49,7 +49,7 @@ class MrpBatchProduct(models.TransientModel):
             for move_raw in wizard.production_id.move_raw_ids:
                 if move_raw.product_id.tracking == "none":
                     continue
-                text += wizard.component_separator + move_raw.product_id.display_name
+                text += (wizard.component_separator or '') + move_raw.product_id.display_name
             wizard.production_text_help = text
 
     def action_prepare(self):


### PR DESCRIPTION
When user unsets the Component separator in Batch Production of serial number,
A traceback will appear.

Steps to reproduce the error:
- Create two Product A and B
    - Tracked by Unique Serial Number
- Create a MO > Product: Product A > Quantity: 2
- Components > Product: Product B > To Consume: 2
- Confirm > Produce All
- Unset Component separator > Prepare MO

Traceback:
```
File "/home/odoo/src/odoo/addons/mrp/wizard/mrp_batch_produce.py", line 52, in _compute_production_text_help
    text += wizard.component_separator + move_raw.product_id.display_name
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```

https://github.com/odoo/odoo/blob/47992d61a1ffa96287099be7dee8f9f244d835d4/addons/mrp/wizard/mrp_batch_produce.py#L52
Here, When ``component_separator`` is False.
It will lead to the above traceback.

sentry-6625936682

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
