### PR TITLE
[IMP] web: reset `lastSuiteName` after GC

### DIFF
--- a/addons/web/static/tests/_framework/module_set.hoot.js
+++ b/addons/web/static/tests/_framework/module_set.hoot.js
@@ -592,11 +592,12 @@ export async function runTests(options) {
     // Run all test files
     const filteredSuitePaths = new Set(suites.map((s) => s.fullName));
     let currentAddonsKey = "";
-    let lastSuiteName = undefined;
+    let lastSuiteName = null;
     let lastNumberTests = 0;
     for (const moduleName of testModuleNames) {
         if (lastSuiteName) {
             await __gcAndLogMemory(lastSuiteName, lastNumberTests);
+            lastSuiteName = null;
         }
         const suitePath = getSuitePath(moduleName);
         if (!filteredSuitePaths.has(suitePath)) {


### PR DESCRIPTION
Because the `lastSuiteName` is not reset, if the JS test suite is filtered and a module is not selected, as long as at least one test has run previously the GC will be run.

When trying to run just a few tests which happen to be early in the suite, this can lead to a cascade of GC-ing taking longer than the actual test suite.


Example effect: https://asciinema.org/a/USjAorOttupjBxGwWYBqLL6yA?t=46 (will go dead in 7 days)