### PR TITLE
[FIX] stock: confusing log notes on pickings when editing done quantities

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -569,7 +569,7 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:stock.message_head
 msgid ""
 "<strong>\n"
-"                The done move line has been corrected.\n"
+"                The done quantity has been corrected.\n"
 "            </strong>"
 msgstr ""
 

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -505,9 +505,6 @@ class StockMoveLine(models.Model):
                 # Unreserve and reserve following move in order to have the real reserved quantity on move_line.
                 next_moves |= ml.move_id.move_dest_ids.filtered(lambda move: move.state not in ('done', 'cancel'))
 
-                # Log a note
-                if ml.picking_id:
-                    ml._log_message(ml.picking_id, ml, 'stock.track_move_template', vals)
             move_done = mls.move_id
             if move_done:
                 move_done._check_quantity()

--- a/addons/stock/views/stock_template.xml
+++ b/addons/stock/views/stock_template.xml
@@ -7,7 +7,7 @@
         </t>
         <t t-if="move.state == 'done'">
             <strong>
-                The done move line has been corrected.
+                The done quantity has been corrected.
             </strong>
         </t>
     </template>


### PR DESCRIPTION
Steps:
- Take picking in state done with 5 units of a random product.
- Unlock the picking
- Edit the quantity by adding 1 more unit on a new move line. Nothing will be logged.
- Edit the quantity by editing the previous line from 1 to 2. A message will be logged saying a move line was correct from 1 to 2.

This is confusing to the customer.
Instead, the overall quantity should always be logged when modified (from 5 to 6 and from 6 to 7), whether a new move line is added or not.

opw-4718308

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
