### PR TITLE
[FIX] test_website: adapt rte_translator test

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -70,6 +70,9 @@ This addon provides an extensible, maintainable editor.
             'html_editor/static/src/main/chatgpt/language_selector.dark.scss',
             'html_editor/static/src/main/table/table_align_selector.dark.scss',
         ],
+        'web.assets_tests': [
+            'html_editor/static/tests/tours/**/*',
+        ],
         'web.assets_unit_tests': [
             'html_editor/static/tests/**/*',
         ],

--- a/addons/html_editor/static/tests/tours/helpers/editor.js
+++ b/addons/html_editor/static/tests/tours/helpers/editor.js
@@ -1,0 +1,12 @@
+import { patch } from "@web/core/utils/patch";
+import { Editor } from "@html_editor/editor";
+
+// To expose the editor instance globally for tour.
+export const editorsWeakMap = new WeakMap();
+
+patch(Editor.prototype, {
+    attachTo(editable) {
+        editorsWeakMap.set(editable.ownerDocument, this);
+        return super.attachTo(...arguments);
+    },
+});

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -201,8 +201,6 @@ class TestUiHtmlEditorWithExternal(HttpCaseWithUserDemo):
 
 @odoo.tests.tagged('-at_install', 'post_install')
 class TestUiTranslate(odoo.tests.HttpCase):
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_admin_tour_rte_translator(self):
         self.env['res.lang'].create({
             'name': 'Parseltongue',


### PR DESCRIPTION
This commit adapts the test_admin_tour_rte_translator test, which was
broken due to DOM structure changes in the new website builder.

Enterprise PR: https://github.com/odoo/enterprise/pull/90764