### PR TITLE
[for later][IMP] html_editor: clean system_classes and system_attributes on save

### DIFF
--- a/addons/html_editor/static/src/core/sanitize_plugin.js
+++ b/addons/html_editor/static/src/core/sanitize_plugin.js
@@ -10,7 +10,10 @@ export class SanitizePlugin extends Plugin {
     static id = "sanitize";
     static shared = ["sanitize"];
     resources = {
-        clean_for_save_handlers: this.cleanForSave.bind(this),
+        clean_for_save_handlers: [
+            this.cleanForSave.bind(this),
+            this.cleanSystemAttributes.bind(this),
+        ],
         normalize_handlers: this.normalize.bind(this),
     };
 
@@ -72,6 +75,23 @@ export class SanitizePlugin extends Plugin {
         }
         for (const el of selectElements(root, "[data-oe-aria-label]")) {
             el.removeAttribute("aria-label");
+        }
+    }
+    cleanSystemAttributes({ root }) {
+        const classes = this.getResource("system_classes");
+        const selector = classes.map((c) => `.${c}`).join(",");
+        const elements = root.querySelectorAll(selector);
+        for (const el of elements) {
+            el.classList.remove(...classes);
+        }
+        const attributes = this.getResource("system_attributes");
+        const elementsWithAttributes = root.querySelectorAll(
+            attributes.map((x) => `[${x}]`).join(",")
+        );
+        for (const el of elementsWithAttributes) {
+            for (const attr of attributes) {
+                el.removeAttribute(attr);
+            }
         }
     }
 }

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -297,7 +297,8 @@ describe("system classes and attributes", () => {
                 undo(editor);
                 redo(editor);
             },
-            contentAfter: `<p class="x">b[]</p>`,
+            contentAfterEdit: `<p class="x">b[]</p>`,
+            contentAfter: `<p>b[]</p>`,
             config: { Plugins: Plugins },
         });
     });

--- a/addons/html_editor/static/tests/sanitize.test.js
+++ b/addons/html_editor/static/tests/sanitize.test.js
@@ -1,5 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "./_helpers/editor";
+import { Plugin } from "@html_editor/plugin";
+import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 
 test("sanitize should remove nasty elements", async () => {
     const { editor } = await setupEditor("");
@@ -33,5 +35,25 @@ test("sanitize plugin should handle aria-label attribute with data-oe-aria-label
         contentBefore: `<p data-oe-aria-label="status">a[]</p>`,
         contentAfterEdit: `<p data-oe-aria-label="status" aria-label="status">a[]</p>`,
         contentAfter: `<p data-oe-aria-label="status">a[]</p>`,
+    });
+});
+
+test("should save without system_classes and system_attributes", async () => {
+    await testEditor({
+        contentBefore: `<p class="a foo" data-foo="test">hello[]</p>`,
+        contentAfterEdit: `<p class="a foo" data-foo="test">hello[]</p>`,
+        contentAfter: `<p class="a">hello[]</p>`,
+        config: {
+            Plugins: [
+                ...MAIN_PLUGINS,
+                class extends Plugin {
+                    static id = "testPlugin";
+                    resources = {
+                        system_classes: "foo",
+                        system_attributes: "data-foo",
+                    };
+                },
+            ],
+        },
     });
 });


### PR DESCRIPTION
In order to have a cleaning DOM, remove the sytem classes and system
attributes.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
