### PR TITLE
[FIX] html_builder: avoid reload when addLanguage is discarded

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -279,7 +279,7 @@ export class Builder extends Component {
     }
 
     async onBeforeLeave() {
-        if (this.state.canUndo) {
+        if (this.state.canUndo && !this.editor.shared.savePlugin.isAlreadySaved()) {
             let continueProcess = true;
             await new Promise((resolve) => {
                 this.dialog.add(ConfirmationDialog, {

--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -4,7 +4,8 @@ import { registry } from "@web/core/registry";
 
 export class SavePlugin extends Plugin {
     static id = "savePlugin";
-    static shared = ["save"];
+    static shared = ["save", "isAlreadySaved"];
+    static dependencies = ["history"];
 
     resources = {
         handleNewRecords: this.handleMutations.bind(this),
@@ -76,6 +77,14 @@ export class SavePlugin extends Plugin {
         // used to track dirty out of the editable scope, like header, footer or wrapwrap
         const willSaves = this.getResource("save_handlers").map((c) => c());
         await Promise.all(saveProms.concat(willSaves));
+        this.lastSavedStep = this.dependencies.history.getHistorySteps().at(-1);
+    }
+
+    isAlreadySaved() {
+        return (
+            !this.dependencies.history.getHistorySteps().length ||
+            this.lastSavedStep === this.dependencies.history.getHistorySteps().at(-1)
+        );
     }
 
     /**

--- a/addons/html_builder/static/tests/helpers.js
+++ b/addons/html_builder/static/tests/helpers.js
@@ -63,7 +63,7 @@ class BuilderContainer extends Component {
                 </div>
             </div>
             <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
-            <div t-if="state.isEditing" t-att-class="{'o_builder_sidebar_open': state.isEditing}" class="o-website-builder_sidebar border-start border-dark">
+            <div t-if="state.isEditing" t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar}" class="o-website-builder_sidebar border-start border-dark">
                 <Builder t-props="this.getBuilderProps()"/>
             </div>
         </div>`;
@@ -71,7 +71,7 @@ class BuilderContainer extends Component {
     static props = { content: String, Plugins: Array };
 
     setup() {
-        this.state = useState({ isMobile: false, isEditing: false });
+        this.state = useState({ isMobile: false, isEditing: false, showSidebar: true });
         this.iframeRef = useRef("iframe");
         const originalIframeLoaded = new Promise((resolve) => {
             this._originalIframeLoadedResolve = resolve;

--- a/addons/website/static/src/builder/plugins/customize_website_plugin.js
+++ b/addons/website/static/src/builder/plugins/customize_website_plugin.js
@@ -155,7 +155,6 @@ export class CustomizeWebsitePlugin extends Plugin {
                 },
             },
             addLanguage: {
-                reload: {},
                 preview: false,
                 apply: async () => {
                     const def = new Deferred();
@@ -174,8 +173,8 @@ export class CustomizeWebsitePlugin extends Plugin {
                     if (!save) {
                         return;
                     }
+                    this.config.builderSidebar.toggle(false);
                     await this.dependencies.savePlugin.save(/* not in translation */);
-                    // TODO doAction in savePlugin.save ?
                     await this.services.action.doAction("base.action_view_base_language_install", {
                         additionalContext: {
                             params: {
@@ -185,7 +184,8 @@ export class CustomizeWebsitePlugin extends Plugin {
                         },
                         onClose: def.resolve,
                     });
-                    return def;
+                    await def;
+                    this.config.builderSidebar.toggle(true);
                 },
             },
             customizeBodyBgType: {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -49,7 +49,7 @@ export class WebsiteBuilder extends Component {
         useSubEnv({
             builderRef: useRef("container"),
         });
-        this.state = useState({ isEditing: false, key: 1 });
+        this.state = useState({ isEditing: false, showSidebar: true, key: 1 });
         this.websiteContext = useState(this.websiteService.context);
         this.component = useComponent();
 
@@ -167,7 +167,15 @@ export class WebsiteBuilder extends Component {
             iframeLoaded: this.iframeLoaded,
             isMobile: this.websiteContext.isMobile,
             Plugins: websitePlugins,
-            config: { initialTarget: this.target, initialTab: this.initialTab },
+            config: {
+                initialTarget: this.target,
+                initialTab: this.initialTab,
+                builderSidebar: {
+                    toggle: (show) => {
+                        this.state.showSidebar = show ?? !this.state.showSidebar;
+                    },
+                },
+             },
             getThemeTab: () =>
                 odoo.loader.modules.get("@website/builder/plugins/theme/theme_tab").ThemeTab,
         };

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -15,7 +15,7 @@
             <ResourceEditor close="() => this.websiteContext.showResourceEditor = false"/>
         </ResizablePanel>
         <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
-        <div t-att-class="{'o_builder_sidebar_open': state.isEditing}" class="o-website-builder_sidebar border-start border-dark">
+        <div t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar}" class="o-website-builder_sidebar border-start border-dark">
             <LazyComponent  t-if="state.isEditing" Component="'website.Builder'" props="() => this.menuProps" bundle="'html_builder.assets'" t-key="state.key"/>
         </div>
     </div>


### PR DESCRIPTION
**[FIX] html_builder: avoid reload when addLanguage is discarded**
    
    Steps to reproduce:
    - Edit the website and go to the Theme tab
    - Click on "Add a Language"
    - Press Escape
    => The iframe is reloaded.
    
    This commit makes sure that the commit is only reloaded when a language
    is actually validated.

**[FIX] html_builder: keep track of last saved step**
    
    After calling `savePlugin.save()` explicitly, if you try to leave the
    builder, it will prompt a new dialog saying that there are some unsaved
    changes on the page (through `onBeforeLeave`). This is because it only
    checks whether there are existing steps, and steps are not removed after
    a save. By tracking the last saved step we can bypass the unnecessary
    prompt.
    
    This PR follows [the refactor into html_builder].
    
    [the refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
    
    Related to task-4367641
