### PR TITLE
[IMP] website: allow bulk translation of selection field options

### DIFF
--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -289,7 +289,9 @@ export class TranslationPlugin extends Plugin {
         }
         for (const translateSelectEl of this.translateSelectEls) {
             this.addDomListener(translateSelectEl, "click", (ev) => {
-                const translateSelectEl = ev.target;
+                const translateSelectEl = ev.currentTarget
+                    .closest(".o_translation_select")
+                    ?.querySelectorAll(".o_translation_select_option");
                 this.dialogService.add(SelectTranslateDialog, {
                     node: translateSelectEl,
                     addStep: this.dependencies.history.addStep,

--- a/addons/website/static/src/builder/translation_components/selectTranslateDialog.js
+++ b/addons/website/static/src/builder/translation_components/selectTranslateDialog.js
@@ -7,21 +7,29 @@ export class SelectTranslateDialog extends Component {
     static components = { WebsiteDialog };
     static template = "website_builder.SelectTranslateDialog";
     static props = {
-        node: { validate: (p) => p.nodeType === Node.ELEMENT_NODE },
+        node: {
+            validate: (p) =>
+                Array.isArray(p) && p.every(n => n.nodeType === Node.ELEMENT_NODE),
+        },
         addStep: Function,
         close: Function,
     };
     setup() {
-        this.inputEl = useRef("input");
+        this.inputEls = useRef("selectTranslateDialog");
     }
 
     onInputChange() {
-        const value = this.inputEl.el.value;
-        this.optionEl.textContent = value;
-        this.optionEl.classList.toggle(
-            "oe_translated",
-            value !== this.optionEl.dataset.initialTranslationValue
-        );
+        const inputs = this.inputEls.el.querySelectorAll(".select-translate-input");
+        const values = Array.from(inputs).map(input => input.value);
+        const options = this.optionEl;
+        values.map((value, index) => [value, options[index]])
+            .forEach(([value, option]) => {
+                option.textContent = value;
+                option.classList.toggle(
+                    "oe_translated",
+                    value !== option.dataset.initialTranslationValue
+                );
+            });
     }
 
     get optionEl() {

--- a/addons/website/static/src/builder/translation_components/selectTranslateDialog.xml
+++ b/addons/website/static/src/builder/translation_components/selectTranslateDialog.xml
@@ -4,11 +4,16 @@
     <WebsiteDialog close.bind="addStepAndClose"
         title.translate="Translate Selection Option"
         showSecondaryButton="false">
-        <input
-            t-ref="input"
-            type="text" class="form-control my-3"
-            t-att-value="optionEl.textContent or ''"
-            t-on-change="onInputChange"/>
+        <div t-ref="selectTranslateDialog">
+            <t t-foreach="this.props.node" t-as="selectNode" t-key="selectNode.dataset.initialTranslationValue">
+                <input
+                    type="text"
+                    class="form-control my-3 select-translate-input"
+                    t-att-value="selectNode.textContent || ''"
+                    t-on-change="onInputChange"
+                />
+            </t>
+        </div>
     </WebsiteDialog>
 </t>
 


### PR DESCRIPTION
### Before this PR

Translating selection field options was a manual and repetitive task. Users had to click on each option individually to open a separate dialog for translation. For example, translating five options required five separate interactions—one dialog per option—resulting in unnecessary time consumption and poor user experience.

---

### After this PR

When translation is triggered, **all options within the selection field** are presented in a **single dialog**. Each option is shown as a separate input field, allowing users to **edit all translations in one go**. Upon confirmation, the UI:

* Updates the text content of each option
* Applies the `oe_translated` class where translations differ from the original value

This significantly improves efficiency and usability when translating selection fields with multiple options.

task-4610335