### PR TITLE
[FIX] account: use move currency when aggregating taxes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3329,7 +3329,7 @@ class AccountMove(models.Model):
                     tax_values[key] += diff_sign * abs_delta_to_add
                     abs_diff -= abs_delta_to_add
 
-        return self.env['account.tax']._aggregate_taxes(
+        return self.env['account.tax'].with_company(self.company_id)._aggregate_taxes(
             to_process,
             filter_tax_values_to_apply=filter_tax_values_to_apply,
             grouping_key_generator=grouping_key_generator,
@@ -3434,7 +3434,7 @@ class AccountMove(models.Model):
                 bases_details[frozendict(grouping_dict)] = base_detail
 
                 # Compute the tax amounts.
-                tax_details_with_epd = self.env['account.tax']._aggregate_taxes(
+                tax_details_with_epd = self.env['account.tax'].with_company(self.company_id)._aggregate_taxes(
                     to_process,
                     grouping_key_generator=grouping_key_generator,
                 )


### PR DESCRIPTION
**Steps to reproduce:**
- Install account_accountant and l10n_es_edi_tbai
- Create 2 companies with 2 different currencies having different rounding factors:
  * a Spanish company with EUR (rounding factor: 0.01)
  * another company with another currency (rounding factor: 1.0)
- For the other company, select "Round Globally" in Accounting settings

- Switch to the Spanish company
- Create an invoice:
  * Customer: [a Spanish customer]
  * Lines: [any with a tax generating a tax amount with a decimal part]
- Save the invoice

- In the company selector, select both companies with the other one as the main one
- Confirm the invoice
- Send it to "TicketBAI (ES)"
- Download the electronic invoice and check it

**Issue:**
In the XML, the value of "CuotaImpuesto" is the tax amount but it has been rounded with the decimal precision of the currency of the main selected company instead of tthe currency of the invoice.

**Cause:**
In "_prepare_invoice_aggregated_taxes" method, "_aggregate_taxes" is called in which some rounding are done using the currency of "self.env.company".
But in this case, "self.env.company" is not the company of the invoice and the currency used for the rounding isn't the one set on the invoice.

opw-4724945




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
