### PR TITLE
[IMP] tools,web,website: move `DotDict` and `MockRequest`

### DIFF
--- a/addons/rpc/tests/test_xmlrpc.py
+++ b/addons/rpc/tests/test_xmlrpc.py
@@ -11,7 +11,6 @@ from odoo.http import _request_stack
 from odoo.service import common as auth
 from odoo.service import model
 from odoo.tests import common
-from odoo.tools import DotDict
 
 
 class TestExternalAPI(SavepointCaseWithUserDemo):
@@ -180,9 +179,9 @@ class TestAPIKeys(common.HttpCase):
             raise ValueError("There is no json here")
         # needs a fake request in order to call methods protected with check_identity
         self.http_request_key = self.canonical_tag
-        fake_req = DotDict({
+        fake_req = common.DotDict({
             # various things go and access request items
-            'httprequest': DotDict({
+            'httprequest': common.DotDict({
                 'environ': {'REMOTE_ADDR': 'localhost'},
                 'cookies': {common.TEST_CURSOR_COOKIE_NAME: self.canonical_tag},
                 'args': {},

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -220,7 +220,7 @@ class TestPDFQuoteBuilder(SaleManagementCommon):
         if 'website' not in self.env:
             self.skipTest("Module `website` not found")
         else:
-            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+            from odoo.addons.web.tests.utils import MockRequest  # noqa: PLC0415
 
         # Upload document without Sale Order Template
         with (
@@ -249,7 +249,7 @@ class TestPDFQuoteBuilder(SaleManagementCommon):
         if 'website' not in self.env:
             self.skipTest("Module `website` not found")
         else:
-            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+            from odoo.addons.web.tests.utils import MockRequest  # noqa: PLC0415
 
         # Upload a document for a Sale Order Template without company id
         self.empty_order_template.company_id = False

--- a/addons/survey/tests/test_survey_results.py
+++ b/addons/survey/tests/test_survey_results.py
@@ -4,7 +4,7 @@ import json
 
 from odoo.addons.survey.controllers.main import Survey
 from odoo.addons.survey.tests import common
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 
 
 class TestSurveyResults(common.TestSurveyResultsCommon):

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -5,7 +5,7 @@ import logging
 import psycopg2
 
 from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 import odoo.tests
 from odoo.tests.common import TransactionCase
 

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests import standalone
 
 

--- a/addons/web/tests/__init__.py
+++ b/addons/web/tests/__init__.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import utils
+
 from . import test_db_manager
 from . import test_health
 from . import test_image

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import odoo.tests
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.exceptions import UserError
 from odoo.http import root
 from odoo.tools import mute_logger

--- a/addons/web/tests/utils.py
+++ b/addons/web/tests/utils.py
@@ -1,0 +1,105 @@
+import contextlib
+import werkzeug.urls
+from unittest.mock import Mock, MagicMock, patch
+from werkzeug.exceptions import NotFound
+from werkzeug.test import EnvironBuilder
+
+import odoo.http
+from odoo.tests.common import DotDict, HOST, HttpCase
+from odoo.tools.misc import frozendict
+
+
+@contextlib.contextmanager
+def MockRequest(
+    env, *, path='/mockrequest', routing=True, multilang=True,
+    context=frozendict(), cookies=frozendict(), country_code=None,
+    website=None, remote_addr=HOST, environ_base=None, url_root=None,
+):
+    lang_code = context.get('lang', env.context.get('lang', 'en_US'))
+    env = env(context=dict(context, lang=lang_code))
+    if HttpCase.http_port():
+        base_url = HttpCase.base_url()
+    else:
+        base_url = f"http://{HOST}:{odoo.tools.config['http_port']}"
+    request = Mock(
+        # request
+        httprequest=Mock(
+            host='localhost',
+            path=path,
+            app=odoo.http.root,
+            environ=dict(
+                EnvironBuilder(
+                    path=path,
+                    base_url=base_url,
+                    environ_base=environ_base,
+                ).get_environ(),
+                REMOTE_ADDR=remote_addr,
+            ),
+            cookies=cookies,
+            referrer='',
+            remote_addr=remote_addr,
+            url_root=url_root,
+            args=[],
+        ),
+        type='http',
+        future_response=odoo.http.FutureResponse(),
+        params={},
+        redirect=env['ir.http']._redirect,
+        session=DotDict(
+            odoo.http.get_default_session(),
+            context={'lang': ''},
+            force_website_id=website and website.id,
+        ),
+        geoip=odoo.http.GeoIP('127.0.0.1'),
+        db=env.registry.db_name,
+        env=env,
+        registry=env.registry,
+        cr=env.cr,
+        uid=env.uid,
+        context=env.context,
+        cookies=cookies,
+        lang=env['res.lang']._get_data(code=lang_code),
+        website=website,
+        render=lambda *a, **kw: '<MockResponse>',
+    )
+    if url_root is not None:
+        request.httprequest.url = werkzeug.urls.url_join(url_root, path)
+    if website:
+        request.website_routing = website.id
+    if country_code:
+        try:
+            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
+        except TypeError:
+            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
+
+    # The following code mocks match() to return a fake rule with a fake
+    # 'routing' attribute (routing=True) or to raise a NotFound
+    # exception (routing=False).
+    #
+    #   router = odoo.http.root.get_db_router()
+    #   rule, args = router.bind(...).match(path)
+    #   # arg routing is True => rule.endpoint.routing == {...}
+    #   # arg routing is False => NotFound exception
+    router = MagicMock()
+    match = router.return_value.bind.return_value.match
+    if routing:
+        match.return_value[0].routing = {
+            'type': 'http',
+            'website': True,
+            'multilang': multilang
+        }
+    else:
+        match.side_effect = NotFound
+
+    def update_context(**overrides):
+        request.env = request.env(context=dict(request.context, **overrides))
+        request.context = request.env.context
+
+    request.update_context = update_context
+
+    with contextlib.ExitStack() as s:
+        odoo.http._request_stack.push(request)
+        s.callback(odoo.http._request_stack.pop)
+        s.enter_context(patch('odoo.http.root.get_db_router', router))
+
+        yield request

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -5,8 +5,9 @@ from lxml import etree
 import re
 from markupsafe import Markup
 
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import distance, MockRequest
+from odoo.addons.website.tools import distance
 import odoo.tests
 from odoo.tests.common import TransactionCase
 

--- a/addons/website/tests/test_get_current_website.py
+++ b/addons/website/tests/test_get_current_website.py
@@ -2,7 +2,7 @@
 import json
 
 from odoo import Command
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -4,7 +4,7 @@ import json
 import lxml.html
 from urllib.parse import urlparse
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests import HttpCase, tagged
 
 

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -5,7 +5,7 @@ from lxml import html
 from unittest.mock import Mock, patch
 from werkzeug.urls import url_parse
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests import common
 
 

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -4,7 +4,7 @@ from lxml import html
 from unittest.mock import patch
 
 from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.fields import Command
 from odoo.http import root
 from odoo.tests import common, HttpCase, tagged

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -2,7 +2,7 @@
 
 from odoo import http
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests.common import TransactionCase
 
 

--- a/addons/website/tests/test_redirect.py
+++ b/addons/website/tests/test_redirect.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, tagged
 

--- a/addons/website/tests/test_res_users.py
+++ b/addons/website/tests/test_res_users.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.exceptions import ValidationError
 from odoo.service.model import retrying
 from odoo.tests.common import TransactionCase, new_test_user

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -5,7 +5,8 @@ from lxml import html
 from werkzeug.urls import url_encode
 
 from odoo.tests import HttpCase, tagged
-from odoo.addons.website.tools import MockRequest, create_image_attachment
+from odoo.addons.web.tests.utils import MockRequest
+from odoo.addons.website.tools import create_image_attachment
 from odoo.tests.common import HOST
 from odoo.tools import config
 import unittest

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from odoo.http import request
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 from odoo.addons.website.controllers.form import WebsiteForm
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.tests.common import tagged, TransactionCase
 import unittest
 

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -1,115 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import contextlib
 import re
 import werkzeug.urls
 from lxml import etree
-from unittest.mock import Mock, MagicMock, patch
 
-from werkzeug.exceptions import NotFound
-from werkzeug.test import EnvironBuilder
-
-import odoo.http
-from odoo.tools.misc import hmac, DotDict, frozendict
+from odoo.tools.misc import hmac
 
 HOST = '127.0.0.1'
-
-
-@contextlib.contextmanager
-def MockRequest(
-    env, *, path='/mockrequest', routing=True, multilang=True,
-    context=frozendict(), cookies=frozendict(), country_code=None,
-    website=None, remote_addr=HOST, environ_base=None, url_root=None,
-):
-    # TODO move MockRequest to a package in addons/web/tests
-    from odoo.tests.common import HttpCase  # noqa: PLC0415
-    lang_code = context.get('lang', env.context.get('lang', 'en_US'))
-    env = env(context=dict(context, lang=lang_code))
-    if HttpCase.http_port():
-        base_url = HttpCase.base_url()
-    else:
-        base_url = f"http://{HOST}:{odoo.tools.config['http_port']}"
-    request = Mock(
-        # request
-        httprequest=Mock(
-            host='localhost',
-            path=path,
-            app=odoo.http.root,
-            environ=dict(
-                EnvironBuilder(
-                    path=path,
-                    base_url=base_url,
-                    environ_base=environ_base,
-                ).get_environ(),
-                REMOTE_ADDR=remote_addr,
-            ),
-            cookies=cookies,
-            referrer='',
-            remote_addr=remote_addr,
-            url_root=url_root,
-            args=[],
-        ),
-        type='http',
-        future_response=odoo.http.FutureResponse(),
-        params={},
-        redirect=env['ir.http']._redirect,
-        session=DotDict(
-            odoo.http.get_default_session(),
-            context={'lang': ''},
-            force_website_id=website and website.id,
-        ),
-        geoip=odoo.http.GeoIP('127.0.0.1'),
-        db=env.registry.db_name,
-        env=env,
-        registry=env.registry,
-        cr=env.cr,
-        uid=env.uid,
-        context=env.context,
-        cookies=cookies,
-        lang=env['res.lang']._get_data(code=lang_code),
-        website=website,
-        render=lambda *a, **kw: '<MockResponse>',
-    )
-    if url_root is not None:
-        request.httprequest.url = werkzeug.urls.url_join(url_root, path)
-    if website:
-        request.website_routing = website.id
-    if country_code:
-        try:
-            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
-        except TypeError:
-            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
-
-    # The following code mocks match() to return a fake rule with a fake
-    # 'routing' attribute (routing=True) or to raise a NotFound
-    # exception (routing=False).
-    #
-    #   router = odoo.http.root.get_db_router()
-    #   rule, args = router.bind(...).match(path)
-    #   # arg routing is True => rule.endpoint.routing == {...}
-    #   # arg routing is False => NotFound exception
-    router = MagicMock()
-    match = router.return_value.bind.return_value.match
-    if routing:
-        match.return_value[0].routing = {
-            'type': 'http',
-            'website': True,
-            'multilang': multilang
-        }
-    else:
-        match.side_effect = NotFound
-
-    def update_context(**overrides):
-        request.env = request.env(context=dict(request.context, **overrides))
-        request.context = request.env.context
-
-    request.update_context = update_context
-
-    with contextlib.ExitStack() as s:
-        odoo.http._request_stack.push(request)
-        s.callback(odoo.http._request_stack.pop)
-        s.enter_context(patch('odoo.http.root.get_db_router', router))
-
-        yield request
 
 # Fuzzy matching tools
 

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -3,7 +3,7 @@ import json
 
 from odoo.exceptions import UserError
 from odoo.tests.common import users, HttpCase, tagged
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 from odoo.addons.mail.controllers.thread import ThreadController
 

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -12,7 +12,7 @@ from odoo.tools import mute_logger
 from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website_crm_partner_assign.controllers.main import (
     WebsiteAccount,
     WebsiteCrmPartnerAssign,

--- a/addons/website_event/tests/test_event_internals.py
+++ b/addons/website_event/tests/test_event_internals.py
@@ -5,8 +5,8 @@ from datetime import datetime, timedelta
 
 from odoo.fields import Datetime as FieldsDatetime
 from odoo.tests.common import users
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website.tests.test_website_visitor import MockVisitor
-from odoo.addons.website.tools import MockRequest
 from odoo.addons.website_event.controllers.main import WebsiteEventController
 from odoo.addons.event.tests.common import EventCase
 

--- a/addons/website_forum/tests/test_forum_controller.py
+++ b/addons/website_forum/tests/test_forum_controller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website_forum.controllers.website_forum import WebsiteForum
 from odoo.addons.website_forum.tests.common import KARMA, TestForumCommon
 

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -6,7 +6,7 @@ import odoo.tests
 from odoo.tools import html2plaintext
 import unittest
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website_hr_recruitment.controllers.main import WebsiteHrRecruitment
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/addons/website_project/tests/test_project_portal_access.py
+++ b/addons/website_project/tests/test_project_portal_access.py
@@ -6,7 +6,7 @@ from odoo.tests import HttpCase
 
 from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.project.tests.test_project_sharing import TestProjectSharingCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 
 
 class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -7,7 +7,7 @@ from odoo.tools import lazy
 
 from odoo.addons.delivery.tests.common import DeliveryCommon
 from odoo.addons.product.tests.common import ProductCommon
-from odoo.addons.website.tools import MockRequest as websiteMockRequest
+from odoo.addons.web.tests.utils import MockRequest as websiteMockRequest
 from odoo.addons.website_sale.models.website import (
     CART_SESSION_CACHE_KEY,
     FISCAL_POSITION_SESSION_CACHE_KEY,

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -7,7 +7,7 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 

--- a/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
+++ b/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
@@ -4,7 +4,7 @@ from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -4,7 +4,7 @@ import logging
 
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 
 
 _logger = logging.getLogger(__name__)

--- a/addons/website_sale/tests/test_website_sequence.py
+++ b/addons/website_sale/tests/test_website_sequence.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 from odoo.tools import SQL
 
 from odoo.addons.base.tests.common import BaseCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.web.tests.utils import MockRequest
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import odoo
 from odoo.http import content_disposition, root
 from odoo.tests import tagged
-from odoo.tests.common import HOST, BaseCase, get_db_name, new_test_user
+from odoo.tests.common import HOST, BaseCase, DotDict, get_db_name, new_test_user
 from odoo.tools import config, file_path, parse_version
 
 from .test_common import TestHttpBase
@@ -64,7 +64,7 @@ class TestHttpMisc(TestHttpBase):
 
     def test_misc2_local_redirect(self):
         def local_redirect(path):
-            fake_req = odoo.tools.misc.DotDict(db=False)
+            fake_req = DotDict(db=False)
             return odoo.http.Request.redirect(fake_req, path, local=True).headers['Location']
         self.assertEqual(local_redirect('https://www.example.com/hello?a=b'), '/hello?a=b')
         self.assertEqual(local_redirect('/hello?a=b'), '/hello?a=b')

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -62,7 +62,7 @@ from odoo.fields import Command
 from odoo.modules.registry import Registry, DummyRLock
 from odoo.service import security
 from odoo.sql_db import Cursor, Savepoint
-from odoo.tools import config, float_compare, mute_logger, profiler, SQL, DotDict
+from odoo.tools import config, float_compare, mute_logger, profiler, SQL
 from odoo.tools.mail import single_email_re
 from odoo.tools.misc import find_in_path, lower_logging
 from odoo.tools.xml_utils import _validate_xml
@@ -300,6 +300,19 @@ def _normalize_arch_for_assert(arch_string, parser_method="xml"):
     parser = Parser(remove_blank_text=True)
     arch_string = etree.fromstring(arch_string, parser=parser)
     return etree.tostring(arch_string, pretty_print=True, encoding='unicode')
+
+
+class DotDict(dict):
+    """Helper for dot.notation access to dictionary attributes
+
+        E.g.
+          foo = DotDict({'bar': False})
+          return foo.bar
+    """
+    def __getattr__(self, attrib):
+        val = self.get(attrib)
+        return DotDict(val) if isinstance(val, dict) else val
+
 
 class BlockedRequest(requests.exceptions.ConnectionError):
     pass

--- a/odoo/tools/image.py
+++ b/odoo/tools/image.py
@@ -16,7 +16,6 @@ except ImportError:
 from random import randrange
 
 from odoo.exceptions import UserError
-from odoo.tools.misc import DotDict
 from odoo.tools.translate import LazyTranslate
 
 
@@ -514,19 +513,20 @@ def is_image_size_above(base64_source_1, base64_source_2):
 
     def get_image_size(base64_source):
         source = base64.b64decode(base64_source)
+
         if (source[0:4] == b'RIFF' and source[8:15] == b'WEBPVP8'):
             size = get_webp_size(source)
             if size:
-                return DotDict({'width': size[0], 'height': size[0]})
-            else:
-                # False for unknown WEBP format
-                return False
-        else:
-            return image_fix_orientation(binary_to_image(source))
+                return size[0], size[0]
+            # False for unknown WEBP format
+            return False
 
-    image_source = get_image_size(base64_source_1)
-    image_target = get_image_size(base64_source_2)
-    return image_source.width > image_target.width or image_source.height > image_target.height
+        fixed_image = image_fix_orientation(binary_to_image(source))
+        return fixed_image.width, fixed_image.height
+
+    source_width, source_height = get_image_size(base64_source_1)
+    target_width, target_height = get_image_size(base64_source_2)
+    return source_width > target_width or source_height > target_height
 
 
 def image_guess_size_from_field_name(field_name: str) -> Tuple[int, int]:

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -62,7 +62,6 @@ __all__ = [
     'DEFAULT_SERVER_TIME_FORMAT',
     'NON_BREAKING_SPACE',
     'SKIPPED_ELEMENT_TYPES',
-    'DotDict',
     'LastOrderedSet',
     'OrderedSet',
     'Reverse',
@@ -1666,18 +1665,6 @@ class ReadonlyDict(Mapping[K, T], typing.Generic[K, T]):
 
     def __iter__(self):
         return iter(self._data__)
-
-
-class DotDict(dict):
-    """Helper for dot.notation access to dictionary attributes
-
-        E.g.
-          foo = DotDict({'bar': False})
-          return foo.bar
-    """
-    def __getattr__(self, attrib):
-        val = self.get(attrib)
-        return DotDict(val) if isinstance(val, dict) else val
 
 
 def get_diff(data_from, data_to, custom_style=False, dark_color_scheme=False):


### PR DESCRIPTION
The `DotDict` class can produce unexpected behaviour
if used incorrectly.
This commit moves this class so that it is only used in tests.

The `MockRequest` context manager uses the `DotDict`.
As we cannot import objects from the test framework and
`MockRequest` is only used in tests, it makes sense to move it
to `odoo.addons.web.tests.utils`.

task-4822364