### PR TITLE
[FIX] base: show type for address types without name

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -988,11 +988,13 @@ class ResPartner(models.Model):
         'show_email', 'show_vat', 'lang', 'formatted_display_name'
     )
     def _compute_display_name(self):
+        type_description = dict(self._fields['type']._description_selection(self.env))
         for partner in self:
             if partner._context.get("formatted_display_name"):
                 name = partner.name or ''
                 if partner.parent_id or partner.company_name:
-                    name = f"{partner.company_name or partner.parent_id.name} \t --{partner.name}--"
+                    name = (f"{partner.company_name or partner.parent_id.name} \t "
+                            f"--{partner.name or type_description.get(partner.type, '')}--")
 
                 if partner._context.get('show_email') and partner.email:
                     name = f"{name} \t --{partner.email}--"

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1014,6 +1014,14 @@ class TestPartnerAddressCompany(TransactionCase):
         res_bhide = test_partner_bhide.with_context(show_address=1).display_name
         self.assertEqual(res_bhide, "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
 
+        # Check that a child contact having no name shows the formatted display name as {parent_name} \t --{contact_type}--
+        test_partner_invoice = self.env['res.partner'].create({'parent_id': self.test_parent.id, 'type': 'invoice'})
+        self.assertEqual(
+            test_partner_invoice.with_context(formatted_display_name=True).display_name,
+            "GhostStep \t --Invoice--",
+            "Formatted display name should show parent name and type when child contact has no name",
+        )
+
     def test_accessibility_of_company_partner_from_branch(self):
         """ Check accessibility of company partner from branch. """
         company = self.env['res.company'].create({'name': 'company'})


### PR DESCRIPTION
Steps to reproduce
===============
1. Create a company called Acme.
2. Create a child contact of type Invoicing address but do not give it any name.
3. Go to Sales.
4. Open the dropdown to select customer ---> Recipient without name will show False after the parent name

From commit [Commit 1], formatted display name was added. After this commit, add a fallback as customer's type to the name.

[Commit 1]: https://github.com/odoo/odoo/commit/4f594949164f7ee6753f1da92222d2bd904d1d58

Task-4812554
