### PR TITLE
[for later][REF] html_builder: simplify makePreviewableOperation

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -17,7 +17,7 @@ export function useColorPickerBuilderComponent() {
     const { getAllActions, callOperation } = getAllActionsAndOperations(comp);
     const getAction = comp.env.editor.shared.builderActions.getAction;
     const state = useDomState(getState);
-    const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(
+    const applyOperation = comp.env.editor.shared.history.makePreviewableOperation(
         (applySpecs) => {
             const proms = [];
             for (const applySpec of applySpecs) {

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2many.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2many.js
@@ -27,7 +27,7 @@ export class BuilderMany2Many extends Component {
         this.fields = useService("field");
         const { getAllActions, callOperation } = getAllActionsAndOperations(this);
         this.callOperation = callOperation;
-        this.applyOperation = this.env.editor.shared.history.makePreviewableAsyncOperation(
+        this.applyOperation = this.env.editor.shared.history.makePreviewableOperation(
             this.callApply.bind(this)
         );
         this.state = useState({

--- a/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_many2one.js
@@ -32,7 +32,7 @@ export class BuilderMany2One extends Component {
         useBuilderComponent();
         const { getAllActions, callOperation } = getAllActionsAndOperations(this);
         this.callOperation = callOperation;
-        this.applyOperation = this.env.editor.shared.history.makePreviewableAsyncOperation(
+        this.applyOperation = this.env.editor.shared.history.makePreviewableOperation(
             this.callApply.bind(this)
         );
         const getAction = this.env.editor.shared.builderActions.getAction;

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -454,7 +454,7 @@ export function useClickableBuilderComponent() {
     const onReady = usePrepareAction(getAllActions);
     const { reload } = useReloadAction(getAllActions);
 
-    const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(callApply);
+    const applyOperation = comp.env.editor.shared.history.makePreviewableOperation(callApply);
     const inheritedActionIds =
         comp.props.inheritedActions || comp.env.weContext.inheritedActions || [];
 
@@ -621,7 +621,7 @@ export function useInputBuilderComponent({
         await Promise.all(proms);
     }
 
-    const applyOperation = comp.env.editor.shared.history.makePreviewableAsyncOperation(callApply);
+    const applyOperation = comp.env.editor.shared.history.makePreviewableOperation(callApply);
     const operationWithReload = useOperationWithReload(callApply, reload);
     function getState(editingElement) {
         if (!isConnectedElement(editingElement)) {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
@@ -1,7 +1,7 @@
 import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, click, Deferred, hover, runAllTimers } from "@odoo/hoot-dom";
+import { animationFrame, click, Deferred, hover, microTick, runAllTimers } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -32,6 +32,7 @@ test("call a specific action with some params and value", async () => {
     expect(".options-container").toBeDisplayed();
     expect("[data-action-id='customAction']").toHaveText("MyAction");
     await click("[data-action-id='customAction']");
+    await microTick();
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });
@@ -44,6 +45,7 @@ test("call a shorthand action", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await click("[data-class-action='my-custom-class']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveClass("my-custom-class");
 });
 test("call a shorthand action and a specific action", async () => {
@@ -63,6 +65,7 @@ test("call a shorthand action and a specific action", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await click("[data-action-id='customAction'][data-class-action='my-custom-class']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveClass("my-custom-class");
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction", "customAction"]);
@@ -192,13 +195,16 @@ test("clean another action", async () => {
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
+    await microTick();
     expect(".options-container").toBeDisplayed();
     await click("[data-class-action='my-custom-class1']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
         "test-options-target o-paragraph my-custom-class1"
     );
     await click("[data-class-action='my-custom-class2']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
         "test-options-target o-paragraph my-custom-class2"
@@ -227,10 +233,13 @@ test("clean should provide the next action value", async () => {
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
+    await microTick();
     expect(".options-container").toBeDisplayed();
 
     await click("[data-class-action='c1']");
+    await microTick();
     await click("[data-class-action='c2']");
+    await microTick();
     expect.verifySteps([
         "customAction apply",
         "customAction apply",
@@ -268,9 +277,12 @@ test("clean should only be called on the currently selected item", async () => {
     });
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
+    await microTick();
     await click("[data-action-id='customAction1']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveClass("c1");
     await click("[data-action-id='customAction2']");
+    await microTick();
     expect(":iframe .test-options-target").toHaveClass("c2");
     expect.verifySteps([
         "customAction1 apply",

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -1,6 +1,6 @@
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
-import { click, Deferred, hover, press, tick } from "@odoo/hoot-dom";
+import { click, Deferred, delay, hover, press, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -22,6 +22,7 @@ test("should apply backgroundColor to the editing element", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o-color-1']");
+    await delay();
     expect(":iframe .test-options-target").toHaveClass("test-options-target bg-o-color-1");
 });
 
@@ -35,6 +36,7 @@ test("should apply o_cc color", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o_cc3']");
+    await delay();
     expect(":iframe .test-options-target").toHaveClass("test-options-target o_cc3");
 });
 
@@ -48,6 +50,7 @@ test("should apply color to the editing element", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o-color-1']");
+    await delay();
     expect(":iframe .test-options-target").toHaveClass("test-options-target text-o-color-1");
 });
 

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
@@ -3,6 +3,7 @@ import { expect, test } from "@odoo/hoot";
 import {
     animationFrame,
     click,
+    microTick,
     press,
     queryAllTexts,
     queryFirst,
@@ -18,7 +19,6 @@ import {
 } from "../../website_helpers";
 
 defineWebsiteModels();
-
 test("call a specific action with some params and value (BuilderSelectItem)", async () => {
     addActionOption({
         customAction: {
@@ -41,6 +41,7 @@ test("call a specific action with some params and value (BuilderSelectItem)", as
     await animationFrame();
     expect("[data-action-id='customAction']").toHaveText("MyAction");
     await click("[data-action-id='customAction']");
+    await microTick();
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });

--- a/addons/website/static/tests/builder/options/card_option.test.js
+++ b/addons/website/static/tests/builder/options/card_option.test.js
@@ -1,7 +1,7 @@
 import { expect, test } from "@odoo/hoot";
 import { defineWebsiteModels, dummyBase64Img, setupWebsiteBuilder } from "../website_helpers";
 import { contains } from "@web/../tests/web_test_helpers";
-import { animationFrame, click, queryOne, setInputRange, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, microTick, queryOne, setInputRange, waitFor } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
@@ -43,12 +43,15 @@ test("set card aligment", async () => {
     expect("[data-label='Alignment'] button[title='Left']").toHaveClass("active");
 
     await click("[data-label='Alignment'] button[title='Center']");
+    await microTick();
     expect(":iframe .s_card").toHaveClass("mx-auto");
 
     await click("[data-label='Alignment'] button[title='Right']");
+    await microTick();
     expect(":iframe .s_card").toHaveClass("ms-auto");
 
     await click("[data-label='Alignment'] button[title='Left']");
+    await microTick();
     expect(":iframe .s_card").toHaveClass("me-auto");
 });
 

--- a/addons/website/static/tests/builder/options/grid_column_option.test.js
+++ b/addons/website/static/tests/builder/options/grid_column_option.test.js
@@ -2,6 +2,7 @@ import { expect, test } from "@odoo/hoot";
 import { click, Deferred, edit, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../website_helpers";
+import { delay } from "@web/core/utils/concurrency";
 
 defineWebsiteModels();
 
@@ -11,6 +12,7 @@ test("Using the Padding (Y, X) option should display a padding preview", async (
     await waitFor("[data-label='Padding (Y, X)'] input");
     await click(queryAll("[data-label='Padding (Y, X)'] input")[0]);
     await edit(20);
+    await delay();
     const def = new Deferred();
     expect(queryFirst(":iframe .s_banner .o_grid_item")).toHaveClass("o_we_padding_highlight");
     queryFirst(":iframe .s_banner .o_grid_item").addEventListener("animationend", () => {


### PR DESCRIPTION
The logic of `makePreviewableOperation` and
`makePreviewableAsyncOperation` was the same except that one was synchronous and the other was asynchronous. This commit simplifies the code by merging them into a single function `makePreviewableOperation`, which can handle both synchronous and asynchronous operations.






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
