### PR TITLE
[FIX] l10n_it_edi_withholding: prevent existing tax loaded at install

### DIFF
--- a/addons/l10n_it_edi_withholding/__init__.py
+++ b/addons/l10n_it_edi_withholding/__init__.py
@@ -12,6 +12,10 @@ def _l10n_it_edi_withholding_post_init(env):
         ChartTemplate = env['account.chart.template'].with_company(company)
         ChartTemplate._load_data({
             'account.account': ChartTemplate._get_it_withholding_account_account(),
-            'account.tax': ChartTemplate._get_it_withholding_account_tax(),
+            'account.tax': {
+                xml_id: data
+                for xml_id, data in ChartTemplate._get_it_withholding_account_tax().items()
+                if not env.ref(f"account.{company.id}_{xml_id}", raise_if_not_found=False)
+            },
             'account.tax.group': ChartTemplate._get_it_withholding_account_tax_group(),
         })


### PR DESCRIPTION
- Install l10n_it_edi.
- Install l10n_it_edi_withholding
- Uninstall l10n_it_edi_withholding
- Attempt an install of l10n_it_edi_withholding

The following error appears: Invoice and credit note distribution should each contain exactly one line for the base.

When uninstalling l10n_it_edi_withholding, the account.tax data are not unlinked which causes issues when _l10n_it_edi_withholding_post_init tries to _load_data with them.

This commit prevents already existing account tax from being loaded from data during the installation.

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4798659)
opw-4798659