### PR TITLE
[FIX] hr_holidays: update stats widget after employee change

### DIFF
--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.js
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.js
@@ -16,15 +16,15 @@ export class LeaveStatsComponent extends Component {
         this.state = useState({
             leaves: [],
             departmentLeaves: [],
+            department: this.props.record.data.department_id,
+            employee: this.props.record.data.employee_id,
         });
 
         this.date = this.props.record.data.date_from || DateTime.now();
-        this.department = this.props.record.data.department_id;
-        this.employee = this.props.record.data.employee_id;
 
         onWillStart(async () => {
-            await this.loadLeaves(this.date, this.employee);
-            await this.loadDepartmentLeaves(this.date, this.department, this.employee);
+            await this.loadLeaves(this.date, this.state.employee);
+            await this.loadDepartmentLeaves(this.date, this.state.department, this.state.employee);
         });
 
         useRecordObserver(async (record) => {
@@ -34,7 +34,7 @@ export class LeaveStatsComponent extends Component {
             const department = record.data.department_id;
 
             const proms = [];
-            if (dateChanged || (employee && (this.employee && this.employee[0]) !== employee[0])) {
+            if (dateChanged || (employee && (this.state.employee && this.state.employee[0]) !== employee[0])) {
                 proms.push(this.loadLeaves(dateFrom, employee));
             }
 
@@ -47,8 +47,8 @@ export class LeaveStatsComponent extends Component {
             await Promise.all(proms);
 
             this.date = dateFrom;
-            this.employee = employee;
-            this.department = department;
+            this.state.employee = employee;
+            this.state.department = department;
         });
     }
 

--- a/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
+++ b/addons/hr_holidays/static/src/leave_stats/leave_stats.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <div t-name="hr_holidays.LeaveStatsComponent" class="o_leave_stats">
-        <div t-if="employee" id="o_leave_stats_employee">
+        <div t-if="state.employee" id="o_leave_stats_employee">
             <div class="o_hr_leave_subtitle">
-                <t t-esc="employee[1]"/> in <t t-esc="thisYear"/>
+                <t t-esc="state.employee[1]"/> in <t t-esc="thisYear"/>
             </div>
             <div t-if="state.leaves.length === 0">
                 None
@@ -14,9 +14,9 @@
             </div>
         </div>
 
-        <div t-if="department" id="o_leave_stats_department">
+        <div t-if="state.department" id="o_leave_stats_department">
             <div class="o_horizontal_separator o_hr_leave_subtitle">
-                <t t-esc="department[1]"/>
+                <t t-esc="state.department[1]"/>
             </div>
             <div t-if="state.departmentLeaves.length === 0">
                 None

--- a/addons/hr_holidays/static/tests/leave_stats_tests.js
+++ b/addons/hr_holidays/static/tests/leave_stats_tests.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-import { selectDropdownItem, editInput } from "@web/../tests/helpers/utils";
+import { clickSave, selectDropdownItem, editInput } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
 let serverData;
@@ -176,4 +176,31 @@ QUnit.test("leave stats reload when employee/department changes", async (assert)
     await selectDropdownItem(document.body, "employee_id", "Jesus");
     // Set department => should load department's data
     await selectDropdownItem(document.body, "department_id", "R&D");
+});
+
+QUnit.test("leave stats renders after multi-employee", async (assert) => {
+    await makeView({
+        serverData,
+        type: "form",
+        resModel: "hr.leave",
+        arch: `
+            <form string="Leave">
+                <field name="employee_id"/>
+                <field name="department_id"/>
+                <field name="date_from"/>
+                <widget name="hr_leave_stats"/>
+            </form>`,
+        resId: 12,
+    });
+    
+    await selectDropdownItem(document.body, "employee_id", "Jesus");
+    await clickSave(document.body);
+
+    const $leaveTypeBody = $(".o_leave_stats #o_leave_stats_employee");
+    const $leavesDepartmentBody = $(".o_leave_stats #o_leave_stats_department");
+    assert.containsOnce($leaveTypeBody, "span:contains(Legal Leave)");
+    assert.containsOnce($leaveTypeBody, "span:contains(13)");
+    assert.containsN($leavesDepartmentBody, "span:contains(Jesus)", 2);
+    assert.containsOnce($leavesDepartmentBody, "span:contains(Richard)");
+    assert.containsOnce($leavesDepartmentBody, "div.o_horizontal_separator:contains(R&D)");
 });


### PR DESCRIPTION
When creating a new Time Off allocation, the stats widget was not updated after changing the employee or switching from multi-employee to single-employee mode.

Steps to reproduce:
-------------------
* In Time Off app, got to Management > Time Off
* Create a New Time Off request
* Add a second Employee on the form
* Remove in of the Employees

> Observation:
Stats widget on the right was not updated

Why the fix:
------------
We needed to trigger a rerender of the component when it's modified.

opw-4595273

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
