### PR TITLE
[FIX] bus: allow customizing GC retention window

### DIFF
--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -20,6 +20,7 @@ _logger = logging.getLogger(__name__)
 
 # longpolling timeout connection
 TIMEOUT = 50
+DEFAULT_GC_RETENTION_SECONDS = 60 * 60 * 24  # 24 hours
 
 # custom function to call instead of default PostgreSQL's `pg_notify`
 ODOO_NOTIFY_FUNCTION = os.getenv('ODOO_NOTIFY_FUNCTION', 'pg_notify')
@@ -91,12 +92,13 @@ class ImBus(models.Model):
 
     @api.autovacuum
     def _gc_messages(self):
-        timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT*2)
-        domain = [('create_date', '<', timeout_ago)]
-        records = self.search(domain, limit=models.GC_UNLINK_LIMIT)
-        if len(records) >= models.GC_UNLINK_LIMIT:
-            self.env.ref('base.autovacuum_job')._trigger()
-        return records.unlink()
+        gc_retention_seconds = int(
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("bus.gc_retention_seconds", DEFAULT_GC_RETENTION_SECONDS)
+        )
+        timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=gc_retention_seconds)
+        self.env.cr.execute("DELETE FROM bus_bus WHERE create_date < %s", (timeout_ago,))
 
     @api.model
     def _sendone(self, target, notification_type, message):

--- a/addons/bus/tests/__init__.py
+++ b/addons/bus/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import common
 from . import test_assetsbundle
+from . import test_bus_gc
 from . import test_bus_presence
 from . import test_health
 from . import test_ir_model

--- a/addons/bus/tests/test_bus_gc.py
+++ b/addons/bus/tests/test_bus_gc.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from freezegun import freeze_time
+
+from odoo.tests import HttpCase, tagged
+from odoo.addons.bus.models.bus import DEFAULT_GC_RETENTION_SECONDS
+
+
+@tagged("-at_install", "post_install")
+class TestBusGC(HttpCase):
+    def test_default_gc_retention_window(self):
+        self.env["ir.config_parameter"].search([("key", "=", "bus.gc_retention_seconds")]).unlink()
+        self.env["bus.bus"].search([]).unlink()
+        self.env["bus.bus"].create({"channel": "foo", "message": "bar"})
+        self.assertEqual(self.env["bus.bus"].search_count([]), 1)
+
+        with freeze_time(datetime.now() + timedelta(seconds=DEFAULT_GC_RETENTION_SECONDS / 2)):
+            self.env["bus.bus"]._gc_messages()
+            self.assertEqual(self.env["bus.bus"].search_count([]), 1)
+        with freeze_time(datetime.now() + timedelta(seconds=DEFAULT_GC_RETENTION_SECONDS + 1)):
+            self.env["bus.bus"]._gc_messages()
+            self.assertEqual(self.env["bus.bus"].search_count([]), 0)
+
+    def test_custom_gc_retention_window(self):
+        self.env["bus.bus"].search([]).unlink()
+        self.env["ir.config_parameter"].set_param("bus.gc_retention_seconds", 25000)
+        self.env["bus.bus"].create({"channel": "foo", "message": "bar"})
+        self.assertEqual(self.env["bus.bus"].search_count([]), 1)
+
+        with freeze_time(datetime.now() + timedelta(seconds=15000)):
+            self.env["bus.bus"]._gc_messages()
+            self.assertEqual(self.env["bus.bus"].search_count([]), 1)
+        with freeze_time(datetime.now() + timedelta(seconds=30000)):
+            self.env["bus.bus"]._gc_messages()
+            self.assertEqual(self.env["bus.bus"].search_count([]), 0)


### PR DESCRIPTION
Before this commit, the bus GC would remove every message
older than 120 seconds. This could lead to missed messages
if a disconnection occurred during the GC process.

To minimize the impact of GC, the retention window should be extended.
This commit introduces the `bus.gc_retention_seconds` config parameter,
which allows customizing this window. The default is set to 24 hours,
which seems reasonable (messages won't be cleared overnight).

Since the GC will now process larger batches, the deletion is not made
with a direct query: no need to fetch all records before calling `unlink`,
no need to schedule other vacuums when the batch is too big.