### PR TITLE
[IMP] point_of_sale: set payment term on invoice when using 'pay_later'

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -803,6 +803,11 @@ class PosOrder(models.Model):
         rounding_method = pos_config.rounding_method
         amount_total = sum(order.amount_total for order in self)
         move_type = 'out_invoice' if amount_total >= 0 else 'out_refund'
+        invoice_payment_term_id = (
+            self.partner_id.property_payment_term_id.id
+            if self.partner_id.property_payment_term_id and any(p.payment_method_id.type == 'pay_later' for p in self.payment_ids)
+            else False
+        )
 
         vals = {
             'invoice_origin': ', '.join(ref or '' for ref in self.mapped('pos_reference')),
@@ -817,7 +822,7 @@ class PosOrder(models.Model):
             'invoice_user_id': self.user_id.id,
             'fiscal_position_id': fiscal_position.id,
             'invoice_line_ids': self._prepare_invoice_lines(move_type),
-            'invoice_payment_term_id': False,
+            'invoice_payment_term_id': invoice_payment_term_id,
             'invoice_cash_rounding_id': rounding_method.id,
         }
         if is_single_order and self.refunded_order_id.account_move:

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -3,7 +3,7 @@
 
 import time
 from freezegun import freeze_time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import odoo
 from odoo import fields, tools
@@ -1182,6 +1182,51 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         self.assertEqual(len(picking_mls_no_stock), 0)
         self.assertEqual(len(picking_mls_stock), 1)
         self.assertEqual(len(pickings.picking_type_id), 1)
+
+    def test_pos_order_invoice_payment_term(self):
+        """ Test that when invoicing a POS order paid with customer account, the partner's payment term is then applied to the invoice. """
+        self.customer_account_payment_method = self.env['pos.payment.method'].create({
+            'name': 'Customer Account',
+            'split_transactions': True,
+        })
+        payment_methods = self.pos_config.payment_method_ids | self.customer_account_payment_method
+        self.pos_config.write({'payment_method_ids': [Command.set(payment_methods.ids)]})
+
+        pay_term_30 = self.env.ref('account.account_payment_term_30days')
+        partner_a = self.env["res.partner"].create({
+            'name': 'APartner',
+            'property_payment_term_id': pay_term_30.id,
+        })
+
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': partner_a.id,
+            'lines': [Command.create({
+                'product_id': self.product_a.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 1,
+                'price_subtotal': 10,
+                'price_subtotal_incl': 10,
+            })],
+            'amount_paid': 10.0,
+            'amount_total': 10.0,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': True,
+            'last_order_preparation_change': '{}'
+        })
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': 10.0,
+            'payment_method_id': self.customer_account_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+
+        self.assertEqual(order.account_move.invoice_date_due, (datetime.now() + timedelta(days=30)).date())
 
     def test_order_refund_picking(self):
         self.pos_config.open_ui()


### PR DESCRIPTION
Sets the `invoice_payment_term_id` on POS invoices when the customer has a payment term and at least one payment method is of type `pay_later`. This ensures correct invoice terms are applied for deferred payments.

task-id: 4808683


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
