### PR TITLE
[FIX] pos_restaurant: fix order table transferring

### DIFF
--- a/addons/point_of_sale/static/tests/pos/tours/slow_network_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/slow_network_tour.js
@@ -1,0 +1,28 @@
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
+import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("test_order_slow_network", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.addOrderline("Desk Pad", "1"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("1.98"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+
+            ProductScreen.addOrderline("Desk Pad", "2"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.totalIs("3.96"),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
+            ReceiptScreen.clickNextOrder(),
+        ].flat(),
+});

--- a/addons/point_of_sale/tests/__init__.py
+++ b/addons/point_of_sale/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_report_pos_order
 from . import test_report_session
 from . import test_res_config_settings
 from . import test_stock_product_updates
+from . import test_frontend_slow_network

--- a/addons/point_of_sale/tests/test_frontend_slow_network.py
+++ b/addons/point_of_sale/tests/test_frontend_slow_network.py
@@ -1,0 +1,19 @@
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@tagged('post_install', '-at_install')
+class TestFrontendSlowNetwork(TestPointOfSaleHttpCommon):
+    def start_slow_network_tour(self, tour_name, login="pos_admin", **kwargs):
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, tour_name, login=login, **kwargs)
+
+    def test_order_slow_network(self):
+        self.start_slow_network_tour('test_order_slow_network')
+
+        active_session_id = self.main_pos_config.current_session_id.id
+        orders = self.env['pos.order'].search([('session_id', '=', active_session_id)])
+        prices = orders.mapped('amount_total')
+
+        self.assertEqual(len(orders), 2, "There should be two orders created in the session.")
+        self.assertEqual(prices, [3.96, 1.98], "The total amounts of the orders should be 1.98 and 3.96 respectively.")

--- a/addons/pos_restaurant/static/tests/tours/slow_network_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/slow_network_tour.js
@@ -1,0 +1,40 @@
+import * as FloorScreen from "@pos_restaurant/../tests/tours/utils/floor_screen_util";
+import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
+import * as ChromePos from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
+import * as ChromeRestaurant from "@pos_restaurant/../tests/tours/utils/chrome";
+import * as ProductScreenPos from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
+import * as ProductScreenResto from "@pos_restaurant/../tests/tours/utils/product_screen_util";
+import { registry } from "@web/core/registry";
+
+const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
+const Chrome = { ...ChromePos, ...ChromeRestaurant };
+
+registry.category("web_tour.tours").add("test_table_merge_slow_network", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            FloorScreen.clickFloor("Main Floor"),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.clickPlanButton(),
+
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            Chrome.clickPlanButton(),
+
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Minute Maid", 2),
+            Chrome.clickPlanButton(),
+
+            FloorScreen.isShown(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickControlButton("Transfer"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.isShown(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/__init__.py
+++ b/addons/pos_restaurant/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_frontend
 from . import test_pos_restaurant_flow
+from . import test_frontend_slow_network

--- a/addons/pos_restaurant/tests/test_frontend_slow_network.py
+++ b/addons/pos_restaurant/tests/test_frontend_slow_network.py
@@ -1,0 +1,16 @@
+from odoo.tests import tagged
+from odoo.addons.point_of_sale.tests.test_frontend_slow_network import TestFrontendSlowNetwork
+from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontendCommon
+
+
+@tagged('post_install', '-at_install')
+class TestFrontendSlowNetworkRestaurant(TestFrontendSlowNetwork, TestFrontendCommon):
+    def test_table_merge_slow_network(self):
+        self.start_slow_network_tour('test_table_merge_slow_network')
+
+        active_session_id = self.main_pos_config.current_session_id.id
+        orders = self.env['pos.order'].search([('session_id', '=', active_session_id)])
+        cancelled_orders = orders.filtered(lambda o: o.state == 'cancel')
+
+        self.assertEqual(len(orders), 3, "There should be three orders created in the session.")
+        self.assertEqual(len(cancelled_orders), 1, "There should be one cancelled order in the session.")


### PR DESCRIPTION
Before this change, when transferring a command from one table to
another, the order was not saved correctly if the network was slow.

As we no longer wait for the command to be synchronized, the transfer of
the table was reset when the RPC call was not completed on time.

This leads to an error when the user is on the product screen of the new
table, as the order is not found due to the reset.

Details:
- Click transfer button leave the table and launch a SYNC RPC.
- Click to fast on another table to transfer the order will mount the
  product screen of the new table. Which will read the current state of
  the order. If the first RPC is not completed, the order state is still
  the old one, and the transfer is not done.