### PR TITLE
[FIX] payment{,_stripe}: avoid logging secret values

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -464,10 +464,11 @@ class PaymentTransaction(models.Model):
 
         # Complete generic processing values with provider-specific values.
         processing_values.update(self._get_specific_processing_values(processing_values))
+        secret_keys = self._get_specific_secret_keys()
         _logger.info(
             "generic and provider-specific processing values for transaction with reference "
             "%(ref)s:\n%(values)s",
-            {'ref': self.reference, 'values': pprint.pformat(processing_values)},
+            {'ref': self.reference, 'values': pprint.pformat(processing_values - secret_keys)},
         )
 
         # Render the html form for the redirect flow if available.
@@ -513,6 +514,14 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         return dict()
+
+    def _get_specific_secret_keys(self):
+        """ Return dict keys of provider-specific values that should be hidden when logged.
+
+        :return: The provider-specific secret keys
+        :rtype: dict_keys
+        """
+        return dict().keys()
 
     def _get_mandate_values(self):
         """ Return a dict of module-specific values used to create a mandate.

--- a/addons/payment_stripe/controllers/main.py
+++ b/addons/payment_stripe/controllers/main.py
@@ -11,12 +11,11 @@ from werkzeug.exceptions import Forbidden
 from odoo import http
 from odoo.exceptions import ValidationError
 from odoo.http import request
-from odoo.tools.misc import file_open
+from odoo.tools import file_open, mute_logger
 
 from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment_stripe import utils as stripe_utils
 from odoo.addons.payment_stripe.const import HANDLED_WEBHOOK_EVENTS
-
 
 _logger = logging.getLogger(__name__)
 
@@ -49,7 +48,8 @@ class StripeController(http.Controller):
                 payload={'expand[]': 'payment_method'},  # Expand all required objects.
                 method='GET',
             )
-            _logger.info("Received payment_intents response:\n%s", pprint.pformat(payment_intent))
+            logged_intent = payment_intent - tx_sudo._get_specific_secret_keys()
+            _logger.info("Received payment_intents response:\n%s", pprint.pformat(logged_intent))
             self._include_payment_intent_in_notification_data(payment_intent, data)
         else:
             # Fetch the SetupIntent and PaymentMethod objects from Stripe.
@@ -65,7 +65,8 @@ class StripeController(http.Controller):
         tx_sudo._handle_notification_data('stripe', data)
 
         # Redirect the user to the status page.
-        return request.redirect('/payment/status')
+        with mute_logger('werkzeug'):  # avoid logging secret URL params
+            return request.redirect('/payment/status')
 
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def stripe_webhook(self):

--- a/addons/payment_stripe/models/payment_transaction.py
+++ b/addons/payment_stripe/models/payment_transaction.py
@@ -43,6 +43,18 @@ class PaymentTransaction(models.Model):
             ),
         }
 
+    def _get_specific_secret_keys(self):
+        """ Override of payment to return Stripe-specific secret keys.
+
+        Note: self.ensure_one() from `_get_processing_values`
+
+        :return: The provider-specific secret keys
+        :rtype: dict_keys
+        """
+        if self.provider_code == 'stripe':
+            return {'client_secret': None}.keys()
+        return super()._get_specific_secret_keys()
+
     def _send_payment_request(self):
         """ Override of payment to send a payment request to Stripe with a confirmed PaymentIntent.
 


### PR DESCRIPTION
Versions
--------
- 17.0+

Steps
-----
1. Create a Stripe transaction;
2. check server logs.

Issue
-----
The `client_secret` value gets logged, Stripe documentation says this value should not be stored or logged[^1].

[^1]: https://docs.stripe.com/api/payment_intents/object#payment_intent_object-client_secret

Cause
-----
Currently we're just raw-logging the processing values.

Solution
--------
Add a `_get_specific_secret_keys` method to `payment.transaction`, to be used when logging processing values that may contain secret information.

Also mute the logger when redirecting to `/payment/status` from Stripe, as the `client_secret` would otherwise be logged by `werkzeug`.

opw-4818301