### PR TITLE
[FIX] website: export shape plugins

### DIFF
--- a/addons/website/static/src/builder/plugins/image/image_shape_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_shape_option_plugin.js
@@ -27,7 +27,7 @@ const SVG_DUR_TIMECOUNT_VAL_REGEX =
     /(?<attribute_name>\sdur="\s*)(?<value>(?:\d+(?:\.\d+)?)|(?:\.\d+))(?<unit>h|min|ms|s)?\s*"/gm;
 const CSS_ANIMATION_RATIO_REGEX = /(--animation_ratio: (?<ratio>\d*(\.\d+)?));/m;
 
-class ImageShapeOptionPlugin extends Plugin {
+export class ImageShapeOptionPlugin extends Plugin {
     static id = "imageShapeOption";
     static dependencies = ["history", "userCommand", "imagePostProcess"];
     static shared = [

--- a/addons/website/static/src/js/tours/homepage.js
+++ b/addons/website/static/src/js/tours/homepage.js
@@ -56,7 +56,7 @@ registerThemeHomepageTour('homepage', () => [
     goBackToBlocks(),
     ...insertSnippet(snippets[1]),
     ...insertSnippet(snippets[2]),
-    ...clickOnSnippet(snippets[2], { position: "top" }),
+    ...clickOnSnippet(snippets[2], "top"),
     changeBackgroundColor(),
     goBackToBlocks(),
     ...insertSnippet(snippets[3]),

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -353,7 +353,7 @@ export function insertSnippet(snippet, { position = "bottom", ignoreLoading = fa
         trigger: ".o_website_preview :iframe .odoo-editor-editable",
         noPrepend: true,
     }];
-    const snippetIDSelector = snippet.id ? `[data-snippet="${snippet.id}"]` : `[data-snippet^="${snippet.customID}"]`;
+    const snippetIDSelector = snippet.id ? `[data-snippet-id="${snippet.id}"]` : `[data-snippet-id^="${snippet.customID}_"]`;
     if (snippet.groupName) {
         insertSnippetSteps.push({
             content: markup(_t("Click on the <b>%s</b> category.", blockEl)),
@@ -365,7 +365,7 @@ export function insertSnippet(snippet, { position = "bottom", ignoreLoading = fa
             content: markup(_t("Click on the <b>%s</b> building block.", snippet.name)),
             // FIXME `:not(.d-none)` should obviously not be needed but it seems
             // currently needed when using a tour in user/interactive mode.
-            trigger: `:iframe .o_snippet_preview_wrap > ${snippetIDSelector}:not(.d-none)`,
+            trigger: `.modal .show:iframe .o_snippet_preview_wrap${snippetIDSelector}:not(.d-none)`,
             noPrepend: true,
             tooltipPosition: "top",
             run: "click",


### PR DESCRIPTION
[FIX] website: export image shape option plugin
In order to be patchable (in particular by design themes), the
`ImageShapeOptionPlugin` plugin has been exported.

Related to task-4367641
runbot-223813
runbot-223815


--------------------------------------------------------------------------------------------------------------------------------------------

[FIX] website: correct second argument of clickOnSnippet
This commit fixes a typo that appeared since [the website refactoring];
the second argument of `clickOnSnippet` has to be a string but was an
object.

[the website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641
runbot-223813
runbot-223815

--------------------------------------------------------------------------------------------------------------------------------------------

[FIX] website: restore the way to compute and use snippetIDSelector
Since the [the website refactoring], the way to compute and use
`snippetIDSelector` has been modified for no good reason. This commit
reverts those changes.

[the website refactoring]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641
runbot-223813
runbot-223815