### PR TITLE
[FIX] website: searchbar button behavior

### DIFF
--- a/addons/website/static/src/snippets/s_searchbar/search_bar_btn.edit.js
+++ b/addons/website/static/src/snippets/s_searchbar/search_bar_btn.edit.js
@@ -1,0 +1,20 @@
+import { Interaction } from "@web/public/interaction";
+import { registry } from "@web/core/registry";
+
+export class SearchBarBtnEdit extends Interaction {
+    static selector = ".o_searchbar_form .oe_search_button";
+
+    dynamicContent = {
+        _root: {
+            "t-on-click": this.onClick,
+        },
+    };
+
+    onClick(ev) {
+        ev.preventDefault();
+    }
+}
+
+registry.category("public.interactions.edit").add("website.search_bar_btn", {
+    Interaction: SearchBarBtnEdit,
+});


### PR DESCRIPTION
problem:
The searchbar button was clickable and redirected to the search results page even while editing the website. It shouldn't be able to redirect while the editor is opened.

fix:
added an edit interaction for the searchbar button. It will preventdefault the button on click, so it doesn't submit the searchbar form while the editor is opened.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
