### PR TITLE
[IMP] web: improve tabs readability

### DIFF
--- a/addons/web/static/src/core/notebook/notebook.xml
+++ b/addons/web/static/src/core/notebook/notebook.xml
@@ -5,7 +5,7 @@
         <div t-attf-class="o_notebook d-flex w-100 {{ props.orientation === 'horizontal' ? 'horizontal flex-column' : 'vertical flex-row' }} {{ props.className }}" t-if="state.currentPage">
             <div class="o_notebook_headers" t-att-class="{ 'm-0': props.orientation === 'vertical' }">
                 <ul t-attf-class="nav nav-tabs {{ props.orientation === 'horizontal' ? 'flex-row flex-nowrap' : 'flex-column p-0' }}">
-                    <li t-foreach="navItems" t-as="navItem" t-key="navItem[0]" class="nav-item flex-nowrap cursor-pointer" t-if="navItem[1].isVisible" t-attf-class="{{ navItem[1].isDisabled ? 'disabled' : '' }}">
+                    <li t-foreach="navItems" t-as="navItem" t-key="navItem[0]" class="nav-item flex-nowrap cursor-pointer position-relative" t-if="navItem[1].isVisible" t-attf-class="{{ navItem[1].isDisabled ? 'disabled' : '' }}">
                         <a class="nav-link" t-attf-class="{{ navItem[0] === state.currentPage ? 'active' : '' }} {{ props.orientation === 'vertical' ? 'p-3 rounded-0' : '' }} {{ navItem[1].className || '' }}" t-att-name="navItem[1].name" t-on-click.prevent="() => this.activatePage(navItem[0])" href="#" role="tab" tabindex="0">
                             <i t-if="props.icons and props.icons[navItem[0]]" t-attf-class="fa {{ props.icons[navItem[0]] }} me-2" />
                             <t t-esc="navItem[1].title" />


### PR DESCRIPTION
This PR accentuates the difference between an active tab and other tabs, as well as adding a small hover effect.

task-4797562

Requires : https://github.com/odoo/enterprise/pull/86399

| Before | After |
|--------|--------|
| <img width="348" alt="tab-before" src="https://github.com/user-attachments/assets/a2c8eae4-1701-457b-ad84-f2b19433a513" /> | <img width="348" alt="tab-after" src="https://github.com/user-attachments/assets/3493c161-ec46-4569-9716-33fc94ea9447" /> | 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
