### PR TITLE
[FIX] partnership: share partnership with children of the partner

### DIFF
--- a/addons/partnership/models/res_partner.py
+++ b/addons/partnership/models/res_partner.py
@@ -12,6 +12,7 @@ class ResPartner(models.Model):
     def write(self, values):
         if values.get('grade_id'):
             grade = self.env['res.partner.grade'].browse(values['grade_id'])
+            self.child_ids.grade_id = grade
             if grade.default_pricelist_id:
                 pricelist = values.get('specific_property_product_pricelist') or values.get('property_product_pricelist')
                 if pricelist and pricelist != grade.default_pricelist_id.id:

--- a/addons/partnership/models/sale_order.py
+++ b/addons/partnership/models/sale_order.py
@@ -33,7 +33,4 @@ class SaleOrder(models.Model):
         for so in self:
             if not so.assigned_grade_id:
                 continue
-            partner_id = so.partner_id.commercial_partner_id
-            partner_id.grade_id = so.assigned_grade_id
-            if pricelist := so.assigned_grade_id.default_pricelist_id:
-                partner_id.specific_property_product_pricelist = pricelist
+            so.partner_id.grade_id = so.assigned_grade_id

--- a/addons/partnership/tests/common.py
+++ b/addons/partnership/tests/common.py
@@ -25,3 +25,4 @@ class PartnershipCommon(ProductCommon):
             'partner_id': cls.partner.id,
             'order_line': [Command.create({'product_id': cls.partnership_product.id})],
         })
+        cls.partner.child_ids = [Command.create({'name': 'Child 1'})]

--- a/addons/partnership/tests/test_partnership.py
+++ b/addons/partnership/tests/test_partnership.py
@@ -23,6 +23,50 @@ class TestPartnership(PartnershipCommon):
             "Selling the partnership should assign the pricelist to the partner",
         )
 
+    def test_sell_basic_partnership_to_partner_with_children(self):
+        self.sale_order_partnership.action_confirm()
+        self.assertEqual(
+            self.partner.child_ids.grade_id,
+            self.partnership_product.grade_id,
+            "Selling the partnership should assign the grade to the children of the partner",
+        )
+        self.assertEqual(
+            self.partner.child_ids.specific_property_product_pricelist,
+            self.partnership_product.grade_id.default_pricelist_id,
+            "Selling the partnership should assign the pricelist to the children of the partner",
+        )
+
+    def test_sell_basic_partnership_to_children_partners(self):
+        partner_with_children = self.env['res.partner'].create({
+            'name': 'Parent Company',
+            'child_ids': [
+                Command.create({'name': 'Child Company 1'}),
+                Command.create({'name': 'Child Company 2'}),
+            ],
+        })
+        for child in partner_with_children.child_ids:
+            sale_order_partnership_with_child = self.env['sale.order'].create({
+                'partner_id': child.id,
+                'order_line': [Command.create({'product_id': self.partnership_product.id})],
+            })
+            sale_order_partnership_with_child.action_confirm()
+            self.assertEqual(
+                child.grade_id,
+                self.partnership_product.grade_id,
+                "Selling the partnership to the child should assign the grade to the child",
+            )
+            self.assertFalse(
+                partner_with_children.grade_id,
+                "Selling the partnership to the child should not assign the grade to the parent",
+            )
+            for c in partner_with_children.child_ids:
+                if c != child:
+                    self.assertFalse(
+                        c.grade_id,
+                        "Selling the partnership to the child should not assign the grade to another child",
+                    )
+            child.grade_id = False
+
     def test_constrains_uniqueness_partnership_grade(self):
         partnership = self.env['product.product'].create({
             'name': 'Partnership',


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
Correct the behaviour of the member level assignment in membership when childs partners are concerned. 
Current behavior before PR:
When buying a membership with a child partner apply the Level and the Pricelist to the Parent but those are not forwarded to the child.
Desired behavior after PR is merged:
A partner buying a membership should forward the membership level and Pricelist to its children. A child buying a membership should get that membership without forwarding it to its parent.

TASK-4801759

