### PR TITLE
[PERF] core: speed up file_open

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -224,15 +224,13 @@ actual arch.
                 ('xml' in config['dev_mode'] and not view.arch_updated)
             if read_file and view.arch_fs and (view.xml_id or view.key):
                 xml_id = view.xml_id or view.key
-                # It is safe to split on / herebelow because arch_fs is explicitely stored with '/'
                 try:
-                    fullpath = file_path(view.arch_fs)
-                except FileNotFoundError:
+                    # reading the file will raise an OSError if it is unreadable
+                    arch_fs = get_view_arch_from_file(file_path(view.arch_fs, check_exists=False), xml_id)
+                except OSError:
                     _logger.warning("View %s: Full path [%s] cannot be found.", xml_id, view.arch_fs)
                     arch_fs = False
-                    continue
 
-                arch_fs = get_view_arch_from_file(fullpath, xml_id)
                 # replace %(xml_id)s, %(xml_id)d, %%(xml_id)s, %%(xml_id)d by the res_id
                 if arch_fs:
                     arch_fs = resolve_external_ids(arch_fs, xml_id).replace('%%', '%')

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -233,9 +233,9 @@ class TestRemoveAccents(BaseCase):
 
 class TestAddonsFileAccess(BaseCase):
 
-    def assertCannotAccess(self, path, ExceptionType=OSError, filter_ext=None):
+    def assertCannotAccess(self, path, ExceptionType=OSError, filter_ext=None, check_exists=True):
         with self.assertRaises(ExceptionType):
-            file_path(path, filter_ext=filter_ext)
+            file_path(path, filter_ext=filter_ext, check_exists=check_exists)
 
     def assertCanRead(self, path, needle='', mode='r', filter_ext=None):
         with file_open(path, mode, filter_ext) as f:
@@ -243,7 +243,7 @@ class TestAddonsFileAccess(BaseCase):
 
     def assertCannotRead(self, path, ExceptionType=OSError, filter_ext=None):
         with self.assertRaises(ExceptionType):
-            file_open(path, filter_ext=filter_ext)
+            file_open(path, filter_ext=filter_ext).close()
 
     def test_file_path(self):
         # absolute path
@@ -266,6 +266,10 @@ class TestAddonsFileAccess(BaseCase):
 
         # files in root_path are allowed
         self.assertTrue(file_path('tools/misc.py'))
+
+        # absolute or relative inexisting files are ok
+        self.assertTrue(file_path(config.root_path + '/__inexisting', check_exists=False))
+        self.assertTrue(file_path('base/__inexisting_file', check_exists=False))
 
         # errors when outside addons_paths
         self.assertCannotAccess('/doesnt/exist')
@@ -309,6 +313,10 @@ class TestAddonsFileAccess(BaseCase):
 
         # files in root_path are allowed
         self.assertCanRead('tools/misc.py')
+
+        # absolute or relative inexisting files are ok
+        self.assertCannotRead(config.root_path + '/__inexisting')
+        self.assertCannotRead('base/__inexisting_file')
 
         # errors when outside addons_paths
         self.assertCannotRead('/doesnt/exist')

--- a/odoo/addons/base/tests/test_misc.py
+++ b/odoo/addons/base/tests/test_misc.py
@@ -233,7 +233,7 @@ class TestRemoveAccents(BaseCase):
 
 class TestAddonsFileAccess(BaseCase):
 
-    def assertCannotAccess(self, path, ExceptionType=FileNotFoundError, filter_ext=None):
+    def assertCannotAccess(self, path, ExceptionType=OSError, filter_ext=None):
         with self.assertRaises(ExceptionType):
             file_path(path, filter_ext=filter_ext)
 
@@ -241,7 +241,7 @@ class TestAddonsFileAccess(BaseCase):
         with file_open(path, mode, filter_ext) as f:
             self.assertIn(needle, f.read())
 
-    def assertCannotRead(self, path, ExceptionType=FileNotFoundError, filter_ext=None):
+    def assertCannotRead(self, path, ExceptionType=OSError, filter_ext=None):
         with self.assertRaises(ExceptionType):
             file_open(path, filter_ext=filter_ext)
 
@@ -293,7 +293,7 @@ class TestAddonsFileAccess(BaseCase):
         self.assertCanRead(__file__, test_needle.encode(), mode='rb', filter_ext=('.py',))
 
         # directory target *is* an error
-        with self.assertRaises(FileNotFoundError):
+        with self.assertRaises(IsADirectoryError):
             file_open(os.path.join(__file__, '..'))
 
         # relative path

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -3,6 +3,7 @@
 import collections
 import configparser as ConfigParser
 import errno
+import functools
 import logging
 import optparse
 import glob
@@ -759,11 +760,11 @@ class configmanager:
     def _is_addons_path(cls, path):
         for f in os.listdir(path):
             modpath = os.path.join(path, f)
-            if os.path.isdir(modpath):
-                def hasfile(filename):
-                    return os.path.isfile(os.path.join(modpath, filename))
-                if hasfile('__init__.py') and hasfile('__manifest__.py'):
-                    return True
+
+            def hasfile(filename):
+                return os.path.isfile(os.path.join(modpath, filename))
+            if hasfile('__init__.py') and hasfile('__manifest__.py'):
+                return True
         return False
 
     @classmethod
@@ -957,7 +958,7 @@ class configmanager:
     def __getitem__(self, key):
         return self.options[key]
 
-    @property
+    @functools.cached_property
     def root_path(self):
         return self._normalize(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -981,7 +982,7 @@ class configmanager:
                 # try to make +rx placeholder dir, will need manual +w to activate it
                 os.makedirs(d, 0o500)
             except OSError:
-                logging.getLogger(__name__).debug('Failed to create addons data dir %s', d)
+                self._log(logging.DEBUG, 'Failed to create addons data dir %s', d)
         return d
 
     @property

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -193,7 +193,7 @@ def exec_pg_environ():
 # ----------------------------------------------------------
 
 
-def file_path(file_path: str, filter_ext: tuple[str, ...] = ('',), env: Environment | None = None) -> str:
+def file_path(file_path: str, filter_ext: tuple[str, ...] = ('',), env: Environment | None = None, *, check_exists: bool = True) -> str:
     """Verify that a file exists under a known `addons_path` directory and return its full path.
 
     Examples::
@@ -206,14 +206,12 @@ def file_path(file_path: str, filter_ext: tuple[str, ...] = ('',), env: Environm
     :param list[str] filter_ext: optional list of supported extensions (lowercase, with leading dot)
     :param env: optional environment, required for a file path within a temporary directory
         created using `file_open_temporary_directory()`
+    :param check_exists: check that the file exists (default: True)
     :return: the absolute path to the file
     :raise FileNotFoundError: if the file is not found under the known `addons_path` directories
     :raise ValueError: if the file doesn't have one of the supported extensions (`filter_ext`)
     """
     import odoo.addons  # noqa: PLC0415
-    root_path = os.path.abspath(config.root_path)
-    temporary_paths = env.transaction._Transaction__file_open_tmp_paths if env else ()
-    addons_paths = [*odoo.addons.__path__, root_path, *temporary_paths]
     is_abs = os.path.isabs(file_path)
     normalized_path = os.path.normpath(os.path.normcase(file_path))
 
@@ -222,15 +220,31 @@ def file_path(file_path: str, filter_ext: tuple[str, ...] = ('',), env: Environm
 
     # ignore leading 'addons/' if present, it's the final component of root_path, but
     # may sometimes be included in relative paths
-    if normalized_path.startswith('addons' + os.sep):
-        normalized_path = normalized_path[7:]
+    normalized_path = normalized_path.removeprefix('addons' + os.sep)
+
+    # if path is relative and represents a loaded module, accept only the
+    # __path__ for that module; otherwise, search in all accepted paths
+    file_path_split = normalized_path.split(os.path.sep)
+    if not is_abs and (module := sys.modules.get(f'odoo.addons.{file_path_split[0]}')):
+        addons_paths = list(map(os.path.dirname, module.__path__))
+    else:
+        root_path = os.path.abspath(config.root_path)
+        temporary_paths = env.transaction._Transaction__file_open_tmp_paths if env else ()
+        addons_paths = [*odoo.addons.__path__, root_path, *temporary_paths]
 
     for addons_dir in addons_paths:
         # final path sep required to avoid partial match
         parent_path = os.path.normpath(os.path.normcase(addons_dir)) + os.sep
-        fpath = (normalized_path if is_abs else
-                 os.path.normpath(os.path.normcase(os.path.join(parent_path, normalized_path))))
-        if fpath.startswith(parent_path) and os.path.exists(fpath):
+        if is_abs:
+            fpath = normalized_path
+        else:
+            fpath = os.path.normpath(os.path.join(parent_path, normalized_path))
+        if fpath.startswith(parent_path) and (
+            # we check existence when asked or we have multiple paths to check
+            # (there is one possibility for absolute paths)
+            (not check_exists and (is_abs or len(addons_paths) == 1))
+            or os.path.exists(fpath)
+        ):
             return fpath
 
     raise FileNotFoundError("File not found: " + file_path)
@@ -255,7 +269,7 @@ def file_open(name: str, mode: str = "r", filter_ext: tuple[str, ...] = (), env:
     :raise FileNotFoundError: if the file is not found under the known `addons_path` directories
     :raise ValueError: if the file doesn't have one of the supported extensions (`filter_ext`)
     """
-    path = file_path(name, filter_ext=filter_ext, env=env)
+    path = file_path(name, filter_ext=filter_ext, env=env, check_exists=False)
     encoding = None
     if 'b' not in mode:
         # Force encoding for text mode, as system locale could affect default encoding,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Checking that a path exists right before opening it is useless because `open` will already check if the path is a readable file.
We can already reduce a few syscalls during startup in `odoo.tools.config` and when reading views from the disk.

Current behavior before PR:
- file_open call
  - file_path
    - exists
  - is_file
  - open

Desired behavior after PR is merged:
- file_open call
  - file_path
    - exists (only for relative paths where module is not loaded)
  - open

See details in commit messages.

## benchmark

```
# before
In [4]: %timeit file_open('base/models/res_partner.py')
27.1 μs ± 246 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
In [5]: %timeit file_open('/opt/odoo/odoo/addons/base/models/res_partner.py')
26.2 μs ± 316 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# after
In [3]: %timeit file_open('base/models/res_partner.py')
11.4 μs ± 48.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
In [4]: %timeit file_open('/opt/odoo/odoo/addons/base/models/res_partner.py')
12.6 μs ± 119 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
