### PR TITLE
[FIX] website: remove offset classes on clone

### DIFF
--- a/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/layout_option/layout_option_plugin.js
@@ -33,8 +33,8 @@ class LayoutOptionPlugin extends Plugin {
                 applyTo: ":scope > *:has(> .row)",
             }),
         ],
-
         builder_actions: this.getActions(),
+        on_cloned_handlers: this.onCloned.bind(this),
     };
 
     getActions() {
@@ -169,6 +169,14 @@ class LayoutOptionPlugin extends Plugin {
             const hasDesktopOffset = columnEl.className.match(/(^|\s+)offset-lg-[1-9][0-1]?(?!\S)/);
             columnEl.classList.toggle("offset-lg-0", hasMobileOffset && !hasDesktopOffset);
         }
+    }
+
+    onCloned({ cloneEl }) {
+        const cloneElClassList = cloneEl.classList;
+        const offsetClasses = [...cloneElClassList].filter((cls) =>
+            cls.match(/^offset-(lg-)?([0-9]{1,2})$/)
+        );
+        cloneElClassList.remove(...offsetClasses);
     }
 }
 registry.category("website-plugins").add(LayoutOptionPlugin.id, LayoutOptionPlugin);

--- a/addons/website/static/tests/builder/options/layout_option.test.js
+++ b/addons/website/static/tests/builder/options/layout_option.test.js
@@ -56,3 +56,11 @@ test("Changing the number of columns to 'None' (0)", async () => {
     await contains("[data-action-id='changeColumnCount'][data-action-value='0']").click();
     expect(":iframe .s_text_block .row").toHaveCount(0);
 });
+
+test("Adding columns does not introduce extra offset (offset class removed on clone)", async () => {
+    await setupWebsiteBuilderWithSnippet(["s_text_block"]);
+    await contains(":iframe .s_text_block").click();
+    await contains("[data-label='Layout'] .dropdown").click();
+    await contains("[data-action-id='changeColumnCount'][data-action-value='5']").click();
+    expect(":iframe .s_text_block .container > .row > .offset-lg-1").toHaveCount(1);
+});


### PR DESCRIPTION
> [LEBL] 5 columns (on s_text, for example) doesn't work as expected, the 5th line is in another row, but I still got the overlay,

In the old website editor, offset classes are removed from cloned elements (see the `onClone` override in `registry['sizing_x']`). This behaviour was missing in the new editor. The presence of extra offsets caused problems, for example when setting the number of column equal to 5 in a text snippet.

This commit introduces an `onCloned` handler that removes offset classes.
