### PR TITLE
[FIX] website: missing bg image classes

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_image_option.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option.js
@@ -4,6 +4,19 @@ import { getBgImageURLFromEl, normalizeColor } from "@html_builder/utils/utils_c
 export class BackgroundImageOption extends BaseOptionComponent {
     static template = "html_builder.BackgroundImageOption";
     static props = {};
+    setup() {
+        // done here because we have direct access to the editing element 
+        // (which we don't have in the normalize of the current plugin)
+        this.toggleBgImageClasses();
+        super.setup();
+    }
+    toggleBgImageClasses() {
+        this.env.editor.shared.history.ignoreDOMMutations(() => {
+            const editingEl = this.env.getEditingElement();
+            const backgroundURL = getBgImageURLFromEl(editingEl);
+            this.env.editor.shared.backgroundImageOption.setImageBackground(editingEl, backgroundURL);
+        })
+    }
     showMainColorPicker() {
         const editingEl = this.env.getEditingElement();
         const src = new URL(getBgImageURLFromEl(editingEl), window.location.origin);

--- a/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option_plugin.js
@@ -6,12 +6,10 @@ import { registry } from "@web/core/registry";
 import { convertCSSColorToRgba } from "@web/core/utils/colors";
 import { getBackgroundImageColor } from "./background_image_option";
 
-// TODO: support the setTarget
-
 export class BackgroundImageOptionPlugin extends Plugin {
     static id = "backgroundImageOption";
     static dependencies = ["builderActions", "media", "style"];
-    static shared = ["changeEditingEl"];
+    static shared = ["changeEditingEl", "setImageBackground"];
     resources = {
         builder_actions: this.getActions(),
     };
@@ -167,9 +165,9 @@ export class BackgroundImageOptionPlugin extends Plugin {
      */
     setImageBackground(el, backgroundURL) {
         if (backgroundURL) {
-            el.classList.add("oe_img_bg", "o_bg_img_center");
+            el.classList.add("oe_img_bg", "o_bg_img_center", "o_bg_img_origin_border_box");
         } else {
-            el.classList.remove("oe_img_bg", "o_bg_img_center", "o_modified_image_to_save");
+            el.classList.remove("oe_img_bg", "o_bg_img_center", "o_bg_img_origin_border_box", "o_modified_image_to_save");
         }
         // TODO: check this comment
         // We use selectStyle so that if when a background image is removed the

--- a/addons/website/static/tests/builder/website_builder/background_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/background_option.test.js
@@ -78,6 +78,18 @@ test("toggle Show/Hide on mobile of the shape background", async () => {
     expect(":iframe section .o_we_shape").not.toHaveClass("o_shape_show_mobile");
 });
 
+test("Check if an element with a background image has necessary classes", async () => {
+    await setupWebsiteBuilder(`
+        <section class="s_banner overflow-hidden" style="background-color:(0, 0, 0, 0); 
+                background-image: url(&quot;/website_slides/static/src/img/banner_default.svg&quot;); height: 300px" data-snippet="s_banner">
+            AAA
+        </section>`);
+    await contains(":iframe section").click();
+    expect(":iframe section").toHaveClass("oe_img_bg");
+    expect(":iframe section").toHaveClass("o_bg_img_center");
+    expect(":iframe section").toHaveClass("o_bg_img_origin_border_box");
+})
+
 test("Change the background position and apply", async () => {
     await dragAndDropBgImage();
     await contains(".overlay .btn-primary").click();


### PR DESCRIPTION
Steps to reproduce the issue we had:
- Go to website courses
- Start editing
- Click on the image banner

-> Position option doesn't work properly (its value is always Repeat
Position), and the image isn't styled correctly - not centered. This is
because of the missing image classes, which previously were added in old
snippet widget. This PR follows [the html_builder refactoring].

[the html_builder refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641
