### PR TITLE
[FIX] point_of_sale: laggy ticket screen switch

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -84,20 +84,21 @@ export class TicketScreen extends Component {
         Object.assign(this.state, this.props.stateOverride || {});
 
         onMounted(this.onMounted);
-        onWillStart(async () => {
+        onWillStart(() => {
             if (!this.pos.loadingOrderState) {
-                try {
-                    this.pos.loadingOrderState = true;
-                    await this.pos.getServerOrders();
-                } catch (error) {
-                    if (error instanceof ConnectionLostError) {
-                        Promise.reject(error);
-                        return error;
-                    }
-                    throw error;
-                } finally {
-                    this.pos.loadingOrderState = false;
-                }
+                this.pos.loadingOrderState = true;
+                // Start fetching orders without blocking screen rendering
+                this.pos
+                    .getServerOrders()
+                    .catch((error) => {
+                        if (error instanceof ConnectionLostError) {
+                            return;
+                        }
+                        throw error;
+                    })
+                    .finally(() => {
+                        this.pos.loadingOrderState = false;
+                    });
             }
         });
     }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -3,7 +3,7 @@
 
     <t t-name="point_of_sale.TicketScreen">
         <t t-set="_filteredOrderList" t-value="getFilteredOrderList()" />
-        <div class="ticket-screen screen h-100 bg-100">
+        <div class="ticket-screen screen h-100 bg-100" t-att-class="{'loading-orders': this.pos.loadingOrderState}">
             <div class="screen-full-width d-flex w-100 h-100">
                 <t t-set="usePreset" t-value="pos.config.use_presets and pos.models['pos.preset'].length > 1" />
                 <div t-if="!ui.isSmall || pos.ticket_screen_mobile_pane === 'left'" class="rightpane pane-border d-flex flex-column flex-grow-1 w-100 h-100 h-lg-100 pe-lg-0 bg-view border-end overflow-y-auto">

--- a/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/payment_screen_tour.js
@@ -110,6 +110,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingUp", {
             PaymentScreen.clickValidate(),
 
             Chrome.clickOrders(),
+            TicketScreen.isReady(),
             TicketScreen.selectFilter("Paid"),
             TicketScreen.selectOrder("001"),
             inLeftSide([
@@ -138,6 +139,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
             PaymentScreen.clickValidate(),
 
             Chrome.clickOrders(),
+            TicketScreen.isReady(),
             TicketScreen.selectFilter("Paid"),
             TicketScreen.selectOrder("001"),
             inLeftSide([

--- a/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
@@ -267,3 +267,10 @@ export function noOrderIsThere() {
         trigger: ".ticket-screen:not(:has(.order-row))",
     };
 }
+
+export function isReady() {
+    return {
+        content: "Wait for the Ticket Screen to be ready",
+        trigger: ".ticket-screen:not(.loading-orders)",
+    };
+}


### PR DESCRIPTION
Steps to reproduce:
- Open point of sale
- Create some orders
- Switch to Orders screen

Current behavior:
- Some lag before able to switch the screen

Expected result:
- Should be able to switch screen smoothly

Explanation:
getServerOrders is call and await in onWillStart. Therefore unless the promised solved, which is calling the server, the UI will not update.
We could put the getServerOrders in background to lazy load the orders. Also we should put the function in useDebounced to prevent multiple requests sent to the server when users switch to ticket screens multiple times.