### PR TITLE
[FIX] web, html_editor: allow alt key detection on Mac for delete

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -43,7 +43,7 @@ import {
 import { CTYPES } from "../utils/content_types";
 import { withSequence } from "@html_editor/utils/resource";
 import { compareListTypes } from "@html_editor/main/list/utils";
-import { hasTouch, isBrowserChrome } from "@web/core/browser/feature_detection";
+import { hasTouch, isBrowserChrome, isMacOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} RangeLike
@@ -75,14 +75,26 @@ export class DeletePlugin extends Plugin {
             { id: "deleteBackwardLine", run: () => this.delete("backward", "line") },
             { id: "deleteForwardLine", run: () => this.delete("forward", "line") },
         ],
-        shortcuts: [
-            { hotkey: "backspace", commandId: "deleteBackward" },
-            { hotkey: "delete", commandId: "deleteForward" },
-            { hotkey: "control+backspace", commandId: "deleteBackwardWord" },
-            { hotkey: "control+delete", commandId: "deleteForwardWord" },
-            { hotkey: "control+shift+backspace", commandId: "deleteBackwardLine" },
-            { hotkey: "control+shift+delete", commandId: "deleteForwardLine" },
-        ],
+        get shortcuts() {
+            if (isMacOS()) {
+                return [
+                    { hotkey: "backspace", commandId: "deleteBackward" },
+                    { hotkey: "delete", commandId: "deleteForward" },
+                    { hotkey: "alt+backspace", commandId: "deleteBackwardWord" },
+                    { hotkey: "alt+delete", commandId: "deleteForwardWord" },
+                    { hotkey: "control+backspace", commandId: "deleteBackwardLine" },
+                    { hotkey: "control+delete", commandId: "deleteForwardLine" },
+                ];
+            }
+            return [
+                { hotkey: "backspace", commandId: "deleteBackward" },
+                { hotkey: "delete", commandId: "deleteForward" },
+                { hotkey: "control+backspace", commandId: "deleteBackwardWord" },
+                { hotkey: "control+delete", commandId: "deleteForwardWord" },
+                { hotkey: "control+shift+backspace", commandId: "deleteBackwardLine" },
+                { hotkey: "control+shift+delete", commandId: "deleteForwardLine" },
+            ];
+        },
         /** Handlers */
         beforeinput_handlers: [
             withSequence(5, this.onBeforeInputInsertText.bind(this)),

--- a/addons/html_editor/static/src/core/shortcut_plugin.js
+++ b/addons/html_editor/static/src/core/shortcut_plugin.js
@@ -1,3 +1,4 @@
+import { isMacOS } from "@web/core/browser/feature_detection";
 import { Plugin } from "../plugin";
 
 /**
@@ -43,6 +44,7 @@ export class ShortCutPlugin extends Plugin {
             area: () => this.editable,
             bypassEditableProtection: true,
             allowRepeat: true,
+            rawModifiers: isMacOS(),
         });
     }
 }

--- a/addons/web/static/tests/core/hotkey_sevice.test.js
+++ b/addons/web/static/tests/core/hotkey_sevice.test.js
@@ -342,7 +342,7 @@ test("the overlay of hotkeys is correctly displayed on MacOs", async () => {
     await mountWithCleanup(MyComponent);
 
     // apply an existent hotkey
-    await keyDown("ctrl");
+    await keyDown("meta");
     expect(getOverlays()).toEqual(["B", "C"], { message: "should display the overlay" });
     await press("b");
     await tick();
@@ -350,7 +350,7 @@ test("the overlay of hotkeys is correctly displayed on MacOs", async () => {
     expect(getOverlays()).toEqual([], { message: "shouldn't display the overlay" });
 
     // apply a non-existent hotkey
-    await keyDown("ctrl");
+    await keyDown("meta");
     expect(getOverlays()).toEqual(["B", "C"], { message: "should display the overlay" });
     await press("x");
     expect(getOverlays()).toEqual([], { message: "shouldn't display the overlay" });


### PR DESCRIPTION
Problem:
On Mac, users often use `alt+backspace` to delete the last word. However, in the `delete_plugin`, this cannot be intercepted because the `alt` key on Mac is not detected correctly — `ctrl` is interpreted as `alt`.

Solution:
Enable reading of raw key events and explicitly detect the `alt` key, allowing proper handling of `alt+backspace`.

Steps to reproduce:
- On a Mac, open the HTML editor.
- Write two words.
- Press `alt+backspace` to remove the last word. → The last word is unexpectedly removed.
- Press `control+backspace` to remove the line. → Only the last word is removed instead.

opw-4781484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
