### PR TITLE
[FIX] l10n_es_edi_facturae: correct credit note facturae

### DIFF
--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -370,8 +370,8 @@ class AccountMove(models.Model):
             'Invoices': [{
                 'invoice_record': self,
                 'invoice_currency': inv_curr,
-                'InvoiceDocumentType': 'FC',
-                'InvoiceClass': 'OO',
+                'InvoiceDocumentType': 'FA' if self.l10n_es_is_simplified else 'FC',
+                'InvoiceClass': 'OR' if self.move_type in ['out_refund', 'in_refund'] else 'OO',
                 'Corrective': self._l10n_es_edi_facturae_get_corrective_data(),
                 'InvoiceIssueData': {
                     'OperationDate': operation_date,

--- a/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_refund_document.xml
@@ -61,7 +61,7 @@
       <InvoiceHeader>
         <InvoiceNumber>RINV/2023/00001</InvoiceNumber>
         <InvoiceDocumentType>FC</InvoiceDocumentType>
-        <InvoiceClass>OO</InvoiceClass>
+        <InvoiceClass>OR</InvoiceClass>
         <Corrective>
           <InvoiceNumber>INV/2023/00001</InvoiceNumber>
           <ReasonCode>10</ReasonCode>

--- a/addons/l10n_es_edi_facturae/tests/data/expected_simplified_document.xml
+++ b/addons/l10n_es_edi_facturae/tests/data/expected_simplified_document.xml
@@ -1,0 +1,240 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<fac:Facturae xmlns:fac="http://www.facturae.gob.es/formato/Versiones/Facturaev3_2_2.xml">
+  <FileHeader>
+    <SchemaVersion>3.2.2</SchemaVersion>
+    <Modality>I</Modality>
+    <InvoiceIssuerType>EM</InvoiceIssuerType>
+    <Batch>
+      <BatchIdentifier>INV/2023/00001</BatchIdentifier>
+      <InvoicesCount>1</InvoicesCount>
+      <TotalInvoicesAmount>
+        <TotalAmount>121.00</TotalAmount>
+      </TotalInvoicesAmount>
+      <TotalOutstandingAmount>
+        <TotalAmount>121.00</TotalAmount>
+      </TotalOutstandingAmount>
+      <TotalExecutableAmount>
+        <TotalAmount>121.00</TotalAmount>
+      </TotalExecutableAmount>
+      <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+    </Batch>
+  </FileHeader>
+  <Parties>
+    <SellerParty>
+      <TaxIdentification>
+        <PersonTypeCode>J</PersonTypeCode>
+        <ResidenceTypeCode>R</ResidenceTypeCode>
+        <TaxIdentificationNumber>ES59962470K</TaxIdentificationNumber>
+      </TaxIdentification>
+      <LegalEntity>
+        <CorporateName>company_1_data</CorporateName>
+        <TradeName>company_1_data</TradeName>
+        <AddressInSpain>
+          <Address>C. de Embajadores, 68-116</Address>
+          <PostCode>12345</PostCode>
+          <Town>Madrid</Town>
+          <Province>Madrid</Province>
+          <CountryCode>ESP</CountryCode>
+        </AddressInSpain>
+      </LegalEntity>
+    </SellerParty>
+    <BuyerParty>
+      <TaxIdentification>
+        <PersonTypeCode>F</PersonTypeCode>
+        <ResidenceTypeCode>R</ResidenceTypeCode>
+        <TaxIdentificationNumber>ESA12345674</TaxIdentificationNumber>
+      </TaxIdentification>
+      <Individual>
+        <Name>Simplified Invoice</Name>
+        <FirstSurname>Partner</FirstSurname>
+        <SecondSurname>(ES)</SecondSurname>
+        <AddressInSpain>
+          <PostCode>False</PostCode>
+          <Province>Spain</Province>
+          <CountryCode>ESP</CountryCode>
+        </AddressInSpain>
+      </Individual>
+    </BuyerParty>
+  </Parties>
+  <Invoices>
+    <Invoice>
+      <InvoiceHeader>
+        <InvoiceNumber>INV/2023/00001</InvoiceNumber>
+        <InvoiceDocumentType>FA</InvoiceDocumentType>
+        <InvoiceClass>OO</InvoiceClass>
+      </InvoiceHeader>
+      <InvoiceIssueData>
+        <IssueDate>2023-01-01</IssueDate>
+        <InvoiceCurrencyCode>EUR</InvoiceCurrencyCode>
+        <TaxCurrencyCode>EUR</TaxCurrencyCode>
+        <LanguageName>en</LanguageName>
+      </InvoiceIssueData>
+      <TaxesOutputs>
+        <Tax>
+          <TaxTypeCode>01</TaxTypeCode>
+          <TaxRate>21.000</TaxRate>
+          <TaxableBase>
+            <TotalAmount>100.00</TotalAmount>
+          </TaxableBase>
+          <TaxAmount>
+            <TotalAmount>21.00</TotalAmount>
+          </TaxAmount>
+        </Tax>
+      </TaxesOutputs>
+      <InvoiceTotals>
+        <TotalGrossAmount>100.00</TotalGrossAmount>
+        <TotalGrossAmountBeforeTaxes>100.00</TotalGrossAmountBeforeTaxes>
+        <TotalTaxOutputs>21.00</TotalTaxOutputs>
+        <TotalTaxesWithheld>0.00</TotalTaxesWithheld>
+        <InvoiceTotal>121.00</InvoiceTotal>
+        <TotalOutstandingAmount>121.00</TotalOutstandingAmount>
+        <TotalExecutableAmount>121.00</TotalExecutableAmount>
+      </InvoiceTotals>
+      <Items>
+        <InvoiceLine>
+          <FileDate>2023-01-01</FileDate>
+          <ItemDescription>product_a</ItemDescription>
+          <Quantity>1.0</Quantity>
+          <UnitOfMeasure>01</UnitOfMeasure>
+          <UnitPriceWithoutTax>100.00</UnitPriceWithoutTax>
+          <TotalCost>100.00</TotalCost>
+          <GrossAmount>100.00</GrossAmount>
+          <TaxesOutputs>
+            <Tax>
+              <TaxTypeCode>01</TaxTypeCode>
+              <TaxRate>21.000</TaxRate>
+              <TaxableBase>
+                <TotalAmount>100.00</TotalAmount>
+              </TaxableBase>
+              <TaxAmount>
+                <TotalAmount>21.00</TotalAmount>
+              </TaxAmount>
+            </Tax>
+          </TaxesOutputs>
+        </InvoiceLine>
+      </Items>
+      <PaymentDetails>
+        <Installment>
+          <InstallmentDueDate>2023-01-01</InstallmentDueDate>
+          <InstallmentAmount>121.00</InstallmentAmount>
+          <PaymentMeans>04</PaymentMeans>
+          <AccountToBeCredited>
+            <IBAN>ES9121000418450200051332</IBAN>
+            <BIC>CAIXESBBXXX</BIC>
+          </AccountToBeCredited>
+        </Installment>
+      </PaymentDetails>
+    </Invoice>
+  </Invoices>
+<ds:Signature xmlns:ds="http://www.w3.org/2000/09/xmldsig#" Id="Signature-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+  <ds:SignedInfo>
+    <ds:CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+    <ds:SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+    <ds:Reference Type="http://www.w3.org/2000/09/xmldsig#Object" URI="" Id="Reference-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+      <ds:Transforms>
+        <ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+      </ds:Transforms>
+      <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+      <ds:DigestValue>2JTZ5hH6cu2LWsdL7PBAmSEGDEtTfnSEGtoOa3tnj6o=</ds:DigestValue>
+    </ds:Reference>
+    <ds:Reference Type="http://uri.etsi.org/01903#SignedProperties" URI="#SignatureProperties-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+      <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+      <ds:DigestValue>eazxxVbxtBOO3kXeqSJc3MJNY5se6lPtcbeksevz6lU=</ds:DigestValue>
+    </ds:Reference>
+    <ds:Reference URI="#KeyInfo-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+      <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+      <ds:DigestValue>+8P6L2nyCl6ViPlDPBo6pw7UVuidB4IYGzJiqgsf+Qo=</ds:DigestValue>
+    </ds:Reference>
+  </ds:SignedInfo>
+  <ds:SignatureValue>sW/TcdWJ9uuvLmWkt0m4fl+tF/I+m8X17xQuZy/Lvxdd23V1weXV1Qpro2OkWzMtU5KnxaPqQLlM
+oRqEADnxeuxFYC74h/tjXpan5SRGBklsE7wmIgO1x2RO7zGjUa2C3m2yhHRDlJkaCBdLpvkNN6uo
+zpURL7Ko7LF8w1BYGYkbJe53ZMx7KlHDkzpB2NDaR20ncoPl+KvxKE3FP2PKRyuILcgQfRnyraGG
+i2WftOGCW2QJp4F8kr4IFPqCAfD57A+f1fmU5H/wovlD3ltcPYFSmcE2rNYrLVWTh2cCKUk+OQIR
+PSU6STtsbtrheI1f+On/2hZo4pcIVnKqVMaEqw==
+</ds:SignatureValue>
+  <ds:KeyInfo Id="KeyInfo-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+    <ds:X509Data>
+      <ds:X509Certificate>MIID8jCCAtqgAwIBAgIUYBl+61DsTkNyyUFGveskbaGP/SkwDQYJKoZIhvcNAQELBQAwgYoxCzAJ
+BgNVBAYTAkJFMRIwEAYDVQQIDAlXYWxsb25uaWExEjAQBgNVBAcMCVJhbWlsbGllczENMAsGA1UE
+CgwET2RvbzEMMAoGA1UECwwDUiZEMRgwFgYDVQQDDA9ydW5ib3Qub2Rvby5jb20xHDAaBgkqhkiG
+9w0BCQEWDWluZm9Ab2Rvby5jb20wHhcNMjIwNDI2MDczMTUwWhcNMjMwNDI2MDczMTUwWjCBlTEL
+MAkGA1UEBhMCQkUxEjAQBgNVBAgMCVdhbGxvbm5pYTESMBAGA1UEBwwJUmFtaWxsaWVzMRIwEAYD
+VQQKDAlPZG9vIFMuQS4xGTAXBgNVBAsMEFImRCAtIEFjY291bnRpbmcxETAPBgNVBAMMCG9kb28u
+Y29tMRwwGgYJKoZIhvcNAQkBFg1pbmZvQG9kb28uY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAtGUbyNJrA3yyOC01gIMR1A1rWIHCHD+afLCLCddBDZwC4Q034yFBuMqQFNWaxxLc
+9s+wFbNZqu5D7rynN3qXvWJj40VZxygoV/09y71IhaspuAZ0rdzYsqjDmTJiPSrEl6iydF2eq6sJ
+4J0ItCUFc2e88B25wz7esslAN249C20oQj5ZiGifR4P0CRQSmDy0SPYZGxTurVwtq6IsYbOqEw8/
+Wqx6ApOltperFX88DZCdbY59ZedqQrGQh2Z5Au7h/8nhmdbpz7Ixw2zocxVigR0ClNDpKKxvolX1
+virQpICkfWcAaWAYAMCL4KhvISclysD+5juDLpGCLHPtKxBXTQIDAQABo0MwQTAfBgNVHSMEGDAW
+gBTmxEG4Ub7b5wRXqWea94Vs1hB13zAJBgNVHRMEAjAAMBMGA1UdEQQMMAqCCG9kb28uY29tMA0G
+CSqGSIb3DQEBCwUAA4IBAQAFLvTlSELTVWRfIlGthoFOmkv8MrwJuo8y7qTmvsFXeA2hZtsPdNxx
+iwAGPobiUO0GCEPUFKZ7NksQa7DAKGXfb5RSwfujDfEMAhgi00+wF1VIKeKqnGt4idzCr+2NtiQY
+e9oK+Ee7o82llnNFwbWvRKx55lhHW3bwN6Tl31qUYbxacJyA9z5sQpe2zImWMVsm4g7OAjzg3Cn2
+0TFu+0XekB892n7DYh4gHiMWaMOVYmi/aEWLSqxMlbiHQr75FmPftozFvTxW26jU3ALhq+yXPVa4
+lg4r/h6HH5TbtSjYzTSJ4MvMyrECgIQYf0zsS4D6K/GvCZbu7LKHRwuC0fis
+</ds:X509Certificate>
+    </ds:X509Data>
+    <ds:KeyValue>
+      <ds:RSAKeyValue>
+        <ds:Modulus>tGUbyNJrA3yyOC01gIMR1A1rWIHCHD+afLCLCddBDZwC4Q034yFBuMqQFNWaxxLc9s+wFbNZqu5D
+7rynN3qXvWJj40VZxygoV/09y71IhaspuAZ0rdzYsqjDmTJiPSrEl6iydF2eq6sJ4J0ItCUFc2e8
+8B25wz7esslAN249C20oQj5ZiGifR4P0CRQSmDy0SPYZGxTurVwtq6IsYbOqEw8/Wqx6ApOltper
+FX88DZCdbY59ZedqQrGQh2Z5Au7h/8nhmdbpz7Ixw2zocxVigR0ClNDpKKxvolX1virQpICkfWcA
+aWAYAMCL4KhvISclysD+5juDLpGCLHPtKxBXTQ==
+</ds:Modulus>
+        <ds:Exponent>AQAB
+</ds:Exponent>
+      </ds:RSAKeyValue>
+    </ds:KeyValue>
+  </ds:KeyInfo>
+  <ds:Object>
+    <xades:QualifyingProperties xmlns:xades="http://uri.etsi.org/01903/v1.3.2#" Target="#Signature-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+      <xades:SignedProperties Id="SignatureProperties-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+        <xades:SignedSignatureProperties>
+          <xades:SigningTime>2023-01-01T00:00:00</xades:SigningTime>
+          <xades:SigningCertificate>
+            <xades:Cert>
+              <xades:CertDigest>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <ds:DigestValue>FHf2lN+5FALNa7JXV2+pByL92/dr8LeCVhpItYic5oA=</ds:DigestValue>
+              </xades:CertDigest>
+              <xades:IssuerSerial>
+                <ds:X509IssuerName>CN=runbot.odoo.com, OU=R&amp;D, O=Odoo, C=BE, ST=Wallonnia, L=Ramillies, 1.2.840.113549.1.9.1=info@odoo.com</ds:X509IssuerName>
+                <ds:X509SerialNumber>548631688851000697209704649636588277530075594025</ds:X509SerialNumber>
+              </xades:IssuerSerial>
+            </xades:Cert>
+          </xades:SigningCertificate>
+          <xades:SignaturePolicyIdentifier>
+            <xades:SignaturePolicyId>
+              <xades:SigPolicyId>
+                <xades:Identifier>http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf</xades:Identifier>
+                <xades:Description>Política de firma electrónica para facturación electrónica con formato Facturae</xades:Description>
+              </xades:SigPolicyId>
+              <xades:SigPolicyHash>
+                <ds:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+                <ds:DigestValue>Ohixl6upD6av8N7pEvDABhEL6hM=</ds:DigestValue>
+              </xades:SigPolicyHash>
+              <xades:SigPolicyQualifiers>
+                <xades:SigPolicyQualifier>
+                  <xades:SPURI>http://www.facturae.es/politica_de_firma_formato_facturae/politica_de_firma_formato_facturae_v3_1.pdf</xades:SPURI>
+                </xades:SigPolicyQualifier>
+              </xades:SigPolicyQualifiers>
+            </xades:SignaturePolicyId>
+          </xades:SignaturePolicyIdentifier>
+        </xades:SignedSignatureProperties>
+        <xades:SignedDataObjectProperties>
+          <xades:DataObjectFormat ObjectReference="#Reference-Document-028f5c6abda3c765f2562e5848fbb071a1eb0409">
+            <xades:Description/>
+            <xades:ObjectIdentifier>
+              <xades:Identifier Qualifier="OIDAsURN">urn:oid:1.2.840.10003.5.109.10</xades:Identifier>
+              <xades:Description/>
+            </xades:ObjectIdentifier>
+            <xades:MimeType>text/xml</xades:MimeType>
+            <xades:Encoding/>
+          </xades:DataObjectFormat>
+        </xades:SignedDataObjectProperties>
+      </xades:SignedProperties>
+    </xades:QualifyingProperties>
+  </ds:Object>
+</ds:Signature>
+</fac:Facturae>

--- a/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_facturae/tests/test_edi_xml.py
@@ -362,3 +362,30 @@ class TestEdiFacturaeXmls(AccountTestInvoicingCommon):
 
         # Check first invoice's lines.
         self.assertEqual(tax_amounts, [21.0, -20.0])
+
+    def test_simplified_invoice(self):
+        """
+        Test that in the facturae xml uses the correct InvoiceDocumentType for simplified invoices
+        """
+
+        partner = self.env.ref('l10n_es.partner_simplified')
+        partner.vat = 'ESA12345674'
+        partner.country_id = self.env['res.country'].search([('code', '=', 'ES')])
+
+        # We need to patch dates and uuid to ensure the signature's consistency
+        with freeze_time(datetime(2023, 1, 1)):
+            invoice = self.create_invoice(
+                partner_id=partner.id,
+                move_type='out_invoice',
+                invoice_line_ids=[
+                    {'price_unit': 100.0, 'tax_ids': [self.tax.id]},
+                ],
+            )
+            invoice.action_post()
+            generated_file, errors = invoice._l10n_es_edi_facturae_render_facturae()
+            self.assertFalse(errors)
+            self.assertTrue(generated_file)
+
+            with file_open("l10n_es_edi_facturae/tests/data/expected_simplified_document.xml", "rt") as f:
+                expected_xml = lxml.etree.fromstring(f.read().encode())
+            self.assertXmlTreeEqual(lxml.etree.fromstring(generated_file), expected_xml)


### PR DESCRIPTION
With a Spanish company and `l10n_es_edi_facturae`:

- Create an invoice with a Spanish contact and confirm it.
- Create a credit note for this invoice. Send and print it.

In the Facturae XML, the `InvoiceClass` uses `OO` instead of `OR` (as specified on page 24 of [the specifications](https://www.facturae.gob.es/formato/Versiones/Esquema_castellano_v3_2_x_06_06_2017_unificado.pdf)).

This commit also removes the hard-coded `'FC'` for `InvoiceDocumentType`, writing `'FA'` instead in the case of a simplified invoice.

opw-4806099

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
