### PR TITLE
[FIX] website: force animation in the animateOption Plugin

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/animate_option_plugin.js
@@ -112,7 +112,7 @@ class AnimateOptionPlugin extends Plugin {
                         this.setImagesLazyLoading(editingElement);
                     }
                 },
-                apply: ({ editingElement, value: effectName }) => {
+                apply: ({ editingElement, value: effectName, params: { forceAnimation } }) => {
                     if (animationWithFadein.includes(effectName)) {
                         editingElement.classList.add("o_anim_fade_in");
                     }
@@ -130,6 +130,9 @@ class AnimateOptionPlugin extends Plugin {
                         //     optionName: "ImageTools",
                         //     name: "enable_hover_effect",
                         // });
+                    }
+                    if (forceAnimation) {
+                        this.forceAnimation(editingElement);
                     }
                 },
             },


### PR DESCRIPTION
We had a problem with animation when we tried to add several blocks > add a "Columns" snippet > add an "On Appearance" animation to a column > change it to "On Scroll" > scroll the page > the column doesn't animate. See [1]. To fix this we have to force animation after setting the animation mode.

[1]:https://drive.google.com/file/d/1JRpc2dBrBs2ERjKD5DpuOLkUCEzXT-AE/view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
