### PR TITLE
[FIX] account_accountant,accountant: Better onboarding tours

### DIFF
--- a/addons/account/data/account_tour.xml
+++ b/addons/account/data/account_tour.xml
@@ -2,6 +2,6 @@
 <odoo>
     <record id="account_tour" model="web_tour.tour">
         <field name="name">account_tour</field>
-        <field name="sequence">60</field>
+        <field name="sequence">50</field>
     </record>
 </odoo>

--- a/addons/account/static/src/js/tours/account.js
+++ b/addons/account/static/src/js/tours/account.js
@@ -5,6 +5,10 @@ import { stepUtils } from "@web_tour/tour_utils";
 import { markup } from "@odoo/owl";
 
 export const accountTourSteps = {
+    draftInvoiceSelector:
+        ":has(.o_field_widget[name=move_type] span[raw-value=out_invoice]):has(.o_arrow_button_current[data-value=draft])",
+    postedInvoiceSelector:
+        ":has(.o_field_widget[name=move_type] span[raw-value=out_invoice]):has(.o_arrow_button_current[data-value=posted])",
     goToAccountMenu(description="Open Invoicing Menu") {
         return stepUtils.goToAppSteps('account.menu_finance', description);
     },
@@ -14,11 +18,18 @@ export const accountTourSteps = {
     newInvoice() {
         return [
             {
-                trigger: "button.o_list_button_add",
+                trigger: ".out_invoice_tree button.o_list_button_add",
                 content: _t("Now, we'll create your first invoice"),
                 run: "click",
             },
         ];
+    },
+    endSteps() {
+        return [{
+            isActive: ["auto"],
+            trigger: '.breadcrumb-item',
+            run: "click",
+        }];
     },
 }
 
@@ -29,65 +40,65 @@ registry.category("web_tour.tours").add('account_tour', {
     ...accountTourSteps.onboarding(),
     ...accountTourSteps.newInvoice(),
     {
-        trigger: "div[name=partner_id] .o_input_dropdown",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=partner_id] .o_input_dropdown`,
         content: markup(_t("Write a customer name to <b>create one</b> or <b>see suggestions</b>.")),
         tooltipPosition: "right",
         run: "click",
     },
     {
         isActive: ["auto"],
-        trigger: "div[name=partner_id] input",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=partner_id] input`,
         run: "edit Test Customer",
     },
     {
         isActive: ["auto"],
-        trigger: ".o_m2o_dropdown_option a:contains('Create')",
+        trigger: `body${accountTourSteps.draftInvoiceSelector} .o_m2o_dropdown_option a:contains('Create')`,
         content: _t("Select first partner"),
         run: "click",
     },
     {
         isActive: ["auto"],
-        trigger: ".modal-content button.btn-primary",
+        trigger: `body${accountTourSteps.draftInvoiceSelector} .modal-content button.btn-primary`,
         content: markup(_t("Once everything is set, you are good to continue. You will be able to edit this later in the <b>Customers</b> menu.")),
         run: "click",
     },
     {
-        trigger: "div[name=invoice_line_ids] .o_field_x2many_list_row_add a",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] .o_field_x2many_list_row_add a`,
         content: _t("Add a line to your invoice"),
         run: "click",
     },
     {
-        trigger: "div[name=invoice_line_ids] div[name=product_id]",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id]`,
         content: _t("Fill in the details of the product or see the suggestion."),
         tooltipPosition: "bottom",
         run: "click",
     },
     {
         isActive: ["auto"],
-        trigger: "div[name=invoice_line_ids] div[name=product_id] input",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] input`,
         run: "edit Test Product",
     },
     {
         isActive: ["auto"],
-        trigger: "div[name=invoice_line_ids] div[name=product_id] .o_m2o_dropdown_option_create a:contains(create)",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] .o_m2o_dropdown_option_create a:contains(create)`,
         content: _t("Create the product."),
         run: "click",
     },
     {
-        trigger: "div[name=invoice_line_ids] div[name=product_id] button[id=labelVisibilityButtonId]",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] button[id=labelVisibilityButtonId]`,
         content: _t("Click here to add a description to your product."),
         tooltipPosition: "bottom",
         run: "click",
     },
     {
-        trigger: "div[name=invoice_line_ids] div[name=product_id] textarea",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] textarea`,
         content: _t("Add a description to your item."),
         tooltipPosition: "bottom",
         run: "edit A very useful description.",
     },
     {
         isActive: ["auto"],
-        trigger: "div[name=invoice_line_ids] div[name=product_id] textarea",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=product_id] textarea`,
         run: function () {
             // Since the t-on-change of the input is not triggered by the run: "edit" action,
             // we need to dispatch the event manually requiring a function.
@@ -97,55 +108,48 @@ registry.category("web_tour.tours").add('account_tour', {
         },
     },
     {
-        trigger: "div[name=invoice_line_ids] td[name=price_unit]",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] td[name=price_unit]`,
         content: _t("Verify the price and update if necessary."),
         tooltipPosition: "bottom",
         run: "click",
     },
     {
         isActive: ["auto"],
-        trigger: "div[name=invoice_line_ids] div[name=price_unit] input",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} div[name=invoice_line_ids] div[name=price_unit] input`,
         content: _t("Set a price."),
         run: "edit 100",
     },
     ...stepUtils.saveForm(),
     {
-        trigger: "button[name=action_post]",
+        trigger: `.o_form_view_container${accountTourSteps.draftInvoiceSelector} button[name=action_post]`,
         content: _t("Once your invoice is ready, confirm it."),
         run: "click",
     },
     {
-        trigger: "button[name=action_invoice_sent]:contains(send)",
+        trigger: `.o_form_view_container${accountTourSteps.postedInvoiceSelector} button[name=action_invoice_sent]:contains(send)`,
         content: _t("Send the invoice to the customer and check what he'll receive."),
         tooltipPosition: "bottom",
         run: "click",
     },
     {
-        trigger: ".o_field_widget[name=mail_partner_ids] input",
-        content: _t("Send the invoice to the customer and check what he'll receive."),
-        tooltipPosition: "bottom",
-        run: "edit Test Customer",
-    },
-    {
-        trigger: ".o-mail-RecipientsInputTagsListPopover input",
+        // RecipientsInputTagsListPopover will not display if the customer already has an email address
+        // unless it's possible to have optional steps, we will only use it for tests at the moment.
+        isActive: ["auto"],
+        trigger: `body${accountTourSteps.postedInvoiceSelector} .o-mail-RecipientsInputTagsListPopover input`,
         content: markup(_t("Write here <b>your own email address</b> to test the flow.")),
         run: "edit customer@example.com",
     },
     {
         isActive: ["auto"],
-        trigger: ".o-mail-RecipientsInputTagsListPopover .btn-primary",
+        trigger: `body${accountTourSteps.postedInvoiceSelector} .o-mail-RecipientsInputTagsListPopover .btn-primary`,
         content: _t("Validate."),
         run: "click",
     },
     {
-        trigger: ".modal button[name=action_send_and_print]",
+        trigger: `body${accountTourSteps.postedInvoiceSelector} .modal button[name=action_send_and_print]`,
         content: _t("Let's send the invoice."),
         tooltipPosition: "top",
         run: "click",
     },
-    {
-        trigger: "button[name=action_invoice_sent]:contains(send).btn-secondary",
-        content: _t("The invoice having been sent, the button has changed priority."),
-        run() {},
-    },
+    ...accountTourSteps.endSteps(),
 ]});

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -593,6 +593,9 @@
             <field name="inherit_id" ref="account.view_invoice_tree"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <list position="attributes">
+                    <attribute name="class">out_invoice_tree</attribute>
+                </list>
                 <button name="action_force_register_payment" position="before">
                     <button name="action_send_and_print" type="object" string="Send"/>
                 </button>


### PR DESCRIPTION
Current behavior before PR:

account_accountant tour was displayed before accountant tour, which showed to the user how to do banks and vendor bills before invoices.

The text showed for the invoicing app talked about accounting which is only done in the accounting module.

Some of the buttons, such as "New" would be displayed at the right place but when switching with another tab with a "New" button it would also display on those.

Desired behavior after PR is merged:

first, the user goes through the account onboarding then goes back to the dashboard and does the account_accountant onboarding.

The text showed for invoicing stays the same whenever it's invoicing community or enterprise, and shows a different one for accounting.

Text is displayed on the right button if it's intended to be only a specified page.

task-4822215

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
