### PR TITLE
[FIX] website, *: adapt mysterious egg tours

### DIFF
--- a/addons/test_website/tests/test_systray.py
+++ b/addons/test_website/tests/test_systray.py
@@ -39,9 +39,6 @@ class TestSystray(HttpCase):
     def test_01_admin(self):
         self.start_tour(self.env['website'].get_client_action_url('/test_model/1'), 'test_systray_admin', login="admin")
 
-    # TODO master-mysterious-egg fix error
-    # need to convert auto_hide_menu.js
-
     @mute_logger('odoo.addons.http_routing.models.ir_http', 'odoo.http')
     def test_02_reditor_tester(self):
         self.user_test.group_ids |= self.group_restricted_editor

--- a/addons/website/tests/test_configurator.py
+++ b/addons/website/tests/test_configurator.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from unittest.mock import patch
-import unittest
 
 import odoo.tests
 
@@ -93,8 +92,6 @@ class TestConfiguratorCommon(odoo.tests.HttpCase):
 @odoo.tests.common.tagged('post_install', '-at_install')
 class TestConfiguratorTranslation(TestConfiguratorCommon):
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_01_configurator_translation(self):
         parseltongue = self.env['res.lang'].create({
             'name': 'Parseltongue',

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -27,8 +27,10 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
         ],
         'html_builder.assets': [
             'website_mass_mailing/static/src/js/mass_mailing_form_editor.js',
-            'website_mass_mailing/static/src/scss/website_mass_mailing_edit_mode.scss',
             'website_mass_mailing/static/src/website_builder/**/*',
+        ],
+        'website.assets_edit_frontend': [
+            'website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.inside.scss',
         ],
         'web.assets_tests': [
             'website_mass_mailing/static/tests/tours/**/*',

--- a/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
+++ b/addons/website_mass_mailing/static/tests/tours/snippet_newsletter_block_with_edit.js
@@ -38,7 +38,7 @@ registerWebsitePreviewTour('snippet_newsletter_block_with_edit', {
     },
     {
         content: 'Toggle the option to display the Thanks message',
-        trigger: 'we-button[data-toggle-thanks-message] we-checkbox',
+        trigger: "div[data-action-id='toggleThanksMessage'] input[type='checkbox']",
         run: "click",
     },
     {

--- a/addons/website_mass_mailing/tests/test_snippets.py
+++ b/addons/website_mass_mailing/tests/test_snippets.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import HttpCase, tagged
-import unittest
 
 
 @tagged('post_install', '-at_install')
@@ -16,8 +15,6 @@ class TestSnippets(HttpCase):
         emails = mailing_list.contact_ids.mapped('email')
         self.assertIn("hello@world.com", emails)
 
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_snippet_newsletter_block_with_edit(self):
         self.env.ref('base.user_admin').email = 'admin@yourcompany.example.com'
         admin_email = self.env.ref('base.user_admin').email

--- a/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_editor_tour.js
@@ -37,11 +37,11 @@ registerWebsitePreviewTour("shop_editor_set_product_ribbon", {
     run: "click",
 }, {
     content: "Open the ribbon selector",
-    trigger: ".o_wsale_ribbon_select we-toggler",
+    trigger: ".o_wsale_ribbon_select + button:contains('None')",
     run: "click",
 }, {
     content: "Select a ribbon",
-    trigger: '.o_wsale_ribbon_select we-button:contains("Sale")',
+    trigger: ".o_popover div:contains('Sale')",
     run: "click",
 },
 ...clickOnSave(),

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -6,11 +6,8 @@ from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo, HttpCaseWithUserPortal
 from odoo.addons.sale.tests.product_configurator_common import TestProductConfiguratorCommon
 from odoo.addons.website.tests.common import HttpCaseWithWebsiteUser
-import unittest
 
 
-# TODO master-mysterious-egg fix error
-@unittest.skip("prepare mysterious-egg for merging")
 @tagged('post_install', '-at_install')
 class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductConfiguratorCommon, HttpCaseWithWebsiteUser):
 


### PR DESCRIPTION
*= website_sale, test_website, website_mass_mailing
This PR adapts 4 tests:

1. test_01_configurator_translation: Removed skip tag, no changes needed.
2. TestCustomize: Removed skip tag and adapted selector.
3. test_02_reditor_tester: Removed unwanted comment.
4. test_snippet_newsletter_block_with_edit: The toggle option to display the 'Thank You' message for the newsletter snippet was not working. After this PR, it will work as expected. Also adapted the selector for the toggle option and removed the skip tag.

