### PR TITLE
[IMP] website: Floating Blocks option

### DIFF
--- a/addons/html_builder/static/src/utils/grid_layout_utils.js
+++ b/addons/html_builder/static/src/utils/grid_layout_utils.js
@@ -8,7 +8,7 @@ const defaultGridPadding = 10; // 10px (see `--grid-item-padding-(x|y)` CSS vari
 export const layoutOptionSelector = {
     selector: "section, section.s_carousel_wrapper .carousel-item, .s_carousel_intro_item",
     exclude:
-        ".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images",
+        ".s_dynamic, .s_dynamic_snippet_content, .s_dynamic_snippet_title, .s_masonry_block, .s_framed_intro, .s_features_grid, .s_media_list, .s_table_of_content, .s_process_steps, .s_image_gallery, .s_pricelist_boxed, .s_quadrant, .s_pricelist_cafe, .s_faq_horizontal, .s_image_frame, .s_card_offset, .s_contact_info, .s_tabs, .s_tabs_images, .s_floating_blocks .s_floating_blocks_block",
     applyTo: ":scope > *:has(> .row), :scope > .s_allow_columns",
 };
 

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -275,6 +275,7 @@
         'website.assets_edit_frontend': [
             'website/static/src/**/*.edit.js',
             'website/static/src/**/*.edit.scss',
+            'website/static/src/**/*.edit.xml',
             'website/static/src/core/website_edit_service.js',
         ],
         'website.inside_builder_style': [
@@ -362,6 +363,9 @@
             ('remove', 'website/static/src/snippets/**/options.js'),
             'website/static/src/snippets/**/*.xml',
             'website/static/src/xml/**/*.xml',
+            ## TODO: remove the following line when cleaning up residuals files
+            ## from the old editor
+            ('remove', 'website/static/src/snippets/s_floating_blocks/options.xml'),
             ('remove', 'website/static/src/xml/website.editor.xml'),
             ('remove', 'website/static/src/xml/web_editor.xml'),
             'website/static/src/snippets/s_table_of_content/000.scss',

--- a/addons/website/static/src/builder/plugins/content_width_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/content_width_option_plugin.js
@@ -13,7 +13,7 @@ class ContentWidthOptionPlugin extends Plugin {
                 template: "website.ContentWidthOption",
                 selector: "section, .s_carousel .carousel-item, .s_carousel_intro_item",
                 exclude:
-                    "[data-snippet] :not(.oe_structure) > [data-snippet],#footer > *,#o_wblog_post_content *",
+                    "[data-snippet] :not(.oe_structure) > [data-snippet],#footer > *,#o_wblog_post_content *,.s_floating_blocks .s_floating_blocks_block",
                 applyTo:
                     ":scope > .container, :scope > .container-fluid, :scope > .o_container_small",
             }),

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_mobile_option.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_mobile_option.js
@@ -1,0 +1,13 @@
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
+import { isMobileView } from "@html_builder/utils/utils";
+
+export class FloatingBlocksBlockMobileOption extends BaseOptionComponent {
+    static template = "website.FloatingBlocksBlockMobileOption";
+    static props = {};
+    setup() {
+        super.setup();
+        this.state = useDomState((editingElement) => ({
+            isMobileView: isMobileView(editingElement),
+        }));
+    }
+}

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option.js
@@ -1,0 +1,12 @@
+import { BaseOptionComponent } from "@html_builder/core/utils";
+import { BorderConfigurator } from "@html_builder/plugins/border_configurator_option";
+import { AddElementOption } from "@website/builder/plugins/layout_option/add_element_option";
+
+export class FloatingBlocksBlockOption extends BaseOptionComponent {
+    static template = "website.FloatingBlocksBlockOption";
+    static components = {
+        BorderConfigurator,
+        AddElementOption,
+    };
+    static props = {};
+}

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_block_option_plugin.js
@@ -1,0 +1,41 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { withSequence } from "@html_editor/utils/resource";
+import { BEGIN } from "@html_builder/utils/option_sequence";
+import { LAYOUT_GRID } from "@website/builder/option_sequence";
+import { FloatingBlocksBlockOption } from "./floating_blocks_block_option";
+import { FloatingBlocksBlockMobileOption } from "./floating_blocks_block_mobile_option";
+
+class FloatingBlocksBlockOptionPlugin extends Plugin {
+    static id = "floatingBlocksBlockOptionPlugin";
+    resources = {
+        builder_options: [
+            withSequence(BEGIN, {
+                OptionComponent: FloatingBlocksBlockMobileOption,
+                selector: ".s_floating_blocks .s_floating_blocks_block",
+                applyTo: ".container-fluid",
+            }),
+            withSequence(LAYOUT_GRID, {
+                OptionComponent: FloatingBlocksBlockOption,
+                selector: ".s_floating_blocks .s_floating_blocks_block",
+            }),
+        ],
+        dropzone_selector: [
+            // Lock grid-items within their grid
+            {
+                selector: ".s_floating_blocks_block_grid .o_grid_item",
+                dropLockWithin: ".s_floating_blocks_block_grid",
+            },
+            // Lock block-items within the snippet
+            {
+                selector: ".s_floating_blocks .s_floating_blocks_block",
+                dropLockWithin: ".s_floating_blocks",
+                dropNear: ".s_floating_blocks .s_floating_blocks_block",
+            },
+        ],
+    };
+}
+
+registry
+    .category("website-plugins")
+    .add(FloatingBlocksBlockOptionPlugin.id, FloatingBlocksBlockOptionPlugin);

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="website.FloatingBlocksOption">
+    <BuilderRow label.translate="Cards">
+        <BuilderButton
+            title.translate="Add a new Card"
+            action="'addCard'"
+            preview="false"
+            className="'o_we_bg_success'">
+            Add New
+        </BuilderButton>
+    </BuilderRow>
+    <hr/>
+    <BuilderRow label.translate="Cards Design">
+            Global options for all inner cards.
+    </BuilderRow>
+    <!-- Apply global cards options to ".s_floating_blocks_wrapper".
+    Each Card will inherit these values in CSS -->
+    <BuilderRow label.translate="Roundness" level="1"
+        tooltip.translate="Applies to all cards">
+        <BuilderRange
+            applyTo="'.s_floating_blocks_wrapper'"
+            action="'floatingBlocksRoundness'"
+            max="5"
+            displayRangeValue="false"/>
+    </BuilderRow>
+    <BuilderRow label.translate="Shadows" level="1"
+        tooltip.translate="Applies to all cards">
+        <BuilderCheckbox
+            applyTo="'.s_floating_blocks_wrapper'"
+            classAction="'s_floating_blocks_wrapper_shadow'"
+            preview="false"/>
+        </BuilderRow>
+</t>
+
+<t t-name="website.FloatingBlocksBlockOption">
+    <AddElementOption applyTo="'.o_grid_mode'"/>
+    <BorderConfigurator withRoundCorner="false" label.translate="Border"/>
+</t>
+
+<t t-name="website.FloatingBlocksBlockMobileOption">
+    <BuilderRow label.translate="Vert. Alignment" tooltip.translate="Vertical Alignment" t-if="state.isMobileView">
+        <BuilderButtonGroup>
+            <BuilderButton title.translate="Align Top" classAction="'align-self-start'"
+                    iconImg="'/website/static/src/img/snippets_options/align_solo_top.svg'"/>
+            <BuilderButton title.translate="Align Middle" classAction="'align-self-center'"
+                    iconImg="'/website/static/src/img/snippets_options/align_solo_middle.svg'"/>
+            <BuilderButton title.translate="Align Bottom" classAction="'align-self-end'"
+                    iconImg="'/website/static/src/img/snippets_options/align_solo_bottom.svg'"/>
+        </BuilderButtonGroup>
+    </BuilderRow>
+</t>
+
+<t t-name="website.s_floating_blocks.new_card">
+    <section data-name="Card" class="s_floating_blocks_block s_col_no_resize position-sticky d-flex py-5 o_cc o_cc1">
+        <div class="container-fluid align-self-end">
+            <div class="s_floating_blocks_block_grid row mx-0 o_grid_mode" data-row-count="8">
+                <div class="o_grid_item g-height-4 col-lg-8 order-lg-0" style="z-index: 1; grid-area: 1 / 1 / 5 / 9;">
+                    <p class="lead">A great subtitle</p>
+                    <h2 class="display-4-fs">Card Title</h2>
+                </div>
+
+                <div class="o_grid_item g-height-2 g-col-lg-4 col-lg-4" style="z-index: 2; --grid-item-padding-y: 0px; --grid-item-padding-x: 0px; grid-area: 7 / 1 / 9 / 5;">
+                    <a href="#" title="" role="button" class="btn btn-lg btn-secondary">Button</a>
+                </div>
+            </div>
+        </div>
+    </section>
+</t>
+
+</templates>

--- a/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/floating_blocks/floating_blocks_option_plugin.js
@@ -1,0 +1,46 @@
+import { Plugin } from "@html_editor/plugin";
+import { registry } from "@web/core/registry";
+import { withSequence } from "@html_editor/utils/resource";
+import { after } from "@html_builder/utils/option_sequence";
+import { DEVICE_VISIBILITY } from "@website/builder/option_sequence";
+import { renderToElement } from "@web/core/utils/render";
+
+class FloatingBlocksOptionPlugin extends Plugin {
+    static id = "floatingBlocksOptionPlugin";
+    resources = {
+        builder_options: [
+            withSequence(after(DEVICE_VISIBILITY), {
+                template: "website.FloatingBlocksOption",
+                selector: ".s_floating_blocks",
+            }),
+        ],
+        builder_actions: {
+            floatingBlocksRoundness: {
+                getValue: ({ editingElement }) => {
+                    for (let x = 0; x <= 5; x++) {
+                        if (editingElement.classList.contains(`rounded-${x}`)) {
+                            return x;
+                        }
+                    }
+                    return 0;
+                },
+                apply: ({ editingElement, value }) => {
+                    for (let x = 0; x <= 5; x++) {
+                        editingElement.classList.remove(`rounded-${x}`);
+                    }
+                    editingElement.classList.add(`rounded-${value}`);
+                },
+            },
+            addCard: {
+                apply: ({ editingElement: el }) => {
+                    const newCardEl = renderToElement("website.s_floating_blocks.new_card");
+                    const wrapperEl = el.querySelector(".s_floating_blocks_wrapper");
+                    wrapperEl.appendChild(newCardEl);
+                    newCardEl.scrollIntoView({ behavior: "smooth", block: "center" });
+                },
+            },
+        },
+    };
+}
+
+registry.category("website-plugins").add(FloatingBlocksOptionPlugin.id, FloatingBlocksOptionPlugin);

--- a/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
@@ -138,7 +138,9 @@ class ChangeColumnCountAction extends BuilderAction {
         if (itemsDelta > 0) {
             for (let i = 0; i < itemsDelta; i++) {
                 const lastEl = rowEl.lastElementChild;
-                this.dependencies.clone.cloneElement(lastEl);
+                this.dependencies.clone.cloneElement(lastEl, {
+                    activateClone: false,
+                });
             }
         }
 

--- a/addons/website/static/src/builder/plugins/options/background_option.js
+++ b/addons/website/static/src/builder/plugins/options/background_option.js
@@ -22,7 +22,8 @@ export class WebsiteBackgroundOption extends BaseOptionComponent {
         const { showColorFilter } = useBackgroundOption(this.isActiveItem);
         this.showColorFilter = () => showColorFilter() || this.isActiveItem("toggle_bg_video_id");
         this.websiteBgOptionDomState = useDomState((el) => ({
-            applyTo: el.querySelector(".s_parallax_bg") ? ".s_parallax_bg" : "",
+            // Only search for .s_parallax_bg that are direct children
+            applyTo: el.querySelector(":scope > .s_parallax_bg") ? ".s_parallax_bg" : "",
         }));
     }
 }

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option_plugin.js
@@ -15,7 +15,7 @@ class ScrollButtonOptionPlugin extends Plugin {
                 OptionComponent: ScrollButtonOption,
                 selector: "section",
                 exclude:
-                    "[data-snippet] :not(.oe_structure) > [data-snippet],.s_instagram_page,.o_mega_menu > section,.s_appointments .s_dynamic_snippet_content",
+                    "[data-snippet] :not(.oe_structure) > [data-snippet],.s_instagram_page,.o_mega_menu > section,.s_appointments .s_dynamic_snippet_content,.s_floating_blocks,.s_floating_blocks .s_floating_blocks_block",
             }),
         ],
         builder_actions: {

--- a/addons/website/static/src/core/website_edit_service.js
+++ b/addons/website/static/src/core/website_edit_service.js
@@ -206,7 +206,7 @@ registry.category("services").add("website_edit", {
                 }),
                 patch(publicInteractions.constructor.prototype, {
                     shouldStop(el, interaction) {
-                        if (super.shouldStop(el, interaction)) {
+                        if (super.shouldStop(el, interaction) || interaction.el.contains(el)) {
                             if (this.isRefreshing) {
                                 return interaction.interaction.shouldStop();
                             }

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -5,6 +5,7 @@ import { cookie } from "@web/core/browser/cookie";
 import { markup } from "@odoo/owl";
 import { omit } from "@web/core/utils/objects";
 import { waitForStable } from "@web/core/macro";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 export function addMedia(position = "right") {
     return {
@@ -325,6 +326,7 @@ export function clickOnSave(position = "bottom", timeout = 50000) {
             noPrepend: true,
             timeout,
         },
+        stepUtils.waitIframeIsReady(),
     ];
 }
 

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.js
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.js
@@ -1,0 +1,43 @@
+import { registry } from "@web/core/registry";
+import { FloatingBlocks } from "./floating_blocks";
+
+const FloatingBlocksEdit = (I) =>
+    class extends I {
+        dynamicContent = {
+            ...this.dynamicContent,
+            ".s_floating_blocks_alert_empty": {
+                "t-on-click": this.onAddCard.bind(this),
+            },
+        };
+        shouldStop() {
+            // The interaction is restarted every time that the content of
+            // s_floating_blocks changes. This is needed to provide the correct
+            // visual effect when a block is added, removed or moved. This
+            // approach is simple, but has the drawback of restarting the
+            // interaction also when the content of a block is changed (which is
+            // not needed). A more complex approach would be to assign unique
+            // IDs to the blocks and check if their order has changed.
+            return true;
+        }
+        setup() {
+            super.setup();
+            // The "No card" message must be injected *before* the removal of
+            // the last block, otherwise the snippet could be automatically
+            // removed by the editor during edition:
+            // see remove_plugin.isEmptyAndRemovable()
+            this.renderAt(
+                "website.s_floating_blocks.alert.empty",
+                {},
+                this.el.querySelector(".s_floating_blocks_wrapper")
+            );
+        }
+        onAddCard() {
+            const applySpec = { editingElement: this.el };
+            this.services["website_edit"].applyAction("addCard", applySpec);
+        }
+    };
+
+registry.category("public.interactions.edit").add("website.floating_blocks", {
+    Interaction: FloatingBlocks,
+    mixin: FloatingBlocksEdit,
+});

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.scss
@@ -34,10 +34,17 @@
 // Edit mode
 // =========
 .s_floating_blocks {
+    &:has(.s_floating_blocks_block) .s_floating_blocks_alert_empty {
+        // Hide the empty alert when there are blocks.
+        display: none;
+    }
     .s_floating_blocks_block {
         > .container, > .container-fluid, > .o_container_small {
             // Ensure that grid items cannot be moved outside their cards.
             overflow: hidden;
         }
+    }
+    .s_floating_blocks_alert_empty {
+        cursor: pointer;
     }
 }

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.xml
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.edit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website.s_floating_blocks.alert.empty">
+        <div class="container">
+            <div role="dialog" class="s_floating_blocks_alert_empty alert alert-info mx-auto text-center" style="width: var(--breakpoint-sm)">
+                <i class="fa fa-plus-circle"/>
+                <span class="o_add_images"> Add Cards</span><br />
+                <small><strong>TIP:</strong> You need at least two cards to perform the effect</small>
+            </div>
+        </div>
+    </t>
+
+</templates>

--- a/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.js
+++ b/addons/website/static/src/snippets/s_floating_blocks/floating_blocks.js
@@ -175,9 +175,3 @@ export class FloatingBlocks extends Interaction {
 registry
     .category("public.interactions")
     .add("website.floating_blocks", FloatingBlocks);
-
-registry
-    .category("public.interactions.edit")
-    .add("website.floating_blocks", {
-        Interaction: FloatingBlocks,
-    });

--- a/addons/website/static/tests/builder/options/floating_blocks_option.test.js
+++ b/addons/website/static/tests/builder/options/floating_blocks_option.test.js
@@ -1,0 +1,41 @@
+import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../website_helpers";
+import { expect, test } from "@odoo/hoot";
+import { contains, onRpc } from "@web/../tests/web_test_helpers";
+
+defineWebsiteModels();
+
+// TODO Re-enable once interactions run within iframe in hoot tests.
+// Note: without interactions within the iframe, this test will fail because the
+// alert message is not rendered.
+test.skip("alert message displayed if floating blocks has no cards", async () => {
+    await setupWebsiteBuilderWithSnippet("s_floating_blocks");
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    expect(":iframe .s_floating_blocks_alert_empty").toHaveCount(1);
+    expect(":iframe .s_floating_blocks_alert_empty").toBeVisible();
+});
+
+// TODO Re-enable once interactions run within iframe in hoot tests.
+// Note: without interactions within the iframe, this test will fail because the
+// alert message is not rendered, consequently the floating block wrapper will
+// be empty after the removal of the last card, and remove_plugin will remove it
+test.skip("floating blocks snippet are not removed on save even if empty", async () => {
+    const resultSave = [];
+    onRpc("ir.ui.view", "save", ({ args }) => {
+        resultSave.push(args[1]);
+        return true;
+    });
+    await setupWebsiteBuilderWithSnippet("s_floating_blocks");
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    await contains(":iframe .s_floating_blocks_block").click();
+    await contains(".options-container[data-container-title='Card'] .oe_snippet_remove").click();
+    await contains(".o-snippets-top-actions button:contains(Save)").click();
+    expect(resultSave[0]).toInclude("s_floating_blocks");
+});

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -1,4 +1,3 @@
-import { stepUtils } from "@web_tour/tour_service/tour_utils";
 import {
     addMedia,
     changeOption,
@@ -15,7 +14,6 @@ registerWebsitePreviewTour('snippet_image_gallery', {
 }, () => [
     ...insertSnippet({id: 's_images_wall', name: 'Images Wall', groupName: "Images"}),
     ...clickOnSave(),
-    stepUtils.waitIframeIsReady(),
     {
         content: 'Click on an image of the Image Wall',
         trigger: ':iframe .s_image_gallery img',

--- a/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_add_to_cart_snippet_tour.js
@@ -8,7 +8,6 @@ import {
     changeOptionInPopover,
 } from "@website/js/tours/tour_utils";
 import { assertCartContains } from '@website_sale/js/tours/tour_utils';
-import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
 
 function editAddToCartSnippet() {
@@ -29,14 +28,12 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...clickOnSnippet({id: 's_add_to_cart'}),
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product No Variant", true),
         ...clickOnSave(),
-        stepUtils.waitIframeIsReady(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
 
         // Product with 2 variants with visitor choice (will open modal)
         ...editAddToCartSnippet(),
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 1", true),
         ...clickOnSave(),
-        stepUtils.waitIframeIsReady(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
         clickOnElement("continue shopping", ":iframe .modal button:contains(Continue Shopping)"),
 
@@ -45,7 +42,6 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Product", "Product Yes Variant 2", true),
         ...changeOptionInPopover("Add to Cart Button", "Variant", "Product Yes Variant 2 (Pink)"),
         ...clickOnSave(),
-        stepUtils.waitIframeIsReady(),
         clickOnElement("add to cart button", ":iframe .s_add_to_cart_btn"),
         // Since 18.2, even if a specific variant is selected, the product configuration modal is displayed
         // The variant set on the modal used the default variants attributes (so will not correspond to the selected variant)
@@ -72,7 +68,6 @@ registerWebsitePreviewTour('add_to_cart_snippet_tour', {
         ...changeOptionInPopover("Add to Cart Button", "Action", "Buy Now", false),
         // At this point the "Add to cart" button was changed to a "Buy Now" button
         ...clickOnSave(),
-        stepUtils.waitIframeIsReady(),
         clickOnElement('"Buy Now" button', ':iframe .s_add_to_cart_btn'),
         {
             // wait for the page to load, as the next check was sometimes too fast


### PR DESCRIPTION
This commit introduces a refactor of the `s_floating_blocks` snippet [1] for the new website builder [2] and two additional changes described below.

1. Change in `s_floating_blocks` behaviour. The alert message  `s_floating_blocks.alert.empty` is now clickable. On click, a new card is created. This is similar to what already happens in `s_image_gallery`.

2. Change in `WebsiteBackgroundOption`. The definition of `applyTo` in `websiteBgOptionDomState` is changed to target only direct children of the element. Without this change, the option was not working properly with `s_floating_blocks`, because when a card had a background image, also the "Floating Block" element had the background image icon active (same for background videos).

[1] https://github.com/odoo/odoo/commit/493ea3e
[2] https://github.com/odoo/odoo/commit/9fe45e2