### PR TITLE
[FIX] website, html_builder: implement promptSaveRedirect

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -102,6 +102,9 @@ export class Builder extends Component {
                         ...param,
                     });
                 },
+                closeEditor: async () => {
+                    await this.props.closeEditor();
+                },
                 resources: {
                     trigger_dom_updated: () => {
                         editorBus.trigger("DOM_UPDATED");


### PR DESCRIPTION
This was forgotten in the website refactor [1].

It needs a form_editor_actions containing a field with a createAction.
website_project has one to test.

Steps to reproduce:
- Drop a form snippet
- Select action "Create a Task"
- Click on the "+" next to project to Create New
- It should open a pop up to warn you that you will be redirected to Project

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641