### PR TITLE
[IMP] website_sale: adapt and re-enable tours

### DIFF
--- a/addons/website_sale/static/src/js/tours/website_sale_shop.js
+++ b/addons/website_sale/static/src/js/tours/website_sale_shop.js
@@ -15,12 +15,12 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     trigger: ":iframe .js_sale",
 },
 {
-    trigger: ".o_menu_systray .o_new_content_container > a",
+    trigger: ".o_menu_systray .o_new_content_container > button",
     content: _t("Let's create your first product."),
     tooltipPosition: "bottom",
     run: "click",
 }, {
-    trigger: "a[data-module-xml-id='base.module_website_sale']",
+    trigger: "button[data-module-xml-id='base.module_website_sale']",
     content: markup(_t("Select <b>New Product</b> to create it and manage its properties to boost your sales.")),
     tooltipPosition: "bottom",
     run: "click",
@@ -36,7 +36,7 @@ registerWebsitePreviewTour("test_01_admin_shop_tour", {
     run: "click",
 },
 {
-    trigger: "#oe_snippets.o_loaded",
+    trigger: ".o_builder_sidebar_open",
 },
 {
     trigger: ":iframe .product_price .oe_currency_value:visible",
@@ -71,7 +71,7 @@ goBackToBlocks(),
 }), {
     // Wait until the drag and drop is resolved (causing a history step)
     // before clicking save.
-    trigger: ".o_we_external_history_buttons button.fa-undo:not([disabled])",
+    trigger: ".o-snippets-top-actions button.fa-undo:not([disabled])",
 }, {
     trigger: "button[data-action=save]",
     content: markup(_t("Once you click on <b>Save</b>, your product is updated.")),

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow_backend.js
@@ -6,15 +6,15 @@ registerWebsitePreviewTour('website_sale_tour_backend', {
 }, () => [
         {
             content: "open customize tab",
-            trigger: '.o_we_customize_snippet_btn',
+            trigger: "[data-name='customize']",
             run: "click",
         },
         {
-            trigger: "#oe_snippets .o_we_customize_panel",
+            trigger: ".o_builder_sidebar_open .o_customize_tab",
         },
         {
             content: "Enable Extra step",
-            trigger: '[data-customize-website-views="website_sale.extra_info"] we-checkbox',
+            trigger: "[data-action-param='{\"views\":[\"website_sale.extra_info\"]}'] input[type='checkbox']",
             run: "click",
         },
         ...clickOnSave(),

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -8,13 +8,10 @@ from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
-import unittest
 
 _logger = logging.getLogger(__name__)
 
 
-# TODO master-mysterious-egg fix error
-@unittest.skip("prepare mysterious-egg for merging")
 @tagged('post_install', '-at_install')
 class TestSaleProcess(HttpCaseWithUserDemo, WebsiteSaleCommon, HttpCaseWithWebsiteUser):
 


### PR DESCRIPTION
The `TestSaleProcess` class tours was previously broken due to DOM structure changes introduced by the new website builder and was consequently disabled.

This commit updates the tour steps to align with the new DOM and re-enables the associated test.