### PR TITLE
[FIX] l10n_din5008: fix report formatting with regular paper format

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -34,7 +34,9 @@
         <!-- New report layout for din5008 format -->
         <template id="external_layout_din5008">
             <div>
-                <div t-attf-class="header din_page o_company_#{company.id}_layout #{'din_page_pdf' if report_type == 'pdf' else ''}">
+                <t t-set="is_din_paperformat"
+                    t-value="company.paperformat_id in [env.ref('l10n_din5008.paperformat_euro_din_a', raise_if_not_found=False), env.ref('l10n_din5008.paperformat_euro_din', raise_if_not_found=False)]" />
+                <div t-attf-class="header din_page o_company_#{company.id}_layout #{'din_page_pdf' if report_type == 'pdf' and is_din_paperformat else ''}">
                     <table class="company_header table-borderless" t-att-style="'height: %dmm;' % (din_header_spacing or 27)">
                         <tr>
                             <td><div class="h3 mt0" t-field="company.report_header"/></td>
@@ -45,7 +47,7 @@
 
                 <t t-set="layout_background_url"
                     t-value="'data:image/png;base64,%s' % company.layout_background_image.decode('utf-8') if company.layout_background_image and company.layout_background == 'Custom' else '/base/static/img/bg_background_template.jpg' if company.layout_background == 'Geometric' else ''" />
-                <div t-attf-class="din_page invoice_note article o_company_#{company.id}_layout {{'o_report_layout_background' if company.layout_background in ['Geometric', 'Custom']  else  ''}} #{'din_page_pdf' if report_type == 'pdf' else ''}"
+                <div t-attf-class="din_page invoice_note article o_company_#{company.id}_layout {{'o_report_layout_background' if company.layout_background in ['Geometric', 'Custom']  else  ''}} #{'din_page_pdf' if report_type == 'pdf' and is_din_paperformat else ''}"
                      t-attf-style="{{ 'background-image: url(%s);' % layout_background_url if layout_background_url else '' }}"
                      t-att-data-oe-model="o and o._name"
                      t-att-data-oe-id="o and o.id">
@@ -128,7 +130,7 @@
                     <t t-out="0"/>
                 </div>
 
-                <div t-attf-class="din_page footer o_company_#{company.id}_layout #{'din_page_pdf' if report_type == 'pdf' else ''}">
+                <div t-attf-class="din_page footer o_company_#{company.id}_layout #{'din_page_pdf' if report_type == 'pdf' and is_din_paperformat else ''}">
                     <div class="text-end page_number">
                         <div class="text-muted">
                             Page: <span class="page"/> of <span class="topage"/>


### PR DESCRIPTION
Issue
-----
Reports printed using the DIN5008 layout but not the paper format have a big empty vertical band. The issue was reported for Return Slips but is common to all external documents.

![image](https://github.com/user-attachments/assets/c3311fc1-1e7f-4d3f-8f9a-6bddb8242dde)

Steps to reproduce
-----
- Go to Settings > Companies > Configure Document Layout
- Set the Layout to DIN 5008
- Set Paper format to A4 (anything except DIN5008)
- Download the PDF Preview

-> The printed pdf has an empty vertical band to the right of the document

Cause
-----
87b067a added a new `din_page_pdf` class that we apply when printing the pdf

https://github.com/odoo/odoo/blob/846c9746a601f52ddb768be4e4c7bfc21d6eeb23/addons/l10n_din5008/report/din5008_report.xml#L37

This forces a specific width to the contents

https://github.com/odoo/odoo/blob/846c9746a601f52ddb768be4e4c7bfc21d6eeb23/addons/l10n_din5008/static/src/scss/report_din5008.scss#L124-L127

This works with the DIN paper format because it applies adequate margins

https://github.com/odoo/odoo/blob/846c9746a601f52ddb768be4e4c7bfc21d6eeb23/addons/l10n_din5008/report/din5008_report.xml#L5-L18

For regular formats, we are better off with the default dynamic behaviour.

Visual comparison
-----
Left is before the fix, right is after the fix.
![image](https://github.com/user-attachments/assets/12d3fa71-bd41-4474-9e03-252902401539)

-----
Ticket:
opw-4660716
