### PR TITLE
[IMP] html_editor: improve link popover interface

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.xml
+++ b/addons/html_editor/static/src/main/link/link_popover.xml
@@ -24,7 +24,7 @@
                                 class="o_we_href_input_link border-dark-subtle form-control form-control-sm"
                                 t-model="state.url"
                                 title="URL"
-                                placeholder="Paste or type your URL"
+                                placeholder="e.g. https://www.odoo.com"
                                 t-on-keydown="onKeydownEnter"
                                 t-on-input="onChange"/>
                             <span class="ms-1" t-if="props.canUpload and !state.url">
@@ -86,8 +86,8 @@
                         </t>
                         <t t-if="props.allowTargetBlank">
                             <div class="d-flex mb-1 target-blank-option">
-                                <label class="me-1">Open link in a new window</label>
-                                <input type="checkbox" t-att-checked="state.linkTarget === '_blank'" t-on-change="(ev)=>this.state.linkTarget = ev.target.checked ? '_blank' : ''"/>
+                                <input class="me-1" type="checkbox" t-att-checked="state.linkTarget === '_blank'" t-on-change="(ev)=>this.state.linkTarget = ev.target.checked ? '_blank' : ''"/>
+                                <label>Open in new window</label>
                             </div>
                         </t>
                         <div class="mt-3">


### PR DESCRIPTION
This commit improves the UX of the edition of links in the editor.
The link edition menu can be accessed by clicking on a link in edit mode.

* The placeholder for the link input field has been improved to provide
  a clearer example of the expected URL format.
* The "Open link in a new window" checkbox has been modified with a more concise message and
  the checkbox positioned on the left for better visual consistency.