### PR TITLE
[FIX] html_builder, website: use <svg> element for builder svg images

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -6,7 +6,7 @@
         <!-- Render the SelectItem(s) into an invisible node to ensure the label of the
         button is being set. -->
         <div t-ref="root" class="w-100">
-            <div t-att-class="'d-none ' + props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
+            <div inert="" class="h-0 w-0 overflow-hidden" t-att-class="props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
             <Dropdown state="this.dropdown">
                 <button class="btn btn-primary text-start o-dropdown-caret w-100 overflow-hidden" t-ref="button" t-att-id="props.id"
                     style="min-width: 0; text-overflow: ellipsis;">

--- a/addons/html_builder/static/src/core/img.js
+++ b/addons/html_builder/static/src/core/img.js
@@ -1,4 +1,25 @@
-import { Component, onWillStart, xml } from "@odoo/owl";
+import { Component, onWillStart, onWillUpdateProps, useEffect, useRef, xml } from "@odoo/owl";
+import { Cache } from "@web/core/utils/cache";
+
+const svgCache = new Cache(async (src) => {
+    let text;
+    try {
+        const response = await window.fetch(src);
+        text = await response.text();
+    } catch {
+        // In some tours, the tour finishes before the fetch is done
+        // and when a tour is finished, the python side will ask the
+        // browser to stop loading resources. This causes the fetch
+        // to fail and throw an error which crashes the test even
+        // though it completed successfully.
+        // So return an empty SVG to ensure everything completes
+        // correctly.
+        text = "<svg></svg>";
+    }
+    const parser = new window.DOMParser();
+    const xmlDoc = parser.parseFromString(text, "text/xml");
+    return xmlDoc.getElementsByTagName("svg")[0];
+}, JSON.stringify);
 
 export class Img extends Component {
     static props = {
@@ -8,9 +29,51 @@ export class Img extends Component {
         alt: { type: String, optional: true },
         attrs: { type: Object, optional: true },
     };
-    static template = xml`<img t-att-src="props.src" t-att-class="props.class" t-att-style="props.style" t-att-alt="props.alt" t-att="props.attrs"/>`;
+    static template = xml`
+        <svg t-if="isSvg(props.src)" t-ref="svg"
+             xmlns="http://www.w3.org/2000/svg"
+             t-att-width="svg.width"
+             t-att-viewBox="svg.viewBox"
+             t-att-fill="svg.fill"
+             class="hb-svg d-flex m-auto"
+             t-att-class="props.class"
+             t-att-style="props.style"
+             t-att="props.attrs"/>
+        <img t-else=""
+             t-att-src="props.src"
+             t-att-class="props.class"
+             t-att-style="props.style"
+             t-att-alt="props.alt"
+             t-att="props.attrs"/>
+        `;
+
     setup() {
-        onWillStart(async () => this.loadImage());
+        this.svgRef = useRef("svg");
+        this.svg = {};
+
+        onWillStart(async () => {
+            await this.handleImgLoad(this.props.src);
+        });
+        onWillUpdateProps(async (nextProps) => {
+            if (this.props.src !== nextProps.src) {
+                await this.handleImgLoad(nextProps.src);
+            }
+        });
+        useEffect(() => {
+            if (this.isSvg(this.props.src) && this.svg.children.length) {
+                // We can't use t-out with markup because it is parsed as HTML,
+                // but SVG need to be parsed as XML for all features to work.
+                this.svgRef.el.replaceChildren(...this.svg.children);
+            }
+        });
+    }
+
+    async handleImgLoad(src) {
+        if (this.isSvg(src)) {
+            this.svg = await this.getSvg();
+        } else {
+            await this.loadImage(src);
+        }
     }
 
     loadImage() {
@@ -20,5 +83,19 @@ export class Img extends Component {
             img.onerror = () => resolve({ status: "error" });
             img.src = this.props.src;
         });
+    }
+
+    isSvg(src) {
+        return src.split(".").pop() === "svg";
+    }
+
+    async getSvg() {
+        const svgEl = (await svgCache.read(this.props.src)).cloneNode(true);
+        return {
+            viewBox: svgEl.getAttribute("viewBox"),
+            width: svgEl.getAttribute("width") || "",
+            fill: svgEl.getAttribute("fill") || "",
+            children: svgEl.children,
+        };
     }
 }

--- a/addons/html_builder/static/src/core/operation.js
+++ b/addons/html_builder/static/src/core/operation.js
@@ -50,8 +50,12 @@ export class Operation {
             (() => {
                 this.cancelPrevious = null;
                 isCancel = true;
-                cancelPrevious?.();
                 cancelResolve?.();
+                // Cancel in the mutex to wait for the revert before the next
+                // apply.
+                this.mutex.exec(async () => {
+                    await cancelPrevious?.();
+                });
             });
 
         const cancelTimePromise = new Promise((resolve) => setTimeout(resolve, cancelTime));

--- a/addons/html_builder/static/src/core/utils.js
+++ b/addons/html_builder/static/src/core/utils.js
@@ -469,8 +469,10 @@ export function useClickableBuilderComponent() {
 
     const withLoadingEffect = useWithLoadingEffect(getAllActions);
 
+    let preventNextPreview = false;
     const operation = {
         commit: () => {
+            preventNextPreview = false;
             if (reload) {
                 callOperation(operationWithReload);
             } else {
@@ -482,6 +484,11 @@ export function useClickableBuilderComponent() {
             }
         },
         preview: () => {
+            // Avoid previewing the same option twice.
+            if (preventNextPreview) {
+                return;
+            }
+            preventNextPreview = true;
             callOperation(applyOperation.preview, {
                 operationParams: {
                     cancellable: true,
@@ -490,6 +497,7 @@ export function useClickableBuilderComponent() {
             });
         },
         revert: () => {
+            preventNextPreview = false;
             // The `next` will cancel the previous operation, which will revert
             // the operation in case of a preview.
             comp.env.editor.shared.operation.next();

--- a/addons/html_builder/static/src/sidebar/option_container.scss
+++ b/addons/html_builder/static/src/sidebar/option_container.scss
@@ -1,3 +1,17 @@
+@mixin hb-svg-icon(
+        $graphic: $o-we-sidebar-content-field-color,
+        $subdle: $o-we-sidebar-content-field-color,
+        $subdle-opacity: 0.5) {
+    .hb-svg {
+        .o_graphic {
+            fill: $graphic;
+        }
+        .o_subdle {
+            fill: rgba($subdle, $subdle-opacity);
+        }
+    }
+}
+
 .options-container {
     .btn {
         color: $o-we-fg-light;
@@ -5,11 +19,17 @@
         padding: 1px 6px;
         border: none;
         min-width: min-content;
+        min-height: 1.5rem;
+
+        @include hb-svg-icon($o-we-sidebar-content-field-clickable-color, $o-we-sidebar-content-field-clickable-color);
 
         &.active {
-            color: $o-we-fg-lighter;
             background-color: $o-we-bg-light !important;
+        }
 
+        &:not([disabled]):hover, &.active {
+            color: $o-we-fg-lighter;
+            @include hb-svg-icon($o-we-sidebar-content-field-pressed-color, $subdle-opacity: .75);
         }
 
         &>img {
@@ -28,7 +48,7 @@
     .btn-primary.o_we_bg_danger {
         color: white;
         background-color: #e6586c !important;
-    }   
+    }
 
     .btn-primary.o_we_bg_success {
         color: white;
@@ -74,4 +94,21 @@
 
 .o_we_img_animate:hover img {
     content: image-set(var(--animate-src));
+}
+
+.o_hb_device {
+    .hb-svg {
+        fill: $o-we-sidebar-content-field-clickable-color;
+
+        &:hover {
+            fill: $o-we-sidebar-content-field-pressed-color;
+        }
+    }
+    &.active .hb-svg {
+        fill: $o-we-color-danger;
+
+        &:hover {
+            fill: darken($o-we-color-danger, 7.5%);
+        }
+    }
 }

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -26,6 +26,9 @@ export function patchWithCleanupImg() {
     });
     patchWithCleanup(Img.prototype, {
         loadImage: () => {},
+        getSvg: function () {
+            this.isSvg = () => false;
+        },
     });
 }
 

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -138,6 +138,11 @@ export class ColorPicker extends Component {
         this.props.applyColorPreview(color);
     }
 
+    onCustomColorPreview(ev) {
+        this.props.applyColorResetPreview();
+        this.onColorPreview(ev);
+    }
+
     onColorHover(ev) {
         if (this.getTarget(ev).tagName !== "BUTTON") {
             return;

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -28,12 +28,14 @@
                     t-on-click="onColorApply"
                     t-on-mouseover="onColorHover"
                     t-on-mouseout="onColorHoverOut"
-                    t-on-focusin="onColorFocusin"/>
+                    t-on-focusin="onColorFocusin"
+                    t-on-focusout="onColorHoverOut"/>
         </div>
         <t t-if="state.activeTab==='theme'">
             <div class="pt-2 px-2 pb-3 d-flex flex-column gap-1 o_cc_preview_wrapper"
                 t-on-click="onColorApply"
                 t-on-mouseover="onColorHover"
+                t-on-mouseout="onColorHoverOut"
                 t-on-mouseleave="() => this.props.applyColorResetPreview()"
                 t-on-focusin="onColorHover"
                 t-on-focusout="onColorHoverOut"
@@ -44,14 +46,16 @@
                     <t t-set="activeClass" t-value="this.props.state.selectedColorCombination === className ? 'selected' : ''"/>
                     <button
                             type="button"
-                            class="w-100 p-0 border-0 bg-transparent p-2 d-flex justify-content-between align-items-center color-combination-button"
+                            class="w-100 p-0 border-0 bg-transparent color-combination-button"
                             t-att-class="[className, activeClass].join(' ')"
                             t-att-data-color="className"
                             t-attf-title="Preset {{number}}">
-                        <h1 class="m-0 fs-4">Title</h1>
-                        <p class="m-0 flex-grow-1">Text</p>
-                        <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm me-1 d-flex flex-column justify-content-center btn-primary"><small>Button</small></span>
-                        <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm d-flex flex-column justify-content-center btn-secondary"><small>Button</small></span>
+                        <div inert="" class="p-2 d-flex justify-content-between align-items-center">
+                            <h1 class="m-0 fs-4">Title</h1>
+                            <p class="m-0 flex-grow-1">Text</p>
+                            <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm me-1 d-flex flex-column justify-content-center btn-primary"><small>Button</small></span>
+                            <span class="py-1 px-1 rounded-1 fs-6 btn btn-sm lh-1 btn btn-sm d-flex flex-column justify-content-center btn-secondary"><small>Button</small></span>
+                        </div>
                     </button>
                 </t>
             </div>
@@ -63,7 +67,8 @@
                 t-on-mouseout="onColorHoverOut"
                 t-ref="solidTabRef"
                 t-on-keydown="colorPickerNavigation"
-                t-on-focusin="onColorFocusin">
+                t-on-focusin="onColorFocusin"
+                t-on-focusout="onColorHoverOut">
                 <div class="o_colorpicker_section">
                     <button data-color="o-color-1" t-attf-style="background-color: var(--o-color-1)" class="btn o_color_button"/>
                     <button data-color="o-color-3" t-attf-style="background-color: var(--o-color-3)" class="btn o_color_button"/>
@@ -83,13 +88,13 @@
         </t>
         <t t-if="state.activeTab==='custom'">
             <div class="p-1" t-on-keydown="colorPickerNavigation">
-                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin">
+                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
                         <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
                     <button class="o_color_button btn selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>
-                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin">
+                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                     <button data-color="black" class="btn o_color_button bg-black"></button>
                     <button data-color="900" class="o_color_button btn" style="background-color: var(--900)"></button>
                     <button data-color="800" class="o_color_button btn" style="background-color: var(--800)"></button>
@@ -102,13 +107,13 @@
                 <CustomColorPicker
                     defaultColor="this.state.currentCustomColor"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
-                    onColorPreview.bind="onColorPreview"
+                    onColorPreview.bind="onCustomColorPreview"
                     showRgbaField="props.showRgbaField"
                     noTransparency="props.noTransparency" />
             </div>
         </t>
         <t t-if="state.activeTab==='gradient'">
-            <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin">
+            <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                 <t t-foreach="this.DEFAULT_GRADIENT_COLORS" t-as="gradient" t-key="gradient">
                     <button class="w-50 m-0 o_color_button o_gradient_color_button btn" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>

--- a/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
@@ -5,11 +5,12 @@
     <BuilderRow label.translate="Shape" level="1" t-if="isActiveItem('toggle_bg_shape_id')">
         <button class="btn btn-primary" t-on-click="this.showBackgroundShapes" t-out="state.shapeName"/>
         <BuilderButton
-            title.translate="Show/Hide on Mobile"
-            preview="false"
-            action="'showOnMobile'"
-            iconImg="'/html_builder/static/img/options/mobile_invisible.svg'"
-        />
+                title.translate="Show/Hide on Mobile"
+                preview="false"
+                action="'showOnMobile'"
+                className="'o_hb_device'">
+            <Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
+        </BuilderButton>
         <BuilderButton action="'setBackgroundShape'" actionValue="''" preview="false" icon="'fa-times'"/>
     </BuilderRow>
 

--- a/addons/website/static/src/builder/plugins/options/footer_option.xml
+++ b/addons/website/static/src/builder/plugins/options/footer_option.xml
@@ -7,42 +7,42 @@
             <BuilderSelectItem title.translate="Default"
                 actionParam="{ view: 'website.footer_custom', vars: { 'footer-template': 'default' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_default.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Descriptive"
                 actionParam="{ view: 'website.template_footer_descriptive', vars: { 'footer-template': 'descriptive' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_descriptive.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Centered"
                 actionParam="{ view: 'website.template_footer_centered', vars: { 'footer-template': 'centered' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_centered.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Links"
                 actionParam="{ view: 'website.template_footer_links', vars: { 'footer-template': 'links' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_links.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Minimalist"
                 actionParam="{ view: 'website.template_footer_minimalist', vars: { 'footer-template': 'minimalist' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_minimalist.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Contact"
                 actionParam="{ view: 'website.template_footer_contact', vars: { 'footer-template': 'contact' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_contact.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Call-to-action"
                 actionParam="{ view: 'website.template_footer_call_to_action', vars: { 'footer-template': 'call_to_action' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_call_to_action.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem title.translate="Headline"
                 actionParam="{ view: 'website.template_footer_headline', vars: { 'footer-template': 'headline' } }"
             >
-                <Img src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
+                <Img attrs="{ style: 'width: 100%;' }" src="'/website/static/src/img/snippets_options/footer_template_headline.svg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -19,7 +19,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_default.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_default.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Hamburger menu"
@@ -35,7 +35,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_hamburger.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_hamburger.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Rounded box menu"
@@ -51,7 +51,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_boxed.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_boxed.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Stretch menu"
@@ -67,7 +67,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_stretch.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_stretch.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Vertical"
@@ -83,7 +83,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_vertical.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_vertical.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu with Search bar"
@@ -99,7 +99,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_search.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_search.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 1"
@@ -115,7 +115,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_one.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_one.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 2"
@@ -131,7 +131,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_two.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_two.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 3"
@@ -147,7 +147,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 4"
@@ -163,7 +163,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Sidebar"
@@ -179,7 +179,7 @@
                     }
                 ]"
             >
-                <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sidebar.svg'"/>
+                <Img attrs="{style:'width: 100%;'}" src="'/website/static/src/img/snippets_options/header_template_sidebar.svg'"/>
             </BuilderSelectItem>
 
         </BuilderSelect>

--- a/addons/website/static/src/builder/plugins/options/mega_menu_option.xml
+++ b/addons/website/static/src/builder/plugins/options/mega_menu_option.xml
@@ -11,7 +11,7 @@
                     view: `${templatePrefix}s_mega_menu_multi_menus`,
                     templateClass: 's_mega_menu_multi_menus',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_multi_menus.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Image Menu"
@@ -19,7 +19,7 @@
                     view: `${templatePrefix}s_mega_menu_menu_image_menu`,
                     templateClass: 's_mega_menu_menu_image_menu',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menu_image_menu.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Odoo Menu"
@@ -27,7 +27,7 @@
                     view: `${templatePrefix}s_mega_menu_odoo_menu`,
                     templateClass: 's_mega_menu_odoo_menu',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_odoo_menu.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Little Icons"
@@ -35,7 +35,7 @@
                     view: `${templatePrefix}s_mega_menu_little_icons`,
                     templateClass: 's_mega_menu_little_icons',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_little_icons.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Big Icons Subtitles"
@@ -43,7 +43,7 @@
                     view: `${templatePrefix}s_mega_menu_big_icons_subtitles`,
                     templateClass: 's_mega_menu_big_icons_subtitles',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_big_icons_subtitles.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Images Subtitles"
@@ -51,7 +51,7 @@
                     view: `${templatePrefix}s_mega_menu_images_subtitles`,
                     templateClass: 's_mega_menu_images_subtitles',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.8em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_images_subtitles.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Logos"
@@ -59,7 +59,7 @@
                     view: `${templatePrefix}s_mega_menu_menus_logos`,
                     templateClass: 's_mega_menu_menus_logos',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_menus_logos.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Thumbnails"
@@ -67,7 +67,7 @@
                     view: `${templatePrefix}s_mega_menu_thumbnails`,
                     templateClass: 's_mega_menu_thumbnails',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_thumbnails.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Cards"
@@ -75,7 +75,7 @@
                     view: `${templatePrefix}s_mega_menu_cards`,
                     templateClass: 's_mega_menu_cards',
                 }">
-                <Img class="'w-75 m-auto d-inline-block'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg'"/>
+                <Img class="'w-75 m-auto'" style="'margin-block: -0.25em !important;'" src="'/website/static/src/img/snippets_thumbs/s_mega_menu_cards.svg'"/>
             </BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>

--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -2,8 +2,12 @@
 <templates xml:space="preserve">
 
 <t t-name="website.DeviceVisibility">
-    <BuilderButton action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false"><Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/></BuilderButton>
-    <BuilderButton action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false"><Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" /></BuilderButton>
+    <BuilderButton className="'o_hb_device'" action="'toggleDeviceVisibility'" actionParam="'no_desktop'" preview="false">
+		<Img src="'/html_builder/static/img/options/desktop_invisible.svg'" style="'width: 12px'"/>
+	</BuilderButton>
+    <BuilderButton className="'o_hb_device'" action="'toggleDeviceVisibility'" actionParam="'no_mobile'" preview="false">
+		<Img src="'/html_builder/static/img/options/mobile_invisible.svg'" style="'width: 12px'" />
+	</BuilderButton>
 </t>
 
 <t t-name="website.DeviceVisibilityOption">

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_button.test.js
@@ -32,6 +32,7 @@ test("call a specific action with some params and value", async () => {
     expect(".options-container").toBeDisplayed();
     expect("[data-action-id='customAction']").toHaveText("MyAction");
     await click("[data-action-id='customAction']");
+    await animationFrame();
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });
@@ -44,6 +45,7 @@ test("call a shorthand action", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await click("[data-class-action='my-custom-class']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("my-custom-class");
 });
 test("call a shorthand action and a specific action", async () => {
@@ -63,6 +65,7 @@ test("call a shorthand action and a specific action", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await click("[data-action-id='customAction'][data-class-action='my-custom-class']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("my-custom-class");
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction", "customAction"]);
@@ -194,11 +197,13 @@ test("clean another action", async () => {
     await contains(":iframe .test-options-target").click();
     expect(".options-container").toBeDisplayed();
     await click("[data-class-action='my-custom-class1']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
         "test-options-target o-paragraph my-custom-class1"
     );
     await click("[data-class-action='my-custom-class2']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveAttribute(
         "class",
         "test-options-target o-paragraph my-custom-class2"
@@ -231,6 +236,7 @@ test("clean should provide the next action value", async () => {
 
     await click("[data-class-action='c1']");
     await click("[data-class-action='c2']");
+    await animationFrame();
     expect.verifySteps([
         "customAction apply",
         "customAction apply",
@@ -269,8 +275,10 @@ test("clean should only be called on the currently selected item", async () => {
     await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
     await contains(":iframe .test-options-target").click();
     await click("[data-action-id='customAction1']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("c1");
     await click("[data-action-id='customAction2']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("c2");
     expect.verifySteps([
         "customAction1 apply",

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -1,6 +1,6 @@
 import { undo } from "@html_editor/../tests/_helpers/user_actions";
 import { expect, test } from "@odoo/hoot";
-import { click, Deferred, hover, press, tick } from "@odoo/hoot-dom";
+import { animationFrame, click, Deferred, hover, press, tick } from "@odoo/hoot-dom";
 import { xml } from "@odoo/owl";
 import { contains } from "@web/../tests/web_test_helpers";
 import {
@@ -22,6 +22,7 @@ test("should apply backgroundColor to the editing element", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o-color-1']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("test-options-target bg-o-color-1");
 });
 
@@ -35,6 +36,7 @@ test("should apply o_cc color", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o_cc3']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("test-options-target o_cc3");
 });
 
@@ -48,6 +50,7 @@ test("should apply color to the editing element", async () => {
     expect(".options-container").toBeDisplayed();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await click(".o-overlay-item [data-color='o-color-1']");
+    await animationFrame();
     expect(":iframe .test-options-target").toHaveClass("test-options-target text-o-color-1");
 });
 
@@ -119,15 +122,8 @@ test("apply custom action", async () => {
     await contains(":iframe .test-options-target").click();
     await contains(".we-bg-options-container .o_we_color_preview").click();
     await contains(".o-overlay-item [data-color='#FF0000']").click();
-    // 3 times for hover (preview), focus (preview), click
-    expect.verifySteps([
-        "load",
-        "apply rgb(255, 0, 0)",
-        "load",
-        "apply rgb(255, 0, 0)",
-        "load",
-        "apply rgb(255, 0, 0)",
-    ]);
+    // Applied twice for hover (preview) and click (commit).
+    expect.verifySteps(["load", "apply rgb(255, 0, 0)", "load", "apply rgb(255, 0, 0)"]);
 });
 
 test("apply custom async action", async () => {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_number_input.test.js
@@ -539,7 +539,7 @@ describe("sanitized values", () => {
         `);
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit("-1", { instantly: true });
-        expect.verifySteps(["customAction ", "customAction 0", "customAction 0"]); // input, input, change
+        expect.verifySteps(["customAction ", "customAction 0"]); // input, change
         expect(".options-container input").toHaveValue("0");
     });
     test("use max when the given value is bigger", async () => {
@@ -560,7 +560,8 @@ describe("sanitized values", () => {
         `);
         await contains(":iframe .test-options-target").click();
         await contains(".options-container input").edit("11", { instantly: true });
-        expect.verifySteps(["customAction ", "customAction 10", "customAction 10"]); // input, input, change
+        await animationFrame();
+        expect.verifySteps(["customAction ", "customAction 10"]); // input, change
         expect(".options-container input").toHaveValue("10");
     });
     test("multi values: trailing space in BuilderNumberInput is ignored", async () => {

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_select_item.test.js
@@ -39,8 +39,9 @@ test("call a specific action with some params and value (BuilderSelectItem)", as
     expect(".options-container").toBeDisplayed();
     await click(".we-bg-options-container .dropdown");
     await animationFrame();
-    expect("[data-action-id='customAction']").toHaveText("MyAction");
-    await click("[data-action-id='customAction']");
+    expect(".popover [data-action-id='customAction']").toHaveText("MyAction");
+    await click(".popover [data-action-id='customAction']");
+    await animationFrame();
     // The function `apply` should be called twice (on hover (for preview), then, on click).
     expect.verifySteps(["customAction myParam myValue", "customAction myParam myValue"]);
 });

--- a/addons/website/static/tests/builder/options/card_option.test.js
+++ b/addons/website/static/tests/builder/options/card_option.test.js
@@ -23,10 +23,11 @@ test("set card width", async () => {
     expect("[data-action-id='setCardWidth'] input").toHaveValue(100);
 
     await setInputRange("[data-action-id='setCardWidth'] input", 50);
+    await animationFrame();
     expect(":iframe .s_card").toHaveStyle({ maxWidth: "50%" });
 });
 
-test("set card aligment", async () => {
+test("set card alignment", async () => {
     await setupWebsiteBuilder(simpleCardHtml);
     await contains(":iframe .s_card").click();
     await waitFor("[data-action-id='setCardWidth'] input");
@@ -43,12 +44,15 @@ test("set card aligment", async () => {
     expect("[data-label='Alignment'] button[title='Left']").toHaveClass("active");
 
     await click("[data-label='Alignment'] button[title='Center']");
+    await animationFrame();
     expect(":iframe .s_card").toHaveClass("mx-auto");
 
     await click("[data-label='Alignment'] button[title='Right']");
+    await animationFrame();
     expect(":iframe .s_card").toHaveClass("ms-auto");
 
     await click("[data-label='Alignment'] button[title='Left']");
+    await animationFrame();
     expect(":iframe .s_card").toHaveClass("me-auto");
 });
 
@@ -201,6 +205,7 @@ test("set cover image width", async () => {
     // Width option is now available
     expect("[data-label='Width']").toHaveCount(1);
     await setInputRange("[data-label='Width'] input", 25);
+    await animationFrame();
     const cardImageWidthValue =
         queryOne(":iframe .s_card").style.getPropertyValue("--card-img-size-h");
     expect(parseFloat(cardImageWidthValue)).toBeWithin(24.9, 25.1);
@@ -212,6 +217,7 @@ test("cover image set to wide aspect ratio can be vertically aligned", async () 
     await waitFor("[data-action-id='alignCoverImage']");
     expect("[data-label='Alignment'] [data-action-id='alignCoverImage'").toHaveCount(1);
     await setInputRange("[data-action-id='alignCoverImage'] input", 50);
+    await animationFrame();
     expect(":iframe .s_card .o_card_img_wrapper").toHaveClass("o_card_img_adjust_v");
     expect(":iframe .s_card").toHaveStyle({ "--card-img-ratio-align": "50%" });
 });

--- a/addons/website/static/tests/builder/options/grid_column_option.test.js
+++ b/addons/website/static/tests/builder/options/grid_column_option.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { click, Deferred, edit, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, click, Deferred, edit, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../website_helpers";
 
@@ -17,6 +17,7 @@ test("Using the Padding (Y, X) option should display a padding preview", async (
         def.resolve();
     });
     await def;
+    await animationFrame();
     expect(queryFirst(":iframe .s_banner .o_grid_item")).not.toHaveClass("o_we_padding_highlight");
 });
 

--- a/addons/website/static/tests/builder/options/rating_option.test.js
+++ b/addons/website/static/tests/builder/options/rating_option.test.js
@@ -29,10 +29,12 @@ test("change rating score", async () => {
     await contains(".options-container [data-action-id='activeIconsNumber'] input").click();
     await clear();
     await fill("1");
+    await animationFrame();
     expect(":iframe .s_rating .s_rating_active_icons i").toHaveCount(1);
     await contains(".options-container [data-action-id='totalIconsNumber'] input").click();
     await clear();
     await fill("4");
+    await animationFrame();
     expect(":iframe .s_rating .s_rating_inactive_icons i").toHaveCount(3);
     expect(":iframe .s_rating").toHaveInnerHTML(
         `<h4 class="s_rating_title">Quality</h4>

--- a/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
+++ b/addons/website_sale/static/src/website_builder/website_sale_show_empty_option.xml
@@ -4,7 +4,9 @@
     <t t-name="website_sale.ShowEmptyOption">
         <BuilderContext action="'websiteConfig'">
             <BuilderRow label.translate="Show Empty" id="'show_empty_opt'">
-                <BuilderButton title.translate="Show/hide shopping cart" className="'o_btn_show_empty_cart fa fa-shopping-cart d-flex justify-content-center flex-grow-1'" actionParam="{views: ['!website_sale.header_hide_empty_cart_link']}" />
+                <BuilderButton title.translate="Show/hide shopping cart" icon="'fa-shopping-cart'"
+                    className="'o_btn_show_empty_cart flex-grow-1'"
+                    actionParam="{views: ['!website_sale.header_hide_empty_cart_link']}"/>
             </BuilderRow>
         </BuilderContext>
     </t>


### PR DESCRIPTION
**[FIX] html_builder, website: avoid previewing the same action twice**

On `BuilderSelectItem`s, the action is previewed on mouseover and on
focusin. This means that when using the mouse and clicking on an item,
there are always 2 previews before committing (on click). This commit
blocks the second preview if the current item is already being
previewed.

In addition, we also make sure that the test tests the actual dropdown
item, and not the component marked with `ignoreBuilderItem`. By
targeting the proper item, we ensure that all events (hover, focusin,
click) are dispatched: the ignored one being in a `.d-none` container,
the `focusin` event was not dispatched.

**[FIX] html_builder, website: use <svg> element for builder svg images**

- use actual `<svg>` elements instead of `img` to be able to update the
colors through CSS
- cache them to avoid flickers when selecting content in
`<BuilderSelect>`s

- correct the `hide on mobile` icon for background shapes
- adapt the buttons' CSS to get the right color

- use `inert` with classes `h-0 w-0 overflow-hidden` instead of `d-none`
to hide `WithIgnoreItem` content. This allows the use of SVG's gradients
and other elements targeted with their ID. Indeed, when targetting
`#myLinearGradient`, it will first match the one in the ignore slot
because it appears before in the DOM. If it is hidden with `d-none`, it
is ignored. If it is hidden through other means, it will be taken into
account. Furthermore, we can't rely on `visibility: hidden` or
`opacity: 0`, as those also prevent some features from working (e.g.
`<clipPath>`). Setting both height and width to 0 visually hides it, and
using `inert` ensures that we can't interact with it.

This PR follows [the refactor into html_builder].

[the refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641