### PR TITLE
[FIX] html_builder, website: set enabledTabs on colorpickers

### DIFF
--- a/addons/html_builder/static/src/plugins/shadow_option.xml
+++ b/addons/html_builder/static/src/plugins/shadow_option.xml
@@ -11,7 +11,7 @@
     </BuilderRow>
     <BuilderContext t-if="!this.isActiveItem('no_shadow')" action="props.setShadowAction">
         <BuilderRow label.translate="Color" level="1">
-            <BuilderColorPicker actionParam="'color'"/>
+            <BuilderColorPicker actionParam="'color'"  enabledTabs="['solid', 'custom']"/>
         </BuilderRow>
 
         <BuilderRow label.translate="Offset (X, Y)" level="1">

--- a/addons/website/static/src/builder/plugins/background_option/background_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_option.xml
@@ -32,17 +32,9 @@
         <ImageFormatOption level="2" computeMaxDisplayWidth="this.computeMaxDisplayWidth"/>
         <!-- Color filter -->
         <BuilderRow t-if="this.showColorFilter()" label.translate="Color Filter" level="2">
-            <!-- TODO handle all the attributes -->
-            <BuilderColorPicker action="'selectFilterColor'"/>
+            <!-- TODO handle data-opacity="0.5" -->
+            <BuilderColorPicker action="'selectFilterColor'" enabledTabs="['custom', 'gradient']" selectedTab="'gradient'"/>
         </BuilderRow>
-        <!-- <div t-att-data-js="with_colors and with_color_combinations and 'ColoredLevelBackground' or 'BackgroundToggler'"
-            <we-colorpicker string="Color Filter"
-                            data-opacity="0.5"
-                            data-with-gradients="1"
-                            data-selected-tab="gradients"
-                            data-excluded="theme, common"
-            />
-        </div> -->
         <BackgroundShapeOption t-if="props.withShapes"/>
     </t>
 </t>

--- a/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_shape_option.xml
@@ -20,10 +20,10 @@
 
     <BuilderRow label.translate="Colors" level="2">
         <t t-foreach="getDefaultColorNames()" t-as="colorName" t-key="colorName_index">
-            <BuilderColorPicker action="'backgroundShapeColor'" actionParam="colorName"/>
+            <BuilderColorPicker action="'backgroundShapeColor'" actionParam="colorName" enabledTabs="['solid', 'custom']"/>
         </t>
         <!-- TODO handle all the attributes -->
-        <BuilderColorPicker styleAction="'background-color'" applyTo="':scope > .o_we_shape'"/>
+        <BuilderColorPicker styleAction="'background-color'" applyTo="':scope > .o_we_shape'" enabledTabs="['solid', 'custom']"/>
     </BuilderRow>
     <BuilderRow label.translate="Speed" level="2" t-if="state.isAnimated">
         <BuilderRange

--- a/addons/website/static/src/builder/plugins/options/blockquote_option.xml
+++ b/addons/website/static/src/builder/plugins/options/blockquote_option.xml
@@ -16,7 +16,7 @@
 
     <BuilderRow label.translate="Style" applyTo="'.s_blockquote_line_elt'" level="1" t-if="this.isActiveItem('blockquote_with_line_opt')">
         <BuilderNumberInput styleAction="'width'" min="0" unit="'px'"/>
-        <BuilderColorPicker styleAction="'background-color'" />
+        <BuilderColorPicker styleAction="'background-color'" enabledTabs="['solid', 'custom', 'gradient']"/>
     </BuilderRow>
 
     <BuilderRow label.translate="Author Alignment" applyTo="'.s_blockquote_infos'">

--- a/addons/website/static/src/builder/plugins/rating_option.xml
+++ b/addons/website/static/src/builder/plugins/rating_option.xml
@@ -13,11 +13,11 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="&#8985; Active">
-        <BuilderColorPicker applyTo="'.s_rating_active_icons'" styleAction="'color'"/>
+        <BuilderColorPicker applyTo="'.s_rating_active_icons'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
         <BuilderButton action="'customIcon'" actionParam="'customActiveIcon'" preview="false"><i class="fa fa-fw fa-refresh me-1"/> Replace Icon</BuilderButton>
     </BuilderRow>
     <BuilderRow label.translate="&#8985; Inactive">
-        <BuilderColorPicker applyTo="'.s_rating_inactive_icons'" styleAction="'color'"/>
+        <BuilderColorPicker applyTo="'.s_rating_inactive_icons'" styleAction="'color'" enabledTabs="['solid', 'custom']"/>
         <BuilderButton action="'customIcon'" actionParam="'customInactiveIcon'" preview="false"><i class="fa fa-fw fa-refresh me-1"/> Replace Icon</BuilderButton>
     </BuilderRow>
     <BuilderRow label.translate="Score">


### PR DESCRIPTION
[FIX] html_builder, website: set enabledTabs on colorpickers
    
This commit sets specific enabled tabs on:
- Background video or image: color filter (+ gradient selected)
- Background shape: colors
- Shadow: color
- Blockquote: decoration style
- Rating: active/inactive colors

This PR follows [the refactor into html_builder].

[the refactor into html_builder]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb

Related to task-4367641
