### PR TITLE
[FIX] website_sale: update product info when selecting variant from list

### DIFF
--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -153,6 +153,10 @@ var VariantMixin = {
      * @param {$.Element} $container the container to look into
      */
     getSelectedVariantValues: function ($container) {
+        const combination = $container.find('input.js_product_change:checked').data('combination');
+        if (combination) {
+            return combination;
+        }
         var values = [];
 
         var variantsValuesSelectors = [


### PR DESCRIPTION
Versions
--------
- saas-18.2+

Steps
-----
1. Have a product with two attributes;
2. add a price extra value on one attribute;
3. go to its shop page;
4. open website editor;
5. change Variants display from Options to Products List;
6. save changes;
7. switch between the two variants.

Issue
-----
The price doesn't update after the second change.

Cause
-----
Commit b8d0ab4 removed a `getSelectedVariantValues` override that was meant to handle selector changes when variants are displayed as a list: https://github.com/odoo/odoo/blob/5f0cedd71413f0982d6f8234833a9944b5bebf9c/addons/website_sale/static/src/js/website_sale.js#L85-L98

Solution
--------
Add the logic to handle selector changes in variant lists to the `getSelectedVariantValues` method in the `VariantMixin`.

opw-4794598
