### PR TITLE
[FIX] website: do not redirect after editing menus from the builder

### DIFF
--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -45,7 +45,7 @@ export class MenuDataPlugin extends Plugin {
                     onClickEditMenu: () => {
                         this.services.dialog.add(EditMenuDialog, {
                             save: async () => {
-                                await this.config.reloadEditor({ url: this.document.URL });
+                                await this.config.reloadEditor();
                             },
                         });
                     },


### PR DESCRIPTION
Steps to reproduce:
- Edit a page
- Click on a menu item and click on the "Edit menu" icon
- Add an item and save
- => The iframe is reloaded, but leads to a 404 instead of staying on the same page.

This is because when passing a URL to `reloadEditor`, the given string is then encoded with `encodeURIComponent`, which will append the string to the current domain. We can just leave the parameter empty.

This PR follows [the refactor into html_builder].

[the refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641