### PR TITLE
[IMP] hr_attendance: add 'Attendance: Officer' security group

### DIFF
--- a/addons/hr_attendance/controllers/main.py
+++ b/addons/hr_attendance/controllers/main.py
@@ -86,7 +86,7 @@ class HrAttendance(http.Controller):
 
     @http.route('/hr_attendance/kiosk_mode_menu/<int:company_id>', auth='user', type='http')
     def kiosk_menu_item_action(self, company_id):
-        if request.env.user.has_group("hr_attendance.group_hr_attendance_manager"):
+        if request.env.user.has_group("hr_attendance.group_hr_attendance_user"):
             # Auto log out will prevent users from forgetting to log out of their session
             # before leaving the kiosk mode open to the public. This is a prevention security
             # measure.

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -27,7 +27,7 @@ class ResCompany(models.Model):
         ('back', 'Back Camera'),
     ], string='Barcode Source', default='front')
     attendance_kiosk_delay = fields.Integer(default=10)
-    attendance_kiosk_key = fields.Char(default=lambda s: uuid.uuid4().hex, copy=False, groups='hr_attendance.group_hr_attendance_manager')
+    attendance_kiosk_key = fields.Char(default=lambda s: uuid.uuid4().hex, copy=False, groups='hr_attendance.group_hr_attendance_user')
     attendance_kiosk_url = fields.Char(compute="_compute_attendance_kiosk_url")
     attendance_kiosk_use_pin = fields.Boolean(string='Employee PIN Identification')
     attendance_from_systray = fields.Boolean(string='Attendance From Systray', default=True)

--- a/addons/hr_attendance/models/res_config_settings.py
+++ b/addons/hr_attendance/models/res_config_settings.py
@@ -48,5 +48,5 @@ class ResConfigSettings(models.TransientModel):
             company.write({field: self[field] for field in fields_to_check})
 
     def regenerate_kiosk_key(self):
-        if self.env.user.has_group("hr_attendance.group_hr_attendance_manager"):
+        if self.env.user.has_group("hr_attendance.group_hr_attendance_user"):
             self.company_id._regenerate_attendance_kiosk_key()

--- a/addons/hr_attendance/security/hr_attendance_security.xml
+++ b/addons/hr_attendance/security/hr_attendance_security.xml
@@ -21,12 +21,20 @@
         <field name="comment">The user will have access to the attendance records and reporting of employees where he's set as an attendance manager</field>
     </record>
 
+    <record id="group_hr_attendance_user" model="res.groups">
+        <field name="name">Officer: Manage all attendances</field>
+        <field name="sequence">15</field>
+        <field name="privilege_id" ref="res_groups_privilege_attendances"/>
+        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
+        <field name="comment">The user will have access to all attendance records and reports for all employees.</field>
+    </record>
+    
     <record id="group_hr_attendance_manager" model="res.groups">
         <field name="name">Administrator</field>
         <field name="sequence">20</field>
         <field name="privilege_id" ref="res_groups_privilege_attendances"/>
         <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
-        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_officer'))]"/>
+        <field name="implied_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
     </record>
 
     <data noupdate="1">
@@ -43,7 +51,7 @@
             <field name="name">Attendance Administrator: Full access</field>
             <field name="model_id" ref="model_hr_attendance"/>
             <field name="domain_force">[(1,'=',1)]</field>
-            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'))]"/>
+            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
         </record>
 
         <record id="hr_attendance_rule_attendance_manager_restrict" model="ir.rule">
@@ -111,7 +119,7 @@
             <field name="name">Attendance Admin: full access</field>
             <field name="model_id" ref="model_hr_attendance_overtime"/>
             <field name="domain_force">[(1,'=',1)]</field>
-            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'))]"/>
+            <field name="groups" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
 
         </record>
 

--- a/addons/hr_attendance/security/ir.model.access.csv
+++ b/addons/hr_attendance/security/ir.model.access.csv
@@ -1,7 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_attendance_admin,hr.attendance.admin,model_hr_attendance,group_hr_attendance_manager,1,1,1,1
 access_hr_attendance_admin_overtime,hr.attendance.admin.overtime,model_hr_attendance_overtime,group_hr_attendance_manager,1,1,1,1
+access_hr_attendance_user,hr.attendance.user,model_hr_attendance,group_hr_attendance_user,1,1,1,1
+access_hr_attendance_user_overtime,hr.attendance.user.overtime,model_hr_attendance_overtime,group_hr_attendance_user,1,1,1,1
 access_hr_attendance_officer,hr.attendance.officer,model_hr_attendance,group_hr_attendance_officer,1,1,1,1
 access_hr_attendance_officer_overtime,hr.attendance.officer.overtime,model_hr_attendance_overtime,group_hr_attendance_officer,1,1,1,1
-access_hr_attendance_user,hr.attendance.user,model_hr_attendance,group_hr_attendance_own_reader,1,0,0,0
-access_hr_attendance_overtime_user,hr.attendance.overtime.user,model_hr_attendance_overtime,group_hr_attendance_own_reader,1,0,0,0
+access_hr_attendance_own_reader,hr.attendance.own.reader,model_hr_attendance,group_hr_attendance_own_reader,1,0,0,0
+access_hr_attendance_overtime_own_reader,hr.attendance.overtime.own.reader,model_hr_attendance_overtime,group_hr_attendance_own_reader,1,0,0,0

--- a/addons/hr_attendance/static/src/views/attendance_helper_view.js
+++ b/addons/hr_attendance/static/src/views/attendance_helper_view.js
@@ -13,7 +13,7 @@ export class AttendanceActionHelper extends Component {
             hasDemoData: false,
         });
         onWillStart(async () => {
-            this.hasAttendanceRight = await user.hasGroup("hr_attendance.group_hr_attendance_manager");
+            this.hasAttendanceRight = await user.hasGroup("hr_attendance.group_hr_attendance_user");
             if (this.hasAttendanceRight){
                 this.state.hasDemoData = await this.orm.call("hr.attendance", "has_demo_data", []);
             }

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -99,7 +99,7 @@
                                         ('attendance_manager_id', '=', uid),
                                         ('company_id', 'in', allowed_company_ids),
                                     ]"
-                                    groups="hr_attendance.group_hr_attendance_officer,!hr_attendance.group_hr_attendance_manager"/>
+                                    groups="hr_attendance.group_hr_attendance_officer,!hr_attendance.group_hr_attendance_user"/>
                                 <field
                                     id="employee_manager"
                                     name="employee_id"
@@ -107,7 +107,7 @@
                                     domain="[
                                         ('company_id', 'in', allowed_company_ids),
                                     ]"
-                                    groups="hr_attendance.group_hr_attendance_manager"/>
+                                    groups="hr_attendance.group_hr_attendance_user"/>
                                 <field name="check_in" options="{'rounding': 0}" readonly="not is_manager"/>
                                 <field name="check_out" options="{'rounding': 0}" placeholder="Currently Working" readonly="not is_manager"/>
                             </group>
@@ -436,14 +436,14 @@
         <field name="code">
             action = model._action_open_kiosk_mode()
         </field>
-        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_manager'))]"/>
+        <field name="group_ids" eval="[(4, ref('hr_attendance.group_hr_attendance_user'))]"/>
     </record>
 
     <!-- Menus -->
 
     <menuitem id="menu_hr_attendance_root" name="Attendances" sequence="205" groups="hr_attendance.group_hr_attendance_officer" web_icon="hr_attendance,static/description/icon.png"/>
 
-    <menuitem id="menu_action_open_form" name="Kiosk Mode" action="open_kiosk_url" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance_manager"/>
+    <menuitem id="menu_action_open_form" name="Kiosk Mode" action="open_kiosk_url" parent="menu_hr_attendance_root" sequence="10" groups="hr_attendance.group_hr_attendance_user"/>
 
     <menuitem
         id="menu_hr_attendance_reporting"

--- a/addons/hr_attendance/views/hr_employee_view.xml
+++ b/addons/hr_attendance/views/hr_employee_view.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="hr.view_employee_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//separator[@name='managers_groupby_separator']" position="before">
-                <filter name="group_attendance_manager" string="Attendance Approver" context="{'group_by': 'attendance_manager_id'}" groups="hr_attendance.group_hr_attendance_manager"/>
+                <filter name="group_attendance_manager" string="Attendance Approver" context="{'group_by': 'attendance_manager_id'}" groups="hr_attendance.group_hr_attendance_user"/>
             </xpath>
         </field>
     </record>
@@ -44,7 +44,7 @@
                 </button>
             </button>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_user"/>
             </xpath>
             <xpath expr="//field[@name='barcode']" position="attributes">
                 <attribute name="string">RFID/Badge Number</attribute>
@@ -85,7 +85,7 @@
                 </button>
             </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
-                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" readonly="not can_edit" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" string="Attendance" widget="many2one_avatar_user" readonly="not can_edit" groups="hr_attendance.group_hr_attendance_user"/>
             </xpath>
             <xpath expr="//group[@name='managers']" position="attributes">
                 <attribute name="invisible">0</attribute>
@@ -149,7 +149,7 @@
         <field name="inherit_id" ref="hr.view_employee_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='work_location_id']" position="after">
-                <field name="attendance_manager_id" optional="hide" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_manager"/>
+                <field name="attendance_manager_id" optional="hide" widget="many2one_avatar_user" groups="hr_attendance.group_hr_attendance_user"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- Introduced a new group, 'Attendance: Officer', with permissions similar to the Attendance Administrator group.
- This group can manage all attendances but does **not** have access to attendance configuration settings.

Task: 4826627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
