### PR TITLE
[FIX] mail: removed seen date

### DIFF
--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -15,7 +15,6 @@
                 <img t-att-src="member.persona.avatarUrl" class="w-100 h-100 rounded o_object_fit_cover" />
             </span>
             <span class="fw-bold" t-esc="member.persona.name"/>
-            <span t-if="member.lastSeenDt" class="ms-auto text-muted small" t-out="member.lastSeenDt"/>
         </div>
     </t>
 


### PR DESCRIPTION
Before this commit, the “Seen by” tooltip displayed each member’s channel-level `last_seen_dt`, which for older messages could misleadingly be interpreted as “seen today” even if the user hadn’t actually viewed it recently.

Furthermore `last_seen_dt` isn’t kept up to date client-side (and only gets fetched on reload), thus causing more confusion.

This commit removes the date from the “Seen by” popup. Tracking a true per-message “seen at” timestamp for every user would require significantly more complex modeling and will be revisited later if necessary.

task-4630168