### PR TITLE
[FIX] base_vat: do not preprend country code for Romania

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -166,12 +166,17 @@ class ResPartner(models.Model):
     def fix_eu_vat_number(self, country_id, vat):
         europe = self.env.ref('base.europe')
         country = self.env["res.country"].browse(country_id)
+        # In Romania, the CUI can be used as tax identifier and it is not prefixed with the country code
+        country_codes_to_not_prepend = ['RO']
         if not europe:
             europe = self.env["res.country.group"].search([('name', '=', 'Europe')], limit=1)
         if europe and country and country.id in europe.country_ids.ids:
             vat = re.sub('[^A-Za-z0-9]', '', vat).upper()
             country_code = _eu_country_vat.get(country.code, country.code).upper()
-            if vat[:2] != country_code:
+            if vat[:2] != country_code and (
+                country_code not in country_codes_to_not_prepend or
+                country_code != self.env.company.country_code
+            ):
                 vat = country_code + vat
         return vat
 


### PR DESCRIPTION
**Steps to reproduce:**
- Install base_vat and website_sale
- Execute the following steps as a public user
- From website, go to the Shop
- Add a product to the cart
- Proceed to checkout
- Enter an address in Romania
- Enter a valid CUI as VAT (e.g. 8001011234567)
- Validate the address
- Edit the address to see the issue

**Issue:**
The country code (i.e. RO) has been prepended to the input VAT, which is not correct.
If the Romanian localization is installed and an invoice is created from the order and sent to the government, it will be rejected because of the incorrect VAT.

**Solution:**
Romania can accept the CUI as tax identifier.
The CUI only contains digits.
When formatting the VAT from Romania, the country code will not be prepended automatically.
To reduce the effect of the fix, the code prepend will only be skipped if the country of the customer is the same than the country of the website.

opw-4655064




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
