### PR TITLE
[FIX] html_builder, website: add hotkeys and ensure accessibility

### DIFF
--- a/addons/html_builder/static/src/builder.xml
+++ b/addons/html_builder/static/src/builder.xml
@@ -15,13 +15,13 @@
             </div>
         </div>
         <div class="o-snippets-tabs d-flex justify-content-between mt-2 p-2 pb-0 flex-shrink-0">
-            <button data-name="blocks" class="px-2 cursor-pointer pb-1 pe-auto bg-transparent text-uppercase border-0" t-att-class="{'active text-white': state.activeTab === 'blocks'}" t-on-click="() => this.onTabClick('blocks')" t-att-disabled="props.isTranslation">
+            <button data-name="blocks" data-hotkey="1" class="px-2 cursor-pointer pb-1 pe-auto bg-transparent text-uppercase border-0" t-att-class="{'active text-white': state.activeTab === 'blocks'}" t-on-click="() => this.onTabClick('blocks')" t-att-disabled="props.isTranslation">
                 <span class="ps-1">Blocks</span>
             </button>
             <button data-name="customize" class="px-2 cursor-pointer pb-1 bg-transparent text-uppercase border-0" t-att-class="{'active text-white': state.activeTab === 'customize'}" t-on-click="() => this.onTabClick('customize')">
                 <span>Customize</span>
             </button>
-            <button data-name="theme" t-if="ThemeTab" class="px-2 cursor-pointer pb-1 bg-transparent text-uppercase border-0" t-att-class="{'active text-white': state.activeTab === 'theme'}" t-on-click="() => this.onTabClick('theme')" t-att-disabled="props.isTranslation">
+            <button data-name="theme" t-if="ThemeTab" data-hotkey="2" class="px-2 cursor-pointer pb-1 bg-transparent text-uppercase border-0" t-att-class="{'active text-white': state.activeTab === 'theme'}" t-on-click="() => this.onTabClick('theme')" t-att-disabled="props.isTranslation">
                 <span class="pe-1">Theme</span>
             </button>
         </div>

--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -5,7 +5,7 @@
     <BuilderComponent>
         <!-- Render the SelectItem(s) into an invisible node to ensure the label of the
         button is being set. -->
-        <div t-ref="root" class="w-100" style="overflow: hidden;">
+        <div t-ref="root" class="w-100">
             <div t-att-class="'d-none ' + props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
             <Dropdown state="this.dropdown">
                 <button class="btn btn-primary text-start o-dropdown-caret w-100 overflow-hidden" t-ref="button" t-att-id="props.id"

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -145,7 +145,10 @@ export class WebsiteBuilder extends Component {
                 if (isEditing) {
                     setTimeout(() => {
                         registry.category("systray").remove("website.WebsiteSystrayItem");
+                        document.querySelector(".o_builder_open .o_main_navbar").classList.add("d-none");
                     }, 200);
+                } else {
+                    document.querySelector(".o_main_navbar")?.classList.remove("d-none");
                 }
             },
             () => [this.state.isEditing]

--- a/addons/website/static/tests/builder/setup_html_builder.test.js
+++ b/addons/website/static/tests/builder/setup_html_builder.test.js
@@ -6,7 +6,7 @@ import {
 } from "./website_helpers";
 import { Builder } from "@html_builder/builder";
 import { expect, test } from "@odoo/hoot";
-import { animationFrame } from "@odoo/hoot-dom";
+import { animationFrame, waitFor } from "@odoo/hoot-dom";
 import { patchWithCleanup, contains } from "@web/../tests/web_test_helpers";
 
 defineWebsiteModels();
@@ -53,4 +53,10 @@ test("Set and update the 'contenteditable' attribute on the editable elements", 
     await contains(".overlay .oe_snippet_remove").click();
     expect(wrapwrapEl.getAttribute("contenteditable")).toBe("false");
     expect(wrapEl.getAttribute("contenteditable")).toBe("false");
+});
+
+test("Admin navbar is hidden in edit mode", async () => {
+    await setupWebsiteBuilder("<section><p>TEST</p></section>");
+    await waitFor(":iframe section");
+    expect(".o_main_navbar").not.toBeVisible();
 });

--- a/addons/website/static/tests/builder/snippets_menu.test.js
+++ b/addons/website/static/tests/builder/snippets_menu.test.js
@@ -2,7 +2,7 @@ import { WebsiteBuilder } from "@website/client_actions/website_preview/website_
 import { setContent } from "@html_editor/../tests/_helpers/selection";
 import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
-import { animationFrame, click, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, press, queryAllTexts, queryOne, waitFor } from "@odoo/hoot-dom";
 import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import {
     defineWebsiteModels,
@@ -129,4 +129,21 @@ test("Clicking on the 'BLOCKS' or 'THEME' tab should deactivate the options", as
     await contains(".o-snippets-tabs button:contains('CUSTOMIZE')").click();
     expect(".o-snippets-tabs button:contains('CUSTOMIZE')").toHaveClass("active");
     expect(".o_customize_tab .options-container").toHaveCount(0);
+});
+
+test("Hotkeys on Theme and Blocks tab", async () => {
+    await setupWebsiteBuilder("<section><p>TEST</p></section>");
+    await waitFor(":iframe section");
+    expect("[data-name=blocks]").toHaveClass("active");
+    expect("[data-name=theme]").not.toHaveClass("active");
+    await press(["alt", "2"]);
+    await animationFrame();
+    await animationFrame();
+    expect("[data-name=blocks]").not.toHaveClass("active");
+    expect("[data-name=theme]").toHaveClass("active");
+    await press(["alt", "1"]);
+    await animationFrame();
+    await animationFrame();
+    expect("[data-name=blocks]").toHaveClass("active");
+    expect("[data-name=theme]").not.toHaveClass("active");
 });


### PR DESCRIPTION
- Bring back hotkeys on Blocks and Theme tabs
- Add .d-none on the admin navbar to disable its hotkeys while in edit
- Remove `overflow: hidden` on the BuilderSelect container so that the outline appears on focus. The overflow is already hidden anyway on the button itself.

This PR follows [the refactor into html_builder].

[the refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641