### PR TITLE
[FIX] hr: handle missing 'name' key in employee creation

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -383,7 +383,7 @@ class HrEmployeePrivate(models.Model):
 
     def _prepare_resource_values(self, vals, tz):
         resource_vals = super()._prepare_resource_values(vals, tz)
-        vals.pop('name')  # Already considered by super call but no popped
+        vals.pop('name', None)  # Already considered by super call but no popped
         # We need to pop it to avoid useless resource update (& write) call
         # on every newly created resource (with the correct name already)
         user_id = vals.pop('user_id', None)


### PR DESCRIPTION
Currently, when a user creates a custom form view for the **employee page** without Adding a required field **name** and trying to create an employee, an error is encountered.

**Steps to Reproduce:**
- Install **HR** module.
- Create a new **empty form view** for the `hr.employee` model.
- Open the newly created view and click on save.

**Error:**
`KeyError: 'name'`

**Root Cause:**
The `_prepare_resource_values` method assumes the 'name' key is present in vals at [1] tries to pop it without checking for its existence.

[1]- https://github.com/odoo/odoo/blob/06ec1de2dd8ec5fdb104275cf2bbb3f9f73841da/addons/hr/models/hr_employee.py#L386

**Solution:**
This commit ensures that if the `name` key is not present, the method returns `None` instead of raising Error.

Sentry-6234873849





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
