### PR TITLE
[IMP] web: tree editor: various improvements

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -42,7 +42,7 @@ export class Domain {
 
     /**
      * Combine various domains together with `AND` operator
-     * @param {DomainRepr} domains
+     * @param {DomainRepr[]} domains
      * @returns {Domain}
      */
     static and(domains) {
@@ -51,7 +51,7 @@ export class Domain {
 
     /**
      * Combine various domains together with `OR` operator
-     * @param {DomainRepr} domains
+     * @param {DomainRepr[]} domains
      * @returns {Domain}
      */
     static or(domains) {
@@ -356,7 +356,10 @@ function matchCondition(record, condition) {
             if (fieldValue === false) {
                 return isNot;
             }
-            return Boolean(new RegExp(escapeRegExp(value).replace(/%/g, ".*")).test(fieldValue)) != isNot;
+            return (
+                Boolean(new RegExp(escapeRegExp(value).replace(/%/g, ".*")).test(fieldValue)) !=
+                isNot
+            );
         case "ilike":
         case "not ilike":
             if (fieldValue === false) {
@@ -368,7 +371,11 @@ function matchCondition(record, condition) {
             if (fieldValue === false) {
                 return isNot;
             }
-            return Boolean(new RegExp(escapeRegExp(value).replace(/%/g, ".*"), "i").test(fieldValue)) != isNot;
+            return (
+                Boolean(
+                    new RegExp(escapeRegExp(value).replace(/%/g, ".*"), "i").test(fieldValue)
+                ) != isNot
+            );
         case "any":
         case "not any":
             return true;

--- a/addons/web/static/src/core/domain_selector/domain_selector.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector.js
@@ -7,7 +7,6 @@ import {
     formatValue,
     condition,
 } from "@web/core/tree_editor/condition_tree";
-import { useLoadFieldInfo } from "@web/core/model_field_selector/utils";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { deepEqual } from "@web/core/utils/objects";
 import { getDomainDisplayedOperators } from "@web/core/domain_selector/domain_selector_operator_editor";
@@ -44,7 +43,6 @@ export class DomainSelector extends Component {
 
     setup() {
         this.fieldService = useService("field");
-        this.loadFieldInfo = useLoadFieldInfo(this.fieldService);
         this.makeGetFieldDef = useMakeGetFieldDef(this.fieldService);
 
         this.tree = null;

--- a/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.xml
+++ b/addons/web/static/src/core/domain_selector_dialog/domain_selector_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.DomainSelectorDialog">
-        <Dialog title="dialogTitle">
+        <Dialog title="dialogTitle" size="'xl'">
             <div t-if="props.text" class="mb-3" t-out="props.text"/>
             <DomainSelector t-props="domainSelectorProps" />
             <t t-set-slot="footer">

--- a/addons/web/static/src/core/expression_editor_dialog/expression_editor_dialog.xml
+++ b/addons/web/static/src/core/expression_editor_dialog/expression_editor_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ExpressionEditorDialog">
-        <Dialog title.translate="Edit Condition">
+        <Dialog title.translate="Edit Condition" size="'xl'">
             <ExpressionEditor t-props="expressionEditorProps" />
             <t t-set-slot="footer">
                 <button class="btn btn-primary" t-on-click="onConfirm" t-ref="confirm">Confirm</button>

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -55,7 +55,7 @@ const { DateTime } = luxon;
  * @property {boolean} [distributeNot]
  */
 
-export const TERM_OPERATORS_NEGATION = {
+const TERM_OPERATORS_NEGATION = {
     "<": ">=",
     ">": "<=",
     "<=": ">",
@@ -350,10 +350,6 @@ function getNormalizedCondition(condition) {
     return { ...condition, operator, negate };
 }
 
-function normalizeCondition(condition) {
-    Object.assign(condition, getNormalizedCondition(condition));
-}
-
 /**
  * @param {AST[]} ASTs
  * @param {Options} [options={}]
@@ -398,7 +394,6 @@ function _construcTree(ASTs, options = {}, negate = false) {
                 tree.value = Array.isArray(tree.value) ? tree.value : [tree.value];
             }
         }
-        normalizeCondition(tree);
     }
     let remaimingASTs = tailASTs;
     if (tree.type === "connector") {
@@ -869,7 +864,7 @@ function normalizeConnector(connector) {
         if (newTree.negate) {
             const newChild = { ...child, negate: !child.negate };
             if (newChild.type === "condition") {
-                return getNormalizedCondition(newChild);
+                return newChild;
             }
             return newChild;
         }

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -1651,23 +1651,3 @@ export function treeFromDomain(domain, options = {}) {
     const tree = construcTree(domain, options);
     return applyTransformations(FULL_VIRTUAL_OPERATORS_CREATION, tree, options);
 }
-
-/**
- * @param {DomainRepr} domain a string representation of a domain
- * @param {Options} [options={}]
- * @returns {string} an expression
- */
-export function expressionFromDomain(domain, options = {}) {
-    const tree = treeFromDomain(domain, options);
-    return expressionFromTree(tree, options);
-}
-
-/**
- * @param {string} expression an expression
- * @param {Options} [options={}]
- * @returns {string} a string representation of a domain
- */
-export function domainFromExpression(expression, options = {}) {
-    const tree = treeFromExpression(expression, options);
-    return domainFromTree(tree);
-}

--- a/addons/web/static/src/core/tree_editor/tree_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor.js
@@ -1,7 +1,6 @@
 import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
-import { ModelFieldSelector } from "@web/core/model_field_selector/model_field_selector";
 import { useLoadFieldInfo } from "@web/core/model_field_selector/utils";
 import {
     areEquivalentTrees,
@@ -28,7 +27,6 @@ export class TreeEditor extends Component {
     static components = {
         Dropdown,
         DropdownItem,
-        ModelFieldSelector,
         TreeEditor,
     };
     static props = {

--- a/addons/web/static/src/core/tree_editor/tree_editor.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor.xml
@@ -176,7 +176,7 @@
         </t>
         <t t-elif="info.component">
             <div t-attf-class="o_tree_editor_editor #{_classes}">
-                <t t-component="info.component" t-props="info.extractProps({ update, value })" />
+                <t t-component="info.component" t-props="info.extractProps({ update, value, displayPlaceholder })" />
             </div>
         </t>
     </t>

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.js
@@ -3,12 +3,12 @@ import { TagsList } from "@web/core/tags_list/tags_list";
 import { _t } from "@web/core/l10n/translation";
 
 export class Input extends Component {
-    static props = ["value", "update", "startEmpty?"];
+    static props = ["value", "update", "placeholder?", "startEmpty?"];
     static template = "web.TreeEditor.Input";
 }
 
 export class Select extends Component {
-    static props = ["value", "update", "options", "addBlankOption?"];
+    static props = ["value", "update", "options", "placeholder?", "addBlankOption?"];
     static template = "web.TreeEditor.Select";
 
     deserialize(value) {

--- a/addons/web/static/src/core/tree_editor/tree_editor_components.xml
+++ b/addons/web/static/src/core/tree_editor/tree_editor_components.xml
@@ -2,14 +2,14 @@
 <templates xml:space="preserve">
 
     <t t-name="web.TreeEditor.Input">
-        <input type="text" class="o_input" t-att-value="props.startEmpty ? '' : props.value" t-on-change="(ev) => props.update(ev.target.value)" />
+        <input type="text" class="o_input" t-att-value="props.startEmpty ? '' : props.value" t-att-placeholder="props.placeholder" t-on-change="(ev) => props.update(ev.target.value)" />
     </t>
 
     <t t-name="web.TreeEditor.Select">
         <select class="o_input pe-3 text-truncate" t-on-change="(ev) => props.update(deserialize(ev.target.value))">
-            <option t-if="props.addBlankOption" hidden="true" />
+            <option class="o_select_placeholder" t-if="props.addBlankOption" hidden="true" t-esc="props.placeholder ? props.placeholder : ''"/>
             <t t-foreach="props.options" t-as="option" t-key="serialize(option[0])">
-                <option t-att-value="serialize(option[0])" t-att-selected="!props.addBlankOption and option[0] === props.value" t-esc="option[1]" />
+                <option class="text-black" t-att-value="serialize(option[0])" t-att-selected="!props.addBlankOption and option[0] === props.value" t-esc="option[1]" />
             </t>
         </select>
     </t>
@@ -57,6 +57,7 @@
                     <t t-set="info" t-value="props.editorInfo" />
                     <t t-set="value" t-value="props.editorInfo.defaultValue()" />
                     <t t-set="update" t-value="(val) => this.update(val)" />
+                    <t t-set="displayPlaceholder" t-value="!tags.length" />
                 </t>
             </div>
         </div>

--- a/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_datetime_options.js
@@ -25,7 +25,7 @@ const CURRENT_MONTH = `context_today().month`;
 const CURRENT_DAY = `context_today().day`;
 
 let day_of_week_options;
-export const OPTIONS = {
+export const OPTIONS_WITH_SELECT = {
     month_number: [
         [CURRENT_MONTH, _t("This month")],
         ...range(1, 12).map((month) => [
@@ -67,34 +67,23 @@ function fromSelectValue(v) {
     return typeof v === "string" ? new Expression(v) : v;
 }
 
-function makePartialValueEditorInfo(name) {
-    const options = OPTIONS[name];
+export function getEditorInfoForOptionsWithSelect(name, params) {
+    const options = OPTIONS_WITH_SELECT[name];
+    const getOption = (value) => options.find(([v]) => v === toSelectValue(value)) || null;
     return {
         component: Select,
-        extractProps: ({ value, update }) => ({
+        extractProps: ({ value, update, displayPlaceholder }) => ({
             value: toSelectValue(value),
             update: (value) => update(fromSelectValue(value)),
             options,
+            addBlankOption: params.addBlankOption,
+            placeholder: displayPlaceholder && _t(`Select one or several criteria`),
         }),
         defaultValue: getCurrent(UNITS[name]),
-        isSupported: (value) =>
-            typeof value !== "string" && options.find(([v]) => v === toSelectValue(value)),
+        isSupported: (value) => typeof value !== "string" && getOption(value),
         message: _t("Value not in selection"),
     };
 }
-
-let day_of_week_editor_info;
-export const OPTIONS_WITH_SELECT = {
-    month_number: makePartialValueEditorInfo("month_number"),
-    day_of_month: makePartialValueEditorInfo("day_of_month"),
-    quarter_number: makePartialValueEditorInfo("quarter_number"),
-    get day_of_week() {
-        if (!day_of_week_editor_info) {
-            day_of_week_editor_info = makePartialValueEditorInfo("day_of_week");
-        }
-        return day_of_week_editor_info;
-    },
-};
 
 export const OPTIONS_WITH_INPUT = {
     year_number: {

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -1,11 +1,6 @@
 import { _t } from "@web/core/l10n/translation";
-import {
-    formatValue,
-    TERM_OPERATORS_NEGATION,
-    toValue,
-} from "@web/core/tree_editor/condition_tree";
-import { sprintf } from "@web/core/utils/strings";
 import { parseExpr } from "@web/core/py_js/py";
+import { formatValue, toValue } from "@web/core/tree_editor/condition_tree";
 import { Select } from "@web/core/tree_editor/tree_editor_components";
 
 const OPERATOR_DESCRIPTIONS = {
@@ -93,18 +88,20 @@ function getOperatorDescription(operator, fieldDefType) {
     return description;
 }
 
-export function getOperatorLabel(operator, fieldDefType, negate = false) {
+export function getOperatorLabel(
+    operator,
+    fieldDefType,
+    negate = false,
+    getDescr = (operator, fieldDefType) => null
+) {
     let label;
     if (typeof operator === "string" && operator in OPERATOR_DESCRIPTIONS) {
-        if (negate && operator in TERM_OPERATORS_NEGATION) {
-            return getOperatorDescription(TERM_OPERATORS_NEGATION[operator], fieldDefType);
-        }
-        label = getOperatorDescription(operator, fieldDefType);
+        label = getDescr(operator, fieldDefType) || getOperatorDescription(operator, fieldDefType);
     } else {
         label = formatValue(operator);
     }
     if (negate) {
-        return sprintf(`not %s`, label);
+        return _t(`not %(operator_label)s`, { operator_label: label });
     }
     return label;
 }

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -14,7 +14,7 @@ import {
     normalizeValue,
     splitPath,
 } from "@web/core/tree_editor/condition_tree";
-import { OPTIONS } from "@web/core/tree_editor/tree_editor_datetime_options";
+import { OPTIONS_WITH_SELECT } from "@web/core/tree_editor/tree_editor_datetime_options";
 import { getOperatorLabel } from "@web/core/tree_editor/tree_editor_operator_editor";
 import { unique, zip } from "@web/core/utils/arrays";
 import { useService } from "@web/core/utils/hooks";
@@ -28,8 +28,12 @@ import { Within } from "./tree_editor_components";
  * @returns
  */
 function formatValue(val, disambiguate, fieldDef, displayNames) {
-    if (fieldDef?.type === "date_option" && fieldDef.name in OPTIONS && typeof val !== "string") {
-        const options = OPTIONS[fieldDef.name];
+    if (
+        fieldDef?.type === "date_option" &&
+        fieldDef.name in OPTIONS_WITH_SELECT &&
+        typeof val !== "string"
+    ) {
+        const options = OPTIONS_WITH_SELECT[fieldDef.name];
         const valToCompare = val instanceof Expression ? val._expr : val;
         const [, label] = (options || []).find(([v]) => v === valToCompare) || [];
         if (label !== undefined) {

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -175,23 +175,20 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
         operator = operator === "in" ? "not_set" : "set";
     }
     const fieldDef = getFieldDef(path);
-    let operatorLabel = getOperatorLabel(operator, fieldDef?.type, negate);
-    switch (operator) {
-        case "=":
-        case "in":
-            operatorLabel = "=";
-            break;
-        case "!=":
-        case "not in":
-            operatorLabel = _t("not =");
-            break;
-        case "any":
-            operatorLabel = ":";
-            break;
-        case "not any":
-            operatorLabel = _t(": not");
-            break;
-    }
+    const operatorLabel = getOperatorLabel(operator, fieldDef?.type, negate, (operator) => {
+        switch (operator) {
+            case "=":
+            case "in":
+                return "=";
+            case "!=":
+            case "not in":
+                return _t("not =");
+            case "any":
+                return ":";
+            case "not any":
+                return _t(": not");
+        }
+    });
 
     const pathDescription = getPathDescription(path);
     const description = {

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -3279,3 +3279,50 @@ test("hide today, next, last operators when allowExpressions = False", async () 
         "not set",
     ]);
 });
+
+test("many2one: placeholders for in operator", async () => {
+    await makeDomainSelector({
+        domain: `[("product_id", "in", [])]`,
+    });
+    expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
+        "placeholder",
+        `Select one or several criteria`
+    );
+});
+
+test("datetime: placeholders for in operator", async () => {
+    await makeDomainSelector({
+        domain: `[("datetime", "in", [])]`,
+    });
+    expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
+        "placeholder",
+        `Select one or several criteria`
+    );
+});
+
+test("date: placeholders for in operator", async () => {
+    await makeDomainSelector({
+        domain: `[("date", "in", [])]`,
+    });
+    expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
+        "placeholder",
+        `Select one or several criteria`
+    );
+});
+
+test("char: placeholders for in operator", async () => {
+    await makeDomainSelector({
+        domain: `[("display_name", "in", [])]`,
+    });
+    expect(`${SELECTORS.valueEditor} input`).toHaveAttribute(
+        "placeholder",
+        `Press "Enter" to add criterion`
+    );
+});
+
+test("selection: placeholders for in operator", async () => {
+    await makeDomainSelector({
+        domain: `[("state", "in", [])]`,
+    });
+    expect(`${SELECTORS.valueEditor} select`).toHaveValue(`Select one or several criteria`);
+});

--- a/addons/web/static/tests/core/domain_selector/domain_selector.test.js
+++ b/addons/web/static/tests/core/domain_selector/domain_selector.test.js
@@ -801,11 +801,11 @@ test("support of connector '!' (mode readonly)", async () => {
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "=", "def"), ("foo", "!=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\nnot =\nabc\nany\nof:\nFoo\nnot =\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nnot =\nabc\nany\nof:\nFoo\nnot =\ndef\nFoo\nnot not =\nghi`,
         },
         {
             domain: `["!", "|", ("foo", "=", "abc"), "&", ("foo", "!=", "def"), "!", ("foo", "=", "ghi")]`,
-            result: `Match\nall\nof the following rules:\nFoo\nnot =\nabc\nany\nof:\nFoo\n=\ndef\nFoo\n=\nghi`,
+            result: `Match\nall\nof the following rules:\nFoo\nnot =\nabc\nany\nof:\nFoo\nnot not =\ndef\nFoo\n=\nghi`,
         },
     ];
 
@@ -2878,7 +2878,7 @@ test("datetime options (readonly)", async () => {
                 ("datetime.minute_number", "!=", 40),
                 ("datetime.second_number", "!=", 30),
             ]`,
-            text: `Datetime ➔ Time = 15:40:30`,
+            text: `Datetime ➔ Time ➔ Hour not not = 15`, // first line here
         },
         {
             domain: `[

--- a/addons/web/static/tests/core/tree_editor/condition_tree.test.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree.test.js
@@ -6,15 +6,23 @@ import {
     complexCondition,
     condition,
     connector,
-    domainFromExpression,
     domainFromTree,
     expression,
-    expressionFromDomain,
     expressionFromTree,
     treeFromDomain,
     treeFromExpression,
 } from "@web/core/tree_editor/condition_tree";
 import { makeMockEnv } from "@web/../tests/web_test_helpers";
+
+function expressionFromDomain(domain, options = {}) {
+    const tree = treeFromDomain(domain, options);
+    return expressionFromTree(tree, options);
+}
+
+function domainFromExpression(expression, options = {}) {
+    const tree = treeFromExpression(expression, options);
+    return domainFromTree(tree);
+}
 
 describe.current.tags("headless");
 

--- a/addons/web/static/tests/core/tree_editor/condition_tree.test.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree.test.js
@@ -144,7 +144,7 @@ test("domainFromTree . treeFromDomain", async () => {
         },
         {
             domain: `["!", ("foo", "=", False)]`,
-            result: `[("foo", "!=", False)]`,
+            result: `["!", ("foo", "=", False)]`,
         },
         {
             domain: `[("foo", "=?", False)]`,


### PR DESCRIPTION
We bring several improvements to the tree editor/domain selector.
- We make various editors display placeholders when used for a in/not in operator.
- we stop distribute "!" on operators completely since it is not valid generally
- We check equality on every update since we have more and more operations that do not modify the trees at the level of the final conditions they represent 
- The domain selector/expression editor dialogs have now bigger sizes

Part of task ID: 4610804
