### PR TITLE
[FIX] l10n_test_pos_qr_payment: test setup ACLs

### DIFF
--- a/addons/l10n_test_pos_qr_payment/tests/common.py
+++ b/addons/l10n_test_pos_qr_payment/tests/common.py
@@ -35,7 +35,7 @@ class TestPosQrCommon(AccountTestInvoicingHttpCommon):
         cls.company = cls.company_data['company']
         cls.pos_receivable_bank = cls.copy_account(cls.company.account_default_pos_receivable_account_id, {'name': 'POS Receivable Bank'})
         cls.outstanding_bank = cls.copy_account(cls.inbound_payment_method_line.payment_account_id, {'name': 'Outstanding Bank'})
-        cls.bank_pm = cls.env['pos.payment.method'].create({
+        cls.bank_pm = cls.env['pos.payment.method'].sudo().create({
             'name': 'Bank',
             'journal_id': cls.company_data['default_journal_bank'].id,
             'receivable_account_id': cls.pos_receivable_bank.id,
@@ -43,7 +43,7 @@ class TestPosQrCommon(AccountTestInvoicingHttpCommon):
             'company_id': cls.company.id,
         })
 
-        cls.main_pos_config = cls.env['pos.config'].create({
+        cls.main_pos_config = cls.env['pos.config'].sudo().create({
             'name': 'Shop',
             'module_pos_restaurant': False,
             'journal_id': cls.company_data['default_journal_sale'].id,

--- a/addons/l10n_test_pos_qr_payment/tests/test_pos_qr_payment.py
+++ b/addons/l10n_test_pos_qr_payment/tests/test_pos_qr_payment.py
@@ -21,7 +21,7 @@ class TestUiSEPA(TestPosQrCommon):
         cls.company_data['default_journal_bank'].write({'bank_account_id': cls.bank_account.id})
 
         # Setup QR Payment method for SEPA
-        qr_payment = cls.env['pos.payment.method'].create({
+        qr_payment = cls.env['pos.payment.method'].sudo().create({
             'name': 'QR Code',
             'journal_id': cls.company_data['default_journal_bank'].id,
             'payment_method_type': "qr_code",
@@ -81,7 +81,7 @@ class TestUiCH(TestPosQrCommon):
         cls.company_data['default_journal_bank'].write({'bank_account_id': cls.bank_account.id})
 
         # Setup QR Payment method for Swiss QR
-        qr_payment = cls.env['pos.payment.method'].create({
+        qr_payment = cls.env['pos.payment.method'].sudo().create({
             'name': 'QR Code',
             'journal_id': cls.company_data['default_journal_bank'].id,
             'payment_method_type': "qr_code",
@@ -141,7 +141,7 @@ class TestUiHK(TestPosQrCommon):
         cls.company_data['default_journal_bank'].write({'bank_account_id': cls.bank_account.id})
 
         # Setup QR Payment method for EMV(FPS)
-        qr_payment = cls.env['pos.payment.method'].create({
+        qr_payment = cls.env['pos.payment.method'].sudo().create({
             'name': 'QR Code',
             'journal_id': cls.company_data['default_journal_bank'].id,
             'payment_method_type': "qr_code",
@@ -196,7 +196,7 @@ class TestUIBR(TestPosQrCommon):
         cls.company_data['default_journal_bank'].write({'bank_account_id': cls.bank_account.id})
 
         # Setup QR Payment method for PIX
-        qr_payment = cls.env['pos.payment.method'].create({
+        qr_payment = cls.env['pos.payment.method'].sudo().create({
             'name': 'QR Code',
             'journal_id': cls.company_data['default_journal_bank'].id,
             'payment_method_type': "qr_code",


### PR DESCRIPTION
Creating POS payment methods requires being a POS admin, which the POS user is not, and the test user may not be.

Bypass issue by creating payment methods in sudo.

https://runbot.odoo.com/odoo/error/222989

