### PR TITLE
[FIX] website_sale: ensure that product is publish in test

### DIFF
--- a/addons/website_sale/tests/test_website_sale_shop_redirects.py
+++ b/addons/website_sale/tests/test_website_sale_shop_redirects.py
@@ -102,6 +102,7 @@ class TestWebsiteSaleShopRedirects(HttpCase, WebsiteSaleCommon):
         # Add a different published product to category so that it is accessible to public users
         self.env['product.template'].create({
             'name': 'Test Product',
+            'is_published': True,
             'public_categ_ids': [
                 Command.link(category.id),
             ],


### PR DESCRIPTION
756fdb2 introduced a test that wrongly assumed that the product was published.

This commit ensures that the said product will always be published so that the category is accessible from the eCommerce