### PR TITLE
[FIX] web: reposition the color picker on change tabs

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -3,6 +3,7 @@ import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/cu
 import { usePopover } from "@web/core/popover/popover_hook";
 import { isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { GradientPicker } from "./gradient_picker/gradient_picker";
+import { POSITION_BUS } from "../position/position_hook";
 
 // These colors are already normalized as per normalizeCSSColor in @web/legacy/js/widgets/colorpicker
 export const DEFAULT_COLORS = [
@@ -74,6 +75,13 @@ export class ColorPicker extends Component {
             showGradientPicker: false,
         });
         this.usedCustomColors = this.props.getUsedCustomColors();
+        useEffect(
+            () => {
+                // Recompute the positioning of the popover if any.
+                this.env[POSITION_BUS]?.trigger("update");
+            },
+            () => [this.state.activeTab]
+        );
     }
 
     getDefaultTab() {

--- a/addons/web/static/src/core/position/position_hook.js
+++ b/addons/web/static/src/core/position/position_hook.js
@@ -24,7 +24,7 @@ import {
  * @property {() => void} unlock allows further positioning updates (triggers an update right away)
  */
 
-const POSITION_BUS = Symbol("position-bus");
+export const POSITION_BUS = Symbol("position-bus");
 
 /**
  * Makes sure that the `popper` element is always


### PR DESCRIPTION
The color picker has multiple tabs, which don't all have the same height. When it opens to the top of the toolbar, changing tabs had the effect of having the color picker disconnected from the toolbar. This ensures a recomputing of its position whenever the tab changes.

![image](https://github.com/user-attachments/assets/06a39a5d-ed02-4436-838e-5473831fc5c8)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
