### PR TITLE
[FIX] website, html_builder: await reloadEditor everywhere

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -96,8 +96,8 @@ export class Builder extends Component {
                         editorBus.trigger("DOM_UPDATED");
                     }
                 },
-                reloadEditor: (param = {}) => {
-                    this.props.reloadEditor({
+                reloadEditor: async (param = {}) => {
+                    await this.props.reloadEditor({
                         initialTab: this.state.activeTab,
                         ...param,
                     });

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -586,7 +586,7 @@ function useOperationWithReload(callApply, reload) {
         await Promise.all([callApply(...args), env.editor.shared.savePlugin.save()]);
         const target = env.editor.shared["builder-options"].getReloadSelector(editingElement);
         const url = reload.getReloadUrl?.();
-        env.editor.config.reloadEditor({ target, url });
+        await env.editor.config.reloadEditor({ target, url });
     };
 }
 export function useInputBuilderComponent({

--- a/addons/website/static/src/builder/plugins/font/add_font_dialog.js
+++ b/addons/website/static/src/builder/plugins/font/add_font_dialog.js
@@ -323,7 +323,7 @@ export class AddFontDialog extends Component {
         if (styleEl) {
             delete styleEl.dataset.fontPreview;
         }
-        this.props.reloadEditor();
+        await this.props.reloadEditor();
         return true;
     }
 }

--- a/addons/website/static/src/builder/plugins/menu_data_plugin.js
+++ b/addons/website/static/src/builder/plugins/menu_data_plugin.js
@@ -44,8 +44,8 @@ export class MenuDataPlugin extends Plugin {
                     },
                     onClickEditMenu: () => {
                         this.services.dialog.add(EditMenuDialog, {
-                            save: () => {
-                                this.config.reloadEditor({ url: this.document.URL });
+                            save: async () => {
+                                await this.config.reloadEditor({ url: this.document.URL });
                             },
                         });
                     },


### PR DESCRIPTION
reloadEditor, defined in website/.../website_preview/website_builder_actions.js, is in async function. That information is lost along the way, because of props, but it should still be awaited.