### PR TITLE
[FIX] pos_self_order: fix traceback when 0 priced order

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_mobile_tour.js
@@ -256,3 +256,20 @@ registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
         Utils.checkIsNoBtn("Ok"),
     ],
 });
+
+registry.category("web_tour.tours").add("self_order_mobile_0_price_order", {
+    steps: () =>
+        [
+            Utils.checkIsNoBtn("My Order"),
+            Utils.clickBtn("Order Now"),
+            LandingPage.selectLocation("Eat In"),
+            ProductPage.clickProduct("Ketchup"),
+            Utils.clickBtn("Order"),
+            CartPage.checkProduct("Ketchup", "0", "1"),
+            Utils.clickBtn("Pay"),
+            CartPage.selectTable("3"),
+            ConfirmationPage.isShown(),
+            Utils.clickBtn("Ok"),
+            Utils.clickBtn("My Order"),
+        ].flat(),
+});

--- a/addons/pos_self_order/tests/self_order_common_test.py
+++ b/addons/pos_self_order/tests/self_order_common_test.py
@@ -54,6 +54,14 @@ class SelfOrderCommonTest(odoo.tests.HttpCase):
             'available_in_pos': True,
             'pos_categ_ids': [(4, pos_categ_misc.id)],
         })
+        cls.ketchup = cls.env['product.product'].create({
+            'name': 'Ketchup',
+            'is_storable': True,
+            'list_price': 0,
+            'taxes_id': False,
+            'available_in_pos': True,
+            'pos_categ_ids': [(4, pos_categ_misc.id)],
+        })
 
         #desk organizer
         cls.desk_organizer = cls.env['product.product'].create({

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -76,3 +76,37 @@ class TestSelfOrderMobile(SelfOrderCommonTest):
 
         # Cancel in each
         self.start_tour(self_route, "self_order_mobile_each_cancel")
+
+    def test_self_order_mobile_0_price_order(self):
+        self.pos_config.write({
+            'takeaway': True,
+            'self_ordering_takeaway': True,
+            'self_ordering_mode': 'mobile',
+            'self_ordering_pay_after': 'each',
+            'self_ordering_service_mode': 'table',
+        })
+
+        floor = self.env["restaurant.floor"].create({
+            "name": 'Main Floor',
+            "background_color": 'rgb(249,250,251)',
+            "table_ids": [(0, 0, {
+                "table_number": 1,
+            }), (0, 0, {
+                "table_number": 2,
+            }), (0, 0, {
+                "table_number": 3,
+            })],
+        })
+
+        # Only set one floor to the pos_config, otherwise it can have two table with the same name
+        # which will cause the test to fail
+        self.pos_config.write({
+            "floor_ids": [(6, 0, [floor.id])],
+        })
+
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.pos_config.current_session_id.set_opening_control(0, "")
+        self_route = self.pos_config._get_self_order_route()
+
+        # Zero priced order
+        self.start_tour(self_route, "self_order_mobile_0_price_order")


### PR DESCRIPTION
Issue: 
When [currentOrder](https://github.com/odoo/odoo/blob/a43ef8e15f4e0ee28bdb1975a8a359d3373e8d2c/addons/pos_self_order/static/src/app/self_order_service.js#L377) evaluates orders, it returns an order only if it's in  'draft' state or 'paid' with zero amount in kiosk mode.

https://github.com/odoo/odoo/blob/a43ef8e15f4e0ee28bdb1975a8a359d3373e8d2c/addons/pos_self_order/static/src/app/self_order_service.js#L377-L386

If self_ordering_mode is not 'kiosk' (e.g., 'mobile'), such orders do not match the filter. 
(Note: 0 priced orders are considered as 'paid')

if order is not found (because it didn't pass the filter), a new order is created and returned
https://github.com/odoo/odoo/blob/a43ef8e15f4e0ee28bdb1975a8a359d3373e8d2c/addons/pos_self_order/static/src/app/self_order_service.js#L393-L412
and the original order context— like access_token and tracking_number—is lost in new order, raising a traceback.

Steps to reproduce:
- Enable the self-ordering for a POS Restaurant
- change the price of a product available for self-ordering to 0
- open the self-ordering and just order the product

FIx:
As this is a corner  case, concerning, 0 priced orders from `mobile` mode, we return the original order in this case, else return the current order

Note: 
- A [fix](https://github.com/odoo/odoo/commit/9f1441cc43c951356dc1a48555621c326a5be8f2
) was applied for this exact issue, but it gradully got removed later in other PRs.
 [here](https://github.com/odoo/odoo/pull/192874/files#diff-0c985bf4d5fc0f1d25c9014209f090dd09727488ec15ca71897986119d49d5bfL366) and [here](https://github.com/odoo/odoo/pull/197569/files#diff-0c985bf4d5fc0f1d25c9014209f090dd09727488ec15ca71897986119d49d5bfL706-R640)
- issue only in 18.0

opw-4677724




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
