### PR TITLE
[FIX] website_sale: check for view correctly

### DIFF
--- a/addons/website_sale/controllers/combo_configurator.py
+++ b/addons/website_sale/controllers/combo_configurator.py
@@ -20,9 +20,11 @@ class WebsiteSaleComboConfiguratorController(SaleComboConfiguratorController, We
         self._populate_currency_and_pricelist(kwargs)
         request.update_context(display_default_code=False)  # Hide internal product reference
         res = super().sale_combo_configurator_get_data(*args, **kwargs)
+        is_quantity_view_enabled = request.website.is_view_active('website_sale.product_quantity')
         res.update({
             'show_quantity': (
-                bool(request.website.is_view_active('website_sale.product_quantity'))
+                # if view doesn't exist default to true
+                is_quantity_view_enabled if is_quantity_view_enabled is not None else True
             ),
         })
         return res


### PR DESCRIPTION
commit 163b337fce6d3d67412f0e34e8120fbd5d02f463 didn't take into consideration that is_view_enabled can return None and the intended default behavior should be to show it by default



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
