### PR TITLE
[FIX] html_editor: update font size selector on set tag in toolbar

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -115,14 +115,15 @@ export class BuilderOptionsPlugin extends Plugin {
         if (!this.target || !this.target.isConnected) {
             this.lastContainers = this.lastContainers.filter((c) => c.element.isConnected);
             this.target = this.lastContainers.at(-1)?.element;
-            this.dependencies.history.setStepExtra("optionSelection", this.target);
-            this.dispatchTo("change_current_options_containers_listeners", this.lastContainers);
-            return;
         }
 
         const newContainers = this.computeContainers(this.target);
         // Do not update the containers if they did not change or not forced to update.
-        if (newContainers.length === this.lastContainers.length && !force) {
+        if (
+            this.target?.isConnected &&
+            newContainers.length === this.lastContainers.length &&
+            !force
+        ) {
             const previousIds = this.lastContainers.map((c) => c.id);
             const newIds = newContainers.map((c) => c.id);
             const areSameElements = newIds.every((id, i) => id === previousIds[i]);


### PR DESCRIPTION
In website builder:

1. Select text
2. Change heading type in the toolbar

-> the font size selector in the toolbar is blank:

![image](https://github.com/user-attachments/assets/81d24546-ae34-4caf-90e2-8e3725d887fb)

This is because the font size input is in an iframe, and a chain of events triggered by changing the heading type (`setTag`) leads to the iframe's document to be re-rendered. This only happens in the website builder because of a call to `updateContainers` as a step_added handler that triggers the `change_current_options_containers_listeners`.

These listeners are triggered because `setTag` replaced the block which was the target of the `BuilderOptionsPlugin` with another. The target is not connected anymore so it was assumed we would always need to reset the containers, but the target didn't really change, it was simply replaced to change its tag. So this allows going through the checks to see if updating the containers is needed before triggering the listeners. Since in this case it isn't, they won't be and the iframe will remain intact.

![image](https://github.com/user-attachments/assets/a0cb2c5f-56e5-4140-978d-17906e1ae634)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
