### PR TITLE
[FIX] crm: crm_tour: remove delay

### DIFF
--- a/addons/crm/static/src/js/tours/crm.js
+++ b/addons/crm/static/src/js/tours/crm.js
@@ -3,7 +3,6 @@ import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 import { markup } from "@odoo/owl";
-import { delay } from "@odoo/hoot-dom";
 
 registry.category("web_tour.tours").add('crm_tour', {
     url: "/odoo",
@@ -81,12 +80,6 @@ registry.category("web_tour.tours").add('crm_tour', {
     content: markup(_t("Drag your opportunity to <b>Won</b> when you get the deal. Congrats!")),
     tooltipPosition: "right",
     run: "drag_and_drop(.o_opportunity_kanban .o_kanban_group:eq(3))",
-},
-{
-    trigger: "body:not(:has(.o_reward_rainbow_man))",
-    async run() {
-        await delay(3000);
-    }
 },
 {
     trigger: ".o_kanban_record",


### PR DESCRIPTION
Since [1], we now wait ´onClose´ before closing modals and this delay is not necessary anymore.

Before [1], the tour clicked on a kanban record that should have opened a form view but that was cancelled by the ´switchView()´ because a modal was detected.
The issue was that modal was closed too soon leaving the tour clicking on the kanban card while the instance of modal is still alive even if not in the DOM anymore.

Now that modal closing is synchronized, we can safely remove this delay without any risk of being blocked by the ´switchView()´ because of a modal residue.

[1] https://github.com/odoo/odoo/pull/210521

runbot-error: 181875

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
