### PR TITLE
[REV] sale: re-add empty line to SOL attribute description

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -422,7 +422,7 @@ class SaleOrderLine(models.Model):
         if not self.product_custom_attribute_value_ids and not no_variant_ptavs:
             return ""
 
-        name = ""
+        name = "\n"
 
         custom_ptavs = self.product_custom_attribute_value_ids.custom_product_template_attribute_value_id
         multi_ptavs = no_variant_ptavs.filtered(lambda ptav: ptav.display_type == 'multi').sorted()

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -341,11 +341,34 @@ class TestSaleOrder(SaleCommon):
 
     def test_sol_names(self):
         """Check that the SOL description gets used for the display name."""
+        no_variant_attr = self.env['product.attribute'].create({
+            'name': "Attribute",
+            'create_variant': 'no_variant',
+            'value_ids': [
+                Command.create({'name': "Value 1", 'sequence': 1}),
+                Command.create({'name': "Value 2", 'sequence': 2}),
+            ],
+        })
+        no_variant_product_tmpl = self.env['product.template'].create({
+            'name': "No Variant",
+            'attribute_line_ids': [Command.create({
+                'attribute_id': no_variant_attr.id,
+                'value_ids': no_variant_attr.value_ids.ids,
+            })],
+        })
+        no_variant_product = no_variant_product_tmpl.product_variant_id
+        ptals = no_variant_product_tmpl.valid_product_template_attribute_line_ids
+        ptav1 = next(iter(ptals.product_template_value_ids))
+
         self.sale_order.order_line = [
             Command.create({'is_downpayment': True}),
             Command.create({'display_type': 'line_note', 'name': "Foo\nBar\nBaz"}),
+            Command.create({
+                'product_id': no_variant_product.id,
+                'product_no_variant_attribute_value_ids': ptav1.ids,
+            }),
         ]
-        sol1, sol2, sol3, sol4 = self.sale_order.order_line
+        sol1, sol2, sol3, sol4, sol5 = self.sale_order.order_line
         sol1.name += "\nOK THANK YOU\nGOOD BYE"
 
         self.assertEqual(
@@ -367,6 +390,12 @@ class TestSaleOrder(SaleCommon):
             sol4.display_name,
             f"{self.sale_order.name} - Foo ({self.partner.name})",
             "Multi-line note should display the first line only",
+        )
+        self.assertIn(f"{no_variant_attr.name}: {ptav1.name}", sol5.name.split('\n'))
+        self.assertEqual(
+            sol5.display_name,
+            f"{self.sale_order.name} - {no_variant_product.name} ({self.partner.name})",
+            "Lines with attribute-based descriptions should display the product name",
         )
 
     def test_state_changes(self):

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -321,7 +321,7 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
         })
         sale_order.action_confirm()
         pol = sale_order._get_purchase_orders().order_line
-        self.assertEqual(pol.name, f"{self.service_purchase_1.display_name}\n{product_attribute.name}: {product_attribute_value.name}: {custom_value}")
+        self.assertEqual(pol.name, f"{self.service_purchase_1.display_name}\n\n{product_attribute.name}: {product_attribute_value.name}: {custom_value}")
 
     def test_service_to_purchase_multi_company(self):
         """Test the service to purchase in a multi-company environment

--- a/addons/website_sale/tests/test_website_sale_product_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_product_configurator.py
@@ -156,7 +156,7 @@ class TestWebsiteSaleProductConfigurator(
         # Check the name of the created sale order line
         new_sale_order = self.env['sale.order'].search([]) - old_sale_order
         new_order_line = new_sale_order.order_line
-        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\nNever attribute size: M never\nNever attribute size custom: Yes never custom: TEST')
+        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\n\nNever attribute size: M never\nNever attribute size custom: Yes never custom: TEST')
 
     def test_product_configurator_force_dialog(self):
         """ Test that the product configurator is shown if forced. """


### PR DESCRIPTION
This reverts commit 2094747717be

Versions
--------
- 18.0+

Steps
-----
1. Create a service product that creates a task on order confirmation;
2. add an attribute that does not create variants;
3. add the product to an order;
4. confirm the order.

Issue
-----
1. The task is named as the attribute.
2. The line's `display_name` shows the attribute instead of the product.

Cause
-----
Commit 2094747717be removed the extra new line that was added before attribute-based line descriptions for custom attributes and attributes that create no variants.

This did not impact the task or display name in previous versions, as the default sale order description started with the product name, and could be replaced.
But as of 18.0, while the default sale order description still starts with the product name, it's no longer possible to replace it, hence it gets skipped to get the first line of the editable description, which in this case is the attribute name.

Solution
--------
By re-adding the empty line before the attribute descriptions, the display & task names will fall back on the product name.

See commit 47d223759f07 for display name & c3877b2acd74 for task names.

Also adds a test to prevent regression.

opw-4792351