### PR TITLE
[FIX] mrp: use the product's UoM precision for product_qty in unbuild

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -26,6 +26,7 @@ class MrpUnbuild(models.Model):
         required=True, index=True)
     product_qty = fields.Float(
         'Quantity', default=1.0,
+        digits='Product Unit of Measure',
         compute='_compute_product_qty', store=True, precompute=True, readonly=False,
         required=True)
     product_uom_id = fields.Many2one(

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -5218,6 +5218,27 @@ class TestMrpOrder(TestMrpCommon):
         wos_to_set.write({ 'date_start': date_start, 'date_finished': date_finished })
         self.assertTrue(mo.workorder_ids[-1].show_json_popover)
 
+    def test_product_qty_digits_precision(self):
+        self.env['decimal.precision'].search([('name', '=', 'Product Unit of Measure')]).digits = 5
+        self.bom_1.product_uom_id.rounding = 0.00001
+        mo = self.env['mrp.production'].create({
+            'bom_id': self.bom_1.id,
+            'product_qty': 1.23456,
+        })
+        mo.action_confirm()
+        self.assertEqual(mo.product_qty, 1.23456)
+        mo.button_mark_done()
+        self.assertEqual(mo.state, 'done')
+        # unbuild the MO
+        unbuild_form = Form(self.env['mrp.unbuild'])
+        unbuild_form.product_id = self.bom_1.product_id
+        unbuild_form.product_qty = 1.23456
+        unbuild_form.mo_id = mo
+        unbuild_order = unbuild_form.save()
+        unbuild_order.action_unbuild()
+        self.assertEqual(unbuild_order.state, 'done')
+        self.assertEqual(unbuild_order.product_qty, 1.23456)
+
 
 @tagged('-at_install', 'post_install')
 class TestTourMrpOrder(HttpCase):


### PR DESCRIPTION
Steps to reproduce the bug:
- Set the decimal precision and rounding accuracy for the unit of measure to more than 2 digits (e.g. 3)
- Create a storable product “P1”
- Create a manufacturing order to produce 1.234 units
    - Confirm and validate it
- Try to unbuild the MO

Problem:
The unbuild form does not respect the product's UoM decimal precision, allowing only 2 digits for product_qty.

opw-4818591
