### PR TITLE
[FIX] web: error_service: swallow Promise rejected with error event

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -5,6 +5,14 @@ import { browser } from "../browser/browser";
 import { registry } from "../registry";
 import { completeUncaughtError, getErrorTechnicalName } from "./error_utils";
 
+export class HTMLElementLoadingError extends Error {
+    static message = "Error loading an HTML Element";
+    constructor(message = HTMLElementLoadingError.message, event) {
+        super(message);
+        this.event = event;
+    }
+}
+
 /**
  * Uncaught Errors have 4 properties:
  * - name: technical name of the error (UncaughtError, ...)
@@ -140,7 +148,28 @@ export const errorService = {
         });
 
         browser.addEventListener("unhandledrejection", async (ev) => {
-            const error = ev.reason;
+            let error = ev.reason;
+
+            if (error && error.type === "error" && "eventPhase" in error) {
+                // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event
+                // See also MDN's img, script and iframe docs. The error Event *doesn't* bubble.
+                // We sometimes reject a promise with the Event dispatched by the "error" handler
+                // of an HTMLElement. If the code throwing that at us doesn't wrap the event in an
+                // actual Error, there is no reason to do more than the spec: we do not handle
+                // this error bubbling to us via the Promise being rejected.
+                if (!error.bubbles) {
+                    ev.preventDefault();
+                    return;
+                }
+                // If for some reason the error Event bubbles then do something
+                // a bit meaningful.
+                let message;
+                if (error.target) {
+                    message = `${HTMLElementLoadingError.message}: ${error.target.nodeName}`;
+                }
+                error = new HTMLElementLoadingError(message, error);
+            }
+
             let traceback;
             if (isBrowserChrome() && ev instanceof CustomEvent && error === undefined) {
                 // This fix is ad-hoc to a bug in the Honey Paypal extension


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event See also MDN's img, script and iframe docs. The error Event *doesn't* bubble.

We sometimes reject a promise with the Event dispatched by the "error" handler of an HTMLElement. If the code throwing that at us doesn't wrap the event in an actual Error, there is no reason to do more than the spec: we do not handle this error bubbling to us via the Promise being rejected.

This allows to silence errors coming from a failed load of an Element that was wrapped into a promise. Website uses that in image_processing for example.

runbot-error-70404

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
