### PR TITLE
[IMP] web,*: move AutoComplete slots from source to option

### DIFF
--- a/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
+++ b/addons/google_address_autocomplete/static/src/address_autocomplete/google_address_autocomplete.js
@@ -71,11 +71,13 @@ export class AddressAutoComplete extends CharField {
                         suggestions.results = suggestions.results.map((result) => ({
                             label: result.formatted_address,
                             onSelect: () => this.selectAddressProposition(result),
+                            slotName: "option",
                         }));
                         if (suggestions.results.length) {
                             suggestions.results.push({
-                                label: "&#160;",
                                 cssClass: "pe-none o-google-credits",
+                                label: "&#160;",
+                                slotName: "option",
                             });
                         }
                         return suggestions.results;
@@ -83,7 +85,6 @@ export class AddressAutoComplete extends CharField {
                         return [];
                     }
                 },
-                optionSlot: "option",
                 placeholder: _t("Searching for addresses..."),
             },
         ];

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/kanban_many2one_avatar_employee_field.xml
@@ -6,10 +6,10 @@
             <t t-set-slot="avatar">
                 <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
             </t>
-            <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+            <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                    <t t-out="recordItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
+++ b/addons/hr/static/src/views/fields/many2one_avatar_employee_field/many2one_avatar_employee_field.xml
@@ -8,10 +8,10 @@
                 <AvatarEmployee cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
-                        <AvatarEmployee resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <AvatarEmployee resModel="relation" resId="recordItemScope.data.record.id" canOpenPopover="false"/>
+                        <t t-out="recordItemScope.label"/>
                     </div>
                 </t>
             </Many2One>

--- a/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
+++ b/addons/l10n_in/static/src/components/hsn_autocomplete/hsn_autocomplete.js
@@ -59,6 +59,7 @@ export class L10nInHsnAutoComplete extends CharField {
                                 },
                                 label: item.c,
                                 onSelect: () => this.selectSuggestion(item.c, item.n),
+                                slotName: "option",
                             });
                         }
                     }
@@ -83,7 +84,6 @@ export class L10nInHsnAutoComplete extends CharField {
                         return [];
                     }
                 },
-                optionSlot: "option",
                 placeholder: _t("Searching..."),
             },
         ];

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/kanban_many2one_avatar_user_field.xml
@@ -7,10 +7,10 @@
             <t t-set-slot="avatar">
                 <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true" displayName="displayName"/>
             </t>
-            <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+            <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                    <t t-out="recordItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.xml
@@ -7,10 +7,10 @@
                 <Avatar cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id" noSpacing="true"/>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <div class="o_avatar_many2x_autocomplete d-flex align-items-center">
-                        <Avatar resModel="relation" resId="autoCompleteItemScope.record.id" canOpenPopover="false"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <Avatar resModel="relation" resId="recordItemScope.data.record.id" canOpenPopover="false"/>
+                        <t t-out="recordItemScope.label"/>
                     </div>
                 </t>
             </Many2One>

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -42,13 +42,13 @@ export class PartnerAutoCompleteCharField extends CharField {
                             data: suggestion,
                             label: suggestion.name,
                             onSelect: () => this.onSelectPartnerAutocompleteOption(suggestion),
+                            slotName: "partnerOption",
                         }));
                     }
                     else {
                         return [];
                     }
                 },
-                optionSlot: "partnerOption",
                 placeholder: _t('Searching Autocomplete...'),
             },
         ];

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -77,13 +77,13 @@ class PartnerAutoCompleteMany2one extends Component {
                             data: suggestion,
                             label: suggestion.name,
                             onSelect: () => this.onSelectPartnerAutocompleteOption(suggestion),
+                            slotName: "partnerOption",
                         }));
                     }
                     else {
                         return [];
                     }
                 },
-                optionSlot: "partnerOption",
                 placeholder: _t("Searching Autocomplete..."),
             },
         ];

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
@@ -2,11 +2,11 @@
 <templates>
     <t t-name="resource_mail.Many2ManyAvatarResourceField.option" t-inherit="web.Many2ManyTagsAvatarField.option">
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="before">
-            <i t-if="autoCompleteItemScope.record.resource_type === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
-            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ autoCompleteItemScope.record.color }}"/>
+            <i t-if="recordItemScope.data.record.resource_type === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
+            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ recordItemScope.data.record.color }}"/>
         </xpath>
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="attributes">
-            <attribute name="t-if" add="&amp;&amp; autoCompleteItemScope.record.resource_type !== 'material'" separator=" "/>
+            <attribute name="t-if" add="&amp;&amp; recordItemScope.data.record.resource_type !== 'material'" separator=" "/>
         </xpath>
     </t>
 

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/kanban_many2one_avatar_resource_field.xml
@@ -17,17 +17,17 @@
                     <AvatarResource cssClass="'o_m2o_avatar'" resModel="relation" resId="value.id"/>
                 </t>
             </t>
-            <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+            <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <t t-if="autoCompleteItemScope.record.resource_type === 'material'">
-                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="autoCompleteItemScope.record.id">
+                    <t t-if="recordItemScope.data.record.resource_type === 'material'">
+                        <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="recordItemScope.data.record.id">
                             <i class="fa fa-wrench"/>
                         </span>
                     </t>
-                    <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
-                        <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
+                    <t t-elif="recordItemScope.data.record.resource_type === 'user'">
+                        <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
                     </t>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <t t-out="recordItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.xml
@@ -18,17 +18,17 @@
                 </t>
             </t>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                        <t t-if="autoCompleteItemScope.record.resource_type === 'material'">
-                            <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="autoCompleteItemScope.record.id">
+                        <t t-if="recordItemScope.data.record.resource_type === 'material'">
+                            <span class="d-inline-flex align-items-center justify-content-center rounded o_material_resource cursor-default me-1" t-att-title="recordItemScope.data.record.id">
                                 <i class="fa fa-wrench"/>
                             </span>
                         </t>
-                        <t t-elif="autoCompleteItemScope.record.resource_type === 'user'">
-                            <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
+                        <t t-elif="recordItemScope.data.record.resource_type === 'user'">
+                            <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
                         </t>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <t t-out="recordItemScope.label"/>
                     </span>
                 </t>
             </Many2One>

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -19,7 +19,6 @@ export class AutoComplete extends Component {
                 shape: {
                     placeholder: { type: String, optional: true },
                     options: [Array, Function],
-                    optionSlot: { type: String, optional: true },
                 },
             },
         },
@@ -247,7 +246,6 @@ export class AutoComplete extends Component {
             options: [],
             isLoading: false,
             placeholder: source.placeholder,
-            optionSlot: source.optionSlot,
         };
     }
 

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -65,7 +65,7 @@
                                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
                                         t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
-                                        <t t-slot="{{ source.optionSlot }}" label="option.label" data="option.data">
+                                        <t t-slot="{{ option.slotName }}" label="option.label" data="option.data">
                                             <t t-out="option.label"/>
                                         </t>
                                     </t>

--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -16,12 +16,12 @@
                 getIds.bind="getIds"
                 update.bind="update"
             >
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <span t-if="isAvatarModel" class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{autoCompleteItemScope.data.record.id}}/avatar_128"/>
-                        <t t-esc="autoCompleteItemScope.label"/>
+                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                        <t t-esc="recordItemScope.label"/>
                     </span>
-                    <t t-else="" t-esc="autoCompleteItemScope.label"/>
+                    <t t-else="" t-esc="recordItemScope.label"/>
                 </t>
             </RecordAutocomplete>
         </div>

--- a/addons/web/static/src/core/record_selectors/record_autocomplete.js
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.js
@@ -33,7 +33,6 @@ export class RecordAutocomplete extends Component {
             {
                 placeholder: _t("Loading..."),
                 options: this.loadOptionsSource.bind(this),
-                optionSlot: this.props.slots?.autoCompleteItem ? "option" : undefined,
             },
         ];
     }
@@ -63,6 +62,7 @@ export class RecordAutocomplete extends Component {
             },
             label,
             onSelect: () => this.props.update([id]),
+            slotName: "recordItem",
         }));
         if (SEARCH_LIMIT < nameGets.length) {
             options.push({

--- a/addons/web/static/src/core/record_selectors/record_autocomplete.xml
+++ b/addons/web/static/src/core/record_selectors/record_autocomplete.xml
@@ -10,16 +10,8 @@
             class="props.className"
             sources="sources"
             onChange.bind="onChange"
-        >
-            <t t-set-slot="option" t-slot-scope="optionScope">
-                <t t-if="optionScope.data.record">
-                    <t t-slot="autoCompleteItem" label="optionScope.label" data="optionScope.data"/>
-                </t>
-                <t t-else="">
-                    <t t-esc="optionScope.label"/>
-                </t>
-            </t>
-        </AutoComplete>
+            slots="props.slots"
+        />
     </t>
 
 </templates>

--- a/addons/web/static/src/core/record_selectors/record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/record_selector.xml
@@ -18,12 +18,12 @@
                 getIds="() => []"
                 update.bind="update"
             >
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <span t-if="isAvatarModel" class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{autoCompleteItemScope.data.record.id}}/avatar_128"/>
-                        <t t-esc="autoCompleteItemScope.label"/>
+                        <img class="rounded me-1" t-attf-src="/web/image/{{props.resModel}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                        <t t-esc="recordItemScope.label"/>
                     </span>
-                    <t t-else="" t-esc="autoCompleteItemScope.label"/>
+                    <t t-else="" t-esc="recordItemScope.label"/>
                 </t>
             </RecordAutocomplete>
             <span class="o_dropdown_button"/>

--- a/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.js
+++ b/addons/web/static/src/views/calendar/calendar_filter_section/calendar_filter_section.js
@@ -40,7 +40,6 @@ export class CalendarFilterSection extends Component {
                 {
                     placeholder: _t("Loading..."),
                     options: (request) => this.loadSource(request),
-                    optionSlot: "option",
                 },
             ],
             value: "",
@@ -106,6 +105,7 @@ export class CalendarFilterSection extends Component {
             onSelect: () => {
                 return this.props.model.createFilter(this.section.fieldName, result[0]);
             },
+            slotName: "option",
         }));
 
         if (records.length > 7) {

--- a/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags/many2many_tags_field.xml
@@ -24,9 +24,9 @@
                     nameCreateField="props.nameCreateField"
                     searchThreshold="props.searchThreshold"
                 >
-                    <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
-                        <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }">
-                            <t t-out="autoCompleteItemScope.label"/>
+                    <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
+                        <span t-att-class="{ 'fw-bold': isSelected(recordItemScope.data.record) }">
+                            <t t-out="recordItemScope.label"/>
                         </span>
                     </t>
                 </Many2XAutocomplete>

--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -23,7 +23,7 @@
                     isToMany="true"
                     specification="specification"
                 >
-                    <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                    <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                         <t t-call="{{ constructor.optionTemplate }}"/>
                     </t>
                 </Many2XAutocomplete>
@@ -33,9 +33,9 @@
 
     <t t-name="web.Many2ManyTagsAvatarField.option">
         <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-            <img t-if="autoCompleteItemScope.record.id" class="rounded me-1"
-                t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-            <span t-att-class="{ 'fw-bold': isSelected(autoCompleteItemScope.record) }" t-out="autoCompleteItemScope.label"/>
+            <img t-if="recordItemScope.data.record.id" class="rounded me-1"
+                t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+            <span t-att-class="{ 'fw-bold': isSelected(recordItemScope.data.record) }" t-out="recordItemScope.label"/>
         </span>
     </t>
 

--- a/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/kanban_many2one_avatar_field.xml
@@ -9,10 +9,10 @@
                     <img t-attf-src="/web/image/{{relation}}/{{props.record.data[props.name].id}}/avatar_128" class="rounded"/>
                 </span>
             </t>
-            <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+            <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                 <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                    <t t-out="autoCompleteItemScope.label"/>
+                    <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                    <t t-out="recordItemScope.label"/>
                 </span>
             </t>
         </KanbanMany2One>

--- a/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2one_avatar/many2one_avatar_field.xml
@@ -14,10 +14,10 @@
                 </t>
             </span>
             <Many2One t-props="m2oProps" cssClass="'w-100'">
-                <t t-set-slot="autoCompleteItem" t-slot-scope="autoCompleteItemScope">
+                <t t-set-slot="recordItem" t-slot-scope="recordItemScope">
                     <span class="o_avatar_many2x_autocomplete o_avatar d-flex align-items-center">
-                        <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{autoCompleteItemScope.record.id}}/avatar_128"/>
-                        <t t-out="autoCompleteItemScope.label"/>
+                        <img class="rounded me-1" t-attf-src="/web/image/{{relation}}/{{recordItemScope.data.record.id}}/avatar_128"/>
+                        <t t-out="recordItemScope.label"/>
                     </span>
                 </t>
             </Many2One>

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -296,7 +296,6 @@ export class Many2XAutocomplete extends Component {
         return {
             placeholder: _t("Loading..."),
             options: this.loadOptionsSource.bind(this),
-            optionSlot: this.props.slots?.autoCompleteItem ? "option" : undefined,
         };
     }
 
@@ -353,6 +352,7 @@ export class Many2XAutocomplete extends Component {
             data: { record },
             label: label ? highlightText(request, label, "text-primary fw-bold") : _t("Unnamed"),
             onSelect: () => this.props.update([record]),
+            slotName: "recordItem",
         };
     }
 
@@ -389,6 +389,7 @@ export class Many2XAutocomplete extends Component {
                         this.props.searchThreshold > 1
                             ? _t("Start typing %s characters", this.props.searchThreshold)
                             : _t("Start typing..."),
+                    slotName: "startTypingItem",
                 });
             }
         } else {
@@ -403,6 +404,7 @@ export class Many2XAutocomplete extends Component {
                 options.push({
                     cssClass: "o_m2o_no_result",
                     label: _t("No records"),
+                    slotName: "noRecordsItem",
                 });
             }
         }
@@ -424,6 +426,7 @@ export class Many2XAutocomplete extends Component {
                             this.onQuickCreateError(e, request);
                         }
                     },
+                    slotName: "createItem",
                 });
             }
 
@@ -432,6 +435,7 @@ export class Many2XAutocomplete extends Component {
                     cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create_edit",
                     label: _t("Create and edit..."),
                     onSelect: slowCreate,
+                    slotName: "createEditItem",
                 });
             }
         } else if (canCreateEdit && !addSearchMore) {
@@ -439,6 +443,7 @@ export class Many2XAutocomplete extends Component {
                 cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_create_new",
                 label: _t("Create..."),
                 onSelect: slowCreate,
+                slotName: "createEditItem",
             });
         }
 
@@ -447,6 +452,7 @@ export class Many2XAutocomplete extends Component {
                 cssClass: "o_m2o_dropdown_option o_m2o_dropdown_option_search_more",
                 label: this.SearchMoreButtonLabel,
                 onSelect: this.onSearchMore.bind(this, request),
+                slotName: "searchMoreItem",
             });
         }
 

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -32,16 +32,7 @@
             t-on-click="onSearchMore"
             t-on-barcode-search="onBarcodeSearch"
         />
-        <AutoComplete t-else="" t-props="autoCompleteProps">
-            <t t-set-slot="option" t-slot-scope="optionScope">
-                <t t-if="optionScope.data.record">
-                    <t t-slot="autoCompleteItem" t-props="optionScope.data" label="optionScope.label"/>
-                </t>
-                <t t-else="">
-                    <t t-esc="optionScope.label"/>
-                </t>
-            </t>
-        </AutoComplete>
+        <AutoComplete t-else="" t-props="autoCompleteProps"/>
         <span class="o_dropdown_button" />
     </div>
 </t>

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.js
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.js
@@ -1,42 +1,14 @@
 import { rpc } from "@web/core/network/rpc";
-import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { Component, useRef, useState } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { AutoComplete } from "@web/core/autocomplete/autocomplete";
 import { Dialog } from "@web/core/dialog/dialog";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
-class GoogleFontAutoComplete extends AutoComplete {
-    setup() {
-        super.setup();
-        this.inputRef = useRef("input");
-        this.sourcesListRef = useRef("sourcesList");
-        useEffect(
-            (el) => {
-                el.setAttribute("id", "google_font");
-            },
-            () => [this.inputRef.el]
-        );
-    }
-
-    get dropdownOptions() {
-        return {
-            ...super.dropdownOptions,
-            position: "bottom-fit",
-        };
-    }
-
-    onInput(ev) {
-        super.onInput(ev);
-        if (this.sourcesListRef.el) {
-            this.sourcesListRef.el.scrollTop = 0;
-        }
-    }
-}
-
 export class AddFontDialog extends Component {
     static template = "website.dialog.addFont";
-    static components = { GoogleFontAutoComplete, Dialog };
+    static components = { AutoComplete, Dialog };
     static props = {
         close: Function,
         allFonts: Array,

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.xml
@@ -44,7 +44,7 @@
                     </div>
                     <div class="col-form-label col-md-8 o_field_widget">
                         <div class="o_input_dropdown">
-                            <GoogleFontAutoComplete value="state.googleFontFamily" placeholder.translate="Select a Google Font..." sources="getGoogleFontList"/>
+                            <AutoComplete value="state.googleFontFamily" placeholder.translate="Select a Google Font..." sources="getGoogleFontList" id="'google_font'" menuPositionOptions="{ position: 'bottom-fit', }"/>
                             <span class="o_dropdown_button" />
                         </div>
                     </div>

--- a/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
+++ b/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.js
@@ -35,12 +35,13 @@ export class UrlAutoComplete extends Component {
     get sources() {
         return [
             {
-                optionSlot: "option",
                 options: async (term) => {
                     const makeItem = (item) => ({
                         cssClass: "ui-autocomplete-item",
+                        data: item,
                         label: item.label,
                         onSelect: this.onSelect.bind(this, item.value),
+                        slotName: "item",
                     });
 
                     if (term[0] === "#") {
@@ -70,6 +71,7 @@ export class UrlAutoComplete extends Component {
                                 cssClass: "ui-autocomplete-category",
                                 data: { separator: true },
                                 label: other.title,
+                                slotName: "category",
                             });
                             for (const page of other.values) {
                                 choices.push(makeItem(page));

--- a/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.xml
+++ b/addons/website/static/src/components/autocomplete_with_pages/url_autocomplete.xml
@@ -9,14 +9,17 @@
             sources="sources"
             targetDropdown="props.targetDropdown"
         >
-            <t t-set-slot="option" t-slot-scope="optionScope">
-                <div t-att-class="{
-                    'fw-bold text-capitalize p-2': optionScope.data.separator,
-                }">
-                    <t t-if="optionScope.data.icon and optionScope.data.icon.length">
-                        <img t-att-src="optionScope.data.icon" width="24px" height="24px" class="me-2 rounded"/>
+            <t t-set-slot="category" t-slot-scope="categoryScope">
+                <div class="fw-bold text-capitalize p-2">
+                    <t t-out="categoryScope.label"/>
+                </div>
+            </t>
+            <t t-set-slot="item" t-slot-scope="itemScope">
+                <div>
+                    <t t-if="itemScope.data.icon and itemScope.data.icon.length">
+                        <img t-att-src="itemScope.data.icon" width="24px" height="24px" class="me-2 rounded"/>
                     </t>
-                    <t t-out="optionScope.label"/>
+                    <t t-out="itemScope.label"/>
                 </div>
             </t>
         </AutoCompleteWithPages>


### PR DESCRIPTION
* google_address_autocomplete,hr,l10n_in,mail, partner_autocomplete,resource_mail,website

Before this commit, we defined the slot used to render autocomplete items on the source props (with `optionSlot`). Now, the slot to use is defined on the options. That makes the options customization easier inside a same source.