### PR TITLE
[FIX] web: make root of SelectionBox available from the props

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.xml
+++ b/addons/web/static/src/views/kanban/kanban_controller.xml
@@ -32,7 +32,7 @@
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
                     <div t-if="hasSelectedRecords" class="o_selection_container d-flex gap-1 w-100 w-md-auto">
-                       <SelectionBox />
+                       <SelectionBox root="this.model.root"/>
                         <t t-if="!env.isSmall">
                             <t t-foreach="headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                                 <MultiRecordViewButton

--- a/addons/web/static/src/views/list/list_controller.xml
+++ b/addons/web/static/src/views/list/list_controller.xml
@@ -63,7 +63,7 @@
                 </t>
                 <t t-set-slot="control-panel-selection-actions">
                     <div t-if="hasSelectedRecords" class="o_selection_container m-1 m-md-0 d-flex gap-1">
-                        <SelectionBox />
+                        <SelectionBox root="this.model.root"/>
                         <t t-if="!env.isSmall">
                             <t t-foreach="archInfo.headerButtons" t-as="button" t-key="button.id" t-if="!evalViewModifier(button.invisible)">
                                 <MultiRecordViewButton

--- a/addons/web/static/src/views/view_components/selection_box.js
+++ b/addons/web/static/src/views/view_components/selection_box.js
@@ -3,9 +3,11 @@ import { Component, useState } from "@odoo/owl";
 export class SelectionBox extends Component {
     static components = {};
     static template = "web.SelectionBox";
-    static props = {};
+    static props = {
+        root: { type: Object, optional: true },
+    };
     setup() {
-        this.root = useState(this.env.model.root);
+        this.root = this.props.root || useState(this.env.model.root);
     }
     get nbSelected() {
         return this.selectedRecords.length;


### PR DESCRIPTION
Before this commit, if the parent of the SelectionBox component had updated its 'root' from the model, the component was not rerendered, and it was misbehaving in those case (e.g. after an upload of a Document, the selection was not working with the right root, and the component failed to be updated accordingly.

Now, the component can receive a root as a props.

task-4664231