### PR TITLE
[FIX] web, *: fix highlight text in settings

### DIFF
--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -14,7 +14,7 @@ import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
 import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card_resource/avatar_card_resource_popover";
 import { Domain } from "@web/core/domain";
 import { KanbanMany2ManyTagsAvatarFieldTagsList } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
-import { highlightText } from "@web/core/utils/strings";
+import { highlightText, odoomark } from "@web/core/utils/strings";
 
 
 export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
@@ -51,7 +51,7 @@ export class AvatarResourceMany2XAutocomplete extends Many2XAutocomplete {
             value: result.id,
             resourceType: result.resource_type,
             colorIndex: result.color,
-            label: highlightText(request, result.display_name, "text-primary fw-bold"),
+            label: highlightText(request, odoomark(result.display_name), "text-primary fw-bold"),
             color: result.color,
         };
     }

--- a/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
+++ b/addons/uom/static/src/components/many2x_uom_tags/many2x_uom_tags.js
@@ -8,7 +8,7 @@ import {
 import { UomAutoComplete } from "@uom/components/uom_autocomplete/uom_autocomplete";
 import { roundPrecision } from "@web/core/utils/numbers";
 import { onWillUpdateProps } from "@odoo/owl";
-import { highlightText } from "@web/core/utils/strings";
+import { highlightText, odoomark } from "@web/core/utils/strings";
 
 export function getProductRelatedModel() {
     const field = this.props.record.fields[this.props.productField];
@@ -82,7 +82,9 @@ export class Many2XUomTagsAutocomplete extends Many2XAutocomplete {
     mapRecordToOption(result, request) {
         return {
             value: result.id,
-            label: result.name ? highlightText(request, result.name, "text-primary fw-bold") : _t("Unnamed"),
+            label: result.name
+                ? highlightText(request, odoomark(result.name), "text-primary fw-bold")
+                : _t("Unnamed"),
             displayName: result.name,
             relative_info: result.relative_info,
         };

--- a/addons/web/static/src/core/utils/strings.js
+++ b/addons/web/static/src/core/utils/strings.js
@@ -1,5 +1,5 @@
 import { isObject } from "./objects";
-import { markup } from "@odoo/owl";
+import { htmlEscape, markup } from "@odoo/owl";
 
 export const nbsp = "\u00a0";
 
@@ -151,22 +151,20 @@ export function odoomark(text) {
 
 /**
  * Returns a markuped version of the input text where
- * the query is highlighted using the input classes and
- * a b tag if it is part of the text
+ * the query is highlighted using the input classes
+ * if it is part of the text.
  *
  * @param {string} query
- * @param {string} text
+ * @param {string | ReturnType<markup>} text
  * @param {string} classes
- * @returns {string}
+ * @returns {string | ReturnType<markup>}
  */
 export function highlightText(query, text, classes) {
     if (!query) {
-        return odoomark(text);
+        return text;
     }
     const regex = new RegExp(`(${escapeRegExp(escape(query))})+(?=(?:[^>]*<[^<]*>)*[^<>]*$)`, "ig");
-    return markup(
-        odoomark(text).toString().replaceAll(regex, `<span class="${classes}">$1</span>`)
-    );
+    return markup(htmlEscape(text).replaceAll(regex, markup`<span class="${classes}">$1</span>`));
 }
 
 /* eslint-disable */

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -47,7 +47,7 @@ import {
     useState,
     useSubEnv,
 } from "@odoo/owl";
-import { highlightText } from "@web/core/utils/strings";
+import { highlightText, odoomark } from "@web/core/utils/strings";
 
 //
 // Commons
@@ -362,7 +362,9 @@ export class Many2XAutocomplete extends Component {
         const label = record.__formatted_display_name || record.display_name;
         return {
             value: record.id,
-            label: label ? highlightText(request, label, "text-primary fw-bold") : _t("Unnamed"),
+            label: label
+                ? highlightText(request, odoomark(label), "text-primary fw-bold")
+                : _t("Unnamed"),
         };
     }
 

--- a/addons/web/static/src/views/widgets/documentation_link/documentation_link.xml
+++ b/addons/web/static/src/views/widgets/documentation_link/documentation_link.xml
@@ -7,7 +7,7 @@
                 <span>View Documentation</span>
             </t>
             <t t-else="">
-                <i t-if="props.icon" t-att-class="'fa ' + props.icon"></i>
+                <i t-if="props.icon" class="fa pe-1" t-att-class="props.icon"></i>
                 <span t-esc="props.label"/>
             </t>
         </a>

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_view.scss
@@ -163,6 +163,7 @@ body:not(.o_touch_device) .o_settings_container .o_field_selection {
 
            .highlighter {
                background: yellow;
+               font-weight: bold;
            }
 
             .o_datepicker .o_datepicker_button {

--- a/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
+++ b/addons/web/static/tests/webclient/settings_form_view/settings_form_view.test.js
@@ -647,32 +647,28 @@ test("resIds should contains only 1 id", async () => {
     serverState.lang = "en_US";
     serverState.multiLang = true;
 
-    onRpc("get_installed", () => {
-        return [
-            ["en_US", "English"],
-            ["fr_BE", "French (Belgium)"],
-        ];
-    });
-    onRpc("get_field_translations", () => {
-        return [
-            [
-                {
-                    lang: "en_US",
-                    source: "My little Foo Value",
-                    value: "My little Foo Value",
-                },
-                {
-                    lang: "fr_BE",
-                    source: "My little Foo Value",
-                    value: "Valeur de mon petit Foo",
-                },
-            ],
+    onRpc("get_installed", () => [
+        ["en_US", "English"],
+        ["fr_BE", "French (Belgium)"],
+    ]);
+    onRpc("get_field_translations", () => [
+        [
             {
-                translation_type: "char",
-                translation_show_source: true,
+                lang: "en_US",
+                source: "My little Foo Value",
+                value: "My little Foo Value",
             },
-        ];
-    });
+            {
+                lang: "fr_BE",
+                source: "My little Foo Value",
+                value: "Valeur de mon petit Foo",
+            },
+        ],
+        {
+            translation_type: "char",
+            translation_show_source: true,
+        },
+    ]);
     onRpc("execute", ({ args }) => {
         expect(args[0].length).toBe(1);
         return true;
@@ -1841,6 +1837,30 @@ test("standalone field labels with string inside a settings page", async () => {
                 </SettingsApp>
             </SettingsPage>`;
     expect(compiled.firstChild).toHaveInnerHTML(expectedCompiled);
+});
+
+test("field and artificial label inside a settings page", async () => {
+    ResConfigSettings._fields.count = fields.Integer();
+    await mountView({
+        type: "form",
+        resModel: "res.config.settings",
+        arch: /* xml */ `
+            <form js_class="base_settings">
+                <app string="CRM" name="crm">
+                    <setting id="setting_id">
+                        <field name="count" />
+                        <span class="o_form_label">
+                            items
+                        </span>
+                    </setting>
+                </app>
+            </form>
+        `,
+    });
+    expect(".o_field_integer[name=count]").toHaveCount(1);
+    expect("span.o_form_label").toHaveInnerHTML(
+        `<span searchabletext="\n                            items\n                        ">\n                            items\n                        </span>`
+    );
 });
 
 test("highlight Element with inner html/fields", async () => {


### PR DESCRIPTION
This commit removes the use of odoomark in highlightText as it was unintentionally inserting excessive `<br>` tags in the settings module.
It is now required to first use odoomark on the input text before using highlightText to combine both behaviors.
Some spacing issues are also handled in consequence to this change. It also restores bold styling for search result highlights which was using `<b>` tags before but was removed with the new highlight system.
