### PR TITLE
[FIX] web_editor: prevent duplicate image save on first upload

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6471,7 +6471,7 @@ const ImageHandlerOption = SnippetOptionWidget.extend({
             img.dataset.originalMimetype = "image/webp";
             img.dataset.resizeWidth = this.optimizedWidth;
         }
-        await this._applyOptions();
+        await this._applyOptions(false);
         await this.updateUI();
     },
     /**


### PR DESCRIPTION
This PR aims to prevent the creation of duplicate image attachments when uploading an image for the first time in Website Editor.

---

### Steps to Reproduce

1. Open Website → Edit mode.
2. Drag and drop any snippet that contains an image (e.g., cover, banner, image block).
3. Upload an image using the image upload option.
4. Check the attachments.
   → You will notice multiple attachments of the same image being created(by odooBot).

---
### Impact
* Prevents unnecessary saves and duplicate attachments.

task-4812410