### PR TITLE
[FIX] orm, test_import_export: prevent error when exporting Property fields

### DIFF
--- a/addons/test_import_export/tests/test_properties.py
+++ b/addons/test_import_export/tests/test_properties.py
@@ -267,6 +267,12 @@ class TestPropertiesExportImport(HttpCase):
             ]
         )
 
+    def test_export_properties_field(self):
+        """Test that the 'properties' field exports as a dictionary."""
+        export_data = self.properties_records[0].export_data(['properties']).get('datas', [])
+        self.assertIsInstance(export_data[0][0], dict)
+        self.assertEqual(export_data[0][0], {'char_prop': 'Not the default', 'selection_prop': 'selection_2'})
+
     def test_import_properties(self):
         def_record_1 = self.definition_records[0]
         def_record_2 = self.definition_records[1]

--- a/odoo/orm/fields_properties.py
+++ b/odoo/orm/fields_properties.py
@@ -207,6 +207,12 @@ class Properties(Field):
         """If we write a list on the child, update the definition record."""
         return value
 
+    def convert_to_export(self, value, record):
+        """ Convert value from the record format to the export format. """
+        if isinstance(value, Property):
+            value = value._values
+        return value or ''
+
     def _get_res_ids_per_model(self, env, values_list):
         """Read everything needed in batch for the given records.
 


### PR DESCRIPTION
Currently, an error occurs when exporting the product record.

Steps to Reproduce:

 - Install the `stock` module.
 - Go to any product and click the `Edit Properties` in the Actions.
 - In the new property field, enter any value.
 - In the list view, select that product and click `Export` from the Actions.
 - In the Available Fields section, search for `Properties`, add them, and click `Expor`'.

`TypeError: Unsupported type <class 'odoo.orm.fields_properties.Property'> in write()`

This error occurs when a user exports a product record and includes Properties in the wizard. 
The 'Properties' field is a dynamic field that maps to fields.Property, which is not supported by 
the export mechanism. As a result, a TypeError is raised.

This commit ensures that if the export value is an instance of Property,then `convert_to_export` 
returns its exportable values.

sentry-6618087979


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
