### PR TITLE
[IMP] test_lint: help n00bs write docstrings

### DIFF
--- a/odoo/addons/test_lint/tests/test_docstring.py
+++ b/odoo/addons/test_lint/tests/test_docstring.py
@@ -71,6 +71,21 @@ Absent from function: {func_missing}
 Absent from docstring: {doc_missing}
 """
 
+PARSE_ERROR = '''Unable to parse the docstring as reStructuredText.
+"""
+{doc}
+"""
+{error}
+Learn rst:
+
+* https://docutils.sourceforge.io/docs/user/rst/quickref.html
+* https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
+* https://www.sphinx-doc.org/en/master/usage/domains/python.html
+
+Online editor:
+
+* https://rsted.info.ucl.ac.be/'''
+
 
 def extract_docstring_params(doctree):
     params = {}  # sorted set
@@ -213,7 +228,10 @@ class TestDocstring(BaseCase):
                             settings=settings,
                         )
                         if stderr.tell():
-                            self.fail(stderr.getvalue())
+                            self.fail(PARSE_ERROR.format(
+                                doc=inspect.cleandoc(method.__doc__).strip(),
+                                error=stderr.getvalue(),
+                            ))
 
                     self._test_docstring_params(method, doctree)
 


### PR DESCRIPTION
Example output:

```
01:29.700 ERROR o.a.test_lint.t.test_docstring: FAIL: Subtest TestDocstring.test_docstring (module='base', model='ir.cron', method='method_direct_trigger')
Traceback (most recent call last):
  File "/home/julien/Odoo/community/odoo/addons/test_lint/tests/test_docstring.py", line 231, in test_docstring
    self.fail(PARSE_ERROR.format(
AssertionError: Error while parsing the docstring as reStructuredText.
"""
Run the CRON job in the current (HTTP) thread.

The job is still ran as it would be by the scheduler: a new cursor
is used for the execution of the job.

caca:
    - truc
- moche

:raises UserError: when the job is already running
"""
<string>:8: (WARNING/2) Definition list ends without a blank line; unexpected unindent.

Learn rst:

* https://docutils.sourceforge.io/docs/user/rst/quickref.html
* https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
* https://www.sphinx-doc.org/en/master/usage/domains/python.html

Online editor:

* https://rsted.info.ucl.ac.be/
```