### PR TITLE
[FIX] point_of_sale: save customer when setting it in restaurant

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1994,7 +1994,9 @@ export class PosStore extends WithLazyGetterTrap {
     }
     // There for override to do something before adding partner to current order from partner list
     setPartnerToCurrentOrder(partner) {
-        this.getOrder().setPartner(partner);
+        const order = this.getOrder();
+        order.setPartner(partner);
+        this.addPendingOrder([order.id]);
     }
     async selectPartner(currentOrder = this.getOrder()) {
         // FIXME, find order to refund when we are in the ticketscreen.

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -667,3 +667,20 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_customer_alone_saved", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickTable("5"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.clickOrders(),
+            Chrome.clickRegister(),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Deco Addict"),
+            Chrome.clickOrders(),
+            Chrome.clickRegister(),
+            ProductScreen.customerIsSelected("Deco Addict"),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -605,3 +605,9 @@ class TestFrontend(TestFrontendCommon):
         self.pos_config.write({'iface_tipproduct': True, 'tip_product_id': self.tip.id})
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('test_tip_after_payment')
+
+    def test_customer_alone_saved(self):
+        """
+        Tests that when a customer is set, it will be saved and not be reset even if this is the only thing that changed in the order
+        """
+        self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_customer_alone_saved', login="pos_user")


### PR DESCRIPTION
**Problem:**
When setting a customer for an order in the restaurant, it wasn't recorded unless a product was ordered with it. If all we it is add a client in an already existing order, the client won't be recorded and will not be set after we leave the page.

**Steps to reproduce:**
- Choose a table, create a new order and put a product in it, ordering it is not required.
- Go to another table, or just quit the command.
- Go back in the initial order, set a client and go to the *orders* tab without doing anything else.
- The order won't have a client, and going back to the order itself, the client is not set.

**Why the fix:**
The order wasn't read as having changed, so no data was saved. When we set it at first or with a product, it was concidered changed enough for it to be saved. But when changing the customer and only the customer, it wasn't reported to the pending orders.

opw-4818110