### PR TITLE
[IMP] web: /doc dynamic model documentation

### DIFF
--- a/addons/api_doc/__init__.py
+++ b/addons/api_doc/__init__.py
@@ -1,0 +1,2 @@
+from . import controllers
+from . import models

--- a/addons/api_doc/__manifest__.py
+++ b/addons/api_doc/__manifest__.py
@@ -1,0 +1,49 @@
+{
+    'name': 'API Documentation',
+    'category': 'Hidden',
+    'version': '1.0',
+    'description': """
+Odoo Dynamic API Documentation
+==============================
+
+This module provides a dynamic documentation page for developpers at the
+/doc URL. The documentation is generated using the database to lists the
+models and their fields and methods. It also provide a playground to run
+the methods over HTTP, with examples in various programming languages.
+""",
+    'depends': ['web'],
+    'auto_install': True,
+    'data': [
+        'security/res_groups.xml',
+        'views/docclient.xml',
+    ],
+    'assets': {
+        'api_doc.assets': [
+            # Libs
+            'web/static/src/libs/fontawesome/css/font-awesome.css',
+            'web/static/src/scss/fontawesome_overridden.scss',
+
+            # Core
+            'web/static/src/module_loader.js',
+            'web/static/lib/owl/owl.js',
+            'web/static/lib/owl/odoo_module.js',
+
+            # Utils
+            'web/static/src/core/utils/functions.js',
+            'web/static/src/core/utils/reactive.js',
+            'web/static/src/core/browser/browser.js',
+            'web/static/src/core/utils/timing.js',
+            'web/static/src/core/template_inheritance.js',
+            'web/static/src/core/templates.js',
+            'web/static/src/core/registry.js',
+            'web/static/src/session.js',
+            'web/static/src/core/assets.js',
+            'web/static/src/core/code_editor/**',
+
+            'api_doc/static/src/**/*',
+        ],
+    },
+    'bootstrap': True,
+    'author': 'Odoo S.A.',
+    'license': 'LGPL-3',
+}

--- a/addons/api_doc/controllers/__init__.py
+++ b/addons/api_doc/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import api_doc

--- a/addons/api_doc/controllers/api_doc.py
+++ b/addons/api_doc/controllers/api_doc.py
@@ -1,0 +1,640 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import inspect
+import io
+import json
+import logging
+import typing
+from http import HTTPStatus
+
+import docutils.core
+from werkzeug.exceptions import NotFound
+from werkzeug.http import is_resource_modified, parse_cache_control_header
+
+import odoo
+from odoo import http
+from odoo.exceptions import AccessError
+from odoo.http import request
+from odoo.modules.module_graph import ModuleGraph
+from odoo.service.model import get_public_method
+from odoo.tools import hmac, json_default, lazy_classproperty, py_to_js_locale
+
+logger = logging.getLogger(__name__)
+
+
+class DocController(http.Controller):
+    """
+    A single page application that provides an OpenAPI-like interface
+    feeded by a reflection of the registry (fields and methods) in JSON
+    documents.
+    """
+
+    @http.route(['/doc', '/doc/<model_name>', '/doc/index.html'], type='http', auth='user')
+    def doc_client(self, mod=None, **kwargs):
+        if not self.env.user.has_group('api_doc.group_allow_doc'):
+            raise AccessError(self.env._(
+                "This page is only accessible to %s users.",
+                self.env.ref('api_doc.group_allow_doc').sudo().name))
+        res = request.render('api_doc.docclient')
+        res.headers['X-Frame-Options'] = 'deny'
+        return res
+
+    @http.route('/doc/index.json', type='http', auth='user')
+    def doc_index(self):
+        """
+        Get a listing of all modules, models, methods and fields. But
+        only their technical name and translated "human" name.
+
+        It returns a json-serialized dictionnary with the following
+        structure:
+
+        .. code-block:: python
+            {
+                'modules': list[str],
+                'models': [
+                    {
+                        'model': str,
+                        'name': str,
+                        'fields': {
+                            name: {'string': str}
+                            for name in fields_get()
+                        },
+                        'methods': list[str],
+                    }
+                    for model in ...
+                ]
+            }
+        """
+        if not self.env.user.has_group('api_doc.group_allow_doc'):
+            raise AccessError(self.env._(
+                "This page is only accessible to %s users.",
+                self.env.ref('api_doc.group_allow_doc').sudo().name))
+
+        # Cache key
+        db_registry_sequence, _ = self.env.registry.get_sequences(self.env.cr)
+        unique = hmac(
+            self.env(su=True),
+            scope='/doc/index.json',
+            message=(
+                db_registry_sequence,
+                self.env.lang,
+                sorted(self.env.user.all_group_ids.ids),
+            ),
+        )
+
+        # Client cache
+        use_cache = not parse_cache_control_header(
+            request.httprequest.headers.get('Cache-Control')).no_cache
+        if use_cache and not is_resource_modified(request.httprequest.environ, etag=unique):
+            return request.make_response('', status=HTTPStatus.NOT_MODIFIED)
+
+        # Server cache, use an attachment and not ormcache because the
+        # index gets very large (>1MiB) when there are many modules
+        # installed.
+        # TODO: gzip
+        filename = f'odoo-doc-index-{db_registry_sequence}-{unique}.json'
+        index_attach = self.env['ir.attachment'].search([('name', '=', filename)], limit=1)
+        if not index_attach:
+            # No cache, generate the index and save it.
+            modules, models = self._doc_index()
+            index_attach = self.env['ir.attachment'].create({
+                'name': filename,
+                'description': (
+                    "Generated /doc/index.json document.\n\n"
+                    f"Sequence: {db_registry_sequence}\n"
+                    f"Lang: {self.env.lang}\n"
+                    f"Groups: {sorted(self.env.user.all_group_ids.ids)}"
+                ),
+                'mimetype': 'application/json; charset=utf-8',
+                'raw': json.dumps(
+                    {'modules': modules, 'models': models},
+                    ensure_ascii=False,
+                    default=json_default,
+                ),
+                'public': False,
+            })
+            logger.info("new index attachment: %s", filename)
+
+        response = index_attach._to_http_stream().get_response(etag=unique)
+        response.headers['Content-Language'] = py_to_js_locale(self.env.lang)
+        return response
+
+    def _doc_index(self):
+        modules = get_sorted_installed_modules(self.env)
+        models = [
+            {
+                'model': ir_model.model,
+                'name': ir_model.name,
+                'fields': {
+                    field.name: {'string': field.field_description}
+                    for field in ir_model.field_id
+                    # sorted(ir_model.field_id, key=partial(sort_key_field, modules, Model))
+                    if Model._has_field_access(Model._fields[field.name], 'read')
+                },
+                'methods': [
+                    method_name
+                    for method_name in dir(Model)
+                    if is_public_method(Model, method_name)
+                ],
+                # sorted(..., key=partial(sort_key_method, modules, type(Model))),
+            }
+            for ir_model in self.env['ir.model'].sudo().search([])
+            if (Model := self.env[ir_model.model]).has_access('read')
+        ]
+        return modules, models
+
+    @http.route('/doc/<model_name>.json', type='http', auth='user', readonly=True)
+    def doc_model(self, model_name):
+        """
+        Get a complete listing of all the methods and fields for a
+        specific model. The listing includes the htmlified docstring of
+        the model, an enriched fields_get(), the methods signature,
+        parameters and htmlified docstrings.
+
+        It returns a json-serialized dictionnary with the following
+        structure:
+
+        .. code-block:: python
+
+            {
+                'model': str,
+                'name': str,
+                'doc': str | None,
+                'fields': dict[str, dict],  # fields_get indexed by field name
+                'methods': dict[str, dict],  # _doc_method indexed by method name
+            }
+        """
+        if not self.env.user.has_group('api_doc.group_allow_doc'):
+            raise AccessError(self.env._(
+                "This page is only accessible to %s users.",
+                self.env.ref('api_doc.group_allow_doc').sudo().name))
+        if model_name not in self.env:
+            raise NotFound()
+
+        Model = self.env[model_name]
+        Model.check_access('read')
+        ir_model = self.env['ir.model']._get(model_name)
+
+        # Client cache
+        db_registry_sequence, _ = self.env.registry.get_sequences(self.env.cr)
+        unique = hmac(
+            self.env(su=True),
+            scope='/doc/<model_name>.json',
+            message=(
+                db_registry_sequence,
+                self.env.lang,
+                sorted(self.env.user.all_group_ids.ids),
+            ),
+        )
+        use_cache = not parse_cache_control_header(
+            request.httprequest.headers.get('Cache-Control')).no_cache
+        if use_cache and not is_resource_modified(request.httprequest.environ, etag=unique):
+            return request.make_response('', status=HTTPStatus.NOT_MODIFIED)
+
+        # No cache, generate the document and send it.
+        result = {
+            'model': model_name,
+            'name': ir_model.name,
+            'doc': None,  # TODO
+            'fields': {
+                field['name']: dict(
+                    field,
+                    module=next(iter(Model._fields[field['name']]._modules), None),
+                )
+                for field in Model.fields_get().values()
+            },
+            'methods': {
+                method_name: self._doc_method(Model, model_name, method, method_name)
+                for method_name in dir(Model)
+                if (method := is_public_method(Model, method_name))
+            },
+        }
+
+        response = request.make_json_response(result)
+        response.headers['ETag'] = unique
+        response.headers['Cache-Control'] = 'no-cache, private'  # no-chache != no-store
+        response.headers['Content-Language'] = py_to_js_locale(self.env.lang)
+        return response
+
+    def _doc_method(self, model, model_name, method, method_name):
+        """
+        Get the JSON reflection of a method.
+
+        It returns a dict with the following structure:
+
+        .. code-block:: python
+
+            {
+                'signature': str,
+                'parameters': {
+                    p.name: {
+                        'name': str,
+                        'kind': typing.Literal[
+                            'POSITIONAL_ONLY',
+                            'VAR_POSITIONAL',
+                            'KEYWORD_ONLY',
+                            'VAR_KEYWORD',
+                        ],
+                        'default': typing.Any,
+                        'annotation': str,
+                        'doc': str,
+                    }
+                    for p in function_parameters
+                },
+                'return': {
+                    'annotation': str,
+                    'doc': str,
+                },
+                'raise': dict[str, str],  # {exception name: doc}
+                'doc': str,
+                'api': list[str],
+                'model': str,
+                'module': str,
+            }
+
+        Of the above structure, only the entries ``signature``,
+        ``parameters``, ``model`` and ``module`` are garanteed to be
+        present. All other entries are optional and mean the information
+        is absent.
+
+        Inside the sub-dict for the parameters, only ``name`` is
+        guaranteed to be present. When ``kind`` is absent it means the
+        parameter is ``'POSITIONAL_OR_KEYWORD'``. When the other entries
+        are absent it means that the information is missing.
+        """
+
+        # find what module/model introduced the method, for grouping
+        introducing_class = next(
+            parent_class
+            for parent_class in reversed(type(model).mro())
+            if hasattr(parent_class, method_name)
+        )
+
+        signature = parse_signature(method)
+        return signature.as_dict() | {
+            'model': introducing_class._name or 'core',
+            'module': introducing_class._module or 'core',
+        }
+
+
+def get_sorted_installed_modules(env):
+    names = env['ir.module.module'].sudo().search([
+        ('state', '=', 'installed'),
+    ]).mapped('name')
+    graph = ModuleGraph(env.cr)
+    graph.extend(names)
+    return [p.name for p in graph]
+
+
+def is_public_method(model, name):
+    try:
+        return get_public_method(model, name)
+    except (AttributeError, AccessError):
+        return None
+
+
+DOC_API_MAGIC_COLUMNS = list(odoo.models.MAGIC_COLUMNS)
+DOC_API_MAGIC_COLUMNS.insert(1, 'display_name')
+def sort_key_field(sorted_module_list, model, field):  # noqa: E302
+    """
+    Key function to sort fields with the following order:
+
+    (1) core fields < (2) model fields < (3) custom ``x_`` fields
+
+    1. The core fields have a hardcoded order, like `id` is first.
+    2. The model fields are sorted first by *introducing module* (i.e.
+       base then web then website then ecommerce), and second by
+       alphabetical order.
+    3. The custom fields are sorted solely by alphabetical order.
+    """
+    if introducing_modules := model._fields[field['name']]._modules:
+        depth = sorted_module_list.index(introducing_modules[0])
+        return 2, depth, field['name']
+
+    if field['name'] in DOC_API_MAGIC_COLUMNS:
+        return 1, DOC_API_MAGIC_COLUMNS.index(field['name'])
+
+    assert field['name'].startswith('x_'), field['name']
+    return 3, field['name']
+
+
+def sort_key_method(sorted_module_list, model_cls, method_name):
+    """
+    Key function to sort fields by the following criteria:
+
+    1) Depth of the module that introduced the method in the dependency grap.
+    2) Alphabetical order.
+    """
+    introducing_class = next(
+        parent_class
+        for parent_class
+        in reversed(model_cls.mro())
+        if hasattr(parent_class, method_name)
+    )
+    if introducing_class._module:
+        depth = sorted_module_list.index(introducing_class._module)
+    else:
+        depth = -1
+    return depth, method_name
+
+
+def parse_signature(method) -> Signature:
+    isign = inspect.signature(method)
+
+    # strip self and cls from the signature
+    param_iter = iter(isign.parameters.values())
+    for param in param_iter:
+        if param.name in ('self', 'cls'):
+            isign = isign.replace(parameters=param_iter)
+        break
+
+    # replace BaseModel and such by list[int], see /json/2
+    return_type = str(isign.return_annotation).strip("'\"").rpartition('.')[2]
+    if return_type in ('Self', 'BaseModel', 'Model'):
+        isign = isign.replace(return_annotation='list[int]')
+
+    # parse the signature
+    parameters = {
+        param_name: Param.from_inspect(param)
+        for param_name, param in isign.parameters.items()
+    }
+    returns = Return.from_inspect(isign.return_annotation)
+
+    # accumate the decorators such as @api.model
+    api = []
+    if getattr(method, '_api_model', False):
+        api.append('model')
+    if getattr(method, '_readonly', False):
+        api.append('readonly')
+
+    signature = Signature(parameters, returns, api, raise_={}, doc=None)
+
+    # if the method has a docstring, use it to enhance the signature
+    if method.__doc__:
+        enhance_signature_using_docstring(signature, method)
+
+    return signature
+
+
+def enhance_signature_using_docstring(signature, method):
+    docstring = inspect.cleandoc(method.__doc__)
+    doctree = _DocUtils.tree(docstring)
+
+    # extract the ":param [annotation] <name>: text" and alike fields
+    # from the docstring
+    field_lists = [node for node in doctree if node.tagname == 'field_list']
+    for field_list in field_lists:
+        for field in field_list:
+            field_name, field_body = field.children
+            kind, _, name = str(field_name[0]).partition(' ')
+            match (RST_INFO_FIELDS.get(kind), name.strip()):
+                # unrecognized kind, e.g. var, meta, ...
+                case (None, _):
+                    pass
+                # :param <annotation> <name>: <rst>
+                case ('param', annotation_name) if ' ' in annotation_name:
+                    annotation, _, name = annotation_name.rpartition(' ')
+                    if param := signature.parameters.get(name.strip()):
+                        if not param.annotation:
+                            param.annotation = annotation.strip()
+                        param.doc = _DocUtils.html_firstchild(field_body)
+                # :param <name>: <rst>
+                case ('param', name):
+                    if param := signature.parameters.get(name):
+                        param.doc = _DocUtils.html_firstchild(field_body)
+                # :type <name>: <annotation>
+                case ('type', name):
+                    if (param := signature.parameters.get(name)) and not param.annotation:
+                        param.annotations = field_body.children[0].astext().strip()
+                # :returns: <rst>
+                case ('returns', ''):
+                    signature.return_.doc = _DocUtils.html_firstchild(field_body)
+                # :rtype: <annotation>
+                case ('rtype', ''):
+                    if not signature.return_.annotation:
+                        signature.return_.annotation = field_body.children[0].astext().strip()
+                # :raises <exception>: <rst>
+                case ('raises', exception):
+                    signature.raise_[exception] = _DocUtils.html_firstchild(field_body)
+                case _:
+                    logger.warning(RST_PARSE_ERROR.format(docstring, f"cannot parse {field_name[0]}"))
+        doctree.remove(field_list)
+
+    signature.doc = _DocUtils.html(doctree)
+
+
+RST_INFO_FIELDS = {
+    'param': 'param',
+    'parameter': 'param',
+    'arg': 'param',
+    'argument': 'param',
+    'key': 'param',
+    'keyword': 'param',
+
+    'type': 'type',
+
+    'raises': 'raises',
+    'raise': 'raises',
+    'except': 'raises',
+    'exception': 'raises',
+
+    'returns': 'returns',
+    'return': 'returns',
+
+    'rtype': 'rtype',
+}
+RST_PARSE_ERROR = '''\
+Unable to parse the docstring as reStructuredText.
+Want to help fix the docstrings? Check out the test_docstring linter!
+"""
+{}
+"""
+{}'''
+
+
+def stringify_annotation(annotation) -> str | None:
+    if annotation is inspect._empty:
+        return None
+    if isinstance(annotation, str):
+        return annotation
+    if isinstance(annotation, type):
+        return annotation.__name__
+    return str(annotation)
+
+
+@dataclasses.dataclass
+class Signature:
+    parameters: dict[str, Param]
+    return_: Return
+    api: list[str]
+    raise_: dict[str, str]
+    doc: str | None
+
+    def as_dict(self):
+        d = {
+            'signature': self.stringify(annotation=False),
+            'parameters': {
+                (p := param.as_dict()).pop('name'): p
+                for param in self.parameters.values()
+            },
+        }
+        if return_dict := self.return_.as_dict():
+            d['return'] = return_dict
+        if self.api:
+            d['api'] = self.api
+        if self.raise_:
+            d['raise'] = self.raise_
+        if self.doc is not None:
+            d['doc'] = self.doc
+        return d
+
+    def stringify(self, annotation=True, default=True, return_annotation=True):
+        out = ['(']
+        for name, param in self.parameters.items():
+            out.append(name)
+            if annotation and param.annotation:
+                out.append(f': {param.annotation}')
+                if default and param.default is not inspect._empty:
+                    out.append(f' = {param.default!r}')
+            elif default and param.default is not inspect._empty:
+                out.append(f'={param.default!r}')
+            out.append(', ')
+        if self.parameters:
+            out.pop()  # remove trailing ', '
+        out.append(')')
+        if return_annotation and self.return_.annotation:
+            out.append(f' -> {self.return_.annotation}')
+        return ''.join(out)
+
+
+@dataclasses.dataclass
+class Param:
+    name: str
+    kind: typing.Literal[
+        # def foo(pos_only, /, pos_or_kw, *var_pos, kw_only, **var_kw)
+        'POSITIONAL_ONLY',
+        'POSITIONAL_OR_KEYWORD',
+        'VAR_POSITIONAL',
+        'KEYWORD_ONLY',
+        'VAR_KEYWORD',
+    ]
+    default: typing.Any | inspect._empty
+    annotation: str | None
+    doc: str | None
+
+    @classmethod
+    def from_inspect(cls, parameter):
+        return cls(
+            name=parameter.name,
+            kind=parameter.kind.name,
+            default=parameter.default,
+            annotation=stringify_annotation(parameter.annotation),
+            doc=None,
+        )
+
+    def as_dict(self):
+        d = dict(vars(self))
+        if self.kind == 'POSITIONAL_OR_KEYWORD':
+            # most (99%) params are POSITIONAL_OR_KEYWORD
+            # make the export smaller by ignoring those
+            d.pop('kind')
+        if self.annotation is None:
+            d.pop('annotation')
+        if self.doc is None:
+            d.pop('doc')
+        if self.default is inspect._empty:
+            d.pop('default')
+        else:
+            # ignore the default value when it is not json serializable
+            try:
+                json.dumps(self.default)
+            except ValueError:
+                d.pop('default')
+        return d
+
+
+@dataclasses.dataclass
+class Return:
+    annotation: str | None
+    doc: str | None
+
+    @classmethod
+    def from_inspect(cls, return_annotation):
+        return cls(stringify_annotation(return_annotation), doc=None)
+
+    def as_dict(self):
+        d = dict(vars(self))
+        if self.annotation is None:
+            d.pop('annotation')
+        if self.doc is None:
+            d.pop('doc')
+        return d
+
+
+# This class could had been a python module, but lazy_classproperty
+# works much better than odoo.tools.lazy.
+class _DocUtils:
+    """ Helpers for docutils """
+    @lazy_classproperty
+    def _new_docutils_root(cls):
+        # surely there's a better way, but that'll do
+        return docutils.core.publish_doctree("").copy
+
+    @classmethod
+    def _make_settings(cls, writer_name, settings_overrides):
+        pub = docutils.core.Publisher()
+        pub.set_components('standalone', 'restructuredtext', writer_name)
+        pub.process_programmatic_settings(None, settings_overrides, None)
+        return pub.settings
+
+    @lazy_classproperty
+    def _settings_pseudoxml(cls):
+        return cls._make_settings('pseudoxml', {
+            'report_level': 3,
+            'halt_level': 5,
+            'raw_enabled': False,
+            'file_insertion_enabled': False,
+        })
+
+    @lazy_classproperty
+    def _settings_html(cls):
+        return cls._make_settings('html', {
+            'report_level': 3,
+            'halt_level': 5,
+            'embed_stylesheet': False,
+            'raw_enabled': False,
+            'file_insertion_enabled': False,
+        })
+
+    @classmethod
+    def tree(cls, docstring):
+        with contextlib.redirect_stderr(io.StringIO()) as stderr:
+            doctree = docutils.core.publish_doctree(
+                docstring,
+                settings=cls._settings_pseudoxml,
+            )
+            if stderr.tell():
+                logger.warning(RST_PARSE_ERROR.format(docstring, stderr.getvalue()))
+            return doctree
+
+    @classmethod
+    def html(cls, tree):
+        root = cls._new_docutils_root()
+        root.append(tree)
+        html = docutils.core.publish_from_doctree(
+            root,
+            writer_name='html',
+            settings=cls._settings_html,
+        )
+        head = b'\n</head>\n<body>\n<div class="document">'
+        tail = b'</div>\n</body>\n</html>\n'
+        return html.partition(head)[2].removesuffix(tail).strip().decode()
+
+    @classmethod
+    def html_firstchild(cls, tree):
+        if not tree.children:
+            return ''
+        return cls.html(tree.children[0])

--- a/addons/api_doc/models/__init__.py
+++ b/addons/api_doc/models/__init__.py
@@ -1,0 +1,1 @@
+from . import ir_attachment

--- a/addons/api_doc/models/ir_attachment.py
+++ b/addons/api_doc/models/ir_attachment.py
@@ -1,0 +1,23 @@
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class IrAttachment(models.Model):
+    _inherit = 'ir.attachment'
+
+    @api.autovacuum
+    def _gc_doc_index(self):
+        """ Garbage collect the outdated /doc/index.json attachments. """
+        sequence = str(self.env.registry.get_sequences(self.env.cr)[0])
+        attachments = self.search_fetch(
+            [('name', 'like', R'odoo-doc-index-%-%.json')],
+            ['name'],
+        ).filtered(
+            lambda doc: doc.name.split('-')[3] != sequence,
+        )
+        if attachments:
+            attachments.unlink()
+        _logger.info("GC'd %s /doc cached index", len(attachments))

--- a/addons/api_doc/security/res_groups.xml
+++ b/addons/api_doc/security/res_groups.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<odoo>
+    <data>
+        <record model="res.groups" id="group_allow_doc">
+            <field name="name">Technical Documentation</field>
+            <field name="user_ids" eval="[Command.link(ref('base.user_root'))]"/>
+            <field name="implied_by_ids" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+    </data>
+</odoo>

--- a/addons/api_doc/static/src/components/doc_loading_indicator.js
+++ b/addons/api_doc/static/src/components/doc_loading_indicator.js
@@ -1,0 +1,23 @@
+import { Component, xml } from "@odoo/owl";
+
+export class DocLoadingIndicator extends Component {
+    static template = xml`
+        <div t-if="!props.isLoaded" class="o-doc-load-wrapper o-fade-in position-relative h-100 w-100 bg-2 rounded">
+            <div class="o-doc-load-activity position-absolute h-100"></div>
+        </div>
+        <div t-else="" t-att-class="props.class">
+            <t t-slot="default"/>
+        </div>
+    `;
+
+    static components = {};
+    static props = {
+        isLoaded: { type: Boolean },
+        class: { type: String, optional: true },
+        slots: true,
+    };
+
+    static defaultProps = {
+        class: "",
+    };
+}

--- a/addons/api_doc/static/src/components/doc_method.js
+++ b/addons/api_doc/static/src/components/doc_method.js
@@ -1,0 +1,81 @@
+import { Component, useState } from "@odoo/owl";
+import { DocRequest } from "@api_doc/components/doc_request";
+import { DocTable, TABLE_TYPES } from "@api_doc/components/doc_table";
+import { getParameterDefaultValue } from "@api_doc/utils/doc_model_utils";
+import { useDocUI } from "@api_doc/utils/doc_ui_store";
+
+export class DocMethod extends Component {
+    static template = "web.DocMethod";
+    static components = {
+        DocRequest,
+        DocTable,
+    };
+    static props = {
+        method: Object,
+        class: String,
+    };
+
+    setup() {
+        this.ui = useDocUI();
+        this.state = useState({ open: true });
+        this.parametersData = {
+            headers: ["Name", "Type", "Default Value", "Description"],
+            items: Object.entries(this.method.parameters).map(([name, options]) => [
+                { type: TABLE_TYPES.Code, value: name },
+                {
+                    type: TABLE_TYPES.Code,
+                    value: "annotation" in options ? options.annotation : "-",
+                },
+                { type: TABLE_TYPES.Code, value: this.getDefaultValue(options) },
+                { type: TABLE_TYPES.Tooltip, value: options.doc || "" },
+            ]),
+        };
+    }
+
+    get method() {
+        return this.props.method;
+    }
+
+    get parameters() {
+        return this.method.parameters.filter((a) => a !== "self");
+    }
+
+    get doc() {
+        return this.method.doc;
+    }
+
+    get isVertical() {
+        return this.ui.size < 1400;
+    }
+
+    getDefaultValue(param) {
+        if ("default" in param) {
+            return typeof param.default === "string" ? `"${param.default}"` : param.default;
+        } else {
+            return "-";
+        }
+    }
+
+    get request() {
+        if (this.method.request) {
+            return this.method.request;
+        }
+
+        const request = {
+            ids: [],
+            kwargs: {},
+            context: {},
+        };
+
+        if (this.method.api) {
+            delete request.ids;
+        }
+
+        for (const paramName in this.method.parameters) {
+            const param = this.method.parameters[paramName];
+            request.kwargs[paramName] = getParameterDefaultValue(paramName, param);
+        }
+
+        return request;
+    }
+}

--- a/addons/api_doc/static/src/components/doc_method.xml
+++ b/addons/api_doc/static/src/components/doc_method.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocMethod">
+    <article class="o-doc-method mb-2 rounded" t-att-class="props.class" t-att-id="this.method.name">
+        <div
+            class="o-doc-method-header position-sticky flex w-100 align-items-center justify-content-between cursor-pointer rounded bg-1"
+            t-on-click="() => this.state.open = !this.state.open"
+            t-att-class="{ ['border-bottom']: this.state.open, o_collapsed: !this.state.open }"
+            role="button"
+        >
+            <div class="icon-btn" role="button" t-att-class="{ o_collapsed: !this.state.open }">
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+            </div>
+            <h4 class="flex-grow ms-1" t-out="this.method.name"></h4>
+            <div class="ms-1 text-muted" t-out="this.method.module"></div>
+        </div>
+
+        <div
+            t-if="state.open"
+            class="o-doc-method-content p-3 bg-1 flex"
+            t-att-class="{ 'flex-column': isVertical }"
+        >
+            <div t-att-class="{ 'w-100': isVertical, 'w-50 pe-2': !isVertical }">
+                <h4>Route</h4>
+                <pre t-out="this.method.url"/>
+
+                <t t-if="doc">
+                    <h4 class="mt-2">Description</h4>
+                    <p class="doc_method_description mb-2" t-out="doc"></p>
+                </t>
+
+                <t t-if="method.signature">
+                    <h4 class="mt-2">Signature</h4>
+                    <pre t-out="method.signature"/>
+                </t>
+
+                <h4 class="mt-2">Parameters</h4>
+                <DocTable
+                    t-if="parametersData.items.length > 0"
+                    data="parametersData"
+                />
+                <div class="text-muted" t-else="">There's no parameters for this method</div>
+            </div>
+            <div t-att-class="{ 'w-100 pt-2 mt-2 border-top': isVertical, 'w-50 ps-2 border-start': !isVertical }">
+                <DocRequest
+                    url="method.url"
+                    request="request"
+                    method="method"
+                />
+            </div>
+        </div>
+    </article>
+</t>
+</templates>

--- a/addons/api_doc/static/src/components/doc_modal_api_key.js
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.js
@@ -1,0 +1,33 @@
+import { Component, useExternalListener, useRef } from "@odoo/owl";
+
+export class ApiKeyModal extends Component {
+    static template = "web.DocApiKeyModal";
+
+    static components = {};
+    static props = {};
+
+    setup() {
+        this.modalRef = useRef("modalRef");
+
+        useExternalListener(window, "keydown", (event) => {
+            if (event.key === "Escape") {
+                this.cancel();
+            }
+        });
+
+        useExternalListener(window, "click", (event) => {
+            if (!this.modalRef.el.contains(event.target)) {
+                this.cancel();
+            }
+        });
+    }
+
+    save() {
+        this.env.modelStore.setAPIKey(this.modalRef.el.querySelector(":scope input").value.trim());
+        this.env.modelStore.showApiKeyModal = false;
+    }
+
+    cancel() {
+        this.env.modelStore.showApiKeyModal = false;
+    }
+}

--- a/addons/api_doc/static/src/components/doc_modal_api_key.xml
+++ b/addons/api_doc/static/src/components/doc_modal_api_key.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocApiKeyModal">
+    <div class="modal-bg flex justify-content-center align-items-center">
+        <div class="modal p-2 flex flex-column mb-1" t-ref="modalRef">
+            <h2 class="mb-2">API key</h2>
+
+            <p>To try the API, please insert your API key here</p>
+            <input
+                class="mt-1"
+                type="text"
+                autocorrect="off"
+            />
+
+            <div class="flex flex-content-between mt-3">
+                <button class="btn me-1" t-on-click="save">Save</button>
+                <button class="btn" t-on-click="cancel">Cancel</button>
+            </div>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/components/doc_modal_search.js
+++ b/addons/api_doc/static/src/components/doc_modal_search.js
@@ -1,0 +1,87 @@
+import { Component, useRef, onMounted, useExternalListener, useState } from "@odoo/owl";
+import { useDebounced } from "@web/core/utils/timing";
+import { search } from "@api_doc/utils/doc_model_search";
+
+export class SearchModal extends Component {
+    static template = "web.DocSearchModal";
+
+    static components = {};
+    static props = {
+        close: { type: Function },
+    };
+
+    setup() {
+        this.seachRef = useRef("seachRef");
+        this.modalRef = useRef("modalRef");
+        this.scrollRef = useRef("scrollRef");
+
+        this.results = [];
+        this.itemHeight = 45;
+        this.itemMargin = 10;
+
+        this.state = useState({
+            resultCount: 0,
+            results: [],
+            activeFilters: {
+                models: true,
+                methods: true,
+                fields: true,
+            },
+        });
+
+        this.search = useDebounced((query) => {
+            this.results = search(this.env.modelStore.models, query, this.state.activeFilters);
+            this.state.resultCount = this.results.length;
+            this.scrollRef.el.scrollTop = 0;
+            this.onScroll(this.scrollRef.el);
+        }, 300);
+
+        useExternalListener(window, "keydown", (event) => {
+            if (event.key === "Escape") {
+                this.props.close();
+            }
+        });
+
+        useExternalListener(window, "click", (event) => {
+            if (!this.modalRef.el.contains(event.target)) {
+                this.props.close();
+            }
+        });
+
+        onMounted(() => {
+            this.seachRef.el.focus();
+        });
+    }
+
+    onInput(event) {
+        if (event.target.value.trim()) {
+            this.search(event.target.value.trim());
+        }
+    }
+
+    onSelect(result) {
+        this.env.modelStore.setActiveModel(result);
+        this.props.close();
+    }
+
+    onFilterClick(filter) {
+        this.state.activeFilters[filter] = !this.state.activeFilters[filter];
+        this.search(this.seachRef.el.value.trim());
+    }
+
+    onScroll(container) {
+        const rowHeight = this.itemHeight + this.itemMargin;
+        const nodePadding = 10;
+
+        let startIndex = Math.floor(container.scrollTop / rowHeight) - nodePadding;
+        startIndex = Math.max(0, startIndex);
+
+        const viewportHeight = container.getBoundingClientRect().height;
+        let visibleCount = Math.ceil(viewportHeight / rowHeight) + 2 * nodePadding;
+        visibleCount = Math.min(this.results.length - startIndex, visibleCount);
+
+        this.state.scrollHeight = this.results.length * rowHeight;
+        this.state.scrollOffsetY = startIndex * rowHeight;
+        this.state.results = this.results.slice(startIndex, startIndex + visibleCount);
+    }
+}

--- a/addons/api_doc/static/src/components/doc_modal_search.xml
+++ b/addons/api_doc/static/src/components/doc_modal_search.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocSearchModal">
+    <div class="modal-bg flex justify-content-center align-items-center">
+        <div class="modal p-2 flex flex-column mb-1" style="height: 40rem; width: 40rem" t-ref="modalRef">
+            <input
+                class="mb-1"
+                type="text"
+                autocorrect="off"
+                placeholder="Find anything..."
+                t-on-input="onInput"
+                t-ref="seachRef"
+            />
+
+            <div class="flex gap-1 mb-1 align-items-center">
+                <div
+                    t-foreach="state.activeFilters"
+                    t-as="filter"
+                    t-key="filter"
+                    class="flex align-items-center cursor-pointer btn"
+                    t-on-click="() => this.onFilterClick(filter)"
+                >
+                    <input class="me-1" type="checkbox" t-att-id="filter" t-att-checked="state.activeFilters[filter]"/>
+                    <label class="text-ellipsis" t-att-for="filter" t-out="filter" t-on-click.prevent=""></label>
+                </div>
+                <div class="text-muted me-1">
+                    <t t-out="this.state.resultCount"/>
+                    results
+                </div>
+            </div>
+
+            <div class="flex flex-column w-100 overflow-auto flex-grow" t-ref="scrollRef" t-on-scroll="(ev) => this.onScroll(ev.target)">
+                <div class="overflow-hidden" t-att-style="`min-height: ${this.state.scrollHeight}px`">
+                    <div t-att-style="`transform: translateY(${this.state.scrollOffsetY}px)`">
+                        <button
+                            t-foreach="state.results"
+                            t-as="result"
+                            t-key="result_index + result.type + '/' + result.label + '/' + result.path"
+                            class="btn mb-1 text-start w-100 flex flex-row"
+                            t-on-click="() => this.onSelect(result)"
+                            t-att-style="`min-height: ${itemHeight}px; max-height: ${itemHeight}px; margin-bottom: ${itemMargin}px`"
+                        >
+                            <div class="h-100 flex-grow">
+                                <h4 t-out="result.label" class="text-ellipsis"></h4>
+                                <div class="text-muted text-ellipsis" t-out="result.path"></div>
+                            </div>
+                            <span class="text-muted h-100" t-out="result.type"></span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/components/doc_model.js
+++ b/addons/api_doc/static/src/components/doc_model.js
@@ -1,0 +1,283 @@
+import { Component, useState, useEffect, onPatched } from "@odoo/owl";
+import { DocTable, TABLE_TYPES } from "@api_doc/components/doc_table";
+import { getCrudMethodsExamples } from "@api_doc/utils/doc_model_utils";
+import { DocMethod } from "@api_doc/components/doc_method";
+import { DocLoadingIndicator } from "@api_doc/components/doc_loading_indicator";
+import { useDocUI } from "@api_doc/utils/doc_ui_store";
+
+const TYPE_COLORS = {
+    "text-green": ["integer", "char", "boolean", "selection", "float"],
+    "text-blue": ["html", "datetime", "date", "binary"],
+    "text-orange": ["many2one", "many2many", "one2many", "many2one_reference"],
+};
+
+function getTypeColor(type) {
+    for (const key in TYPE_COLORS) {
+        if (TYPE_COLORS[key].includes(type)) {
+            return key;
+        }
+    }
+}
+
+function getTypeData(fieldData) {
+    const data = {
+        type: TABLE_TYPES.Code,
+        value: fieldData.type,
+        class: getTypeColor(fieldData.type),
+    };
+
+    if (fieldData.type === "selection") {
+        data.subData = {
+            headers: ["Value", "Label"],
+            items: fieldData.selection,
+        };
+    }
+
+    if (fieldData.relation) {
+        data.relation = fieldData.relation;
+    }
+
+    return data;
+};
+
+export class DocModel extends Component {
+    static template = "web.DocModel";
+    static components = {
+        DocTable,
+        DocMethod,
+        DocLoadingIndicator,
+    };
+    static props = {};
+
+    setup() {
+        this.state = useState({
+            model: undefined,
+            modelData: { items: [] },
+            crudMethods: [],
+            methods: [],
+            fields: { data: { items: [] }},
+            modules: [],
+            activeModules: {
+                core: true,
+                base: false,
+            },
+            showModulesFilter: true,
+        });
+
+        this.ui = useDocUI();
+        this.modelStore = useState(this.env.modelStore);
+        this.update();
+
+        useEffect(
+            () => {
+                this.update();
+            },
+            () => [
+                this.modelStore.activeModel,
+                this.modelStore.activeMethod,
+                this.modelStore.activeField,
+            ],
+        );
+
+        let lastFocusedElement = null
+        onPatched(
+            () => {
+                let el = null;
+                if (this.modelStore.activeMethod) {
+                    el = document.getElementById(this.modelStore.activeMethod);
+                }
+                if (this.modelStore.activeField) {
+                    el = document.getElementById(this.modelStore.activeField);
+                }
+                if (el && el != lastFocusedElement) {
+                    lastFocusedElement = el;
+                    el.scrollIntoView({ behavior: "smooth" });
+                }
+            }
+        );
+    }
+
+    get modelName() {
+        return this.state.model?.name ?? "";
+    }
+
+    async update() {
+        if (!this.state.model || this.state.model.model !== this.modelStore.activeModel.model) {
+            this.updateModel(this.modelStore.activeModel);
+        }
+
+        this.updateActives();
+    }
+
+    updateModel(model) {
+        const modelId = model.model;
+
+        this.state.model = {
+            model: modelId,
+            name: model.name,
+            doc: "",
+            fields: null,
+            error: null,
+        };
+        this.state.modelData = { items: [] };
+        this.state.methods = [];
+        this.state.modules = [];
+
+        this.modelStore.loadModel(modelId)
+            .then((model) => {
+                if (this.state.model.model !== model.model) {
+                    return;
+                }
+
+                this.state.model = model;
+                this.state.modelData = {
+                    items: [
+                        ["Model Name", { type: "code", value: model.model }],
+                        ...(model.doc ? [["Description", model.doc]] : []),
+                    ]
+                };
+
+                this.updateModules();
+                this.updateMethods();
+                this.updateFields();
+
+                const crudExamples = getCrudMethodsExamples(model);
+                for (const method of this.state.methods) {
+                    if (method.name in crudExamples) {
+                        method.request = crudExamples[method.name].request;
+                        method.responseCode = crudExamples[method.name].responseCode;
+                    }
+                }
+                this.updateActives();
+            })
+            .catch((error) => {
+                console.error(error);
+                this.state.error = error;
+            });
+    }
+
+    isModuleActive(module) {
+        return !module || this.state.activeModules[module];
+    }
+
+    updateModules() {
+        const model = this.state.model;
+        let modules = new Set();
+        Object.values(model.fields).forEach((f) => f.module && modules.add(f.module));
+        Object.values(model.methods).forEach((m) => m.module && modules.add(m.module));
+
+        modules = [...modules];
+        modules.sort((a, b) => (a === "core" ? -1 : b === "core" ? 1 : a.localeCompare(b)));
+        this.state.modules = modules;
+    }
+
+    updateMethods() {
+        const model = this.state.model;
+        const methods = [];
+
+        for (const methodName in model.methods) {
+            const method = model.methods[methodName];
+            methods.push({
+                name: methodName,
+                module: method.module,
+                api: method.api,
+                doc: method.doc,
+                model: model.model,
+                signature: `def ${methodName}${method.signature}`,
+                parameters: method.parameters,
+                url: `/json/2/${model.model}/${methodName}`,
+            });
+        }
+
+        const crudOrder = ["search_read", "search", "read", "create", "write", "unlink"];
+        methods.sort((a, b) => {
+            const aIndex = crudOrder.indexOf(a.name);
+            const bIndex = crudOrder.indexOf(b.name);
+            if (aIndex >= 0 && bIndex >= 0) {
+                return aIndex - bIndex;
+            } else if (aIndex >= 0) {
+                return -1;
+            } else if (bIndex >= 0) {
+                return 1;
+            }
+            return a.name.localeCompare(b.name)
+        });
+        this.state.methods = methods;
+    }
+
+    updateFields() {
+        const model = this.state.model;
+        let fields = [];
+        let activeIndex = -1;
+
+        if (model && model.fields) {
+            fields = Object.values(model.fields);
+        }
+
+        fields = fields
+            .filter((fieldData) => this.isModuleActive(fieldData.module))
+            .map((fieldData, index) => {
+                if (fieldData.name === this.modelStore.activeField) {
+                    activeIndex = index
+                }
+                return [
+                    { type: TABLE_TYPES.Code, value: fieldData.name },
+                    getTypeData(fieldData),
+                    fieldData.string,
+                    {
+                        type: TABLE_TYPES.Code,
+                        value: fieldData.required ? "required" : "optional",
+                        class: fieldData.required ? "text-red" : "text-muted",
+                    },
+                    {
+                        type: TABLE_TYPES.Tooltip,
+                        value: fieldData.help,
+                    },
+                    {
+                        type: TABLE_TYPES.Code,
+                        value: fieldData.module || "",
+                    },
+                    {
+                        type: TABLE_TYPES.Id,
+                        value: fieldData.name,
+                    },
+                ]
+            });
+
+        fields.sort((a, b) => a[0].value.localeCompare(b[0].value));
+
+        this.state.fields = {
+            activeIndex,
+            data: {
+                headers: ["Name", "Type", "Description", "Required", "Help", "Module"],
+                items: fields,
+            },
+        };
+    }
+
+    async updateActives() {
+        const method = this.state.model.methods?.[this.modelStore.activeMethod];
+        const activeModules = [];
+        if (method) {
+            activeModules.push(method.module);
+        }
+
+        const fieldData = this.state.model.fields?.[this.modelStore.activeField];
+        if (fieldData) {
+            activeModules.push(fieldData.module);
+        }
+
+        this.setActiveModules(activeModules, true);
+    }
+
+    setActiveModules(modules, active) {
+        for (const module of modules) {
+            this.state.activeModules[module] = active;
+        }
+        this.updateFields();
+    }
+
+    toggleAllModules(select) {
+        this.setActiveModules(this.state.modules, select);
+    }
+}

--- a/addons/api_doc/static/src/components/doc_model.xml
+++ b/addons/api_doc/static/src/components/doc_model.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocModel">
+    <div t-if="!state.error" class="o-doc-model position-relative flex flex-basis flex-column p-3">
+        <h1 class="w-100 mb-1 mt-2" t-out="this.state.model?.name ?? ''"></h1>
+        <DocTable data="state.modelData"/>
+
+        <h2 class="mt-3 mb-1" id="fields">Fields</h2>
+        <DocLoadingIndicator
+            isLoaded="this.state.model and this.state.model.fields != null and this.state.fields.data"
+            class="'o-fade-in'"
+        >
+            <DocTable data="this.state.fields.data" activeIndex="this.state.fields.activeIndex"/>
+        </DocLoadingIndicator>
+
+        <h2 class="mt-3 mb-1" id="methods">Methods</h2>
+        <DocLoadingIndicator
+            isLoaded="this.state.methods and this.state.methods.length > 0"
+            class="'o-fade-in position-relative'"
+        >
+            <DocMethod
+                t-foreach="state.methods"
+                t-as="method"
+                t-key="method.model + '/' + method.name"
+                t-if="isModuleActive(method.module)"
+                method="method"
+                class="modelStore.activeMethod === method.name ? 'o-doc-active' : ''"
+            />
+        </DocLoadingIndicator>
+        <div style="min-height: 30vh"/>
+    </div>
+
+    <aside t-if="!ui.isSmall and !state.error" class="o-doc-model-aside overflow-auto position-sticky block flex-basis bg-default pt-2 pb-2 ps-3 pe-3 border-start">
+        <div
+            class="flex w-100 cursor-pointer capitalize align-items-center"
+            t-on-click="() => this.state.showModulesFilter = !this.state.showModulesFilter"
+            role="button"
+        >
+            <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: !state.showModulesFilter}">
+                <i class="fa fa-angle-right" aria-hidden="true"></i>
+            </div>
+            <h2 class="ms-1">Modules</h2>
+        </div>
+        <t t-if="this.state.showModulesFilter">
+            <span>
+                <a class="me-1" href="#" t-on-click="() => this.toggleAllModules(true)">
+                    Select all
+                </a>
+                <a href="#" t-on-click="() => this.toggleAllModules(false)">
+                    Deselect all
+                </a>
+            </span>
+            <div
+                t-foreach="state.modules"
+                t-as="module"
+                t-key="module"
+                class="flex align-items-center mb-1 cursor-pointer btn"
+                t-on-click="() => this.setActiveModules([module], !this.state.activeModules[module])"
+            >
+                <input class="me-1" type="checkbox" t-att-id="module" t-att-checked="state.activeModules[module]"/>
+                <label class="text-ellipsis" t-att-for="module" t-out="module" t-on-click.prevent=""></label>
+            </div>
+        </t>
+
+        <h2>On This Page</h2>
+        <a
+            t-foreach="state.methods"
+            t-as="method"
+            t-key="method.model + '/' + method.name"
+            t-out="method.name"
+            t-if="isModuleActive(method.module)"
+            t-att-href="'#' + method.name"
+            class="block w-100 text-ellipsis"
+        >
+        </a>
+    </aside>
+
+    <div t-if="state.error" class="flex align-items-center justify-content-center w-100 h-100">
+        <div class="alert error mt-1 flex flex-column">
+            <h5 class="mb-2 flex align-items-center">
+                <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
+                <span>Error while loading model</span>
+            </h5>
+            <div t-out="state.error.message"></div>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/components/doc_request.js
+++ b/addons/api_doc/static/src/components/doc_request.js
@@ -1,0 +1,79 @@
+import { Component, useState } from "@odoo/owl";
+import { LANGUAGES, createRequestCode } from "@api_doc/utils/doc_code_gen";
+import { CodeEditor } from "@web/core/code_editor/code_editor";
+
+class CopyableCodeEditor extends CodeEditor {
+    static template = "web.DocRequest.CodeEditor";
+
+    copyToClipboard() {
+        navigator?.clipboard?.writeText(this.aceEditor.getValue());
+        this.state.copied = true;
+        setTimeout(() => {
+            this.state.copied = false;
+        }, 1000);
+    }
+}
+
+export class DocRequest extends Component {
+    static template = "web.DocRequest";
+
+    static components = {
+        CodeEditor: CopyableCodeEditor,
+    };
+    static props = {
+        url: String,
+        request: { optional: true },
+        method: { type: String, optional: true },
+    };
+    static defaultProps = {
+        httpMethod: "POST",
+    };
+
+    setup() {
+        this.maxLines = Infinity;
+        this.LANGUAGES = LANGUAGES;
+        this.state = useState({
+            exampleLanguage: LANGUAGES.json,
+            exampleCode: "",
+            requestCode: this.createRequestCode(LANGUAGES.json),
+            response: {},
+            requestTab: 0,
+        });
+        this.selectLanguage(localStorage.getItem("doc/code-lang") || LANGUAGES.json);
+    }
+
+    selectLanguage(language) {
+        localStorage.setItem("doc/code-lang", language);
+        this.state.exampleLanguage = language;
+        this.state.exampleCode = this.createRequestCode(language);
+    }
+
+    createRequestCode(language) {
+        return createRequestCode({
+            language,
+            url: window.location.origin + this.props.url,
+            apiKey: this.env.modelStore.apiKey,
+            requestObj: this.props.request,
+        });
+    }
+
+    get responseText() {
+        const response = this.state.response;
+        return response.error || response.body;
+    }
+
+    get hasResponse() {
+        return this.state.response.error || this.state.response.body;
+    }
+
+    async execute() {
+        this.state.response = {};
+        const result = await this.env.modelStore.executeRequest(
+            this.props.url,
+            this.state.requestCode
+        );
+        if (result) {
+            this.state.response = result;
+        }
+    }
+}

--- a/addons/api_doc/static/src/components/doc_request.xml
+++ b/addons/api_doc/static/src/components/doc_request.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocRequest">
+    <div class="o_doc_request h-100">
+        <div class="flex justify-content-between align-items-center mb-1">
+            <h3>Request</h3>
+            <div class="flex">
+                <select class="me-1" t-on-change="event => this.selectLanguage(event.target.value)">
+                    <option
+                        t-foreach="LANGUAGES"
+                        t-as="lang"
+                        t-key="lang"
+                        t-att-selected="state.exampleLanguage === lang"
+                        t-att-value="lang"
+                        t-out="lang"
+                    />
+                </select>
+                <button
+                    class="btn primary flex align-items-center"
+                    t-on-click="execute"
+                    t-att-disabled="state.exampleLanguage !== 'json'"
+                >
+                    <span>Run</span>
+                    <i class="fa fa-play ms-1" aria-hidden="true"></i>
+                </button>
+            </div>
+        </div>
+
+        <CodeEditor
+            mode="LANGUAGES[state.exampleLanguage]"
+            value="state.exampleLanguage === 'json' ? state.requestCode : state.exampleCode"
+            readonly="state.exampleLanguage !== 'json'"
+            onChange="value => this.state.requestCode = value"
+            maxLines="maxLines"
+            theme="'monokai'"
+            showLineNumbers="false"
+        />
+
+        <div class="mt-2 flex align-items-center mb-1">
+            <h3>Response</h3>
+            <span t-if="hasResponse and !state.response.error" class="badge success ms-1">Success</span>
+            <span t-if="hasResponse and state.response.error" class="badge error ms-1">Failed</span>
+        </div>
+
+        <t t-if="hasResponse">
+            <CodeEditor
+                t-if="!state.response.error"
+                mode="'json'"
+                value="state.response.body"
+                readonly="true"
+                maxLines="maxLines"
+                theme="'monokai'"
+                showLineNumbers="false"
+            />
+            <div t-else="" class="alert error mt-1flex flex-column">
+                <h5 class="mb-2 flex align-items-center">
+                    <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
+                    <span>Error <t t-out="state.response.status"/> while executing request</span>
+                </h5>
+                <div>
+                    <div t-out="responseText"></div>
+                </div>
+            </div>
+        </t>
+        <p t-else="" class="text-muted">Run to get a response</p>
+    </div>
+</t>
+
+<t t-name="web.DocRequest.CodeEditor">
+    <div class="o-doc-code-editor position-relative p-2 rounded w-100">
+        <t t-call="web.CodeEditor"></t>
+        <button
+            class="position-absolute p-1 top-0 end-0 d-flex align-items-center cursor-pointer"
+            t-on-click="copyToClipboard"
+            type="button"
+        >
+            <i t-if="!state.copied" class="fa fa-clipboard fs-6 text-light"/>
+            <span t-else="" class="fs-6 text-light">Copied!</span>
+        </button>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/components/doc_sidebar.js
+++ b/addons/api_doc/static/src/components/doc_sidebar.js
@@ -1,0 +1,73 @@
+import { Component, useEffect, useRef, useState } from "@odoo/owl";
+import { simplifyString } from "@api_doc/utils/doc_model_search";
+
+export class DocSidebar extends Component {
+    static template = "web.DocSidebar";
+
+    static components = {};
+    static props = {};
+
+    setup() {
+        this.containerRef = useRef("containerRef");
+        this.modelStore = useState(this.env.modelStore);
+        this.state = useState({
+            collapseAddons: {},
+            searchValue: "",
+        });
+
+        useEffect(
+            () => {
+                this.containerRef.el?.querySelector(":scope .o_active")?.scrollIntoView();
+            },
+            () => [this.containerRef.el]
+        );
+    }
+
+    onSearchInput(event) {
+        this.state.searchValue = event.target.value;
+        this.containerRef.el.scrollTop = 0;
+    }
+
+    toggleAddon(addonName) {
+        this.state.collapseAddons[addonName] = !this.isCollapsed(addonName);
+    }
+
+    isCollapsed(addonName) {
+        return this.state.collapseAddons[addonName];
+    }
+
+    isActiveItem(model) {
+        return (
+            this.modelStore.activeModel &&
+            model.name === this.modelStore.activeModel.name &&
+            model.model == this.modelStore.activeModel.model
+        );
+    }
+
+    get filteredAddons() {
+        const queryStr = simplifyString(this.state.searchValue);
+
+        if (queryStr <= 0) {
+            return [...this.modelStore.addons];
+        } else {
+            const visibleAddons = [];
+            for (const addon of this.modelStore.addons) {
+                let models = addon.models;
+                if (!addon.name.includes(queryStr)) {
+                    models = addon.models.filter(
+                        (model) =>
+                            simplifyString(model.name).includes(queryStr) ||
+                            simplifyString(model.model).includes(queryStr)
+                    );
+                }
+                if (models.length > 0) {
+                    visibleAddons.push({
+                        name: addon.name,
+                        models,
+                    });
+                }
+            }
+            return visibleAddons;
+        }
+    }
+}

--- a/addons/api_doc/static/src/components/doc_sidebar.xml
+++ b/addons/api_doc/static/src/components/doc_sidebar.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocSidebar">
+    <div class="o-doc-sidebar position-sticky bg-1 border-end flex flex-column">
+        <div>
+            <input t-on-input="onSearchInput" class="w-100" placeholder="Search for models..."/>
+        </div>
+        <div class="o-doc-sidebar-content h-100 flex-basis flex flex-column gap-1" t-ref="containerRef">
+            <t t-foreach="filteredAddons" t-as="addon" t-key="addon.name">
+                <div
+                    class="position-sticky bg-1 top-0 flex w-100 cursor-pointer capitalize user-select-none"
+                    t-on-click="() => this.toggleAddon(addon.name)"
+                    role="button"
+                >
+                    <div class="icon-btn ps-1" role="button" t-att-class="{ o_collapsed: isCollapsed(addon.name)}">
+                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                    </div>
+                    <h3 class="ms-1" t-out="addon.name"></h3>
+                </div>
+
+                <div t-if="!isCollapsed(addon.name)" class="ms-1 ps-1 border-start">
+                    <t t-foreach="addon.models" t-as="model" t-key="model.model">
+                        <a
+                            class="btn block bg-none user-select-none"
+                            href="#"
+                            t-on-click="() => this.modelStore.setActiveModel({ model })"
+                            t-att-class="{ o_active: isActiveItem(model) }"
+                            role="button"
+                        >
+                            <div t-out="model.name"></div>
+                            <small class="block" t-out="model.model"></small>
+                        </a>
+                    </t>
+                </div>
+            </t>
+        </div>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/components/doc_table.js
+++ b/addons/api_doc/static/src/components/doc_table.js
@@ -1,0 +1,115 @@
+import { Component, useState, useExternalListener, useRef, onWillRender } from "@odoo/owl";
+
+export const TABLE_TYPES = {
+    Id: "id",
+    Code: "code-like",
+    Tooltip: "tooltip",
+};
+
+export class DocTable extends Component {
+    static components = { DocTable };
+    static template = "web.DocTable";
+
+    static props = {
+        data: true,
+    };
+
+    setup() {
+        this.subTableRef = useRef("subTableRef");
+        this.state = useState({
+            sortBy: 0,
+            sortOrder: "desc",
+            subTable: undefined,
+        });
+
+        onWillRender(() => {
+            this.items = this.computeItems();
+        });
+
+        useExternalListener(window, "click", (event) => {
+            if (
+                this.subTableRef.el &&
+                this.subTableRef.el !== event.target &&
+                !this.subTableRef.el.contains(event.target)
+            ) {
+                this.state.subTable = null;
+            }
+        });
+
+        useExternalListener(window, "scroll", () => (this.state.subTable = null));
+    }
+
+    computeItems() {
+        if (this.state.sortBy >= 0) {
+            const items = [...this.props.data.items];
+            items.sort((itemA, itemB) => {
+                const a = this.getValue(itemA[this.state.sortBy]);
+                const b = this.getValue(itemB[this.state.sortBy]);
+                if (this.state.sortOrder === "asc") {
+                    return b.localeCompare(a);
+                } else {
+                    return a.localeCompare(b);
+                }
+            });
+            return items;
+        } else {
+            return this.props.data.items;
+        }
+    }
+
+    showSubTable(event, subData) {
+        if (subData) {
+            this.state.subTable = subData;
+            const rect = event.target.getBoundingClientRect();
+            this.state.subTableStyle = `top: ${rect.bottom + 3}px; left: ${
+                rect.left
+            }px; z-index: 50;`;
+        }
+    }
+
+    getId(values) {
+        return values.find((v) => v.type === TABLE_TYPES.Id)?.value;
+    }
+
+    getTag(row) {
+        return row && typeof row === "object" && row.type === "code" ? "pre" : "span";
+    }
+
+    getValue(row) {
+        return String(row && typeof row === "object" ? row.value : row);
+    }
+
+    getClass(row) {
+        const classList = [];
+        if (row && typeof row === "object") {
+            if (row.type === "code") {
+                classList.push("font-monospace");
+            }
+            if (row.class) {
+                classList.push(row.class);
+            }
+        }
+        return classList.join(" ");
+    }
+
+    onRowHeaderClick(rowIndex) {
+        if (this.state.sortBy === rowIndex) {
+            this.state.sortOrder = this.state.sortOrder === "asc" ? "desc" : "asc";
+        }
+        this.state.sortBy = rowIndex;
+    }
+
+    getSortIcon(rowIndex) {
+        if (this.state.sortBy !== rowIndex) {
+            return "fa fa-sort";
+        } else if (this.state.sortOrder === "asc") {
+            return "fa fa-sort-asc";
+        } else {
+            return "fa fa-sort-desc";
+        }
+    }
+
+    goToModel(model) {
+        this.env.modelStore.setActiveModel({ model });
+    }
+}

--- a/addons/api_doc/static/src/components/doc_table.xml
+++ b/addons/api_doc/static/src/components/doc_table.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+
+<t t-name="web.DocTable">
+    <div class="overflow-auto w-100 p-1">
+        <table class="o-doc-table rounded bg-1 w-100">
+            <tr t-if="props.data.headers" class="bg-1">
+                <th
+                    t-foreach="props.data.headers"
+                    t-as="header"
+                    t-key="header_index"
+                    t-on-click="() => this.onRowHeaderClick(header_index)"
+                    class="position-relative text-nowrap text-start cursor-pointer user-select-none pt-1 pb-1 ps-2"
+                    t-attf-style="width: {{ 100 / props.data.headers.length }}%"
+                >
+                    <span class="me-2" t-out="header"></span>
+                    <i
+                        t-att-class="getSortIcon(header_index)"
+                        aria-hidden="true"
+                    ></i>
+                </th>
+            </tr>
+
+            <tr
+                t-foreach="items"
+                t-as="rows"
+                t-key="rows_index"
+                class="bg-1"
+                t-att-class="{ 'o-doc-active': rows_index === props.activeIndex }"
+                t-att-id="getId(rows)"
+            >
+                <td
+                    t-foreach="rows"
+                    t-as="row"
+                    t-key="row_index"
+                    class="text-start"
+                >
+                    <i
+                        t-if="row.subData"
+                        class="fa fa-bars o-doc-sub-table-btn inline me-1 cursor-pointer"
+                        aria-hidden="true"
+                        t-on-click="(ev) => this.showSubTable(ev, row.subData)"
+                    />
+
+                    <t t-if="row and row.type == 'tooltip'">
+                        <div t-if="row.value" class="tooltip w-100 h-100">
+                            <i class="fa fa-question-circle" aria-hidden="true"></i>
+                            <span class="tooltiptext" t-out="row.value"></span>
+                        </div>
+                    </t>
+                    <t t-else="" t-tag="getTag(row)" t-att-class="getClass(row)" t-out="getValue(row)"/>
+
+                    <a
+                        t-if="row.relation"
+                        class="cursor-pointer text-muted ms-1"
+                        href="#"
+                        t-on-click="() => this.goToModel(row.relation)"
+                    >
+                        <t t-out="row.relation"/>
+                        <i
+                            class="fa fa-external-link ps-1 inline"
+                            aria-hidden="true"
+                        ></i>
+                    </a>
+                </td>
+            </tr>
+
+            <tr t-if="items.length === 0 and props.data.headers" class="bg-1">
+                <td t-foreach="props.data.headers" t-as="row" t-key="row_index" t-attf-style="width: {{ 100 / props.data.headers.length }}%" class="text-start text-muted">
+                    <t t-if="row_index === 0">
+                        No Data
+                    </t>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <div
+        t-if="state.subTable"
+        class="o-doc-sub-table overflow-auto position-fixed bg-1 p-1 shadow border z-index-1 rounded"
+        t-att-style="state.subTableStyle"
+        t-ref="subTableRef"
+    >
+        <DocTable data="state.subTable"/>
+    </div>
+</t>
+
+</templates>

--- a/addons/api_doc/static/src/doc_client.css
+++ b/addons/api_doc/static/src/doc_client.css
@@ -1,0 +1,814 @@
+:root {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu,
+        "Noto Sans", Arial, "Odoo Unicode Support Noto", sans-serif, "Apple Color Emoji",
+        "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    font-size: 0.875rem;
+    line-height: 1.5;
+
+    --size-1: .5rem;
+    --size-2: 1rem;
+    --size-3: 1.5rem;
+    --size-4: 2rem;
+
+
+    --red:rgb(229, 107, 86);
+    --green:rgb(34, 158, 79);
+    --blue:rgb(66, 161, 205);
+    --orange:rgb(216, 99, 36);
+
+    --background:rgb(246, 246, 246);
+    --background-1:rgb(239, 239, 239);
+    --background-2:rgb(230, 230, 230);
+    --btn:rgb(225, 223, 225);
+    --btn-primary:rgb(107, 62, 102);
+    --border:rgb(207, 207, 207);
+    --text:rgb(37, 36, 39);
+    --text-primary: rgb(179, 95, 169);
+    --text-active:rgb(242, 247, 248);
+    --text-light:rgb(50, 52, 52);
+    --success:rgb(56, 207, 111);
+    --error:rgb(231, 90, 65);
+    --error-background:rgb(241, 219, 215);
+    --error-text:rgb(49, 33, 30);
+
+    --code-editor: #282c34;
+}
+
+body[theme="odoo-dark"] {
+    --green:rgb(56, 207, 111);
+    --blue:rgb(102, 197, 242);
+    --orange:rgb(240, 122, 59);
+
+    --background:rgb(38, 42, 54);
+    --background-1:rgb(28, 32, 41);
+    --background-2:rgb(14, 16, 22);
+    --btn:#3C3E4B;
+    --btn-primary: #6b3e66;
+    --border: #3C3E4B;
+    --text:rgb(245, 245, 245);
+    --text-active:rgb(246, 239, 248);
+    --text-light:rgb(229, 235, 235);
+    --success:rgb(56, 207, 111);
+    --error:rgb(190, 49, 77);
+    --error-background:rgb(45, 21, 27);
+    --error-text:rgb(241, 229, 230);
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+    padding: 0;
+    margin: 0;
+    border-color: transparent;
+    border-style: solid;
+    border-width: 0;
+}
+
+body {
+    max-width: 100vw;
+    color: var(--text);
+    background: var(--background);
+    overflow-y: scroll;
+    scrollbar-color: var(--border) var(--background-2);
+    scrollbar-width: thin;
+
+    --header-size: 4rem;
+}
+
+header {
+    height: var(--header-size);
+    top: 0;
+    z-index: 50;
+    border-bottom: 1px solid var(--border);
+    padding: 0 1rem;
+
+    h2 {
+        margin-right: 1rem;
+        font-size: 1.2em;
+        font-weight: 400;
+
+        @media (max-width: 600px) {
+            font-size: 0.8em;
+        }
+    }
+
+    input {
+        min-width: 15rem;
+    }
+}
+
+main {
+    margin-top: var(--header-size);
+    width: 100%;
+    max-width: 100%;
+}
+
+/* #region ======================== HTML Defaults ========================= */
+h5 {
+    font-size: 1em;
+}
+
+p {
+    color: rgb(from var(--text) r g b / 0.8)
+}
+
+input, select {
+    color: var(--text);
+    border-radius: 5px;
+    padding: .5rem .75rem;
+    background: var(--btn);
+}
+
+input[type=checkbox] {
+    accent-color: var(--text-primary);
+    border: none;
+    background-color: var(--btn);
+	outline: none;
+}
+
+small {
+    font-style: italic;
+    opacity: 0.6;
+}
+
+a {
+    text-decoration: none;
+    color: var(--text-primary);
+}
+a:hover {
+    text-decoration: underline;
+}
+a:hover:not(.btn) {
+    color: var(--text-primary);
+    opacity: 1;
+    i {
+        color: var(--text-primary);
+    }
+}
+
+i {
+    color: var(--text);
+    opacity: 1;
+}
+
+code {
+    padding: 0 .3rem;
+    background-color: var(--background-1);
+    border-radius: 5px;
+}
+
+pre {
+    margin-bottom: 0;
+    padding: .15rem .3rem;
+    background-color: var(--background-2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    border-radius: 5px;
+    overflow: auto;
+
+    code {
+        padding: 0;
+        background: none;
+        border-radius: 0;
+    }
+
+    i {
+        color: #fff;
+        opacity: 1;
+    }
+    i::before {
+        color: #fff;
+        opacity: 1;
+    }
+}
+/* #endregion */
+
+/* #region ========================== Components ========================== */
+.badge {
+    font-size: .8em;
+    padding: .15rem .3rem;
+    border-radius: 3px;
+
+    &.success {
+        background-color: var(--success);
+    }
+    &.error {
+        background-color: var(--error);
+    }
+}
+
+.alert {
+    padding: 1rem 1.15rem;
+
+    &.error {
+        --text: var(--error-text);
+        color: var(--error-text);
+        background-color: var(--error-background);
+        border-radius: 5px;
+
+        h5, i {
+            color: var(--error);
+        }
+    }
+}
+
+.modal-bg {
+    z-index: 100;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(10px);
+}
+
+.modal {
+    background: var(--background);
+    border-radius: 5px;
+    box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.3);
+    max-width: 100vw;
+    max-height: 100vh;
+}
+
+.tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+.tooltip .tooltiptext {
+    position: absolute;
+    visibility: hidden;
+    bottom: 120%;
+    left: -50%;
+    width: auto;
+    min-width: 10rem;
+    max-width: 25rem;
+    z-index: 1;
+    background-color: var(--background);
+    color: var(--text);
+    padding: .3rem .5rem;
+    border-radius: 6px;
+    text-align: center;
+    transition: opacity 0.25s;
+    opacity: 0;
+    box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.3);
+}
+
+.tooltip:hover .tooltiptext {
+    visibility: visible;
+    opacity: 1;
+}
+
+.btn {
+    background: var(--btn);
+    padding: .5rem .75rem;
+    color: var(--text);
+    border-radius: 5px;
+    cursor: pointer;
+    text-decoration: none;
+    z-index: 0;
+    transition: .05s ease-in-out;
+
+    &:disabled, &[disabled] {
+        opacity: 0.5;
+    }
+
+    &:hover, &.active, &.o_active {
+        background: var(--btn-primary);
+        color: var(--text-active);
+        box-shadow: 0px 0px 15px -5px var(--btn-primary);
+        z-index: 1;
+    }
+
+    &.primary {
+        background: var(--btn-primary);
+        color: var(--text-active);
+
+        i {
+            color: var(--text-active);
+        }
+    }
+}
+
+.icon-btn {
+    padding-right: .2rem;
+    padding-top: .15rem;
+    height: fit-content;
+}
+.icon-btn i {
+    transition: .2s ease-in-out;
+    transform: rotate(90deg);
+    font-size: 18px;
+}
+.icon-btn.o_collapsed i {
+    transform: rotate(0deg);
+}
+
+/* Code Viewer */
+.o-doc-code-editor, .o-doc-code-editor .ace_editor {
+    background-color: var(--code-editor) !important;
+}
+
+.o-doc-code-editor .ace_active-line {
+    background-color: hsl(from var(--code-editor) h s calc(l * 0.8)) !important;
+}
+
+.o-doc-code-editor button {
+    background: none;
+    color: #fff;
+}
+.o-doc-code-editor i {
+    color: inherit;
+    padding: .25rem .5rem;
+    font-size: .8em;
+    z-index: 1;
+    opacity: 0.5;
+
+    &:hover {
+        opacity: 1;
+    }
+}
+
+/* Tables */
+.o-doc-table {
+    border-collapse: collapse;
+
+    tr {
+        font-size: .85em;
+        scroll-margin-top: 10rem;
+
+        &:nth-child(even) {
+            background-color: hsl(from var(--background-1) h s calc(l - 4));
+        }
+    }
+
+    td, th {
+        padding: .25rem 1rem;
+        &:nth-child(1) {
+            padding: .25rem 2rem;
+        }
+    }
+
+    th {
+        opacity: 0.6;
+        font-weight: 400;
+        font-style: italic;
+
+        i {
+            position: absolute;
+            right: 10px;
+            top: 30%;
+        }
+    }
+
+    th:hover i {
+        color: var(--text-primary);
+        text-shadow: 0 0 2px var(--text-primary);
+    }
+}
+
+.o-doc-sub-table-btn:hover {
+    color: var(--text-primary);
+}
+
+.o-doc-sub-table {
+    max-height: 30vh;
+}
+
+/* Loading Indicators */
+.o-doc-load-wrapper {
+    z-index: 50;
+    overflow: hidden;
+}
+
+.o-doc-load-activity {
+    left: -45%;
+    width: 45%;
+    background-image: linear-gradient(
+        to left,
+        rgb(from var(--background) r g b / .05),
+        rgb(from var(--background) r g b / .3),
+        rgb(from var(--background) r g b / .6),
+        rgb(from var(--background) r g b / .3),
+        rgb(from var(--background) r g b / .05)
+    );
+    animation: doc-loading 1s infinite;
+    z-index: 52;
+}
+
+@keyframes doc-loading {
+    0%{
+        left: -45%;
+    }
+    100%{
+        left: 100%;
+    }
+}
+
+.o-fade-in {
+    animation: o-animation-fade-in .25s;
+}
+
+@keyframes o-animation-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+/* Sidebar */
+.o-doc-sidebar {
+    --sidebar-pe: 1rem;
+    min-width: 20rem;
+    max-width: 30rem;
+    top: var(--header-size);
+    padding: 1rem 0 0 1rem;
+    height: calc(100vh - var(--header-size));
+
+    > div {
+        padding: 0 calc(var(--sidebar-pe) + 1rem) 1.5rem 0;
+    }
+
+    a {
+        scroll-margin: 3rem;
+    }
+
+    .o-doc-sidebar-content {
+        flex: 1;
+        padding: 0 var(--sidebar-pe) 10rem 0;
+        overflow-y: scroll;
+    }
+}
+
+/* Model */
+.o-doc-model {
+    width: 30rem;
+    max-width: 100vw;
+}
+
+.o-doc-model-aside {
+    top: var(--header-size);
+    max-width: 20rem;
+    max-height: calc(100vh - var(--header-size));
+    padding-bottom: 10rem;
+}
+
+.o-doc-method {
+    scroll-margin-top: 5rem;
+
+    .o-doc-method-header {
+        padding: 1rem 1.5rem;
+        top: var(--header-size);
+        z-index: 10;
+
+        &:not(.o_collapsed) {
+            border-bottom-left-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+
+    .o-doc-method-content {
+        border-bottom-left-radius: 5px;
+        border-bottom-right-radius: 5px;
+    }
+}
+
+.o-doc-spinner {
+    animation: o-doc-spin 2s linear infinite;
+}
+
+@keyframes o-doc-spin {
+    100% {
+        transform: rotate(360deg);
+    }
+}
+
+.o-doc-active {
+    outline: 1px solid var(--btn-primary);
+}
+
+.o-code-editor i, .o-code-editor span {
+    color: #ffffff;
+}
+
+/* #endregion */
+
+/* #region ============================= Utils ============================ */
+
+.bg-default {
+    background: var(--background);
+}
+
+.bg-1 {
+    background: var(--background-1);
+}
+
+.bg-2 {
+    background: var(--background-2);
+}
+
+.bg-none {
+    background: none;
+}
+
+.cursor-pointer {
+    cursor: pointer;
+}
+
+.capitalize {
+    text-transform: capitalize;
+}
+
+.text-muted {
+    color: var(--text);
+    opacity: 0.5;
+    font-style: italic;
+}
+
+.text-ellipsis {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.text-start {
+    text-align: start;
+}
+
+.text-vertical-center {
+    vertical-align: middle;
+}
+
+.text-red {
+    color: var(--red);
+}
+
+.text-green {
+    color: var(--green);
+}
+
+.text-blue {
+    color: var(--blue);
+}
+
+.text-orange {
+    color: var(--orange);
+}
+
+.text-nowrap {
+    white-space: nowrap;
+}
+
+.fs-6 {
+    font-size: .8em;
+}
+
+.font-monospace {
+    font-family: monospace;
+}
+
+.rounded {
+    border-radius: 5px;
+}
+
+.border {
+    border: 1px solid var(--border);
+}
+.border-top {
+    border-top: 1px solid var(--border);
+}
+.border-bottom {
+    border-bottom: 1px solid var(--border);
+}
+.border-end {
+    border-right: 1px solid var(--border);
+}
+.border-start {
+    border-left: 1px solid var(--border);
+}
+
+.shadow {
+    box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
+}
+
+.position-relative {
+    position: relative;
+}
+
+.position-fixed {
+    position: fixed;
+}
+
+.position-absolute {
+    position: absolute;
+}
+
+.position-sticky {
+    position: sticky;
+    z-index: 1;
+}
+
+.overflow-auto {
+    overflow: auto;
+}
+
+.overflow-y-auto {
+    overflow-y: auto;
+}
+
+.overflow-hidden {
+    overflow: hidden;
+}
+
+.top-0 {
+    top: 0;
+}
+.top-1 {
+    top: var(--size-1);
+}
+.top-2 {
+    top: var(--size-2);
+}
+.top-3 {
+    top: var(--size-3);
+}
+
+.end-0 {
+    right: 0;
+}
+
+.block {
+    display: block;
+}
+
+.inline {
+    display: inline;
+}
+
+/* Flex */
+.flex {
+    display: flex;
+    flex-wrap: nowrap;
+}
+
+.flex-wrap {
+    flex-wrap: wrap;
+}
+
+.flex-column {
+    flex-direction: column;
+}
+
+.flex-basis {
+    flex: 1 1 auto;
+}
+
+.flex-grow {
+    flex-grow: 1;
+}
+
+.align-items-center {
+    align-items: center;
+}
+
+.justify-content-between {
+    justify-content: space-between;
+}
+
+.justify-content-center {
+    justify-content: center;
+}
+
+.gap-1 {
+    gap: var(--size-1);
+}
+
+/* Sizing */
+.h-100 {
+    height: 100%;
+}
+
+.w-100 {
+    width: 100%;
+}
+
+.w-50 {
+    width: 50%;
+}
+
+.min-w-50 {
+    min-width: 50%;
+}
+
+.m-1 {
+    margin: var(--size-1);
+}
+
+.m-2 {
+    margin: var(--size-2);
+}
+
+.me-1 {
+    margin-right: var(--size-1);
+}
+
+.me-2 {
+    margin-right: var(--size-2);
+}
+
+.ms-1 {
+    margin-left: var(--size-1);
+}
+
+.ms-2 {
+    margin-left: var(--size-2);
+}
+
+.mt-1 {
+    margin-top: var(--size-1);
+}
+
+.mt-2 {
+    margin-top: var(--size-2);
+}
+
+.mt-3 {
+    margin-top: var(--size-3);
+}
+
+.mt-4 {
+    margin-top: var(--size-4);
+}
+
+.mb-1 {
+    margin-bottom: var(--size-1);
+}
+
+.mb-2 {
+    margin-bottom: var(--size-2);
+}
+
+.mb-3 {
+    margin-bottom: var(--size-3);
+}
+
+.p-0 {
+    padding: 0;
+}
+
+.p-1 {
+    padding: var(--size-1);
+}
+
+.p-2 {
+    padding: var(--size-2);
+}
+
+.p-3 {
+    padding: var(--size-3);
+}
+
+.ps-1 {
+    padding-left: var(--size-1);
+}
+
+.ps-2 {
+    padding-left: var(--size-2);
+}
+
+.ps-3 {
+    padding-left: var(--size-3);
+}
+
+.pe-1 {
+    padding-right: var(--size-1);
+}
+
+.pe-2 {
+    padding-right: var(--size-2);
+}
+
+.pe-3 {
+    padding-right: var(--size-3);
+}
+
+.pt-1 {
+    padding-top: var(--size-1);
+}
+
+.pt-2 {
+    padding-top: var(--size-2);
+}
+
+.pt-3 {
+    padding-top: var(--size-3);
+}
+
+.user-select-none {
+    user-select: none;
+}
+/* #endregion*/

--- a/addons/api_doc/static/src/doc_client.js
+++ b/addons/api_doc/static/src/doc_client.js
@@ -1,0 +1,118 @@
+import { Component, useState, xml, onMounted, useSubEnv } from "@odoo/owl";
+import { ModelStore } from "@api_doc/doc_model_store";
+import { useDocUI } from "@api_doc/utils/doc_ui_store";
+import { ApiKeyModal } from "@api_doc/components/doc_modal_api_key";
+import { SearchModal } from "@api_doc/components/doc_modal_search";
+import { DocSidebar } from "@api_doc/components/doc_sidebar";
+import { DocModel } from "@api_doc/components/doc_model";
+
+export class DocClient extends Component {
+    static template = xml`
+        <header class="position-fixed bg-1 flex gap-1 align-items-center justify-content-between w-100">
+            <div class="flex">
+                <h2>Odoo Runtime Doc</h2>
+            </div>
+            <div>
+                <input
+                    t-on-click="() => this.state.showSearchModal = true"
+                    placeholder="Find anything..."
+                />
+            </div>
+            <div class="flex gap-1">
+                <button class="btn" role="button" t-on-click="() => this.env.modelStore.showApiKeyModal = true">
+                    <i class="fa fa-key" aria-hidden="true"></i>
+                </button>
+                <button class="btn" role="button" t-on-click="() => this.toggleTheme()">
+                    <i class="fa fa-moon-o" aria-hidden="true"></i>
+                </button>
+            </div>
+        </header>
+        <main class="position-relative flex">
+            <DocSidebar t-if="!ui.isSmall"/>
+            <t t-if="modelStore.models.length > 0">
+                <DocModel t-if="modelStore.activeModel"/>
+            </t>
+            <div t-elif="!modelStore.error" class="h-100 w-100 flex align-items-center justify-content-center gap-1">
+                <i class="fa fa-spinner o-doc-spinner" aria-hidden="true"></i>
+                <div>Loading Models</div>
+            </div>
+
+            <div t-if="modelStore.error" class="flex align-items-center justify-content-center w-100 h-100">
+                <div class="alert error mt-1 flex flex-column">
+                    <h5 class="mb-2 flex align-items-center">
+                        <i class="pe-1 fa fa-exclamation-triangle" aria-hidden="true"></i>
+                        <span>Error while loading models</span>
+                    </h5>
+                    <div t-out="modelStore.error.message"></div>
+                </div>
+            </div>
+        </main>
+        <ApiKeyModal t-if="modelStore.showApiKeyModal"/>
+        <SearchModal
+            t-if="state.showSearchModal"
+            close="() => this.state.showSearchModal = false"
+        />
+    `;
+
+    static components = {
+        DocSidebar,
+        DocModel,
+        ApiKeyModal,
+        SearchModal,
+    };t
+    static props = {};
+
+    setup() {
+        this.setTheme(localStorage.getItem("theme") || "odoo-dark");
+
+        this.ui = useDocUI();
+        this.modelStore = useState(new ModelStore());
+        useSubEnv({ modelStore: this.modelStore });
+
+        this.state = useState({ showSearchModal: false });
+
+        onMounted(async () => {
+            await this.modelStore.loadModels();
+            this.selectUrlModel();
+        });
+
+        window.addEventListener("popstate", () => {
+            this.selectUrlModel();
+        });
+    }
+
+    selectUrlModel() {
+        const actives = {};
+        const parts = window.location.pathname.split("/");
+        const docIndex = parts.indexOf("doc");
+        const urlModel = parts[docIndex + 1];
+        if (urlModel) {
+            const model = this.modelStore.getBasicModelData(urlModel);
+            if (model) {
+                actives.model = model;
+            }
+        }
+
+        const hash = window.location.hash.substring(1);
+        const model = actives.model;
+        if (model && hash) {
+            if (model.methods.includes(hash)) {
+                actives.method = hash;
+            } else if (model.fields[hash]) {
+                actives.field = hash;
+            }
+        }
+
+        this.modelStore.setActiveModel(actives);
+    }
+
+    toggleTheme() {
+        this.setTheme(this.theme === "odoo-dark" ? "odoo-light" : "odoo-dark");
+    }
+
+    setTheme(theme) {
+        this.theme = theme;
+        localStorage.setItem("theme", theme);
+        document.body.setAttribute("theme", theme);
+    }
+}

--- a/addons/api_doc/static/src/doc_model_store.js
+++ b/addons/api_doc/static/src/doc_model_store.js
@@ -1,0 +1,166 @@
+import { markRaw, markup } from "@odoo/owl";
+import { Reactive } from "@web/core/utils/reactive";
+
+function tryParseJSON(jsonString) {
+    try {
+        const json = JSON.parse(jsonString);
+        return json && typeof json === "object" ? json : null;
+    } catch {
+        return null;
+    }
+}
+
+export class ModelStore extends Reactive {
+    constructor() {
+        super();
+
+        this.models = [];
+        this._addons = {};
+
+        this.apiKey = null;
+        this.showApiKeyModal = false;
+
+        this.activeModel = null;
+        this.activeField = null;
+        this.activeMethod = null;
+        this.error = null;
+    }
+
+    get addons() {
+        return Object.values(this._addons);
+    }
+
+    async loadModels() {
+        try {
+            console.info("Loading Models...");
+            const response = await fetch("/doc/index.json");
+            const { models } = await response.json();
+            console.info("Models List Loaded", models);
+
+            models.sort((a, b) => a.model.localeCompare(b.model));
+
+            const addons = {};
+            for (const model of models) {
+                const addonName = model.model.split(".")[0];
+
+                if (addons[addonName]) {
+                    addons[addonName].models.push(model);
+                } else {
+                    addons[addonName] = {
+                        name: addonName,
+                        models: [model],
+                    };
+                }
+            }
+
+            const other = { name: "other", models: [] };
+            for (const category in addons) {
+                const models = addons[category].models;
+                if (models.length <= 3) {
+                    other.models.push(...models);
+                    delete addons[category];
+                }
+            }
+            addons["other"] = other;
+
+            this.models = markRaw(models);
+            this._addons = markRaw(addons);
+        } catch (e) {
+            this.error = e;
+        }
+    }
+
+    async loadModel(modelId) {
+        let model = null;
+        try {
+            const response = await fetch(`/doc/${modelId}.json`);
+            model = await response.json();
+        } catch (e) {
+            throw e;
+        }
+
+        if (model.doc) {
+            model.doc = markup(model.doc);
+        }
+
+        Object.values(model.methods).forEach((method) => {
+            method.doc = method.doc ? markup(method.doc) : null;
+        });
+
+        console.info("Model Loaded: ", model);
+        return model;
+    }
+
+    getBasicModelData(modelId) {
+        return this.models.find((m) => m.model === modelId);
+    }
+
+    setAPIKey(apiKey) {
+        if (typeof apiKey === "string" && apiKey.length > 0) {
+            this.apiKey = apiKey;
+        }
+    }
+
+    setActiveModel({ model, method = null, field = null }) {
+        if (typeof model === "string") {
+            model = this.getBasicModelData(model);
+        }
+
+        if (model) {
+            this.activeModel = model;
+            this.activeMethod = method;
+            this.activeField = field;
+
+            let url = `/doc/${model.model}`;
+            if (method || field) {
+                url += "#" + (method || field);
+            }
+            window.history.pushState({}, "", url);
+        }
+    }
+
+    async executeRequest(url, requestBody) {
+        if (!this.apiKey) {
+            this.showApiKeyModal = true;
+            return null;
+        }
+
+        const result = {
+            status: null,
+            body: null,
+            error: null,
+        };
+
+        try {
+            const request = {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `Bearer ${this.apiKey}`,
+                },
+                body: requestBody,
+            };
+
+            const response = await fetch(url, request);
+            result.status = response.status;
+
+            const body = await response.text();
+            const json = tryParseJSON(body);
+
+            if (response.ok) {
+                result.body = json ? JSON.stringify(json, null, 2) : body;
+            } else {
+                result.error = !json
+                    ? body
+                    : [
+                        `<h3 class="mb-1">${json.message}</h3>`,
+                        `<pre class="p-2">${json.debug}</pre>`,
+                    ].join("\n");
+            }
+        } catch (error) {
+            result.error = error;
+        }
+
+        return result;
+    }
+}

--- a/addons/api_doc/static/src/start_doc_client.js
+++ b/addons/api_doc/static/src/start_doc_client.js
@@ -1,0 +1,13 @@
+import { App, whenReady } from "@odoo/owl";
+import { getTemplate } from "@web/core/templates";
+import { DocClient } from "@api_doc/doc_client";
+
+export async function startDocClient() {
+    await whenReady();
+    const app = new App(DocClient, {
+        getTemplate,
+    });
+    app.mount(document.body);
+}
+
+startDocClient();

--- a/addons/api_doc/static/src/utils/doc_code_gen.js
+++ b/addons/api_doc/static/src/utils/doc_code_gen.js
@@ -1,0 +1,81 @@
+export const LANGUAGES = {
+    json: "json",
+    javascript: "javascript",
+    python: "python",
+    cURL: "bash",
+};
+
+function noQuotesStringify(obj) {
+    var json = JSON.stringify(obj, null, 4);
+    return json.replace(/^[\t ]*"[^:\n\r]+(?<!\\)":/gm, (m) => m.replace(/"/g, ""));
+}
+
+export function createRequestCode({ language, url, requestObj }) {
+    if (LANGUAGES[language] === LANGUAGES.json) {
+        return JSON.stringify(requestObj, null, 4);
+    } else if (LANGUAGES[language] === LANGUAGES.javascript) {
+        const objStr = noQuotesStringify(requestObj).replace(/\n/gm, "\n    ");
+
+        return `\
+(async () => {
+    // You MUST store this key securely. Place it in an
+    // environment variable or in in a file outside of
+    // git (e.g. your home directory).
+    const apiKey = "YOUR_API_KEY";
+
+    const request = {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + apiKey,
+            // "X-Odoo-Database": "...",
+        },
+        body: ${objStr},
+    };
+
+    const response = await fetch("${url}", request);
+    if (response.ok) {
+        const data = await response.json();
+        console.log(data)
+    } else {
+        // Handle errors
+    }
+})();`;
+    } else if (LANGUAGES[language] === LANGUAGES.cURL) {
+        const objStr = JSON.stringify(requestObj);
+
+        return `\
+curl '${url}'\\
+  -X POST \\
+  --oauth2-bearer YOUR_API_KEY \\
+# -H "X-Odoo-Database: ..." \\
+  -H "Content-Type: application/json" \\
+  -d '${objStr}'
+`;
+    } else if (LANGUAGES[language] === LANGUAGES.python) {
+        const objStr = JSON.stringify(requestObj, null, 4)
+            .replace(/\bnull\b/g, "None")
+            .replaceAll("\n", "\n    ")
+            .trim();
+
+        return `\
+# You MUST store this key securely. Place it in an
+# environment variable or in in a file outside of
+# git (e.g. your home directory).
+api_key = "YOUR_API_KEY"
+
+${"import"} requests
+response = requests.post(
+    "${url}",
+    headers={
+        "Authorization": f"Bearer {api_key}",
+        # "X-Odoo-Database": "...",
+    },
+    json=${objStr},
+)
+response.raise_for_status()
+data = response.json()
+print(data)
+`;
+    }
+}

--- a/addons/api_doc/static/src/utils/doc_model_search.js
+++ b/addons/api_doc/static/src/utils/doc_model_search.js
@@ -1,0 +1,82 @@
+export function simplifyString(str) {
+    return (
+        str
+            ?.trim()
+            .toLowerCase()
+            .replace(/[^a-zA-Z\d]/g, "") ?? ""
+    );
+}
+
+function stringMatch(query, str) {
+    if (simplifyString(str).includes(query)) {
+        return query.length / str.length;
+    } else {
+        return 0;
+    }
+}
+
+export function search(models, query, filters) {
+    query = simplifyString(query);
+
+    const results = [];
+    for (const model of models) {
+        const modelMatch = stringMatch(query, model.model);
+        const modelNameMatch = stringMatch(query, model.name);
+        if (filters.models && (modelMatch > 0 || modelNameMatch > 0)) {
+            results.push({
+                priority: 10 * Math.max(modelMatch, modelNameMatch),
+                model,
+                type: "model",
+                label: model.name,
+                path: model.model,
+            });
+        }
+
+        if (filters.fields) {
+            for (const field in model.fields) {
+                const path = `${model.model}/${field}`;
+                const pathMatch = stringMatch(query, path);
+                const fieldMatch = stringMatch(query, field);
+                const labelMatch = stringMatch(query, model.fields[field].string);
+                if (pathMatch > 0 || fieldMatch > 0 || labelMatch > 0) {
+                    results.push({
+                        priority: 5 * Math.max(pathMatch, fieldMatch, labelMatch),
+                        model,
+                        field,
+                        type: "field",
+                        label: model.fields[field].string,
+                        path,
+                    });
+                }
+            }
+        }
+
+        if (filters.methods) {
+            for (const method of model.methods) {
+                const path = `${model.model}/${method}`;
+                const pathMatch = stringMatch(query, path);
+                const methodMatch = stringMatch(query, method);
+                if (pathMatch > 0 || methodMatch > 0) {
+                    results.push({
+                        priority: 5 * Math.max(pathMatch, methodMatch),
+                        model,
+                        method,
+                        type: "method",
+                        label: method,
+                        path: path,
+                    });
+                }
+            }
+        }
+    }
+
+    results.sort((a, b) => {
+        if (a.priority === b.priority) {
+            return a.label.localeCompare(b.label);
+        } else {
+            return b.priority - a.priority;
+        }
+    });
+
+    return results;
+}

--- a/addons/api_doc/static/src/utils/doc_model_utils.js
+++ b/addons/api_doc/static/src/utils/doc_model_utils.js
@@ -1,0 +1,164 @@
+const FIELDS_DEFAULT = [
+    {
+        types: ["integer", "float", "many2one_reference"],
+        value: 0,
+    },
+    {
+        types: ["char", "selection", "html"],
+        value: "",
+    },
+    {
+        types: ["boolean", "many2one"],
+        value: false,
+    },
+    {
+        types: ["datetime", "date"],
+        value: Date.now.toString(),
+    },
+    {
+        types: ["binary"],
+        value: null,
+    },
+    {
+        types: ["one2many", "many2many"],
+        value: "[]",
+    },
+];
+
+function getFieldDefaultValue(field) {
+    for (const fieldDefault of FIELDS_DEFAULT) {
+        if (fieldDefault.types.includes(field.type)) {
+            return fieldDefault.value;
+        }
+    }
+    return null;
+}
+
+export function getCreateDict(model) {
+    const value = {};
+    for (const fieldName in model.fields) {
+        if (model.fields[fieldName].required) {
+            value[fieldName] = getFieldDefaultValue(model.fields[fieldName]);
+        }
+    }
+    return value;
+}
+
+export function getCrudMethodsExamples(model) {
+    return {
+        create: {
+            responseCode: `true`,
+            request: {
+                kwargs: {
+                    vals_list: [getCreateDict(model)],
+                },
+            },
+        },
+        read: {
+            request: {
+                ids: [0, 1],
+                kwargs: {
+                    fields: ["display_name", "name", "create_date"],
+                },
+            },
+        },
+        search: {
+            responseCode: `\
+[
+    1,
+    2
+]`,
+            request: {
+                kwargs: {
+                    domain: [["display_name", "ilike", "a%"]],
+                },
+            },
+        },
+        search_count: {
+            responseCode: `10`,
+            request: {
+                kwargs: {
+                    domain: [["display_name", "ilike", "a%"]],
+                },
+            },
+        },
+        search_read: {
+            responseCode: `10`,
+            request: {
+                kwargs: {
+                    domain: [["display_name", "ilike", "a%"]],
+                    fields: ["display_name"],
+                    limit: 20,
+                },
+            },
+        },
+        unlink: {
+            responseCode: `true`,
+            request: {
+                ids: [],
+            },
+        },
+        write: {
+            responseCode: `true`,
+            request: {
+                ids: [0],
+                kwargs: {
+                    values: {
+                        display_name: "Dope New Name",
+                    },
+                },
+            },
+        },
+        name_search: {
+            request: {
+                kwargs: {
+                    domain: [["display_name", "ilike", "a%"]],
+                },
+            },
+            responseCode: `\
+[
+    [
+        1,
+        "Record 1 Name"
+    ],
+    [
+        2,
+        "Record 2 Name"
+    ]
+]`,
+        },
+        read_group: {
+            name: "read_group",
+            request: {
+                kwargs: {
+                    fields: ["id", "display_name", "write_date"],
+                    groupby: "write_date",
+                    domain: [["display_name", "ilike", "a%"]],
+                },
+            },
+        },
+    };
+}
+
+export function getParameterDefaultValue(name, parameter) {
+    if ("default" in parameter) {
+        return parameter.default;
+    } else if (/\bdomaintype\b/i.test(parameter.type)) {
+        return [[ "display_name", "ilike", "a%"]];
+    } else if (/\bstr\b/i.test(parameter.type)) {
+        return "";
+    } else if (/\b(int|float|complex)\b/i.test(parameter.type)) {
+        return 0;
+    } else if (/\bbool\b/i.test(parameter.type)) {
+        return false;
+    } else if (
+        /args/i.test(name) ||
+        /\b(list|sequence|collection|tuple|range|set)\b/i.test(parameter.annotation)
+    ) {
+        return [];
+    } else if (/dict|kwargs/i.test(parameter.annotation)) {
+        return {};
+    } else {
+        return "";
+    }
+}

--- a/addons/api_doc/static/src/utils/doc_ui_store.js
+++ b/addons/api_doc/static/src/utils/doc_ui_store.js
@@ -1,0 +1,24 @@
+import { useEnv, useExternalListener, useState, useSubEnv } from "@odoo/owl";
+
+function isSmall() {
+    return window.innerWidth < 960;
+}
+
+export function useDocUI() {
+    const env = useEnv();
+    if (env.ui) {
+        return useState(env.ui);
+    }
+    const ui = useState({
+        isSmall: isSmall(),
+        size: window.innerWidth,
+    });
+
+    useSubEnv({ ui });
+    useExternalListener(window, "resize", () => {
+        ui.size = window.innerWidth;
+        ui.isSmall = isSmall();
+    });
+
+    return ui;
+}

--- a/addons/api_doc/tests/__init__.py
+++ b/addons/api_doc/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_doc

--- a/addons/api_doc/tests/test_doc.py
+++ b/addons/api_doc/tests/test_doc.py
@@ -1,0 +1,186 @@
+import textwrap
+from http import HTTPStatus
+
+from odoo.fields import Command
+from odoo.tests import new_test_user, tagged
+
+from odoo.addons.base.tests.common import HttpCaseWithUserDemo
+
+
+@tagged("-at_install", "post_install")
+class TestDoc(HttpCaseWithUserDemo):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user_demo.write({
+            'group_ids': [Command.link(cls.env.ref('api_doc.group_allow_doc').id)],
+        })
+
+    def test_doc_access(self):
+        e = "This page is only accessible to Technical Documentation users."
+        new_test_user(self.env, login='test_doc_access')
+        self.authenticate('test_doc_access', 'test_doc_access')
+        for path in ('/doc', '/doc/index.json', '/doc/res.company.json'):
+            with self.subTest(path=path):
+                with self.assertLogs('odoo.http') as capture:
+                    res = self.url_open(path)
+                self.assertEqual(res.status_code, 403)
+                self.assertIn(e, res.text)
+                self.assertEqual(capture.output, [f'WARNING:odoo.http:{e}'])
+
+    def test_doc_web_client(self):
+        self.authenticate('demo', 'demo')
+        res = self.url_open('/doc', allow_redirects=False)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers.get('Content-Type'), 'text/html; charset=utf-8')
+        self.assertTrue(res.content, "There must be a rich web client")
+
+    def test_doc_index(self):
+        self.authenticate('demo', 'demo')
+        res = self.url_open('/doc/index.json', allow_redirects=False)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+
+        json = res.json()
+        self.assertEqual(set(json), {'models', 'modules'})
+
+        self.assertGreater(set(json['modules']), {'base', 'web', 'api_doc'})
+        # if we ever enable module sorting
+        # self.assertLess(
+        #     json['modules'].index('base'),
+        #     json['modules'].index('web'),
+        #     "verify that both base and web are installed, and that "
+        #     "they are ordered according to the dependency graph",
+        # )
+
+        res_partner = next(
+            (model for model in json['models'] if model['model'] == 'res.partner'),
+            None,
+        )
+        self.assertTrue(res_partner, "res.partner not found in json['models']")
+        res_partner_fields = res_partner.pop('fields')
+        res_partner_methods = res_partner.pop('methods')
+        self.assertEqual(res_partner, {'name': "Contact", 'model': 'res.partner'})
+        self.assertGreater(set(res_partner_methods), {'search', 'create_company'})
+        self.assertGreater(set(res_partner_fields), {'id', 'create_uid', 'lang', 'tz'})
+
+    def test_doc_model(self):
+        self.authenticate('demo', 'demo')
+        res = self.url_open('/doc/res.partner.json', allow_redirects=False)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.headers.get('Content-Type'), 'application/json; charset=utf-8')
+
+        json = res.json()
+        fields = json.pop('fields', None)
+        methods = json.pop('methods', None)
+        self.maxDiff = None
+        self.assertEqual(json, {
+            'model': 'res.partner',
+            'name': 'Contact',
+            'doc': None,
+        })
+        self.assertGreater(set(fields), {'id', 'create_uid', 'lang', 'tz'})
+        fields['id'].pop('ai', None)
+        self.assertEqual(fields['id'], {
+            'change_default': False,
+            'company_dependent': False,
+            'default_export_compatible': False,
+            'depends': [],
+            'exportable': True,
+            'groupable': True,
+            'manual': False,
+            'module': None,
+            'name': 'id',
+            'readonly': True,
+            'required': False,
+            'searchable': True,
+            'sortable': True,
+            'store': True,
+            'string': 'ID',
+            'type': 'integer',
+        })
+        self.assertGreater(set(methods), {'search', 'create_company'})
+        self.assertEqual(methods['search'], {
+            'model': 'core',
+            'module': 'core',
+            'signature': '(domain, offset=0, limit=None, order=None) -> list[int]',
+            'parameters': {
+                'domain': {
+                    'annotation': 'DomainType',
+                    'doc': textwrap.dedent("""\
+                        <p><tt class="docutils literal">A search domain &lt;reference/orm/domains&gt;</tt>. Use an empty
+                        list to match all records.</p>""",
+                    ),
+                },
+                'offset': {
+                    'default': 0,
+                    'annotation': 'int',
+                    'doc': """<p>number of results to ignore (default: none)</p>""",
+                },
+                'limit': {
+                    'default': None,
+                    'annotation': 'int | None',
+                    'doc': """<p>maximum number of records to return (default: all)</p>""",
+                },
+                'order': {
+                    'default': None,
+                    'annotation': 'str | None',
+                    'doc': """<p>sort string</p>""",
+                }
+            },
+            'doc': textwrap.dedent("""\
+                <div class="document">
+
+
+                <p>Search for the records that satisfy the given <tt class="docutils literal">domain</tt>
+                <tt class="docutils literal">search domain &lt;reference/orm/domains&gt;</tt>.</p>
+                <p>This is a high-level method, which should not be overridden. Its actual
+                implementation is done by method <tt class="docutils literal">_search</tt>.</p>
+                </div>"""
+            ),
+            'raise': {
+                'AccessError': """<p>if user is not allowed to access requested information</p>""",
+            },
+            'return': {
+                'annotation': 'list[int]',
+                'doc': """<p>at most <tt class="docutils literal">limit</tt> records matching the search criteria</p>""",
+            },
+            'api': ['model', 'readonly'],
+        })
+
+    def test_doc_cache(self):
+        self.authenticate('demo', 'demo')
+
+        # request the document first
+        res = self.url_open('/doc/index.json', allow_redirects=False)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(res.content, "We should have downloaded the document")
+
+        # ensure the necessary is there to cache the document
+        cache_control = sorted(res.headers.get('Cache-Control', '').split(', '))
+        self.assertEqual(cache_control, ['no-cache', 'private'])
+        etag_demo = res.headers.get('ETag', '')
+        self.assertTrue(etag_demo)
+
+        # request the document again, this time using the cache
+        res = self.url_open(
+            '/doc/index.json',
+            headers={'If-None-Match': etag_demo},
+            allow_redirects=False,
+        )
+        res.raise_for_status()
+        self.assertEqual(res.status_code, HTTPStatus.NOT_MODIFIED)
+        self.assertFalse(res.content, "We should not have downloaded the document")
+
+        # request the document again, this time as admin
+        self.authenticate('admin', 'admin')
+        res = self.url_open('/doc/index.json', allow_redirects=False)
+        res.raise_for_status()
+        self.assertEqual(res.status_code, 200, "It must not be 304 - Not Modified")
+        etag_admin = res.headers.get('ETag', '')
+        self.assertTrue(etag_admin)
+        self.assertNotEqual(etag_demo, etag_admin)

--- a/addons/api_doc/views/docclient.xml
+++ b/addons/api_doc/views/docclient.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="api_doc.docclient">
+        <t t-call="web.layout">
+            <t t-set="html_data" t-value="{'style': 'height: 100%;'}"/>
+            <t t-set="title">Odoo Runtime Doc</t>
+            <t t-set="head">
+                <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no"/>
+                <t t-call-assets="api_doc.assets" />
+            </t>
+        </t>
+    </template>
+</odoo>

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1475,22 +1475,22 @@ class MailThread(models.AbstractModel):
     @api.model
     def message_new(self, msg_dict, custom_values=None):
         """Called by ``message_process`` when a new message is received
-           for a given thread model, if the message did not belong to
-           an existing thread.
-           The default behavior is to create a new record of the corresponding
-           model (based on some very basic info extracted from the message).
-           Additional behavior may be implemented by overriding this method.
+        for a given thread model, if the message did not belong to
+        an existing thread.
+        The default behavior is to create a new record of the corresponding
+        model (based on some very basic info extracted from the message).
+        Additional behavior may be implemented by overriding this method.
 
-           :param dict msg_dict: a map containing the email details and
-                                 attachments. See ``message_process`` and
-                                ``mail.message.parse`` for details.
-           :param dict custom_values: optional dictionary of additional
-                                      field values to pass to create()
-                                      when creating the new thread record.
-                                      Be careful, these values may override
-                                      any other values coming from the message.
-           :rtype: int
-           :return: the id of the newly created thread object
+        :param dict msg_dict: a map containing the email details and
+                             attachments. See ``message_process`` and
+                             ``mail.message.parse`` for details.
+        :param dict custom_values: optional dictionary of additional
+                                  field values to pass to create()
+                                  when creating the new thread record.
+                                  Be careful, these values may override
+                                  any other values coming from the message.
+        :rtype: int
+        :return: the id of the newly created thread object
         """
         data = {}
         if isinstance(custom_values, dict):
@@ -1512,6 +1512,7 @@ class MailThread(models.AbstractModel):
            with update_vals taken from the incoming email.
            Additional behavior may be implemented by overriding this
            method.
+
            :param dict msg_dict: a map containing the email details and
                                attachments. See ``message_process`` and
                                ``mail.message.parse()`` for details.
@@ -1757,22 +1758,22 @@ class MailThread(models.AbstractModel):
         :return: A dict with the following structure, where each field may not
             be present if missing in original message::
 
-            { 'message_id': msg_id,
-              'subject': subject,
-              'email_from': from,
-              'to': to + delivered-to,
-              'cc': cc,
-              'recipients': delivered-to + to + cc + resent-to + resent-cc,
-              'body': unified_body,
-              'references': references,
-              'in_reply_to': in-reply-to,
-              'is_bounce': True if it has been detected as a bounce email
-              'parent_id': parent mail.message based on in_reply_to or references,
-              'is_internal': answer to an internal message (note),
-              'date': date,
-              'attachments': [('file1', 'bytes'),
-                              ('file2', 'bytes')}
-            }
+                { 'message_id': msg_id,
+                  'subject': subject,
+                  'email_from': from,
+                  'to': to + delivered-to,
+                  'cc': cc,
+                  'recipients': delivered-to + to + cc + resent-to + resent-cc,
+                  'body': unified_body,
+                  'references': references,
+                  'in_reply_to': in-reply-to,
+                  'is_bounce': True if it has been detected as a bounce email
+                  'parent_id': parent mail.message based on in_reply_to or references,
+                  'is_internal': answer to an internal message (note),
+                  'date': date,
+                  'attachments': [('file1', 'bytes'),
+                                  ('file2', 'bytes')}
+                }
         """
         if not isinstance(message, EmailMessage):
             raise ValueError(_('Message should be a valid EmailMessage instance'))
@@ -2508,17 +2509,19 @@ class MailThread(models.AbstractModel):
         through mail.thread and lessen usage of composer itself.
 
         Default values
-          * subtype_id: will be False, forced by composer in mass mode;
+
+        * subtype_id: will be False, forced by composer in mass mode;
 
         :param record/str source_ref: reference to a source for rendering.
           It can be one of
-            * a MailTemplate record. It will be used to render the various
-              message values (body, subject, recipients, ...). It should behave
-              like using the mail composer with a template;
-            * an IrUIView record. It will be used to render the content
-              (body). Other fields are left to the caller and/or default values
-              computation;
-            * an XmlID of a MailTemplate or of an IrUiView: see above;
+
+          * a MailTemplate record. It will be used to render the various
+            message values (body, subject, recipients, ...). It should behave
+            like using the mail composer with a template;
+          * an IrUIView record. It will be used to render the content
+            (body). Other fields are left to the caller and/or default values
+            computation;
+          * an XmlID of a MailTemplate or of an IrUiView: see above;
         :param dict render_values: additional rendering values for qweb context;
 
         :param str message_type: one of 'notification' or 'comment';
@@ -2582,18 +2585,20 @@ class MailThread(models.AbstractModel):
         body using QWeb.
 
         Default values
-          * subtype_id: if not given, fallback on ``note`` to be consistent
-            with what message_post does;
+
+        * subtype_id: if not given, fallback on ``note`` to be consistent
+          with what message_post does;
 
         :param record/str source_ref: reference to a source for rendering.
           It can be one of
-            * a MailTemplate record. It will be used to render the various
-              message values (body, subject, recipients, ...). It should behave
-              like using the mail composer with a template;
-            * an IrUIView record. It will be used to render the content
-              (body). Other fields are left to the caller and/or default values
-              computation;
-            * an XmlID of a MailTemplate or of an IrUiView: see above
+
+          * a MailTemplate record. It will be used to render the various
+            message values (body, subject, recipients, ...). It should behave
+            like using the mail composer with a template;
+          * an IrUIView record. It will be used to render the content
+            (body). Other fields are left to the caller and/or default values
+            computation;
+          * an XmlID of a MailTemplate or of an IrUiView: see above
         :param dict render_values: additional rendering values for qweb context;
 
         :param str message_type: one of 'notification' or 'comment';

--- a/addons/transifex/models/models.py
+++ b/addons/transifex/models/models.py
@@ -8,14 +8,30 @@ class Base(models.AbstractModel):
     _inherit = 'base'
 
     def get_field_translations(self, field_name, langs=None):
-        """ get model/model_term translations for records with transifex url
+        """
+        Get model/model_term translations for records with transifex url
+
         :param str field_name: field name
         :param list langs: languages
 
-        :return: (translations, context) where
-            translations: list of dicts like [{"lang": lang, "source": source_term, "value": value_term,
-                    "module": module, "transifexURL": transifex_url}]
-            context: {"translation_type": "text"/"char", "translation_show_source": True/False}
+        :return: a 2-items tuple ``(translations, context)`` where
+
+            translations:
+                list of dicts like::
+
+                    [{
+                        "lang": lang,
+                        "source": source_term,
+                        "value": value_term,
+                        "module": module,
+                        "transifexURL": transifex_url
+                    }]
+
+            context:
+                dict like::
+
+                    {"translation_type": "text"/"char",
+                     "translation_show_source": True/False}
         """
         translations, context = super().get_field_translations(field_name, langs=langs)
         external_id = self.get_external_id().get(self.id)

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -320,6 +320,7 @@ This module provides the core of the Odoo Web Client.
             "web/static/lib/ace/mode-qweb.js",
             "web/static/lib/ace/mode-python.js",
             "web/static/lib/ace/mode-scss.js",
+            "web/static/lib/ace/mode-json.js",
             "web/static/lib/ace/theme-monokai.js",
         ],
 

--- a/addons/web/static/lib/ace/mode-json.js
+++ b/addons/web/static/lib/ace/mode-json.js
@@ -1,0 +1,278 @@
+define("ace/mode/json_highlight_rules", ["require", "exports", "module", "ace/lib/oop", "ace/mode/text_highlight_rules"], function (require, exports, module) {
+    "use strict";
+    var oop = require("../lib/oop");
+    var TextHighlightRules = require("./text_highlight_rules").TextHighlightRules;
+    var JsonHighlightRules = function () {
+        this.$rules = {
+            "start": [
+                {
+                    token: "variable", // single line
+                    regex: '["](?:(?:\\\\.)|(?:[^"\\\\]))*?["]\\s*(?=:)'
+                }, {
+                    token: "string", // single line
+                    regex: '"',
+                    next: "string"
+                }, {
+                    token: "constant.numeric", // hex
+                    regex: "0[xX][0-9a-fA-F]+\\b"
+                }, {
+                    token: "constant.numeric", // float
+                    regex: "[+-]?\\d+(?:(?:\\.\\d*)?(?:[eE][+-]?\\d+)?)?\\b"
+                }, {
+                    token: "constant.language.boolean",
+                    regex: "(?:true|false)\\b"
+                }, {
+                    token: "text", // single quoted strings are not allowed
+                    regex: "['](?:(?:\\\\.)|(?:[^'\\\\]))*?[']"
+                }, {
+                    token: "comment", // comments are not allowed, but who cares?
+                    regex: "\\/\\/.*$"
+                }, {
+                    token: "comment.start", // comments are not allowed, but who cares?
+                    regex: "\\/\\*",
+                    next: "comment"
+                }, {
+                    token: "paren.lparen",
+                    regex: "[[({]"
+                }, {
+                    token: "paren.rparen",
+                    regex: "[\\])}]"
+                }, {
+                    token: "punctuation.operator",
+                    regex: /[,]/
+                }, {
+                    token: "text",
+                    regex: "\\s+"
+                }
+            ],
+            "string": [
+                {
+                    token: "constant.language.escape",
+                    regex: /\\(?:x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|["\\\/bfnrt])/
+                }, {
+                    token: "string",
+                    regex: '"|$',
+                    next: "start"
+                }, {
+                    defaultToken: "string"
+                }
+            ],
+            "comment": [
+                {
+                    token: "comment.end", // comments are not allowed, but who cares?
+                    regex: "\\*\\/",
+                    next: "start"
+                }, {
+                    defaultToken: "comment"
+                }
+            ]
+        };
+    };
+    oop.inherits(JsonHighlightRules, TextHighlightRules);
+    exports.JsonHighlightRules = JsonHighlightRules;
+
+});
+
+define("ace/mode/matching_brace_outdent", ["require", "exports", "module", "ace/range"], function (require, exports, module) {
+    "use strict";
+    var Range = require("../range").Range;
+    var MatchingBraceOutdent = function () { };
+    (function () {
+        this.checkOutdent = function (line, input) {
+            if (!/^\s+$/.test(line))
+                return false;
+            return /^\s*\}/.test(input);
+        };
+        this.autoOutdent = function (doc, row) {
+            var line = doc.getLine(row);
+            var match = line.match(/^(\s*\})/);
+            if (!match)
+                return 0;
+            var column = match[1].length;
+            var openBracePos = doc.findMatchingBracket({ row: row, column: column });
+            if (!openBracePos || openBracePos.row == row)
+                return 0;
+            var indent = this.$getIndent(doc.getLine(openBracePos.row));
+            doc.replace(new Range(row, 0, row, column - 1), indent);
+        };
+        this.$getIndent = function (line) {
+            return line.match(/^\s*/)[0];
+        };
+    }).call(MatchingBraceOutdent.prototype);
+    exports.MatchingBraceOutdent = MatchingBraceOutdent;
+
+});
+
+define("ace/mode/folding/cstyle", ["require", "exports", "module", "ace/lib/oop", "ace/range", "ace/mode/folding/fold_mode"], function (require, exports, module) {
+    "use strict";
+    var oop = require("../../lib/oop");
+    var Range = require("../../range").Range;
+    var BaseFoldMode = require("./fold_mode").FoldMode;
+    var FoldMode = exports.FoldMode = function (commentRegex) {
+        if (commentRegex) {
+            this.foldingStartMarker = new RegExp(this.foldingStartMarker.source.replace(/\|[^|]*?$/, "|" + commentRegex.start));
+            this.foldingStopMarker = new RegExp(this.foldingStopMarker.source.replace(/\|[^|]*?$/, "|" + commentRegex.end));
+        }
+    };
+    oop.inherits(FoldMode, BaseFoldMode);
+    (function () {
+        this.foldingStartMarker = /([\{\[\(])[^\}\]\)]*$|^\s*(\/\*)/;
+        this.foldingStopMarker = /^[^\[\{\(]*([\}\]\)])|^[\s\*]*(\*\/)/;
+        this.singleLineBlockCommentRe = /^\s*(\/\*).*\*\/\s*$/;
+        this.tripleStarBlockCommentRe = /^\s*(\/\*\*\*).*\*\/\s*$/;
+        this.startRegionRe = /^\s*(\/\*|\/\/)#?region\b/;
+        this._getFoldWidgetBase = this.getFoldWidget;
+        this.getFoldWidget = function (session, foldStyle, row) {
+            var line = session.getLine(row);
+            if (this.singleLineBlockCommentRe.test(line)) {
+                if (!this.startRegionRe.test(line) && !this.tripleStarBlockCommentRe.test(line))
+                    return "";
+            }
+            var fw = this._getFoldWidgetBase(session, foldStyle, row);
+            if (!fw && this.startRegionRe.test(line))
+                return "start"; // lineCommentRegionStart
+            return fw;
+        };
+        this.getFoldWidgetRange = function (session, foldStyle, row, forceMultiline) {
+            var line = session.getLine(row);
+            if (this.startRegionRe.test(line))
+                return this.getCommentRegionBlock(session, line, row);
+            var match = line.match(this.foldingStartMarker);
+            if (match) {
+                var i = match.index;
+                if (match[1])
+                    return this.openingBracketBlock(session, match[1], row, i);
+                var range = session.getCommentFoldRange(row, i + match[0].length, 1);
+                if (range && !range.isMultiLine()) {
+                    if (forceMultiline) {
+                        range = this.getSectionRange(session, row);
+                    }
+                    else if (foldStyle != "all")
+                        range = null;
+                }
+                return range;
+            }
+            if (foldStyle === "markbegin")
+                return;
+            var match = line.match(this.foldingStopMarker);
+            if (match) {
+                var i = match.index + match[0].length;
+                if (match[1])
+                    return this.closingBracketBlock(session, match[1], row, i);
+                return session.getCommentFoldRange(row, i, -1);
+            }
+        };
+        this.getSectionRange = function (session, row) {
+            var line = session.getLine(row);
+            var startIndent = line.search(/\S/);
+            var startRow = row;
+            var startColumn = line.length;
+            row = row + 1;
+            var endRow = row;
+            var maxRow = session.getLength();
+            while (++row < maxRow) {
+                line = session.getLine(row);
+                var indent = line.search(/\S/);
+                if (indent === -1)
+                    continue;
+                if (startIndent > indent)
+                    break;
+                var subRange = this.getFoldWidgetRange(session, "all", row);
+                if (subRange) {
+                    if (subRange.start.row <= startRow) {
+                        break;
+                    }
+                    else if (subRange.isMultiLine()) {
+                        row = subRange.end.row;
+                    }
+                    else if (startIndent == indent) {
+                        break;
+                    }
+                }
+                endRow = row;
+            }
+            return new Range(startRow, startColumn, endRow, session.getLine(endRow).length);
+        };
+        this.getCommentRegionBlock = function (session, line, row) {
+            var startColumn = line.search(/\s*$/);
+            var maxRow = session.getLength();
+            var startRow = row;
+            var re = /^\s*(?:\/\*|\/\/|--)#?(end)?region\b/;
+            var depth = 1;
+            while (++row < maxRow) {
+                line = session.getLine(row);
+                var m = re.exec(line);
+                if (!m)
+                    continue;
+                if (m[1])
+                    depth--;
+                else
+                    depth++;
+                if (!depth)
+                    break;
+            }
+            var endRow = row;
+            if (endRow > startRow) {
+                return new Range(startRow, startColumn, endRow, line.length);
+            }
+        };
+    }).call(FoldMode.prototype);
+
+});
+
+define("ace/mode/json", ["require", "exports", "module", "ace/lib/oop", "ace/mode/text", "ace/mode/json_highlight_rules", "ace/mode/matching_brace_outdent", "ace/mode/folding/cstyle", "ace/worker/worker_client"], function (require, exports, module) {
+    "use strict";
+    var oop = require("../lib/oop");
+    var TextMode = require("./text").Mode;
+    var HighlightRules = require("./json_highlight_rules").JsonHighlightRules;
+    var MatchingBraceOutdent = require("./matching_brace_outdent").MatchingBraceOutdent;
+    var CStyleFoldMode = require("./folding/cstyle").FoldMode;
+    var WorkerClient = require("../worker/worker_client").WorkerClient;
+    var Mode = function () {
+        this.HighlightRules = HighlightRules;
+        this.$outdent = new MatchingBraceOutdent();
+        this.$behaviour = this.$defaultBehaviour;
+        this.foldingRules = new CStyleFoldMode();
+    };
+    oop.inherits(Mode, TextMode);
+    (function () {
+        this.lineCommentStart = "//";
+        this.blockComment = { start: "/*", end: "*/" };
+        this.getNextLineIndent = function (state, line, tab) {
+            var indent = this.$getIndent(line);
+            if (state == "start") {
+                var match = line.match(/^.*[\{\(\[]\s*$/);
+                if (match) {
+                    indent += tab;
+                }
+            }
+            return indent;
+        };
+        this.checkOutdent = function (state, line, input) {
+            return this.$outdent.checkOutdent(line, input);
+        };
+        this.autoOutdent = function (state, doc, row) {
+            this.$outdent.autoOutdent(doc, row);
+        };
+        this.createWorker = function (session) {
+            var worker = new WorkerClient(["ace"], "ace/mode/json_worker", "JsonWorker");
+            worker.attachToDocument(session.getDocument());
+            worker.on("annotate", function (e) {
+                session.setAnnotations(e.data);
+            });
+            worker.on("terminate", function () {
+                session.clearAnnotations();
+            });
+            return worker;
+        };
+        this.$id = "ace/mode/json";
+    }).call(Mode.prototype);
+    exports.Mode = Mode;
+
+}); (function () {
+    window.require(["ace/mode/json"], function (m) {
+        if (typeof module == "object" && typeof exports == "object" && module) {
+            module.exports = m;
+        }
+    });
+})();

--- a/addons/web/static/src/core/code_editor/code_editor.js
+++ b/addons/web/static/src/core/code_editor/code_editor.js
@@ -23,6 +23,7 @@ export class CodeEditor extends Component {
         maxLines: { type: Number, optional: true },
         sessionId: { type: [Number, String], optional: true },
         initialCursorPosition: { type: Object, optional: true },
+        showLineNumbers: { type: Boolean, optional: true },
     };
     static defaultProps = {
         readonly: false,
@@ -31,6 +32,7 @@ export class CodeEditor extends Component {
         class: "",
         theme: "",
         sessionId: 1,
+        showLineNumbers: true,
     };
 
     static MODES = ["javascript", "xml", "qweb", "scss", "python"];
@@ -104,7 +106,7 @@ export class CodeEditor extends Component {
         );
 
         useEffect(
-            (readonly) => {
+            (readonly, showLineNumbers) => {
                 this.aceEditor.setOptions({
                     readOnly: readonly,
                     highlightActiveLine: !readonly,
@@ -113,14 +115,14 @@ export class CodeEditor extends Component {
 
                 this.aceEditor.renderer.setOptions({
                     displayIndentGuides: !readonly,
-                    showGutter: !readonly,
+                    showGutter: !readonly && showLineNumbers,
                 });
 
                 this.aceEditor.renderer.$cursorLayer.element.style.display = readonly
                     ? "none"
                     : "block";
             },
-            () => [this.props.readonly]
+            () => [this.props.readonly, this.props.showLineNumbers]
         );
 
         useEffect(

--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -10,6 +10,7 @@ class Base(models.AbstractModel):
     def get_base_url(self):
         """
         Returns the base url for a given record, given the following priority:
+
         1. If the record has a `website_id` field, we use the url from this
            website as base url, if set.
         2. If the record has a `company_id` field, we use the website from that

--- a/odoo/_monkeypatches/docutils.py
+++ b/odoo/_monkeypatches/docutils.py
@@ -1,0 +1,29 @@
+"""
+The docstrings can use many more roles and directives than the one
+present natively in docutils. That's because we use Sphinx to render
+them in the documentation, and Sphinx defines the "Python Domain", a set
+of additional rules and directive to understand the python language.
+
+It is not desirable to add a dependency on Sphinx in community, as it is
+a *too big* dependency.
+
+The following code adds a bunch of dummy elements for the missing roles
+and directives, so docutils is able to parse them with no warning.
+"""
+
+import docutils.nodes
+import docutils.parsers.rst.directives.admonitions
+
+
+def _role_literal(name, rawtext, text, lineno, inliner, options=None, content=None):
+    literal = docutils.nodes.literal(rawtext, text)
+    return [literal], []
+
+
+def patch_module():
+    for role in ('attr', 'class', 'func', 'meth', 'ref', 'const', 'samp', 'term'):
+        docutils.parsers.rst.roles.register_local_role(role, _role_literal)
+
+    for directive in ('attribute', 'deprecated'):
+        docutils.parsers.rst.directives.register_directive(
+            directive, docutils.parsers.rst.directives.admonitions.Note)

--- a/odoo/addons/test_lint/tests/test_docstring.py
+++ b/odoo/addons/test_lint/tests/test_docstring.py
@@ -154,29 +154,6 @@ class TestDocstring(BaseCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        # The docstrings can use many more roles and directives than the
-        # one present natively in docutils. That's because we use Sphinx
-        # to render them in the documentation, and Sphinx defines the
-        # "Python Domain", a set of additional rules and directive to
-        # understand the python language.
-        #
-        # It is not desirable to add a dependency on Sphinx in
-        # community, at least not only for this linter.
-        #
-        # The following code adds a bunch of dummy elements for the
-        # missing roles and directives, so docutils is able to parse
-        # them with no warning.
-
-        def role_function(name, rawtext, text, lineno, inliner, options=None, content=None):
-            return [docutils.nodes.inline(rawtext, text)], []
-
-        for role in ('attr', 'class', 'func', 'meth', 'ref', 'const', 'samp', 'term'):
-            docutils.parsers.rst.roles.register_local_role(role, role_function)
-
-        for directive in ('attribute', 'deprecated'):
-            docutils.parsers.rst.directives.register_directive(
-                directive, docutils.parsers.rst.directives.admonitions.Note)
-
         doctree = docutils.core.publish_doctree("", settings_overrides={
             'report_level': DOCUTILS_CRITICAL,
             'halt_level': DOCUTILS_CRITICAL,

--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -44,6 +44,10 @@ def get_public_method(model: BaseModel, name: str):
     not prefixed with "_") and are not decorated with `@api.private`.
     """
     assert isinstance(model, BaseModel)
+    e = f"Private methods (such as '{model._name}.{name}') cannot be called remotely."
+    if name.startswith('_'):
+        raise AccessError(e)
+
     cls = type(model)
     method = getattr(cls, name, None)
     if not callable(method):
@@ -52,8 +56,8 @@ def get_public_method(model: BaseModel, name: str):
     for mro_cls in cls.mro():
         if not (cla_method := getattr(mro_cls, name, None)):
             continue
-        if name.startswith('_') or getattr(cla_method, '_api_private', False):
-            raise AccessError(f"Private methods (such as '{model._name}.{name}') cannot be called remotely.")  # pylint: disable=missing-gettext
+        if getattr(cla_method, '_api_private', False):
+            raise AccessError(e)
 
     return method
 

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -24,6 +24,8 @@ crypt_context = CryptContext(schemes=['pbkdf2_sha512', 'plaintext'],
 
 _dangerous_logger = logging.getLogger(__name__)  # use config._log() instead
 
+optparse._ = str  # disable gettext
+
 DEFAULT_SERVER_WIDE_MODULES = ['base', 'rpc', 'web']
 REQUIRED_SERVER_WIDE_MODULES = ['base', 'web']
 


### PR DESCRIPTION
The technical documentation at https://odoo.com/documentation lacks a
complete API reference where the fields and methods of all models is
listed. Building such a reference, in the static page, is actually not
possible, as the available fields and methods depend on the database's
registry.

This work is about bringing the missing API reference, as a dedicated
`/doc` page for every database.

There are three controllers:

* `/doc`: a web-client that fetches and consumes the below json
  documents and renders them in a good looking web page.
* `/doc/index.json`: a listing of available models with their fields and
  methods names, but no advanced information.
* `/doc/<model>.json`: a single model but with comprehensive fields and
  methods info.

task-4572591