### PR TITLE
[FIX] website: adapt redirection logic using skipConfigurator method

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -501,7 +501,6 @@ class Website(models.Model):
     @api.model
     def configurator_init(self):
         r = dict()
-        theme = self.env["ir.module.module"].search([("name", "=", "theme_default")])
         current_website = self.get_current_website()
         company = current_website.company_id
         configurator_features = self.env['website.configurator.feature'].search([])
@@ -517,8 +516,7 @@ class Website(models.Model):
         r['logo'] = False
         if not company.uses_default_logo:
             r['logo'] = company.logo.decode('utf-8')
-        if current_website.configurator_done:
-            r['redirect_url'] = theme.button_choose_theme()
+        r['configurator_done'] = current_website.configurator_done
         try:
             result = self._website_api_rpc('/api/website/1/configurator/industries', {'lang': self.env.context.get('lang')})
             r['industries'] = result['industries']

--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -783,13 +783,7 @@ export class Configurator extends Component {
 
             await store.start(() => this.getInitialState());
             this.updateStorage(store);
-            if (store.redirect_url) {
-                // If redirect_url exists, it means configurator_done is already
-                // true, so we can skip the configurator flow.
-                this.clearStorage();
-                await this.action.doAction(store.redirect_url);
-            }
-            if (!store.industries) {
+            if (!store.industries || store.configurator_done) {
                 await this.skipConfigurator();
             }
         });
@@ -860,7 +854,7 @@ export class Configurator extends Component {
         const r = {
             industries: results.industries,
             logo: results.logo ? 'data:image/png;base64,' + results.logo : false,
-            redirect_url: results.redirect_url,
+            configurator_done: results.configurator_done,
         };
         r.industries = r.industries.map((industry, index) => ({
             ...industry,


### PR DESCRIPTION
**Purpose:**
The Forward-port for [PR](https://github.com/odoo/odoo/pull/197593) is already merged into master, so this PR aims to adapt the redirection logic using the skipConfigurator method. In that PR, users were redirected to the home screen if configurator_done was True, and redirection was handled using doAction(redirect_url), where redirect_url was a dictionary containing the next action, fetched from the button_choose_theme method.

We didn't use the skipConfigurator method earlier because, in stable branches, skipConfigurator method incorrectly redirect to the theme selection page instead of the home screen. This issue is now fixed in the master branch, so we can use the skipConfigurator method in master.

**Key Changes:**
If current_website.configurator_done is True, we now simply call skipConfigurator.

This PR aims to adapt the redirection logic in master and utilize the skipConfigurator method.

task-4555467