### PR TITLE
[FIX] stock_dropshipping,sale_mrp: change qty SOL kit with dropshippe…

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_sale_dropshipping.py
@@ -290,3 +290,43 @@ class TestSaleDropshippingFlows(TestMrpSubcontractingCommon):
         sale_order.picking_ids[1].button_validate()
 
         self.assertEqual(sale_order.order_line.qty_delivered, 1.0)
+
+    def test_kit_dropshipped_change_qty_SO(self):
+        # Create BoM
+        product_a, product_b, final_product = self.env['product.product'].create([{
+            'name': p_name,
+            'type': 'product',
+            'seller_ids': [(0, 0, {
+                'partner_id': self.supplier.id,
+            })],
+        } for p_name in ['Comp 1', 'Comp 2', 'Final Product']])
+        product_a.route_ids = self.env.ref('stock_dropshipping.route_drop_shipping')
+        product_b.route_ids = self.env.ref('stock_dropshipping.route_drop_shipping')
+        self.env['mrp.bom'].create({
+            'product_id': final_product.id,
+            'product_tmpl_id': final_product.product_tmpl_id.id,
+            'product_qty': 1,
+            'consumption': 'flexible',
+            'type': 'phantom',
+            'bom_line_ids': [
+                (0, 0, {'product_id': product_a.id, 'product_qty': 1}),
+                (0, 0, {'product_id': product_b.id, 'product_qty': 1}),
+            ]
+        })
+
+        # Create sale order
+        partner = self.env['res.partner'].create({'name': 'Testing Man'})
+        so = self.env['sale.order'].create({
+            'partner_id': partner.id,
+        })
+        sol = self.env['sale.order.line'].create({
+            'name': "Order line",
+            'product_id': final_product.id,
+            'order_id': so.id,
+            'product_uom_qty': 25,
+        })
+        so.action_confirm()
+
+        user_admin = self.env['res.users'].search([('login', '=', 'admin')])
+        sol.with_user(user_admin).write({'product_uom_qty': 10})
+        self.assertEqual(sol.purchase_line_ids.mapped('product_uom_qty'), [10, 10])

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -131,11 +131,13 @@ class SaleOrderLine(models.Model):
         # We don't try to be too smart and keep a simple approach: we use the quantity of entire
         # kits that are currently in delivery
         bom = self.env['mrp.bom'].sudo()._bom_find(self.product_id, bom_type='phantom', company_id=self.company_id.id)[self.product_id]
-        if bom:
+        if bom and self.move_ids:
             moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped)
             filters = self._get_incoming_outgoing_moves_filter()
             order_qty = previous_product_uom_qty.get(self.id, 0) if previous_product_uom_qty else self.product_uom_qty
             order_qty = self.product_uom._compute_quantity(order_qty, bom.product_uom_id)
             qty = moves._compute_kit_quantities(self.product_id, order_qty, bom, filters)
             return bom.product_uom_id._compute_quantity(qty, self.product_uom)
+        elif bom and previous_product_uom_qty:
+            return previous_product_uom_qty.get(self.id)
         return super(SaleOrderLine, self)._get_qty_procurement(previous_product_uom_qty=previous_product_uom_qty)

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -42,7 +42,8 @@ class SaleOrderLine(models.Model):
     def _get_qty_procurement(self, previous_product_uom_qty):
         # People without purchase rights should be able to do this operation
         purchase_lines_sudo = self.sudo().purchase_line_ids
-        if purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
+        # We make sure that it's not a kit with dropshipped components
+        if self.product_id == purchase_lines_sudo.product_id and purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
             qty = 0.0
             for po_line in purchase_lines_sudo.filtered(lambda r: r.state != 'cancel'):
                 qty += po_line.product_uom._compute_quantity(po_line.product_qty, self.product_uom, rounding_method='HALF-UP')


### PR DESCRIPTION
…d comp

**Problem:**
when updating the quantity of a sale order line for a kit whose components are dropshipped, the update of the quantity of the linked Purchase order lines is wrongly computed

**Steps to reproduce:**
- enable the dropshipping setting
- create a new storable product
- in the purchase tab set a vendor
- in the inventory tab check only the dropship route
- repeat these operations for another product
- create a third storable product
- create a BOM for this product and set it as "kit"
- add the two first products you created in the components
- create a new quotation for the kit product, set a quantity of 25 and confirm
- modify the quantity to 10 and save
- click on the purchase smart button

**Current behavior:**
the quantities of the two purchase order lines have been updated to -15

**Expected behavior:**
it should be 10

**Cause of the issue:**
When we change the quantity on the sale order line: The method action_stock_rule from SaleOrderLine is triggered. It will create a procurement:
https://github.com/odoo/odoo/blob/2e7fd1c45a0f68d123e85c95f3eb3a7fd5395527/addons/sale_stock/models/sale_order_line.py#L338 To compute the quantity used for this procurement,the computation is : product_qty = line.product_uom_qty - qty
where qty is line._get_qty_procurement
https://github.com/odoo/odoo/blob/2e7fd1c45a0f68d123e85c95f3eb3a7fd5395527/addons/sale_stock/models/sale_order_line.py#L313

The error comes from the _get_qty_procurement

- The "normal" behaviour of _get_qty_procurement is to compute the difference between outgoing moves and incoming moves https://github.com/odoo/odoo/blob/2e7fd1c45a0f68d123e85c95f3eb3a7fd5395527/addons/sale_stock/models/sale_order_line.py#L253-L263

- Basic _get_qty_procurement wouldn't work for a kit as a move is created for each components.
So there is an override of the method to handle this case https://github.com/odoo/odoo/blob/2e7fd1c45a0f68d123e85c95f3eb3a7fd5395527/addons/sale_mrp/models/sale_order_line.py#L128-L141 this override calls _compute_kit_quantities on the stock moves linked to the sale order line via its move_ids attribute. _compute_kit_quantities does a computation of the ratios for each component and returns the minimum

- Basic _get_qty_procurement wouldn't work either for a dropshipped product as no move is created when confirming the sale order. So there is another override of the method to compute this case https://github.com/odoo/odoo/blob/2e7fd1c45a0f68d123e85c95f3eb3a7fd5395527/addons/stock_dropshipping/models/sale.py#L42-L51 This override uses the purchase order line linked to the sale order line via its purchase_line_ids to compute the quantity.

Neither of those two overrides would work for a kit with dropshipped components.
The first one would fail because no stock moves are created. The second one would fail because adding the value of each purchase order line created returns a value too high

**fix**
for this specific case we just take the previous quantity

opw-4743482
