### PR TITLE
[IMP] server: add preload profiler

### DIFF
--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -57,7 +57,7 @@ except ImportError:
 from odoo import api, sql_db
 from odoo.modules.registry import Registry
 from odoo.release import nt_service_name
-from odoo.tools import config, osutil, OrderedSet
+from odoo.tools import config, osutil, OrderedSet, profiler
 from odoo.tools.cache import log_ormcache_stats
 from odoo.tools.misc import stripped_sys_argv, dumpstacks
 from .db import list_dbs
@@ -1385,36 +1385,47 @@ def preload_registries(dbnames):
     # TODO: move all config checks to args dont check tools.config here
     dbnames = dbnames or []
     rc = 0
+
+    preload_profiler = contextlib.nullcontext()
+
     for dbname in dbnames:
+        if os.environ.get('ODOO_PROFILE_PRELOAD'):
+            interval = float(os.environ.get('ODOO_PROFILE_PRELOAD_INTERVAL', '0.1'))
+            collectors = [profiler.PeriodicCollector(interval=interval)]
+            if os.environ.get('ODOO_PROFILE_PRELOAD_SQL'):
+                collectors.append('sql')
+            preload_profiler = profiler.Profiler(db=dbname, collectors=collectors)
         try:
-            threading.current_thread().dbname = dbname
-            update_module = config['init'] or config['update']
-            registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
+            with preload_profiler:
+                threading.current_thread().dbname = dbname
+                update_module = config['init'] or config['update']
 
-            # run post-install tests
-            if config['test_enable']:
-                from odoo.tests import loader  # noqa: PLC0415
-                t0 = time.time()
-                t0_sql = sql_db.sql_counter
-                module_names = (registry.updated_modules if update_module else
-                                sorted(registry._init_modules))
-                _logger.info("Starting post tests")
-                tests_before = registry._assertion_report.testsRun
-                post_install_suite = loader.make_suite(module_names, 'post_install')
-                if post_install_suite.has_http_case():
-                    with registry.cursor() as cr:
-                        env = api.Environment(cr, api.SUPERUSER_ID, {})
-                        env['ir.qweb']._pregenerate_assets_bundles()
-                result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
-                registry._assertion_report.update(result)
-                _logger.info("%d post-tests in %.2fs, %s queries",
-                             registry._assertion_report.testsRun - tests_before,
-                             time.time() - t0,
-                             sql_db.sql_counter - t0_sql)
+                registry = Registry.new(dbname, update_module=update_module, install_modules=config['init'], upgrade_modules=config['update'])
 
-                registry._assertion_report.log_stats()
-            if registry._assertion_report and not registry._assertion_report.wasSuccessful():
-                rc += 1
+                # run post-install tests
+                if config['test_enable']:
+                    from odoo.tests import loader  # noqa: PLC0415
+                    t0 = time.time()
+                    t0_sql = sql_db.sql_counter
+                    module_names = (registry.updated_modules if update_module else
+                                    sorted(registry._init_modules))
+                    _logger.info("Starting post tests")
+                    tests_before = registry._assertion_report.testsRun
+                    post_install_suite = loader.make_suite(module_names, 'post_install')
+                    if post_install_suite.has_http_case():
+                        with registry.cursor() as cr:
+                            env = api.Environment(cr, api.SUPERUSER_ID, {})
+                            env['ir.qweb']._pregenerate_assets_bundles()
+                    result = loader.run_suite(post_install_suite, global_report=registry._assertion_report)
+                    registry._assertion_report.update(result)
+                    _logger.info("%d post-tests in %.2fs, %s queries",
+                                registry._assertion_report.testsRun - tests_before,
+                                time.time() - t0,
+                                sql_db.sql_counter - t0_sql)
+
+                    registry._assertion_report.log_stats()
+                if registry._assertion_report and not registry._assertion_report.wasSuccessful():
+                    rc += 1
         except Exception:
             _logger.critical('Failed to initialize database `%s`.', dbname, exc_info=True)
             return -1

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -51,7 +51,7 @@ def _get_stack_trace(frame, limit_frame=None):
         stack.append(_format_frame(frame))
         frame = frame.f_back
     if frame is None and limit_frame:
-        _logger.error("Limit frame was not found")
+        _logger.runbot("Limit frame was not found")
     return list(reversed(stack))
 
 


### PR DESCRIPTION
Being able to profile the install or tests without to much modifications in the code can be needed, especially to have a nightly profiling the code every night.

Since the total install and test can be very long, using the default profiler parameters would most likely lead to memory errors. This is why this default profiler doesn't profile sql and has a low frequency. The information is still statistically relevant to identify the big pieces.

Note that profiling the registry loading in order to have one profile per module could also be useful, but this is not implemented here.

The profiler is activated by setting the environment variable `ODOO_PROFILE_PRELOAD` to `1`. The other environment variables `ODOO_PROFILE_PRELOAD_SQL` and `ODOO_PROFILE_PRELOAD_INTERVAL` can be used to tweak the profiling collectors parameters.

