### PR TITLE
[IMP] web, mail, *: use range instead of array keys

### DIFF
--- a/addons/account/static/tests/section_and_note.test.js
+++ b/addons/account/static/tests/section_and_note.test.js
@@ -1,6 +1,7 @@
 import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { expect, getFixture, test } from "@odoo/hoot";
 import { animationFrame, edit, press, queryAllTexts } from "@odoo/hoot-dom";
+import { range } from "@web/core/utils/numbers";
 import {
     clickSave,
     contains,
@@ -49,7 +50,7 @@ class Invoice extends models.Model {
     _records = [
         {
             id: 1,
-            invoice_line_ids: Array.from({ length: InvoiceLine._records.length }, (_, i) => i + 1),
+            invoice_line_ids: range(1, InvoiceLine._records.length + 1),
         },
     ];
 

--- a/addons/base_import/static/tests/import_records.test.js
+++ b/addons/base_import/static/tests/import_records.test.js
@@ -1,6 +1,7 @@
 import { importRecordsItem } from "@base_import/import_records/import_records";
 import { before, expect, test } from "@odoo/hoot";
 import { animationFrame, press } from "@odoo/hoot-dom";
+import { range } from "@web/core/utils/numbers";
 import {
     clearRegistry,
     contains,
@@ -200,9 +201,9 @@ test(`import should not be available in cog menu dropdown in dialog view`, async
     class Bar extends models.Model {
         name = fields.Char();
 
-        _records = Array.from({ length: 10 }, (_, i) => ({
-            id: i + 1,
-            name: `Bar ${i + 1}`,
+        _records = range(1, 11).map((id) => ({
+            id,
+            name: `Bar ${id}`,
         }));
         _views = {
             list: `<list><field name="display_name"/></list>`,

--- a/addons/hr_attendance/static/src/components/pin_code/pin_code.js
+++ b/addons/hr_attendance/static/src/components/pin_code/pin_code.js
@@ -1,5 +1,6 @@
 import { Component, onWillStart, useState, onWillDestroy } from "@odoo/owl";
 import { browser } from "@web/core/browser/browser";
+import { range } from "@web/core/utils/numbers";
 
 export class KioskPinCode extends Component {
     static template = "hr_attendance.KioskPinConfirm";
@@ -11,7 +12,7 @@ export class KioskPinCode extends Component {
 
     setup() {
         this.padButtons = [
-            ...Array.from({ length: 9 }, (_, i) => [i + 1]), // [[1], ..., [9]]
+            ...range(1, 10).map((i) => [i]),
             ["C", "btn-warning"],
             [0],
             ["OK", "btn-primary"],
@@ -23,14 +24,8 @@ export class KioskPinCode extends Component {
         this.checkedIn = this.props.employeeData.attendance_state === 'checked_in';
 
         const onKeyDown = async (ev) => {
-            const allowedKeys = [...Array(10).keys()].reduce((acc, value) => { // { from '0': '0' ... to '9': '9' }
-                acc[value] = value;
-                return acc;
-            }, {
-                'Delete': 'C',
-                'Enter': 'OK',
-                'Backspace': null,
-            });
+            const allowedKeys = { Delete: "C", Enter: "OK", Backspace: null };
+            Object.assign(allowedKeys, range(10)); // { from '0': 0 ... to '9': 9 }
             const key = ev.key;
 
             if (!Object.keys(allowedKeys).includes(key)) {

--- a/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.js
+++ b/addons/hr_holidays/static/src/components/float_time_selection/float_time_selection_popover.js
@@ -1,9 +1,8 @@
 import { Component, useState } from "@odoo/owl";
+import { range } from "@web/core/utils/numbers";
 
-const numberRange = (min, max) => [...Array(max - min)].map((_, i) => i + min);
-
-const HOURS = numberRange(0, 24).map((hour) => [hour, String(hour)]);
-const MINUTES = numberRange(0, 60).map((minute) => [minute, String(minute || 0).padStart(2, "0")]);
+const HOURS = range(24).map((hour) => [hour, String(hour)]);
+const MINUTES = range(60).map((minute) => [minute, String(minute || 0).padStart(2, "0")]);
 
 export class FloatTimeSelectionPopover extends Component {
     static props = {

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.xml
@@ -73,7 +73,7 @@
                 </t>
             </t>
             <!-- 20 placeholders is just enough for a 5K screen, change this if ImageWidget.MIN_ROW_HEIGHT changes -->
-            <t t-foreach="[...Array(20).keys()]" t-as="i" t-key="i">
+            <t t-foreach="Array(20)" t-as="i" t-key="i_index">
                 <div class="o_we_attachment_placeholder"/>
             </t>
         </t>

--- a/addons/html_editor/static/src/main/star_plugin.js
+++ b/addons/html_editor/static/src/main/star_plugin.js
@@ -75,7 +75,7 @@ export class StarPlugin extends Plugin {
     }
 
     addStars({ length }) {
-        const stars = Array.from({ length }, () => '<i class="fa fa-star-o"></i>').join("");
+        const stars = Array(length).fill('<i class="fa fa-star-o"></i>').join("");
         const html = `\u200B<span contenteditable="false" class="o_stars">${stars}</span>\u200B`;
         this.dependencies.dom.insert(parseHTML(this.document, html));
         this.dependencies.history.addStep();

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -51,6 +51,7 @@ import { expectElementCount } from "./_helpers/ui_expectations";
 import { ToolbarPlugin } from "@html_editor/main/toolbar/toolbar_plugin";
 import { ImageCrop } from "@html_editor/main/media/image_crop";
 import { Editor } from "@html_editor/editor";
+import { range } from "@web/core/utils/numbers";
 
 test.tags("desktop");
 test("toolbar is only visible when selection is not collapsed in desktop", async () => {
@@ -1074,7 +1075,7 @@ describe("compact toolbar", () => {
         icon: "fa-square",
         ...obj,
     });
-    const repeat = (count, fn) => Array.from({ length: count }, fn);
+    const repeat = (count, fn) => range(count).map(fn);
 
     test("toolbar should not open in compact mode if expanded toolbar has less than 7 items", async () => {
         class TestPlugin extends Plugin {

--- a/addons/html_editor/static/tests/wysiwyg.test.js
+++ b/addons/html_editor/static/tests/wysiwyg.test.js
@@ -4,7 +4,6 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { setupWysiwyg } from "./_helpers/editor";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { expectElementCount } from "./_helpers/ui_expectations";
-import { range } from "@web/core/utils/numbers";
 import { htmlJoin } from "@web/core/utils/html";
 import { markup } from "@odoo/owl";
 
@@ -44,9 +43,7 @@ describe("Wysiwyg Component", () => {
         const { el } = await setupWysiwyg({
             iframe: true,
             config: {
-                content: htmlJoin(
-                    range(0, 30).map(() => markup`<p>editable text inside the iframe</p>`)
-                ),
+                content: htmlJoin(Array(30).fill(markup`<p>editable text inside the iframe</p>`)),
             },
         });
 

--- a/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.js
+++ b/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { range } from "@web/core/utils/numbers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
 
 import { Component, useRef } from "@odoo/owl";
@@ -11,7 +12,7 @@ class VerificationCodeWidget extends Component {
 
     setup() {
         super.setup();
-        this.inputs = [...Array(6)].map((_, i) => useRef(`input_${i}`));
+        this.inputs = range(6).map((i) => useRef(`input_${i}`));
     }
 
     /*

--- a/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
+++ b/addons/l10n_dk/static/src/components/verification_code_widget/verification_code_widget.xml
@@ -3,12 +3,12 @@
 
     <t t-name="l10n_dk.VerificationCodeWidget">
         <div class="row w-50 mt-0 pt-0" t-on-focusout="_save">
-            <t t-foreach="[...Array(6).keys()]" t-as="i" t-key="i">
+            <t t-foreach="Array(6)" t-as="i" t-key="i_index">
                 <input class="verification_code col border border-2 rounded m-1 p-0 text-center"
                        type="text"
                        maxlength="1"
-                       t-att-id="i"
-                       t-ref="input_{{i}}"
+                       t-att-id="i_index"
+                       t-ref="input_{{i_index}}"
                        t-on-keyup="onKeyUp"
                        t-on-paste="onPaste"/>
             </t>

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -180,7 +180,7 @@
         <t t-if="isMobileOS and isReverse" t-call="mail.Message.emptyQuickAction"/>
         <div class="d-flex rounded-1 overflow-hidden gap-1" t-att-class="{ 'flex-row-reverse': isReverse }">
             <ActionList actions="actions" inline="true" fw="false"/>
-            <t t-foreach="Array.from({ length: quickActionCount - quickActions.length - 1 })" t-as="emptyQuickAction" t-key="emptyQuickAction_index">
+            <t t-foreach="Array(Math.max(quickActionCount - quickActions.length - 1, 0))" t-as="i" t-key="i_index">
                 <t t-call="mail.Message.emptyQuickAction"/>
             </t>
         </div>

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -38,7 +38,7 @@
                             </div>
                         </div>
                         <t t-if="state.categories.length === 0">
-                            <t t-foreach="Array(10).keys()" t-as="category" t-key="category_index">
+                            <t t-foreach="Array(10)" t-as="i" t-key="i_index">
                                 <div class="col">
                                     <div class="position-relative ratio ratio-16x9 cursor-pointer rounded overflow-hidden" aria-label="list-item">
                                         <div class="position-absolute w-100 h-100 top-0 start-0 text-center o-text-white align-middle fs-2 o-bg-black bg-opacity-50"/>

--- a/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
+++ b/addons/mail/static/src/views/web/fields/html_mail_field/convert_inline.js
@@ -1,6 +1,7 @@
 import { isBlock } from "@html_editor/utils/blocks";
 import { getAdjacentPreviousSiblings } from "@html_editor/utils/dom_traversal";
 import { blendColors } from "@web/core/utils/colors";
+import { range } from "@web/core/utils/numbers";
 
 function parentsGet(node, root = undefined) {
     const parents = [];
@@ -1653,7 +1654,7 @@ function _computeStyleAndSpecificityOnRules(cssRules) {
  * @returns {Element[]}
  */
 function _createColumnGrid() {
-    return new Array(12).fill().map(() => document.createElement("td"));
+    return range(12).map(() => document.createElement("td"));
 }
 /**
  * Return a comment element with the given content, wrapped in an mso condition.

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -341,11 +341,7 @@ test("More than 7 actually folded chat windows shows a 'hidden' chat bubble menu
 
 test("Can close all chat windows at once", async () => {
     const pyEnv = await startServer();
-    const channelIds = pyEnv["discuss.channel"].create(
-        Array(20)
-            .keys()
-            .map((i) => ({ name: String(i) }))
-    );
+    const channelIds = pyEnv["discuss.channel"].create(range(20).map((i) => ({ name: String(i) })));
     setupChatHub({ folded: channelIds.reverse() });
     await start();
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
@@ -359,9 +355,7 @@ test("Can close all chat windows at once", async () => {
 
 test("Don't show chat hub in discuss app", async () => {
     const pyEnv = await startServer();
-    const channelIds = pyEnv["discuss.channel"].create(
-        range(0, 20).map((i) => ({ name: String(i) }))
-    );
+    const channelIds = pyEnv["discuss.channel"].create(range(20).map((i) => ({ name: String(i) })));
     setupChatHub({ folded: channelIds.reverse() });
     await start();
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -35,6 +35,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 
 import { rpc } from "@web/core/network/rpc";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -244,9 +245,7 @@ test("chat window: close on ESCAPE", async () => {
 test("chat window: close on ESCAPE (multi)", async () => {
     const pyEnv = await startServer();
     const channelIds = pyEnv["discuss.channel"].create(
-        Array(4)
-            .keys()
-            .map((i) => ({ name: `channel_${i}` }))
+        range(4).map((i) => ({ name: `channel_${i}` }))
     );
     patchUiSize({ width: 1920 });
     setupChatHub({ opened: channelIds.reverse() });

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -19,6 +19,8 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { Deferred, advanceTime } from "@odoo/hoot-mock";
+
+import { range } from "@web/core/utils/numbers";
 import {
     defineActions,
     getService,
@@ -436,13 +438,11 @@ test("scroll position is kept when navigating from one record to another", async
     // Fill both channels with random messages in order for the scrollbar to
     // appear.
     pyEnv["mail.message"].create(
-        Array(50)
-            .fill(0)
-            .map((_, index) => ({
-                body: "Non Empty Body ".repeat(25),
-                model: "res.partner",
-                res_id: index < 20 ? partnerId_1 : partnerId_2,
-            }))
+        range(50).map((index) => ({
+            body: "Non Empty Body ".repeat(25),
+            model: "res.partner",
+            res_id: index < 20 ? partnerId_1 : partnerId_2,
+        }))
     );
     await start();
     await openFormView("res.partner", partnerId_1);

--- a/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
+++ b/addons/mail/static/tests/chatter/web/follower_list_menu.test.js
@@ -7,9 +7,11 @@ import {
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
+
 import { describe, expect, test } from "@odoo/hoot";
 import { tick } from "@odoo/hoot-dom";
 import { mockService, serverState } from "@web/../tests/web_test_helpers";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -114,10 +116,10 @@ test("click on remove follower", async () => {
 test("Load 100 followers at once", async () => {
     const pyEnv = await startServer();
     const partnerIds = pyEnv["res.partner"].create(
-        [...Array(210).keys()].map((i) => ({ display_name: `Partner${i}`, name: `Partner${i}` }))
+        range(210).map((i) => ({ display_name: `Partner${i}`, name: `Partner${i}` }))
     );
     pyEnv["mail.followers"].create(
-        [...Array(210).keys()].map((i) => ({
+        range(210).map((i) => ({
             is_active: true,
             partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
             res_id: partnerIds[0],
@@ -141,14 +143,14 @@ test("Load 100 followers at once", async () => {
 test("Load 100 recipients at once", async () => {
     const pyEnv = await startServer();
     const partnerIds = pyEnv["res.partner"].create(
-        [...Array(210).keys()].map((i) => ({
+        range(210).map((i) => ({
             display_name: `Partner${i}`,
             name: `Partner${i}`,
             email: `partner${i}@example.com`,
         }))
     );
     pyEnv["mail.followers"].create(
-        [...Array(210).keys()].map((i) => ({
+        range(210).map((i) => ({
             is_active: true,
             partner_id: i === 0 ? serverState.partnerId : partnerIds[i],
             res_id: partnerIds[0],

--- a/addons/mail/static/tests/chatter/web/form_renderer.test.js
+++ b/addons/mail/static/tests/chatter/web/form_renderer.test.js
@@ -11,6 +11,8 @@ import {
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test, expect } from "@odoo/hoot";
 
+import { range } from "@web/core/utils/numbers";
+
 describe.current.tags("desktop");
 defineMailModels();
 
@@ -20,15 +22,15 @@ test.skip("Form view not scrolled when switching record", async () => {
     const pyEnv = await startServer();
     const [partnerId_1, partnerId_2] = pyEnv["res.partner"].create([
         {
-            description: [...Array(60).keys()].join("\n"),
+            description: range(60).join("\n"),
             display_name: "Partner 1",
         },
         {
-            description: [...Array(60).keys()].join("\n"),
+            description: range(60).join("\n"),
             display_name: "Partner 2",
         },
     ]);
-    const messages = [...Array(60).keys()].map((id) => ({
+    const messages = range(60).map((id) => ({
         body: "not empty",
         model: "res.partner",
         res_id: id < 29 ? partnerId_1 : partnerId_2,

--- a/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
+++ b/addons/mail/static/tests/discuss/call/peer_to_peer.test.js
@@ -4,6 +4,7 @@ import { browser } from "@web/core/browser/browser";
 import { onRpc, mountWebClient } from "@web/../tests/web_test_helpers";
 import { defineMailModels, mockGetMedia, onlineTest } from "@mail/../tests/mail_test_helpers";
 import { PeerToPeer, STREAM_TYPE, UPDATE_EVENT } from "@mail/discuss/call/common/peer_to_peer";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -66,7 +67,7 @@ onlineTest("mesh peer to peer connections", async () => {
     const channelId = 2;
     const network = new Network();
     const userCount = 10;
-    const users = Array.from({ length: userCount }, (_, i) => network.register(i));
+    const users = range(userCount).map((i) => network.register(i));
     const promises = [];
     for (const user of users) {
         user.p2p.connect(user.id, channelId);

--- a/addons/mail/static/tests/discuss/core/discuss_performance.test.js
+++ b/addons/mail/static/tests/discuss/core/discuss_performance.test.js
@@ -75,8 +75,8 @@ test("replying to message should only render relevant part", async () => {
     // For example, it should not render all messages when selecting message to reply
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
-    const messageIds = range(0, 10).map((i) =>
-        pyEnv["mail.message"].create({ body: `${i}`, model: "discuss.channel", res_id: channelId })
+    const messageIds = pyEnv["mail.message"].create(
+        range(10).map((i) => ({ body: `${i}`, model: "discuss.channel", res_id: channelId }))
     );
     messageIds.pop(); // remove last as this is the one to be replied to
     let replying = false;
@@ -114,8 +114,8 @@ test("right-click message selection should only render relevant part", async () 
     // For example, it should not render all messages when right-click selecting message from opening dropdown with actions
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
-    const messageIds = range(0, 10).map((i) =>
-        pyEnv["mail.message"].create({ body: `${i}`, model: "discuss.channel", res_id: channelId })
+    const messageIds = pyEnv["mail.message"].create(
+        range(10).map((i) => ({ body: `${i}`, model: "discuss.channel", res_id: channelId }))
     );
     messageIds.pop(); // remove last as this is the one to be right-clicking
     let rightClicking = false;

--- a/addons/mail/static/tests/discuss_app/discuss.test.js
+++ b/addons/mail/static/tests/discuss_app/discuss.test.js
@@ -53,6 +53,7 @@ import {
 import { makeRecordFieldLocalId } from "@mail/model/misc";
 import { Settings } from "@mail/core/common/settings_model";
 import { toRawValue } from "@mail/utils/common/local_storage";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -2106,7 +2107,7 @@ test("failure on loading more messages should display error and prompt retry but
         name: "General",
     });
     const messageIds = pyEnv["mail.message"].create(
-        [...Array(60).keys()].map(() => ({
+        range(60).map(() => ({
             body: "coucou",
             model: "discuss.channel",
             res_id: channelId,
@@ -2145,7 +2146,7 @@ test("Retry loading more messages on failed load more messages should load more 
         name: "General",
     });
     const messageIds = pyEnv["mail.message"].create(
-        [...Array(90).keys()].map(() => ({
+        range(90).map(() => ({
             body: "coucou",
             model: "discuss.channel",
             res_id: channelId,

--- a/addons/mail/static/tests/discuss_app/inbox.test.js
+++ b/addons/mail/static/tests/discuss_app/inbox.test.js
@@ -15,6 +15,7 @@ import { Deferred } from "@odoo/hoot-mock";
 import { mockService, serverState, withUser } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -414,23 +415,19 @@ test("inbox: mark as read should not display jump to present", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "General" });
     const msgIds = pyEnv["mail.message"].create(
-        Array(30)
-            .keys()
-            .map((i) => ({
-                body: "not empty".repeat(100),
-                model: "discuss.channel",
-                needaction: true,
-                res_id: channelId,
-            }))
+        range(30).map(() => ({
+            body: "not empty".repeat(100),
+            model: "discuss.channel",
+            needaction: true,
+            res_id: channelId,
+        }))
     );
     pyEnv["mail.notification"].create(
-        Array(30)
-            .keys()
-            .map((i) => ({
-                mail_message_id: msgIds[i],
-                notification_type: "inbox",
-                res_partner_id: serverState.partnerId,
-            }))
+        range(30).map((i) => ({
+            mail_message_id: msgIds[i],
+            notification_type: "inbox",
+            res_partner_id: serverState.partnerId,
+        }))
     );
     await start();
     await openDiscuss("mail.box_inbox");

--- a/addons/mail/static/tests/inline/utils.js
+++ b/addons/mail/static/tests/inline/utils.js
@@ -2,6 +2,7 @@ import {
     TABLE_ATTRIBUTES,
     TABLE_STYLES,
 } from "@mail/views/web/fields/html_mail_field/convert_inline";
+import { range } from "@web/core/utils/numbers";
 
 const tableAttributesString = Object.keys(TABLE_ATTRIBUTES)
     .map((key) => `${key}="${TABLE_ATTRIBUTES[key]}"`)
@@ -113,9 +114,9 @@ export function getTableHtml(matrix, containerWidth) {
  * @returns {string}
  */
 export function getRegularGridHtml(nRows, nCols) {
-    const matrix = new Array(nRows)
-        .fill()
-        .map((_, iRow) => new Array(Array.isArray(nCols) ? nCols[iRow] : nCols).fill());
+    const matrix = range(nRows).map((iRow) =>
+        Array(Array.isArray(nCols) ? nCols[iRow] : nCols).fill()
+    );
     return getGridHtml(matrix);
 }
 /**
@@ -135,15 +136,11 @@ export function getRegularGridHtml(nRows, nCols) {
  * @returns {string}
  */
 export function getRegularTableHtml(nRows, nCols, colspan, width, containerWidth) {
-    const matrix = new Array(nRows)
-        .fill()
-        .map((_, iRow) =>
-            new Array(Array.isArray(nCols) ? nCols[iRow] : nCols)
-                .fill()
-                .map(() => [
-                    Array.isArray(colspan) ? colspan[iRow] : colspan,
-                    Array.isArray(width) ? width[iRow] : width,
-                ])
-        );
+    const matrix = range(nRows).map((iRow) =>
+        range(Array.isArray(nCols) ? nCols[iRow] : nCols).map(() => [
+            Array.isArray(colspan) ? colspan[iRow] : colspan,
+            Array.isArray(width) ? width[iRow] : width,
+        ])
+    );
     return getTableHtml(matrix, containerWidth);
 }

--- a/addons/mail/static/tests/message/message_reply.test.js
+++ b/addons/mail/static/tests/message/message_reply.test.js
@@ -13,6 +13,7 @@ import { disableAnimations } from "@odoo/hoot-mock";
 import { serverState } from "@web/../tests/web_test_helpers";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 
+import { range } from "@web/core/utils/numbers";
 import { getOrigin } from "@web/core/utils/urls";
 
 describe.current.tags("desktop");
@@ -47,14 +48,12 @@ test("click on message in reply to scroll to the parent message", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "general" });
     const [oldestMessageId] = pyEnv["mail.message"].create(
-        Array(20)
-            .fill(0)
-            .map(() => ({
-                body: "Non Empty Body ".repeat(25),
-                message_type: "comment",
-                model: "discuss.channel",
-                res_id: channelId,
-            }))
+        range(20).map(() => ({
+            body: "Non Empty Body ".repeat(25),
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        }))
     );
     pyEnv["mail.message"].create({
         body: "Response to first message",

--- a/addons/mail/static/tests/suggestion/suggestion.test.js
+++ b/addons/mail/static/tests/suggestion/suggestion.test.js
@@ -1329,7 +1329,7 @@ test("Mention with @-role trigger one RPC only", async () => {
 test("Mentioning @everyone with more than 50 members shows warning dialog", async () => {
     const pyEnv = await startServer();
     const partnerIds = pyEnv["res.partner"].create(
-        range(0, MENTION_AMOUNT_WARNING + 1).map(() => ({ name: "" }))
+        range(MENTION_AMOUNT_WARNING + 1).map(() => ({ name: "" }))
     );
     const channelId = pyEnv["discuss.channel"].create({
         name: "General",
@@ -1357,7 +1357,7 @@ test("Mentioning @-role with more than 50 users shows warning dialog", async () 
     const pyEnv = await startServer();
     const roleId = pyEnv["res.role"].create({ name: "VIPs" });
     pyEnv["res.users"].create(
-        range(0, MENTION_AMOUNT_WARNING + 1).map(() => ({ role_ids: [roleId] }))
+        range(MENTION_AMOUNT_WARNING + 1).map(() => ({ role_ids: [roleId] }))
     );
     const channelId = pyEnv["discuss.channel"].create({ name: "General", channel_type: "channel" });
     pyEnv["res.role"]._applyComputesAndValidate();

--- a/addons/mail/static/tests/thread/thread.test.js
+++ b/addons/mail/static/tests/thread/thread.test.js
@@ -32,6 +32,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { rpc } from "@web/core/network/rpc";
+import { range } from "@web/core/utils/numbers";
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -194,14 +195,12 @@ test("scroll position is kept when navigating from one channel to another [CAN F
     // Fill both channels with random messages in order for the scrollbar to
     // appear.
     pyEnv["mail.message"].create(
-        Array(50)
-            .fill(0)
-            .map((_, index) => ({
-                body: "Non Empty Body ".repeat(25),
-                message_type: "comment",
-                model: "discuss.channel",
-                res_id: index < 20 ? channelId_1 : channelId_2,
-            }))
+        range(50).map((index) => ({
+            body: "Non Empty Body ".repeat(25),
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: index < 20 ? channelId_1 : channelId_2,
+        }))
     );
     await start();
     await openDiscuss(channelId_1);
@@ -229,14 +228,12 @@ test("thread is still scrolling after scrolling up then to bottom", async () => 
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({ name: "channel-1" });
     pyEnv["mail.message"].create(
-        Array(20)
-            .fill(0)
-            .map(() => ({
-                body: "Non Empty Body ".repeat(25),
-                message_type: "comment",
-                model: "discuss.channel",
-                res_id: channelId,
-            }))
+        range(20).map(() => ({
+            body: "Non Empty Body ".repeat(25),
+            message_type: "comment",
+            model: "discuss.channel",
+            res_id: channelId,
+        }))
     );
     await start();
     await openDiscuss(channelId);

--- a/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
+++ b/addons/mail/static/tests/tours/discuss_sub_channel_search_tour.js
@@ -4,6 +4,7 @@ import { status } from "@odoo/owl";
 
 import { registry } from "@web/core/registry";
 import { Deferred } from "@web/core/utils/concurrency";
+import { range } from "@web/core/utils/numbers";
 import { patch } from "@web/core/utils/patch";
 import { effect } from "@web/core/utils/reactive";
 
@@ -38,7 +39,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
         {
             trigger: ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(30)",
         },
-        ...Array.from({ length: 30 }, (_, index) => 99 - index).map((i) => ({
+        ...range(99, 69).map((i) => ({
             trigger: `.o-mail-SubChannelPreview:text(Sub Channel ${i})`,
         })),
         {
@@ -67,7 +68,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
         },
         // Already fetched sub channels are shown in addition to the one
         // that was fetched during the search.
-        ...Array.from({ length: 30 }, (_, index) => 99 - index).map((i) => ({
+        ...range(99, 69).map((i) => ({
             trigger: `.o-mail-SubChannelPreview:text(Sub Channel ${i})`,
         })),
         {
@@ -86,7 +87,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             trigger:
                 ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(61):contains(Sub Channel 40)",
         },
-        ...Array.from({ length: 60 }, (_, index) => 99 - index).map((i) => ({
+        ...range(99, 39).map((i) => ({
             trigger: `.o-mail-SubChannelPreview:text(Sub Channel ${i})`,
         })),
         {
@@ -104,7 +105,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             trigger:
                 ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(90):contains(Sub Channel 11)",
         },
-        ...Array.from({ length: 90 }, (_, index) => 99 - index).map((i) => ({
+        ...range(99, 9).map((i) => ({
             trigger: `.o-mail-SubChannelPreview:text(Sub Channel ${i})`,
         })),
         {
@@ -121,7 +122,7 @@ registry.category("web_tour.tours").add("test_discuss_sub_channel_search", {
             trigger:
                 ".o-mail-SubChannelList .o-mail-SubChannelPreview:count(100):contains(Sub Channel 0)",
         },
-        ...Array.from({ length: 99 }, (_, index) => 99 - index).map((i) => ({
+        ...range(99, 0).map((i) => ({
             trigger: `.o-mail-SubChannelPreview:text(Sub Channel ${i})`,
         })),
     ],

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -1,7 +1,7 @@
 import { registry } from "@web/core/registry";
 import { constructFullProductName, constructAttributeString } from "@point_of_sale/utils";
 import { parseFloat } from "@web/views/fields/parsers";
-import { formatFloat } from "@web/core/utils/numbers";
+import { formatFloat, range } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 import { localization as l10n } from "@web/core/l10n/localization";
 import { PosOrderlineAccounting } from "./accounting/pos_order_line_accounting";
@@ -164,11 +164,7 @@ export class PosOrderline extends PosOrderlineAccounting {
                 id: lotLine.id,
                 text: lotLine.lot_name,
             }))
-            .concat(
-                Array.from(Array(nExtraLines)).map((_) => ({
-                    text: "",
-                }))
-            );
+            .concat(range(nExtraLines).map(() => ({ text: "" })));
         return isAllowOnlyOneLot ? [tempLines[0]] : tempLines;
     }
 

--- a/addons/point_of_sale/static/src/app/models/pos_preset.js
+++ b/addons/point_of_sale/static/src/app/models/pos_preset.js
@@ -1,4 +1,5 @@
 import { registry } from "@web/core/registry";
+import { range } from "@web/core/utils/numbers";
 import { Base } from "./related_models";
 
 const { DateTime } = luxon;
@@ -96,7 +97,7 @@ export class PosPreset extends Base {
         const slots = {};
 
         // Compute slots for next 7 days
-        for (const i of [...Array(7).keys()]) {
+        for (const i of range(7)) {
             const dateNow = now.plus({ days: i });
             const getDateTime = (hour) =>
                 DateTime.fromObject({

--- a/addons/point_of_sale/static/tests/customer_display/customer_display_utils.js
+++ b/addons/point_of_sale/static/tests/customer_display/customer_display_utils.js
@@ -1,4 +1,5 @@
 import { run } from "@point_of_sale/../tests/generic_helpers/utils";
+import { range } from "@web/core/utils/numbers";
 
 export function postMessage(message, description = "") {
     return run(() => {
@@ -33,10 +34,10 @@ export const ADD_PRODUCT_SELECTED =
 
 export const ADD_MULTI_PRODUCTS = (() => {
     const count = 20;
-    const lines = Array.from({ length: count }, (_, i) => {
+    const lines = range(1, count + 1).map((i) => {
         const price = (Math.random() * 100 + 1).toFixed(2);
         return {
-            productName: `Product ${i + 1}`,
+            productName: `Product ${i}`,
             price: `$${price}`,
             qty: "1.00",
             unit: "Units",
@@ -46,7 +47,7 @@ export const ADD_MULTI_PRODUCTS = (() => {
             comboParent: "",
             packLotLines: [],
             price_without_discount: `$${price}`,
-            isSelected: i === count - 1,
+            isSelected: i === count,
             imageSrc: "/web/image/product.product/855/image_128",
         };
     });

--- a/addons/point_of_sale/static/tests/unit/services/render_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/render_service.test.js
@@ -1,6 +1,7 @@
 import { expect, getFixture, test } from "@odoo/hoot";
 import { mockFetch } from "@odoo/hoot-mock";
 import { Component, xml } from "@odoo/owl";
+import { range } from "@web/core/utils/numbers";
 import { allowTranslations, mountWithCleanup } from "@web/../tests/web_test_helpers";
 import { htmlToCanvas } from "@point_of_sale/app/services/render_service";
 import { definePosModels } from "../data/generate_model_definitions";
@@ -31,10 +32,7 @@ test("htmlToCanvas", async () => {
     const node = document.createElement("div");
     node.classList.add("render-container");
     target.appendChild(node);
-
-    const asciiChars = Array.from({ length: 256 }, (_, i) => String.fromCharCode(i)).join("");
-    node.textContent = asciiChars;
-
+    node.textContent = String.fromCharCode(...range(256));
     let canvas = null;
     try {
         canvas = await htmlToCanvas(node, { addClass: "pos-receipt-print" });

--- a/addons/portal/static/src/interactions/portal_home_counters.js
+++ b/addons/portal/static/src/interactions/portal_home_counters.js
@@ -1,6 +1,7 @@
-import { Interaction } from "@web/public/interaction";
-import { registry } from "@web/core/registry";
 import { rpc } from "@web/core/network/rpc";
+import { registry } from "@web/core/registry";
+import { range } from "@web/core/utils/numbers";
+import { Interaction } from "@web/public/interaction";
 
 export class PortalHomeCounters extends Interaction {
     static selector = ".o_portal_my_home";
@@ -26,7 +27,7 @@ export class PortalHomeCounters extends Interaction {
         const counterByRpc = Math.ceil(needed.length / numberRpc);
         const countersAlwaysDisplayed = this.getCountersAlwaysDisplayed();
 
-        const proms = [...Array(Math.min(numberRpc, needed.length)).keys()].map(async (i) => {
+        const proms = range(Math.min(numberRpc, needed.length)).map(async (i) => {
             const documentsCountersData = await rpc("/my/counters", {
                 counters: needed.slice(i * counterByRpc, (i + 1) * counterByRpc),
             });

--- a/addons/pos_loyalty/static/src/app/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/app/models/pos_order.js
@@ -1,6 +1,6 @@
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
 import { patch } from "@web/core/utils/patch";
-import { floatIsZero } from "@web/core/utils/numbers";
+import { floatIsZero, range } from "@web/core/utils/numbers";
 import { _t } from "@web/core/l10n/translation";
 import { loyaltyIdsGenerator } from "@pos_loyalty/app/services/pos_store";
 const { DateTime } = luxon;
@@ -629,7 +629,7 @@ patch(PosOrder.prototype, {
                     // In this case we count the points per rule
                     if (rule.reward_point_mode === "unit") {
                         splitPoints.push(
-                            ...Array.apply(null, Array(totalProductQty)).map((_) => ({
+                            ...range(totalProductQty).map(() => ({
                                 points: rule.reward_point_amount,
                             }))
                         );
@@ -649,7 +649,7 @@ patch(PosOrder.prototype, {
                             );
                             if (pointsPerUnit > 0) {
                                 splitPoints.push(
-                                    ...Array.apply(null, Array(line.getQuantity())).map(() => {
+                                    ...range(line.getQuantity()).map(() => {
                                         if (line._gift_barcode && line.getQuantity() == 1) {
                                             return {
                                                 points: pointsPerUnit,

--- a/addons/pos_self_order_event/static/src/app/pages/event_page/event_page.js
+++ b/addons/pos_self_order_event/static/src/app/pages/event_page/event_page.js
@@ -6,6 +6,7 @@ import { isValidEmail } from "@point_of_sale/utils";
 import { useService } from "@web/core/utils/hooks";
 import { rpc } from "@web/core/network/rpc";
 import { _t } from "@web/core/l10n/translation";
+import { range } from "@web/core/utils/numbers";
 import { useStickyTitleObserver } from "@pos_self_order/app/utils/sticky_title_observer";
 
 export class EventPage extends Component {
@@ -61,10 +62,10 @@ export class EventPage extends Component {
     get ticketForms() {
         return this.eventTickets.flatMap((ticket) => {
             const qty = this.state.ticketQuantities[ticket.id] || 0;
-            return Array.from({ length: qty }, (_, i) => ({
+            return range(1, qty + 1).map((index) => ({
                 ticketId: ticket.id,
                 ticketName: ticket.name,
-                index: i + 1,
+                index,
             }));
         });
     }

--- a/addons/spreadsheet/static/src/chart/data_source/chart_data_source.js
+++ b/addons/spreadsheet/static/src/chart/data_source/chart_data_source.js
@@ -2,6 +2,7 @@ import { OdooViewsDataSource } from "@spreadsheet/data_sources/odoo_views_data_s
 import { _t } from "@web/core/l10n/translation";
 import { GraphModel as ChartModel } from "@web/views/graph/graph_model";
 import { Domain } from "@web/core/domain";
+import { range } from "@web/core/utils/numbers";
 
 export class ChartDataSource extends OdooViewsDataSource {
     /**
@@ -69,7 +70,7 @@ export class ChartDataSource extends OdooViewsDataSource {
 
         const dataPoints = this._model.dataPoints;
         const groupBy = this._metaData.groupBy;
-        const datasets = new Array(groupBy.length).fill().map(() => ({ data: [], domains: [] }));
+        const datasets = range(groupBy.length).map(() => ({ data: [], domains: [] }));
         const labels = new Array();
         const domainMapping = {};
         for (const gb of groupBy) {

--- a/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
+++ b/addons/spreadsheet_dashboard/static/tests/dashboard/dashboard_action.test.js
@@ -610,13 +610,13 @@ describe("Quick search bar", () => {
 
         const children = queryAll(".o-dropdown-item.o_indent");
         expect(children.map((el) => el.innerText)).toEqual([
-            ...range(0, 9).map((i) => "name" + i),
+            ...range(9).map((i) => `name${i}`),
             "Load more",
         ]);
         await contains(children.at(-1)).click();
 
         expect(queryAllTexts(".o-dropdown-item.o_indent")).toEqual(
-            range(0, 15).map((i) => "name" + i)
+            range(15).map((i) => `name${i}`)
         );
     });
 

--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -5,6 +5,7 @@ import { localization } from "../l10n/localization";
 import { ensureArray } from "../utils/arrays";
 import { TimePicker } from "@web/core/time_picker/time_picker";
 import { Time } from "@web/core/l10n/time";
+import { range } from "@web/core/utils/numbers";
 
 const { DateTime, Info } = luxon;
 
@@ -91,12 +92,6 @@ const getStartOfWeek = (date) => {
     const { weekStart } = localization;
     return date.set({ weekday: date.weekday < weekStart ? weekStart - 7 : weekStart });
 };
-
-/**
- * @param {number} min
- * @param {number} max
- */
-const numberRange = (min, max) => [...Array(max - min)].map((_, i) => i + min);
 
 /**
  * @param {NullableDateTime | "today"} value
@@ -224,8 +219,8 @@ const PRECISION_LEVELS = new Map()
         getTitle: (date) => String(date.year),
         getItems: (date, { maxDate, minDate }) => {
             const startOfYear = date.startOf("year");
-            return numberRange(0, 12).map((i) => {
-                const startOfMonth = startOfYear.plus({ month: i });
+            return range(12).map((month) => {
+                const startOfMonth = startOfYear.plus({ month });
                 const range = [startOfMonth, startOfMonth.endOf("month")];
                 return toDateItem({
                     isValid: isInRange(range, [minDate, maxDate]),
@@ -243,7 +238,7 @@ const PRECISION_LEVELS = new Map()
         getTitle: (date) => `${getStartOfDecade(date) - 1} - ${getStartOfDecade(date) + 10}`,
         getItems: (date, { maxDate, minDate }) => {
             const startOfDecade = date.startOf("year").set({ year: getStartOfDecade(date) });
-            return numberRange(-GRID_MARGIN, GRID_COUNT + GRID_MARGIN).map((i) => {
+            return range(-GRID_MARGIN, GRID_COUNT + GRID_MARGIN).map((i) => {
                 const startOfYear = startOfDecade.plus({ year: i });
                 const range = [startOfYear, startOfYear.endOf("year")];
                 return toDateItem({
@@ -263,7 +258,7 @@ const PRECISION_LEVELS = new Map()
         getTitle: (date) => `${getStartOfCentury(date) - 10} - ${getStartOfCentury(date) + 100}`,
         getItems: (date, { maxDate, minDate }) => {
             const startOfCentury = date.startOf("year").set({ year: getStartOfCentury(date) });
-            return numberRange(-GRID_MARGIN, GRID_COUNT + GRID_MARGIN).map((i) => {
+            return range(-GRID_MARGIN, GRID_COUNT + GRID_MARGIN).map((i) => {
                 const startOfDecade = startOfCentury.plus({ year: i * 10 });
                 const range = [startOfDecade, startOfDecade.plus({ year: 10, millisecond: -1 })];
                 return toDateItem({

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -25,6 +25,7 @@ import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 import { Dialog } from "../dialog/dialog";
 import { getTemplate } from "@web/core/templates";
+import { range } from "@web/core/utils/numbers";
 
 /**
  * @typedef Emoji
@@ -247,8 +248,8 @@ export class EmojiPicker extends Component {
         if (panel.length > 0) {
             if (repr.length > 0) {
                 panel.push(
-                    ...[...Array(maxAvailableNavbarItemAmountAtOnce - panel.length)].map(
-                        (_, idx) => "empty_" + idx
+                    ...range(maxAvailableNavbarItemAmountAtOnce - panel.length).map(
+                        (idx) => `empty_${idx}`
                     )
                 );
             }

--- a/addons/web/static/src/core/time_picker/time_picker.js
+++ b/addons/web/static/src/core/time_picker/time_picker.js
@@ -6,9 +6,7 @@ import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { Time, parseTime } from "@web/core/l10n/time";
 import { mergeClasses } from "@web/core/utils/classname";
 import { useChildRef } from "@web/core/utils/hooks";
-
-const HOURS = [...Array(24)].map((_, i) => i);
-const MINUTES = [...Array(60)].map((_, i) => i);
+import { range } from "@web/core/utils/numbers";
 
 /**
  * @typedef TimePickerProps
@@ -150,8 +148,8 @@ export class TimePicker extends Component {
     getSuggestions(props) {
         const suggestions = [];
         const rounding = props.minutesRounding <= 5 ? 15 : props.minutesRounding;
-        const minutes = MINUTES.filter((m) => !(m % rounding));
-        for (const hour of HOURS) {
+        const minutes = range(0, 60, rounding);
+        for (const hour of range(24)) {
             for (const minute of minutes) {
                 suggestions.push(new Time({ hour, minute }));
             }

--- a/addons/web/static/src/search/utils/dates.js
+++ b/addons/web/static/src/search/utils/dates.js
@@ -2,7 +2,7 @@ import { _t } from "@web/core/l10n/translation";
 import { Domain } from "@web/core/domain";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { localization } from "@web/core/l10n/localization";
-import { clamp } from "@web/core/utils/numbers";
+import { clamp, range } from "@web/core/utils/numbers";
 import { pick } from "@web/core/utils/objects";
 
 export const QUARTERS = {
@@ -216,21 +216,20 @@ export function toGeneratorId(unit, offset) {
 
 function getMonthPeriodOptions(referenceMoment, optionsParams) {
     const { startYear, endYear, startMonth, endMonth } = optionsParams;
-    return [...Array(endMonth - startMonth + 1).keys()]
-        .map((i) => {
-            const monthOffset = startMonth + i;
+    return range(startMonth, endMonth + 1)
+        .map((months) => {
             const date = referenceMoment.plus({
-                months: monthOffset,
+                months,
                 years: clamp(0, startYear, endYear),
             });
             const yearOffset = date.year - referenceMoment.year;
             return {
-                id: toGeneratorId("month", monthOffset),
+                id: toGeneratorId("month", months),
                 defaultYearId: toGeneratorId("year", clamp(yearOffset, startYear, endYear)),
                 description: date.toFormat("MMMM"),
                 granularity: "month",
                 groupNumber: 1,
-                plusParam: { months: monthOffset },
+                plusParam: { months },
             };
         })
         .reverse();
@@ -247,16 +246,15 @@ function getQuarterPeriodOptions(optionsParams) {
 
 function getYearPeriodOptions(referenceMoment, optionsParams) {
     const { startYear, endYear } = optionsParams;
-    return [...Array(endYear - startYear + 1).keys()]
-        .map((i) => {
-            const offset = startYear + i;
-            const date = referenceMoment.plus({ years: offset });
+    return range(startYear, endYear + 1)
+        .map((years) => {
+            const date = referenceMoment.plus({ years });
             return {
-                id: toGeneratorId("year", offset),
+                id: toGeneratorId("year", years),
                 description: date.toFormat("yyyy"),
                 granularity: "year",
                 groupNumber: 2,
-                plusParam: { years: offset },
+                plusParam: { years },
             };
         })
         .reverse();

--- a/addons/web/static/src/views/fields/properties/property_tags.js
+++ b/addons/web/static/src/views/fields/properties/property_tags.js
@@ -9,6 +9,7 @@ import { standardFieldProps } from "@web/views/fields/standard_field_props";
 import { useTagNavigation } from "@web/core/record_selectors/tag_navigation_hook";
 
 import { Component } from "@odoo/owl";
+import { range } from "@web/core/utils/numbers";
 
 class PropertyTagsColorListPopover extends Component {
     static template = "web.PropertyTagsColorListPopover";
@@ -268,7 +269,7 @@ export class PropertyTags extends Component {
             return;
         }
         this.popover.open(event.currentTarget, {
-            colors: [...Array(ColorList.COLORS.length).keys()],
+            colors: range(ColorList.COLORS.length),
             tag: { id: tagId, colorIndex: tagColor },
             switchTagColor: this.onTagColorSwitch.bind(this),
         });

--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -16,6 +16,7 @@ import {
     getPickerCell,
     editTime,
 } from "../../datetime/datetime_test_helpers";
+import { range } from "@web/core/utils/numbers";
 
 const { DateTime } = luxon;
 
@@ -32,15 +33,7 @@ const formatForStep = (value) =>
  */
 const pad2 = (value) => String(value).padStart(2, "0");
 
-/**
- * @template {any} [T=number]
- * @param {number} length
- * @param {(index: number) => T} mapping
- */
-const range = (length, mapping) => [...Array(length)].map((_, i) => mapping(i));
-
-const MINUTES = range(60, (i) => i).filter((i) => i % 15 === 0);
-const TIME_OPTIONS = range(24, String).flatMap((h) => MINUTES.map((m) => `${h}:${pad2(m)}`));
+const TIME_OPTIONS = range(24).flatMap((h) => [0, 15, 30, 45].map((m) => `${h}:${pad2(m)}`));
 
 defineParams({
     lang_parameters: {

--- a/addons/web/static/tests/core/virtual_grid_hook.test.js
+++ b/addons/web/static/tests/core/virtual_grid_hook.test.js
@@ -4,6 +4,7 @@ import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, useRef, xml } from "@odoo/owl";
 import { mountWithCleanup, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { localization } from "@web/core/l10n/localization";
+import { range } from "@web/core/utils/numbers";
 import { useVirtualGrid } from "@web/core/virtual_grid_hook";
 
 function objectToStyle(obj) {
@@ -75,27 +76,23 @@ function getTestComponent(virtualGridParams) {
                 scrollableRef,
                 ...virtualGridParams,
             });
-            this.virtualGrid.setRowsHeights(Array.from({ length: ROW_COUNT }, () => ITEM_HEIGHT));
-            this.virtualGrid.setColumnsWidths(
-                Array.from({ length: COLUMN_COUNT }, () => ITEM_WIDTH)
-            );
+            this.virtualGrid.setRowsHeights(Array(ROW_COUNT).fill(ITEM_HEIGHT));
+            this.virtualGrid.setColumnsWidths(Array(COLUMN_COUNT).fill(ITEM_WIDTH));
         }
         get innerStyle() {
             return `height: ${ROW_COUNT * ITEM_HEIGHT}px; width: ${COLUMN_COUNT * ITEM_WIDTH}px;`;
         }
         get virtualRows() {
             const [rowStart, rowEnd] = this.virtualGrid.rowsIndexes;
-            return Array.from({ length: ROW_COUNT }, (_, i) => ({ id: i + 1 })).slice(
-                rowStart,
-                rowEnd + 1
-            );
+            return range(1, ROW_COUNT + 1)
+                .map((id) => ({ id }))
+                .slice(rowStart, rowEnd + 1);
         }
         get virtualColumns() {
             const [colStart, colEnd] = this.virtualGrid.columnsIndexes;
-            return Array.from({ length: COLUMN_COUNT }, (_, i) => ({ id: i + 1 })).slice(
-                colStart,
-                colEnd + 1
-            );
+            return range(1, COLUMN_COUNT + 1)
+                .map((id) => ({ id }))
+                .slice(colStart, colEnd + 1);
         }
     }
     return TestComponent;
@@ -219,7 +216,7 @@ test("with columns only", async () => {
         setup() {
             const scrollableRef = useRef("pseudoScrollable");
             this.virtualGrid = useVirtualGrid({ scrollableRef });
-            this.virtualGrid.setColumnsWidths(Array.from({ length: 100 }, () => 1));
+            this.virtualGrid.setColumnsWidths(Array(100).fill(1));
         }
     }
     const comp = await mountWithCleanup(C);
@@ -236,7 +233,7 @@ test("with rows only", async () => {
         setup() {
             const scrollableRef = useRef("pseudoScrollable");
             this.virtualGrid = useVirtualGrid({ scrollableRef });
-            this.virtualGrid.setRowsHeights(Array.from({ length: 100 }, () => 1));
+            this.virtualGrid.setRowsHeights(Array(100).fill(1));
         }
     }
     const comp = await mountWithCleanup(C);

--- a/addons/web/static/tests/model/sample_server.test.js
+++ b/addons/web/static/tests/model/sample_server.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
+import { range } from "@web/core/utils/numbers";
 import { SampleServer } from "@web/model/sample_server";
 
 const {
@@ -389,7 +390,7 @@ describe("RPC calls", () => {
     test("'read': more than all available ids", async () => {
         const server = new DeterministicSampleServer("hobbit", fields.hobbit);
         const amount = MAIN_RECORDSET_SIZE + 3;
-        const ids = new Array(amount).fill().map((_, i) => i + 1);
+        const ids = range(1, amount + 1);
         const result = await server.mockRpc({
             method: "read",
             model: "hobbit",
@@ -408,7 +409,7 @@ describe("RPC calls", () => {
             groupBy: [],
         });
         expect(result).toHaveLength(1);
-        const ids = new Array(16).fill(0).map((_, index) => index + 1);
+        const ids = range(1, 17);
         expect(result[0]["id:array_agg"]).toEqual(ids);
     });
 });

--- a/addons/web/static/tests/search/search_panel_desktop.test.js
+++ b/addons/web/static/tests/search/search_panel_desktop.test.js
@@ -18,6 +18,7 @@ import {
     toggleSearchBarMenu,
 } from "@web/../tests/web_test_helpers";
 
+import { range } from "@web/core/utils/numbers";
 import { SearchBarMenu } from "@web/search/search_bar_menu/search_bar_menu";
 import { SearchPanel } from "@web/search/search_panel/search_panel";
 import { WebClient } from "@web/webclient/webclient";
@@ -2182,9 +2183,9 @@ test("scroll position is kept when switching between controllers", async () => {
 });
 
 test("search panel is not instantiated in dialogs", async () => {
-    Company._records = Array.from(Array(8), (_, i) => ({
-        id: i + 1,
-        name: `Company${i + 1}`,
+    Company._records = range(1, 9).map((id) => ({
+        id: id,
+        name: `Company${id}`,
     }));
     Company._views = {
         [["list", false]]: /* xml */ `<list><field name="name"/></list>`,

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -24,6 +24,7 @@ import { selectDateRange } from "./calendar_test_helpers";
 
 import { Domain } from "@web/core/domain";
 import { notificationService } from "@web/core/notifications/notification_service";
+import { range } from "@web/core/utils/numbers";
 import { CalendarModel } from "@web/views/calendar/calendar_model";
 import { WebClient } from "@web/webclient/webclient";
 
@@ -764,7 +765,7 @@ test("multi_create: test popover", async () => {
 test.tags("desktop");
 test("multi_create: avoid trigger add/del event on specific element", async () => {
     function makeEvents(numberOfEvent) {
-        return [...Array(numberOfEvent).keys()].map((i) => ({
+        return range(numberOfEvent).map((i) => ({
             id: i,
             name: `event ${i}`,
             date_start: "2019-03-13",

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -71,6 +71,7 @@ import { calendarView } from "@web/views/calendar/calendar_view";
 import { CalendarYearRenderer } from "@web/views/calendar/calendar_year/calendar_year_renderer";
 import { WebClient } from "@web/webclient/webclient";
 import { serializeDateTime } from "@web/core/l10n/dates";
+import { range } from "@web/core/utils/numbers";
 
 class Event extends models.Model {
     name = fields.Char();
@@ -1605,9 +1606,9 @@ test(`render popover with modifiers`, async () => {
 test.tags("desktop");
 test(`render popover: inside fullcalendar popover`, async () => {
     // add 10 records the same day
-    Event._records = Array.from({ length: 10 }).map((_, i) => ({
-        id: i + 1,
-        name: `event ${i + 1}`,
+    Event._records = range(1, 11).map((id) => ({
+        id,
+        name: `event ${id}`,
         start: "2016-12-14 10:00:00",
         stop: "2016-12-14 15:00:00",
         user_id: serverState.userId,
@@ -2597,24 +2598,24 @@ test(`dynamic filters with selection fields`, async () => {
 });
 
 test(`Colors: cycling through available colors`, async () => {
-    FilterPartner._records = Array.from({ length: 56 }, (_, i) => ({
-        id: i + 1,
+    FilterPartner._records = range(1, 57).map((id) => ({
+        id,
         user_id: serverState.userId,
-        partner_id: i + 1,
+        partner_id: id,
         is_checked: true,
     }));
-    CalendarPartner._records = Array.from({ length: 56 }, (_, i) => ({
-        id: i + 1,
-        name: `partner ${i + 1}`,
+    CalendarPartner._records = range(1, 57).map((id) => ({
+        id,
+        name: `partner ${id}`,
     }));
-    Event._records = Array.from({ length: 56 }, (_, i) => ({
-        id: i + 1,
+    Event._records = range(1, 57).map((id) => ({
+        id,
         user_id: serverState.userId,
-        partner_id: i + 1,
-        name: `event ${i + 1}`,
-        start: `2016-12-12 0${i % 10}:00:00`,
-        stop: `2016-12-12 0${i % 10}:00:00`,
-        attendee_ids: [i + 1],
+        partner_id: id,
+        name: `event ${id}`,
+        start: `2016-12-12 0${(id - 1) % 10}:00:00`,
+        stop: `2016-12-12 0${(id - 1) % 10}:00:00`,
+        attendee_ids: [id],
     }));
     await mountView({
         resModel: "event",

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -37,6 +37,7 @@ import {
 } from "@web/../tests/web_test_helpers";
 
 import { user } from "@web/core/user";
+import { range } from "@web/core/utils/numbers";
 import { Record } from "@web/model/record";
 import { Field } from "@web/views/fields/field";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
@@ -3671,9 +3672,7 @@ test("focus when closing many2one modal in many2one modal", async () => {
 
 test("search more pager is reset when doing a new search", async () => {
     Partner._fields.datetime = fields.Datetime({ string: "Datetime Field", searchable: true });
-    Partner._records.push(
-        ...new Array(170).fill().map((_, i) => ({ id: i + 10, name: "Partner " + i }))
-    );
+    Partner._records.push(...range(170).map((i) => ({ id: i + 10, name: `Partner ${i}` })));
     Partner._views = {
         list: `
             <list>
@@ -4001,7 +4000,8 @@ test("many2one search with formatted name", async () => {
         {
             id: 1,
             display_name: "Paul Eric",
-            __formatted_display_name: "Research & Development Test: **Paul** --Eric-- `good guy`\n\tMore text",
+            __formatted_display_name:
+                "Research & Development Test: **Paul** --Eric-- `good guy`\n\tMore text",
         },
     ]);
     await mountView({

--- a/addons/web/static/tests/views/fields/statusbar_field.test.js
+++ b/addons/web/static/tests/views/fields/statusbar_field.test.js
@@ -28,6 +28,7 @@ import {
     pagerPrevious,
 } from "@web/../tests/web_test_helpers";
 import { EventBus } from "@odoo/owl";
+import { range } from "@web/core/utils/numbers";
 import { WebClient } from "@web/webclient/webclient";
 
 class Partner extends models.Model {
@@ -1199,10 +1200,7 @@ test("[adjust] statusbar with a lot of stages, click to change stage", async () 
     resize({ width: 800 });
     class Stage extends models.Model {
         name = fields.Char();
-        _records = Array.from(Array(6).keys()).map((i) => {
-            const id = i + 1;
-            return { id, name: `Stage with very long name ${id}` };
-        });
+        _records = range(1, 7).map((id) => ({ id, name: `Stage with very long name ${id}` }));
     }
     defineModels([Stage]);
     Partner._fields.stage_id = { type: "many2one", relation: "stage" };

--- a/addons/website/static/src/client_actions/configurator/configurator.xml
+++ b/addons/website/static/src/client_actions/configurator/configurator.xml
@@ -265,11 +265,11 @@
                             <button class="btn btn-primary btn-lg px-4 py-2 center-block" t-on-click="getMoreThemes" t-ref="extraThemesButton">View more themes</button>
                         </p>
                     </t>
-                    <t t-elif="state.extraThemes.length" t-foreach="[...Array(Math.ceil(state.extraThemes.length/3)).keys()]" t-as="nbrExtraRow" t-key="nbrExtraRow">
+                    <t t-elif="state.extraThemes.length" t-foreach="Array(Math.ceil(state.extraThemes.length/3))" t-as="nbrExtraRow" t-key="nbrExtraRow_index">
                         <div class="row pb-4 pt-5">
-                            <t t-foreach="[...Array(3).keys()]" t-as="nbrExtraCol" t-key="nbrExtraCol">
+                            <t t-foreach="Array(3)" t-as="nbrExtraCol" t-key="nbrExtraCol_index">
                                 <div class="col-12 col-lg-4 d-flex align-items-end mb-4 mb-lg-0">
-                                    <t t-set="extraThemeId" t-value="nbrExtraRow * 3 + nbrExtraCol"/>
+                                    <t t-set="extraThemeId" t-value="nbrExtraRow_index * 3 + nbrExtraCol_index"/>
                                     <t t-set="extraThemeName" t-value="getExtraThemeName(extraThemeId)"/>
                                     <t t-if="extraThemeName">
                                         <div class="theme_preview border rounded position-relative w-100 small o_configurator_show_fast">

--- a/addons/website/static/src/components/website_loader/website_loader.xml
+++ b/addons/website/static/src/components/website_loader/website_loader.xml
@@ -60,7 +60,7 @@
         </div>
         <div id="o_website_loader_animations_steps" class="d-none d-lg-block position-relative flex-grow-1 overflow-hidden" role="presentation">
             <div id="o_website_loader_step_colors">
-                <t t-foreach="[...Array(64).keys()]" t-as="cell" t-key="cell">
+                <t t-foreach="Array(64)" t-as="cell" t-key="cell_index">
                     <span/>
                 </t>
             </div>

--- a/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
+++ b/addons/website/static/src/snippets/s_dynamic_snippet_carousel/000.xml
@@ -20,20 +20,20 @@
              t-att-data-bs-interval="interval" data-bs-ride="carousel">
             <!-- Content -->
             <t t-set="slideSize" t-value="rowSize * rowPerSlide" />
-            <t t-set="slideIndexGenerator" t-value="Array.from(Array(Math.ceil(data.length/slideSize)).keys())"/>
-            <t t-set="rowIndexGenerator" t-value="Array.from(Array(rowPerSlide).keys())"/>
-            <t t-set="colIndexGenerator" t-value="Array.from(Array(rowSize).keys())"/>
+            <t t-set="slideIndexGenerator" t-value="Array(Math.ceil(data.length/slideSize))"/>
+            <t t-set="rowIndexGenerator" t-value="Array(rowPerSlide)"/>
+            <t t-set="colIndexGenerator" t-value="Array(rowSize)"/>
             <div class="carousel-inner w-100 mx-auto" role="listbox"
                  aria-label="Carousel">
                 <t t-foreach="slideIndexGenerator" t-as="slideIndex" t-key="slideIndex_index">
-                    <t t-set="slideOffset" t-value="slideIndex * slideSize"/>
+                    <t t-set="slideOffset" t-value="slideIndex_index * slideSize"/>
                     <div t-attf-class="carousel-item #{extraClasses || ''} #{slideIndex_first ? 'active' : ''}" role="option">
                         <t t-foreach="rowIndexGenerator" t-as="rowIndex" t-key="rowIndex_index">
-                            <t t-set="rowOffset" t-value="slideOffset + (rowIndex * rowSize)"/>
+                            <t t-set="rowOffset" t-value="slideOffset + (rowIndex_index * rowSize)"/>
                             <t t-if="rowOffset &lt; data.length">
                                 <div t-attf-class="s_dynamic_snippet_row row g-3 #{extraRowClass || ''}">
                                     <t t-foreach="colIndexGenerator" t-as="colIndex" t-key="colIndex_index">
-                                        <t t-set="itemIndex" t-value="rowOffset + colIndex"/>
+                                        <t t-set="itemIndex" t-value="rowOffset + colIndex_index"/>
                                         <t t-if="itemIndex &lt; data.length">
                                             <div t-attf-class="#{colClass || ''}">
                                                 <t t-out="data[itemIndex]"/>

--- a/addons/website_sale/static/src/website_builder/products_item_option.xml
+++ b/addons/website_sale/static/src/website_builder/products_item_option.xml
@@ -5,11 +5,11 @@
             <BuilderRow label.translate="Size">
                 <BuilderButtonGroup action="'setItemSize'">
                     <table t-ref="table" t-on-mouseenter="_onTableMouseEnter" t-on-mouseleave="_onTableMouseLeave">
-                        <t t-foreach="[0, 1, 2, 3]" t-as="i" t-key="i">
+                        <t t-foreach="Array(4)" t-as="i" t-key="i_index">
                             <tr>
-                                <t t-foreach="[...Array(this.maxWidth).keys()]" t-as="j" t-key="j">
-                                    <td t-on-mouseover="()=>this._onTableCellMouseOver(i, j)" t-on-click="()=>this._onTableCellMouseClick(i, j)">
-                                        <BuilderButton preview="false" actionValue="[i, j]" className="'border-0'" />
+                                <t t-foreach="Array(this.maxWidth)" t-as="j" t-key="j_index">
+                                    <td t-on-mouseover="()=>this._onTableCellMouseOver(i_index, j_index)" t-on-click="()=>this._onTableCellMouseClick(i_index, j_index)">
+                                        <BuilderButton preview="false" actionValue="[i_index, j_index]" className="'border-0'" />
                                     </td>
                                 </t>
                             </tr>


### PR DESCRIPTION
\* = account, base_import, hr_attendance, hr_holidays, html_editor, l10n_dk, point_of_sale, portal, pos_loyalty, pos_self_order_event, spreadsheet, spreadsheet_dashboard, website, website_sale

The code is simpler when using range.

Note 1: in templates Owl already provides the keys as `_index` so explicitly using `keys()` or `range()` is not necessary.

Note 2: when filling the result with a static value (no following `map()`), using `Array(n).fill(x)` is more efficient.

task-4822140

https://github.com/odoo/enterprise/pull/86408

Note: `range` also appears to be more efficient
firefox
<img width="306" height="98" alt="image" src="https://github.com/user-attachments/assets/e8441c89-8863-4e75-990c-2d30869301df" />

chrome
<img width="315" height="96" alt="image" src="https://github.com/user-attachments/assets/ab0c5be8-deee-4a45-892f-009b6de84dc7" />