### PR TITLE
[FIX] mail: restore missing field titles in user preferences

### DIFF
--- a/addons/calendar/views/res_users_views.xml
+++ b/addons/calendar/views/res_users_views.xml
@@ -18,7 +18,7 @@
             <field name="model">res.users</field>
             <field name="inherit_id" ref="base.view_users_form"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='signature']" position="after">
+                <xpath expr="//group[@name='messaging']|//field[@name='signature']" position="after">
                     <group string="Calendar" name="calendar">
                         <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
                     </group>


### PR DESCRIPTION
**Issue:**
The "Email Signature" field title is missing in the User Preferences tab when calendar is installed.

**Steps to reproduce:**
1. Ensure the Calendar app is installed.
2. Go to Settings > Users.
3. Open any user form and navigate to the Preferences tab.

This patch mirror this commit: https://github.com/odoo/odoo/commit/af701b3e5bd9106c6ccea5b4a59b9e79424b3a26
by targetting the wrapping group instead of the field

opw-4796115