### PR TITLE
[FIX] mail: close tab with call does not jump to other tab

### DIFF
--- a/addons/mail/static/src/discuss/call/common/rtc_service.js
+++ b/addons/mail/static/src/discuss/call/common/rtc_service.js
@@ -41,7 +41,6 @@ function subscribe(target, event, f) {
 }
 
 const SW_MESSAGE_TYPE = {
-    UNEXPECTED_CALL_TERMINATION: "UNEXPECTED_CALL_TERMINATION",
     POST_RTC_LOGS: "POST_RTC_LOGS",
 };
 export const CONNECTION_TYPES = { P2P: "p2p", SERVER: "server" };
@@ -440,10 +439,6 @@ export class Rtc extends Record {
 
         browser.addEventListener("pagehide", () => {
             if (this.state.channel) {
-                browser.navigator.serviceWorker?.controller?.postMessage({
-                    name: SW_MESSAGE_TYPE.UNEXPECTED_CALL_TERMINATION,
-                    channelId: this.state.channel.id,
-                });
                 const data = JSON.stringify({
                     params: { channel_id: this.state.channel.id, session_id: this.selfSession.id },
                 });
@@ -1283,9 +1278,7 @@ export class Rtc extends Record {
             // only register the beforeunload event if there is a call as FireFox will not place
             // the pages with beforeunload listeners in the bfcache.
             subscribe(browser, "beforeunload", (event) => {
-                if (this.store.env.services["multi_tab"].isOnLastTab) {
-                    event.preventDefault();
-                }
+                event.preventDefault();
             })
         );
     }

--- a/addons/mail/static/src/service_worker.js
+++ b/addons/mail/static/src/service_worker.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-restricted-globals */
 
 const MESSAGE_TYPE = {
-    UNEXPECTED_CALL_TERMINATION: "UNEXPECTED_CALL_TERMINATION",
+    UNEXPECTED_CALL_TERMINATION: "UNEXPECTED_CALL_TERMINATION", // deprecated
     POST_RTC_LOGS: "POST_RTC_LOGS",
 };
 const PUSH_NOTIFICATION_TYPE = {
@@ -247,6 +247,7 @@ self.addEventListener("pushsubscriptionchange", async (event) => {
 self.addEventListener("message", async ({ data, source }) => {
     switch (data.name) {
         case MESSAGE_TYPE.UNEXPECTED_CALL_TERMINATION:
+            // deprecated
             openDiscussChannel(data.channelId, { joinCall: true, source });
             break;
         case MESSAGE_TYPE.POST_RTC_LOGS: {

--- a/addons/mail/static/tests/discuss/call/call.test.js
+++ b/addons/mail/static/tests/discuss/call/call.test.js
@@ -131,26 +131,12 @@ test("should disconnect when closing page while in call", async () => {
             asyncStep(`sendBeacon_leave_call:${blobData.params.channel_id}`);
         }
     });
-    patchWithCleanup(navigator, {
-        serviceWorker: {
-            controller: {
-                postMessage(data) {
-                    if (data.name === "UNEXPECTED_CALL_TERMINATION") {
-                        asyncStep(`postMessage:${data.name}:${data.channelId}`);
-                    }
-                },
-            },
-        },
-    });
 
     await click("[title='Start a Call']");
     await contains(".o-discuss-Call");
     // simulate page close
     await manuallyDispatchProgrammaticEvent(window, "pagehide");
-    await waitForSteps([
-        `postMessage:UNEXPECTED_CALL_TERMINATION:${channelId}`,
-        `sendBeacon_leave_call:${channelId}`,
-    ]);
+    await waitForSteps([`sendBeacon_leave_call:${channelId}`]);
 });
 
 test("should display invitations", async () => {


### PR DESCRIPTION
Revert partially https://github.com/odoo/odoo/pull/189428

PR above was a piece of making calls more transparent among browser tabs. One aspect was to enable most call actions in all tabs, while the PR above solved accidental disconnect from closing or refreshing tab making call.

Solution was to jump the call to another tab. While this is good to keep the call ongoing with no friction in action that reloads the page that had originally the call, in practice this jump to another tab can actually make it harder to find the tab that is actually making the call. This is especially bothering because not all call actions are available in other tabs of the call due to browser limitations, e.g. enabling camera and screen sharing.

This commit disabled the feature for call to jump to another tab. Instead, it asks user to confirm the closing or refresh of tab while there's a call, similarly to when there was only 1 tab before this commit.