### PR TITLE
[IMP] account_peppol: sending method settings UX

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -220,7 +220,7 @@
                             <group id="invoice_send_settings"
                                    string="Customer Invoices"
                                    groups="account.group_account_invoice,account.group_account_readonly">
-                                <field name="invoice_sending_method" placeholder="e-Invoicing &amp; Email"/>
+                                <field name="invoice_sending_method"/>
                                 <field name="invoice_edi_format"
                                        placeholder="XML format"
                                        invisible="not display_invoice_edi_format"/>

--- a/addons/account_peppol/static/src/components/account_sending_method_selection/account_sending_method_selection.js
+++ b/addons/account_peppol/static/src/components/account_sending_method_selection/account_sending_method_selection.js
@@ -1,0 +1,14 @@
+import { registry } from "@web/core/registry";
+import { FilterableSelectionField, filterableSelectionField } from "@web/views/fields/selection/filterable_selection_field";
+
+// for falsy option, display placeholder in the select options instead of an empty field
+export class AccountSendingMethodSelection extends FilterableSelectionField {
+    static template = "account.AccountSendingMethodSelection";
+}
+
+export const accountSendingMethodSelection = {
+    ...filterableSelectionField,
+    component: AccountSendingMethodSelection,
+};
+
+registry.category("fields").add("account_sending_method_selection", accountSendingMethodSelection);

--- a/addons/account_peppol/static/src/components/account_sending_method_selection/account_sending_method_selection.xml
+++ b/addons/account_peppol/static/src/components/account_sending_method_selection/account_sending_method_selection.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="account.AccountSendingMethodSelection" t-inherit="web.SelectionField" t-inherit-mode="primary">
+        <xpath expr="//select/option" position="attributes">
+            <attribute name="t-esc">this.props.placeholder || ''</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -12,7 +12,8 @@
                     <field name="available_peppol_edi_formats" invisible="1"/>
                 </xpath>
                 <xpath expr="//field[@name='invoice_sending_method']" position="attributes">
-                    <attribute name="widget">filterable_selection</attribute>
+                    <attribute name="placeholder">e-Invoicing &amp; Email</attribute>
+                    <attribute name="widget">account_sending_method_selection</attribute>
                     <attribute name="options">{'whitelist_fname': 'available_peppol_sending_methods'}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='invoice_edi_format']" position="attributes">


### PR DESCRIPTION
The default sending method for invoices on a contact is misleading. In the base `account` module, the dropdown has a placeholder that says "e-Invoicing & email", but in reality, it only sends by email unless `account_peppol` is installed, in which case it sends by both email and PEPPOL.

Since commit b6598d9a2f, default falsy option in selection fields no longer show placeholder text. This led to confusion: users wanted to set "PEPPOL and email" as the default but couldn’t figure out how, because that combination is actually the default behavior when no specific option is selected.

task-4816300