### PR TITLE
[FIX] payment_adyen: handle connection error when making a payment

### DIFF
--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -122,7 +122,7 @@ class PaymentProvider(models.Model):
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError:
-                _logger.exception(
+                _logger.warning(
                     "invalid API request at %s with data %s: %s", url, payload, response.text
                 )
                 msg = response.json().get('message', '')
@@ -130,7 +130,7 @@ class PaymentProvider(models.Model):
                     "Adyen: " + _("The communication with the API failed. Details: %s", msg)
                 )
         except requests.exceptions.ConnectionError:
-            _logger.exception("unable to reach endpoint at %s", url)
+            _logger.warning("unable to reach endpoint at %s", url)
             raise ValidationError("Adyen: " + _("Could not establish the connection to the API."))
         return response.json()
 


### PR DESCRIPTION
Currently, an error occurs when the Adyen API endpoint is unreachable due to invalid domains or DNS resolution issues, the system logs a full traceback.

**Error:**
`ConnectionError: HTTPSConnectionPool(host='000.adyen.com', port=443): Max
  retries exceeded with url: /checkout/V71/paymentMethods (Caused by
  NameResolutionError('<urllib3.connection.HTTPSConnection object at
  0x7c4ec2c8f140>: Failed to resolve '000.adyen.com' ([Errno -2] Name or service
  not known)'))`

**Root Cause:**
At [1] and [2], using `logger.exception` for `HTTPError` and `ConnectionError` causes unnecessary tracebacks for user-side issues like invalid API domains.

[1]
https://github.com/odoo/odoo/blob/bfb9c0141e595c97cd25ace1a219183cc213b0c4/addons/payment_adyen/models/payment_provider.py#L124-L127 [2]
https://github.com/odoo/odoo/blob/bfb9c0141e595c97cd25ace1a219183cc213b0c4/addons/payment_adyen/models/payment_provider.py#L132-L133

This commit ensures `ConnectionError` and `HTTPError` are logged as `warnings` instead of `exceptions`, preventing unnecessary tracebacks.

sentry - 4955120723