### PR TITLE
[IMP] point_of_sale: Add WebRTC peer-to-peer connections for POS systems

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -245,6 +245,13 @@ class PosConfig(models.Model):
             'deleted_record_ids': delete_record_ids,
         }
 
+    def webrtc_signal(self, login_number, data):
+        self.ensure_one()
+        self._notify('WEBRTC_SIGNAL', {
+            'data': data,
+            'login_number': login_number
+        })
+
     @api.model
     def _load_pos_data_domain(self, data):
         return [('id', '=', data['pos.session'][0]['config_id'])]

--- a/addons/point_of_sale/static/src/app/services/webrtc_service.js
+++ b/addons/point_of_sale/static/src/app/services/webrtc_service.js
@@ -1,0 +1,11 @@
+import { registry } from "@web/core/registry";
+import { WebRTCDataChannel } from "@point_of_sale/app/webrtc/webrtc";
+
+export const webRTCDataChannelService = {
+    dependencies: WebRTCDataChannel.serviceDependencies,
+    async start(env, deps) {
+        return new WebRTCDataChannel(env, deps).ready;
+    },
+};
+
+registry.category("services").add("webrtc_data_channel", webRTCDataChannelService);

--- a/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
+++ b/addons/point_of_sale/static/src/app/utils/devices_synchronisation.js
@@ -84,6 +84,11 @@ export default class DevicesSynchronisation {
      * and synchronize the records with other devices.
      */
     async readDataFromServer() {
+        // FIXME - WebRTC testing
+        if (!this.isNoSet) {
+            return false;
+        }
+
         const serverOpenOrders = this.pos.getOpenOrders().filter((o) => typeof o.id === "number");
         const { domain, recordIds } = this.constructOrdersDomain(serverOpenOrders);
         let response = {};

--- a/addons/point_of_sale/static/src/app/utils/enhanced_console.js
+++ b/addons/point_of_sale/static/src/app/utils/enhanced_console.js
@@ -1,0 +1,20 @@
+export default function enhancedConsole(type, tag, message, error = false) {
+    if (odoo.debug !== "assets") {
+        return;
+    }
+
+    const styles = {
+        info: "color: skyblue",
+        warn: "color: orange",
+        error: "color: red",
+        debug: "color: silver",
+        success: "color: lime",
+    };
+
+    if (styles[type] === undefined) {
+        console.info(`%c[ENHANCED_CONSOLE] Invalid type: ${type}`, "color: red; font-weight: bold");
+        return;
+    }
+
+    console.info(`%c[${tag}]`, `font-weight: bold; ${styles[type]}`, message, error);
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc.js
@@ -1,0 +1,435 @@
+import { getOnNotified } from "@point_of_sale/utils";
+import { WebRTCPeer } from "@point_of_sale/app/webrtc/webrtc_peer";
+import { webRTCPeerOffer } from "./webrtc_peer_offer";
+import { webRTCPeerAnswer, webRTCHandlePeerAnswer } from "./webrtc_peer_answer";
+import { webRTCPeerCandidate } from "./webrtc_peer_candidate";
+import enhancedConsole from "../utils/enhanced_console";
+import { identifierToString } from "./webrtc_utils";
+import { debounce } from "@web/core/utils/timing";
+
+/**
+ * Handles WebRTC peer-to-peer connections between users in a
+ * Point ofSale (POS) system.
+ *
+ * This module establishes WebRTC connections between multiple clients
+ * via a central signaling server, using a structured multi-step
+ * initialization process. Each user is uniquely identified by an ID.
+ *
+ * Simplified sequence of communication:
+ * ┌────────────┐            ┌────────┐            ┌────────────┐
+ * │  PoS A     │            │ Server │            │  PoS B     │
+ * └────┬───────┘            └────────┘            └────────────┘
+ *      └──▶──"init" (id=A)───▶──┐
+ *                               └───▶───"init" (id=A)───▶──┐
+ *                               ┌───◀───"offer" (id=B)──◀──┘
+ *      ┌──◀──"offer" (id=B)──◀──┘
+ *      └──▶──"answer" (id=A)─▶──┐
+ *                               └───▶───"answer" (id=A)─▶──┐
+ *                               ┌──◀─"candidate" (id=B)─◀──┘
+ *      ┌─◀─"candidate" (id=B)─◀─┘
+ *      └─▶─"candidate" (id=A)─▶─┐
+ *                               └──▶─"candidate" (id=A)─▶──┐
+ * ┌────────────────────────────────────────────────────────────┐
+ * │      WebRTC connection established: data channel open      │
+ * └────────────────────────────────────────────────────────────┘
+ *
+ * Detailed Steps:
+ * 1. PoS A opens the POS and sends an "init" message to the server
+ *    with its ID.
+ * 2. The server forwards this "init" message to all other connected
+ *    clients (e.g., PoS B).
+ * 3. PoS B receives the "init" and:
+ *    - Creates a new RTCPeerConnection.
+ *    - Creates an SDP offer.
+ *    - Sends an "offer" message to the server with its ID and offer.
+ * 4. The server relays the "offer" to PoS A.
+ * 5. PoS A receives the "offer" and:
+ *    - Creates its own RTCPeerConnection.
+ *    - Sets the offer as the remote description.
+ *    - Creates an SDP answer.
+ *    - Sends an "answer" message to the server with its ID and answer.
+ * 6. The server forwards the "answer" to PoS B.
+ * 7. PoS B sets the answer as the remote description.
+ * 8. PoS B starts gathering ICE candidates and sends them to the
+ *    server.
+ * 9. The server relays ICE candidates from PoS B to PoS A.
+ * 10. PoS A starts gathering its own ICE candidates and sends them
+ *     to the server.
+ * 11. The server relays ICE candidates from PoS A to PoS B.
+ * 12. Both PoS A and PoS B receive and add ICE candidates to their
+ *     peer connections.
+ * 13. Once enough candidates are exchanged and a viable path is found,
+ *     the WebRTC peer-to-peer connection is established.
+ * 14. A WebRTC data channel is now open between PoS A and PoS B.
+ *
+ * We need a STUN and TURN server to ensure that webRTC connections can
+ * be established even when clients are behind NATs or firewalls.
+ * The STUN server helps clients discover their public IP address and
+ * port, while the TURN server relays traffic if a direct peer-to-peer
+ * connection cannot be established.
+ */
+export class WebRTCDataChannel {
+    static serviceDependencies = ["orm", "bus_service"];
+
+    constructor() {
+        this.setup(...arguments).then(() => this);
+    }
+
+    async setup(env, { orm, bus_service }) {
+        this.env = env;
+        this.orm = orm;
+        this.bus = bus_service;
+
+        this.ready = new Promise((r) => (this.markReady = r));
+        this.peers = new Map();
+        this.onMessage = null;
+        this.onPeerChange = null;
+        this.messagesQueue = [];
+        this.debounceSendMessage = debounce(this.sendMessage.bind(this), 1000);
+
+        this.initializeBusListeners();
+        this.startHeartbeat();
+
+        this.markReady(this);
+    }
+
+    get nextPeerIdentifier() {
+        return {
+            config_id: odoo.pos_config_id,
+            device_a: odoo.login_number,
+            device_b: null,
+        };
+    }
+
+    /**
+     * Initializes the WebRTC connection by sending an "init" message
+     * to the server. This message will be receved by other peers
+     * to establish a WebRTC connection.
+     * @returns {Promise<void>}
+     */
+    async init() {
+        try {
+            await this.orm.call("pos.config", "webrtc_signal", [
+                odoo.pos_config_id,
+                odoo.login_number,
+                {
+                    data: { type: "init" },
+                    identifier: this.nextPeerIdentifier,
+                },
+            ]);
+            enhancedConsole("info", "WEBRTC", "Sent init message to signaling server.");
+        } catch {
+            enhancedConsole("error", "WEBRTC", "Failed to reach signaling server.");
+        }
+    }
+
+    /**
+     * Starts a heartbeat that sends a ping message to all connected peers
+     * every second. This helps to keep the connections alive and detect outdated peers.
+     *
+     * The heartbeat will check the state of each peer's send channel and
+     * if the channel is not open or the peer is outdated, it will clean up that peer.
+     * @return {void}
+     */
+    startHeartbeat() {
+        this.heartbeatInterval = setInterval(() => {
+            for (const peer of this.peers.values()) {
+                try {
+                    if (peer.isOutdated) {
+                        this.cleanPeer(peer.id);
+                    }
+                } catch (error) {
+                    enhancedConsole(
+                        "error",
+                        "WEBRTC",
+                        `${peer.id} - Failed to send heartbeat`,
+                        error
+                    );
+                }
+            }
+
+            if (this.peers.size === 0) {
+                this.init();
+            }
+        }, 5000);
+    }
+
+    /**
+     * Exposed method to send a message to all connected peers.
+     * This method iterates over all peers and sends the provided data.
+     *
+     * @param {Object} data - The data to be sent to all peers.
+     * @returns {Promise<void>}
+     */
+    async sendMessage() {
+        const messages = [...this.messagesQueue];
+        this.messagesQueue = [];
+
+        const data = {};
+        const deletion = {};
+        for (const message of messages) {
+            if (message.model && !data[message.model]) {
+                data[message.model] = {};
+                deletion[message.model] = [];
+            }
+
+            if (["update", "create"].includes(message.event)) {
+                data[message.model][message.id] = message.data;
+            }
+
+            if (message.event === "delete" && message.id) {
+                deletion[message.model].push(message.id);
+            }
+        }
+
+        let shouldSend = false;
+        for (const key of Object.keys(data)) {
+            data[key] = Object.values(data[key]);
+
+            if (data[key].length > 0 || deletion[key].length > 0) {
+                shouldSend = true;
+            }
+        }
+
+        if (!shouldSend) {
+            return;
+        }
+
+        for (const peer of this.peers.values()) {
+            peer.sendMessage({ data, deletion });
+        }
+    }
+
+    /**
+     * Creates a new WebRTC peer connection for the given identifier.
+     * If a peer with the same identifier already exists, it will be cleaned up first.
+     *
+     * @param {Object} params - The parameters for creating a new peer.
+     * @param {Object} params.identifier - The identifier for the new peer connection.
+     * @param {boolean} [params.isInitiator=false] - Whether this peer is the initiator of the connection.
+     * @returns {Promise<WebRTCPeer|boolean>} - The newly created peer or false if initialization failed.
+     */
+    async createNewPeer({ identifier, isInitiator = false }) {
+        try {
+            const id = identifierToString(identifier);
+            if (this.peers.has(id)) {
+                this.cleanPeer(id);
+            }
+
+            const peer = new WebRTCPeer({
+                orm: this.orm,
+                identifier: identifier,
+                messageCallback: this.onMessage,
+            });
+            await peer.init({ isInitiator });
+
+            peer.peer.onconnectionstatechange = () => {
+                const state = peer.peer.connectionState;
+                if (["disconnected", "failed", "closed"].includes(state)) {
+                    this.cleanPeer(peer.id);
+                }
+            };
+
+            return peer;
+        } catch {
+            enhancedConsole("error", "WEBRTC", `Failed to initialize first peer connection.`);
+            return false;
+        }
+    }
+
+    /**
+     * Initializes the bus listeners for WebRTC signaling messages.
+     * The Odoo Websocket will be used as a signaling server to exchange
+     * WebRTC signaling messages between peers.
+     */
+    initializeBusListeners() {
+        this.onNotified = getOnNotified(this.bus, odoo.access_token);
+        this.onNotified("WEBRTC_SIGNAL", (message) => {
+            if (odoo.login_number === message.login_number) {
+                return;
+            }
+
+            this.handlePeerSignal(message);
+        });
+    }
+
+    /**
+     * Initializes the first peer connection based on the incoming "init" message.
+     * It will send an offer to the signaling server to establish a WebRTC connection with
+     * other peers.
+     *
+     * @param {Object} message - The message containing the identifier for the new peer.
+     * @param {Object} message.data - The data containing the identifier.
+     * @param {Object} message.data.data - The data containing the type of message (should be "init").
+     * @param {Object} message.data.identifier - The identifier for the new peer connection.
+     * @returns {Promise<void>}
+     */
+    async initializeFirstPeerConnection(message) {
+        const loginNbr = odoo.login_number;
+        const identifier = message.data.identifier;
+
+        identifier.device_b = loginNbr;
+        const newPeer = await this.createNewPeer({ identifier: identifier, isInitiator: true });
+        if (newPeer) {
+            await webRTCPeerOffer({ peer: newPeer, orm: this.orm });
+            this.peers.set(newPeer.id, newPeer);
+        }
+    }
+
+    /**
+     * Handles incoming WebRTC offer messages. The message identifier device_a must
+     * match the current device. That's because the init message contains the current device
+     * identifier, and the offer is sent to all potential peers.
+     *
+     * @param {Object} message - The incoming message containing the offer.
+     * @param {Object} message.data - The data containing the identifier and offer.
+     * @param {Object} message.data.data - WebRTC offer data.
+     * @param {Object} message.data.identifier - The identifier for the peer connection.
+     * @returns {Promise<void>}
+     */
+    async handleOffer(message) {
+        if (message.data.identifier.device_a !== odoo.login_number) {
+            return;
+        }
+
+        const peer = await this.createNewPeer({ identifier: message.data.identifier });
+        if (!peer) {
+            return;
+        }
+
+        this.peers.set(peer.id, peer);
+
+        if (peer) {
+            enhancedConsole("info", "WEBRTC", `${peer.id} - Offer received`);
+            await webRTCPeerAnswer({ orm: this.orm, peer, message });
+
+            if (peer.pendingCandidates && peer.pendingCandidates.length) {
+                for (const candidateMsg of peer.pendingCandidates) {
+                    await webRTCPeerCandidate({ orm: this.orm, peer, message: candidateMsg });
+                }
+                peer.pendingCandidates = [];
+            }
+        } else {
+            enhancedConsole("warn", "WEBRTC", `Failed to create peer for offer`);
+        }
+    }
+
+    /**
+     * Handles incoming WebRTC answer messages. The message identifier device_b must
+     * match the current device. This is because the answer is sent in response to an offer
+     * that was initiated by the current device.
+     *
+     * @param {Object} message - The incoming message containing the answer.
+     * @param {Object} message.data - The data containing the identifier and answer.
+     * @param {Object} message.data.data - WebRTC answer data.
+     * @param {Object} message.data.identifier - The identifier for the peer connection.
+     * @returns {Promise<void>}
+     */
+    async handleAnswer(message) {
+        if (message.data.identifier.device_b !== odoo.login_number) {
+            return;
+        }
+
+        const id = identifierToString(message.data.identifier);
+        const peer = this.peers.get(id);
+
+        if (peer) {
+            enhancedConsole("info", "WEBRTC", `${peer.id} - Answer received`);
+            await webRTCHandlePeerAnswer({ orm: this.orm, peer, message });
+
+            if (peer.pendingCandidates && peer.pendingCandidates.length) {
+                for (const candidateMsg of peer.pendingCandidates) {
+                    await webRTCPeerCandidate({ orm: this.orm, peer, message: candidateMsg });
+                }
+
+                peer.pendingCandidates = [];
+            }
+        } else {
+            enhancedConsole("warn", "WEBRTC", `Failed to create an answer for ${id}`);
+        }
+    }
+
+    /**
+     * Handles incoming WebRTC candidate messages. If the peer connection is already established,
+     * it will add the candidate to the peer connection. If not, it will queue the candidate
+     * until the peer connection is established.
+     *
+     * @param {Object} message - The incoming message containing the candidate.
+     * @param {Object} message.data - The data containing the identifier and candidate.
+     * @param {Object} message.data.data - WebRTC candidate data.
+     * @param {Object} message.data.identifier - The identifier for the peer connection.
+     * @returns {Promise<void>}
+     */
+    async handleCandidate(message) {
+        const id = identifierToString(message.data.identifier);
+        const peer = this.peers.get(id);
+
+        if (peer && peer.peer.remoteDescription && peer.peer.remoteDescription.type) {
+            enhancedConsole("info", "WEBRTC", `${peer.id} - Candidate received`);
+            await webRTCPeerCandidate({ orm: this.orm, peer, message });
+        } else if (peer) {
+            peer.pendingCandidates = peer.pendingCandidates || [];
+            peer.pendingCandidates.push(message);
+            enhancedConsole("warn", "WEBRTC", `${peer.id} - Candidate queued`);
+        } else {
+            enhancedConsole("warn", "WEBRTC", `Failed to handle candidate for ${id}`);
+        }
+    }
+
+    /**
+     * Handles incoming WebRTC signaling messages. Depending on the type of message,
+     * it will call the appropriate handler for offer, answer, or initialization.
+     * @param {Object} message - The incoming message containing the signaling data.
+     * @param {Object} message.data - The data containing the identifier and signaling data.
+     * @param {Object} message.data.data - The signaling data containing the type (offer, answer, init).
+     * @param {Object} message.data.identifier - The identifier for the peer connection.
+     * @returns {Promise<void>}
+     */
+    async handlePeerSignal(message) {
+        switch (message.data.data.type) {
+            case "offer":
+                await this.handleOffer(message);
+                break;
+            case "answer":
+                await this.handleAnswer(message);
+                break;
+            case "init":
+                await this.initializeFirstPeerConnection(message);
+                break;
+        }
+
+        if (message.data.data.candidate) {
+            await this.handleCandidate(message);
+        }
+    }
+
+    /**
+     * Sometimes, a peer connection may become outdated or disconnected.
+     * This function cleans up the peer connection by closing it and removing it
+     * from the peers map.
+     *
+     * @param {string} peerId - The identifier of the peer to clean up.
+     */
+    cleanPeer(peerId) {
+        const peer = this.peers.get(peerId);
+        if (!peer) {
+            return;
+        }
+
+        try {
+            if (peer.peer) {
+                peer.peer.close();
+            }
+        } catch (error) {
+            enhancedConsole(
+                "error",
+                "WEBRTC",
+                `${peer.id} - Failed to close peer connection`,
+                error
+            );
+        }
+
+        enhancedConsole("warn", "WEBRTC", `${peer.id} - Cleaning`);
+        this.peers.delete(peerId);
+    }
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc_peer.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc_peer.js
@@ -1,0 +1,168 @@
+import enhancedConsole from "../utils/enhanced_console";
+import { identifierToString } from "./webrtc_utils";
+
+const { DateTime } = luxon;
+
+const OUTDATED_PEER_STATE = ["disconnected", "failed", "closed"];
+const OUTDATED_PEER_TIMEOUT = 5000;
+const PEER_CONFIGURATION = {
+    iceServers: [
+        { urls: "stun:stun.l.google.com:19302" },
+        { urls: "stun:stun2.l.google.com:19302" },
+        { urls: "stun:stun3.l.google.com:19302" },
+        {
+            urls: ["turn:david-monnom.be:3478"],
+            username: "moda",
+            credential: "D5B3dzef53xrv64bnju3",
+        },
+    ],
+};
+
+/**
+ * WebRTCPeer class manages a WebRTC peer connection.
+ * It handles the creation of the peer, sending and receiving messages,
+ * and managing ICE candidates.
+ */
+export class WebRTCPeer {
+    constructor(...args) {
+        this.setup(...args);
+    }
+
+    setup({ identifier, orm, messageCallback }) {
+        this.identifier = identifier;
+        this.orm = orm;
+        this.messageCallback = messageCallback;
+        this.pendingCandidates = [];
+        this.createUnix = DateTime.now().toMillis();
+        this.peer = null;
+        this.sendChannel = null;
+    }
+
+    get id() {
+        return identifierToString(this.identifier);
+    }
+
+    /**
+     * Check if the peer is outdated based on its connection state or creation time.
+     * A peer is considered outdated if it is in a disconnected, failed, or closed state,
+     * or if it has been created for more than OUTDATED_PEER_TIMEOUT milliseconds without
+     * being connected.
+     * @returns {boolean} True if the peer is outdated, false otherwise.
+     */
+    get isOutdated() {
+        return (
+            (this.peer && OUTDATED_PEER_STATE.includes(this.peer.connectionState)) ||
+            (DateTime.now().toMillis() - this.createUnix > OUTDATED_PEER_TIMEOUT &&
+                this.peer.connectionState !== "connected")
+        );
+    }
+
+    /**
+     * Initialize the WebRTCPeer instance.
+     * This method sets up the peer connection, creates a data channel if the peer is the initiator,
+     * and handles incoming data channels if the peer is not the initiator.
+     * @param {Object} options - Options for initializing the peer.
+     * @param {boolean} options.isInitiator - Whether this peer is the initiator of the connection.
+     * @returns {Promise<void>} A promise that resolves when the peer is initialized.
+     */
+    async init({ isInitiator = false } = {}) {
+        try {
+            this.peer = new RTCPeerConnection(PEER_CONFIGURATION);
+            this.peer.onicecandidate = this.onIceCandidateCallback.bind(this);
+
+            if (isInitiator) {
+                this.sendChannel = this.peer.createDataChannel("sendChannel");
+                this.setupChannelEvents(this.sendChannel);
+
+                try {
+                    this.localOffer = await this.peer.createOffer();
+                    await this.peer.setLocalDescription(this.localOffer);
+                } catch (error) {
+                    enhancedConsole(
+                        "error",
+                        "WEBRTC",
+                        `${this.id} - Failed to create offer: ${error.message}`
+                    );
+                }
+            } else {
+                this.peer.ondatachannel = (event) => {
+                    this.sendChannel = event.channel;
+                    this.setupChannelEvents(this.sendChannel);
+                };
+            }
+
+            enhancedConsole("success", "WEBRTC", `${this.id} - Local peer created`);
+        } catch {
+            enhancedConsole("error", "WEBRTC", `${this.id} - Error creating local peer`);
+        }
+    }
+
+    setupChannelEvents(channel) {
+        channel.onmessage = this.peerChannelOnMessageCallback.bind(this);
+        channel.onopen = this.peerChannelOnOpenCallback.bind(this);
+        channel.onclose = this.peerChannelOnCloseCallback.bind(this);
+    }
+
+    sendMessage(data) {
+        if (this.sendChannel && this.sendChannel.readyState === "open") {
+            this.sendChannel.send(JSON.stringify(data));
+        } else {
+            enhancedConsole("warn", "WEBRTC", `${this.id} - Tried to send but channel not open`);
+        }
+    }
+
+    close() {
+        try {
+            if (this.sendChannel) {
+                this.sendChannel.close();
+            }
+            if (this.peer) {
+                this.peer.close();
+            }
+
+            enhancedConsole("info", "WEBRTC", `${this.id} - Peer closed`);
+        } catch {
+            enhancedConsole("error", "WEBRTC", `${this.id} - Error closing peer`);
+        }
+    }
+
+    async onIceCandidateCallback(event) {
+        if (!event.candidate) {
+            enhancedConsole("warn", "WEBRTC", `${this.id} - Ice candidate empty`);
+            return;
+        }
+
+        try {
+            await this.orm.call("pos.config", "webrtc_signal", [
+                odoo.pos_config_id,
+                odoo.login_number,
+                {
+                    data: event.candidate,
+                    identifier: this.identifier,
+                },
+            ]);
+        } catch {
+            enhancedConsole("error", "WEBRTC", `${this.id} - Error sending ICE candidate`);
+        }
+    }
+
+    peerChannelOnMessageCallback(event) {
+        try {
+            this.messageCallback && this.messageCallback(JSON.parse(event.data));
+        } catch {
+            enhancedConsole("error", "WEBRTC", `${this.id} - Decoding message failed`);
+        }
+    }
+
+    peerChannelOnOpenCallback() {
+        enhancedConsole("success", "WEBRTC", `${this.id} - Data channel opened`);
+    }
+
+    peerChannelOnCloseCallback() {
+        enhancedConsole("warn", "WEBRTC", `${this.id} - Data channel closed`);
+    }
+
+    addCandidateErrorCallback(error) {
+        enhancedConsole("error", "WEBRTC", `${this.id} - Error adding ICE candidate`);
+    }
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_answer.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_answer.js
@@ -1,0 +1,53 @@
+import enhancedConsole from "../utils/enhanced_console";
+
+/**
+ * This function is called when a new ICE candidate is received from the server.
+ * It adds the candidate to the peer connection.
+ *
+ * @param {Object} orm - The ORM instance to call the server.
+ * @param {Object} peer - The WebRTCPeer instance that will handle the candidate.
+ * @param {Object} message - The message containing the offer data.
+ */
+export async function webRTCPeerAnswer({ orm, peer, message }) {
+    try {
+        await peer.peer.setRemoteDescription(message.data.data);
+        const answer = await peer.peer.createAnswer();
+        await peer.peer.setLocalDescription(answer);
+        await orm.call("pos.config", "webrtc_signal", [
+            odoo.pos_config_id,
+            odoo.login_number,
+            {
+                data: answer,
+                identifier: message.data.identifier,
+            },
+        ]);
+        enhancedConsole("info", "WEBRTC", `${peer.id} - Answer sent`);
+    } catch {
+        enhancedConsole(
+            "error",
+            "WEBRTC",
+            `${peer.id} - Error setting remote description or answering`
+        );
+    }
+}
+
+/**
+ * This function is called when a peer receives an answer from another peer.
+ * It sets the remote description for the peer connection.
+ *
+ * @param {Object} peer - The WebRTCPeer instance that will handle the answer.
+ * @param {Object} message - The message containing the answer data.
+ */
+export async function webRTCHandlePeerAnswer({ peer, message }) {
+    try {
+        await peer.peer.setRemoteDescription(message.data.data);
+        enhancedConsole("success", "WEBRTC", `${peer.id} - Answer set`);
+    } catch (error) {
+        enhancedConsole(
+            "error",
+            "WEBRTC",
+            `${peer.id} - Error setting remote description for answer`,
+            error
+        );
+    }
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_candidate.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_candidate.js
@@ -1,0 +1,17 @@
+import enhancedConsole from "../utils/enhanced_console";
+
+/**
+ * This function is called when a new ICE candidate is received from the server.
+ * It adds the candidate to the peer connection.
+ *
+ * @param {Object} peer - The WebRTCPeer instance that will handle the candidate.
+ * @param {Object} message - The message containing the ICE candidate data.
+ */
+export async function webRTCPeerCandidate({ peer, message }) {
+    try {
+        await peer.peer.addIceCandidate(message.data.data);
+        enhancedConsole("success", "WEBRTC", `${peer.id} - Ice candidate added`);
+    } catch {
+        enhancedConsole("red", "WEBRTC", `${peer.id} - Error adding ICE candidate`);
+    }
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_offer.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc_peer_offer.js
@@ -1,0 +1,31 @@
+import enhancedConsole from "../utils/enhanced_console";
+
+/**
+ * This function is called up when the point of sale is initialized to create an offer
+ * WebRTC connection. This offer will be sent to the server to be broadcast
+ * to other peers.
+ *
+ * A peer will be created to generate the offer; this peer may sometimes remain inactive
+ * if the point of sale is not in use. It is therefore important to manage the creation
+ * and destruction of peers.
+ *
+ * @param {Object} orm - The ORM instance to call the server.
+ * @param {Object} peer - The WebRTCPeer instance that will create the offer.
+ */
+export async function webRTCPeerOffer({ orm, peer }) {
+    const offer = peer.localOffer;
+
+    try {
+        await orm.call("pos.config", "webrtc_signal", [
+            odoo.pos_config_id,
+            odoo.login_number,
+            {
+                data: offer,
+                identifier: peer.identifier,
+            },
+        ]);
+        enhancedConsole("info", "WEBRTC", `${peer.id} - Offer sent`);
+    } catch {
+        enhancedConsole("red", "WEBRTC", `${peer.id} - Error sending offer`);
+    }
+}

--- a/addons/point_of_sale/static/src/app/webrtc/webrtc_utils.js
+++ b/addons/point_of_sale/static/src/app/webrtc/webrtc_utils.js
@@ -1,0 +1,14 @@
+export function identifierToString(identifier) {
+    if (identifier.device_b === null) {
+        identifier.device_b = odoo.login_number;
+    }
+
+    const values = Object.values(identifier);
+    const sortedValues = values.sort((a, b) => {
+        const aInt = parseInt(a, 10);
+        const bInt = parseInt(b, 10);
+        return aInt < bInt ? -1 : aInt > bInt ? 1 : 0;
+    });
+
+    return sortedValues.join("-");
+}

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -84,6 +84,11 @@
             "point_of_sale/static/src/app/utils/numbers.js",
             "point_of_sale/static/src/app/hooks/hooks.js",
             "point_of_sale/static/src/app/utils/debug-formatter.js",
+
+            # WebRTC assets
+            "point_of_sale/static/src/app/services/webrtc_service.js",
+            "point_of_sale/static/src/app/utils/enhanced_console.js",
+            "point_of_sale/static/src/app/webrtc/**/*",
         ],
         # Assets tests
         "pos_self_order.assets_tests": [

--- a/addons/pos_self_order/static/src/app/services/data_service.js
+++ b/addons/pos_self_order/static/src/app/services/data_service.js
@@ -44,4 +44,5 @@ patch(PosData.prototype, {
         return recordMap;
     },
     async checkAndDeleteMissingOrders(results) {},
+    async initWebRTCService() {},
 });


### PR DESCRIPTION
Handles WebRTC peer-to-peer connections between users in a Point of Sale
(POS) system.

This commit adds WebRTC connections between multiple clients via a
central signaling server, using a structured multi-step initialization
process. Each user is uniquely identified by an ID.

Detailed Steps:
1. PoS A opens the POS and sends an "init" message to the server
   with its ID.
2. The server forwards this "init" message to all other connected
   clients (e.g., PoS B).
3. PoS B receives the "init" and:
   - Creates a new RTCPeerConnection.
   - Creates an SDP offer.
   - Sends an "offer" message to the server with its ID and offer.
4. The server relays the "offer" to PoS A.
5. PoS A receives the "offer" and:
   - Creates its own RTCPeerConnection.
   - Sets the offer as the remote description.
   - Creates an SDP answer.
   - Sends an "answer" message to the server with its ID and answer.
6. The server forwards the "answer" to PoS B.
7. PoS B sets the answer as the remote description.
8. PoS B starts gathering ICE candidates and sends them to the
   server.
9. The server relays ICE candidates from PoS B to PoS A.
10. PoS A starts gathering its own ICE candidates and sends them
    to the server.
11. The server relays ICE candidates from PoS A to PoS B.
12. Both PoS A and PoS B receive and add ICE candidates to their
    peer connections.
13. Once enough candidates are exchanged and a viable path is found,
    the WebRTC peer-to-peer connection is established.
14. A WebRTC data channel is now open between PoS A and PoS B.

We need a STUN and TURN server to ensure that webRTC connections can
be established even when clients are behind NATs or firewalls.
The STUN server helps clients discover their public IP address and
port, while the TURN server relays traffic if a direct peer-to-peer
connection cannot be established.