### PR TITLE
[FIX] mail: better color for messaging menu item bg

### DIFF
--- a/addons/mail/static/src/core/public_web/notification_item.dark.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.dark.scss
@@ -3,8 +3,8 @@
     --mail-NotificationItem-bg: #{lighten(mix($gray-100, $gray-200, 65%), 1.5%)};
 
     &.o-important {
-        background-color: mix($gray-100, darken($info, 5%), 85.5%) !important;
-        border-color: lighten(mix($gray-100, darken($info, 5%), 85.5%), 5%) !important;
+        background-color: mix($gray-100, darken($info, 5%), 82.5%) !important;
+        border-color: lighten(mix($gray-100, darken($info, 5%), 82.5%), 5%) !important;
     }
     &:hover, &.o-active {
         background-color: mix($o-gray-200, $o-gray-300) !important;

--- a/addons/mail/static/src/core/public_web/notification_item.scss
+++ b/addons/mail/static/src/core/public_web/notification_item.scss
@@ -7,6 +7,9 @@
         background-color: mix($o-view-background-color, lighten($info, 5%), 87.5%);
         border-color: darken(mix($o-view-background-color, $info, 87.5%), 7.5%) !important;
     }
+    &:not(.o-important) {
+        --border-opacity: .35;
+    }
     &.o-active {
         outline-color: rgba($o-action, var(--mail-NotificationItem-activeOutlineOpacity, 0.5));
     }

--- a/addons/mail/static/src/core/public_web/notification_item.xml
+++ b/addons/mail/static/src/core/public_web/notification_item.xml
@@ -5,8 +5,8 @@
     <ActionSwiper onLeftSwipe="props.onSwipeLeft ? props.onSwipeLeft : undefined" onRightSwipe="props.onSwipeRight ? props.onSwipeRight : undefined">
         <button class="o-mail-NotificationItem list-group-item d-flex cursor-pointer align-items-center w-100 gap-2 position-relative border o-rounded-bubble o-py-1_5 shadow-sm" t-on-click="onClick" t-ref="root" t-att-class="{
             'o-important': props.muted === 0,
-            'text-muted border-transparent': props.muted === 1,
-            'opacity-50 border-transparent': props.muted === 2,
+            'text-muted border-secondary': props.muted === 1,
+            'opacity-50 border-secondary': props.muted === 2,
             'px-1 o-small': ui.isSmall,
             'border-top-0': props.first,
             'p-2': !ui.isSmall,


### PR DESCRIPTION
- non-important notification item border around them to give a better visual spacing between items now that there's shadow on them
- important notification bg in dark theme has now lighter color, making them a bit more catchy than non-muted items.