### PR TITLE
Master speedup view validation xdo

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -20,7 +20,6 @@ from odoo.exceptions import ValidationError, AccessError, UserError
 from odoo.fields import Domain
 from odoo.http import request
 from odoo.modules.module import get_resource_from_path
-from odoo.service.model import get_public_method
 from odoo.tools import _, config, frozendict, SQL
 from odoo.tools.convert import _fix_multiple_roots
 from odoo.tools.misc import file_path, get_diff, ConstantMapping
@@ -1723,9 +1722,8 @@ actual arch.
                         action_name=name, model_name=name_manager.model._name,
                     )
                     self._raise_view_error(msg, node)
-                try:
-                    get_public_method(name_manager.model, name)
-                except (AttributeError, AccessError):
+                # get_public_method(name_manager.model, name) is too slow for this validation, a more naive check is acceptable.
+                if name.startswith('_') or (hasattr(func, '_api_private') and func._api_private):
                     msg = _(
                         "%(method)s on %(model)s is private and cannot be called from a button",
                         method=name, model=name_manager.model._name,


### PR DESCRIPTION
During upgrades, it looks like a big part of the view validation is taken by one single check, checking that the method on a button is public.

![image](https://github.com/user-attachments/assets/8253fdc9-1cc4-407e-9e9c-90cc748a6094)

This was actually slown down by the introduction of [api.private](https://github.com/odoo/odoo/pull/195402). The check now needs to get the mro and find if the method is _api_private using get_public_method. This is actually quite slow and not relevant in the context of view validation. This check is there to avoid development mistakes (in code or editing views in database). Missing a few corner cases is not a problem here. The change was most likely made to allow to deprecate check_method_name.

This pr simplifies the check to remove 5-8 minutes on upgrade builds.

After this pr, upgrade build validate views takes around ~3m30s (was ~11 minutes)