### PR TITLE
[FIX] website: align footer templates

### DIFF
--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -7,42 +7,42 @@
             <BuilderSelectItem title.translate="Default"
                 actionParam="{ view: 'website.footer_custom', vars: { 'footer-template': 'default' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Descriptive"
                 actionParam="{ view: 'website.template_footer_descriptive', vars: { 'footer-template': 'descriptive' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Centered"
                 actionParam="{ view: 'website.template_footer_centered', vars: { 'footer-template': 'centered' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Links"
                 actionParam="{ view: 'website.template_footer_links', vars: { 'footer-template': 'links' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Minimalist"
                 actionParam="{ view: 'website.template_footer_minimalist', vars: { 'footer-template': 'minimalist' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Contact"
                 actionParam="{ view: 'website.template_footer_contact', vars: { 'footer-template': 'contact' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Call-to-action"
                 actionParam="{ view: 'website.template_footer_call_to_action', vars: { 'footer-template': 'call_to_action' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Headline"
                 actionParam="{ view: 'website.template_footer_headline', vars: { 'footer-template': 'headline' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
+                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>


### PR DESCRIPTION
Previously, the footer templates' images were misaligned because of the missing styling.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
