### PR TITLE
[FIX] website: prevent error on creating new website

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -323,8 +323,11 @@ class Website(models.Model):
 
     def create_and_redirect_configurator(self):
         self._force()
-        configurator_action_todo = self.env.ref('website.website_configurator_todo')
-        return configurator_action_todo.action_launch()
+        configurator_action_todo = self.env.ref('website.website_configurator_todo', raise_if_not_found=False)
+        if configurator_action_todo:
+            return configurator_action_todo.action_launch()
+        else:
+            raise UserError(_("The configurator action could not be found."))
 
     def _idna_url(self, url):
         return get_base_domain(url.lower(), True).encode('idna').decode('ascii')


### PR DESCRIPTION
This error occurs when a new website is created.

Steps to reproduce:
---
- Install `website` module
- Search for `website_configurator_todo` in External Identifiers and Delete
- Webiste > Configuration > Setting > Create a New website

Traceback:
---
`ValueError: External ID not found in the system: website.website_configurator_todo`

This commit resolves the issue by raising an error when the reference ID is not found.

sentry-6635248240

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
