### PR TITLE
[FIX] web: list column widths: better retro-compatibility

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -419,7 +419,7 @@ export const dateTimeField = {
         showTime: exprToBoolean(options.show_time ?? true),
     }),
     supportedTypes: ["datetime"],
-    listViewWidth: ({ options }) =>
+    listViewWidth: ({ options = {} }) =>
         exprToBoolean(options.show_time ?? true) ? FIELD_WIDTHS.datetime : FIELD_WIDTHS.date,
 };
 
@@ -451,7 +451,7 @@ export const dateRangeField = {
         },
     ],
     supportedTypes: ["date", "datetime"],
-    listViewWidth: ({ type, options }) => {
+    listViewWidth: ({ type, options = {} }) => {
         let width;
         if (type === "datetime" && exprToBoolean(options.show_time ?? true)) {
             width = FIELD_WIDTHS.datetime;

--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -447,7 +447,7 @@ export function useMagicColumnWidths(tableRef, getState) {
             ev.preventDefault();
             ev.stopPropagation();
             let delta = ev.clientX - initialX;
-            delta = this.isRTL ? -delta : delta;
+            delta = localization.direction === "rtl" ? -delta : delta;
             const newWidth = Math.max(10, initialWidth + delta);
             const tableDelta = newWidth - initialWidth;
             th.style.width = `${Math.floor(newWidth)}px`;


### PR DESCRIPTION
This commit is a followup of [1]. It does two things:

1) it fixes the "rtl" check that was forwardported from 16.0, where the callback was defined in the renderer and for which `this` was unambiguously the renderer. As of 18.0, the code was moved to an hook, so using `this.isRTL` worked, but kind of by chance. This commit removes the ambiguity and makes the code a bit more robust.

2) using the newly added parameters `options` in `listViewWidths` callbacks looked harmless. Indeed, it causes no issue in standard odoo. However, as reported in [2], there is a world where `options` is undefined. I couldn't really find how, as it works fine even with the suggested culprit [3]. So this commit simply adds a fallback, which makes sense in stable in case there would be custom code calling those `listViewWidths` functions without options. In master though, we expect from people to adapt their code with respect to this change.

[1] https://github.com/odoo/odoo/pull/210584
[2] https://github.com/odoo/odoo/issues/211243
[3] https://github.com/OCA/web/tree/18.0/web_remember_tree_column_width

closes #211243

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
