### PR TITLE
[IMP] sale_management: Warn when changing customer on sent quotations

### DIFF
--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -200,7 +200,7 @@ class SaleOrder(models.Model):
             if sent_orders := self.filtered(lambda so: so.state == 'sent'):
                 sent_orders.activity_schedule(
                     activity_type_id=self.env.ref('mail.mail_activity_data_todo').id,
-                    user_id=self.env.user_id.id,
+                    user_id=self.env.user.id,
                     date_deadline=fields.Date.today(),
                     summary=_("Urgent: Customer change in sent quotation"),
                     note=_(

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -200,7 +200,7 @@ class SaleOrder(models.Model):
             if sent_orders := self.filtered(lambda so: so.state == 'sent'):
                 sent_orders.activity_schedule(
                     activity_type_id=self.env.ref('mail.mail_activity_data_todo').id,
-                    user_id=self.user_id.id,
+                    user_id=self.env.user_id.id,
                     date_deadline=fields.Date.today(),
                     summary=_("Urgent: Customer change in sent quotation"),
                     note=_(

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 from itertools import chain, starmap, zip_longest
-from markupsafe import Markup
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Warns user when changing customer on a sent quotation.

Current behavior before PR:
Customer changes on sent quotations go unnoticed.

Desired behavior after PR is merged:
An activity is scheduled to alert the user when the customer is changed on a sent quotation.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
