### PR TITLE
[IMP] l10n_ar: allow registering sales with LSG documents

### DIFF
--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -108,17 +108,18 @@ class AccountJournal(models.Model):
         receipt_codes = ['4', '9', '15']
         expo_codes = ['19', '20', '21']
         zeta_codes = ['80', '83']
-        codes_issuer_is_supplier = [
+        lsg_codes = ['331']
+        no_pos_docs = [
             '23', '24', '25', '26', '27', '28', '33', '43', '45', '46', '48', '58', '60', '61', '150', '151', '157',
             '158', '161', '162', '164', '166', '167', '171', '172', '180', '182', '186', '188', '332']
         codes = []
         if (self.type == 'sale' and not self.l10n_ar_is_pos) or (self.type == 'purchase' and afip_pos_system in ['II_IM', 'RLI_RLM']):
-            codes = codes_issuer_is_supplier
+            codes = no_pos_docs + lsg_codes
         elif self.type == 'purchase' and afip_pos_system == 'RAW_MAW':
-            # electronic invoices (wsfev1) (intersection between available docs on ws and codes_issuer_is_supplier)
+            # electronic invoices (wsfev1) (intersection between available docs on ws and no_pos_docs)
             codes = ['60', '61']
         elif self.type == 'purchase':
-            return [('code', 'not in', codes_issuer_is_supplier)]
+            return [('code', 'not in', no_pos_docs)]
         elif afip_pos_system == 'II_IM':
             # pre-printed invoice
             codes = usual_codes + receipt_codes + expo_codes + invoice_m_code + receipt_m_code


### PR DESCRIPTION
The grain secondary settlement ("Liquidación Secundaria de Granos" - LSG) is an electronic document that supports grain purchase and sale and consignment transactions between intermediaries, cooperatives, consignees, exporters, brokers and future market operators. This document is emitted by the intermediary of the operation so, in Odoo, if the user is the seller or purchaser of the operation, it will need to register that document in a sale or purchase journal accordingly.
This PR aims to include this document in the list of the available ones to allow the user to select it when registering either a sale or a purchase. 
![image](https://github.com/user-attachments/assets/cd257bb9-8337-46c0-a699-7ed973338ac7)

**Behaviour before this PR:**
When the user creates an invoice in a sale or purchase journal, the document type "331 - SECONDARY GRAIN LIQUIDATION" is not available to select, although it is activated.

**Behaviour after this PR:**
When the user creates an invoice in a sale or purchase journal, the document type "331 -SECONDARY GRAIN LIQUIDATION" is appears in the list of documents (the document type should be activated before)

**Steps to reproduce:**

1. Install l10n_ar
2. Go to "Document Types" menu and activate "331 - SECONDARY GRAIN LIQUIDATION" 
3. Create or use a sale or purchase journal that has "Is AFIP POS?" as False.
4. Create an invoice in that journal and check that the document type with code 331 is not available to select.
 
![image](https://github.com/user-attachments/assets/710ac57c-8f2c-4398-88c7-ef8c3c8581f3)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
