### PR TITLE
[FIX] web, website: allow robots take extra rules

### DIFF
--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -164,3 +164,19 @@ class Home(http.Controller):
         headers = [('Content-Type', 'application/json'),
                    ('Cache-Control', 'no-store')]
         return request.make_response(data, headers, status=status)
+
+    @http.route(['/robots.txt'], type='http', auth="none")
+    def robots(self, **kwargs):
+        allowed_routes = self._get_allowed_robots_routes()
+        robots_content = ["User-agent: *", "Disallow: /"]
+        robots_content.extend(f"Allow: {route}" for route in allowed_routes)
+
+        return request.make_response("\n".join(robots_content), [('Content-Type', 'text/plain')])
+
+    def _get_allowed_robots_routes(self):
+        """Override this method to return a list of allowed routes.
+
+        :return: A list of URL paths that should be allowed by robots.txt
+              Examples: ['/social_instagram/', '/sitemap.xml', '/web/']
+        """
+        return []

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -214,7 +214,18 @@ class Website(Home):
 
     @http.route(['/robots.txt'], type='http', auth="public", website=True, sitemap=False)
     def robots(self, **kwargs):
-        return request.render('website.robots', {'url_root': request.httprequest.url_root}, mimetype='text/plain')
+        # Don't use `request.website.domain` here, the template is in charge of
+        # detecting if the current URL is the domain one and add a `Disallow: /`
+        # if it's not the case to prevent the crawler to continue.
+        allowed_routes = self._get_allowed_robots_routes()
+        content = request.env['ir.ui.view']._render_template('website.robots',
+            {'url_root': request.httprequest.url_root})
+
+        if allowed_routes:
+            content += '\nUser-agent: *'
+            content += '\n' + '\n'.join(f"Allow: {route}" for route in allowed_routes)
+
+        return request.make_response(content, headers=[('Content-Type', 'text/plain')])
 
     @http.route('/sitemap.xml', type='http', auth="public", website=True, multilang=False, sitemap=False)
     def sitemap_xml_index(self, **kwargs):


### PR DESCRIPTION
Added the dirty hook `_get_additional_robots_rules_web` to allow modules to add extra rules to the robots.txt file whenever it's needed.

Previously, it was blocking all the user-agents when we didn't have website installed.


Part of https://github.com/odoo/enterprise/pull/85990
opw-4726371
