### PR TITLE
account: invoice copy modifies source invoice

### DIFF
--- a/addons/account/tests/test_account_move_duplicate.py
+++ b/addons/account/tests/test_account_move_duplicate.py
@@ -100,3 +100,24 @@ class TestAccountMoveDuplicate(AccountTestInvoicingCommon):
         bill5 = bill4.copy()
         bill5.ref = bill4.ref
         self.assertEqual(bill5.duplicated_ref_ids, bill4)
+
+    def test_invoice_duplicate_posted(self):
+        # Values shouldn't be modified on a record that is being modified.
+        # Create is an api.model method, and shouldn't modify self even if set.
+        invoice_copy = self.init_invoice(
+            'in_invoice', products=self.product_a + self.product_b, post=True
+        )
+        values_before = invoice_copy.read(["is_manually_modified", "needed_terms_dirty"])
+        invoice_copy.copy()
+        values_after = invoice_copy.read(["is_manually_modified", "needed_terms_dirty"])
+        self.assertEqual(values_before, values_after)
+
+    def test_invoice_create_with_recordset(self):
+        # Create is an api.model method, and shouldn't modify self even if set.
+        invoice_create = self.init_invoice(
+            'in_invoice', products=self.product_a + self.product_b, post=True
+        )
+        values_before = invoice_create.read(["is_manually_modified", "needed_terms_dirty"])
+        invoice_create.create({})
+        values_after = invoice_create.read(["is_manually_modified", "needed_terms_dirty"])
+        self.assertEqual(values_before, values_after)


### PR DESCRIPTION
When duplicating an account move, the origin move shouldn't be modified.
The reason for that is when `create` is called, operations are done on self, like check and sync balance, which is wrong.
create is an `api.model` method and shouldn't alter the record if set.

This PR doesn't include a fix, just tests that reproduces issue explained on ticket `#4823689`

ping @william-andre 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
