### PR TITLE
[IMP] l10n_hu_edi: copy delivery date to credit/debit notes

### DIFF
--- a/addons/l10n_hu_edi/tests/__init__.py
+++ b/addons/l10n_hu_edi/tests/__init__.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_credit_debit_notes
 from . import test_flows_live
 from . import test_flows_mocked
 from . import test_invoice_xml

--- a/addons/l10n_hu_edi/tests/test_credit_debit_notes.py
+++ b/addons/l10n_hu_edi/tests/test_credit_debit_notes.py
@@ -1,0 +1,44 @@
+from odoo.tests.common import tagged
+from odoo.addons.l10n_hu_edi.tests.common import L10nHuEdiTestCommon
+from freezegun import freeze_time
+
+
+@tagged('post_install_l10n', '-at_install', 'post_install')
+class TestL10nHuEdiCreditDebitNotes(L10nHuEdiTestCommon):
+    """Tests for Credit and Debit Notes in the Hungarian EDI localization."""
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref='hu'):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+    @freeze_time('2025-01-01')
+    def test_credit_note_preserves_delivery_date(self):
+        """Ensure that the credit note inherits the delivery date from the original invoice."""
+        invoice = self.create_invoice_simple()
+        invoice.action_post()
+
+        credit_note = self.create_reversal(invoice)
+        self.assertEqual(
+            invoice.delivery_date,
+            credit_note.delivery_date,
+            "Credit note should inherit the delivery date from the original invoice."
+        )
+
+    @freeze_time('2025-01-01')
+    def test_debit_note_preserves_delivery_date(self):
+        """Ensure that the debit note inherits the delivery date from the original invoice."""
+        invoice = self.create_invoice_simple()
+        invoice.action_post()
+
+        wizard = self.env['account.debit.note'].with_context(
+            active_ids=invoice.ids,
+            active_model='account.move'
+        ).create({'reason': 'Test debit note'})
+        wizard.create_debit()
+
+        debit_note = invoice.debit_note_ids
+        self.assertEqual(
+            invoice.delivery_date,
+            debit_note.delivery_date,
+            "Debit note should inherit the delivery date from the original invoice."
+        )

--- a/addons/l10n_hu_edi/wizard/__init__.py
+++ b/addons/l10n_hu_edi/wizard/__init__.py
@@ -1,3 +1,4 @@
+from . import account_move_debit
 from . import account_move_reversal
 from . import account_move_send
 from . import l10n_hu_edi_cancellation

--- a/addons/l10n_hu_edi/wizard/account_move_debit.py
+++ b/addons/l10n_hu_edi/wizard/account_move_debit.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class AccountDebitNote(models.TransientModel):
+    _inherit = 'account.debit.note'
+
+    def _prepare_default_values(self, move):
+        default_values = super()._prepare_default_values(move)
+        if move.company_id.account_fiscal_country_id.code == "HU":
+            default_values.update({
+                'delivery_date': move.delivery_date
+            })
+        return default_values

--- a/addons/l10n_hu_edi/wizard/account_move_reversal.py
+++ b/addons/l10n_hu_edi/wizard/account_move_reversal.py
@@ -4,6 +4,14 @@ from odoo import models
 class AccountMoveReversal(models.TransientModel):
     _inherit = 'account.move.reversal'
 
+    def _prepare_default_reversal(self, move):
+        res = super()._prepare_default_reversal(move)
+        if move.company_id.account_fiscal_country_id.code == "HU":
+            res.update({
+                'delivery_date': move.delivery_date
+            })
+        return res
+
     def reverse_moves(self, is_modify=False):
         action = super().reverse_moves(is_modify=is_modify)
         if is_modify:


### PR DESCRIPTION
This **PR** enhances the default values for Hungarian electronic invoicing (EDI) by ensuring the delivery date is copied from the original invoice to the corresponding credit or debit note.

**task**-4818819
