### PR TITLE
[FIX] point_of_sale: ensure country is set for test branch company

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1922,6 +1922,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Branch 1',
             'parent_id': self.env.company.id,
             'chart_template': self.env.company.chart_template,
+            'country_id': self.env.company.country_id.id,
         })
 
         self.env.cr.precommit.run()


### PR DESCRIPTION
The test `test_pos_branch_account` was failing due to a `UserError` raised from the `l10n_de_pos_cert` module, which requires that a country be set on the company before opening the POS UI (`open_ui`). Since the test creates a new `res.company` record to represent a branch, the required `country_id` was missing, causing the test to crash instead of evaluating the intended logic.

This change sets the `country_id` on the created branch company.

build_error-223267

