### PR TITLE
[FIX] mail: prevent duplicate chat

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -12,7 +12,7 @@ from odoo.addons.base.models.avatar_mixin import get_hsl_from_seed
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools import html_escape
-from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT, mute_logger
 
 _logger = logging.getLogger(__name__)
 
@@ -855,6 +855,9 @@ class Channel(models.Model):
             :returns: channel_info of the created or existing channel
             :rtype: dict
         """
+        with mute_logger("odoo.sql_db"):
+            self.env.cr.execute("LOCK TABLE mail_channel IN EXCLUSIVE MODE NOWAIT")
+            self.env.cr.execute("LOCK TABLE mail_channel_member IN EXCLUSIVE MODE NOWAIT")
         if self.env.user.partner_id.id not in partners_to:
             partners_to.append(self.env.user.partner_id.id)
         if len(partners_to) > 2:


### PR DESCRIPTION
A chat between 2 persons should be unique, but it can currently be created multiple times because we don't have a lock in channel_get.

The easiest way to reproduce the issue is to have multiple tab opens and invite a user. When the invited user joins for the first time, a chat will be created, but one chat might be created per open tab.

task-4664353