### PR TITLE
[FIX] website: render alignment controller just after width option

### DIFF
--- a/addons/website/static/src/builder/plugins/size_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/size_option_plugin.js
@@ -1,5 +1,5 @@
 import { after } from "@html_builder/utils/option_sequence";
-import { WIDTH } from "@website/builder/option_sequence";
+import { BLOCK_ALIGN } from "@website/builder/option_sequence";
 import { withSequence } from "@html_editor/utils/resource";
 import { Plugin } from "@html_editor/plugin";
 import { registry } from "@web/core/registry";
@@ -8,7 +8,7 @@ class SizeOptionPlugin extends Plugin {
     static id = "sizeOption";
     resources = {
         builder_options: [
-            withSequence(after(WIDTH), {
+            withSequence(after(BLOCK_ALIGN), {
                 template: "html_builder.SizeOption",
                 selector: ".s_alert",
             }),


### PR DESCRIPTION
Fixes the following:
> [CHGO] when setting the width of s_alert to something else than 100%, the alignment controller is rendered as a sublevel but not directly after the width option