### PR TITLE
[FIX] orm: cache update incorrectly invokes modified()

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -37,7 +37,7 @@ class HrLeaveAccrualLevel(models.Model):
     added_value_type = fields.Selection([
         ('day', 'Days'),
         ('hour', 'Hours')
-    ], compute="_compute_added_value_type", store=True, required=True, readonly=False, default="day")
+    ], compute="_compute_added_value_type", precompute=True, store=True, required=True, readonly=False)
     frequency = fields.Selection([
         ('hourly', 'Hourly'),
         ('daily', 'Daily'),
@@ -177,6 +177,8 @@ class HrLeaveAccrualLevel(models.Model):
                 level.added_value_type = "day" if level.accrual_plan_id.time_off_type_id.request_unit in ["day", "half_day"] else "hour"
             elif level.accrual_plan_id.level_ids and level.accrual_plan_id.level_ids[0] != level:
                 level.added_value_type = level.accrual_plan_id.level_ids[0].added_value_type
+            elif not level.added_value_type:
+                level.added_value_type = "day"  # default value
 
     def _set_day(self, day_field, month_field):
         for level in self:

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1889,8 +1889,9 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         })
         # Simulate the onchange of the dialog form view
         # Trigger the `_compute_added_value_type` method (with virtual records)
-        res = self.env['hr.leave.accrual.level'].onchange({'accrual_plan_id': {'id': accrual_plan.id}}, [], {'added_value_type': {}})
-        self.assertEqual(res['value']['added_value_type'], accrual_plan.level_ids[0].added_value_type)
+        form = Form(accrual_plan)
+        with form.level_ids.new() as level:
+            self.assertEqual(level.added_value_type, 'hour')
 
     def test_accrual_immediate_cron_run(self):
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({

--- a/odoo/addons/test_orm/models/test_orm.py
+++ b/odoo/addons/test_orm/models/test_orm.py
@@ -604,6 +604,7 @@ class TestOrmMove(models.Model):
     # `move_id`, it uses it.  If that field was not initialized properly, the
     # ORM determines its value to be... empty (instead of the payment record.)
     payment_ids = fields.One2many('test_orm.payment', 'move_id')
+    payment_amount = fields.Integer(compute='_compute_payment_amount')
 
     @api.depends('line_ids.quantity')
     def _compute_quantity(self):
@@ -614,6 +615,11 @@ class TestOrmMove(models.Model):
     def _compute_tag_string(self):
         for record in self:
             record.tag_string = (record.tag_name or "") * record.tag_repeat
+
+    @api.depends('payment_ids.amount')
+    def _compute_payment_amount(self):
+        for record in self:
+            record.payment_amount = sum(payment.amount for payment in record.payment_ids)
 
 
 class TestOrmMove_Line(models.Model):
@@ -631,6 +637,7 @@ class TestOrmPayment(models.Model):
     _inherits = {'test_orm.move': 'move_id'}
 
     move_id = fields.Many2one('test_orm.move', required=True, ondelete='cascade')
+    amount = fields.Integer()
 
 
 class TestOrmOrder(models.Model):

--- a/odoo/orm/fields_relational.py
+++ b/odoo/orm/fields_relational.py
@@ -500,7 +500,6 @@ class _RelationalMulti(_Relational):
                 records.env.transaction.field_data_patches[self][record_id].append(new_id)
             else:
                 field_cache[record_id] = tuple(unique(cache_value + (new_id,)))
-        records.modified([self.name])
 
     def _update_cache(self, records, cache_value, dirty=False):
         field_patches = records.env.transaction.field_data_patches.get(self)


### PR DESCRIPTION
### Issue

Consider a child model that `_inherits` from a parent model.  The parent model has a one2many field to the "children" records, and a computed field that depends on a field from the children records.  The computed field is thus inherited on children records.

In a form view, create a new record of the child model.  Modify the dependency of the inherited computed field, and observe the value of the computed field.  When setting the field to any value, the recomputation works as expected.  But when voiding the field, the computed field is not recomputed as expected.

### Explanation

During an onchange, when setting a many2one field, the cache of its inverse fields (one2many) is updated to include the new line.  This also happen when accessing inherited fields, which traverse a many2one field.  The method that inverses the x2many fields invokes method `modified()` to make sure that fields that depend on the x2many field are recomputed as expected.  This call probably dates back to some earlier implementation of the ORM.  We found out that invoking `modified()` in that context is not correct.

First, the said use of `modified()` is useless.  Indeed, the recomputation of dependent fields is already guaranteed by another mechanism, i.e., when invoking `modified()` for the many2one field itself, in this case.  Nothing breaks when we remove the said invocation.

Second, the said use of `modified()` is actually harmful.  During an onchange, a snapshot of the current values in the form is determined based on new records that reproduce the form's current status.  The new records are instanciated with the form values in their cache.  For the snapshot to be correct, one should not recompute any field during that phase.  But the said call to `modified()` causes invalidations and recomputations.  The snapshot is thus not correct, and some modified fields are not returned to the client.

### Solution

Simply remove the incorrect invocation of modified() from the method that updates the cache of the inverse field.

### Extra

The fix actually breaks the behavior of a computed field in model `hr.leave.accrual.level`.  We found out that the field definition was not correct, and that its behavior was not consistent either (form view behaving differently than method `create()`).  As the expected behavior was relying on the bug above, we modified the field's definition.  The field was defined as computed with a default value, but using the default value was not the expected behavior.