### PR TITLE
[FIX] website: cancel drop of google maps snippet

### DIFF
--- a/addons/website/static/src/snippets/s_google_map/google_map.edit.js
+++ b/addons/website/static/src/snippets/s_google_map/google_map.edit.js
@@ -27,6 +27,12 @@ const GoogleMapEdit = (I) =>
                     "initializeGoogleMaps",
                     [this.el, google.maps]
                 );
+            } else {
+                this.websiteEditService.callShared(
+                    "googleMapsOption",
+                    "failedToInitializeGoogleMaps",
+                    [this.el]
+                );
             }
         }
 


### PR DESCRIPTION
The drop of the google maps snippet was not properly cancelled

Steps to reproduce:
- Open website editor
- Drop snippet `s_google_map`
- Discard the dialog asking for the api key
- Bug: the undo button is enabled

task-4367641
