### PR TITLE
[FIX] survey: fix single app query counts

### DIFF
--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -95,7 +95,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page0_q1.id: {'value': ['44.0']},
         }
         post_data = self._format_submission_data(page_0, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=38)
+        r = self._access_submit(survey, answer_token, post_data, query_count=44)  # ! 44 without `website` (single app CI), 37 `survey+website`, 38 "full" runbot
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 
@@ -113,7 +113,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page1_q0.id: {'value': [page1_q0.suggested_answer_ids.ids[0], page1_q0.suggested_answer_ids.ids[1]]},
         }
         post_data = self._format_submission_data(page_1, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=40)
+        r = self._access_submit(survey, answer_token, post_data, query_count=40)  # ! 37 without `website`, 32 `survey+website`, 40 "full" runbot
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 


### PR DESCRIPTION
Two of our query counts were incorrect for survey single app (one causing CI failure) related to queries performed when `website` is not installed.

Follow up of Task 3742599.

See runbot error 112999
