### PR TITLE
[FIX] mail: mail_activity_plan onchange

### DIFF
--- a/addons/mail/models/mail_activity_plan.py
+++ b/addons/mail/models/mail_activity_plan.py
@@ -39,7 +39,12 @@ class MailActivityPlan(models.Model):
     @api.depends('res_model')
     def _compute_res_model_id(self):
         for plan in self:
-            plan.res_model_id = self.env['ir.model']._get_id(plan.res_model)
+            if plan.res_model:
+                # New records may not have the required "res_model" field set yet
+                # (in onchange)
+                plan.res_model_id = self.env['ir.model']._get_id(plan.res_model)
+            else:
+                plan.res_model_id = False
 
     @api.constrains('res_model')
     def _check_res_model_compatibility_with_templates(self):


### PR DESCRIPTION
Trigger an onchange requiring res_model_id to be returned.

Before this commit, there was an error because the dependency field "res_model" was False and injected into a function that required it not to be.

After this commit, there is no crash.

runbot-error-223466

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
