### PR TITLE
[FIX] website: center palette button icon

### DIFF
--- a/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
+++ b/addons/website/static/src/builder/plugins/theme/theme_colors_option.xml
@@ -44,8 +44,7 @@
                         </div>
                     </div>
                     <div class="d-flex flex-column h-100">
-                        <div class="d-flex flex-column h-100 justify-content-between">
-                            <span class="fst-italic">Palette</span>
+                        <div class="d-flex flex-column h-100 justify-content-center">
                             <BuilderSelect action="'changeColorPalette'" actionParam="'color-palettes-name'">
                                 <t t-set-slot="fixedButton">
                                     <Img class="'p-2 h-100'" src="'/website/static/src/img/snippets_options/palette.svg'"/>


### PR DESCRIPTION
Steps to reproduce:
- Go to the website builder in edit mode
- Go to the theme tab

Current behaviour: the "palette" button is not well centered
After this commit: the palette button is centered