### PR TITLE
[FIX] sale: mark orders as sent on scheduled mails

### DIFF
--- a/addons/sale/models/__init__.py
+++ b/addons/sale/models/__init__.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import analytic
 from . import account_move
 from . import account_move_line
+from . import analytic
 from . import chart_template
 from . import crm_team
 from . import ir_config_parameter
+from . import mail_scheduled_message
 from . import payment_provider
 from . import payment_transaction
 from . import product_category

--- a/addons/sale/models/mail_scheduled_message.py
+++ b/addons/sale/models/mail_scheduled_message.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+
+from odoo import api, models
+
+
+class ScheduledMessage(models.Model):
+    _inherit = 'mail.scheduled.message'
+
+    def _post_message(self, raise_exception=True):
+        order_messages = self.env['mail.scheduled.message'].with_context(mark_so_as_sent=True)
+        for scheduled_message in self:
+            notification_parameters = json.loads(scheduled_message.notification_parameters or '{}')
+            if 'mark_so_as_sent' not in notification_parameters:
+                continue
+            if notification_parameters.pop('mark_so_as_sent'):
+                order_messages += scheduled_message
+            scheduled_message.notification_parameters = json.dumps(notification_parameters)
+        if order_messages:
+            super(ScheduledMessage, order_messages)._post_message(raise_exception=raise_exception)
+        if remaining := self - order_messages:
+            super(ScheduledMessage, remaining)._post_message(raise_exception=raise_exception)
+
+    @api.model
+    def _notification_parameters_whitelist(self):
+        return super()._notification_parameters_whitelist() | {'mark_so_as_sent'}

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -534,6 +534,27 @@ class TestSaleOrder(SaleCommon):
 
         self.assertIn(self.partner2, sale_order.message_partner_ids)
 
+    def test_scheduled_mark_so_as_sent(self):
+        """Check that a order gets marked as sent after a scheduled message was sent."""
+        order = self.sale_order
+        composer = self.env['mail.compose.message'].with_context(
+            active_id=order.id,
+            active_ids=order.ids,
+            active_model=order._name,
+            mark_so_as_sent=True,
+        ).new({'body': '<h1>Your Sales Order</h1>'})
+        composer.action_schedule_message(
+            scheduled_date=fields.Datetime.now() + timedelta(hours=1),
+        )
+
+        scheduled_message = self.env['mail.scheduled.message'].search([
+            ('model', '=', order._name),
+            ('res_id', '=', order.id),
+        ], limit=1)
+        self.assertEqual(order.state, 'draft')
+        scheduled_message.post_message()
+        self.assertEqual(order.state, 'sent')
+
     def test_so_discount_is_not_reset(self):
         """ Discounts should not be recomputed on order confirmation """
         with patch(

--- a/addons/sale/wizard/__init__.py
+++ b/addons/sale/wizard/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import base_document_layout
+from . import mail_compose_message
 from . import mass_cancel_orders
 from . import payment_link_wizard
 from . import payment_provider_onboarding_wizard

--- a/addons/sale/wizard/mail_compose_message.py
+++ b/addons/sale/wizard/mail_compose_message.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class MailComposer(models.TransientModel):
+    _inherit = 'mail.compose.message'
+
+    def action_schedule_message(self, scheduled_date=False):
+        return super(
+            MailComposer,
+            self.with_context(schedule_mark_so_as_sent=self.env.context.get('mark_so_as_sent')),
+        ).action_schedule_message(scheduled_date=scheduled_date)
+
+    def _prepare_mail_values_rendered(self, res_ids):
+        values = super()._prepare_mail_values_rendered(res_ids)
+        if self.model == 'sale.order' and self.env.context.get('schedule_mark_so_as_sent'):
+            for res_id in res_ids:
+                values[res_id]['mark_so_as_sent'] = True
+        return values


### PR DESCRIPTION
Versions
--------
- 18.0

Fixed in 18.1+ via 752fdb2d2718

Steps
-----
1. Create a quotation;
2. click "Send by Email";
3. schedule the message to get sent at a later time;
4. wait for the message to send, or click "Send Now" in the chatter;
5. refresh the page.

Issue
-----
Quotation state did not get set to `sent`.

Cause
-----
Before this commit, marking the quotation as `sent` happened via a context value. This worked for earlier versions, but with the introduction of scheduled messaging, the context is no longer available when the scheduled message gets sent.

Solution
--------
Add the `mark_so_as_sent` context value to the `notification_parameters` field of `mail.scheduled.message`, and check for this value in the `_post_message` method that gets called when sending the message. If present, re-introduce the context value in the call to `super`.

opw-4794010