### PR TITLE
[FIX] sale_project: Fix tour for project sale orderline

### DIFF
--- a/addons/sale_project/static/tests/tours/project_create_sol_tour.js
+++ b/addons/sale_project/static/tests/tours/project_create_sol_tour.js
@@ -44,6 +44,20 @@ registry.category("web_tour.tours").add('project_create_sol_tour', {
         run: "click",
     },
     {
+        trigger: "div[name='product_id'] input",
+        content: "Select the product for the Sales Order Item",
+        run: "click",
+    }, {
+        trigger: ".ui-autocomplete > li > a:not(:has(i.fa))",
+        content: "Select the product in the autocomplete dropdown",
+        run: "click",
+    }, 
+    {
+        trigger: ".modal button:contains(save & close)",
+        content: "Save the Sales Order Item",
+        run: "click",
+    },
+    {
         trigger: "body:not(:has(.modal))",
     },
     {


### PR DESCRIPTION
Steps to reproduce the issue:
1- install sale_project without demo data
2- as the test is not deterministic, adding step_delay may help reproducing it


The project creation tour was intermittently failing at the step that attempts to save the project
(.o_form_button_save:enabled). The failure occurred because this step was triggered while a modal
(for creating a Sales Order Item) was still visible and overlaid on top of the main form.

Add missing steps in the project tour to select a product in the Sales Order Item
form and save and close the form.

build_error-163102