### PR TITLE
[FIX] website, html_builder: remove quotes in title.translate

### DIFF
--- a/addons/html_builder/static/src/plugins/border_configurator_option.xml
+++ b/addons/html_builder/static/src/plugins/border_configurator_option.xml
@@ -5,10 +5,10 @@
     <BuilderRow label="props.label">
         <BuilderNumberInput action="props.action" actionParam="{ mainParam: getStyleActionParam('width'), extraClass: props.withBSClass and 'border' }" unit="'px'" min="0" default="0" composable="true"/>
         <BuilderSelect action="props.action" actionParam="getStyleActionParam('style')" t-if="state.hasBorder">
-            <BuilderSelectItem title.translate="'Solid'" actionValue="'solid'"><div class="o_we_border_preview" style="border-style: solid;"/></BuilderSelectItem>
-            <BuilderSelectItem title.translate="'Dashed'" actionValue="'dashed'"><div class="o_we_border_preview" style="border-style: dashed;"/></BuilderSelectItem>
-            <BuilderSelectItem title.translate="'Dotted'" actionValue="'dotted'"><div class="o_we_border_preview" style="border-style: dotted;"/></BuilderSelectItem>
-            <BuilderSelectItem title.translate="'Double'" actionValue="'double'"><div class="o_we_border_preview" style="border-style: double; border-left: none; border-right: none;"/></BuilderSelectItem>
+            <BuilderSelectItem title.translate="Solid" actionValue="'solid'"><div class="o_we_border_preview" style="border-style: solid;"/></BuilderSelectItem>
+            <BuilderSelectItem title.translate="Dashed" actionValue="'dashed'"><div class="o_we_border_preview" style="border-style: dashed;"/></BuilderSelectItem>
+            <BuilderSelectItem title.translate="Dotted" actionValue="'dotted'"><div class="o_we_border_preview" style="border-style: dotted;"/></BuilderSelectItem>
+            <BuilderSelectItem title.translate="Double" actionValue="'double'"><div class="o_we_border_preview" style="border-style: double; border-left: none; border-right: none;"/></BuilderSelectItem>
         </BuilderSelect>
         <BuilderColorPicker action="props.action" actionParam="getStyleActionParam('color')"
             t-if="state.hasBorder"

--- a/addons/website/static/src/builder/plugins/background_option/background_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_option.xml
@@ -9,7 +9,7 @@
         <t t-if="props.withImages">
             <BuilderButton
                 action="'toggleBgImage'"
-                title.translate="'Image'"
+                title.translate="Image"
                 preview="false"
                 className="'ms-auto fa fa-fw fa-camera'"
                 id="'toggle_bg_image_id'"
@@ -20,7 +20,7 @@
                     preview="false"
                     id="'toggle_bg_shape_id'"
                     iconImg="'/html_builder/static/img/options/bg_shape.svg'"
-                    title.translate="'Shape'"
+                    title.translate="Shape"
                 />
             </t>
         </t>

--- a/addons/website/static/src/builder/plugins/options/background_option.xml
+++ b/addons/website/static/src/builder/plugins/options/background_option.xml
@@ -4,7 +4,7 @@
 <t t-name="website.WebsiteBackgroundOption" t-inherit="html_builder.BackgroundOption">
     <xpath expr="//BuilderButton[@action=&quot;'toggleBgImage'&quot;]" position="after">
         <t t-if="props.withVideos">
-            <BuilderButton title.translate="'Video'"
+            <BuilderButton title.translate="Video"
                 className="'fa fa-fw fa-film'"
                 preview="false"
                 action="'toggleBgVideo'"

--- a/addons/website/static/src/builder/plugins/options/countdown_option.xml
+++ b/addons/website/static/src/builder/plugins/options/countdown_option.xml
@@ -13,7 +13,7 @@
             <BuilderSelectItem actionValue="'message_no_countdown'">Show Message and hide countdown</BuilderSelectItem>
             <BuilderSelectItem actionValue="'message'">Show Message and keep countdown</BuilderSelectItem>
         </BuilderSelect>
-        <BuilderButton title.translate="'The message will be visible once the countdown ends'"
+        <BuilderButton title.translate="The message will be visible once the countdown ends"
                        t-if="!this.isActiveItem('no_end_action_opt') and !this.isActiveItem('redirect_end_action_opt')"
                        action="'previewEndMessage'"
                        preview="false"

--- a/addons/website/static/src/builder/plugins/separator_option.xml
+++ b/addons/website/static/src/builder/plugins/separator_option.xml
@@ -13,9 +13,9 @@
     </BuilderRow>
     <BuilderRow label.translate="Alignment" t-if="!this.isActiveItem('so_width_100')">
         <BuilderButtonGroup>
-            <BuilderButton icon="'fa-align-left'" title.translate="'Left'" classAction="'me-auto'"></BuilderButton>
-            <BuilderButton icon="'fa-align-center'" title.translate="'Center'" classAction="'mx-auto'"></BuilderButton>
-            <BuilderButton icon="'fa-align-right'" title.translate="'Right'" classAction="'ms-auto'"></BuilderButton>
+            <BuilderButton icon="'fa-align-left'" title.translate="Left" classAction="'me-auto'"></BuilderButton>
+            <BuilderButton icon="'fa-align-center'" title.translate="Center" classAction="'mx-auto'"></BuilderButton>
+            <BuilderButton icon="'fa-align-right'" title.translate="Right" classAction="'ms-auto'"></BuilderButton>
         </BuilderButtonGroup>
     </BuilderRow>
 </t>


### PR DESCRIPTION
Single quotes were erroneously present in some `title.translate` values. They were displayed in the builder.
Singles quotes imply a static, immutable value which contradicts the nature of `title.translate` values that are intended for translation and thus inherently mutable.
