### PR TITLE
[FIX] hr_appraisal : allow managers to create appraisal campaigns for their employees

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -140,10 +140,6 @@ class HrEmployee(models.Model):
     # employee in company
     parent_id = fields.Many2one(tracking=True)
     child_ids = fields.One2many('hr.employee', 'parent_id', string='Direct subordinates')
-    category_ids = fields.Many2many(
-        'hr.employee.category', 'employee_category_rel',
-        'employee_id', 'category_id', groups="hr.group_hr_user",
-        string='Tags')
     # misc
     notes = fields.Text('Notes', groups="hr.group_hr_user")
     color = fields.Integer('Color Index', default=0)

--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -44,6 +44,10 @@ class HrEmployeeBase(models.AbstractModel):
         ("other", "Other")], compute="_compute_work_location_name_type")
     user_id = fields.Many2one('res.users', help="")
     share = fields.Boolean(related='user_id.share')
+    category_ids = fields.Many2many(
+        'hr.employee.category', 'employee_category_rel',
+        'employee_id', 'category_id',
+        string='Tags')
     resource_id = fields.Many2one('resource.resource')
     resource_calendar_id = fields.Many2one('resource.calendar', check_company=True)
     is_flexible = fields.Boolean(compute='_compute_is_flexible', store=True)

--- a/addons/hr/models/hr_employee_category.py
+++ b/addons/hr/models/hr_employee_category.py
@@ -16,7 +16,7 @@ class HrEmployeeCategory(models.Model):
 
     name = fields.Char(string="Tag Name", required=True)
     color = fields.Integer(string='Color Index', default=_get_default_color)
-    employee_ids = fields.Many2many('hr.employee', 'employee_category_rel', 'category_id', 'employee_id', string='Employees')
+    employee_ids = fields.Many2many('hr.employee.base', 'employee_category_rel', 'category_id', 'employee_id', string='Employees')
 
     _name_uniq = models.Constraint(
         'unique (name)',

--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -15,6 +15,7 @@
         <field name="comment">The user will be able to approve document created by employees.</field>
     </record>
 
+
     <record id="group_hr_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="sequence">20</field>

--- a/addons/hr/security/ir.model.access.csv
+++ b/addons/hr/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_hr_employee_category_user,hr.employee.category.user,model_hr_employee_category,group_hr_user,1,1,1,1
+access_hr_employee_category_user,hr.employee.category.user,model_hr_employee_category,group_hr_user,1,1,1,
 access_hr_employee_category_emp,hr.employee.category.emp,model_hr_employee_category,base.group_user,1,0,0,0
 access_hr_employee_user,hr.employee user,model_hr_employee,group_hr_user,1,1,1,1
 access_hr_employee_system_user,hr.employee system user,model_hr_employee,base.group_system,1,0,0,0

--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -106,6 +106,7 @@
             <field name="model">hr.employee.public</field>
             <field name="arch" type="xml">
                 <list string="Employees" sample="1" expand="context.get('expand', False)">
+                    <field name="avatar_128" widget="image" options="{'size': [24, 24], 'img_class': 'rounded-3'}" width="30" nolabel="1"/>
                     <field name="name"/>
                     <field name="work_phone" class="o_force_ltr"/>
                     <field name="work_email"/>


### PR DESCRIPTION
Currently, employees managers with no access rights are not allowed to create a new appraisal concern for their employees. To grant managers the access to create appraisal campaigns, new customized access rule for employees' managers has been created. Also, both the Kanban and List views have been modified so that only the managers can see the "Launch Campaign" button. Furthermore, some changes have been implemented in the UX for the appraisal campaign wizard, such as removing the mode field and hiding the manager field for non administrator/Officer users, as well as hiding the company,coach,and manager fields from the search employee view.
