### PR TITLE
[FIX] mail: green message bubble tint stronger

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -21,19 +21,19 @@
         }
     }
     &.o-green {
-        background-color: mix($gray-100, darken($success, 10%), 85.5%) !important;
-        border-color: mix(lighten(mix($gray-100, darken($success, 10%), 87.5%), 2.5%), black, 75%) !important;
+        background-color: mix($gray-100, darken($success, 2.5%), 85.5%) !important;
+        border-color: mix(lighten(mix($gray-100, darken($success, 2.5%), 85.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
-            background-color: darken(mix($gray-100, darken($success, 10%), 87.5%), 5%) !important;
+            background-color: darken(mix($gray-100, darken($success, 2.5%), 85.5%), 5%) !important;
         }
     }
     &.o-orange {
-        background-color: mix($gray-100, darken($warning, 10%), 70.5%) !important;
-        border-color: mix(lighten(mix($gray-100, darken($warning, 10%), 72.5%), 2.5%), black, 75%) !important;
+        background-color: mix($gray-100, darken($warning, 5%), 70.5%) !important;
+        border-color: mix(lighten(mix($gray-100, darken($warning, 5%), 70.5%), 2.5%), black, 75%) !important;
     
         &.o-muted {
-            background-color: darken(mix($gray-100,  darken($warning, 10%), 72.5%), 10%) !important;
+            background-color: darken(mix($gray-100,  darken($warning, 5%), 70.5%), 10%) !important;
         }
     }
 }
@@ -49,18 +49,18 @@
     }
     &.o-green {
         .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, darken($success, 10%), 87.5%) !important;
+            color: mix($gray-100, darken($success, 2.5%), 85.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, darken($success, 10%), 87.5%), 2.5%), black, 75%) !important;
+            color: mix(lighten(mix($gray-100, darken($success, 2.5%), 85.5%), 2.5%), black, 75%) !important;
         }
     }
     &.o-orange {
         .o-mail-Message-bubbleTailBg {
-            color: mix($gray-100, darken($warning, 10%), 72.5%) !important;
+            color: mix($gray-100, darken($warning, 5%), 70.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(lighten(mix($gray-100, darken($warning, 10%), 72.5%), 2.5%), black, 75%) !important;
+            color: mix(lighten(mix($gray-100, darken($warning, 5%), 70.5%), 2.5%), black, 75%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -91,16 +91,16 @@
         }
     }
     &.o-green {
-        background-color: mix($o-view-background-color, lighten($success, 5%), 85.5%) !important;
-        border-color: mix(darken(mix($o-view-background-color, lighten($success, 5%), 85.5%), 10%), white, 92.5%) !important;
+        background-color: mix($o-view-background-color, lighten($success, 2.5%), 85.5%) !important;
+        border-color: mix(darken(mix($o-view-background-color, lighten($success, 2.5%), 85.5%), 10%), white, 92.5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, lighten($success, 5%), 90.5%)) !important;
         }
     }
     &.o-orange {
-        background-color: mix($o-view-background-color, lighten($warning, 5%), 75%) !important;
-        border-color: mix(darken(mix($o-view-background-color, lighten($warning, 5%), 75%), 10%), white, 87.5%) !important;
+        background-color: mix($o-view-background-color, lighten($warning, 2.5%), 75%) !important;
+        border-color: mix(darken(mix($o-view-background-color, lighten($warning, 2.5%), 75%), 10%), white, 87.5%) !important;
 
         &.o-muted {
             background-color: mix($white, mix($o-view-background-color, $warning, 75%), 85%) !important;
@@ -124,18 +124,18 @@
     }
     &.o-green {
         .o-mail-Message-bubbleTailBg {
-            color: mix($o-view-background-color, lighten($success, 5%), 85.5%) !important;
+            color: mix($o-view-background-color, lighten($success, 2.5%), 85.5%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(darken(mix($o-view-background-color, lighten($success, 5%), 85.5%), 10%), white, 92.5%) !important;
+            color: mix(darken(mix($o-view-background-color, lighten($success, 2.5%), 85.5%), 10%), white, 92.5%) !important;
         }
     }
     &.o-orange {
         .o-mail-Message-bubbleTailBg {
-            color: mix($o-view-background-color, lighten($warning, 5%), 75%) !important;
+            color: mix($o-view-background-color, lighten($warning, 2.5%), 75%) !important;
         }
         .o-mail-Message-bubbleTailBorder {
-            color: mix(darken(mix($o-view-background-color, lighten($warning, 5%), 75%), 10%), white, 87.5%) !important;
+            color: mix(darken(mix($o-view-background-color, lighten($warning, 2.5%), 75%), 10%), white, 87.5%) !important;
         }
     }
 }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -170,11 +170,11 @@
         <t t-if="isMobileOS">
             <t t-if="isAlignedRight">
                 <t t-call="mail.Message.emptyQuickAction"/>
-                <t t-call="mail.Message.expandAction"/>
+                <t t-if="!props.asCard" t-call="mail.Message.expandAction"/>
             </t>
             <t t-else="">
                 <t t-call="mail.Message.expandAction"/>
-                <t t-call="mail.Message.emptyQuickAction"/>
+                <t t-if="!props.asCard" t-call="mail.Message.emptyQuickAction"/>
             </t>
         </t>
         <t t-else="">

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -5,7 +5,7 @@
 
     &.o-important {
         background-color: mix($o-view-background-color, lighten($info, 5%), 87.5%);
-        border-color: darken(mix($o-view-background-color, lighten($info, 5%), 87.5%), 7.5%) !important;
+        border-color: darken(mix($o-view-background-color, $info, 87.5%), 7.5%) !important;
     }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));


### PR DESCRIPTION
Message bubble green color was not strong enough, especially in dark theme. This makes it hard to distinct self messages in discuss app.

This commit increases slightly the saturation of green message bubble.

This commit also makes the following (kinda) related changes:
- important message bubble orange color is more catchy with also more saturated color
- important messaging menu items are more visually distinct in white theme.