### PR TITLE
[FIX] html_editor: link popover not disappearing when clicking on editor

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -237,6 +237,9 @@ export class LinkPlugin extends Plugin {
         before_paste_handlers: this.updateCurrentLinkSyncState.bind(this),
         after_paste_handlers: this.onPasteNormalizeLink.bind(this),
         selectionchange_handlers: this.handleSelectionChange.bind(this),
+        selection_leave_handlers: () => {
+            this.currentOverlay?.isOpen && this.currentOverlay.close();
+        },
         clean_for_save_handlers: ({ root }) => this.removeEmptyLinks(root),
         normalize_handlers: this.normalizeLink.bind(this),
         after_insert_handlers: this.handleAfterInsert.bind(this),
@@ -706,7 +709,7 @@ export class LinkPlugin extends Plugin {
         } else {
             const closestLinkElement = closestElement(selection.anchorNode, "A");
             if (closestLinkElement && closestLinkElement.isContentEditable) {
-                if (closestLinkElement !== this.linkInDocument) {
+                if (closestLinkElement !== this.linkInDocument || !this.currentOverlay.isOpen) {
                     this.openLinkTools(closestLinkElement);
                 }
             } else if (


### PR DESCRIPTION
Before this commit clicking on the editor with a link popover open would not cause the link popover to close.

Steps to reproduce:
- go to the website homepage
- open the editor
- click on any top menu links like Home or Contact Us
- click anywere on the editor
- the popover from the first click is still open

After the change clicking anywhere on the editor will cause the popover to close.