### PR TITLE
[FIX] mail: removed seen date

### DIFF
--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -15,7 +15,6 @@
                 <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded o_object_fit_cover" />
             </span>
             <span class="fw-bold" t-esc="member.persona.name"/>
-            <span t-if="member.lastSeenDt" class="ms-auto text-muted small" t-out="member.lastSeenDt"/>
         </div>
     </t>
 


### PR DESCRIPTION
This commit removes the date in the message "Seen by" popup.

task-4630168
