### PR TITLE
[IMP] registry: speedup model setup during install

### DIFF
--- a/addons/crm/models/ir_config_parameter.py
+++ b/addons/crm/models/ir_config_parameter.py
@@ -12,7 +12,7 @@ class IrConfig_Parameter(models.Model):
         result = super().write(vals)
         if any(record.key == "crm.pls_fields" for record in self):
             self.env.flush_all()
-            self.env.registry._setup_models__(self.env.cr)
+            self.env.registry._setup_models__(self.env.cr, ['crm.lead'])
         return result
 
     @api.model_create_multi
@@ -20,7 +20,7 @@ class IrConfig_Parameter(models.Model):
         records = super().create(vals_list)
         if any(record.key == "crm.pls_fields" for record in records):
             self.env.flush_all()
-            self.env.registry._setup_models__(self.env.cr)
+            self.env.registry._setup_models__(self.env.cr, ['crm.lead'])
         return records
 
     def unlink(self):
@@ -28,5 +28,5 @@ class IrConfig_Parameter(models.Model):
         result = super().unlink()
         if pls_emptied and not self._context.get(MODULE_UNINSTALL_FLAG):
             self.env.flush_all()
-            self.env.registry._setup_models__(self.env.cr)
+            self.env.registry._setup_models__(self.env.cr, ['crm.lead'])
         return result

--- a/addons/mail/models/ir_model.py
+++ b/addons/mail/models/ir_model.py
@@ -82,10 +82,11 @@ class IrModel(models.Model):
             res = super(IrModel, self).write(vals)
             self.env.flush_all()
             # setup models; this reloads custom models in registry
-            self.pool._setup_models__(self._cr)
+            model_names = self.mapped('model')
+            self.pool._setup_models__(self._cr, model_names)
             # update database schema of models
-            models = self.pool.descendants(self.mapped('model'), '_inherits')
-            self.pool.init_models(self._cr, models, dict(self._context, update_custom_fields=True))
+            model_names = self.pool.descendants(model_names, '_inherits')
+            self.pool.init_models(self._cr, model_names, dict(self._context, update_custom_fields=True))
         else:
             res = super(IrModel, self).write(vals)
         return res

--- a/odoo/addons/base/tests/test_ir_actions.py
+++ b/odoo/addons/base/tests/test_ir_actions.py
@@ -948,7 +948,7 @@ class TestCustomFieldsPostInstall(TestCommonCustomFields):
         self.env.cr.execute("UPDATE ir_model_fields SET name = 'foo' WHERE id = %s", [field.id])
         with self.assertLogs('odoo.registry') as log_catcher:
             # Trick to reload the registry. The above rename done through SQL didn't reload the registry. This will.
-            self.env.registry._setup_models__(self.cr)
+            self.env.registry._setup_models__(self.cr, [self.MODEL])
             self.assertIn(
                 f'The field `{field.name}` is not defined in the `{field.model}` Python class', log_catcher.output[0]
             )

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -245,7 +245,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
             WHERE model = 'x_test_10_compute_store_x_name' AND name = 'x_name'
         """)
         # setting up models should not crash
-        self.registry._setup_models__(self.cr)
+        self.registry._setup_models__(self.cr, ['x_test_10_compute_store_x_name'])
 
     def test_10_context_dependent_related(self):
         self.env['res.lang']._activate_lang('fr_FR')
@@ -608,7 +608,7 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
 
         # this must re-evaluate the field's dependencies
         self.env.flush_all()
-        self.registry._setup_models__(self.cr)
+        self.registry._setup_models__(self.cr, ['test_orm.compute.dynamic.depends'])
         self.assertEqual(self.registry.field_depends[Model.full_name], ('name1', 'name2'))
 
     def test_12_one2many_reference_domain(self):
@@ -4437,7 +4437,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         add_to_registry(self.registry, Foo)
 
         with self.assertRaises(ValueError):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
     def test_ondelete_default_no_default(self):
         from odoo.orm.model_classes import add_to_registry  # noqa: PLC0415
@@ -4454,7 +4454,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         add_to_registry(self.registry, Foo)
 
         with self.assertRaises(AssertionError):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
     def test_ondelete_value_no_valid(self):
         from odoo.orm.model_classes import add_to_registry  # noqa: PLC0415
@@ -4471,7 +4471,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         add_to_registry(self.registry, Foo)
 
         with self.assertRaises(AssertionError):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
     def test_ondelete_required_null_explicit(self):
         from odoo.orm.model_classes import add_to_registry  # noqa: PLC0415
@@ -4488,7 +4488,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         add_to_registry(self.registry, Foo)
 
         with self.assertRaises(ValueError):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
     def test_ondelete_required_null_implicit(self):
         from odoo.orm.model_classes import add_to_registry  # noqa: PLC0415
@@ -4505,7 +4505,7 @@ class TestSelectionOndeleteAdvanced(TransactionCase):
         add_to_registry(self.registry, Foo)
 
         with self.assertRaises(ValueError):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
 
 class TestFieldParametersValidation(TransactionCase):
@@ -4522,7 +4522,7 @@ class TestFieldParametersValidation(TransactionCase):
         self.addCleanup(self.registry.__delitem__, Foo._name)
 
         with self.assertLogs('odoo.fields', level='WARNING') as cm:
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
         self.assertTrue(cm.output[0].startswith(
             "WARNING:odoo.fields:Field test_orm.field_parameter_validation.name: "
@@ -4867,7 +4867,7 @@ class TestWrongRelatedError(TransactionCase):
             "test_orm.wrong_related_path.foo_non_existing does not exist."
         )
         with self.assertRaisesRegex(KeyError, errMsg):
-            self.registry._setup_models__(self.env.cr)
+            self.registry._setup_models__(self.env.cr, [])  # incremental setup
 
 
 class TestPrecomputeModel(TransactionCase):
@@ -4882,7 +4882,7 @@ class TestPrecomputeModel(TransactionCase):
         self.addCleanup(self.registry.reset_changes)
         self.patch(Model.upper, 'precompute', False)
         with self.assertWarns(UserWarning):
-            self.registry._setup_models__(self.cr)
+            self.registry._setup_models__(self.cr, ['test_orm.precompute'])
             self.registry.field_computed
 
     def test_precompute_dependencies_base(self):
@@ -4901,7 +4901,7 @@ class TestPrecomputeModel(TransactionCase):
         self.patch(Model.upper, 'precompute', False)
 
         with self.assertWarns(UserWarning):
-            self.registry._setup_models__(self.cr)
+            self.registry._setup_models__(self.cr, ['test_orm.precompute'])
             self.registry.get_trigger_tree(Model._fields.values())
 
     def test_precompute_dependencies_many2one(self):
@@ -4925,7 +4925,7 @@ class TestPrecomputeModel(TransactionCase):
         self.patch(Model.size, 'precompute', True)
         self.patch(Line.size, 'precompute', False)
         with self.assertWarns(UserWarning):
-            self.registry._setup_models__(self.cr)
+            self.registry._setup_models__(self.cr, ['test_orm.precompute', 'test_orm.precompute.line'])
             self.registry.get_trigger_tree(Model._fields.values())
 
 

--- a/odoo/addons/test_orm/tests/test_fields.py
+++ b/odoo/addons/test_orm/tests/test_fields.py
@@ -1397,6 +1397,14 @@ class TestFields(TransactionCaseWithUserDemo, TransactionExpressionCase):
         text2 = self.registry['test_orm.bar'].text2
         self.assertTrue(text2.trim, "The related field was defined with trim=True")
 
+        # now let's change text.trim, and check that text1 gets the new value;
+        # this tests the behavior of related fields when setting up models
+        # incrementally
+        self.patch(text, 'trim', True)
+        self.registry._setup_models__(self.cr, ['test_orm.foo'])
+        self.assertTrue(self.registry['test_orm.foo'].text.trim)
+        self.assertTrue(self.registry['test_orm.bar'].text1.trim)
+
     def test_25_related_single(self):
         """ test related fields with a single field in the path. """
         record = self.env['test_orm.related'].create({'name': 'A'})

--- a/odoo/orm/model_classes.py
+++ b/odoo/orm/model_classes.py
@@ -313,10 +313,8 @@ def setup_model_classes(env: Environment):
     for model_cls in models_classes:
         _setup(model_cls, env)
 
-    registry._m2m: defaultdict[tuple[str, str, str], list[Field]] = defaultdict(list)
     for model_cls in models_classes:
         _setup_fields(model_cls, env)
-    del registry._m2m
 
     for model_cls in models_classes:
         model_cls(env, (), ())._post_model_setup__()


### PR DESCRIPTION
## Summary

While loading the registry, `_setup` is called on each model which can be slow if many models are present in the registry. Each model and each field will be loaded for each modules, instead of only being reloaded when needed.

This is more visible during install/updates of modules where the setup is called for each module and each model, even if the model was not modified in the current module.

This pr avoids to call `_setup` on models that are not modified trying to keep the parts of the registry that should still be valid.

This approach is obviously more complex than the previous one, since we need to find all possible cases that could lead to a model being modified, but the performance improvement is worth it.

This work was finished by @rco-odoo that took the time to make it correct and cleaner.

A part of the changes regarding get_depends were moved to another pr to #213981

Note that this should also improve the field creation/modification potentially making studio more reactive, but this will still need some tweak to reach the full potential. 


# Some numbers

All number here are indicative and chosen as fairly as possible, the numbers could vary depending on the load, they are an average of the different observations made.

The improvement (with followup pr) could lead to a 30-50% improvement of the install time.
The two main parts of the setup are `setup_model_classes` and `get_depends`
Before the changes
`setup_model_classes` 5-7 minutes
`get_depends + iterations`  ~2m
Total ~8 minutes

After this pr: 
`setup_model_classes` ~1 minutes
`get_depends + iterations`  ~2:30m

After #213981: 
`get_depends + iterations`  ... (a few seconds)
Total: ~1m

Upgrade time: ~40-60 minutes -> ~20-30 minutes
The improvement is even bigger there because setup is called twice, and with more modules.

Full setup time and graph when installing all modules:

# Profiler

Before (7m44) [(here)](https://xavier-do.github.io/profile_results/before.html#localProfilePath=1)

![image](https://github.com/user-attachments/assets/7b0e8e1f-7f89-4b18-8708-9e90881c7d74)

After this pr (2m40) [(here)](https://xavier-do.github.io/profile_results/after.html#localProfilePath=1)
![image](https://github.com/user-attachments/assets/4793e863-91e6-4533-8ca5-de441da40776)

This pr will introduce the setup_model_classes part, targeting ~2m30s , the rest of the improvement will be done in #213981 removing an additionnal ~1m30

Targeted result with followup pr (57 seconds)

![image](https://github.com/user-attachments/assets/e35f049e-84ba-4c8b-abe9-3e890f786b70)

