### PR TITLE
[FIX] website_sale: ignore trailing whitespaces in name during checkout and import

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1431,7 +1431,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             name_change = (
                 'name' in address_values
                 and partner_sudo.name
-                and address_values['name'] != partner_sudo.name
+                and address_values['name'] != partner_sudo.name.strip()
             )
             email_change = (
                 'email' in address_values

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -1,5 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
 from unittest.mock import patch
 
 from werkzeug.exceptions import Forbidden
@@ -611,3 +613,33 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             so.website_id = False
             so._compute_payment_term_id()
             self.assertFalse(so.payment_term_id, "The website default payment term should not be set on a sale order not coming from the website")
+
+    def test_imported_user_with_trailing_name_can_checkout(self):
+        """Ensure that an imported user with trailing spaces in their name can complete checkout without error."""
+
+        imported_user = self.env['res.users'].create({
+            'name': 'Imported User ',  # trailing space
+            'login': 'imported_user',
+            'email': 'imported@example.com',
+        })
+        imported_partner = imported_user.partner_id
+        so = self._create_so(partner_id=imported_partner.id)
+
+        env = api.Environment(self.env.cr, imported_user.id, {})
+        with MockRequest(env, website=self.website.with_env(env), sale_order_id=so.id) as req:
+            req.httprequest.method = "POST"
+
+            values = {
+                'name': 'Imported User',  # trimmed input
+                'email': 'imported@example.com',
+                'street': '123 Some Street',
+                'city': 'Cityville',
+                'zip': '12345',
+                'country_id': self.country_id,
+                'phone': '+33123456789',
+                'partner_id': imported_partner.id,
+                'address_type': 'delivery',
+                'use_delivery_as_billing': 'true',
+            }
+            res = self.WebsiteSaleController.shop_address_submit(**values).data
+            self.assertIsNotNone(json.loads(res).get('redirectUrl'), "We should get a 'redirectUrl' in the response")


### PR DESCRIPTION
**Steps to reproduce:**
1. Install the website_sale app.
2. Import a user with trailing spaces in the Name field.
3. Make this user Admin in settings
4. Log in with that user and go to Website > Shop.
5. Click on new and create a new product
6. Add this product to the cart and proceed to checkout.
7. The checkout form pre-fills the name (with trailing spaces).
8. fill other fields
9. Submitting the form triggers a warning due to changed name.

**Expected behaviour:**
- Name is not changed by us so it should let us checkout
- There should not be trailing spaces in imported char fields
  if trim attribute is true

**Issue:**
- The name field from the form is trimmed in post request,
  but the value from the database (with trailing spaces) is used during comparison
  This results in a false positive change detection.

- User's name with trailing spaces is because of Imported records does not check for
  trim attribute in backend but this is handled in ui.

**Solution:**
- Trim the database value before comparing it to the form input
- Trim the values of char field before importing if trim attribute is true

opw-4794220