### PR TITLE
[FIX] hr_holidays: overlap period warning message shows up in non-booked period

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -264,7 +264,7 @@ class HrLeave(models.Model):
                 ('employee_id', '=', holiday.employee_id.id),
                 ('date_from', '<', holiday.date_to),
                 ('date_to', '>', holiday.date_from),
-                ('id', '!=', holiday.id),
+                ('id', 'not in', holiday.ids),
             ])
             if not conflicting_holidays:
                 holiday.dashboard_warning_message = False

--- a/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
+++ b/addons/hr_holidays/static/src/views/view_dialog/form_view_dialog.js
@@ -71,9 +71,19 @@ export class TimeOffDialogFormController extends FormController {
     }
 
     async onClick(action) {
-        const args = [this.record.resId];
-        await this.orm.call("hr.leave", action, args);
-        this.save(this.record._changes);
+        await this.save(this.record._changes);
+        await this.action.doActionButton({
+            resModel: 'hr.leave',
+            name: action,
+            context: this.context,
+            type: 'object',
+            resId: this.record.resId,
+        });
+
+        this.action.doAction({
+            'type': 'ir.actions.client',
+            'tag': 'soft_reload',
+        });
     }
 
     deleteRecord() {


### PR DESCRIPTION
### Steps to reproduce:
- Create a time-off with dates from X to Y.
- Attempt to modify the start or end date to a value that still falls within the original X–Y range.

### Fix:
- Updated the condition to correctly retrieve the current record's ID using .ids ,since .ids can also include the origin ID.

Task-4819538

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
