### PR TITLE
[FIX] mail: keep display_name as fallback for unnamed contact

### DIFF
--- a/addons/mail/static/src/core/web/recipients_popover.js
+++ b/addons/mail/static/src/core/web/recipients_popover.js
@@ -24,7 +24,7 @@ export class RecipientsPopover extends Component {
     }
 
     get name() {
-        return this.partner.name || _t("Unnamed");
+        return this.partner.name || this.partner.display_name || _t("Unnamed");
     }
 
     get phone() {
@@ -36,7 +36,7 @@ export class RecipientsPopover extends Component {
     }
 
     get fieldNames() {
-        return ["name", "email_normalized", "email", "phone"];
+        return ["name", "email_normalized", "email", "phone", "display_name"];
     }
 
     onClickViewProfile() {

--- a/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
+++ b/addons/mail/static/src/views/web/fields/many2many_tags_email/many2many_tags_email.js
@@ -87,7 +87,8 @@ export class FieldMany2ManyTagsEmail extends Many2ManyTagsField {
      */
     getTagProps(record) {
         return {...super.getTagProps(record),
-            text: record.data.name || record.data.email || _t("Unnamed"),
+            text:
+                record.data.name || record.data.email || record.data.display_name || _t("Unnamed"),
             onClick: (ev) => this.onTagClick(ev, record),
         };
     }

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -166,6 +166,19 @@ export class ResPartner extends webModels.ResPartner {
         }
         return partner.im_status;
     }
+
+    /* override */
+    _compute_display_name() {
+        super._compute_display_name();
+        for (const record of this) {
+            if (record.parent_id && !record.name) {
+                const [parent] = this.env["res.partner"].browse(record.parent_id);
+                const type = this._fields.type.selection.find((item) => item[0] === record.type);
+                record.display_name = `${parent.name}, ${type[1]}`;
+            }
+        }
+    }
+
     /**
      * @param {Array} domain
      * @param {number} limit


### PR DESCRIPTION
Steps to reproduce
===============
1. Create a company called Acme.
2. Create a child contact of type Invoicing address but do not give it any name.
3. Go to Sales.
4. Open send mail composer and add this partner as a recipient. ---> The recipient tag will show Unnamed.

From [Commit 1], the fallback was given Unnamed. 
After this commit we'll use display_name as a fallback for no name and email.

[Commit 1]: https://github.com/odoo/odoo/commit/cba81ac77d3bad1c686d95f3a9a67f6bde51c569

Task-4812554
