### PR TITLE
[FIX] html_editor: prevent text toolbar for image

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -322,7 +322,7 @@ export class ToolbarPlugin extends Plugin {
             .filter(
                 (node) =>
                     this.dependencies.selection.isNodeEditable(node) &&
-                    (!isTextNode(node) || (node.textContent !== "\n" && !isZWS(node)))
+                    (!isTextNode(node) || (node.textContent.trim().length && !isZWS(node)))
             );
     }
 

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -781,6 +781,28 @@ test("toolbar items without namespace default to 'expanded'", async () => {
     expect(".o-we-toolbar .btn[name='test_btn']").toHaveCount(1);
 });
 
+test("toolbar should open with image namespace the selection spans an image and whitespace", async () => {
+    const { el } = await setupEditor(`<p>[abc]</p>`);
+    // Make sure we start with a compact toolbar so we know that at the end when
+    // we don't anymore it did in fact change and we're not just lagging behind
+    // the DOM.
+    await animationFrame();
+    expect(".o-we-toolbar").toHaveCount(1);
+    expect(queryOne(".o-we-toolbar").dataset.namespace).toBe("compact");
+    expect(queryAll(".o-we-toolbar .btn-group[name='font']").length).toBe(1);
+    expect(queryAll(".o-we-toolbar .btn-group[name='decoration']").length).toBe(1);
+    setContent(
+        el,
+        `<p>[
+            <img>
+        ]</p>`
+    );
+    await waitFor(".o-we-toolbar[data-namespace='image']");
+    expect(queryOne(".o-we-toolbar").dataset.namespace).toBe("image");
+    expect(queryAll(".o-we-toolbar .btn-group[name='font']").length).toBe(0);
+    expect(queryAll(".o-we-toolbar .btn-group[name='decoration']").length).toBe(0);
+});
+
 test("plugins can create buttons with text in toolbar", async () => {
     class TestPlugin extends Plugin {
         static id = "TestPlugin";


### PR DESCRIPTION
The website builder's social references block has images. When clicking on any of these images, the text toolbar was appearing. This is because the selection traversed a whitespace text node that wasn't filtered out.

![image](https://github.com/user-attachments/assets/d2289f75-e527-43ef-842e-15d8386c76b6)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
