### PR TITLE
[REF] web: useModel: filter model params

### DIFF
--- a/addons/web/static/src/model/model.js
+++ b/addons/web/static/src/model/model.js
@@ -111,10 +111,10 @@ export function useModel(ModelClass, params, options = {}) {
     const model = new ModelClass(component.env, params, services);
     onWillStart(async () => {
         await options.beforeFirstLoad?.();
-        await model.load(component.props);
+        await model.load(getSearchParams(component.props));
         model.whenReady.resolve();
     });
-    onWillUpdateProps((nextProps) => model.load(nextProps));
+    onWillUpdateProps((nextProps) => model.load(getSearchParams(nextProps)));
     return model;
 }
 


### PR DESCRIPTION
This commit filters the params given to the `load` function in the `useModel` hook, like it is done in `useModelWithSampleData`. We only keep keys "context", "domain", "groupBy" and "orderBy", i.e. parameters that can come from the search model, which are the expected (and documented) parameters of `load` in concrete models.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
