### PR TITLE
[IMP] Enable and adapt test_link_to_document tour

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -634,22 +634,30 @@ export function toggleMobilePreview(toggleOn) {
  *                                      the link element.
  * @returns {TourStep[]} The tour steps that opens the link popup.
  */
-export function openLinkPopup(triggerSelector, linkName = "", focusNodeIndex = 0) {
+export function openLinkPopup(
+    triggerSelector,
+    linkName = "",
+    focusNodeIndex = 0,
+    triggerClick = false
+) {
     return [
         {
             content: `Open '${linkName}' link popup`,
             trigger: triggerSelector,
-            async run() {
+            async run(actions) {
+                if (triggerClick) {
+                    actions.click();
+                }
                 const el = this.anchor;
                 const sel = el.ownerDocument.getSelection();
                 sel.collapse(el.childNodes[focusNodeIndex], 1);
                 el.focus();
-            }
+            },
         },
         {
             content: "Check if the link popover opened",
-            trigger: ".o-we-linkpopover"
-        }
+            trigger: ".o-we-linkpopover",
+        },
     ];
 }
 

--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -1,4 +1,8 @@
-import { insertSnippet, registerWebsitePreviewTour } from "@website/js/tours/tour_utils";
+import {
+    insertSnippet,
+    openLinkPopup,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
 import { patch } from "@web/core/utils/patch";
 
 // Opening the system's file selector is not possible programmatically, so we
@@ -22,6 +26,22 @@ const unpatchStep = {
     run: () => unpatch(),
 };
 
+const editLinkPopup = () => [
+    ...openLinkPopup(`:iframe #wrap .s_banner a:nth-child(1)`, "Start Now", 1, true),
+    {
+        trigger: ".o-we-linkpopover .o_we_edit_link",
+        run: "click",
+    },
+];
+
+const saveLinkPopup = () => [
+    {
+        content: "Save the link by clicking on Apply button",
+        trigger: ".o-we-linkpopover .o_we_apply_link",
+        run: "click",
+    },
+];
+
 /**
  * The purpose of this tour is to check the Linktools to create a link to an
  * uploaded document.
@@ -38,34 +58,47 @@ registerWebsitePreviewTour(
             id: "s_banner",
             groupName: "Intro",
         }),
-        {
-            content: "Click on button Start Now",
-            trigger: ":iframe #wrap .s_banner a:nth-child(1)",
-            run: "click",
-        },
         patchStep,
+        ...editLinkPopup(),
+        {
+            trigger: ".o-we-linkpopover .o_we_href_input_link",
+            run: "edit ",
+        },
         {
             content: "Click on link to an uploaded document",
-            trigger: ".o_url_input .o_we_user_value_widget.fa.fa-upload",
+            trigger: ".o-we-linkpopover div.o-autocomplete ~ span > button",
             run: "click",
         },
+        ...saveLinkPopup(),
         {
             content: "Check if a document link is created",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link[href^='/web/content']",
+            trigger: ":iframe #wrap .s_banner a:nth-child(1)[href^='/web/content']",
+        },
+        {
+            content: "Check if by default the option auto-download is enabled",
+            trigger: ":iframe #wrap .s_banner a:nth-child(1)[href$='download=true']",
         },
         unpatchStep,
         {
-            content: "Check if by default the option auto-download is enabled",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link[href$='download=true']",
+            content: `Click on outside to select something else`,
+            trigger: `:iframe #wrap .s_banner p:nth-child(2)`,
+            async run() {
+                const el = this.anchor;
+                const sel = el.ownerDocument.getSelection();
+                sel.collapse(el.childNodes[1], 1);
+                el.focus();
+            },
         },
+        ...editLinkPopup(),
         {
             content: "Deactivate direct download",
-            trigger: ".o_switch > we-checkbox[name='direct_download']",
+            trigger: ".o-we-linkpopover .direct-download-option > input",
             run: "click",
         },
+        ...saveLinkPopup(),
         {
             content: "Check if auto-download is disabled",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link:not([href$='download=true'])",
+            trigger: ":iframe #wrap .s_banner a:nth-child(1):not([href$='download=true'])",
         },
     ]
 );

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -42,8 +42,6 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
     def test_02_image_quality(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_03_link_to_document(self):
         text = b'Lorem Ipsum'
         self.env['ir.attachment'].create({


### PR DESCRIPTION
test_link_to_document tour was broken and disabled after the new website builder changes.

This commit adapts the tour steps accordingly and re-enables the related test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
