### PR TITLE
[FIX] website: update sitemap lastmod on website page view changes

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -12,6 +12,7 @@ import requests
 import threading
 
 from collections import defaultdict
+from datetime import datetime
 from functools import reduce
 from lxml import etree, html
 from psycopg2 import sql
@@ -1252,8 +1253,12 @@ class Website(models.Model):
             record = {'loc': page['url'], 'id': page['id'], 'name': page['name']}
             if page.view_id and page.view_id.priority != 16:
                 record['priority'] = min(round(page.view_id.priority / 32.0, 1), 1)
-            if page['write_date']:
-                record['lastmod'] = page['write_date'].date()
+            last_updated_date = max(
+                [d for d in (page.write_date, page.view_id.write_date) if isinstance(d, datetime)],
+                default=None,
+            )
+            if last_updated_date:
+                record['lastmod'] = last_updated_date.date()
             yield record
 
     def get_website_page_ids(self):

--- a/addons/website/tests/__init__.py
+++ b/addons/website/tests/__init__.py
@@ -25,6 +25,7 @@ from . import test_performance
 from . import test_qweb
 from . import test_redirect
 from . import test_res_users
+from . import test_sitemap
 from . import test_snippets
 from . import test_theme
 from . import test_ui

--- a/addons/website/tests/test_sitemap.py
+++ b/addons/website/tests/test_sitemap.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteSitemap(TransactionCase):
+    def test_sitemap_page_lastmod(self):
+        website = self.env['website'].search([], limit=1)
+        page_url = '/test-page'
+        Page = self.env['website.page']
+        page = Page.create({
+            'name': 'Test Page',
+            'website_id': website.id,
+            'url': page_url,
+            'type': 'qweb',
+            'arch': '<t t-call="website.layout"/>',
+            'is_published': True,
+        })
+        View = self.env['ir.ui.view']
+
+        def set_write_dates(page_date, view_date):
+            self.env.cr.execute(
+                "UPDATE website_page SET write_date = %s WHERE id = %s",
+                (page_date, page.id)
+            )
+            self.env.cr.execute(
+                "UPDATE ir_ui_view SET write_date = %s WHERE id = %s",
+                (view_date, page.view_id.id)
+            )
+            Page.invalidate_model()
+            View.invalidate_model()
+
+        def get_sitemap_lastmod():
+            pages = website._enumerate_pages()
+            return next(p['lastmod'] for p in pages if p['loc'] == page_url)
+
+        old_date = "2002-05-06 12:00:00"
+        new_date = "2014-05-15 12:00:00"
+
+        set_write_dates(new_date, old_date)
+        self.assertEqual(str(get_sitemap_lastmod()), new_date[:10])
+
+        set_write_dates(old_date, new_date)
+        self.assertEqual(str(get_sitemap_lastmod()), new_date[:10])


### PR DESCRIPTION
[FIX] website: update sitemap lastmod on website page view changes

Before this commit, since the introduction of the website page model at
commit [1], the lastmod for pages indicated in the sitemap was not
entirely accurate: it only considered *page record* changes, not their
internal *view changes*.

Steps to reproduce:
- Create a new website page and publish it
- Go to /sitemap.xml, see the page is mentioned with correct lastmod
- Wait for one day **
- Update the page URL
- Go to /sitemap.xml, see the lastmod was updated
- Wait for one day **
- Update the page content
- Go to /sitemap.xml
=> The lastmod was unchanged

**: the lastmod does not show the hours. You will need to update the
    write_date manually in your database to test this. Also, when
    visiting the sitemap, you need to first delete the cached version
    in the backend (Debug -> Settings -> Technical -> Attachments).

[1]: https://github.com/odoo/odoo/commit/4ecbacaf59576a22ff45615a5aa5c67244e4fb93