### PR TITLE
[FIX] mail: fix token lost during mail/view redirection

### DIFF
--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -126,22 +126,11 @@ class MailController(http.Controller):
                 record_action = record_sudo._get_access_action(access_uid=uid)
         else:
             record_action = record_sudo._get_access_action()
-            if suggested_company:
-                cids = [suggested_company.id]
+            # we have an act_url (probably a portal link): we need to retry being logged to check access
             if record_action['type'] == 'ir.actions.act_url' and record_action.get('target_type') != 'public':
-                url_params = {
-                    'model': model,
-                    'id': res_id,
-                    'active_id': res_id,
-                    'action': record_action.get('id'),
-                }
-                if cids:
-                    request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
-                view_id = record_sudo.get_formview_id()
-                if view_id:
-                    url_params['view_id'] = view_id
-                url = '/web/login?redirect=#%s' % url_encode(url_params)
-                return request.redirect(url)
+                return cls._redirect_to_login_with_mail_view(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
 
         record_action.pop('target_type', None)
         # the record has an URL redirection: use it directly

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -96,7 +96,9 @@ class MailController(http.Controller):
         if uid is not None:
             # the record has a window redirection: check access rights
             if not RecordModel.with_user(uid).has_access('read'):
-                return cls._redirect_to_messaging()
+                return cls._redirect_to_generic_fallback(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
             try:
                 # We need here to extend the "allowed_company_ids" to allow a redirection
                 # to any record that the user can access, regardless of currently visible
@@ -121,7 +123,9 @@ class MailController(http.Controller):
                     record_sudo.with_user(uid).with_context(allowed_company_ids=cids).check_access('read')
                     request.future_response.set_cookie('cids', '-'.join([str(cid) for cid in cids]))
             except AccessError:
-                return cls._redirect_to_messaging()
+                return cls._redirect_to_generic_fallback(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
             else:
                 record_action = record_sudo._get_access_action(access_uid=uid)
         else:

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -4102,31 +4102,17 @@ class MailThread(models.AbstractModel):
 
     def _notify_get_action_link(self, link_type, **kwargs):
         """ Prepare link to an action: view document, follow document, ... """
-        params = {
-            'model': kwargs.get('model', self._name),
-            'res_id': kwargs.get('res_id', self.ids and self.ids[0] or False),
-        }
-        # keep only accepted parameters:
-        # - action (deprecated), token (assign), access_token (view)
-        # - auth_signup: auth_signup_token and auth_login
-        # - portal: pid, hash
-        params.update(dict(
-            (key, value)
-            for key, value in kwargs.items()
-            if key in ('action', 'token', 'access_token', 'auth_signup_token',
-                       'auth_login', 'pid', 'hash')
-        ))
+        params = self._notify_get_action_link_params(link_type, **kwargs)
 
         if link_type in ['view', 'assign', 'follow', 'unfollow']:
             base_link = '/mail/%s' % link_type
         elif link_type == 'controller':
             controller = kwargs.get('controller')
-            params.pop('model')
             base_link = '%s' % controller
         else:
             return ''
 
-        if link_type not in ['view']:
+        if link_type != 'view':
             token = self._encode_link(base_link, params)
             params['token'] = token
 
@@ -4135,6 +4121,28 @@ class MailThread(models.AbstractModel):
             link = self[0].get_base_url() + link
 
         return link
+
+    def _notify_get_action_link_params(self, link_type, **kwargs):
+        """ Parameters management for '_notify_get_action_link' """
+        params = {
+            'model': kwargs.get('model', self._name),
+            'res_id': kwargs.get('res_id', self.ids[0] if self else False),
+        }
+        # keep only accepted parameters:
+        # - action (deprecated), token (assign), access_token (view)
+        # - auth_signup: auth_signup_token and auth_login
+        # - portal: pid, hash
+        params.update({
+            key: value
+            for key, value in kwargs.items()
+            if key in ('action', 'token', 'access_token', 'auth_signup_token',
+                       'auth_login', 'pid', 'hash')
+        })
+        if link_type == 'controller':
+            params.pop('model')
+        elif link_type not in ['view', 'assign', 'follow', 'unfollow']:
+            return {}
+        return params
 
     # Notify tools and helpers
     # ------------------------------------------------------------

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -108,6 +108,13 @@ class PortalChatter(http.Controller):
 class MailController(mail.MailController):
 
     @classmethod
+    def _redirect_to_generic_fallback(cls, model, res_id, access_token=None, **kwargs):
+        # Generic fallback for a share user is the customer portal
+        if request.session.uid and request.env.user.share:
+            return request.redirect('/my')
+        return super()._redirect_to_generic_fallback(model, res_id, access_token=access_token, **kwargs)
+
+    @classmethod
     def _redirect_to_record(cls, model, res_id, access_token=None, **kwargs):
         """ If the current user doesn't have access to the document, but provided
         a valid access token, redirect them to the front-end view.

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -406,7 +406,7 @@ class TestMultiCompanySetup(TestMailMCCommon, HttpCase):
                     self.assertEqual(other_activity_group["total_count"], 5)
 
 
-@tagged('-at_install', 'post_install', 'multi_company')
+@tagged('-at_install', 'post_install', 'multi_company', 'mail_controller')
 class TestMultiCompanyRedirect(MailCommon, HttpCase):
 
     def test_redirect_to_records(self):

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -441,8 +441,6 @@ class TestMultiCompanyRedirect(MailCommon, HttpCase):
                 if not login:
                     path = url_parse(response.url).path
                     self.assertEqual(path, '/web/login')
-                    self.assertTrue('cids' in response.request._cookies)
-                    self.assertEqual(response.request._cookies.get('cids'), str(mc_record.company_id.id))
                 else:
                     user = self.env['res.users'].browse(self.session.uid)
                     self.assertEqual(user.login, login)
@@ -518,23 +516,17 @@ class TestMultiCompanyRedirect(MailCommon, HttpCase):
                     self.assertTrue('cids' in response.request._cookies)
                     self.assertEqual(response.request._cookies.get('cids'), str(user_company.id))
 
-        # when being not logged, cids should be added based on
-        # '_get_redirect_suggested_company'
+        # when being not logged, cids should not be added as redirection after
+        # logging will be 'mail/view' again
         for test_record in nothreads:
-            with self.subTest(record_name=test_record.name, user_company=user_company):
+            with self.subTest(record_name=test_record.name):
                 self.authenticate(None, None)
-                self.user_admin.write({'company_id': user_company.id})
                 response = self.url_open(
                     f'/mail/view?model={test_record._name}&res_id={test_record.id}',
                     timeout=15
                 )
                 self.assertEqual(response.status_code, 200)
-
-                if test_record.company_id:
-                    self.assertIn('cids', response.request._cookies)
-                    self.assertEqual(response.request._cookies.get('cids'), str(test_record.company_id.id))
-                else:
-                    self.assertNotIn('cids', response.request._cookies)
+                self.assertNotIn('cids', response.request._cookies)
 
 
 @tagged("-at_install", "post_install", "multi_company")

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -41,6 +41,28 @@ class MailTestPortalNoPartner(models.Model):
             record.access_url = '/my/test_portal_no_partner/%s' % self.id
 
 
+class MailTestPortalPublicAccessAction(models.Model):
+    """ Test 'public' target_type access action """
+    _description = 'Portal Public Access Action'
+    _name = 'mail.test.portal.public.access.action'
+    _inherit = 'mail.test.portal'
+
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        for record in self.filtered('id'):
+            record.access_url = 'http://www.example.com/public_access_action'
+
+    def _get_access_action(self, access_uid=None, force_website=False):
+        # Test 'public' target type
+        return {
+            'type': 'ir.actions.act_url',
+            'url': self.access_url,
+            'target': 'self',
+            'target_type': 'public',
+            'res_id': self.id,
+        }
+
+
 class MailTestRating(models.Model):
     """ A model inheriting from rating.mixin (which inherits from mail.thread) with some fields used for SMS
     gateway, like a partner, a specific mobile phone, ... """

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -2,6 +2,8 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mail_test_portal_user,mail.test.portal.user,model_mail_test_portal,base.group_user,1,1,1,1
 access_mail_test_portal_no_partner_portal,mail.test.portal.no.partner.all,model_mail_test_portal_no_partner,base.group_portal,1,0,0,0
 access_mail_test_portal_no_partner_user,mail.test.portal.no.partner.user,model_mail_test_portal_no_partner,base.group_user,1,1,1,1
+access_mail_test_portal_public_access_action_portal,mail.test.portal.public.access.action.portal,model_mail_test_portal_public_access_action,base.group_portal,1,0,0,0
+access_mail_test_portal_public_access_action_user,mail.test.portal.public.access.action.user,model_mail_test_portal_public_access_action,base.group_user,1,1,1,1
 access_mail_test_rating_all,mail.test.rating.all,model_mail_test_rating,base.group_user,0,0,0,0
 access_mail_test_rating_portal,mail.test.rating.portal,model_mail_test_rating,base.group_portal,1,0,0,0
 access_mail_test_rating_user,mail.test.rating.user,model_mail_test_rating,base.group_user,1,1,1,1

--- a/addons/test_mail_full/tests/__init__.py
+++ b/addons/test_mail_full/tests/__init__.py
@@ -8,6 +8,7 @@ from . import test_message_reaction_controller_portal
 from . import test_portal
 from . import test_portal_attachment_controller
 from . import test_portal_message_update_controller
+from . import test_portal_mixin
 from . import test_portal_thread_controller
 from . import test_rating
 from . import test_res_users

--- a/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
+++ b/addons/test_mail_full/tests/test_message_reaction_controller_portal.py
@@ -1,13 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import odoo
-from odoo.addons.mail.tests.test_message_reaction_controller import (
-    TestMessageReactionControllerCommon,
-)
+from odoo.addons.mail.tests.test_message_reaction_controller import TestMessageReactionControllerCommon
+from odoo.tests import tagged
 
 
-@odoo.tests.tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_controller")
 class TestPortalMessageReactionController(TestMessageReactionControllerCommon):
+
     def test_message_reaction_portal_no_partner(self):
         """Test access of message reaction for portal without partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -331,11 +331,6 @@ class TestPortalFlow(MailCommon, HttpCase):
         support and propagation. """
         self.authenticate(None, None)
         login_url = f'{self.test_base_url}/web/login'
-        odoo_portal_params = {
-            'model': self.record_portal._name,
-            'id': self.record_portal.id,
-            'active_id': self.record_portal.id,
-        }
 
         for url_name, url, exp_url in [
             # valid token -> ok -> redirect to portal URL
@@ -343,19 +338,20 @@ class TestPortalFlow(MailCommon, HttpCase):
                 "No access (portal enabled), token", self.record_portal_url_auth,
                 self.portal_web_url_with_token,
             ),
-            # invalid token -> ko -> redirect to login with just some mail/view params kept (???)
+            # invalid token -> ko -> redirect to login with redirect to original link, will be rejected after login
             (
                 "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
-                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_auth_wrong_token.replace(self.test_base_url, "")})}',
             ),
             # std url, no access to record -> redirect to login, with internal backend redirect ending with a ? (???)
             (
                 'No access record (internal)', self.record_internal_url_base,
                 f'{login_url}?{url_encode({"redirect": f"{self.internal_backend_local_url}?"})}',
             ),
+            # std url, no access to record but portal -> redirect to login, original (local) URL kept as redirection post login to try again (even if faulty)
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
-                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_base.replace(self.test_base_url, "")})}',
             ),
             # not existing -> redirect to login, original (local) URL kept as redirection post login to try again (even if faulty)
             (

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -351,25 +351,24 @@ class TestPortalFlow(MailCommon, HttpCase):
             # std url, no access to record -> redirect to login, with internal backend redirect ending with a ? (???)
             (
                 'No access record (internal)', self.record_internal_url_base,
-                # f'{login_url}?redirect={url_quote(self.record_internal_url_base)}',
                 f'{login_url}?{url_encode({"redirect": f"{self.internal_backend_local_url}?"})}',
             ),
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
                 f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
             ),
-            # not existing -> redirect to login, with a redirect to messaging ending with a ? (???)
+            # not existing -> redirect to login, original (local) URL kept as redirection post login to try again (even if faulty)
             (
                 'Not existing record (internal)', self.record_internal_url_no_exists,
-                f'{login_url}?{url_encode({"redirect": f"{self.discuss_local_url}?"})}',
+                f'{login_url}?{url_encode({"redirect": self.record_internal_url_no_exists.replace(self.test_base_url, "")})}',
             ),
             (
                 'Not existing record (portal enabled)', self.record_portal_url_no_exists,
-                f'{login_url}?{url_encode({"redirect": f"{self.discuss_local_url}?"})}',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_no_exists.replace(self.test_base_url, "")})}',
             ),
             (
                 'Not existing model', self.record_url_no_model,
-                f'{login_url}?{url_encode({"redirect": f"{self.discuss_local_url}?"})}',
+                f'{login_url}?{url_encode({"redirect": self.record_url_no_model.replace(self.test_base_url, "")})}',
             ),
         ]:
             with self.subTest(name=url_name, url=url):

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -282,7 +282,7 @@ class TestPortalFlow(MailCommon, HttpCase):
     def test_portal_access_logged(self):
         """ Check portal behavior when accessing mail/view, notably check token
         support and propagation. """
-        my_discuss_url = f'{self.test_base_url}/my?{url_encode({"subpath": "action-mail.action_discuss"})}'
+        my_url = f'{self.test_base_url}/my'
 
         self.authenticate(self.env.user.login, self.env.user.login)
         for url_name, url, exp_url in [
@@ -294,7 +294,7 @@ class TestPortalFlow(MailCommon, HttpCase):
             # invalid token -> ko -> redirect to my with discuss action (???)
             (
                 "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
-                my_discuss_url,
+                my_url,
             ),
             # std url, no access to record -> redirect to my with subpath being record base portal utl (???)
             (
@@ -304,20 +304,20 @@ class TestPortalFlow(MailCommon, HttpCase):
             # missing tokan -> redirect to my with discuss action (???)
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
-                my_discuss_url,
+                my_url,
             ),
             # not existing -> redirect to my with discuss action (???)
             (
                 'Not existing record (internal)', self.record_internal_url_no_exists,
-                my_discuss_url,
+                my_url,
             ),
             (
                 'Not existing record (portal enabled)', self.record_portal_url_no_exists,
-                my_discuss_url,
+                my_url,
             ),
             (
                 'Not existing model', self.record_url_no_model,
-                my_discuss_url,
+                my_url,
             ),
         ]:
             with self.subTest(name=url_name, url=url):

--- a/addons/test_mail_full/tests/test_portal_attachment_controller.py
+++ b/addons/test_mail_full/tests/test_portal_attachment_controller.py
@@ -1,11 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import odoo
 from odoo.addons.mail.tests.test_attachment_controller import TestAttachmentControllerCommon
+from odoo.tests import tagged
 
 
-@odoo.tests.tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_controller")
 class TestPortalAttachmentController(TestAttachmentControllerCommon):
+
     def test_attachment_upload_portal(self):
         """Test access to upload an attachment on portal"""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})

--- a/addons/test_mail_full/tests/test_portal_message_update_controller.py
+++ b/addons/test_mail_full/tests/test_portal_message_update_controller.py
@@ -1,11 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import odoo
 from odoo.addons.mail.tests.test_message_update_controller import TestMessageUpdateControllerCommon
+from odoo.tests import tagged
 
 
-@odoo.tests.tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_controller")
 class TestPortalMessageUpdateController(TestMessageUpdateControllerCommon):
+
     def test_message_update_portal(self):
         """Test Only Admin and Portal User can update a portal user message on a record with no assigned partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})

--- a/addons/test_mail_full/tests/test_portal_mixin.py
+++ b/addons/test_mail_full/tests/test_portal_mixin.py
@@ -1,0 +1,31 @@
+from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
+from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
+from odoo.tests import tagged, users
+
+
+@tagged('portal')
+class TestPortalMixin(TestMailFullCommon, TestSMSRecipients):
+
+    def setUp(self):
+        super().setUp()
+
+        self.record_portal = self.env['mail.test.portal'].create({
+            'partner_id': self.partner_1.id,
+            'name': 'Test Portal Record',
+        })
+        self.record_portal._portal_ensure_token()
+
+    @users('employee')
+    def test_portal_mixin(self):
+        """ Test internals of portal mixin """
+        customer = self.partner_1.with_env(self.env)
+        record_portal = self.env['mail.test.portal'].create({
+            'partner_id': customer.id,
+            'name': 'Test Portal Record',
+        })
+
+        self.assertFalse(record_portal.access_token)
+        self.assertEqual(record_portal.access_url, '/my/test_portal/%s' % record_portal.id)
+
+        record_portal._portal_ensure_token()
+        self.assertTrue(record_portal.access_token)

--- a/addons/test_mail_full/tests/test_portal_thread_controller.py
+++ b/addons/test_mail_full/tests/test_portal_thread_controller.py
@@ -1,14 +1,10 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-import odoo
-from odoo.addons.mail.tests.test_thread_controller import (
-    MessagePostSubTestData,
-    TestThreadControllerCommon,
-)
+from odoo.addons.mail.tests.test_thread_controller import MessagePostSubTestData, TestThreadControllerCommon
+from odoo.tests import tagged
 
 
-@odoo.tests.tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_controller")
 class TestPortalThreadController(TestThreadControllerCommon):
+
     def test_message_post_access_portal_no_partner(self):
         """Test access of message post for portal without partner."""
         record = self.env["mail.test.portal.no.partner"].create({"name": "Test"})


### PR DESCRIPTION
Global purpose is to make mail/view controller more resilient by
improving redirections when not having access to the record.

Notably
 * correctly route internal users to discuss, portal users to /my
   and unlogged users to login;
 * keep original mail/view route when performing redirection after
   login so that we try the routing again;
 * fix various issues in redirect computation, such as lost access
   token parameter or partial reconstruction of URLs;

Improve test coverage.

Task-