### PR TITLE
[IMP] payment: add default graph and pivot view for transactions

### DIFF
--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -123,10 +123,33 @@
         </field>
     </record>
 
+    <record id="payment_transaction_graph" model="ir.ui.view">
+        <field name="name">payment.transaction.graph</field>
+        <field name="model">payment.transaction</field>
+        <field name="arch" type="xml">
+            <graph string="Payment Transaction">
+                <field name="create_date" interval="month"/>
+                <field name="state"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="payment_transaction_pivot" model="ir.ui.view">
+        <field name="name">payment.transaction.pivot</field>
+        <field name="model">payment.transaction</field>
+        <field name="arch" type="xml">
+            <pivot string="Payment Transaction" display_quantity="1">
+                <field name="create_date" interval="month" type="row"/>
+                <field name="state" type="col"/>
+                <field name="amount" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="action_payment_transaction" model="ir.actions.act_window">
         <field name="name">Payment Transactions</field>
         <field name="res_model">payment.transaction</field>
-        <field name="view_mode">list,kanban,form</field>
+        <field name="view_mode">list,kanban,form,graph,pivot</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_neutral_face">
                 There are no transactions to show


### PR DESCRIPTION
This commit enable the graph and pivot view for transactions, it helps users when they need to get stats about transactions; notably to see or detect increasing error rate and analyze them.

Task-Id: 4809323

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
