### PR TITLE
[FIX] account_payment: preserve vendor payment number after modification

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -982,7 +982,7 @@ class AccountPayment(models.Model):
             pay.move_id \
                 .with_context(skip_invoice_sync=True) \
                 .write({
-                'name': '/',  # Set the name to '/' to allow it to be changed
+                'name': pay.name if pay.name else '/',  # Set the name to '/' to allow it to be changed
                 'date': pay.date,
                 'partner_id': pay.partner_id.id,
                 'currency_id': pay.currency_id.id,

--- a/addons/account_payment/tests/test_account_payment.py
+++ b/addons/account_payment/tests/test_account_payment.py
@@ -296,3 +296,43 @@ class TestAccountPayment(AccountPaymentCommon):
 
         self.assertNotEqual(self.partner.property_account_receivable_id, payment.destination_account_id)
         self.assertEqual(payment.destination_account_id, invoice.line_ids[-1].account_id)
+
+    def test_vendor_payment_name_remains_same_after_repost(self):
+        """
+        Test that modifying and reposting a vendor payment does not change its name.
+        """
+        journal = self.company_data['default_journal_bank']
+
+        payment = self.env['account.payment'].create({
+            'partner_id': self.partner.id,
+            'partner_type': 'supplier',
+            'payment_type': 'outbound',
+            'amount': 10,
+            'journal_id': journal.id,
+            'payment_method_line_id': journal.inbound_payment_method_line_ids[0].id,
+        })
+        payment.action_post()
+
+        original_name = payment.move_id.name
+
+        payment2 = self.env['account.payment'].create({
+            'partner_id': self.partner.id,
+            'partner_type': 'supplier',
+            'payment_type': 'outbound',
+            'amount': 20,
+            'journal_id': journal.id,
+            'payment_method_line_id': journal.inbound_payment_method_line_ids[0].id,
+        })
+
+        payment2.action_post()
+        payment.move_id.button_draft()
+        payment.move_id.line_ids.unlink()
+        payment.amount = 30
+        payment.move_id._compute_name()
+        payment.move_id._post()
+
+        self.assertEqual(
+            payment.move_id.name,
+            original_name,
+            "Payment name should remain the same after reposting"
+        )


### PR DESCRIPTION
**Issue**
When modifying and reposting a vendor payment that does not have the highest sequence number, the payment's name (i.e., number) is regenerated using the next available sequence, rather than preserving the original. This issue only occurs when the Outstanding Payments account is configured for the journal.

**Steps to Reproduce**
1.Install the Accounting module.
2.Go to Accounting > Configuration > Journals, and open a Bank journal.
3.In the Outgoing Payments tab, set an Outstanding Payments Account.
4.Go to Accounting > Vendors > Payments.
5.Create and post two vendor payments (e.g., 00001 and 00002).
6.Reset the first one (00001) to draft, change any field (e.g., amount), and repost it.
7.The number changes to 00003 instead of preserving 00001.

**Root Cause**
When a vendor payment is modified and reposted, Odoo cancels and regenerates the associated account.move. If an Outstanding Payments account is configured — or was configured at any point — this triggers additional logic causing the move name to be reset to '/'. This placeholder indicates that the move is treated as if it were new, prompting Odoo to assign it the next number in the journal’s sequence. As a result, the payment loses its original number even though it conceptually refers to the same transaction.

**Fix**
The fix ensures the original number is preserved by restoring the payment's previous name only when it's clear that the move is being regenerated, not newly created. This is determined by checking that the move is linked to exactly one payment (i.e., a one-to-one relationship) and that its name is '/', indicating the move was regenerated.

Opw-4805870
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
