### PR TITLE
[IMP] website: show label for each font size in toolbar

### DIFF
--- a/addons/html_editor/static/src/main/font/font_plugin.js
+++ b/addons/html_editor/static/src/main/font/font_plugin.js
@@ -90,10 +90,7 @@ export const fontItems = [
 ];
 
 export const fontSizeItems = [
-    {
-        variableName: "display-1-font-size",
-        className: "display-1-fs",
-    },
+    { variableName: "display-1-font-size", className: "display-1-fs" },
     { variableName: "display-2-font-size", className: "display-2-fs" },
     { variableName: "display-3-font-size", className: "display-3-fs" },
     { variableName: "display-4-font-size", className: "display-4-fs" },

--- a/addons/html_editor/static/src/main/font/font_size_selector.xml
+++ b/addons/html_editor/static/src/main/font/font_size_selector.xml
@@ -8,7 +8,7 @@
                 <div data-prevent-closing-overlay="true">
                     <t t-foreach="items" t-as="item" t-key="item_index">
                         <DropdownItem onSelected="() => this.onSelected(item)" t-on-pointerdown.prevent="() => {}">
-                            <t t-esc="item.name"/>
+                            <t t-out="item.name"/>
                         </DropdownItem>
                     </t>
                 </div>

--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -167,7 +167,6 @@ export class ToolbarPlugin extends Plugin {
             }
             groupIds.add(group.id);
         }
-
         this.buttonGroups = this.getButtonGroups();
 
         this.isMobileToolbar = hasTouch() && window.visualViewport;

--- a/addons/website/static/src/builder/plugins/font/font_plugin.js
+++ b/addons/website/static/src/builder/plugins/font/font_plugin.js
@@ -5,12 +5,13 @@ import { Cache } from "@web/core/utils/cache";
 import { loadCSS } from "@web/core/assets";
 import { getCSSVariableValue } from "@html_builder/utils/utils_css";
 import { showAddFontDialog } from "./add_font_dialog";
+import { WebsiteFontSizeSelector } from "./font_size_selector";
 
 // TODO Website-specific
 class FontPlugin extends Plugin {
     static id = "websiteFont";
     static shared = ["addFont", "deleteFont", "getFontsData"];
-    static dependencies = ["savePlugin", "customizeWebsite"];
+    static dependencies = ["savePlugin", "customizeWebsite", "toolbar"];
     resources = {
         // Lists CSS variables that will be reset when a font is deleted if
         // they refer to that font.
@@ -31,6 +32,17 @@ class FontPlugin extends Plugin {
     };
     setup() {
         this.fontsCache = new Cache(this._fetchFonts.bind(this), JSON.stringify);
+        const buttonGroups = this.dependencies.toolbar.getToolbarInfo().buttonGroups;
+        for (const buttonGroup of buttonGroups) {
+            if (buttonGroup.id !== "font") {
+                continue;
+            }
+            for (const button of buttonGroup.buttons) {
+                if (button.id === "font-size") {
+                    button.Component = WebsiteFontSizeSelector;
+                }
+            }
+        }
     }
     destroy() {
         super.destroy();

--- a/addons/website/static/src/builder/plugins/font/font_size_selector.js
+++ b/addons/website/static/src/builder/plugins/font/font_size_selector.js
@@ -1,0 +1,22 @@
+import { FontSizeSelector } from "@html_editor/main/font/font_size_selector";
+
+export class WebsiteFontSizeSelector extends FontSizeSelector {
+    static template = "website.FontSizeSelector";
+    setup() {
+        super.setup();
+        this.fontSizeTags = {
+            "display-1-font-size": "Display 1",
+            "display-2-font-size": "Display 2",
+            "display-3-font-size": "Display 3",
+            "display-4-font-size": "Display 4",
+            "h1-font-size": "Heading 1",
+            "h2-font-size": "Heading 2",
+            "h3-font-size": "Heading 3",
+            "h4-font-size": "Heading 4",
+            "h5-font-size": "Heading 5",
+            "h6-font-size": "Normal",
+            "font-size-base": "Normal",
+            "small-font-size": "Small",
+        };
+    }
+}

--- a/addons/website/static/src/builder/plugins/font/font_size_selector.xml
+++ b/addons/website/static/src/builder/plugins/font/font_size_selector.xml
@@ -1,0 +1,7 @@
+<templates xml:space="preserve">
+    <t t-name="website.FontSizeSelector" t-inherit="html_editor.FontSizeSelector">
+        <xpath expr="//DropdownItem" position="inside">
+            <span class="badge text-bg-secondary ms-3 float-end"><t t-out="fontSizeTags[item.variableName]"/></span>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
Labels were added in the font size selector of the toolbar in the website builder.
These labels are there to make it easier to grasp which font size corresponds to which type of text (Header, Normal, Small,...).