### PR TITLE
[FIX] account_edi_ubl_cii_tax_extension: Fix tax exemption reason codes

### DIFF
--- a/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii_tax_extension/models/account_edi_common.py
@@ -62,16 +62,32 @@ TAX_EXEMPTION_MAPPING = {
     'VATEX-FR-CNWVAT': 'France domestic Credit Notes without VAT, due to supplier forfeit of VAT for discount',
 }
 
+# Some codes were added with _ instead of -, this is a fix for stable version to add them correctly in XML files.
+FIX_WRONG_CODES_MAPPING = {
+    'VATEX_EU_AE': 'VATEX-EU-AE',
+    'VATEX_EU_D': 'VATEX-EU-D',
+    'VATEX_EU_F': 'VATEX-EU-F',
+    'VATEX_EU_G': 'VATEX-EU-G',
+    'VATEX_EU_I': 'VATEX-EU-I',
+    'VATEX_EU_IC': 'VATEX-EU-IC',
+    'VATEX_EU_O': 'VATEX-EU-O',
+    'VATEX_EU_J': 'VATEX-EU-J',
+    'VATEX_FR-FRANCHISE': 'VATEX-FR-FRANCHISE',
+    'VATEX_FR-CNWVAT': 'VATEX-FR-CNWVAT',
+}
+
 
 class AccountEdiCommon(models.AbstractModel):
     _inherit = "account.edi.common"
 
     def _get_tax_unece_codes(self, invoice, tax):
         if tax.ubl_cii_tax_category_code:
-            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(tax.ubl_cii_tax_exemption_reason_code)
+            reason_code = tax.ubl_cii_tax_exemption_reason_code
+            reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
+            tax_exemption_reason = TAX_EXEMPTION_MAPPING.get(reason_code)
             return {
                 'tax_category_code': tax.ubl_cii_tax_category_code,
-                'tax_exemption_reason_code': tax.ubl_cii_tax_exemption_reason_code,
+                'tax_exemption_reason_code': reason_code,
                 'tax_exemption_reason': tax_exemption_reason,
             }
         return super()._get_tax_unece_codes(invoice, tax)

--- a/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
+++ b/addons/account_edi_ubl_cii_tax_extension/tests/test_ubl_cii_tax_extension.py
@@ -3,6 +3,7 @@
 from lxml import etree
 from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.account_edi_ubl_cii_tax_extension.models.account_edi_common import FIX_WRONG_CODES_MAPPING
 from odoo.tests import tagged
 
 
@@ -32,5 +33,7 @@ class TestAccountEdiUblCiiTaxExtension(AccountTestInvoicingCommon):
             xml = self.env['account.edi.xml.ubl_bis3']._export_invoice(invoice)[0]
             root = etree.fromstring(xml)
             for tax, node in zip(taxes, root.findall('.//{*}TaxTotal/{*}TaxSubtotal/{*}TaxCategory')):
+                reason_code = tax.ubl_cii_tax_exemption_reason_code
+                reason_code = FIX_WRONG_CODES_MAPPING.get(reason_code, reason_code)
                 self.assertEqual(node.findtext('.//{*}ID') or False, tax.ubl_cii_tax_category_code)
-                self.assertEqual(node.findtext('.//{*}TaxExemptionReasonCode') or False, tax.ubl_cii_tax_exemption_reason_code)
+                self.assertEqual(node.findtext('.//{*}TaxExemptionReasonCode') or False, reason_code)


### PR DESCRIPTION
Some of the reasons were added with a wrong code.
https://github.com/odoo/odoo/blob/fba7abd168b99157ee9abd1c084720a90196de39/addons/account_edi_ubl_cii_tax_extension/models/account_tax.py#L76-L85
Example: VATEX_EU_AE should have been VATEX-EU-AE...

This fix adds a mapping to correct the codes when exporting XML, since
we cannot update the keys of the selection field directly in stable versions.

Source: https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-tc434/BR-CL-22/

task-4817958 (part of)