### PR TITLE
[FIX] website: preserve highlight style when changing highlight

### DIFF
--- a/addons/website/static/tests/builder/website_builder/highlight.test.js
+++ b/addons/website/static/tests/builder/website_builder/highlight.test.js
@@ -6,6 +6,7 @@ import { defineMailModels } from "@mail/../tests/mail_test_helpers";
 import { expandToolbar } from "@html_editor/../tests/_helpers/toolbar";
 import { HighlightPlugin } from "@website/builder/plugins/highlight/highlight_plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { contains } from "@web/../tests/web_test_helpers";
 
 defineMailModels();
 
@@ -43,5 +44,26 @@ test("Can set a color to a highlight", async () => {
     const color = getComputedStyle(document.documentElement).getPropertyValue("--o-color-1");
     expect("span.o_text_highlight_freehand_2").toHaveStyle({
         "--text-highlight-color": color,
+    });
+});
+
+test("Changing highlight keep the color and the width", async () => {
+    await setupEditor(
+        `<p>
+            <span class="o_text_highlight o_text_highlight_freehand_2" style="--text-highlight-color: #E79C9C; --text-highlight-width: 2px;">[highlight 3]</span>
+        </p>`,
+        { config: { Plugins: [...MAIN_PLUGINS, HighlightPlugin] } }
+    );
+    await expandToolbar();
+    expect(".o-select-highlight").toHaveCount(1);
+    await contains(".o-we-toolbar .o-select-highlight").click();
+    await contains("#highlightPicker").click();
+
+    expect("p>.o_text_highlight_underline").toHaveCount(0);
+    await contains(".o_popover .o_text_highlight_underline").click();
+    expect("p>.o_text_highlight_underline").toHaveCount(1);
+    expect("p>span.o_text_highlight_underline").toHaveStyle({
+        "--text-highlight-color": "#E79C9C",
+        "--text-highlight-width": "2px",
     });
 });


### PR DESCRIPTION
Steps to reproduce:
- Open the website editor
- Select a text
- In the toolbar, click on the highlight button
- Select an highlight
- Select a color and a thickness
- Select another highlight

Before:
When selecting a highlight and changing it, the color and
thickness were reset to default values.

After:
The existing highlight style (color and thickness) is now
preserved when modifying the highlight.
