### PR TITLE
[FIX] mail: keep showing 'is typing...' for long typers

### DIFF
--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -229,7 +229,7 @@ class DiscussChannelMember(models.Model):
             :param is_typing: (boolean) tells whether the members are typing or not
         """
         for member in self:
-            member.channel_id._bus_send_store(member, extra_fields={"isTyping": is_typing})
+            member.channel_id._bus_send_store(member, extra_fields={"isTyping": is_typing, "is_typing_dt": fields.Datetime.now()})
 
     def _notify_mute(self):
         for member in self:

--- a/addons/mail/static/src/discuss/core/common/channel_member_model.js
+++ b/addons/mail/static/src/discuss/core/common/channel_member_model.js
@@ -54,18 +54,29 @@ export class ChannelMember extends Record {
         },
     });
     new_message_separator_ui = null;
+    isTyping = false;
+    is_typing_dt = fields.Datetime({
+        onUpdate() {
+            browser.clearTimeout(this.typingTimeoutId);
+            if (
+                !this.is_typing_dt ||
+                DateTime.now().diff(this.is_typing_dt).milliseconds > Store.OTHER_LONG_TYPING
+            ) {
+                this.isTyping = false;
+            }
+            if (this.isTyping) {
+                this.typingTimeoutId = browser.setTimeout(
+                    () => (this.isTyping = false),
+                    Store.OTHER_LONG_TYPING
+                );
+            }
+        },
+    });
     threadAsTyping = fields.One("Thread", {
         compute() {
             return this.isTyping ? this.channel_id : undefined;
         },
         eager: true,
-        onAdd() {
-            browser.clearTimeout(this.typingTimeoutId);
-            this.typingTimeoutId = browser.setTimeout(
-                () => (this.isTyping = false),
-                Store.OTHER_LONG_TYPING
-            );
-        },
         onDelete() {
             browser.clearTimeout(this.typingTimeoutId);
         },

--- a/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
+++ b/addons/mail/static/tests/mock_server/mock_models/discuss_channel_member.js
@@ -3,6 +3,8 @@ import { mailDataHelpers } from "@mail/../tests/mock_server/mail_mock_server";
 import { fields, getKwArgs, makeKwArgs, models } from "@web/../tests/web_test_helpers";
 import { serializeDateTime, today } from "@web/core/l10n/dates";
 
+const { DateTime } = luxon;
+
 export class DiscussChannelMember extends models.ServerModel {
     _name = "discuss.channel.member";
 
@@ -36,7 +38,11 @@ export class DiscussChannelMember extends models.ServerModel {
                 channel,
                 "mail.record/insert",
                 new mailDataHelpers.Store(DiscussChannelMember.browse(member.id))
-                    .add("discuss.channel.member", { id: member.id, isTyping: is_typing })
+                    .add("discuss.channel.member", {
+                        id: member.id,
+                        isTyping: is_typing,
+                        is_typing_dt: serializeDateTime(DateTime.now()),
+                    })
                     .get_result(),
             ]);
         }


### PR DESCRIPTION
Before this commit, if a user is typing without interrupt for more than 1 minute, other members stop seeing this person from about 40 seconds.

As a reminder, the "is typing..." feature in discuss is implemented as follow:
- when typing, notify `is_typing: true` once every 50 seconds.
- when stop typing for 5 seconds, notify `is_typing: false`.
- other members assume stop typing if nothing received after 60 seconds.

This logic is good, but there was a problem with current implementation: members only send and receive `isTyping: true` through `mail.record/insert` notification. This means a long typer is seen as follow

```
- time: 0sec.   -> is_typing: true sent + received
- time: 50sec.  -> is_typing: true sent + received
- time: 60sec.  -> is_typing: false (assuming stop typing)
- time: 100sec. -> is_typing: true sent + received
```

This is the case because the notification is `mail.record/insert` so from the store data, data of `isTyping` is unchanged. The timeout was made through a change of `isTyping` status, which doesn't in this scenario, hence the problem of assuming stop typing.

This commit fixes the issue by sending the datetime of notified `is_typing` and linking the timeout to the datetime of last notified of `is_typing` of this member. This fix ensures that at the 50sec, the timeouts are refreshed and they have to wait until time 110sec. to assume stop typing, which is good in case the message is very long as typer will warn again at time 100sec. with refreshed datetime.

runbot-223760