### PR TITLE
[FIX] account: pick correct accounts for foreign tax groups

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -928,7 +928,7 @@ class AccountChartTemplate(models.AbstractModel):
         # Assign the account based on the map
         for field, account_name in field_and_names:
             for tax_group in tax_group_data.values():
-                tax_group[field] = existing_accounts.get(account_template_xml_id)
+                tax_group[field] = existing_accounts.get(tax_group.get(field))
 
         for tax_template in tax_data.values():
             # This is required because the country isn't provided directly by the template


### PR DESCRIPTION
The code to create foreign taxes (and tax groups) from another country's chart template had a bug in it (discovered during the change of tax accounts in 18.0).

The process works as follows, given we are a US company wanting to map taxes from the BE localization:
1. We loop over all BE taxes and create a mapping from each account used in a BE tax's repartition lines to a (new) account in the US company, created based on the account in the BE repartition line.
2. We create tax groups in the US company, copied from the BE localization, but their accounts replaced by looking them up in the mapping we created in the previous step.

In the second step however, instead of mapping the account from the original BE tax group, we were mapping the last account encountered in step 1. This was incorrect.

This commit fixes that.

task-3763030

(Backport of 18.0)