### PR TITLE
[IMP] website: allow bulk translation of selection field options

### DIFF
--- a/addons/website/static/src/builder/plugins/translation_plugin.js
+++ b/addons/website/static/src/builder/plugins/translation_plugin.js
@@ -228,8 +228,8 @@ export class TranslationPlugin extends Plugin {
                 optionEl.dataset.initialTranslationValue = optionName;
                 optionEl.className = "o_translation_select_option";
                 selectTranslationEl.appendChild(optionEl);
-                this.translateSelectEls.push(optionEl);
             }
+            this.translateSelectEls.push(selectTranslationEl);
             selectEl.before(selectTranslationEl);
         }
     }
@@ -298,9 +298,8 @@ export class TranslationPlugin extends Plugin {
         }
         for (const translateSelectEl of this.translateSelectEls) {
             this.addDomListener(translateSelectEl, "click", (ev) => {
-                const translateSelectEl = ev.target;
                 this.dialogService.add(SelectTranslateDialog, {
-                    node: translateSelectEl,
+                    node: ev.currentTarget,
                     addStep: this.dependencies.history.addStep,
                 });
             });

--- a/addons/website/static/src/builder/translation_components/selectTranslateDialog.js
+++ b/addons/website/static/src/builder/translation_components/selectTranslateDialog.js
@@ -1,4 +1,4 @@
-import { Component, useRef } from "@odoo/owl";
+import { Component } from "@odoo/owl";
 import { WebsiteDialog } from "@website/components/dialog/dialog";
 
 // Used to translate the text of `<select/>` options since it should not be
@@ -12,23 +12,25 @@ export class SelectTranslateDialog extends Component {
         close: Function,
     };
     setup() {
-        this.inputEl = useRef("input");
+        this.modifiedOptions = {};
     }
 
-    onInputChange() {
-        const value = this.inputEl.el.value;
-        this.optionEl.textContent = value;
-        this.optionEl.classList.toggle(
-            "oe_translated",
-            value !== this.optionEl.dataset.initialTranslationValue
-        );
+    onInputChange(ev) {
+        const index = ev.target.dataset.index;
+        const value = ev.target.value;
+        this.modifiedOptions[index] = value;
     }
 
-    get optionEl() {
-        return this.props.node;
+    get optionEls() {
+        return this.props.node.querySelectorAll(".o_translation_select_option");
     }
 
     addStepAndClose() {
+        for (const [index, newValue] of Object.entries(this.modifiedOptions)) {
+            const optionEl = this.optionEls[index];
+            optionEl.textContent = newValue;
+            optionEl.classList.add("oe_translated");
+        }
         this.props.addStep();
         this.props.close();
     }

--- a/addons/website/static/src/builder/translation_components/selectTranslateDialog.xml
+++ b/addons/website/static/src/builder/translation_components/selectTranslateDialog.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
 <t t-name="website_builder.SelectTranslateDialog">
-    <WebsiteDialog close.bind="addStepAndClose"
+    <WebsiteDialog close.bind="this.props.close"
         title.translate="Translate Selection Option"
-        showSecondaryButton="false">
-        <input
-            t-ref="input"
-            type="text" class="form-control my-3"
-            t-att-value="optionEl.textContent or ''"
-            t-on-change="onInputChange"/>
+        primaryTitle.translate="Save"
+        primaryClick.bind="addStepAndClose"
+        secondaryTitle.translate="Discard">
+        <t t-foreach="this.optionEls" t-as="optionEl" t-key="optionEl_index">
+            <input
+                type="text" class="form-control my-3"
+                t-att-data-index="optionEl_index"
+                t-att-value="optionEl.textContent or ''"
+                t-on-change="onInputChange"
+            />
+        </t>
     </WebsiteDialog>
 </t>
 

--- a/addons/website/static/tests/builder/translation.test.js
+++ b/addons/website/static/tests/builder/translation.test.js
@@ -209,11 +209,17 @@ test("translate select", async () => {
         `,
     });
     await contains(".modal .btn:contains(Ok, never show me this again)").click();
+    expect(":iframe .form-select.s_website_form_input option").toHaveCount(2);
     await contains(":iframe [data-initial-translation-value='Option 1']").click();
-    await contains(".modal .modal-body input").edit("Option fr");
-    await contains(".modal .btn:contains('Ok')").click();
+    expect(".modal .modal-body input").toHaveCount(2);
+    await contains(".modal .modal-body > :nth-child(1)").edit("Option fr 1");
+    await contains(".modal .modal-body > :nth-child(2)").edit("Option fr 2");
+    await contains(".modal .btn:contains('Save')").click();
     expect(queryAllTexts(":iframe [data-initial-translation-value='Option 1']")).toEqual([
-        "Option fr",
+        "Option fr 1",
+    ]);
+    expect(queryAllTexts(":iframe [data-initial-translation-value='Option 2']")).toEqual([
+        "Option fr 2",
     ]);
 });
 


### PR DESCRIPTION
### Before this commit:

Translating selection field options was a manual and repetitive
task. Each option required opening a separate dialog to translate.

<img width="809" height="353" alt="image" src="https://github.com/user-attachments/assets/a7c0c481-a319-4997-bc42-0eb230c0e3e7" />

---

### After this commit:

When triggered, translation opens a single dialog with all selection
options as editable fields. On discard it cancels and On confirmation, the UI:

- Updates the text content of each option
- Applies the `oe_translated` class where translations differ from the
  original value

<img width="824" height="424" alt="image" src="https://github.com/user-attachments/assets/19dfe51c-e8fd-4f1c-979c-b2c03a22de0e" />


task-4610335