### PR TITLE
[FIX] bus: fix wait for channel test helper

### DIFF
--- a/addons/bus/static/tests/bus_test_helpers.js
+++ b/addons/bus/static/tests/bus_test_helpers.js
@@ -220,6 +220,7 @@ export async function waitForChannels(channels, { operation = "add" } = {}) {
     const { env } = MockServer;
     const def = new Deferred();
     let done = false;
+    let failTimeout;
 
     /**
      * @param {boolean} crashOnFail
@@ -262,7 +263,7 @@ export async function waitForChannels(channels, { operation = "add" } = {}) {
 
     await runAllTimers();
 
-    const failTimeout = setTimeout(() => check(true), TIMEOUT);
+    failTimeout = setTimeout(() => check(true), TIMEOUT);
     check(false);
 
     return def;


### PR DESCRIPTION
The wait for channel test helper waits for a bus channel subscription to be made. However, when the test fails before the fail timeout is setup, an error occurs. This commit fixes this issue in order to have proper fail description on those tests instead of a programming error.

fixes runbot-223908

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
