### PR TITLE
[IMP] l10n_si: Added Slovenian structured payment communication standard

### DIFF
--- a/addons/account/tests/test_structured_reference.py
+++ b/addons/account/tests/test_structured_reference.py
@@ -6,6 +6,7 @@ from odoo.addons.account.tools import (
     is_valid_structured_reference_fi,
     is_valid_structured_reference_no_se,
     is_valid_structured_reference_nl,
+    is_valid_structured_reference_si,
     is_valid_structured_reference_iso,
     is_valid_structured_reference,
 )
@@ -108,6 +109,30 @@ class StructuredReferenceTest(TransactionCase):
         # Check the entire string
         self.assertFalse(is_valid_structured_reference_nl('5000056789012345-OTHER-RANDOM-STUFF'))
 
+    def test_structured_reference_si(self):
+        # Valid structured references (must have 2 hyphens and valid check digit)
+        self.assertTrue(is_valid_structured_reference_si("SI01 25-20-85"))
+        self.assertTrue(is_valid_structured_reference_si("  SI01 25  - 2 0-85  "))
+        self.assertTrue(is_valid_structured_reference_si("SI01 19-1235-84505"))
+
+        # Invalid check digit
+        self.assertFalse(is_valid_structured_reference_si("SI01 25-20-84"))
+        self.assertFalse(is_valid_structured_reference_si("SI01 19-1235-84504"))
+
+        # Format errors - wrong prefix
+        self.assertFalse(is_valid_structured_reference_si("SI02 25-20-85"))
+        self.assertFalse(is_valid_structured_reference_si("0519123584503"))
+
+        # Format errors - missing or wrong hyphens
+        self.assertFalse(is_valid_structured_reference_si("SI01 252085"))
+        self.assertFalse(is_valid_structured_reference_si("SI01 25-2085"))
+        self.assertFalse(is_valid_structured_reference_si("SI01 25--20-85"))
+
+        # Format errors - non-numeric or empty parts
+        self.assertFalse(is_valid_structured_reference_si("SI01 ab-cd-ef"))
+        self.assertFalse(is_valid_structured_reference_si("SI01 25-20-"))
+        self.assertFalse(is_valid_structured_reference_si("SI01"))
+
     def test_structured_reference(self):
         # Accepts references in structured format
         self.assertTrue(is_valid_structured_reference(' RF18 5390 0754 7034 '))  # ISO
@@ -116,12 +141,14 @@ class StructuredReferenceTest(TransactionCase):
         self.assertTrue(is_valid_structured_reference('2023 0000 98'))  # FI
         self.assertTrue(is_valid_structured_reference('1234 5678 97'))  # NO-SE
         self.assertTrue(is_valid_structured_reference('5000056789012345'))  # NL
+        self.assertTrue(is_valid_structured_reference("SI01 25-20-85"))  # SI
         # Accept references in unstructured format
         self.assertTrue(is_valid_structured_reference(' RF18539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference(' 020343057642'))  # BE
         self.assertTrue(is_valid_structured_reference('2023000098'))  # FI
         self.assertTrue(is_valid_structured_reference('1234567897'))  # NO-SE
         self.assertTrue(is_valid_structured_reference('5 000 0567 8901 2345'))  # NL
+        self.assertTrue(is_valid_structured_reference("  SI01 25  - 2 0-85  "))  # SI
         # Validates with zero's added in front
         self.assertTrue(is_valid_structured_reference('RF18000000000539007547034'))  # ISO
         self.assertTrue(is_valid_structured_reference('00000000002023000098'))  # FI
@@ -133,9 +160,11 @@ class StructuredReferenceTest(TransactionCase):
         self.assertFalse(is_valid_structured_reference('2023/0000/98'))  # FI
         self.assertFalse(is_valid_structured_reference('1234/5678/97'))  # NO-SE
         self.assertFalse(is_valid_structured_reference('(5)000 0567 8901 2345'))  # NL
+        self.assertFalse(is_valid_structured_reference("0519123584503"))  # SI
         # Does not validate invalid checksum
         self.assertFalse(is_valid_structured_reference('RF17539007547034'))  # ISO
         self.assertFalse(is_valid_structured_reference('020343057641'))  # BE
         self.assertFalse(is_valid_structured_reference('2023000095'))  # FI
         self.assertFalse(is_valid_structured_reference('1234567898'))  # NO-SE
         self.assertFalse(is_valid_structured_reference('6000056789012345'))  # NL
+        self.assertFalse(is_valid_structured_reference("SI01 19-1235-84504"))  # SI

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -107,6 +107,51 @@ def is_valid_structured_reference_nl(reference):
 
     return computed_check == int(check)
 
+
+def is_valid_structured_reference_si(reference):
+    """ Validates a Slovenian structured reference using Model 01 (SI01).
+
+        Format: SI01 (P1-P2-P3)K
+        - Starts with 'SI01'
+        - P1, P2, P3 are numeric segments (max 20 digits total, up to 2 hyphens)
+        - K is a check digit calculated using MOD 11
+
+        :param reference: the reference to check
+        :return: True if reference is a structured reference, False otherwise
+    """
+    sanitized_reference = sanitize_structured_reference(reference)
+
+    if sanitized_reference.startswith('SI01'):
+        sanitized_reference = sanitized_reference[4:]  # Remove SI01
+    else:
+        return False
+
+    # Contains maximum of two hyphens
+    if sanitized_reference.count('-') > 2:
+        return False
+
+    # Validate hyphenated parts using regex: 3 numeric parts (last ends with check digit)
+    match = re.match(r'^(\d+)-(\d+)-(\d+)$', sanitized_reference)
+    if not match:
+        return False
+
+    # Split into main digits and check digit
+    core = sanitized_reference.replace('-', '')
+    if not core.isdigit() or len(core) < 2:
+        return False
+
+    digits, given_check_digit = core[:-1], core[-1]
+
+    weights = list(range(2, 14))
+    weights = weights[0:len(digits)]
+    weighted_sum = sum(int(d) * w for d, w in zip(reversed(digits), weights))
+
+    expected_check_digit = 11 - (weighted_sum % 11)
+    if expected_check_digit in (10, 11):
+        expected_check_digit = 0
+
+    return given_check_digit == str(expected_check_digit)
+
 def is_valid_structured_reference(reference):
     """Check whether the provided reference is a valid structured reference.
     This is currently supporting SEPA enabled countries. More specifically countries covered by functions in this file.
@@ -120,5 +165,6 @@ def is_valid_structured_reference(reference):
         is_valid_structured_reference_fi(reference) or
         is_valid_structured_reference_no_se(reference) or
         is_valid_structured_reference_nl(reference) or
+        is_valid_structured_reference_si(reference) or
         is_valid_structured_reference_iso(reference)
     )

--- a/addons/l10n_si/models/__init__.py
+++ b/addons/l10n_si/models/__init__.py
@@ -1,2 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import account_journal
+from . import account_move
 from . import template_si

--- a/addons/l10n_si/models/account_journal.py
+++ b/addons/l10n_si/models/account_journal.py
@@ -1,0 +1,10 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    invoice_reference_model = fields.Selection(selection_add=[
+        ('si', 'Slovenian 01 (SI01 25-1235-8403)')
+        ], ondelete={'si': lambda recs: recs.write({'invoice_reference_model': 'odoo'})})

--- a/addons/l10n_si/models/account_move.py
+++ b/addons/l10n_si/models/account_move.py
@@ -1,0 +1,55 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _get_invoice_reference_si_partner(self):
+        """
+        Generate the Slovenian structured payment reference using the partner's ID.
+        Format: SI01 (P1-P2-P3)K
+        - P1: Last two digits of the invoice year
+        - P2: Partner ID
+        - P3: Journal ID
+        - K: Check digit
+
+        :return: the formatted structured reference string (SI01...)
+        """
+        self.ensure_one()
+        p3 = str(self.partner_id.id)
+        return self._build_invoice_reference(p3)
+
+    def _get_invoice_reference_si_invoice(self):
+        """
+        Generate the Slovenian structured payment reference using the invoice sequence number.
+
+        Format: SI01 (P1-P2-P3)K
+        - P1: Last two digits of the invoice year
+        - P2: Trailing digits of the invoice name (sequence number)
+        - P3: Journal ID
+        - K: Check digit
+
+        :return: the formatted structured reference string (SI01...)
+        """
+        self.ensure_one()
+        match = re.search(r'(\d+)$', self.name or '')
+        p3 = str(int(match.group(1))) if match else '0'
+        return self._build_invoice_reference(p3)
+
+    def _build_invoice_reference(self, p3):
+        """Builds the reference using a shared structure for both methods."""
+        p1 = str(self.journal_id.id)
+        p2 = str(self.invoice_date.year)[-2:]
+        reference_base = f"{p1}-{p2}-{p3}"
+
+        # Calculate check digit
+        digits = [int(d) for d in reference_base if d.isdigit()]
+        weights = list(range(2, 14))[:len(digits)]
+        weighted_sum = sum(d * w for d, w in zip(reversed(digits), weights))
+        check_digit = 11 - (weighted_sum % 11)
+        check_digit = 0 if check_digit in (10, 11) else check_digit
+        return f"SI01 {reference_base}{check_digit}"

--- a/addons/l10n_si/tests/__init__.py
+++ b/addons/l10n_si/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_get_reference

--- a/addons/l10n_si/tests/test_get_reference.py
+++ b/addons/l10n_si/tests/test_get_reference.py
@@ -1,0 +1,28 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.account.tools import is_valid_structured_reference_si
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class L10n_siInvoiceGetReferenceTest(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('si')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.invoice = cls.init_invoice('out_invoice', products=cls.product_a + cls.product_b)
+
+    def test_get_reference_slovenian_invoice(self):
+        self.assertFalse(self.invoice.payment_reference)
+        self.invoice.journal_id.invoice_reference_model = 'si'
+        self.invoice.action_post()
+        self.assertTrue(is_valid_structured_reference_si(self.invoice.payment_reference))
+
+    def test_get_reference_slovenian_partner(self):
+        self.assertFalse(self.invoice.payment_reference)
+        self.invoice.journal_id.invoice_reference_type = 'partner'
+        self.invoice.journal_id.invoice_reference_model = 'si'
+        self.invoice.action_post()
+        self.assertTrue(is_valid_structured_reference_si(self.invoice.payment_reference))


### PR DESCRIPTION
In this PR:
- Introduced a new "Slovenian 01 (SI0125-1235-8403)" format for payment references, following Slovenia’s Model 01 standard. This format is selectable in Sales journals (Advanced Settings) and set as the default for Slovenian companies.

task-4805083

