### PR TITLE
[FIX] account: identify lines of different account types if any of the lines is off-balance

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1210,7 +1210,7 @@ class AccountMoveLine(models.Model):
 
     @api.constrains('account_id', 'tax_ids', 'tax_line_id', 'reconciled')
     def _check_off_balance(self):
-        for line in self:
+        for line in self.move_id.line_ids:
             if line.account_id.internal_group == 'off_balance':
                 if any(a.internal_group != line.account_id.internal_group for a in line.move_id.line_ids.account_id):
                     raise UserError(_('If you want to use "Off-Balance Sheet" accounts, all the accounts of the journal entry must be of this type'))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Issue: if only one line is edited/added and it's account is not of type off-balance, the check will fail to raise the warning

Steps to reproduce the error:
1. Create entry
2. Account move line 1 with account off balance
3. Account move line 2 with account off balance
4. Save move
5. Edit line 2, change the account to an asset type account.
6. Save move. The system does not give a warning.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
