### PR TITLE
[IMP] pos_restaurant: validating refund unsent order dialog shown

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/receipt_screen_util.js
@@ -239,3 +239,12 @@ export function discardOrderWarningDialog() {
         Dialog.discard(),
     ];
 }
+
+export function confirmOrderWarningDialog() {
+    return [
+        {
+            trigger: `.modal-dialog:contains("It seems that the order has not been sent. Would you like to send it to preparation?")`,
+        },
+        Dialog.confirm(),
+    ];
+}

--- a/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/app/screens/payment_screen/payment_screen.js
@@ -25,7 +25,11 @@ patch(PaymentScreen.prototype, {
         return await super.afterOrderValidation(...arguments);
     },
     async validateOrder(isForceValidate) {
-        if (this.pos.config.module_pos_restaurant && this.pos.getOrder().hasChange) {
+        if (
+            this.pos.config.module_pos_restaurant &&
+            this.pos.getOrder().hasChange &&
+            !this.pos.getOrder().isRefund
+        ) {
             const confirmed = await ask(this.dialog, {
                 title: _t("Warning !"),
                 body: _t(

--- a/addons/pos_restaurant/static/tests/tours/refund_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/refund_tour.js
@@ -43,5 +43,9 @@ registry.category("web_tour.tours").add("RefundStayCurrentTableTour", {
             ProductScreen.isShown(),
             inLeftSide(ProductScreen.orderLineHas("Coca-Cola")),
             ProductScreen.totalAmountIs("-4.40"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.isShown(),
         ].flat(),
 });


### PR DESCRIPTION
Before this commit:
----------------------
- The Send Order to Preparation Display  confirmation dialog also appeared when
  validating a refund, which was not necessary and interrupted the expected
  flow.

After this commit:
------------------------
- No dialog shown for refunds.

Task-4804669

Related PR - https://github.com/odoo/enterprise/pull/86413