### PR TITLE
[FIX] html_editor: do not show hint in non-editable content

### DIFF
--- a/addons/html_editor/static/src/main/hint_plugin.js
+++ b/addons/html_editor/static/src/main/hint_plugin.js
@@ -1,5 +1,5 @@
 import { Plugin } from "@html_editor/plugin";
-import { isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
+import { isContentEditable, isEmptyBlock, isProtected } from "@html_editor/utils/dom_info";
 import { removeClass } from "@html_editor/utils/dom";
 import { selectElements } from "@html_editor/utils/dom_traversal";
 import { closestBlock } from "../utils/blocks";
@@ -23,7 +23,11 @@ export class HintPlugin extends Plugin {
                 return [];
             }
             const blockEl = closestBlock(selectionData.editableSelection.anchorNode);
-            return [blockEl];
+            if (isContentEditable(blockEl.parentElement)) {
+                return [blockEl];
+            } else {
+                return [];
+            }
         },
         system_classes: ["o-we-hint"],
         system_attributes: ["o-we-hint-text"],

--- a/addons/html_editor/static/tests/hint.test.js
+++ b/addons/html_editor/static/tests/hint.test.js
@@ -72,6 +72,13 @@ test("should not display hint in paragraph with media content", async () => {
     expect(getContent(el)).toBe(content);
 });
 
+test("should not display hint in a non-editable paragraph", async () => {
+    const content = '<div contenteditable="false"><p>[]</p></div>';
+    const { el } = await setupEditor(content);
+    // Unchanged, no empty paragraph hint.
+    expect(getContent(el)).toBe(content);
+});
+
 test("should not lose track of temporary hints on split block", async () => {
     const { el, editor, plugins } = await setupEditor("<p>[]</p>", {});
     expect(getContent(el)).toBe(


### PR DESCRIPTION
A non-editable element should not show a hint for edition.

This happened in the following case:

1. Open the website editor in edit mode
2. Click on the header
3. Change the header template to "Menu with Search bar" (the 6th one)
4. Click to the left of "Free Returns and Standard Shipping" in the menu
5. -> A "List" hint appeared.

![image](https://github.com/user-attachments/assets/458271e1-946e-4efa-9e4a-393517355256)

This PR fixes the issue by checking if the element is editable before showing the hint.

Note: will have to be adapted to the new definition of "editable node" when task-4809282 is merged.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
