### PR TITLE
[IMP] account, accountant: rework of To Check

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -110,7 +110,6 @@ class AccountJournal(models.Model):
         Select 'Cash', 'Bank' or 'Credit Card' for journals that are used in customer or vendor payments.
         Select 'General' for miscellaneous operations journals.
         """)
-    autocheck_on_post = fields.Boolean(string="Auto-Check on Post", default=True)
     default_account_type = fields.Char(string='Default Account Type', compute="_compute_default_account_type")
     default_account_id = fields.Many2one(
         comodel_name='account.account', check_company=True, copy=False, ondelete='restrict',

--- a/addons/account/static/src/components/char_with_placeholder_field_to_check/char_with_placeholder_field.xml
+++ b/addons/account/static/src/components/char_with_placeholder_field_to_check/char_with_placeholder_field.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="account.CharWithPlaceholderFieldToCheck" t-inherit="account.CharWithPlaceholderField" t-inherit-mode="extension">
+        <xpath expr="//span" position="after">
+            <span t-if="props.record.data.checked === false and props.record.data.state === 'posted'"
+                  groups="account.group_account_user"
+                  class="badge rounded-pill text-bg-info mx-2 d-inline-flex">
+                To review
+            </span>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/account/static/src/components/char_with_placeholder_field_to_check/char_with_placeholder_field_to_check_to_check.js
+++ b/addons/account/static/src/components/char_with_placeholder_field_to_check/char_with_placeholder_field_to_check_to_check.js
@@ -1,0 +1,16 @@
+import { registry } from "@web/core/registry";
+import {
+    charWithPlaceholderField,
+    CharWithPlaceholderField
+} from "../char_with_placeholder_field/char_with_placeholder_field";
+
+export class CharWithPlaceholderFieldToCheck extends CharWithPlaceholderField {
+    static template = "account.CharWithPlaceholderField";
+}
+
+export const charWithPlaceholderFieldToCheck = {
+    ...charWithPlaceholderField,
+    component: CharWithPlaceholderFieldToCheck,
+};
+
+registry.category("fields").add("char_with_placeholder_field_to_check", charWithPlaceholderFieldToCheck);

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -11,6 +11,7 @@ from . import test_account_inalterable_hash
 from . import test_account_journal
 from . import test_account_account
 from . import test_account_tax
+from . import test_account_to_check
 from . import test_account_analytic
 from . import test_account_payment
 from . import test_account_payment_method_line

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -587,6 +587,24 @@ class AccountTestInvoicingCommon(ProductCommon):
 
         return line
 
+    def _create_invoice(self, **invoice_args):
+        return self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner.id,
+            'invoice_date': '2024-10-10',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'quantity': 10,
+                }),
+                Command.create({
+                    'product_id': self.product_b.id,
+                    'quantity': 5,
+                }),
+            ],
+            **invoice_args,
+        })
+
     def assertInvoiceValues(self, move, expected_lines_values, expected_move_values):
         def sort_lines(lines):
             return lines.sorted(lambda line: (line.sequence, not bool(line.tax_line_id), line.name or line.product_id.display_name or '', line.balance))

--- a/addons/account/tests/test_account_to_check.py
+++ b/addons/account/tests/test_account_to_check.py
@@ -1,0 +1,81 @@
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged('post_install', '-at_install')
+class TestCheckAccountMoves(AccountTestInvoicingCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.simple_accountman.group_ids = cls.env.ref('account.group_account_invoice')
+        cls.bank_journal = cls.env['account.journal'].search([('type', '=', 'bank'), ('company_id', '=', cls.company.id)], limit=1)
+
+    def test_try_check_move_with_invoicing_user(self):
+        if 'accountant' not in self.env["ir.module.module"]._installed():
+            self.skipTest('accountant is not installed')
+        invoice = self._create_invoice(checked=True)
+        invoice.action_post()
+        with self.assertRaisesRegex(ValidationError, 'Validated entries can only be changed by your accountant.'):
+            invoice.with_user(self.simple_accountman).button_draft()
+
+        invoice.button_draft()
+        self.assertEqual(invoice.state, 'draft')
+
+        invoice.action_post()
+        invoice.checked = False
+        invoice.with_user(self.simple_accountman).button_draft()
+        self.assertEqual(invoice.state, 'draft')
+
+    def test_post_move_auto_check(self):
+        if 'accountant' not in self.env["ir.module.module"]._installed():
+            self.skipTest('accountant is not installed')
+        invoice_admin = self._create_invoice()
+        invoice_admin.action_post()
+        # As the user has admin right, the move should be auto checked
+        self.assertTrue(invoice_admin.checked)
+
+        invoice_invoicing = self._create_invoice(user_id=self.simple_accountman.id)
+        invoice_invoicing.with_user(self.simple_accountman).action_post()
+        # As the user has only invoicing right, the move shouldn't be checked
+        self.assertFalse(invoice_invoicing.checked)
+
+    def test_post_move_auto_check_with_auto_post(self):
+        if 'accountant' not in self.env["ir.module.module"]._installed():
+            self.skipTest('accountant is not installed')
+        invoice = self._create_invoice(auto_post='at_date', date=fields.Date.today())
+        self.assertFalse(invoice.checked)
+        with freeze_time(invoice.date + relativedelta(days=1)), self.enter_registry_test_mode():
+            self.env.ref('account.ir_cron_auto_post_draft_entry').method_direct_trigger()
+        self.assertTrue(invoice.checked)
+
+    def test_create_statement_line_auto_check(self):
+        """Test if a user changes the reconciliation on a st_line, it marks the bank move as 'To Review'"""
+        if 'accountant' not in self.env["ir.module.module"]._installed():
+            self.skipTest('accountant is not installed')
+        payment = self.env['account.payment'].create({
+            'payment_type': 'inbound',
+            'payment_method_id': self.env.ref('account.account_payment_method_manual_in').id,
+            'partner_type': 'customer',
+            'amount': 100,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'memo': 'INV/2025/00001',
+        })
+        payment.action_post()
+
+        bank_line_1 = self.env['account.bank.statement.line'].create([{
+            'journal_id': self.bank_journal.id,
+            'date': '2025-01-01',
+            'payment_ref': "INV/2025/00001",
+            'amount': -100,
+        }])
+        bank_line_1._try_auto_reconcile_statement_lines()
+        self.assertTrue(bank_line_1.move_id.checked)
+        with self.assertRaisesRegex(ValidationError, 'Validated entries can only be changed by your accountant.'):
+            bank_line_1.with_user(self.simple_accountman).delete_reconciled_line(payment.move_id.line_ids[0].id)

--- a/addons/account/tests/test_audit_trail.py
+++ b/addons/account/tests/test_audit_trail.py
@@ -86,11 +86,12 @@ class TestAuditTrail(AccountTestInvoicingCommon):
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.action_post()
-        messages.append("Updated\nFalse ⇨ True (Checked)\nFalse ⇨ MISC/2021/04/0001 (Number)\nDraft ⇨ Posted (Status)")
+        messages.append("Updated\nFalse ⇨ True (Reviewed)\nFalse ⇨ MISC/2021/04/0001 (Number)\nDraft ⇨ Posted (Status)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.button_draft()
-        messages.append("Updated\nPosted ⇨ Draft (Status)")
+        messages.append("Updated\nTrue ⇨ False (Reviewed)\nPosted ⇨ Draft (Status)")
+        messages.append("Updated\nTrue ⇨ False (Reviewed)")
         self.assertTrail(self.get_trail(self.move), messages)
 
         self.move.name = "nawak"

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -222,9 +222,9 @@
                         </div>
                         <div id="dashboard_general_right" class="col-auto">
                             <t t-if="dashboard.number_to_check > 0">
-                                <div class="row">
+                                <div class="row" groups="account.group_account_user">
                                     <div class="col overflow-hidden text-start">
-                                        <a type="object" name="open_action" context="{'action_name': 'action_move_journal_line', 'search_default_to_check': True}"><t t-out="dashboard.number_to_check"/> To Check</a>
+                                        <a type="object" name="open_action" context="{'action_name': 'action_move_journal_line', 'search_default_to_check': True}"><t t-out="dashboard.number_to_check"/> To Review</a>
                                     </div>
                                     <div class="col-auto text-end">
                                         <span dir="ltr"><t t-out="dashboard.to_check_balance"/></span>
@@ -361,9 +361,9 @@
                                 </div>
                             </div>
                             <t t-if="dashboard.number_to_check > 0">
-                                <div class="row">
+                                <div class="row" groups="account.group_account_user">
                                     <div class="col overflow-hidden text-start">
-                                        <a type="object" name="open_action" context="{'search_default_to_check': True}"><t t-out="dashboard.number_to_check"/> To Check</a>
+                                        <a type="object" name="open_action" context="{'search_default_to_check': True}"><t t-out="dashboard.number_to_check"/> To Review</a>
                                     </div>
                                     <div class="col-auto text-end">
                                         <span dir="ltr"><t t-out="dashboard.to_check_balance"/></span>

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -15,7 +15,6 @@
                     <field name="currency_id" groups="base.group_multi_currency" optional="hide"/>
                     <field name="code" optional="show"/>
                     <field name="default_account_id" optional="show"/>
-                    <field name="autocheck_on_post" optional="hide"/>
                     <field name="active" optional="hide"/>
                     <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                     <field name="company_id" groups="!base.group_multi_company" column_invisible="True"/>
@@ -159,7 +158,6 @@
                                     <group string="Automation" groups="account.group_account_manager">
                                         <field name="restrict_mode_hash_table" groups="account.group_account_readonly" invisible="type not in ['sale', 'purchase', 'general']"
                                         />
-                                        <field name="autocheck_on_post"/>
                                     </group>
                                     <group string="Emails" name="group_email_alias"
                                            invisible="type not in ('general', 'sale', 'purchase')">

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -332,7 +332,7 @@
                     <filter name="not_secured" string="Not Secured" domain="[('move_id.secured', '=', False), ('move_id.state', '=', 'posted')]"
                             groups="account.group_account_secured,base.group_no_one"/>
                     <separator/>
-                    <filter string="To check" name="to_check" domain="[('move_id.checked', '=', False), ('parent_state', '!=', 'draft')]"/>
+                    <filter string="To Review" name="to_check" domain="[('move_id.checked', '=', False), ('parent_state', '!=', 'draft')]"/>
                     <separator/>
                     <filter string="Unreconciled"
                             domain="[('balance', '!=', 0), ('account_id.reconcile', '=', True), '|', ('matching_number', '=', False), ('matching_number', '=like', 'P%')]"
@@ -475,7 +475,8 @@
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="invoice_date" string="Invoice Date" optional="hide" readonly="state != 'draft'"/>
                     <field name="date" readonly="state in ['cancel', 'posted']"/>
-                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
+                    <field name="name" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field_to_check" placeholder="/"/>
+                    <field name="checked" column_invisible="True" groups="account.group_account_user"/> <!-- To be used for Reviewed badge display, see char_with_placeholder_field_to_check -->
                     <field name="partner_id" optional="show" readonly="state != 'draft'"/>
                     <field name="ref" optional="show"/>
                     <field name="journal_id"/>
@@ -483,7 +484,6 @@
                     <field name="amount_total_signed" sum="Total Amount" string="Total" decoration-bf="1"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-success="state == 'posted'"/>
                     <field name="currency_id" column_invisible="True" readonly="state in ['cancel', 'posted']"/>
-                    <field name="checked" optional="hide" widget="boolean_toggle"/>
                     <field name="activity_ids" widget="list_activity" optional="hide"/>
                 </list>
             </field>
@@ -518,7 +518,8 @@
                     </header>
                     <field name="made_sequence_gap" column_invisible="True"/>
                     <field name="duplicated_ref_ids" column_invisible="True"/>  <!-- Needed for custome view account_tree-->
-                    <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field" placeholder="/"/>
+                    <field name="name" decoration-bf="1" decoration-danger="made_sequence_gap and state == 'posted'" widget="char_with_placeholder_field_to_check" placeholder="/"/>
+                    <field name="checked" column_invisible="True" groups="account.group_account_user"/> <!-- To be used for Reviewed badge display, see char_with_placeholder_field_to_check -->
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" groups="base.group_user" string="Vendor" />
                     <field name="invoice_partner_display_name" column_invisible="context.get('default_move_type') not in ('out_invoice', 'out_refund', 'out_receipt')" groups="base.group_user" string="Customer" />
                     <field name="invoice_date" optional="show" column_invisible="context.get('default_move_type') not in ('in_invoice', 'in_refund', 'in_receipt')" readonly="state != 'draft'" string="Bill Date" decoration-warning="abnormal_date_warning"/>
@@ -539,7 +540,6 @@
                     <field name="amount_residual_signed" string="Amount Due" sum="Amount Due" optional="hide"/>
                     <field name="currency_id" optional="hide" readonly="state in ['cancel', 'posted']"/>
                     <field name="company_currency_id" column_invisible="True"/>
-                    <field name="checked" optional="hide" widget="boolean_toggle"/>
                     <field name="status_in_payment"
                            string="Status"
                            widget="badge"
@@ -659,11 +659,17 @@
             <field name="arch" type="xml">
                 <kanban class="o_kanban_mobile" sample="1" js_class="account_documents_kanban">
                     <field name="currency_id"/>
+                    <field name="checked"/>
                     <templates>
                         <t t-name="card">
                             <div class="d-flex align-items-baseline mb-2">
                                 <field name="partner_id" class="fw-bolder fs-5 me-2" invisible="not partner_id" readonly="state != 'draft'"/>
                                 <field name="journal_id" class="fw-bolder fs-5 me-2" invisible="partner_id"/>
+                                <div invisible="checked or state != 'posted'" groups="account.group_account_user">
+                                    <span class="badge text-bg-info">
+                                        To Review
+                                    </span>
+                                </div>
                                 <field name="amount_total_in_currency_signed" widget="monetary" class="fw-bolder ms-auto flex-shrink-0"/>
                             </div>
                             <footer class="align-items-end">
@@ -768,10 +774,14 @@
                                 groups="account.group_account_invoice"
                                 invisible="state != 'posted' or show_reset_to_draft_button or not need_cancel_request"
                                 data-hotkey="w"/>
+                        <!-- Review button -->
+                        <button name="button_set_checked"
+                                class="btn btn-info"
+                                type="object"
+                                string="Reviewed"
+                                invisible="state != 'posted' or checked"
+                                groups="account.group_account_user"/>
 
-                        <!-- Set as Checked -->
-                        <button name="button_set_checked" string="Set as Checked" type="object" groups="account.group_account_invoice"
-                                invisible="checked or state == 'draft'" data-hotkey="k" />
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"
                                groups="!account.group_account_secured"/>
                         <field name="state" widget="account_move_statusbar_secured" statusbar_visible="draft,posted"
@@ -1489,7 +1499,6 @@
                                         <field name="auto_post_until"
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
-                                        <field name="checked"/>
                                     </group>
                                 </group>
                             </page>
@@ -1505,8 +1514,6 @@
                                         <field name="auto_post_until"
                                                invisible="auto_post in ('no', 'at_date')"
                                                readonly="state != 'draft'"/>
-                                        <field name="checked"
-                                               invisible="move_type != 'entry'" />
                                     </group>
                                     <group>
                                         <field name="fiscal_position_id" readonly="state in ['cancel', 'posted']"/>
@@ -1571,8 +1578,6 @@
                             groups="account.group_account_secured,base.group_no_one"/>
                     <separator/>
                     <filter string="Reversed" name="reversed" domain="[('payment_state', '=', 'reversed')]"/>
-                    <separator/>
-                    <filter string="To Check" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
                     <filter string="Sales" name="sales" domain="[('journal_id.type', '=', 'sale')]" context="{'default_journal_type': 'sale'}"/>
                     <filter string="Purchases" name="purchases" domain="[('journal_id.type', '=', 'purchase')]" context="{'default_journal_type': 'purchase'}"/>
@@ -1653,7 +1658,7 @@
                             domain="[('move_type', '=', 'out_refund')]"
                     />
                     <separator/>
-                    <filter string="To Check" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
+                    <filter string="To Review" name="to_check" domain="[('checked', '=', False), ('state', '!=', 'draft')]"/>
                     <separator/>
                     <!-- not_paid & partial -->
                     <filter name="open" string="To pay" domain="[('state', '=', 'posted'), ('payment_state', 'in', ('not_paid', 'partial'))]"/>
@@ -2080,6 +2085,16 @@ if records:
             <field name="code">
                 action = env.company._action_check_hash_integrity()
             </field>
+        </record>
+
+        <record id="accountant_confirm_entries_action" model="ir.actions.server">
+            <field name="name">Review Entries</field>
+            <field name="model_id" ref="account.model_account_move"/>
+            <field name="binding_model_id" ref="account.model_account_move"/>
+            <field name="binding_view_types">list,kanban</field>
+            <field name="group_ids" eval="[Command.set([ref('account.group_account_user')])]"/>
+            <field name="state">code</field>
+            <field name="code">action = model.check_selected_moves()</field>
         </record>
 
         <!-- ============= LEGACY (kept to not break the previous action with their path ================-->

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -51,7 +51,7 @@
             <xpath expr="//search/group/filter[@name='status']" position="after">
                 <filter string="Peppol status" name="peppol_move_state" context="{'group_by': 'peppol_move_state'}"/>
             </xpath>
-            <xpath expr="//filter[@name='to_check']" position='after'>
+            <xpath expr="//filter[@name='out_refund']" position='after'>
                 <separator/>
                 <filter name="peppol_ready"
                         string="Peppol Ready"

--- a/addons/l10n_gr_edi/views/account_move_views.xml
+++ b/addons/l10n_gr_edi/views/account_move_views.xml
@@ -147,7 +147,7 @@
             <xpath expr="//search/field[@name='journal_id']" position="after">
                 <field name="l10n_gr_edi_state"/>
             </xpath>
-            <xpath expr="//filter[@name='to_check']" position="after">
+            <xpath expr="//filter[@name='out_refund']" position="after">
                 <filter string="To send to MyDATA" name="l10n_gr_edi_state_false"
                         domain="[('l10n_gr_edi_state', 'in', (False, 'bill_fetched'))]"/>
                 <filter string="Sent to MyDATA" name="l10n_gr_edi_state_sent"

--- a/addons/l10n_in_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_ewaybill/views/account_move_views.xml
@@ -5,7 +5,7 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='button_set_checked']" position="after">
+            <xpath expr="//button[@name='button_request_cancel']" position="after">
                 <button name="action_l10n_in_ewaybill_create" 
                         string="Create e-Waybill"
                         class="oe_highlight"

--- a/addons/l10n_it_edi_doi/views/account_move_views.xml
+++ b/addons/l10n_it_edi_doi/views/account_move_views.xml
@@ -9,7 +9,7 @@
             <xpath expr="//search/field[@name='journal_id']" position="after">
                 <field name="l10n_it_edi_doi_id"/>
             </xpath>
-            <xpath expr="//filter[@name='to_check']" position="after">
+            <xpath expr="//filter[@name='out_refund']" position="after">
                 <filter string="Exceeded Declaration of Intent"
                         name="l10n_it_edi_doi_declaration_of_intent_exceeded"
                         domain="[('l10n_it_edi_doi_id.remaining','&lt;', 0)]"/>

--- a/addons/l10n_ro_edi/views/account_move_views.xml
+++ b/addons/l10n_ro_edi/views/account_move_views.xml
@@ -88,7 +88,7 @@
             <xpath expr="//search/field[@name='journal_id']" position="after">
                 <field name="l10n_ro_edi_state"/>
             </xpath>
-            <xpath expr="//filter[@name='to_check']" position="after">
+            <xpath expr="//filter[@name='out_refund']" position="after">
                 <filter string="Sent E-Factura" name="l10n_ro_edi_state_invoice_sent"
                         domain="[('l10n_ro_edi_state', 'in', ['invoice_not_indexed', 'invoice_sent'])]"/>
                 <filter string="Refused E-Factura" name="l10n_ro_edi_state_invoice_refused"


### PR DESCRIPTION
The To Check feature should only be used by the accountants. A random user who only use accounting to create bills and invoices shouldn't be allowed to review and mark a move as checked.

This is why now we only show the feature to accountant (Bookkeeper and Accounting admins) and raise an error if a user without the good rights try to change the checked field.

Linked: https://github.com/odoo/enterprise/pull/86386
Linked: https://github.com/odoo/upgrade/pull/7740

task-4807991