### PR TITLE
[IMP] account: Show "New" button in "Tax Groups" list view

### DIFF
--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -245,7 +245,7 @@
             <field name="name">account.tax.group.list</field>
             <field name="model">account.tax.group</field>
             <field name="arch" type="xml">
-                <list string="Account Tax Group" editable="bottom" create="false" open_form_view="True">
+                <list string="Account Tax Group" editable="bottom" open_form_view="True">
                     <field name="sequence" widget="handle"/>
                     <field name="name"/>
                     <field name="country_id"/>


### PR DESCRIPTION
Creating a Tax Group manually is an advanced configuration, but it should be possible from the list view (available in debug mode). It's already very easy to do from the Tax Group field on Taxes anyway, and it's also possible from the tax group form view. There's no reason to hide/not have a new button on the list view.

task-4798892



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
