### PR TITLE
[FIX] html_editor: link popover not hidden on clicking other element

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -567,6 +567,7 @@ export class LinkPlugin extends Plugin {
                 this.dependencies.selection.focusEditable();
             },
             onEdit: () => {
+                this.LinkPopoverState.editing = true;
                 this.restoreSavePoint = this.dependencies.history.makeSavePoint();
             },
             getInternalMetaData: this.getInternalMetaData,
@@ -738,7 +739,7 @@ export class LinkPlugin extends Plugin {
         } else {
             const closestLinkElement = closestElement(selection.anchorNode, "A");
             if (closestLinkElement && closestLinkElement.isContentEditable) {
-                if (closestLinkElement !== this.linkInDocument) {
+                if (closestLinkElement !== this.linkInDocument || !this.currentOverlay.isOpen) {
                     this.openLinkTools(closestLinkElement);
                 }
             } else if (
@@ -1106,9 +1107,11 @@ export class LinkPlugin extends Plugin {
                 overlay: this.dependencies.overlay.createOverlay(
                     link_popover.PopoverClass,
                     {
-                        closeOnPointerdown: false,
+                        closeOnPointerdown: true,
                     },
-                    { sequence: 50 }
+                    {
+                        sequence: 50,
+                    }
                 ),
                 isAvailable: link_popover.isAvailable,
                 getProps: link_popover.getProps,

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -10,6 +10,7 @@ import {
     select,
     waitFor,
     waitForNone,
+    manuallyDispatchProgrammaticEvent,
 } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { markup } from "@odoo/owl";
@@ -84,6 +85,18 @@ describe("should open a popover", () => {
         queryOne(".o_we_href_input_link").focus();
         await animationFrame();
         expect(queryOne(".o-we-linkpopover").parentElement).toHaveAttribute("style", style);
+    });
+    test("link popover should close when clicking on a contenteditable false element", async () => {
+        await setupEditor(
+            '<p><a href="#">li[]nk</a> <a contenteditable="false">uneditable link</a></p>'
+        );
+        await waitFor(".o-we-linkpopover");
+        expect(".o-we-linkpopover").toHaveCount(1);
+        // click on an uneditable element
+        const nodeEl = queryOne("a[contenteditable='false']");
+        manuallyDispatchProgrammaticEvent(nodeEl, "mousedown");
+        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
+        expect(".o-we-linkpopover").toHaveCount(0);
     });
 });
 


### PR DESCRIPTION
Before this commit clicking on certain elements with a link popover open would not cause the link popover to close.

Steps to reproduce:
- go to the website homepage
- open the editor
- click on any top menu links like Home or Contact Us
- click on the user dropdwon in the topbar (usually Administrator)
- the popover from the first click is still open

After the change clicking anywere that's not the popover's current link will cause the popover to close.
