### PR TITLE
[FIX] website: add vimeo preview for background video

### DIFF
--- a/addons/website/static/src/builder/plugins/options/background_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/background_option_plugin.js
@@ -67,6 +67,9 @@ class WebsiteBackgroundVideoPlugin extends Plugin {
                 noIcons: true,
                 noImages: true,
                 noDocuments: true,
+                isForBgVideo: true,
+                vimeoPreviewIds: ['528686125', '430330731', '509869821', '397142251', '763851966', '486931161',
+                    '499761556', '392935303', '728584384', '865314310', '511727912', '466830211'],
                 save: (media) => {
                     resolve(media.querySelector("iframe").src);
                 },


### PR DESCRIPTION
This was forgotten in the website refactor [1].
    
Steps to reproduce:
- Drop a snippet
- Click on background video
- Popup opens
- It should suggest some vimeo videos
    
[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
Related to task-4367641