### PR TITLE
[FIX] account: only try to create tags if necessary when switching engine

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -539,13 +539,17 @@ class AccountReportExpression(models.Model):
         tax_tags_expressions = self.filtered(lambda x: x.engine == 'tax_tags')
 
         if vals.get('engine') == 'tax_tags':
-            # We already generate the tags for the expressions receiving a new engine, but keeping the same formula
+            # We already generate the tags for the expressions receiving a new engine
             tags_create_vals = []
             for expression_with_new_engine in self - tax_tags_expressions:
-                tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
-                    vals.get('formula') or expression_with_new_engine.formula,
-                    expression_with_new_engine.report_line_id.report_id.country_id.id,
-                )
+                tag_name = vals.get('formula') or expression_with_new_engine.formula
+                country = expression_with_new_engine.report_line_id.report_id.country_id
+                if not self.env['account.account.tag']._get_tax_tags(tag_name, country.id):
+                    tags_create_vals += self.env['account.report.expression']._get_tags_create_vals(
+                        tag_name,
+                        country.id,
+                    )
+
             self.env['account.account.tag'].create(tags_create_vals)
 
         if 'formula' not in vals:

--- a/addons/account/tests/test_tax_report.py
+++ b/addons/account/tests/test_tax_report.py
@@ -276,6 +276,27 @@ class TaxReportTest(AccountTestInvoicingCommon):
         self.assertEqual(len(tags_after), 2, "Changing the engine should have created tags")
         self.assertEqual(tags_after.mapped('name'), ['-Dudu', '+Dudu'])
 
+    def test_change_engine_shared_tags(self):
+        aggregation_line = self.env['account.report.line'].create({
+            'name': "Je ne mange pas de graines !!!",
+            'report_id': self.tax_report_1.id,
+            'expression_ids': [
+                Command.create({
+                    'label': 'balance',
+                    'engine': 'aggregation',
+                    'formula': 'Dudu',
+                }),
+            ],
+        })
+
+        tags_before = self._get_tax_tags(self.test_country_1, tag_name='01')
+        self.assertEqual(len(tags_before), 2, "The tags should already exist because of another expression")
+
+        aggregation_line.expression_ids.write({'engine': 'tax_tags', 'formula': '01'})
+
+        tags_after = self._get_tax_tags(self.test_country_1, tag_name='01')
+        self.assertEqual(tags_after, tags_before, "No new tag should have been created")
+
     def test_change_formula_multiple_fields(self):
         tags_before = self._get_tax_tags(self.test_country_1, tag_name='Buny')
         self.assertFalse(tags_before, "The tags shouldn't exist yet")


### PR DESCRIPTION
Before this commit, when switching to 'tax_tags' the engine of an aggregation, and providing it a formula matching tags already created by another expression, we still tried to create them, resulting in an SQL constraint failing, since the tag got duplicate instead of becoming shared.

