### PR TITLE
[FIX] calendar_sms: prevent sms sending to unrelated events

### DIFF
--- a/addons/calendar_sms/models/calendar_event.py
+++ b/addons/calendar_sms/models/calendar_event.py
@@ -19,7 +19,7 @@ class CalendarEvent(models.Model):
             event._message_sms_with_template(
                 template=alarm.sms_template_id,
                 template_fallback=_("Event reminder: %(name)s, %(time)s.", name=event.name, time=event.display_time),
-                partner_ids=self._sms_get_default_partners().ids,
+                partner_ids=event._sms_get_default_partners().ids,
                 put_in_queue=False
             )
 


### PR DESCRIPTION
With two events having an calendar.alarm
that is set for 1 hour before the event
and a first event having attendees Partner1 and Partner2 
and a second event has attendees Partner2 to Partner3. 

_do_sms_reminder will sent SMS once for each event to attendees from Partner1 to Partner3.

Original issue introduced here: a1087e301122eea626ed30f34198de4666a81bdf

Enabled by recent fix here ce574e5edf7bc848c867727d8c66a8e7802b029f
that is batching events by alarm.


opw-4812919

