### PR TITLE
[IMP] crm: improve CRM usage: rainbowman, assign, stages, ...

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -682,7 +682,7 @@ class ResPartner(models.Model):
         if not self.env.user.has_group('account.group_account_invoice'):
             return data_list
         for partner in self.filtered(lambda p: p._get_account_statistics_count()):
-            stat_info = {'iconClass': 'fa-pencil-square-o', 'value': partner._get_account_statistics_count(), 'label': _('Invoices/Bills/Mandates')}
+            stat_info = {'iconClass': 'fa-pencil-square-o', 'value': partner._get_account_statistics_count(), 'label': _('Invoices/Bills/Mandates'), 'tagClass': 'o_tag_color_9'}
             data_list[partner.id].append(stat_info)
         return data_list
 

--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -58,7 +58,7 @@ class ResPartner(models.Model):
     def _compute_application_statistics_hook(self):
         data_list = super()._compute_application_statistics_hook()
         for partner in self.filtered('meeting_count'):
-            stat_info = {'iconClass': 'fa-calendar', 'value': partner.meeting_count, 'label': _('Meetings')}
+            stat_info = {'iconClass': 'fa-calendar', 'value': partner.meeting_count, 'label': _('Meetings'), 'tagClass': 'o_tag_color_3'}
             data_list[partner.id].append(stat_info)
         return data_list
 

--- a/addons/crm/data/crm_stage_data.xml
+++ b/addons/crm/data/crm_stage_data.xml
@@ -3,19 +3,23 @@
     <record model="crm.stage" id="stage_lead1" forcecreate="False">
         <field name="name">New</field>
         <field name="sequence">1</field>
+        <field name="color">11</field>
     </record>
     <record model="crm.stage" id="stage_lead2" forcecreate="False">
         <field name="name">Qualified</field>
         <field name="sequence">2</field>
+        <field name="color">5</field>
     </record>
     <record model="crm.stage" id="stage_lead3" forcecreate="False">
         <field name="name">Proposition</field>
         <field name="sequence">3</field>
+        <field name="color">8</field>
     </record>
     <record model="crm.stage" id="stage_lead4" forcecreate="False">
         <field name="name">Won</field>
         <field name="fold" eval="False"/>
         <field name="is_won">True</field>
         <field name="sequence">70</field>
+        <field name="color">10</field>
     </record>
 </odoo>

--- a/addons/crm/models/__init__.py
+++ b/addons/crm/models/__init__.py
@@ -15,3 +15,4 @@ from . import crm_lead_scoring_frequency
 from . import utm
 from . import crm_recurring_plan
 from . import mail_activity
+from . import res_users

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1055,6 +1055,11 @@ class CrmLead(models.Model):
         team_id = self.env.context.get('default_team_id')
         if team_id:
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_id)]
+        if self.env.context.get('show_user_team_stages'):
+            team_ids = self.env.user.crm_team_ids._ids
+            if team_id:
+                team_ids += (team_id,)
+            search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_ids', '=', False), ('team_ids', 'in', team_ids)]
         else:
             search_domain = ['|', ('id', 'in', stages.ids), ('team_ids', '=', False)]
 

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1173,31 +1173,34 @@ class CrmLead(models.Model):
         return False
 
     def _get_rainbowman_message(self):
-        if not self.user_id or not self.team_id:
+        self.ensure_one()
+        if not self.user_id:
             return False
-        if not self.expected_revenue:
-            # Show rainbow man for the first won lead of a salesman, even if expected revenue is not set. It is not
-            # very often that leads without revenues are marked won, so simply get count using ORM instead of query
-            today = fields.Datetime.today()
-            user_won_leads_count = self.search_count([
-                ('type', '=', 'opportunity'),
-                ('user_id', '=', self.user_id.id),
-                ('won_status', '=', 'won'),
-                ('date_closed', '>=', date_utils.start_of(today, 'year')),
-                ('date_closed', '<', date_utils.end_of(today, 'year')),
-            ])
-            if user_won_leads_count == 1:
-                return _('Go, go, go! Congrats for your first deal.')
-            return False
-
         self.flush_model()  # flush fields to make sure DB is up to date
-        query = """
-            SELECT
-                SUM(CASE WHEN user_id = %(user_id)s THEN 1 ELSE 0 END) as total_won,
-                MAX(CASE WHEN date_closed >= CURRENT_DATE - INTERVAL '30 days' AND user_id = %(user_id)s THEN expected_revenue ELSE 0 END) as max_user_30,
-                MAX(CASE WHEN date_closed >= CURRENT_DATE - INTERVAL '7 days' AND user_id = %(user_id)s THEN expected_revenue ELSE 0 END) as max_user_7,
-                MAX(CASE WHEN date_closed >= CURRENT_DATE - INTERVAL '30 days' AND team_id = %(team_id)s THEN expected_revenue ELSE 0 END) as max_team_30,
-                MAX(CASE WHEN date_closed >= CURRENT_DATE - INTERVAL '7 days' AND team_id = %(team_id)s THEN expected_revenue ELSE 0 END) as max_team_7
+
+        # checked here as it is its position in the priority order
+        if len(self.message_ids) >= 25:
+            return _('Phew, that took some effort — but you nailed it. Good job!')
+
+        team_condition = f'team_id = {self.team_id.id}' if self.team_id else 'team_id IS NULL'
+        source_case = f'source_id = {self.source_id.id} AND {team_condition}' if self.source_id else 'false'
+        country_case = f'country_id = {self.country_id.id} AND {team_condition}' if self.country_id else 'false'
+        tz_midnight = fields.Datetime.now().astimezone(pytz.timezone(self.env.user.tz or self.user_id.tz or 'UTC')).replace(hour=0, minute=0, second=0)
+        tz_midnight_in_utc = tz_midnight.astimezone(pytz.UTC).replace(tzinfo=None)
+        query = f"""
+        SELECT
+            MAX(CASE WHEN team_id = %(team_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '31 days' AND id <> %(lead_id)s THEN expected_revenue ELSE 0 END) AS max_team_31,
+            MAX(CASE WHEN team_id = %(team_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '7 days'  AND id <> %(lead_id)s THEN expected_revenue ELSE 0 END) AS max_team_7,
+            MAX(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '31 days' AND id <> %(lead_id)s THEN expected_revenue ELSE 0 END) AS max_user_31,
+            MAX(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '7 days'  AND id <> %(lead_id)s THEN expected_revenue ELSE 0 END) AS max_user_7,
+            MIN(CASE WHEN date_closed >= %(tz_midnight)s - INTERVAL '31 days' THEN day_close ELSE 31 END) AS min_day_close_31,
+            COUNT(CASE WHEN user_id = %(user_id)s THEN 1 ELSE NULL END) AS count_user_closed_year,
+            COUNT(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '3 days' AND date_closed < %(tz_midnight)s - INTERVAL '2 days' THEN 1 ELSE NULL END) AS count_user_closed_minus3day,
+            COUNT(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '2 days' AND date_closed < %(tz_midnight)s - INTERVAL '1 days' THEN 1 ELSE NULL END) AS count_user_closed_minus2day,
+            COUNT(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s - INTERVAL '1 days' AND date_closed < %(tz_midnight)s THEN 1 ELSE NULL END) AS count_user_closed_yesterday,
+            COUNT(CASE WHEN user_id = %(user_id)s AND date_closed >= %(tz_midnight)s THEN 1 ELSE NULL END) AS count_user_closed_today,
+            COUNT(CASE WHEN {source_case} THEN 1 ELSE NULL END) AS count_source_closed_year,
+            COUNT(CASE WHEN {country_case} THEN 1 ELSE NULL END) AS count_country_closed_year
             FROM crm_lead
             WHERE
                 type = 'opportunity'
@@ -1206,26 +1209,50 @@ class CrmLead(models.Model):
             AND
                 probability = 100
             AND
-                DATE_TRUNC('year', date_closed) = DATE_TRUNC('year', CURRENT_DATE)
+                DATE_TRUNC('year', date_closed) = DATE_TRUNC('year', %(tz_midnight)s)
             AND
                 (user_id = %(user_id)s OR team_id = %(team_id)s)
         """
-        self.env.cr.execute(query, {'user_id': self.user_id.id,
-                                    'team_id': self.team_id.id})
+        self.env.cr.execute(query, {
+            'user_id': self.env.user.id,
+            'team_id': self.team_id.id or -1,
+            'lead_id': self.id,
+            'tz_midnight': tz_midnight_in_utc,
+        })
         query_result = self.env.cr.dictfetchone()
 
-        message = False
-        if query_result['total_won'] == 1:
-            message = _('Go, go, go! Congrats for your first deal.')
-        elif query_result['max_team_30'] == self.expected_revenue:
-            message = _('Boom! Team record for the past 30 days.')
-        elif query_result['max_team_7'] == self.expected_revenue:
-            message = _('Yeah! Deal of the last 7 days for the team.')
-        elif query_result['max_user_30'] == self.expected_revenue:
-            message = _('You just beat your personal record for the past 30 days.')
-        elif query_result['max_user_7'] == self.expected_revenue:
-            message = _('You just beat your personal record for the past 7 days.')
-        return message
+        if query_result['count_user_closed_year'] == 1:
+            return _('Go, go, go! Congrats for your first deal.')
+        elif self.expected_revenue and query_result['max_team_31'] < self.expected_revenue:
+            return _('Boom! Team record for the past 30 days.')
+        elif self.expected_revenue and query_result['max_team_7'] < self.expected_revenue:
+            return _('Yeah! Best deal out of the last 7 days for the team.')
+        elif self.expected_revenue and query_result['max_user_31'] < self.expected_revenue:
+            return _('You just beat your personal record for the past 30 days.')
+        elif self.expected_revenue and query_result['max_user_7'] < self.expected_revenue:
+            return _('You just beat your personal record for the past 7 days.')
+        elif query_result['count_user_closed_today'] == 5:
+            return _('You\'re on fire! Fifth deal won today 🔥')
+        elif query_result['count_user_closed_today'] == 1 and query_result['count_user_closed_yesterday'] and query_result['count_user_closed_minus2day'] and not query_result['count_user_closed_minus3day']:
+            return _('You\'re on a winning streak. 3 deals in 3 days, congrats!')
+        # check that at least one minute has elapsed since record creation to only account for 'real' leads
+        elif query_result['min_day_close_31'] == self.day_close and self.day_close < 31 \
+            and (self.date_closed - self.create_date).total_seconds() > 60:
+            return _('Wow, that was fast. That deal didn’t stand a chance!')
+        # use duration tracking field to determine if the task jumped from first to last stage
+        # only takes into accounts stages on which the lead has spent at least a minute,
+        # to only account for valid stage movements
+        elif len(stage_ids := [int(stage_id) for stage_id, duration in self.duration_tracking.items() if duration >= 60]) == 1:
+            first_stage = self.env['crm.stage'].search([
+                '|', ('team_ids', 'in', False), ('team_ids', 'in', self.team_id.id),
+            ], order='sequence ASC', limit=1)
+            if first_stage.id == stage_ids[0]:
+                return _('No detours, no delays - from %(stage_name)s straight to the win! 🚀', stage_name=first_stage.name)
+        if query_result['count_country_closed_year'] == 1 and self.country_id:
+            return _('You just expanded the map! First win in %(country)s.', country=self.country_id.name)
+        elif query_result['count_source_closed_year'] == 1 and self.source_id:
+            return _('Yay, your first win from %(utm_source_name)s!', utm_source_name=self.source_id.name)
+        return False
 
     def action_schedule_meeting(self, smart_calendar=True):
         """ Open meeting's calendar view to schedule meeting on current opportunity.

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -51,7 +51,7 @@ class CrmTeam(models.Model):
             team.assignment_max = sum(member.assignment_max for member in team.crm_team_member_ids)
 
     def _compute_assignment_enabled(self):
-        assign_enabled = self.env['ir.config_parameter'].sudo().get_param('crm.lead.auto.assignment', False)
+        assign_enabled = self.env['crm.lead']._is_rule_based_assignment_activated()
         auto_assign_enabled = False
         if assign_enabled:
             assign_cron = self.sudo().env.ref('crm.ir_cron_crm_lead_assign', raise_if_not_found=False)

--- a/addons/crm/models/crm_team_member.py
+++ b/addons/crm/models/crm_team_member.py
@@ -23,10 +23,10 @@ class CrmTeamMember(models.Model):
     assignment_max = fields.Integer('Average Leads Capacity (on 30 days)', default=30)
     lead_day_count = fields.Integer(
         'Leads (last 24h)', compute='_compute_lead_day_count',
-        help='Lead assigned to this member this last day (lost one excluded)')
+        help='Number of leads assigned to this member in the last 24 hours (lost leads excluded)')
     lead_month_count = fields.Integer(
         'Leads (30 days)', compute='_compute_lead_month_count',
-        help='Lead assigned to this member those last 30 days')
+        help='Number of leads assigned to this member in the last 30 days')
 
     @api.depends('user_id', 'crm_team_id')
     def _compute_lead_day_count(self):

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -64,7 +64,7 @@ class ResPartner(models.Model):
             return data_list
         for partner in self.filtered('opportunity_count'):
             data_list[partner.id].append(
-                {'iconClass': 'fa-star', 'value': partner.opportunity_count, 'label': _('Opportunities')}
+                {'iconClass': 'fa-star', 'value': partner.opportunity_count, 'label': _('Opportunities'), 'tagClass': 'o_tag_color_8'}
             )
         return data_list
 

--- a/addons/crm/models/res_users.py
+++ b/addons/crm/models/res_users.py
@@ -1,0 +1,14 @@
+from odoo import _, api, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    @api.depends_context('crm_formatted_display_name_team')
+    def _compute_display_name(self):
+        super()._compute_display_name()
+        team_id = self.env.context.get('crm_formatted_display_name_team', 0)
+        if team_id:
+            leader_id = self.env['crm.team'].browse(team_id).user_id
+            for user in self.filtered(lambda u: u == leader_id):
+                user.display_name += " --%s--" % _("(Team Leader)")

--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -124,7 +124,7 @@
                     <filter string="Date Closed" name="date_closed_filter" date="date_closed"/>
                     <group>
                         <field name="partner_id" filter_domain="[('partner_id','child_of',self)]"/>
-                        <field name="stage_id" domain="['|', ('team_id', '=', False), ('team_id', '=', 'team_id')]"/>
+                        <field name="stage_id" domain="['|', ('team_ids', '=', False), ('team_ids', 'in', 'team_id')]"/>
                         <field name="campaign_id"/>
                         <field name="medium_id"/>
                         <field name="source_id"/>

--- a/addons/crm/static/src/js/fields/many2one_avatar_leader_user.js
+++ b/addons/crm/static/src/js/fields/many2one_avatar_leader_user.js
@@ -1,0 +1,31 @@
+import {
+    many2OneAvatarUserField,
+    Many2OneAvatarUserField,
+} from "@mail/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field";
+import { registry } from "@web/core/registry";
+
+export class Many2OneAvatarLeaderUserField extends Many2OneAvatarUserField {
+    static props = {
+        ...Many2OneAvatarUserField.props,
+        teamField: String,
+    };
+
+    get m2oProps() {
+        return {
+            ...super.m2oProps,
+            context: {
+                ...super.m2oProps.context,
+                crm_formatted_display_name_team: Number(this.props.record.data[this.props.teamField].id),
+            },
+        };
+    }
+}
+
+registry.category("fields").add("many2one_avatar_leader_user", {
+    ...many2OneAvatarUserField,
+    component: Many2OneAvatarLeaderUserField,
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        ...many2OneAvatarUserField.extractProps(fieldInfo, dynamicInfo),
+        teamField: fieldInfo.attrs.teamField,
+    }),
+});

--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.js
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.js
@@ -1,7 +1,5 @@
 import { onWillStart } from "@odoo/owl";
 import { user } from "@web/core/user";
-import { session } from "@web/session";
-import { getCurrency } from "@web/core/currency";
 import { RottingColumnProgress } from "@mail/js/rotting_mixin/rotting_column_progress";
 
 export class CrmColumnProgress extends RottingColumnProgress {
@@ -18,12 +16,10 @@ export class CrmColumnProgress extends RottingColumnProgress {
     }
 
     getRecurringRevenueGroupAggregate(group) {
-        const rrField = this.props.progressBarState.progressAttributes.recurring_revenue_sum_field;
-        const aggregatedValue = this.props.progressBarState.getAggregateValue(group, rrField);
-        let currency = false;
-        if (aggregatedValue.value && rrField.currency_field) {
-            currency = getCurrency(session.company_currency_id);
+        if (!this.showRecurringRevenue) {
+            return {};
         }
-        return { ...aggregatedValue, currency };
+        const rrField = this.props.progressBarState.progressAttributes.recurring_revenue_sum_field;
+        return this.props.progressBarState.getAggregateValue(group, rrField);
     }
 }

--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -4,20 +4,37 @@
         <xpath expr="//div[hasclass('o_column_progress')]" position="attributes">
             <attribute name="class" remove="w-75" add="w-50" separator=" "/>
         </xpath>
+
+        <AnimatedNumber position="before">
+            <div class="ms-auto"/>
+        </AnimatedNumber>
+
+        <AnimatedNumber position="attributes">
+            <!--
+                If the value of the standard aggregate is 0, but the value of the monthly aggregate isn't 0, false or undefined,
+                we want to hide the 0 of the standard aggregate.
+            -->
+            <attribute name="t-if" add="!(props.aggregate.value === 0 and getRecurringRevenueGroupAggregate(props.group).value)" separator=" and "/>
+        </AnimatedNumber>
+
         <AnimatedNumber position="after">
+            <t t-elif="props.aggregate.value === 0"><b/></t>
+
             <t t-if="showRecurringRevenue">
                 <t t-set="rrmAggregate" t-value="getRecurringRevenueGroupAggregate(props.group)"/>
                 <AnimatedNumber
+                    t-if="rrmAggregate.value"
                     value="rrmAggregate.value"
                     title="rrmAggregate.title"
                     duration="1000"
-                    currency="props.aggregate.currency"
+                    currency="rrmAggregate.currency"
                     animationClass="'o_animated_grow_huge'"
                 >
-                    <t t-set-slot="prefix">
-                        <strong>+</strong>
+                    <t t-set-slot="prefix" t-if="props.aggregate.value != 0">
+                        <strong class="me-1">+</strong>
                     </t>
                 </AnimatedNumber>
+                <b t-if="!props.aggregate.value" class="ps-1">MRR</b>
             </t>
         </AnimatedNumber>
     </t>

--- a/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field.test.js
+++ b/addons/crm/static/tests/crm_kanban_progress_bar_mrr_sum_field.test.js
@@ -160,8 +160,9 @@ test("Progressbar: ensure correct MRR sum is displayed if recurring revenues is 
                 </kanban>`,
     });
 
-    // When no values are given in column it should return 0 and counts value if given.
-    expect(queryAllTexts(".o_kanban_counter")).toEqual(["129\n+20", "9\n+0", "21\n+45"], {
+    // When no values are given in column it should return 0 and counts value if given
+    // MRR=0 shouldn't be displayed, however.
+    expect(queryAllTexts(".o_kanban_counter")).toEqual(["129\n+20", "9", "21\n+45"], {
         message: "counter should display the sum of recurring_revenue_monthly values",
     });
 });

--- a/addons/crm/static/tests/crm_mock_server.js
+++ b/addons/crm/static/tests/crm_mock_server.js
@@ -59,7 +59,7 @@ onRpc("get_rainbowman_message", function getRainbowmanMessage({ args, model }) {
         } else if (query_result.max_team_30 === record.planned_revenue) {
             message = "Boom! Team record for the past 30 days.";
         } else if (query_result.max_team_7 === record.planned_revenue) {
-            message = "Yeah! Deal of the last 7 days for the team.";
+            message = "Yeah! Best deal out of the last 7 days for the team.";
         } else if (query_result.max_user_30 === record.planned_revenue) {
             message = "You just beat your personal record for the past 30 days.";
         } else if (query_result.max_user_7 === record.planned_revenue) {

--- a/addons/crm/static/tests/crm_rainbowman.test.js
+++ b/addons/crm/static/tests/crm_rainbowman.test.js
@@ -274,7 +274,7 @@ test("team record 7 days, click on statusbar on desktop", async () => {
 
     await contains(".o_statusbar_status button[data-value='3']").click();
     expect(".o_reward svg.o_reward_rainbow_man").toHaveCount(1);
-    expect.verifySteps(["Yeah! Deal of the last 7 days for the team."]);
+    expect.verifySteps(["Yeah! Best deal out of the last 7 days for the team."]);
 });
 
 test.tags("mobile");
@@ -287,7 +287,7 @@ test("team record 7 days, click on statusbar on mobile", async () => {
     await contains(".o_statusbar_status button.dropdown-toggle").click();
     await contains(".o-dropdown--menu .dropdown-item:contains('Won')").click();
     expect(".o_reward svg.o_reward_rainbow_man").toHaveCount(1);
-    expect.verifySteps(["Yeah! Deal of the last 7 days for the team."]);
+    expect.verifySteps(["Yeah! Best deal out of the last 7 days for the team."]);
 });
 
 test.tags("desktop");
@@ -395,7 +395,7 @@ test("team record 7 days, drag & drop kanban", async () => {
 
     await contains(".o_kanban_record:contains(Lead 1):eq(0)").dragAndDrop(".o_kanban_group:eq(2)");
     expect(".o_reward svg.o_reward_rainbow_man").toHaveCount(1);
-    expect.verifySteps(["Yeah! Deal of the last 7 days for the team."]);
+    expect.verifySteps(["Yeah! Best deal out of the last 7 days for the team."]);
 });
 
 test.tags("desktop");

--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_crm_lead_multicompany
 from . import test_crm_lead_smart_calendar
 from . import test_crm_ui
 from . import test_crm_pls
+from . import test_crm_rainbowman
 from . import test_digest
 from . import test_performances
 from . import test_res_partner

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from ast import literal_eval
+from collections import defaultdict
 from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import patch
@@ -315,7 +316,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
 
     def _create_leads_batch(self, lead_type='lead', count=10, email_dup_count=0,
                             partner_count=0, partner_ids=None, user_ids=None,
-                            country_ids=None, probabilities=None, suffix=''):
+                            country_ids=None, probabilities=None, suffix='', additional_lead_values=defaultdict(None)):
         """ Helper tool method creating a batch of leads, useful when dealing
         with batch processes. Please update me.
 
@@ -333,6 +334,7 @@ class TestCrmCommon(TestSalesCommon, MailCase):
             'name': f'TestLead{suffix}_{x:04d}',
             'type': lead_type if lead_type else types[x % 2],
             'priority': '%s' % (x % 3),
+            **additional_lead_values,
         } for x in range(count)]
 
         # generate customer information

--- a/addons/crm/tests/common.py
+++ b/addons/crm/tests/common.py
@@ -100,28 +100,28 @@ class TestCrmCommon(TestSalesCommon, MailCase):
         cls.stage_team1_1 = cls.env['crm.stage'].create({
             'name': 'New',
             'sequence': 1,
-            'team_id': cls.sales_team_1.id,
+            'team_ids': [cls.sales_team_1.id],
         })
         cls.stage_team1_2 = cls.env['crm.stage'].create({
             'name': 'Proposition',
             'sequence': 5,
-            'team_id': cls.sales_team_1.id,
+            'team_ids': [cls.sales_team_1.id],
         })
         cls.stage_team1_won = cls.env['crm.stage'].create({
             'name': 'Won',
             'sequence': 70,
-            'team_id': cls.sales_team_1.id,
+            'team_ids': [cls.sales_team_1.id],
             'is_won': True,
         })
         cls.stage_gen_1 = cls.env['crm.stage'].create({
             'name': 'Generic stage',
             'sequence': 3,
-            'team_id': False,
+            'team_ids': False,
         })
         cls.stage_gen_won = cls.env['crm.stage'].create({
             'name': 'Generic Won',
             'sequence': 30,
-            'team_id': False,
+            'team_ids': False,
             'is_won': True,
         })
 
@@ -582,7 +582,7 @@ class TestLeadConvertCommon(TestCrmCommon):
         cls.stage_team_convert_1 = cls.env['crm.stage'].create({
             'name': 'New',
             'sequence': 1,
-            'team_id': cls.sales_team_convert.id,
+            'team_ids': [cls.sales_team_convert.id],
         })
 
         cls.lead_1.write({'date_open': Datetime.from_string('2020-01-15 11:30:00')})

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -11,7 +11,7 @@ from odoo.addons.crm.models.crm_lead import PARTNER_FIELDS_TO_SYNC, PARTNER_ADDR
 from odoo.addons.crm.tests.common import TestCrmCommon, INCOMING_EMAIL
 from odoo.addons.mail.tests.common_tracking import MailTrackingDurationMixinCase
 from odoo.addons.phone_validation.tools.phone_validation import phone_format
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo.tests import Form, tagged, users
 from odoo.tools import mute_logger
 

--- a/addons/crm/tests/test_crm_lead.py
+++ b/addons/crm/tests/test_crm_lead.py
@@ -296,7 +296,7 @@ class TestCRMLead(TestCrmCommon):
         stage_team1_won2 = self.env['crm.stage'].create({
             'name': 'Won2',
             'sequence': 75,
-            'team_id': self.sales_team_1.id,
+            'team_ids': [self.sales_team_1.id],
             'is_won': True,
         })
         won_lead = self.lead_team_1_won.with_env(self.env)

--- a/addons/crm/tests/test_crm_lead_multicompany.py
+++ b/addons/crm/tests/test_crm_lead_multicompany.py
@@ -302,6 +302,9 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
         self.assertEqual(crm_lead_form.company_id, self.company_2, 'Crm: company comes from partner')
 
     def test_gateway_incompatible_company_error_on_incoming_email(self):
+        # set automatic assignment to Manual to circumvent automatic lead assignment,
+        # so as to reproduce the conditions in which the original bug appeared
+        self.env['ir.config_parameter'].set_param('crm.lead.auto.assignment', True)
         self.assertTrue(self.sales_team_1.alias_name)
         self.assertFalse(self.sales_team_1.company_id)
         customer_company = self.env['res.partner'].create({
@@ -318,6 +321,7 @@ class TestCRMLeadMultiCompany(TestCrmCommon):
             subject='Team having partner in company',
             target_model='crm.lead',
         )
+        self.assertFalse(new_lead.user_id)
         self.assertEqual(new_lead.company_id, self.company_2)
         self.assertEqual(new_lead.email_from, customer_company.email)
         self.assertEqual(new_lead.partner_id, customer_company)

--- a/addons/crm/tests/test_crm_pls.py
+++ b/addons/crm/tests/test_crm_pls.py
@@ -587,7 +587,7 @@ class TestCrmPls(CrmPlsCommon):
             to have no team assigned to it."""
         Lead = self.env['crm.lead']
         team_id = self.env['crm.team'].create([{'name': 'Team Test'}]).id
-        self.env['crm.stage'].search([('team_id', '=', False)]).write({'team_id': team_id})
+        self.env['crm.stage'].search([('team_ids', '=', False)]).write({'team_ids': [team_id]})
         lead = Lead.create({'name': 'team', 'team_id': team_id, 'probability': 41.23})
         Lead._cron_update_automated_probabilities()
         self.assertEqual(tools.float_compare(lead.probability, 41.23, 2), 0)
@@ -694,16 +694,16 @@ class TestCrmPlsSides(CrmPlsCommon):
             {
                 'name': 'New Stage',
                 'sequence': 1,
-                'team_id': cls.team.id,
+                'team_ids': [cls.team.id],
             }, {
                 'name': 'In Progress Stage',
                 'sequence': 2,
-                'team_id': cls.team.id,
+                'team_ids': [cls.team.id],
             }, {
                 'is_won': True,
                 'name': 'Won Stage',
                 'sequence': 3,
-                'team_id': cls.team.id,
+                'team_ids': [cls.team.id],
             },
         ])
 

--- a/addons/crm/tests/test_crm_rainbowman.py
+++ b/addons/crm/tests/test_crm_rainbowman.py
@@ -1,0 +1,453 @@
+from datetime import datetime
+
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests import tagged, users
+
+
+@tagged('lead_internals')
+class TestCrmLeadRainbowmanMessages(TestCrmCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        # unlink all leads from sales_team_1
+        cls.env['crm.lead'].search([
+            ('team_id', '=', cls.sales_team_1.id),
+        ]).unlink()
+
+        cls.company_casey = cls.env['res.company'].create({
+            'name': 'company_casey',
+        })
+        cls.sales_manager_casey = mail_new_test_user(
+            cls.env,
+            login='sales_manager_casey',
+            name='sales_manager_casey',
+            groups='sales_team.group_sale_manager,base.group_partner_manager',
+            company_id=cls.company_casey.id,
+            company_ids=[(4, cls.company_casey.id)],
+        )
+
+        # cls.env['crm.team.member'].create([
+        #     {'user_id': cls.user_sales_manager.id, 'crm_team_id': cls.sales_team_1.id},
+        #     {'user_id': cls.user_sales_salesman.id, 'crm_team_id': cls.sales_team_1.id},
+        # ])
+
+    def _update_create_date(self, lead, date):
+        self.env.cr.execute("""
+            UPDATE crm_lead
+            SET create_date = %(date)s
+            WHERE id = %(lead_id)s
+        """, {
+            'lead_id': lead.id,
+            'date': date,
+        })
+        lead.invalidate_recordset(['create_date'])
+
+    def _set_won_get_rainbowman_message(self, lead, user, reset_team=False):
+        """
+        Assign the passed user and set the lead as won.
+        Then, if there's a message, return that message.
+        Otherwise, as the result for action_set_won_rainbowman() if there's no message is True,
+        return False to make testing code more readable.
+        """
+
+        # lead.user_id = user
+        # # If reset_team is passed, reset the team to False, as otherwise assigning a user will automatically assign a team
+        # if reset_team:
+        #     lead.team_id = False
+        lead.update({
+            'user_id': user.id,
+            'team_id': False if reset_team else lead.team_id.id,
+        })
+
+        rainbowman_action_result = lead.with_user(user).action_set_won_rainbowman()
+        if rainbowman_action_result and not isinstance(rainbowman_action_result, bool):
+            return rainbowman_action_result['effect']['message']
+        return False
+
+    @users('user_sales_manager')
+    def test_leads_rainbowman(self):
+        """
+        This test ensures that all rainbowman messages can trigger, and that they do so in correct order of priority.
+        """
+
+        # setup timestamps:
+        past = datetime(2024, 12, 15, 12, 0)
+        jan1_10am = datetime(2025, 1, 1, 10, 0)
+        jan1_12pm = datetime(2025, 1, 1, 12, 0)
+        jan2 = datetime(2025, 1, 2, 12, 0)
+        jan3_12pm = datetime(2025, 1, 3, 12, 0)
+        jan3_1pm = datetime(2025, 1, 3, 13, 0)
+        jan4 = datetime(2025, 1, 4, 12, 0)
+        jan12 = datetime(2025, 1, 12, 12, 0)
+        march1 = datetime(2025, 3, 1, 12, 0)
+
+        # setup main batch of leads
+        with self.mock_datetime_and_now(past):
+            leads_norevenue = self._create_leads_batch(
+                count=15,
+                partner_count=5,
+                user_ids=[self.user_sales_manager.id, self.user_sales_salesman.id],
+                lead_type='opportunity',
+                additional_lead_values={
+                    'stage_id': self.stage_team1_1.id,
+                },
+            )
+            leads_revenue = self._create_leads_batch(
+                count=18,
+                partner_count=3,
+                user_ids=[self.user_sales_manager.id, self.user_sales_salesman.id],
+                lead_type='opportunity',
+                additional_lead_values={
+                    'expected_revenue': 500,
+                    'stage_id': self.stage_team1_1.id,
+                },
+            )
+            iter_leads_norevenue = iter(leads_norevenue)
+            iter_leads_revenue = iter(leads_revenue)
+            all_leads = leads_norevenue | leads_revenue
+            # initialize tracking
+            self.flush_tracking()
+
+        # test lead rainbowman messages (leads without expected revenues)
+
+        with self.mock_datetime_and_now(jan1_10am):
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            # switch the stage to avoid having the "first to last stage" message show up all the time
+            all_leads.write({'stage_id': self.stage_team1_2.id})
+            # flush tracking to make sure it's taken into account
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            msg_firstdeal = self._set_won_get_rainbowman_message(next(iter_leads_norevenue), self.user_sales_manager)
+            self.assertEqual(
+                msg_firstdeal,
+                'Go, go, go! Congrats for your first deal.',
+                'First deal',
+            )
+
+            lead_25messages = next(iter_leads_norevenue)
+            self.env['mail.message'].create([
+                {
+                    'model': 'crm.lead',
+                    'res_id': lead_25messages.id,
+                    'body': 'Message',
+                    'message_type': 'comment',
+                } for x in range(25)
+            ])
+            msg_25messages = self._set_won_get_rainbowman_message(lead_25messages, self.user_sales_manager)
+            self.assertEqual(
+                msg_25messages,
+                'Phew, that took some effort — but you nailed it. Good job!',
+                'Win with 25 messages on the counter',
+            )
+
+        with self.mock_datetime_and_now(jan1_12pm):
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            lead_other_first_with_revenue = next(iter_leads_norevenue)
+            lead_other_first_with_revenue.expected_revenue = 100
+            msg_other_first_with_revenue = self._set_won_get_rainbowman_message(lead_other_first_with_revenue, self.user_sales_salesman)
+            self.assertEqual(
+                msg_other_first_with_revenue,
+                'Go, go, go! Congrats for your first deal.',
+                'First deal (another user), even with record revenue',
+            )
+
+            lead_first_country = next(iter_leads_norevenue)
+            lead_first_country.country_id = self.env.ref('base.au')
+            msg_first_country = self._set_won_get_rainbowman_message(lead_first_country, self.user_sales_manager)
+            self.assertEqual(
+                msg_first_country,
+                'You just expanded the map! First win in Australia.',
+                'First win in a country (all team)',
+            )
+
+            lead_second_country = next(iter_leads_norevenue)
+            lead_second_country.country_id = self.env.ref('base.au')
+            msg_second_country = self._set_won_get_rainbowman_message(lead_second_country, self.user_sales_salesman)
+            self.assertFalse(
+                msg_second_country,
+                'Second deal from the same country (all team)',
+            )
+
+            source_facebook_ad = self.env['utm.source'].create({'name': 'Facebook Ad'})
+            lead_first_source = next(iter_leads_norevenue)
+            lead_first_source.source_id = source_facebook_ad
+            msg_first_source = self._set_won_get_rainbowman_message(lead_first_source, self.user_sales_manager)
+            self.assertEqual(
+                msg_first_source,
+                'Yay, your first win from Facebook Ad!',
+                'First win from a UTM source (all team)',
+            )
+
+            lead_second_source = next(iter_leads_norevenue)
+            lead_second_source.source_id = source_facebook_ad.id
+            msg_second_source = self._set_won_get_rainbowman_message(lead_second_source, self.user_sales_salesman)
+            self.assertFalse(
+                msg_second_source,
+                'Second deal from the same source (all team)',
+            )
+
+            lead_combo5 = next(iter_leads_norevenue)
+            msg_combo5 = self._set_won_get_rainbowman_message(lead_combo5, self.user_sales_manager)
+            self.assertEqual(
+                msg_combo5,
+                'You\'re on fire! Fifth deal won today 🔥',
+                'Fifth deal won today (user)',
+            )
+
+        with self.mock_datetime_and_now(jan2):
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            # fast closes:
+            # 10 days ago
+            lead_fastclose_10 = next(iter_leads_norevenue)
+            self._update_create_date(lead_fastclose_10, datetime(2024, 12, 22))
+            msg_fastclose_10 = self._set_won_get_rainbowman_message(lead_fastclose_10, self.user_sales_manager)
+            self.assertEqual(
+                msg_fastclose_10,
+                'Wow, that was fast. That deal didn’t stand a chance!',
+                'Fastest close in 30 days',
+            )
+
+            # 15 days ago
+            lead_fastclose_15 = next(iter_leads_norevenue)
+            self._update_create_date(lead_fastclose_15, datetime(2024, 12, 17))
+            msg_fastclose_15 = self._set_won_get_rainbowman_message(lead_fastclose_15, self.user_sales_manager)
+            self.assertFalse(
+                msg_fastclose_15,
+                'Not the fastest close in 30 days',
+            )
+
+            # Today
+            lead_fastclose_0 = next(iter_leads_norevenue)
+            self._update_create_date(lead_fastclose_0, jan1_12pm)
+            msg_fastclose_0 = self._set_won_get_rainbowman_message(lead_fastclose_0, self.user_sales_manager)
+            self.assertEqual(
+                msg_fastclose_0,
+                'Wow, that was fast. That deal didn’t stand a chance!',
+                'Fastest close in 30 days',
+            )
+
+            self.assertFalse(
+                self._set_won_get_rainbowman_message(next(iter_leads_norevenue), self.user_sales_salesman),
+                'No achievment reached',
+            )
+
+        with self.mock_datetime_and_now(jan3_12pm):
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            lead_3daystreak = next(iter_leads_norevenue)
+            msg_3daystreak = self._set_won_get_rainbowman_message(lead_3daystreak, self.user_sales_manager)
+            self.assertEqual(
+                msg_3daystreak,
+                'You\'re on a winning streak. 3 deals in 3 days, congrats!',
+                'Three-day streak',
+            )
+
+        with self.mock_datetime_and_now(jan3_1pm):
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+
+            # Create new lead with no changed stage to get 'straight to the win' message
+
+            lead_first_to_last = self.env['crm.lead'].create({
+                'name': 'lead',
+                'type': 'opportunity',
+                'stage_id': self.stage_team1_1.id,
+                'user_id': self.user_sales_manager.id,
+            })
+            self._update_create_date(lead_first_to_last, jan1_12pm)
+            self.flush_tracking()
+            all_leads.invalidate_recordset(['duration_tracking'])
+            msg_first_to_last = self._set_won_get_rainbowman_message(lead_first_to_last, self.user_sales_manager)
+            self.assertEqual(
+                msg_first_to_last,
+                'No detours, no delays - from New straight to the win! 🚀',
+                'First stage to last stage',
+            )
+
+            self.assertFalse(
+                self._set_won_get_rainbowman_message(next(iter_leads_norevenue), self.user_sales_manager),
+                'Check that no message is returned if no "achievement" is reached',
+            )
+
+        with self.mock_datetime_and_now(jan4):
+            # test lead rainbowman messages (leads with expected revenues)
+            last_30_days_cases = [
+                (self.user_sales_manager, 650, 'Boom! Team record for the past 30 days.'),
+                (self.user_sales_manager, 550, False),
+                (self.user_sales_manager, 700, 'Boom! Team record for the past 30 days.'),
+                (self.user_sales_manager, 700, False),
+                (self.user_sales_salesman, 600, 'You just beat your personal record for the past 30 days.'),
+                (self.user_sales_salesman, 600, False),
+                (self.user_sales_salesman, 550, False),
+                (self.user_sales_salesman, 1000, 'Boom! Team record for the past 30 days.'),
+                (self.user_sales_manager, 950, 'You just beat your personal record for the past 30 days.'),
+            ]
+            for user, expected_revenue, expected_message in last_30_days_cases:
+                with self.subTest(user=user, revenue=expected_revenue):
+                    lead_revenue = next(iter_leads_revenue)
+                    lead_revenue.expected_revenue = expected_revenue
+                    msg_revenue = self._set_won_get_rainbowman_message(lead_revenue, user)
+                    self.assertEqual(msg_revenue, expected_message)
+
+        with self.mock_datetime_and_now(jan12):
+            last_7_days_cases = [
+                (self.user_sales_manager, 650, 'Yeah! Best deal out of the last 7 days for the team.'),
+                (self.user_sales_manager, 500, False),
+                (self.user_sales_manager, 650, False),
+                (self.user_sales_manager, 800, 'Yeah! Best deal out of the last 7 days for the team.'),
+                (self.user_sales_salesman, 700, 'You just beat your personal record for the past 7 days.'),
+                (self.user_sales_salesman, 650, False),
+                (self.user_sales_salesman, 750, 'You just beat your personal record for the past 7 days.'),
+                (self.user_sales_salesman, 850, 'Yeah! Best deal out of the last 7 days for the team.'),
+            ]
+            for user, expected_revenue, expected_message in last_7_days_cases:
+                with self.subTest(user=user, revenue=expected_revenue):
+                    lead_revenue = next(iter_leads_revenue)
+                    lead_revenue.expected_revenue = expected_revenue
+                    msg_revenue = self._set_won_get_rainbowman_message(lead_revenue, user)
+                    self.assertEqual(msg_revenue, expected_message)
+
+        with self.mock_datetime_and_now(march1):
+            lead_later_record = next(iter_leads_revenue)
+            lead_later_record.expected_revenue = 750
+            msg_later_record = self._set_won_get_rainbowman_message(lead_later_record, self.user_sales_manager)
+            self.assertEqual(msg_later_record, 'Boom! Team record for the past 30 days.', 'Once a month has passed, \
+                monthly team records may be set even if the amount was lower than the alltime max.')
+
+    @users('user_sales_manager')
+    def test_leads_rainbowman_timezones(self):
+        """
+        Users in differing timezones need to get appropriate time-based messages.
+        This test verifies that users in distant timezones still get rainbowman messages
+        when it makes sense from their own point of view.
+        """
+        sales_m10 = mail_new_test_user(         # UTC-10
+            self.env(su=True),
+            login='polynesia_-10',
+            tz='Pacific/Honolulu',
+            name='polynesia_-10',
+            groups='sales_team.group_sale_manager',
+        )
+        sales_p530 = mail_new_test_user(        # UTC+5:30
+            self.env(su=True),
+            login='india_+5:30',
+            tz='Asia/Kolkata',
+            name='india_+5:30',
+            groups='sales_team.group_sale_manager',
+        )
+        sales_p13 = mail_new_test_user(         # UTC+13
+            self.env(su=True),
+            login='samoa_+13',
+            tz='Pacific/Apia',
+            name='samoa_+13',
+            groups='sales_team.group_sale_manager',
+        )
+        sales_users = [sales_m10, sales_p530, sales_p13]
+
+        # All datetimes stored in-DB are in UTC
+        jan9_10_45am = datetime(2025, 1, 9, 10, 45, 0)  # first deal
+        jan9_11_30am = datetime(2025, 1, 9, 11, 30, 0)
+        jan9_4pm = datetime(2025, 1, 9, 16, 0)
+        jan9_6_45pm = datetime(2025, 1, 9, 18, 45)
+        jan9_11pm = datetime(2025, 1, 9, 23, 0)         # polynesia_m10: fifth deal in a day
+        jan10_midnight = datetime(2025, 1, 10, 0, 0)    # samoa_p13: fifth deal in a day
+        jan10_3am = datetime(2025, 1, 10, 3, 0)
+        jan10_8am = datetime(2025, 1, 10, 8, 0)         # india_p530: fifth deal in a day
+        jan10_11am = datetime(2025, 1, 10, 11, 0)       # samoa_p13: three-day streak
+
+        first_deal = 'Go, go, go! Congrats for your first deal.'
+        fifth_deal_day = 'You\'re on fire! Fifth deal won today 🔥'
+        three_day_streak = 'You\'re on a winning streak. 3 deals in 3 days, congrats!'
+        cases = [
+            (jan9_10_45am, {user: first_deal for user in sales_users}),
+            (jan9_11_30am, {}),
+            (jan9_4pm, {}),
+            (jan9_6_45pm, {}),
+            (jan9_11pm, {sales_m10: fifth_deal_day}),
+            (jan10_midnight, {sales_p13: fifth_deal_day}),
+            (jan10_3am, {}),
+            (jan10_8am, {sales_p530: fifth_deal_day}),
+            (jan10_11am, {sales_p13: three_day_streak}),
+        ]
+        leads = self._create_leads_batch(
+            count=27,
+            lead_type='opportunity',
+            additional_lead_values={
+                'stage_id': self.stage_team1_1.id,
+            },
+        )
+        iter_leads = iter(leads)
+        for deal_closing_time, expected_messages in cases:
+            with self.mock_datetime_and_now(deal_closing_time):
+                for sales_user in sales_users:
+                    with self.subTest(username=sales_user.name, time=deal_closing_time):
+                        msg = self._set_won_get_rainbowman_message(next(iter_leads), sales_user)
+                        self.assertEqual(msg, expected_messages.get(sales_user, False))
+
+    @users('sales_manager_casey')
+    def test_leads_rainbowman_no_team(self):
+        past = datetime(2025, 1, 2, 12, 0)
+        past_1pm = datetime(2025, 1, 2, 13, 0)
+        now = datetime(2025, 1, 5, 12, 0)
+
+        with self.mock_datetime_and_now(past):
+            leads = self._create_leads_batch(
+                count=6,
+                user_ids=[self.sales_manager_casey.id, self.user_sales_salesman.id],
+                lead_type='opportunity',
+                additional_lead_values={
+                    'stage_id': self.stage_team1_1.id,
+                },
+            )
+            iter_leads = iter(leads)
+
+        with self.mock_datetime_and_now(past_1pm):
+            # prime the users and leads (to skip first deal closed, fastest close, from first to last...)
+            self.flush_tracking()
+            leads.stage_id = self.stage_gen_1
+            self.flush_tracking()
+            lead_prime_casey = next(iter_leads)
+            lead_prime_benoit = next(iter_leads)
+            self._set_won_get_rainbowman_message(lead_prime_casey, self.sales_manager_casey, reset_team=True)
+            self._set_won_get_rainbowman_message(lead_prime_benoit, self.user_sales_salesman)
+
+        with self.mock_datetime_and_now(now):
+            source_xitter_post = self.env['utm.source'].create({'name': 'Xitter Post'})
+            lead_noteam = next(iter_leads)
+            lead_noteam.source_id = source_xitter_post
+            msg_lead_noteam = self._set_won_get_rainbowman_message(lead_noteam, self.sales_manager_casey, reset_team=True)
+            self.assertEqual(
+                msg_lead_noteam,
+                'Yay, your first win from Xitter Post!',
+                'First win from a UTM source (lead has no team)',
+            )
+
+            # (complete an empty lead to skip the fifth row in a day message)
+            self._set_won_get_rainbowman_message(next(iter_leads), self.sales_manager_casey)
+
+            lead_noteam_samesource = next(iter_leads)
+            lead_noteam_samesource.source_id = source_xitter_post
+            msg_lead_noteam_samesource = self._set_won_get_rainbowman_message(lead_noteam_samesource, self.sales_manager_casey, reset_team=True)
+            self.assertFalse(
+                msg_lead_noteam_samesource,
+                'Second deal from the same source (no team) triggers no message if the source has already been won once for the user',
+            )
+
+            lead_inteam_samesource = next(iter_leads)
+            lead_inteam_samesource.source_id = source_xitter_post
+            msg_lead_inteam_samesource = self._set_won_get_rainbowman_message(lead_inteam_samesource, self.user_sales_salesman)
+            self.assertEqual(
+                msg_lead_inteam_samesource,
+                'Yay, your first win from Xitter Post!',
+                'Benoit can still receive the message as neither he nor his team have a recorded win for this source',
+            )

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -231,8 +231,8 @@
                             </group>
                             <field name="type" invisible="1"/>
                             <group invisible="type == 'lead'">
-                                <field name="user_id"
-                                    context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
+                                <field name="user_id" context="{'default_sales_team_id': team_id}"
+                                    widget="many2one_avatar_leader_user" teamField="team_id"/>
                                 <label for="date_deadline">Expected Closing</label>
                                 <div class="d-flex gap-3 align-items-center">
                                     <field name="date_deadline" nolabel="1" class="oe_inline" placeholder="No closing estimate"/>
@@ -241,8 +241,8 @@
                                 <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                             </group>
                             <group invisible="type == 'opportunity'">
-                                <field name="user_id"
-                                    context="{'default_sales_team_id': team_id}" widget="many2one_avatar_user"/>
+                                <field name="user_id" context="{'default_sales_team_id': team_id}"
+                                    widget="many2one_avatar_leader_user" teamField="team_id"/>
                                 <field name="team_id" options="{'no_open': True, 'no_create': True}" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                             </group>
                             <group name="lead_priority" invisible="type == 'opportunity'">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -579,7 +579,12 @@
                                     <field name="recurring_plan" groups="crm.group_use_recurring_revenues"/>
                                 </t>
                             </div>
-                            <field name="partner_id" class="ms-2 text-truncate" />
+                            <div class="d-flex" invisible="not partner_id">
+                                <field name="partner_id" widget="many2one_avatar" class="text-truncate" readonly="1" options="{'no_create': 1, 'no_open': 1}"/>
+                                <field name="partner_id" class="ms-2 text-truncate"/>
+                            </div>
+                            <field name="contact_name" invisible="partner_id"/>
+                            <field name="partner_name" invisible="partner_id or contact_name"/>
                             <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                             <field name="lead_properties" widget="properties"/>
                             <footer class="pt-1">

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -17,7 +17,7 @@
                             invisible="won_status != 'pending' or not active"/>
                         <field name="stage_id" widget="rotting_statusbar_duration"
                             options="{'clickable': '1', 'fold_field': 'fold'}"
-                            domain="['|', ('team_id', '=', team_id), ('team_id', '=', False)]"
+                            domain="['|', ('team_ids', 'in', team_id), ('team_ids', '=', False)]"
                             invisible="type == 'lead'" readonly="won_status == 'lost' or not active"/>
                     </header>
                     <sheet>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1203,7 +1203,8 @@
             <field name="domain">[('type','=','opportunity')]</field>
             <field name="context">{
                     'default_type': 'opportunity',
-                    'search_default_assigned_to_me': 1
+                    'search_default_assigned_to_me': 1,
+                    'show_user_team_stages': 1,
             }</field>
             <field name="search_view_id" ref="crm.view_crm_case_opportunities_filter"/>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -745,7 +745,8 @@
             <field name="model">crm.lead</field>
             <field name="priority">1</field>
             <field name="arch" type="xml">
-                <list string="Opportunities" sample="1" multi_edit="1">
+                <list string="Opportunities" sample="1" multi_edit="1"
+                    decoration-muted="won_status == 'lost'">
                     <header>
                         <button name="%(crm.crm_lead_lost_action)d" type="action" string="Mark Lost" />
                         <button name="%(crm.action_lead_mass_mail)d" type="action" string="Email" />
@@ -754,6 +755,7 @@
                     <field name="user_company_ids" column_invisible="True"/>
                     <field name="date_deadline" column_invisible="True"/>
                     <field name="activity_calendar_event_id" column_invisible="True"/>
+                    <field name="won_status" column_invisible="True"/>
                     <field name="create_date" optional="hide"/>
                     <field name="name" string="Opportunity" readonly="1"/>
                     <field name="partner_id" optional="hide"/>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -802,7 +802,7 @@
                     <field name="is_rotting" column_invisible="True"/>
                     <field name="rotting_days" column_invisible="True"/>
                     <widget name="mail_activity_mixin_list_reschedule_dropdown"/>
-                    <button name="%(crm.action_lead_mail_compose)d" type="action" string="Email" icon="fa-envelope"/>
+                    <button name="%(crm.action_lead_mail_compose)d" type="action" string="Email" icon="fa-envelope" invisible="won_status == 'lost'"/>
                 </list>
             </field>
         </record>

--- a/addons/crm/views/crm_stage_views.xml
+++ b/addons/crm/views/crm_stage_views.xml
@@ -9,7 +9,7 @@
                 <field name="name"/>
                 <field name="sequence"/>
                 <field name="is_won"/>
-                <field name="team_id"/>
+                <field name="team_ids"/>
             </search>
         </field>
     </record>
@@ -23,7 +23,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name" readonly="1"/>
                 <field name="is_won"/>
-                <field name="team_id"/>
+                <field name="team_ids" widget="many2many_tags"/>
                 <field name="rotting_threshold_days" optional="hide"/>
                 <field name="color" optional="hide" widget="color_picker"/>
             </list>
@@ -47,7 +47,8 @@
                         <group>
                             <field name="fold"/>
                             <field name="color" widget="color_picker"/>
-                            <field name="team_id" options='{"no_open": True, "no_create": True}' invisible="team_count &lt;= 1" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
+                            <field name="team_ids" widget="many2many_tags" placeholder="Shared with all teams"
+                                options='{"no_open": True, "no_create": True}' invisible="team_count &lt;= 1" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
                         </group>
                         <group>
                             <field name="is_won"/>

--- a/addons/crm/views/crm_team_member_views.xml
+++ b/addons/crm/views/crm_team_member_views.xml
@@ -27,7 +27,7 @@
             </field>
             <xpath expr="//main" position="after">
                 <div class="o_member_assignment"
-                        invisible="not assignment_enabled or assignment_optout">
+                        invisible="assignment_optout">
                     <field name="lead_month_count" widget="gauge"
                         options="{'max_field': 'assignment_max'}"
                         invisible="assignment_max == 0"/>
@@ -43,20 +43,21 @@
         <field name="arch" type="xml">
             <xpath expr="//sheet" position="inside">
                 <notebook>
-                    <page string="Lead Assignment" name="lead_assign" invisible="not assignment_enabled">
+                    <page string="Lead Assignment" name="lead_assign">
                         <group>
-                            <div invisible="assignment_optout" colspan="2">
+                            <label for="assignment_max" class="o_form_label text-900" string="Capacity" invisible="assignment_optout"/>
+                            <span invisible="assignment_optout">
                                 <field name="lead_month_count" class="oe_inline"/>
                                 <span> leads assigned the last 30 days out of a maximum of </span>
-                                <field name="assignment_max" class="oe_inline o_field_highlight o_input_6ch"/>
-                            </div>
+                                <field name="assignment_max" class="oe_inline o_field_highlight o_input_6ch border-bottom border-dark"/>
+                            </span>
                             <field name="assignment_optout"/>
                             <field name="assignment_domain_preferred" string="Lead Priority Filter" widget="domain"
                                 options="{'model': 'crm.lead', 'foldable': True}"
-                                invisible="assignment_max == 0 or assignment_optout"/>
+                                invisible="not assignment_enabled or assignment_max == 0 or assignment_optout"/>
                             <field name="assignment_domain" string="Lead Assignment Filter" widget="domain"
                                 options="{'model': 'crm.lead', 'foldable': True}"
-                                invisible="assignment_max == 0 or assignment_optout"/>
+                                invisible="not assignment_enabled or assignment_max == 0 or assignment_optout"/>
                         </group>
                     </page>
                 </notebook>

--- a/addons/crm/wizard/crm_lead_lost_views.xml
+++ b/addons/crm/wizard/crm_lead_lost_views.xml
@@ -6,8 +6,9 @@
             <field name="arch" type="xml">
                 <form string="Lost Lead">
                     <field name="lead_ids" invisible="1"></field>
+                    <field name="lost_reason_id" placeholder="Select a Lost Reason..." widget="selection_badge" />
                     <group>
-                        <field name="lost_reason_id" placeholder="Select a Lost Reason..." options="{'no_create_edit': True}" />
+                        <label for="lost_feedback" class="o_form_label">Closing Note</label>
                         <field name="lost_feedback" placeholder="What went wrong?" nolabel="1" colspan="2"/>
                     </group>
                     <footer>

--- a/addons/crm_livechat/models/chatbot_script_step.py
+++ b/addons/crm_livechat/models/chatbot_script_step.py
@@ -2,7 +2,7 @@
 
 from ast import literal_eval
 
-from odoo import models, fields
+from odoo import _, models, fields
 from odoo.fields import Domain
 from odoo.tools import html2plaintext
 
@@ -77,7 +77,9 @@ class ChatbotScriptStep(models.Model):
             create_values = {"partner_id": self.env.user.partner_id.id}
         create_values.update(self._chatbot_crm_prepare_lead_values(
             discuss_channel, customer_values['description']))
-        return self.env["crm.lead"].create(create_values)
+        new_leads = self.env["crm.lead"].create(create_values)
+        new_leads._assign_userless_lead_in_team(_('livechat discussion'))
+        return new_leads
 
     def _process_step_create_lead_and_forward(self, discuss_channel):
         lead = self._process_step_create_lead(discuss_channel)

--- a/addons/crm_sms/views/crm_lead_views.xml
+++ b/addons/crm_sms/views/crm_lead_views.xml
@@ -36,7 +36,7 @@
                 <button name="%(crm_sms.crm_lead_act_window_sms_composer_single)d" type="action" string="SMS" />
             </xpath>
             <xpath expr="//button[@name='%(crm.action_lead_mail_compose)d']" position="after">
-                <button name="%(crm_sms.crm_lead_act_window_sms_composer_multi)d" type="action" string="SMS" icon="fa-comments" />
+                <button name="%(crm_sms.crm_lead_act_window_sms_composer_multi)d" type="action" string="SMS" icon="fa-comments" invisible="won_status == 'lost'"/>
             </xpath>
         </field>
     </record>

--- a/addons/event_crm/models/event_lead_rule.py
+++ b/addons/event_crm/models/event_lead_rule.py
@@ -4,7 +4,7 @@
 from ast import literal_eval
 from collections import defaultdict
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 
 class EventLeadRule(models.Model):
@@ -109,6 +109,11 @@ class EventLeadRule(models.Model):
         help="Automatically assign the created leads to this Sales Team.")
     lead_user_id = fields.Many2one('res.users', string='Salesperson', help="Automatically assign the created leads to this Salesperson.")
     lead_tag_ids = fields.Many2many('crm.tag', string='Tags', help="Automatically add these tags to the created leads.")
+
+    @api.onchange('lead_sales_team_id')
+    def _onchange_lead_sales_team_id(self):
+        if self.lead_sales_team_id and self.lead_sales_team_id.user_id:
+            self.lead_user_id = self.lead_sales_team_id.user_id
 
     def _run_on_registrations(self, registrations):
         """ Create or update leads based on rule configuration. Two main lead

--- a/addons/event_crm/views/event_lead_rule_views.xml
+++ b/addons/event_crm/views/event_lead_rule_views.xml
@@ -70,7 +70,7 @@
                         <group class="col">
                             <field name="lead_type" groups="crm.group_use_lead"/>
                             <field name="lead_sales_team_id"/>
-                            <field name="lead_user_id" widget="many2one_avatar_user"/>
+                            <field name="lead_user_id" widget="many2one_avatar_leader_user" teamField="lead_sales_team_id"/>
                         </group>
                         <group class="col">
                             <field name="lead_tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -97,5 +97,5 @@ class ResUsers(models.Model):
         super()._compute_display_name()
         for user in self:
             if user.env.context.get("formatted_display_name") and user.leave_date_to:
-                name = "%s \t ✈ --%s %s--" % (user.name, _("Back on"), format_date(self.env, user.leave_date_to, self.env.user.lang, "medium"))
+                name = "%s \t ✈ --%s %s--" % (user.display_name or user.name, _("Back on"), format_date(self.env, user.leave_date_to, self.env.user.lang, "medium"))
                 user.display_name = name.strip()

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -11,7 +11,7 @@ import {
 import { Avatar } from "../avatar/avatar";
 import { Many2XAvatarUserAutocomplete } from "../avatar_autocomplete/avatar_many2x_autocomplete";
 
-class Many2OneAvatarUser extends Many2One {
+export class Many2OneAvatarUser extends Many2One {
     static components = {
         ...Many2One.components,
         Many2XAutocomplete: Many2XAvatarUserAutocomplete,
@@ -46,7 +46,7 @@ export class Many2OneAvatarUserField extends Component {
     }
 }
 
-registry.category("fields").add("many2one_avatar_user", {
+export const many2OneAvatarUserField = {
     ...buildM2OFieldDescription(Many2OneAvatarUserField),
     additionalClasses: ["o_field_many2one_avatar"],
     extractProps(staticInfo, dynamicInfo) {
@@ -59,4 +59,5 @@ registry.category("fields").add("many2one_avatar_user", {
         };
     },
     listViewWidth: [110],
-});
+};
+registry.category("fields").add("many2one_avatar_user", many2OneAvatarUserField);

--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
         if not self.env.user.has_group('point_of_sale.group_pos_user'):
             return data_list
         for partner in self.filtered('pos_order_count'):
-            stat_info = {'iconClass': 'fa-shopping-bag', 'value': partner.pos_order_count, 'label': _('Shopping cart')}
+            stat_info = {'iconClass': 'fa-shopping-bag', 'value': partner.pos_order_count, 'label': _('Shopping cart'), 'tagClass': 'o_tag_color_7'}
             data_list[partner.id].append(stat_info)
         return data_list
 

--- a/addons/purchase/models/res_partner.py
+++ b/addons/purchase/models/res_partner.py
@@ -49,6 +49,6 @@ class ResPartner(models.Model):
         if not self.env.user.has_group('purchase.group_purchase_user'):
             return data_list
         for partner in self.filtered(lambda partner: partner.purchase_order_count):
-            stat_info = {'iconClass': 'fa-credit-card', 'value': partner.purchase_order_count, 'label': _('Purchases')}
+            stat_info = {'iconClass': 'fa-credit-card', 'value': partner.purchase_order_count, 'label': _('Purchases'), 'tagClass': 'o_tag_color_5'}
             data_list[partner.id].append(stat_info)
         return data_list

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -47,7 +47,7 @@ class ResPartner(models.Model):
             return data_list
         for partner in self.filtered('sale_order_count'):
             data_list[partner.id].append(
-                {'iconClass': 'fa-usd', 'value': partner.sale_order_count, 'label': self.env._('Sale Orders')}
+                {'iconClass': 'fa-usd', 'value': partner.sale_order_count, 'label': self.env._('Sale Orders'), 'tagClass': 'o_tag_color_2'}
             )
         return data_list
 

--- a/addons/sale_crm/tests/test_res_partner.py
+++ b/addons/sale_crm/tests/test_res_partner.py
@@ -103,11 +103,11 @@ class TestResPartner(TestCrmCommon):
         for partner, expected in zip(
             (contact_company_1, contact_1, contact_1_1, contact_1_2),
             (
-                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 4},
-                 {'iconClass': 'fa-usd', 'label': 'Sale Orders', 'value': 2}],
-                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 3},
-                 {'iconClass': 'fa-usd', 'label': 'Sale Orders', 'value': 1}],
-                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 2}],
+                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 4, 'tagClass': 'o_tag_color_8'},
+                 {'iconClass': 'fa-usd', 'label': 'Sale Orders', 'value': 2, 'tagClass': 'o_tag_color_2'}],
+                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 3, 'tagClass': 'o_tag_color_8'},
+                 {'iconClass': 'fa-usd', 'label': 'Sale Orders', 'value': 1, 'tagClass': 'o_tag_color_2'}],
+                [{'iconClass': 'fa-star', 'label': 'Opportunities', 'value': 2, 'tagClass': 'o_tag_color_8'}],
                 False,
             ),
             strict=True,

--- a/addons/sales_team/data/crm_team_data.xml
+++ b/addons/sales_team/data/crm_team_data.xml
@@ -5,6 +5,7 @@
             <field name="name">Sales</field>
             <field name="sequence">0</field>
             <field name="company_id" eval="False"/>
+            <field name="user_id" ref="base.user_admin"/>
         </record>
         <record id="crm_team_member_admin_sales" model="crm.team.member" forcecreate="0">
             <field name="crm_team_id" ref="team_sales_department"/>

--- a/addons/sales_team/views/crm_team_member_views.xml
+++ b/addons/sales_team/views/crm_team_member_views.xml
@@ -103,31 +103,31 @@
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <field name="image_1920" widget='image' class="oe_avatar"
-                        invisible="not user_id"
-                        options='{"preview_image": "image_128"}'/>
-                    <div class="oe_title">
-                        <label for="user_id" class="oe_edit_only"/>
-                        <h1 class="d-flex">
-                            <field name="user_id" class="flex-grow-1"
-                                options="{'no_quick_create': True}"/>
-                        </h1>
-                        <!-- <div class="o_row" name="crm_team_id">
-                            <label for="crm_team_id"/> -->
-                            <group name="crm_team_id">
-                                <field id="crm_team_id" name="crm_team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
-                            </group>
-                        <!-- </div> -->
-                    </div>
+                    <field name="image_1920" widget='image' class="float-start pe-3"
+                        invisible="not user_id" nolabel="1"
+                        options='{"preview_image": "image_128", "size": [130,130], "img_class": "rounded border"}'/>
+                    <h1 class="d-flex">
+                        <field name="user_id" class="flex-grow-1" placeholder="e.g. John Doe"
+                            options="{'no_quick_create': True}"/>
+                    </h1>
+                    <group name="crm_team_id">
+                        <field id="crm_team_id" name="crm_team_id" context="{'kanban_view_ref': 'sales_team.crm_team_view_kanban'}"/>
+                    </group>
                     <group name="member_partner_info">
-                        <group>
-                            <field name="email" invisible="not user_id"/>
-                            <field name="company_id" invisible="not user_id"
-                                groups="base.group_multi_company"/>
-                        </group>
-                        <group>
-                            <field name="phone" invisible="not user_id"/>
-                        </group>
+                        <div class="d-flex flex-column flex-grow-1">
+                            <div colspan="2" class="d-flex align-items-baseline" invisible="not user_id">
+                                <i class="fa fa-fw me-1 fa-envelope text-primary" title="Email"/>
+                                <field name="email" nolabel="1"/>
+                            </div>
+                            <div colspan="2" class="d-flex align-items-baseline" invisible="not user_id">
+                                <i class="fa fa-fw me-1 fa-phone text-primary" title="Phone"/>
+                                <field name="phone" nolabel="1"/>
+                            </div>
+                            <div colspan="2" class="d-flex align-items-baseline" invisible="not user_id" groups="base.group_multi_company">
+                                <i class="fa fa-fw me-1 fa-building text-primary" title="Company"/>
+                                <field name="company_id"/>
+                            </div>
+                        </div>
                     </group>
                 </sheet>
                 <chatter/>
@@ -144,7 +144,7 @@
         <field name="arch" type="xml">
             <!-- <xpath expr="//div[@name='crm_team_id']" position="replace"/> -->
             <xpath expr="//group[@name='crm_team_id']" position="replace"/>
-            <xpath expr="//group[@name='member_partner_info']/group" position="attributes">
+            <xpath expr="//group[@name='member_partner_info']/div" position="attributes">
                 <attribute name="class">px-0</attribute>
             </xpath>
         </field>

--- a/addons/web/static/src/views/fields/contact_statistics/contact_statistics.xml
+++ b/addons/web/static/src/views/fields/contact_statistics/contact_statistics.xml
@@ -4,7 +4,7 @@
     <t t-name="web.ContactStatisticsField">
         <div class="d-flex flex-wrap gap-1">
             <span t-foreach="list" t-as="data" t-key="data_index"
-                class="badge bg-secondary rounded-pill smaller" t-att-aria-label="data.label" t-att-title="data.label">
+                t-attf-class="badge bg-secondary rounded-pill smaller #{data.tagClass ? 'o_tag ' + data.tagClass : ''}" t-att-aria-label="data.label" t-att-title="data.label">
                 <i t-attf-class="fa me-1 {{data.iconClass}}" role="img"/>
                 <t t-out="data.value"/>
             </span>

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -108,7 +108,7 @@
                 </t>
             </t>
             <t t-else="">
-                <div t-if="props.addLabel" class="o_kanban_record o-kanban-button-new btn btn-link py-4" accesskey="c" t-on-click.stop.prevent="() => props.onAdd()">
+                <div t-if="props.addLabel" class="o_kanban_record o-kanban-button-new btn btn-link py-4" accesskey="shift+c" t-on-click.stop.prevent="() => props.onAdd()">
                     <t t-out="props.addLabel" />
                 </div>
                 <!-- kanban ghost cards are used to properly space last elements. -->

--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -52,6 +52,8 @@ class CrmLead(models.Model):
                             request.website.crm_default_team_id.id
         values['user_id'] = values.get('user_id') or \
                             request.website.crm_default_user_id.id
+        if not values['user_id'] and values['team_id'] and not self._is_rule_based_assignment_activated():
+            values['user_id'] = self.env['crm.team'].sudo().browse([values['team_id']]).user_id.id
         if values.get('team_id'):
             values['type'] = 'lead' if self.env['crm.team'].sudo().browse(values['team_id']).use_leads else 'opportunity'
         else:

--- a/addons/website_crm/views/crm_lead_views.xml
+++ b/addons/website_crm/views/crm_lead_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="crm.crm_lead_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//button[@name='action_schedule_meeting']" position="after">
-                <button name="action_redirect_to_page_views" type="object" class="oe_stat_button" icon="fa-tags"
+                <button name="action_redirect_to_page_views" type="object" class="oe_stat_button" icon="fa-eye"
                         invisible="visitor_page_count == 0">
                     <field name="visitor_page_count" widget="statinfo" string="Page views"/>
                 </button>

--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -177,7 +177,7 @@ class WebsiteAccount(CustomerPortal):
                 'opportunity': opp,
                 'user_activity': opp.sudo().activity_ids.filtered(lambda activity: activity.user_id == request.env.user)[:1],
                 'stages': request.env['crm.stage'].search([
-                    ('is_won', '!=', True), '|', ('team_id', '=', False), ('team_id', '=', opp.team_id.id)
+                    ('is_won', '!=', True), '|', ('team_ids', '=', False), ('team_ids', 'in', opp.team_id.id)
                 ], order='sequence desc, name desc, id desc'),
                 'activity_types': request.env['mail.activity.type'].sudo().search(['|', ('res_model', '=', opp._name), ('res_model', '=', False)]),
                 'states': request.env['res.country.state'].sudo().search([]),

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -20,7 +20,8 @@
                                     <span class="opacity-50" invisible="partner_longitude &gt;= 0">W </span>
                                     <span class="opacity-50 ps-1">) </span>
                                 </div>
-                                <field name="partner_assigned_id" domain="[('grade_id','!=',False)]" context="{'partner_set_default_grade_activation': 1}"/>
+                                <field name="partner_assigned_id" domain="[('grade_id','!=',False)]" context="{'partner_set_default_grade_activation': 1}"
+                                    widget="many2one_avatar"/>
                             </group>
                             <group>
                                 <button colspan="2" string="Automatic Assignment" name="action_assign_partner" type="object" class="btn-link pt-0 ps-0"/>

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -181,7 +181,7 @@
             <field name="model">crm.lead</field>
             <field name="inherit_id" ref="crm.crm_case_kanban_view_leads"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='partner_id']" position="after">
+                <xpath expr="//field[@name='partner_name']" position="after">
                     <span class="text-truncate" t-if="record.partner_assigned_id.value">
                         <span class="me-1">Partner:</span>
                         <span t-att-title="record.partner_assigned_id.value"><field name="partner_assigned_id"/></span>


### PR DESCRIPTION
Previously, the rainbowman could only be triggered on won 
opportunities with a expected revenue. This meant that the 
rainbowman didn't get triggered for users that didn't use that field.

This commit adds additional triggers for opportunities with no 
expected revenue, such as reaching 5 deals won in a single day or 
closing a deal in a new country.

--

Previously, stage-specific teams were locked to one team and one team
only. As a result, "shared" lead stages between different teams were
accessible to every team, causing clutter.

This commit allows lead stages to be shared between teams. All
tasks belonging to a shared stage will be present in the pipeline
of both teams.

--

Previously, when setting custom aliases for a team, it was not uncommon
for the opportunities generated through sent emails to lay dormant and
unopened for quite some time.

This commit adds a new mode for automatic assigns, 'For Incoming Emails',
which is active by default and can be disabled by switching automatic
assign actions to 'Manual' or 'Auto'. When this mode is active,
a newly received email generating an opportunity will be automatically
attributed to the "least busy user" by lead month count.

A 'Never' assignment mode is also added, disabling automatic assignment
completely (through it is functionally equivalent to setting assignment
mode to Manual and then never running it).

task-4684660
