### PR TITLE
[FIX] account: lighten _check_uom_not_in_invoice constraint

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -124,6 +124,7 @@ class ProductTemplate(models.Model):
               JOIN uom_uom line_uom ON line.product_uom_id = line_uom.id
              WHERE prod_template.id IN %s
                AND line.parent_state = 'posted'
+               AND template_uom.id != line_uom.id
              LIMIT 1
         """, [tuple(self.ids)])
         if self._cr.fetchall():


### PR DESCRIPTION
**Current behavior:**
A write on a product's uom that is the same as the current value is blocked.

**Expected behavior:**
This type of trivial write should be permitted.

**Steps to reproduce:**
1. Create a product with a UoM, generate some journal entries for it

2. Export the product to CSV with import-support formatting

3. Try to import that CSV -> blocked by UoM constraint

**Cause of the issue:**
With the removal of UoM categories, this constraint was made much tighter.

**Fix:**
Don't constrain trivial writes where the new UoM is the old UoM.

opw-4623279