### PR TITLE
[IMP] website_event_*: fix the display of the buttons for the events' menu on the website

### DIFF
--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -37,13 +37,17 @@
             </div>
             <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div name="event_menu_configuration" groups="base.group_no_one">
-                    <label for="website_menu" string="Website Submenu"/>
-                    <field name="website_menu"/>
+                    <span name="website_menu">
+                        <label for="website_menu" string="Website Submenu"/>
+                        <field name="website_menu"/>
+                    </span>
                     <!-- hidden sub-menus, they are triggered all at once based on "website_menu" -->
                     <field name="introduction_menu" invisible="1"/>
                     <field name="register_menu" invisible="1"/>
-                    <label for="community_menu" string="Community" invisible="1"/>
-                    <field name="community_menu" invisible="1"/>
+                    <span name="community_menu" class="d-inline-block ms-2" invisible="1">
+                        <label for="community_menu" string="Community"/>
+                        <field name="community_menu"/>
+                    </span>
                 </div>
             </xpath>
             <field name="tag_ids" position="attributes">

--- a/addons/website_event/views/event_type_views.xml
+++ b/addons/website_event/views/event_type_views.xml
@@ -7,11 +7,11 @@
         <field name="inherit_id" ref="event.view_event_type_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[hasclass('oe_title')]" position="after">
-                    <span name="website_menu">
+                    <span name="website_menu" class="d-inline-block">
                         <label for="website_menu" string="Website Submenu"/>
                         <field name="website_menu"/>
                     </span>
-                    <span name="community_menu" invisible="1">
+                    <span name="community_menu" class="ms-2" invisible="1">
                         <label for="community_menu" string="Community"/>
                         <field name="community_menu"/>
                     </span>

--- a/addons/website_event_booth/views/event_event_views.xml
+++ b/addons/website_event_booth/views/event_event_views.xml
@@ -9,10 +9,12 @@
             <field name="badge_format" position="before">
                 <field name="exhibition_map"/>
             </field>
-            <field name="website_menu" position="after">
-                <label for="booth_menu"/>
-                <field name="booth_menu"/>
-            </field>
+            <xpath expr="//span[@name='website_menu']" position="after">
+                <span name="booth_menu" class="ms-2">
+                    <label for="booth_menu"/>
+                    <field name="booth_menu"/>
+                </span>
+            </xpath>
         </field>
     </record>
 

--- a/addons/website_event_booth/views/event_type_views.xml
+++ b/addons/website_event_booth/views/event_type_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//span[@name='website_menu']" position='after'>
-                <span>
+                <span class="ms-2">
                     <label for="booth_menu" string="Booth Menu Item"/>
                     <field name="booth_menu"/>
                 </span>

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -15,9 +15,11 @@
                     <field name="sponsor_count" string="Sponsors" widget="statinfo"/>
                 </button>
             </field>
-            <xpath expr="//label[@for='community_menu']" position="before">
-                <label for="exhibitor_menu"/>
-                <field name="exhibitor_menu"/>
+            <xpath expr="//span[@name='community_menu']" position="before">
+                <span name="exhibitor_menu" class="ms-2">
+                    <label for="exhibitor_menu"/>
+                    <field name="exhibitor_menu"/>
+                </span>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_exhibitor/views/event_type_views.xml
+++ b/addons/website_event_exhibitor/views/event_type_views.xml
@@ -5,8 +5,8 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-                <xpath expr="//span[@name='community_menu']" position='before'>
-                <span name="exhibitor_menu">
+            <xpath expr="//span[@name='community_menu']" position='before'>
+                <span name="exhibitor_menu" class="ms-2">
                     <label for="exhibitor_menu" string="Exhibitors Menu Item"/>
                     <field name="exhibitor_menu"/>
                 </span>

--- a/addons/website_event_track/views/event_event_views.xml
+++ b/addons/website_event_track/views/event_event_views.xml
@@ -15,11 +15,15 @@
                     <field name="track_count" string="Tracks" widget="statinfo"/>
                 </button>
             </xpath>
-            <xpath expr="//field[@name='website_menu']" position="after">
-                <label for="website_track" string="Showcase Tracks"/>
-                <field name="website_track"/>
-                <label for="website_track_proposal" string="Allow Track Proposals"/>
-                <field name="website_track_proposal"/>
+            <xpath expr="//span[@name='website_menu']" position="after">
+                <span name="website_track" class="ms-2">
+                    <label for="website_track" string="Showcase Tracks"/>
+                    <field name="website_track"/>
+                </span>
+                <span name="website_track_proposal" class="ms-2">
+                    <label for="website_track_proposal" string="Allow Track Proposals"/>
+                    <field name="website_track_proposal"/>
+                </span>
             </xpath>
         </field>
     </record>

--- a/addons/website_event_track/views/event_type_views.xml
+++ b/addons/website_event_track/views/event_type_views.xml
@@ -6,12 +6,12 @@
         <field name="model">event.type</field>
         <field name="inherit_id" ref="website_event.event_type_view_form"/>
         <field name="arch" type="xml">
-                <xpath expr="//span[@name='website_menu']" position='after'>
-                <span>
+            <xpath expr="//span[@name='website_menu']" position='after'>
+                <span class="ms-2">
                     <label for="website_track" string="Tracks Menu Item"/>
                     <field name="website_track"/>
                 </span>
-                <span name="website_track_proposal">
+                <span name="website_track_proposal" class="ms-2">
                     <label for="website_track_proposal" string="Track Proposals Menu Item"/>
                     <field name="website_track_proposal"/>
                 </span>

--- a/addons/website_event_track_quiz/views/event_event_views.xml
+++ b/addons/website_event_track_quiz/views/event_event_views.xml
@@ -6,7 +6,7 @@
         <field name="model">event.event</field>
         <field name="inherit_id" ref="website_event.event_event_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//label[@for='community_menu']" position="attributes">
+            <xpath expr="//span[@name='community_menu']" position="attributes">
                 <attribute name="invisible">0</attribute>
             </xpath>
         </field>


### PR DESCRIPTION
This PR aims to increase distinction between the label-field couples that allow tabs to be displayed in the menu of the event site page. It has been done for stable versions in the https://github.com/odoo/odoo/pull/214135 but adding classes to existing tags instead of including the couples in span tags, as expected by the Odoo framework, to avoid breaking features using the xml structure. This PR fixes that.

Introduced in https://github.com/odoo/odoo/commit/cc9933256a68fe51f2a058955aa401a3c3ebc7e7
18.0 FIX PR: https://github.com/odoo/odoo/pull/214135

Task-4797022