### PR TITLE
[FIX] website: redirect on iframe reloaded

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -406,7 +406,13 @@ export class WebsiteBuilder extends Component {
         this.setIframeLoaded();
         this.websiteService.websiteRootInstance = undefined;
         if (url) {
-            this.websiteContent.el.contentWindow.location = encodeURIComponent(url);
+            const urlObj = new URL(url, this.websiteContent.el.contentWindow.location);
+            const pathSegments = urlObj.pathname.split("/").map(encodeURIComponent);
+            const encodedPath = pathSegments.join("/");
+            this.websiteContent.el.contentWindow.location.href = new URL(
+                encodedPath,
+                this.websiteContent.el.contentWindow.location
+            );
         } else {
             this.websiteContent.el.contentWindow.location.reload();
         }


### PR DESCRIPTION
Encoding the entire URL with encodeURIComponent will break navigation by
converting separators and causing the browser to treat it as a relative
path instead of an absolute URL. This PR follows [the html_builder refactoring]. 

[the html_builder refactoring]: 9fe45e2b7ddb

Related to task-4367641