### PR TITLE
[IMP] hr_work_entry: add new work entry types for Luxembourg

### DIFF
--- a/addons/hr_work_entry/data/hr_work_entry_type_data.xml
+++ b/addons/hr_work_entry/data/hr_work_entry_type_data.xml
@@ -1343,6 +1343,41 @@
         <field name="category" eval="'absence'"/>
     </record>
 
+    <record id="l10n_lu_work_entry_type_sick_leave" model="hr.work.entry.type">
+        <field name="name">Luxembourg Sick Time Off</field>
+        <field name="color">5</field>
+        <field name="code">LUXSICK</field>
+        <field name="country_id" ref="base.lu"/>
+    </record>
+
+    <record id="l10n_lu_work_entry_type_family_reason_leave" model="hr.work.entry.type">
+        <field name="name">Family Reason Time Off</field>
+        <field name="color">5</field>
+        <field name="code">LUFRTO</field>
+        <field name="country_id" ref="base.lu"/>
+    </record>
+
+    <record id="l10n_lu_work_entry_type_maternity_leave" model="hr.work.entry.type">
+        <field name="name">Maternity Leave</field>
+        <field name="color">5</field>
+        <field name="code">LUMAT</field>
+        <field name="country_id" ref="base.lu"/>
+    </record>
+
+    <record id="l10n_lu_work_entry_type_welcome_leave" model="hr.work.entry.type">
+        <field name="name">Welcome Leave</field>
+        <field name="color">5</field>
+        <field name="code">LUACC</field>
+        <field name="country_id" ref="base.lu"/>
+    </record>
+
+    <record id="l10n_lu_work_entry_type_caring_leave" model="hr.work.entry.type">
+        <field name="name">Caring Leave</field>
+        <field name="color">5</field>
+        <field name="code">LUCAR</field>
+        <field name="country_id" ref="base.lu"/>
+    </record>
+
 <!-- MX : Mexico -->
     <record id="l10n_mx_work_entry_type_work_risk_imss" model="hr.work.entry.type">
         <field name="name">Work risk (IMSS)</field>


### PR DESCRIPTION
Added the following work entry types:
- Luxembourg Sick Leave
- Family Reason Time Off
- Maternity Leave
- Welcome Leave
- Caring Leave

task-4737317

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
