### PR TITLE
[FIX] point_of_sale: Fix sending data to preparation display

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -29,13 +29,9 @@ export class ReceiptScreen extends Component {
         this.sendReceipt = useTrackedAsync(this._sendReceiptToCustomer.bind(this));
         this.doFullPrint = useTrackedAsync(() => this.pos.printReceipt());
         this.doBasicPrint = useTrackedAsync(() => this.pos.printReceipt({ basic: true }));
-        onMounted(() => {
-            const order = this.pos.getOrder();
-            this.currentOrder.uiState.locked = true;
 
-            if (!this.pos.config.module_pos_restaurant) {
-                this.pos.sendOrderInPreparation(order, { orderDone: true });
-            }
+        onMounted(() => {
+            this.currentOrder.uiState.locked = true;
         });
     }
     actionSendReceiptOnEmail() {

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -660,23 +660,6 @@ registry.category("web_tour.tours").add("test_product_create_update_from_fronten
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("test_draft_orders_not_syncing", {
-    steps: () =>
-        [
-            Chrome.startPoS(),
-            Dialog.confirm("Open Register"),
-            ProductScreen.orderIsEmpty(),
-            ProductScreen.clickDisplayedProduct("Desk Pad"),
-            Chrome.createFloatingOrder(),
-            ProductScreen.clickDisplayedProduct("Desk Pad"),
-            ProductScreen.clickPayButton(),
-            PaymentScreen.clickPaymentMethod("Bank"),
-            PaymentScreen.clickValidate(),
-            ReceiptScreen.isShown(),
-            Chrome.endTour(),
-        ].flat(),
-});
-
 registry.category("web_tour.tours").add("test_one_attribute_value_scan_barcode", {
     steps: () =>
         [

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -2009,12 +2009,6 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_one_attribute_value_scan_barcode', login="pos_user")
 
-    def test_draft_orders_not_syncing(self):
-        self.main_pos_config.with_user(self.pos_user).open_ui()
-        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_draft_orders_not_syncing', login="pos_user")
-        n_draft_order = self.env['pos.order'].search_count([('state', '=', 'draft')], limit=1)
-        self.assertEqual(n_draft_order, 0, 'There should be no draft orders created')
-
     def test_quantity_package_of_non_basic_unit(self):
         pack_of_12_inch = self.env['uom.uom'].create({
             'name': 'Pack of 12_inch',

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -786,7 +786,10 @@ patch(PosStore.prototype, {
         const order = course.order_id;
         course.fired = true;
         order.deselectCourse();
-        await this.sendOrderInPreparation(order, { firedCourseId: course.id, byPassPrint: true });
+        await this.sendOrderInPreparationUpdateLastChange(order, false, {
+            firedCourseId: course.id,
+            byPassPrint: true,
+        });
         await this.printCourseTicket(course);
         return true;
     },


### PR DESCRIPTION
The preparation display was not receiving the data correctly because of a bad gestion of the asynchronious behavior of the point of sale synching process.

This commit fixes the issue.

