### PR TITLE
[FIX] spreadsheet: fix scorecard/gauge chart `onClick` in dashboard

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
@@ -17,4 +17,18 @@ patch(spreadsheet.components.FigureComponent.prototype, {
     get hasOdooMenu() {
         return this.env.model.getters.getChartOdooMenu(this.props.figure.id) !== undefined;
     },
+    async onClick() {
+        try {
+            const definition = this.env.model.getters.getChartDefinition(this.props.figure.id);
+            if (
+                this.env.isDashboard() &&
+                this.hasOdooMenu &&
+                (definition.type === "scorecard" || definition.type === "gauge")
+            ) {
+                await this.navigateToOdooMenu();
+            }
+        } catch {
+            // Throws if the figure isn't a chart
+        }
+    },
 });

--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.xml
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.xml
@@ -9,6 +9,7 @@
             </div>
         </xpath>
         <xpath expr="//div[hasclass('o-figure')]" position="attributes">
+            <attribute name="t-on-click">() => this.onClick()</attribute>
             <attribute name="t-att-role">env.isDashboard() and hasOdooMenu ? "button" : ""</attribute>
         </xpath>
     </div>

--- a/addons/spreadsheet/static/tests/charts/ui/link_chart_figure.test.js
+++ b/addons/spreadsheet/static/tests/charts/ui/link_chart_figure.test.js
@@ -2,7 +2,11 @@ import { click } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { expect, test, beforeEach } from "@odoo/hoot";
 import { getBasicData, defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
-import { createBasicChart } from "@spreadsheet/../tests/helpers/commands";
+import {
+    createBasicChart,
+    createScorecardChart,
+    createGaugeChart,
+} from "@spreadsheet/../tests/helpers/commands";
 import { mountSpreadsheet } from "@spreadsheet/../tests/helpers/ui";
 import { createModelWithDataSource } from "@spreadsheet/../tests/helpers/model";
 import { mockService, serverState } from "@web/../tests/web_test_helpers";
@@ -260,6 +264,29 @@ test("Click on chart element in dashboard mode do not redirect twice", async fun
     await click(".o-chart-container canvas", { position: "top-left" });
     await animationFrame();
     expect.verifySteps(["chartMenuRedirect"]);
+});
+
+test("Clicking on a scorecard or gauge redirects to the linked menu id", async function () {
+    mockService("action", {
+        doAction: async (actionRequest) => expect.step(actionRequest),
+    });
+
+    const model = await createModelWithDataSource({ serverData });
+    await mountSpreadsheet(model);
+    createScorecardChart(model, "scorecardId");
+    createGaugeChart(model, "gaugeId");
+    model.dispatch("LINK_ODOO_MENU_TO_CHART", { chartId: "scorecardId", odooMenuId: 2 });
+    model.dispatch("LINK_ODOO_MENU_TO_CHART", { chartId: "gaugeId", odooMenuId: 2 });
+    model.updateMode("dashboard");
+    await animationFrame();
+
+    const figures = document.querySelectorAll(".o-figure");
+
+    await click(figures[0]);
+    expect.verifySteps(["menuAction2"]);
+
+    await click(figures[1]);
+    expect.verifySteps(["menuAction2"]);
 });
 
 test("can use menus xmlIds instead of menu ids", async function () {


### PR DESCRIPTION
9674215 broke the on `onClick` of gauge/scorecard in dashboard. We removed the `onClick` of the figure component in favour of a chartJs plugin, but scorecard/gauge charts do not use chartJs.

Task: [4826611](https://www.odoo.com/web#id=4826611&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
