### PR TITLE
[FIX] membership: writing account.move.line update membership lines

### DIFF
--- a/addons/membership/tests/common.py
+++ b/addons/membership/tests/common.py
@@ -13,6 +13,14 @@ class TestMembershipCommon(AccountTestInvoicingCommon):
         super().setUpClass(chart_template_ref=chart_template_ref)
 
         # Test memberships
+        cls.membership = cls.env['product.product'].create({
+            'membership': True,
+            'membership_date_from': datetime.date.today() + relativedelta(months=-1),
+            'membership_date_to': datetime.date.today() + relativedelta(days=-2),
+            'name': 'Basic Limited',
+            'type': 'service',
+            'list_price': 90.00,
+        })
         cls.membership_1 = cls.env['product.product'].create({
             'membership': True,
             'membership_date_from': datetime.date.today() + relativedelta(days=-2),


### PR DESCRIPTION
Impacted versions:

- 14.0
- 15.0
- 16.0
- 17.0
- 18.0

Steps To reproduce:

* create 2 membership product
* create an invoice for a partner with a membership line for the first product
* you will see membership line exist while invoice is draft
* change product on the invoice to use the other member ship product

Current behavior:

- membership line is not updated: membership product / dates / member_price are those from the initial definition

Expected behavior:

- membership line updated to reflected changed on the draft invoice before it becomes confirmed


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
