### PR TITLE
[FIX] website: bring back missing animate on scroll "in/out" option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/animate_option.xml
+++ b/addons/website/static/src/builder/plugins/options/animate_option.xml
@@ -22,6 +22,10 @@
                             id="'animation_on_hover_opt'"
                             t-if="state.canHover">On Hover</BuilderSelectItem>
             </BuilderSelect>
+            <BuilderButtonGroup t-if="isActiveItem('animation_on_scroll_opt')" preview="false" action="'forceAnimation'">
+                <BuilderButton classAction="''">In</BuilderButton>
+                <BuilderButton classAction="'o_animate_out'">Out</BuilderButton>
+            </BuilderButtonGroup>
         </BuilderRow>
         <BuilderRow label.translate="Effect" level="1">
             <BuilderSelect id="'animation_effect_opt'"


### PR DESCRIPTION
During refactor of the website builder, the in/out suboption for on-scroll animation has been missed.

Steps to reproduce:
- Open website editor
- Select something that supports animation (like a button)
- Choose "On Scroll"
- Missing: a sub-option "in/out" should appear

Website refactor: odoo/odoo#187419
task-4367641
