### PR TITLE
[FIX] base: merge pdfs error expected self

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -776,14 +776,17 @@ class IrActionsReport(models.Model):
         raise UserError(_("Odoo is unable to merge the generated PDFs."))
 
     @api.model
-    def _merge_pdfs(self, streams, handle_error=_handle_merge_pdfs_error):
+    def _merge_pdfs(self, streams, handle_error=None):
         writer = PdfFileWriter()
         for stream in streams:
             try:
                 reader = PdfFileReader(stream)
                 writer.appendPagesFromReader(reader)
             except (PdfReadError, TypeError, NotImplementedError, ValueError) as e:
-                handle_error(error=e, error_stream=stream)
+                if handle_error is None:
+                    self._handle_merge_pdfs_error(error=e, error_stream=stream)
+                else:
+                    handle_error(error=e, error_stream=stream)
         result_stream = io.BytesIO()
         streams.append(result_stream)
         try:

--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -7,6 +7,8 @@ from unittest import skipIf
 
 import odoo
 import odoo.tests
+from odoo import tools
+from odoo.exceptions import UserError
 
 try:
     from pdfminer.converter import PDFPageAggregator
@@ -112,6 +114,43 @@ class TestReports(odoo.tests.TransactionCase):
 
         self.assertEqual(b64decode(attach_1.datas), b"1")
         self.assertEqual(pdf[0], b"2")
+
+    def test_merge_pdfs(self):
+        report = self.env['ir.actions.report'].create({
+            'name': 'Test Merge PDFs',
+            'report_name': 'test_report.test_merge_pdfs',
+            'model': 'res.partner',
+        })
+
+        minimal_pdf_content = io.BytesIO(tools.file_open('base/tests/minimal.pdf', 'rb').read())
+        malformed_pdf_content = io.BytesIO(b'not a pdf')
+
+        with self.assertRaises(UserError, msg="Odoo is unable to merge the generated PDFs."):
+            report._merge_pdfs([malformed_pdf_content])
+
+        with self.assertRaises(UserError, msg="Odoo is unable to merge the generated PDFs."):
+            report._merge_pdfs([minimal_pdf_content, malformed_pdf_content])
+
+        failed_streams = []
+
+        # The reason we have the merge_pdf is to allows merging pdfs even if some of them fail.
+        # Bellow we test that the failed streams are correctly handled.
+        def handled_failed_streams(error=None, error_stream=None):
+            failed_streams.append((error, error_stream))
+
+        merged_pdf = report._merge_pdfs([minimal_pdf_content, malformed_pdf_content, minimal_pdf_content], handle_error=handled_failed_streams)
+
+        self.assertEqual(len(failed_streams), 1, "Expecting one failed stream")
+        self.assertEqual(failed_streams[0][1], malformed_pdf_content, "Expecting the failed stream to be the malformed pdf")
+
+        minimal_file = tools.pdf.OdooPdfFileReader(minimal_pdf_content)
+        merged_file = tools.pdf.OdooPdfFileReader(merged_pdf)
+
+        self.assertEqual(
+            minimal_file.getNumPages() * 2,
+            merged_file.getNumPages(),
+            "Expecting the merged pdf to have twice the number of pages as the original pdf"
+        )
 
 
 # Some paper format examples


### PR DESCRIPTION
When merging pdfs, if there is an error when meging those pdfs (due to a malformed PDF for example), the UserError that should be shown to the user is not due to an error in the arguments given to the handle_error function.

The aim here is to keep the same function signature and edit the signature of the local function used when a custom_handle_error was defined and edit the function itself.

The error message appeared when I was working on a task to change a
test and tested it on master and got the following stacktrace:
```
...
  File "/home/odoo/Desktop/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 788, in _merge_pdfs
    handle_error(error=e, error_stream=stream)
TypeError: IrActionsReport._handle_merge_pdfs_error() missing 1 required positional argument: 'self'
```

Discovered during : task-3603619

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
