### PR TITLE
[FIX] web: prevent passing empty context for default field

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -309,7 +309,7 @@ export class Many2XAutocomplete extends Component {
     getCreationContext(value) {
         return makeContext([
             this.props.context,
-            { [`default_${this.props.nameCreateField}`]: value },
+            value && { [`default_${this.props.nameCreateField}`]: value },
         ]);
     }
     onInput({ inputValue }) {

--- a/addons/web/static/tests/views/fields/many2many_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_field.test.js
@@ -1902,6 +1902,14 @@ test("`this` inside rendererProps should reference the component", async () => {
 });
 
 test("empty many2many tags field with no result", async () => {
+    patchWithCleanup(Many2XAutocomplete.prototype, {
+        getCreationContext(value){
+            expect(value).toBe("");
+            const context = super.getCreationContext(value);
+            expect(context[`default_${this.props.nameCreateField}`]).toBe(undefined);
+            return context;
+        }
+    });
     class M2M extends models.Model {
         m2m = fields.Many2many({ relation: "m2m" });
     }

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -32,6 +32,7 @@ import {
     serverState,
     toggleMenuItem,
     toggleSearchBarMenu,
+    patchWithCleanup,
     validateSearch,
 } from "@web/../tests/web_test_helpers";
 
@@ -39,6 +40,7 @@ import { user } from "@web/core/user";
 import { Record } from "@web/model/record";
 import { Field } from "@web/views/fields/field";
 import { WebClient } from "@web/webclient/webclient";
+import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 
 describe.current.tags("desktop");
 
@@ -948,6 +950,14 @@ test("empty readonly many2one field", async () => {
 });
 
 test("empty many2one field with no result", async () => {
+    patchWithCleanup(Many2XAutocomplete.prototype, {
+        getCreationContext(value){
+            expect(value).toBe("");
+            const context = super.getCreationContext(value);
+            expect(context[`default_${this.props.nameCreateField}`]).toBe(undefined);
+            return context;
+        }
+    });
     class M2O extends models.Model {
         m2o = fields.Many2one({ relation: "m2o" });
     }


### PR DESCRIPTION
Currently, an error occurs when the user attempts to create an employee from any view.

Steps to replicate:
- Install `hr_payroll`, go to `Payroll > Work Entries` and click on create.
- Now click on the `Employee`(dont type anything), and click on create.
- Type any name and click save.

Error:
`IndexError: string index out of range`

The error occurs because of the `default_name` being passed as empty string from line [1], which is due to a recent change([PR](https://github.com/odoo/odoo/pull/209835)). This causes the line [2] to receive the `name` as empty string and causes the error.

This commit resolves the issue by passing default value in the context only ifit exists so we don't get any errors during avatar creation.

[1]- https://github.com/odoo/odoo/blob/9cebb8c23d66a6aadd06bf0d806c65b67dc13ae7/addons/web/static/src/views/fields/relational_utils.js#L312

[2]-https://github.com/odoo/odoo/blob/bfc98c30e1a4faa458bc1101dc572e96cfa31d47/odoo/addons/base/models/avatar_mixin.py#L65

sentry-6619892365
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
