### PR TITLE
[IMP] web, *: change xxl breakpoint for the chatter

### DIFF
--- a/addons/account/static/src/scss/account_journal_dashboard.scss
+++ b/addons/account/static/src/scss/account_journal_dashboard.scss
@@ -52,7 +52,7 @@
         }
         &:has(> .o_kanban_record:nth-child(12)) {
             // 3 cards per row for large screens if there are more than 5 cards (+ 6 ghost cards)
-            @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
+            @include media-breakpoint-up(xxl) {
                 --KanbanRecord-width: 31vw;
             }
         }

--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.scss
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.scss
@@ -22,11 +22,11 @@
                 background-color: $border-color;
                 content: "";
 
-                @include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
+                @include media-breakpoint-up(lg) {
                     left: ($o-hrs-timeline-dot-size * .5 + o-to-rem(map-get($spacers, 4))  - o-to-rem($border-width))
                 }
 
-                @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
+                @include media-breakpoint-up(xxl) {
                     left: ($o-hrs-timeline-dot-size * .5 + o-to-rem($o-horizontal-padding)  - o-to-rem($border-width))
                 }
             }

--- a/addons/mail/static/src/core/common/attachment_view.scss
+++ b/addons/mail/static/src/core/common/attachment_view.scss
@@ -35,7 +35,7 @@
     }
 }
 
-@include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
+@include media-breakpoint-up(xxl) {
     .o_attachment_preview {
         display: block;
         flex: auto;

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -13,7 +13,7 @@
     }
 }
 
-@include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
+@include media-breakpoint-up(lg) {
     .o_form_view .o_form_sheet .o_notebook .tab-content .tab-pane .o_mail_body {
         // cancel the padding of the form_sheet when breakpoints are reached
         margin-left: calc(var(--formView-sheet-padding-x) * -1);

--- a/addons/pos_restaurant/static/src/app/components/numpad_dropdown/numpad_dropdown.js
+++ b/addons/pos_restaurant/static/src/app/components/numpad_dropdown/numpad_dropdown.js
@@ -54,7 +54,7 @@ export class NumpadDropdown extends Component {
     }
 
     get isSmall() {
-        return utils.getSize() <= SIZES.VSM;
+        return utils.getSize() <= SIZES.SM;
     }
 
     checkIsValid(buffer) {

--- a/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
+++ b/addons/project/static/src/components/project_right_side_panel/project_right_side_panel.js
@@ -51,7 +51,7 @@ export class ProjectRightSidePanel extends Component {
         switch (this.uiService.size) {
             case SIZES.XS:
                 return 2;
-            case SIZES.VSM:
+            case SIZES.SM:
                 return 3;
             case SIZES.XXL:
                 return 5;

--- a/addons/project_todo/static/src/scss/todo.scss
+++ b/addons/project_todo/static/src/scss/todo.scss
@@ -18,7 +18,7 @@
             width: 35%;
         }
     }
-    @include media-breakpoint-down(xxl, $o-extra-grid-breakpoints) {
+    @include media-breakpoint-down(xxl) {
         .o_widget_todo_chatter_panel {
             min-width: 100%;
         }

--- a/addons/web/static/src/core/ui/ui_service.js
+++ b/addons/web/static/src/core/ui/ui_service.js
@@ -8,7 +8,7 @@ import { getActiveHotkey } from "../hotkeys/hotkey_service";
 
 import { EventBus, reactive, useEffect, useRef } from "@odoo/owl";
 
-export const SIZES = { XS: 0, VSM: 1, SM: 2, MD: 3, LG: 4, XL: 5, XXL: 6 };
+export const SIZES = { XS: 0, SM: 1, MD: 2, LG: 3, XL: 4, XXL: 5 };
 
 function getFirstAndLastTabableElements(el) {
     const tabableEls = getTabableElements(el);
@@ -106,13 +106,12 @@ export function useActiveElement(refName) {
 
 // window size handling
 export const MEDIAS_BREAKPOINTS = [
-    { maxWidth: 474 },
-    { minWidth: 475, maxWidth: 575 },
+    { maxWidth: 575 },
     { minWidth: 576, maxWidth: 767 },
     { minWidth: 768, maxWidth: 991 },
     { minWidth: 992, maxWidth: 1199 },
-    { minWidth: 1200, maxWidth: 1533 },
-    { minWidth: 1534 },
+    { minWidth: 1200, maxWidth: 1399 },
+    { minWidth: 1400 },
 ];
 
 /**

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -172,20 +172,6 @@ $o-input-border-required: $o-brand-primary !default;
 
 // Layout
 //
-// Extension of BS4. This is not redefining the BS4 variable directly as we only
-// need the extra ones for media queries (not creating new breakpoint classes).
-// Note: default BS4 values are hardcoded here while it should be possible to
-// merge with the default BS variable (but we would have to take care of
-// ordering & cie).
-$o-extra-grid-breakpoints: (
-    xs: 0,
-    vsm: 475px,
-    sm: 576px,
-    md: 768px,
-    lg: 992px,
-    xl: 1200px,
-    xxl: 1534px,
-) !default;
 $o-spacer: 16px !default; // = 1rem
 $o-form-spacing-unit: 5px !default;
 $o-horizontal-padding: $o-spacer !default;

--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -255,7 +255,7 @@
                 cursor: pointer;
             }
         }
-        @include media-breakpoint-down(sm, $o-extra-grid-breakpoints) {
+        @include media-breakpoint-down(sm) {
             .o_form_image_controls{
                 position: initial;
                 opacity: 1;

--- a/addons/web/static/src/views/form/button_box/button_box.js
+++ b/addons/web/static/src/views/form/button_box/button_box.js
@@ -17,7 +17,7 @@ export class ButtonBox extends Component {
     setup() {
         const ui = useService("ui");
         onWillRender(() => {
-            const maxVisibleButtons = [0, 0, 0, 7, 4, 5, 8][ui.size] ?? 8;
+            const maxVisibleButtons = [0, 0, 7, 4, 5, 8][ui.size] ?? 8;
             const allVisibleButtons = Object.entries(this.props.slots)
                 .filter(([_, slot]) => this.isSlotVisible(slot))
                 .map(([slotName]) => slotName);

--- a/addons/web/static/src/views/form/form.variables.scss
+++ b/addons/web/static/src/views/form/form.variables.scss
@@ -1,5 +1,5 @@
 $o-sheet-vpadding: $o-spacer * 1.5 !default;
 
 $o-form-renderer-max-width: 2600px !default;
-$o-form-view-sheet-max-width: 1534px !default;
+$o-form-view-sheet-max-width: 1400px !default;
 $o-form-picture-size: 90px !default;

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -1,13 +1,13 @@
 // Define left and right padding according to screen resolution
 @mixin o-form-sheet-inner-left-padding {
     padding-left: $o-horizontal-padding;
-    @include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
+    @include media-breakpoint-up(lg) {
         padding-left: $o-horizontal-padding*2;
     }
 }
 @mixin o-form-sheet-inner-right-padding {
     padding-right: $o-horizontal-padding;
-    @include media-breakpoint-up(lg, $o-extra-grid-breakpoints) {
+    @include media-breakpoint-up(lg) {
         padding-right: $o-horizontal-padding*2;
     }
 }
@@ -275,7 +275,7 @@
             --formView-sheet-padding-x: var(--formView-sheet-padding-x-lg, #{map-get($spacers, 4)});
         }
 
-        @include media-breakpoint-up(xxl, $o-extra-grid-breakpoints) {
+        @include media-breakpoint-up(xxl) {
             --formView-sheet-padding-y: var(--formView-sheet-padding-y-xxl, #{map-get($spacers, 3)});
             --formView-sheet-padding-x: var(--formView-sheet-padding-x-xxl, #{map-get($spacers, 3)});
         }
@@ -408,7 +408,7 @@
             }
         }
 
-        @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {
+        @include media-breakpoint-up(sm) {
             .o_field_widget {
                 &.o_text_overflow {
                     width: 1px!important; // hack to make the table layout believe it is a small element (so that the table does not grow too much) ...
@@ -684,7 +684,7 @@
     // Text field with oe_inline class
     .o_field_text.oe_inline {
         width: 100%!important;
-        @include media-breakpoint-up(vsm, $o-extra-grid-breakpoints) {
+        @include media-breakpoint-up(sm) {
             width: 45%!important;
         }
     }

--- a/addons/web/static/tests/views/form/form_compiler.test.js
+++ b/addons/web/static/tests/views/form/form_compiler.test.js
@@ -196,7 +196,7 @@ test("properly compile sheet", () => {
     `;
     const expected = /*xml*/ `
         <t t-translation="off">
-            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
+            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 5 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_statusbar d-flex justify-content-between py-2"><StatusBarButtons/></div>
                     <div>someDiv</div>
@@ -225,7 +225,7 @@ test("properly compile buttonBox invisible in sheet", () => {
         <t t-translation="off">
             <div class="o_form_renderer"
                  t-att-class="__comp__.props.class"
-                 t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
+                 t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 5 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}"
                  t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
@@ -373,7 +373,7 @@ test("properly compile empty ButtonBox", () => {
     `;
     const expected = /*xml*/ `
         <t t-translation="off">
-            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 6 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
+            <div class="o_form_renderer" t-att-class="__comp__.props.class" t-attf-class="{{__comp__.props.record.isInEdition ? 'o_form_editable' : 'o_form_readonly'}} d-flex d-print-block {{ __comp__.uiService.size &lt; 5 ? &quot;flex-column&quot; : &quot;flex-nowrap h-100&quot; }} {{ __comp__.props.record.dirty ? 'o_form_dirty' : !__comp__.props.record.isNew ? 'o_form_saved' : '' }}" t-ref="compiled_view_root">
                 <div class="o_form_sheet_bg">
                     <div class="o_form_sheet position-relative">
                         <div class="oe_button_box" name="button_box">

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -7852,7 +7852,6 @@ test(`correct amount of buttons`, async () => {
     };
 
     await assertFormContainsNButtonsWithSizeClass(SIZES.XS, 0);
-    await assertFormContainsNButtonsWithSizeClass(SIZES.VSM, 0);
     await assertFormContainsNButtonsWithSizeClass(SIZES.SM, 0);
     await assertFormContainsNButtonsWithSizeClass(SIZES.MD, 7);
     await assertFormContainsNButtonsWithSizeClass(SIZES.LG, 3);


### PR DESCRIPTION
*: account,hr_skills,mail,mass_mailing,pos_restaurant,project,
project_todo,web

The goal is to keep the chatter aside the formview on more devices (small laptop, typically 13" and under).

This change made us use bootstrap default's breakpoint, `xxl: 1400` which is good because it invalidates the 
`$o-extra-grid-breakpoints` map, allowing us to clear all the occurrences that were deviating from bootstrap default and setting our `MEDIAS_BREAKPOINTS` in our ui_services to the default bootstrap values.

`VSM` value was not relevant anymore, bootstrap at the time didn't have as much breakpoints, which probably required this custom breakpoint for mobile devices. Now the `SM` value is the default value used for these viewports.

task-4806037

Enterprise PR: https://github.com/odoo/enterprise/pull/86691

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
