### PR TITLE
[FIX] l10n_hu_edi: correctly determine STORNO for credit notes

### DIFF
--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -493,6 +493,18 @@ class AccountMove(models.Model):
             for batch in split_every(100, batch_company):
                 self.env['account.move'].union(*batch)._l10n_hu_edi_upload_single_batch(connection)
 
+    def _l10n_hu_edi_get_operation_type(self):
+        base_invoice = self._l10n_hu_get_chain_base()
+        modification_invoices = self._l10n_hu_get_chain_invoices() - base_invoice
+
+        all_invoices_residual_zero = all(invoice.amount_residual == 0 for invoice in modification_invoices)
+
+        if self == base_invoice:
+            return 'CREATE'
+        if base_invoice.amount_residual == 0 and all_invoices_residual_zero:
+            return 'STORNO'
+        return 'MODIFY'
+
     def _l10n_hu_edi_upload_single_batch(self, connection):
         try:
             token_result = connection.do_token_exchange(self.company_id.sudo()._l10n_hu_edi_get_credentials_dict())
@@ -510,19 +522,10 @@ class AccountMove(models.Model):
         for i, invoice in enumerate(self, start=1):
             invoice.l10n_hu_edi_batch_upload_index = i
 
-        def get_operation_type(invoice):
-            operation_type = 'MODIFY'
-            base_invoice = invoice._l10n_hu_get_chain_base()
-            if invoice == base_invoice:
-                operation_type = 'CREATE'
-            elif base_invoice.amount_residual == 0:
-                operation_type = 'STORNO'
-            return operation_type
-
         invoice_operations = [
             {
                 'index': invoice.l10n_hu_edi_batch_upload_index,
-                'operation': get_operation_type(invoice),
+                'operation': invoice._l10n_hu_edi_get_operation_type(),
                 'invoice_data': base64.b64decode(invoice.l10n_hu_edi_attachment),
             }
             for invoice in self

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -132,7 +132,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'l10n_hu_edi_replacement_key': 'abcdefghijklmnop',
         })
 
-    def create_invoice_simple(self):
+    def create_invoice_simple(self, amount=None):
         """ Create a really basic invoice - just one line. """
         return self.env['account.move'].create({
             'move_type': 'out_invoice',
@@ -144,7 +144,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'invoice_line_ids': [
                 Command.create({
                     'product_id': self.product_a.id,
-                    'price_unit': 10000.0,
+                    'price_unit': amount or 10000.0,
                     'quantity': 1,
                     'tax_ids': [Command.set(self.tax_vat.ids)],
                 })
@@ -330,12 +330,40 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             ]
         })
 
-    def create_reversal(self, invoice, is_modify=False):
+    def create_reversal(self, invoice, is_modify=False, amount=None):
         """ Create a credit note that reverses an invoice. """
         wizard_vals = {'journal_id': invoice.journal_id.id}
         wizard_reverse = self.env['account.move.reversal'].with_context(active_ids=invoice.ids, active_model='account.move').create(wizard_vals)
         wizard_reverse.reverse_moves(is_modify=is_modify)
-        return wizard_reverse.new_move_ids
+        reversal_moves = wizard_reverse.new_move_ids
+        if amount:
+            reversal_moves.invoice_line_ids.write({
+                'price_unit': amount
+            })
+        return reversal_moves
+
+    def create_debit_note(self, invoice, amount=None):
+        """ Create Debit Note """
+        wizard_vals = {
+            'journal_id': invoice.journal_id.id,
+            'copy_lines': True,
+        }
+        move_debit_note_wiz = self.env['account.debit.note'].with_context(active_model="account.move", active_ids=invoice.ids).create(wizard_vals)
+        move_debit_note_wiz.create_debit()
+        debit_note = self.env['account.move'].search([('debit_origin_id', '=', invoice.id)])
+        if amount:
+            debit_note.invoice_line_ids.write({
+                'price_unit': amount
+            })
+        return debit_note
+
+    def register_payment(self, invoice, amount):
+        payment_register = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=invoice.ids).create({
+            'payment_date': self.today,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'amount': amount,
+        })
+        payment_register.action_create_payments()
 
     def create_cancel_wizard(self):
         """ Create an invoice, send it, and create a cancellation wizard for it. """

--- a/addons/l10n_hu_edi/tests/test_flows_mocked.py
+++ b/addons/l10n_hu_edi/tests/test_flows_mocked.py
@@ -189,6 +189,86 @@ class L10nHuEdiTestFlowsMocked(L10nHuEdiTestCommon, TestAccountMoveSendCommon):
                 send_and_print.action_send_and_print()
                 self.assertRecordValues(new_invoice, [{'l10n_hu_edi_state': 'confirmed', 'l10n_hu_invoice_chain_index': 2}])
 
+    def test_case_1_invoice_payment_storno(self):
+        inv = self.create_invoice_simple(amount=1000)
+        inv.action_post()
+        operation = inv._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'CREATE')
+        self.register_payment(inv, 1000)
+        self.create_reversal(inv, is_modify=True)
+        operation = inv.reversal_move_id._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'STORNO')
+
+    def test_case_2_modify_then_storno(self):
+        inv = self.create_invoice_simple(amount=1000)
+        inv.action_post()
+        operation = inv._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'CREATE')
+        mod1 = self.create_reversal(inv, amount=100)
+        mod1.action_post()
+        operation = mod1._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'MODIFY')
+        storno = self.create_reversal(inv, amount=900)
+        storno.action_post()
+        operation = storno._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'STORNO')
+
+    def test_case_3_multiple_modifications_then_storno(self):
+        inv = self.create_invoice_simple(amount=1000)
+        inv.action_post()
+        operation = inv._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'CREATE')
+        mod1 = self.create_reversal(inv, amount=100)
+        mod1.action_post()
+        operation = mod1._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'MODIFY')
+        mod2 = self.create_reversal(inv, amount=100)
+        mod2.action_post()
+        operation = mod2._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'MODIFY')
+        storno = self.create_reversal(inv, amount=800)
+        storno.action_post()
+        operation = storno._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'STORNO')
+
+    def test_case_4_modification_payment_then_storno(self):
+        inv = self.create_invoice_simple(amount=1000)
+        inv.action_post()
+        operation = inv._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'CREATE')
+        mod1 = self.create_reversal(inv, amount=100)
+        mod1.action_post()
+        operation = mod1._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'MODIFY')
+        self.register_payment(inv, 900)
+        self.create_reversal(inv, is_modify=True)
+        mod2 = inv.reversal_move_id
+        mod2.button_draft()
+        mod2.invoice_line_ids[0].write({
+            'price_unit': 900,
+        })
+        mod2.action_post()
+        # Reconcile the outstanding payment line from mod1 with the invoice
+        inv.js_assign_outstanding_line(mod1.line_ids.filtered(lambda l: l.debit == 0).id)
+        operation = mod2._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'STORNO')
+
+    def test_case_5_debit_note_then_storno(self):
+        inv = self.create_invoice_simple(amount=1000)
+        inv.action_post()
+        operation = inv._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'CREATE')
+        dn = self.create_debit_note(inv, amount=100)
+        dn.action_post()
+        operation = dn._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'MODIFY')
+        storno = self.create_reversal(inv, amount=1100)
+        storno.action_post()
+        # Reconcile the outstanding payment line from dn with the storno
+        storno.js_assign_outstanding_line(dn.line_ids.filtered(lambda l: l.credit == 0).id)
+        operation = storno._l10n_hu_edi_get_operation_type()
+        self.assertEqual(operation, 'STORNO')
+
     # === Helpers === #
 
     @contextlib.contextmanager


### PR DESCRIPTION
Before this PR:
- Previously, a credit note was marked as STORNO if the base invoice's residual amount was zero, regardless of whether any payments had been made. This led to incorrect STORNO reports being sent to NAV in cases where the invoice had been partially or fully paid before reversal.

After this PR:
- If any payment was made, the credit note is marked as MODIFY instead of STORNO.

Example:
- Case 1: No payments before reversal
  Invoice:        1000
  Credit Note 1:  -100
  Credit Note 2:  -900
  => Credit Note 1 should be sent as a Modification, Credit Note 2 as STORNO.

- Case 2: Payments before reversal
  Invoice:        1000
  Payment:        -100
  Credit Note:    -900
  => The Credit Note should be sent as a Modification.

 task-4818762