### PR TITLE
[FIX] stock_account: Rounding error when calculating unit price causes the quantity of goods to be out of stock but the inventory value still remains

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -468,7 +468,10 @@ class ProductProduct(models.Model):
                         break
 
                 # Get the estimated value we will correct.
-                remaining_value_before_vacuum = svl_to_vacuum.unit_cost * qty_taken_on_candidates
+                if product.cost_method == 'average':
+                    remaining_value_before_vacuum = (svl_to_vacuum.value / svl_to_vacuum.quantity) * qty_taken_on_candidates
+                else:
+                    remaining_value_before_vacuum = svl_to_vacuum.unit_cost * qty_taken_on_candidates
                 new_remaining_qty = svl_to_vacuum.remaining_qty + qty_taken_on_candidates
                 corrected_value = remaining_value_before_vacuum - tmp_value
                 svl_to_vacuum.write({


### PR DESCRIPTION
Steps to reproduce the error:

1. Setup company, for example company with company currency VND
1. Create product A, Costing Method: AVCO
2. Enter purchase order 10 units of product A with unit price 1.46 VND
![image](https://github.com/user-attachments/assets/4db1b654-930e-42a8-8ab8-465395232fec)

4. Create sales order with quantity 12 units of product A
![image](https://github.com/user-attachments/assets/c42e83a0-681d-4386-9662-f3e287de01e1)

6. Enter 2 units of product with price 1.46 VND
![image](https://github.com/user-attachments/assets/fd3b6fc2-2af1-45af-a142-1d497fc66acf)


View stock layer, stock quantity is 0 but stock value is 1. This is unexpected.
![image](https://github.com/user-attachments/assets/f2b3e6da-1b0e-4230-8fb0-c5fb5267e5fd)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
