### PR TITLE
[IMP] hr_recruitment: improve talent pool usability and filtering UI

### DIFF
--- a/addons/hr_recruitment/data/mail_message_subtype_data.xml
+++ b/addons/hr_recruitment/data/mail_message_subtype_data.xml
@@ -21,6 +21,14 @@
         <field name="default" eval="True"/>
     </record>
 
+    <!-- Talent-related subtypes for messaging / Chatter -->
+    <record id="mt_talent_new" model="mail.message.subtype">
+        <field name="name">New Talent</field>
+        <field name="res_model">hr.applicant</field>
+        <field name="default" eval="False"/>
+        <field name="description">Talent created</field>
+    </record>
+
     <!-- Job-related subtypes for messaging / Chatter -->
     <record id="mt_job_new" model="mail.message.subtype">
         <field name="name">Job Position created</field>

--- a/addons/hr_recruitment/models/hr_talent_pool.py
+++ b/addons/hr_recruitment/models/hr_talent_pool.py
@@ -51,3 +51,15 @@ class HrTalentPool(models.Model):
         talent_data = {talent_pool.id: count for talent_pool, count in talents}
         for pool in self:
             pool.no_of_talents = talent_data.get(pool.id, 0)
+
+    def action_talent_pool_add_talents(self):
+        self.ensure_one()
+        return {
+            "name": self.env._("Create Talent"),
+            "type": "ir.actions.act_window",
+            "res_model": "hr.applicant",
+            "views": [[False, "form"]],
+            "context": {
+                "default_talent_pool_ids": [self.id],
+            },
+        }

--- a/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
+++ b/addons/hr_recruitment/tests/test_recruitment_talent_pools.py
@@ -2,6 +2,7 @@
 
 from odoo.fields import Domain
 from odoo.tests import Form, tagged, TransactionCase
+from odoo.exceptions import ValidationError
 
 
 @tagged("recruitment")
@@ -278,6 +279,7 @@ class TestRecruitmentTalentPool(TransactionCase):
         """
         self.env["talent.pool.add.applicants"].create({
             "applicant_ids": self.t_applicant_1.ids,
+            "talent_pool_ids": self.t_talent_pool_1,
         }).action_add_applicants_to_pool()
 
         new_email = "updated@gmail.com"
@@ -287,3 +289,14 @@ class TestRecruitmentTalentPool(TransactionCase):
             new_email,
             "The email_from field should be updated successfully",
         )
+
+    def test_talent_must_have_at_least_one_pool(self):
+        """
+        Ensure that removing all the talent pool from a talent created raises a ValidationError.
+        """
+        wizard = Form(self.env["talent.pool.add.applicants"])
+        wizard.talent_pool_ids.add(self.t_talent_pool_1)
+        wizard.applicant_ids.add(self.t_applicant_1)
+        talent = wizard.save()._add_applicants_to_pool()
+        with self.assertRaises(ValidationError):
+            talent.write({"talent_pool_ids": [(5, 0, 0)]})

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -143,7 +143,7 @@
                     <label for="partner_name" class="oe_edit_only" string="Applicant" invisible="is_pool_applicant"/>
                     <label for="partner_name" class="oe_edit_only" string="Talent" invisible="not is_pool_applicant"/>
                     <h1 class="d-flex justify-content-between align-items-center me-4">
-                        <field name="partner_name" options="{'line_breaks': False}" context="{'default_company_id': company_id}"/>
+                        <field name="partner_name" options="{'line_breaks': False}" context="{'default_company_id': company_id}" required="1"/>
                     </h1>
                 </div>
                 <group>
@@ -157,7 +157,7 @@
                     </group>
                     <group>
                         <field name="priority" widget="priority"/>
-                        <field name="job_id" invisible="is_pool_applicant"/>
+                        <field name="job_id" invisible="is_pool_applicant" placeholder="Spontaneous application"/>
                         <field name="talent_pool_ids" widget="many2many_tags" options="{'color_field': 'color'}" invisible="not is_pool_applicant"/>
                         <field name="user_id" widget="many2one_avatar_user" placeholder="Unassigned"/>
                         <field name="interviewer_ids" options="{'no_create': True}" widget="many2many_avatar_user" invisible="is_pool_applicant" placeholder="Who can access applicants" />
@@ -269,6 +269,9 @@
                 <filter string="My Applications" name="my_applications" domain="[('user_id', '=', uid)]"/>
                 <filter string="Unassigned" name="unassigned" domain="[('user_id', '=', False)]"/>
                 <separator/>
+                <filter string="Applicants" name="applicants" domain="[('talent_pool_ids', '=', False)]"/>
+                <filter string="Talents" name="talents" domain="[('talent_pool_ids', '!=', False)]"/>
+                <separator/>
                 <filter string="In Progress" name="ongoing" domain="[('date_closed', '=', False), ('active', '=', True), ('refuse_reason_id', '=', False)]"/>
                 <filter string="Hired" name="hired" domain="[('date_closed', '!=', False)]"/>
                 <separator/>
@@ -303,6 +306,7 @@
                     <filter string="Job" name="job" domain="[]" context="{'group_by': 'job_id'}"/>
                     <filter string="Stage" name="stage" domain="[]" context="{'group_by': 'stage_id'}"/>
                     <filter string="Responsible" name="responsible" domain="[]"  context="{'group_by': 'user_id'}"/>
+                    <filter string="Talent Pool" name="talent_pool" domain="[]" context="{'group_by': 'talent_pool_ids'}"/>
                     <filter string="Creation Date" name="creation_date" context="{'group_by': 'create_date'}"/>
                     <filter string="Hiring Date" name="hired_date" context="{'group_by': 'date_closed'}"/>
                     <filter string="Last Stage Update" name="last_stage_update" context="{'group_by': 'date_last_stage_update'}"/>
@@ -438,7 +442,13 @@
         <field name="res_model">hr.applicant</field>
         <field name="view_mode">kanban,list,form,graph,calendar,pivot,activity</field>
         <field name="search_view_id" ref="hr_applicant_view_search_bis"/>
-        <field name="context">{'search_default_job_id': [active_id], 'default_job_id': active_id, 'dialog_size':'medium', 'allow_search_matching_applicants': 1}</field>
+        <field name="context">{
+            'search_default_job_id': [active_id],
+            'search_default_applicants': 1,
+            'default_job_id': active_id,
+            'dialog_size':'medium',
+            'allow_search_matching_applicants': 1
+        }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No applications yet
@@ -475,7 +485,7 @@
             (5, 0, 0),
             (0, 0, {'view_mode': 'list'}),
             (0, 0, {'view_mode': 'kanban', 'view_id': ref('hr_kanban_view_applicant_talent_pool')})]"/>
-        <field name="context">{'default_talent_pool_ids': active_ids, 'create': False}</field>
+        <field name="context">{'default_talent_pool_ids': active_ids}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No Talents in the pool yet
@@ -500,6 +510,7 @@
         <field name="view_mode">kanban,list,form,pivot,graph,calendar,activity</field>
         <field name="view_id" eval="False"/>
         <field name="search_view_id" ref="hr_applicant_view_search_bis"/>
+        <field name="context">{'search_default_applicants': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No applications yet

--- a/addons/hr_recruitment/views/hr_talent_pool_views.xml
+++ b/addons/hr_recruitment/views/hr_talent_pool_views.xml
@@ -65,9 +65,20 @@
                             Archive</a>
                     </t>
                     <t t-name="card">
-                        <field name="name" class="fw-bold"/>
-                        <field name="pool_manager"/>
-                        <field name="company_id"/>
+                        <div class="row">
+                            <div class="col">
+                                <div class="d-flex flex-column">
+                                    <field name="name" class="fw-bold"/>
+                                    <field name="pool_manager"/>
+                                    <field name="company_id"/>
+                                </div>
+                            </div>
+                            <div class="col d-flex justify-content-end align-items-end mb-1">
+                                <button class="btn btn-primary" name="action_talent_pool_add_talents" type="object">
+                                    New Talent
+                                </button>
+                            </div>
+                        </div>
                         <footer class="justify-content-end">
                             <field name="no_of_talents"/>
                             <span>Talents</span>

--- a/addons/hr_recruitment/views/menuitems.xml
+++ b/addons/hr_recruitment/views/menuitems.xml
@@ -30,7 +30,7 @@
                 groups="hr_recruitment.group_hr_recruitment_interviewer"/>
 
             <menuitem
-                name="Talent Pools"
+                name="By Talent Pools"
                 parent="menu_crm_case_categ0_act_job"
                 id="menu_hr_talent_pools"
                 action="action_hr_talent_pool"


### PR DESCRIPTION
Improved Talent Pool to make the recruitment process easier and the interface more user-friendly.

- Added 'Applicants' and 'Talents' filters in search view.
- Added group-by filter on 'Talent Pool' in search view.
- Renamed menu item to 'By Talent Pools'.
- Added default context filters to pre-select applicants in the job view.
- Added validation to require at least one Talent Pool if applicant is marked as in-pool.
- Renamed chatter string to 'Talent Created' for better clarity.

Task - 4718410