### PR TITLE
[FIX] l10n_hu_edi: rectify company currency validation on Hungarian EDI

### DIFF
--- a/addons/l10n_hu_edi/i18n/hu.po
+++ b/addons/l10n_hu_edi/i18n/hu.po
@@ -6,16 +6,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-03 08:13+0000\n"
-"PO-Revision-Date: 2024-05-03 12:35+0000\n"
-"Last-Translator: Tóth Csaba <csaba.toth@odootech.hu>\n"
-"Language-Team: Hungarian\n"
-"Language: hu\n"
+"POT-Creation-Date: 2025-05-27 12:23+0000\n"
+"PO-Revision-Date: 2025-05-27 12:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
-"Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.4.3\n"
+"Plural-Forms: \n"
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_res_company__l10n_hu_edi_server_mode
@@ -342,17 +340,6 @@ msgstr ""
 #, python-format
 msgid "Could not parse time of previous transaction"
 msgstr "Nem sikerült értelmezni az előző tranzakció idejét"
-
-#. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/__init__.py:0
-#, python-format
-msgid ""
-"Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n"
-"You should set the type manually or reload the CoA before sending invoices to NAV."
-msgstr ""
-"Nem sikerült beállítani a NAV adótípusait az adókra, mert néhány adó hiányzik a l10n_hu-ból.\n"
-"A típusokat kézzel kell beállítani, vagy újra kell tölteni a CoA-t, mielőtt a számlákat elküldi a NAV-nak."
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,field_description:l10n_hu_edi.field_l10n_hu_edi_cancellation__create_uid
@@ -721,10 +708,10 @@ msgstr "Számla beküldés ideje"
 #, python-format
 msgid ""
 "Invoices issued in Hungary must, with few exceptions, be reported to the "
-"NAV's Online-Invoice system!"
+"NAV's Online-Invoice system."
 msgstr ""
 "Magyarországon a kiállított számlákat, néhány kivételtől eltekintve, "
-"kötelező jelenteni az adóhatóság online számla rendszerébe!"
+"kötelező jelenteni az adóhatóság online számla rendszerébe."
 
 #. module: l10n_hu_edi
 #: model:ir.model,name:l10n_hu_edi.model_account_move
@@ -823,8 +810,8 @@ msgid "Linear meter"
 msgstr "Folyóméter"
 
 #. module: l10n_hu_edi
-#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__litre
-msgid "Litre"
+#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__liter
+msgid "Liter"
 msgstr "Liter"
 
 #. module: l10n_hu_edi
@@ -978,13 +965,6 @@ msgid "NAV expected payment mode of the invoice."
 msgstr ""
 
 #. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
-msgid "NAV replied with non-OK funcCode: %s"
-msgstr "A NAV nem OK funcCode-dal válaszolt: %s"
-
-#. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__nonrefundable_vat
 msgid ""
 "NONREFUNDABLE_VAT - VAT incurred under sections 11 or 14, with an agreement "
@@ -1087,6 +1067,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
+msgid "Please set a valid recipient bank account number!"
+msgstr "Kérjük, adjon meg érvényes címzett bankszámlaszámot!"
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
 msgid "Please set any VAT taxes to be 'Affected by previous taxes'!"
 msgstr ""
 "Kérjük, állítsa be az ÁFA adókat úgy, hogy a 'Korábbi adók által érintett' "
@@ -1151,8 +1138,8 @@ msgstr "Kérjük, adja meg a névjegy adószámát a céges partnerekre!"
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
-msgid "Please use HUF as company currency!"
-msgstr "Kérjük, hogy a vállalat pénznemeként HUF-ot használjon!"
+msgid "Please use HUF or EUR as your company currency."
+msgstr "Kérjük, hogy a vállalat pénznemeként HUF-ot vagy EUR-t használjon."
 
 #. module: l10n_hu_edi
 #: model:ir.model.fields,help:l10n_hu_edi.field_account_tax__l10n_hu_tax_type
@@ -1543,6 +1530,7 @@ msgstr "Számla(k) megtekintése"
 
 #. module: l10n_hu_edi
 #. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0

--- a/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
+++ b/addons/l10n_hu_edi/i18n/l10n_hu_edi.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-03 08:13+0000\n"
-"PO-Revision-Date: 2024-05-03 08:13+0000\n"
+"POT-Creation-Date: 2025-05-27 12:22+0000\n"
+"PO-Revision-Date: 2025-05-27 12:22+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -310,15 +310,6 @@ msgstr ""
 #: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
 #, python-format
 msgid "Could not parse time of previous transaction"
-msgstr ""
-
-#. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/__init__.py:0
-#, python-format
-msgid ""
-"Could not set NAV tax types on taxes because some taxes from l10n_hu are missing.\n"
-"You should set the type manually or reload the CoA before sending invoices to NAV."
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -671,7 +662,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Invoices issued in Hungary must, with few exceptions, be reported to the "
-"NAV's Online-Invoice system!"
+"NAV's Online-Invoice system."
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -771,8 +762,8 @@ msgid "Linear meter"
 msgstr ""
 
 #. module: l10n_hu_edi
-#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__litre
-msgid "Litre"
+#: model:ir.model.fields.selection,name:l10n_hu_edi.selection__uom_uom__l10n_hu_edi_code__liter
+msgid "Liter"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -924,13 +915,6 @@ msgid "NAV expected payment mode of the invoice."
 msgstr ""
 
 #. module: l10n_hu_edi
-#. odoo-python
-#: code:addons/l10n_hu_edi/models/l10n_hu_edi_connection.py:0
-#, python-format
-msgid "NAV replied with non-OK funcCode: %s"
-msgstr ""
-
-#. module: l10n_hu_edi
 #: model:ir.model.fields.selection,name:l10n_hu_edi.selection__account_tax__l10n_hu_tax_type__nonrefundable_vat
 msgid ""
 "NONREFUNDABLE_VAT - VAT incurred under sections 11 or 14, with an agreement "
@@ -1003,7 +987,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
-msgid "Please create a sales tax with type ATK (outside the scope of the VAT Act)."
+msgid ""
+"Please create a sales tax with type ATK (outside the scope of the VAT Act)."
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -1021,6 +1006,13 @@ msgstr ""
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
 msgid "Please set NAV credentials in the Accounting Settings!"
+msgstr ""
+
+#. module: l10n_hu_edi
+#. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
+#, python-format
+msgid "Please set a valid recipient bank account number!"
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -1085,7 +1077,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #, python-format
-msgid "Please use HUF as company currency!"
+msgid "Please use HUF or EUR as your company currency."
 msgstr ""
 
 #. module: l10n_hu_edi
@@ -1452,6 +1444,7 @@ msgstr ""
 
 #. module: l10n_hu_edi
 #. odoo-python
+#: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0
 #: code:addons/l10n_hu_edi/models/account_move.py:0

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -343,8 +343,8 @@ class AccountMove(models.Model):
                 'action_text': _('View Company/ies'),
             },
             'company_not_huf': {
-                'records': self.company_id.filtered(lambda c: c.currency_id.name != 'HUF'),
-                'message': _('Please use HUF as company currency!'),
+                'records': self.company_id.filtered(lambda c: c.currency_id.name not in ['HUF', 'EUR']),
+                'message': _('Please use HUF or EUR as your company currency.'),
                 'action_text': _('View Company/ies'),
             },
             'partner_bank_account_invalid': {


### PR DESCRIPTION
Before this **PR**:
Only HUF was allowed as valid currency on company for Hungarian EDI.

After this **PR**:
Now both HUF and EUR is allowed as valid currency for Hungarian EDI.

**task**-4707271
