### PR TITLE
[IMP] mail: add inbox tab & lazy loading to messaging menu

### DIFF
--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime
 from odoo import http
 from odoo.http import request
 from odoo.addons.mail.controllers.thread import ThreadController
@@ -85,6 +86,8 @@ class WebclientController(ThreadController):
             # sudo: mail.notification - return only failures of current user as author
             notifications = request.env["mail.notification"].sudo().search(domain, limit=100)
             notifications.mail_message_id._message_notifications_to_store(store)
+        elif name == "load_messaging_menu_data":
+            self._load_messaging_menu_data(store, params)
 
     @classmethod
     def _process_request_for_internal_user(self, store: Store, name, params):
@@ -104,3 +107,103 @@ class WebclientController(ThreadController):
                 ("group_ids", "in", request.env.user.all_group_ids.ids),
             ]
             store.add(request.env["mail.canned.response"].search(domain))
+
+    @classmethod
+    def _load_messaging_menu_data(self, store: Store, params: dict):
+        """Load messaging menu data for diffrent tabs."""
+        tab = params.get("tab", "main")
+        load_limit = int(params.get("limit", 30))
+        offset = int(params.get("offset", 0))
+        tab_loaders = {
+            "inbox": self._load_inbox_data,
+            "channel": self._load_channel_data,
+            "chat": self._load_chat_data,
+            "main": self._load_main_data,
+        }
+        loader = tab_loaders.get(tab)
+        if loader:
+            loader(store, offset, load_limit)
+
+    def _get_messages(offset: int, limit: int | None, needaction: bool = True):
+        """Fetch messages"""
+        domain = [("needaction", "=", needaction)]
+        return request.env["mail.message"].search(domain, limit=limit, offset=offset, order="id DESC")
+
+    def _get_channels(domain: list = [], offset: int = 0, limit: int | None = None, seprate_by_needaction: bool = False):
+        """Fetch channels based on the provided domain, limit, and channel types."""
+        channels = request.env["discuss.channel"].search(domain, order="last_interest_dt DESC")
+        needaction_channels = channels.filtered(lambda c: c.message_needaction)
+        history_channels = channels.filtered(lambda c: not c.message_needaction)
+        if seprate_by_needaction:
+            return {
+                "needaction": needaction_channels,
+                "history": history_channels,
+            }
+        channels = (needaction_channels + history_channels)
+        if limit:
+            channels = channels[offset:offset + limit]
+        return channels
+
+    @classmethod
+    def _load_inbox_data(self, store: Store, offset: int, limit: int):
+        """Load data for the inbox tab."""
+        inbox_msgs = self._get_messages(offset, limit, True)
+        inbox_msgs_count = request.env["mail.message"].search_count([("needaction", "=", True)])
+        remaining_limit = limit - len(inbox_msgs)
+        history_msgs = request.env["mail.message"].browse()
+        if remaining_limit > 0:
+            history_msgs = self._get_messages(max(0, offset - inbox_msgs_count), remaining_limit, False)
+        all_msgs = inbox_msgs + history_msgs
+        store.add(all_msgs, add_followers=True).resolve_data_request(
+            count=len(all_msgs),
+        )
+
+    @classmethod
+    def _load_channel_data(self, store: Store, offset: int, limit: int):
+        """Load data for channels tab."""
+        domain = [("channel_type", "=", "channel")]
+        channels = self._get_channels(domain, offset, limit, False)
+        store.add(channels).resolve_data_request(count=len(channels))
+
+    @classmethod
+    def _load_chat_data(self, store: Store, offset: int, limit: int):
+        """Load data for chat tab."""
+        domain = [("channel_type", "in", ["chat", "group"])]
+        channels = self._get_channels(domain, offset, limit, False)
+        store.add(channels).resolve_data_request(count=len(channels))
+
+    @classmethod
+    def _load_main_data(self, store: Store, offset: int, limit: int):
+        """Load data for main tab with comprehensive thread and message fetching."""
+        inbox_msgs = self._get_messages(0, None, True)
+        domain = [("channel_type", "in", ["chat", "group", "channel"])]
+        all_channels = self._get_channels(domain, 0, None, True)
+        needaction_channels = all_channels.get("needaction", request.env["discuss.channel"])
+        history_channels = all_channels.get("history", request.env["discuss.channel"])
+
+        def get_sort_key(record):
+            date_val = None
+            if record._name == "discuss.channel":
+                date_val = record.last_interest_dt
+            elif record._name == "mail.message":
+                date_val = record.write_date
+            return date_val or datetime.datetime.min
+        combined_all_unread = [*inbox_msgs, *needaction_channels]
+        sorted_all_unread = sorted(
+            combined_all_unread,
+            key=get_sort_key,
+            reverse=True,
+        )
+        limited_threads_list = [*sorted_all_unread, *history_channels][offset:offset + limit]
+        final_messages = request.env["mail.message"]
+        final_channels = request.env["discuss.channel"]
+        for record in limited_threads_list:
+            if record._name == "mail.message":
+                final_messages |= record
+            elif record._name == "discuss.channel":
+                final_channels |= record
+        store.add(final_channels)
+        store.add(final_messages, add_followers=True)
+        store.resolve_data_request(
+            count=len(limited_threads_list),
+        )

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -162,14 +162,26 @@ export class Store extends BaseStore {
         compute() {
             /** @type {import("models").Thread[]} */
             const searchTerm = cleanTerm(this.discuss.searchTerm);
-            let threads = Object.values(this.Thread.records).filter(
-                (thread) =>
-                    (thread.displayToSelf ||
-                        (thread.needactionMessages.length > 0 && thread.model !== "mail.box")) &&
-                    cleanTerm(thread.displayName).includes(searchTerm)
-            );
             const tab = this.discuss.activeTab;
-            if (tab !== "main") {
+            let threads = Object.values(this.Thread.records);
+            threads =
+                tab === "inbox"
+                    ? threads
+                    : threads.filter(
+                          (thread) =>
+                              (thread.displayToSelf ||
+                                  (thread.needactionMessages.length > 0 &&
+                                      thread.model !== "mail.box")) &&
+                              cleanTerm(thread.displayName).includes(searchTerm)
+                      );
+            if (tab === "inbox") {
+                threads = threads.filter(
+                    (thread) =>
+                        thread.model !== "mail.box" &&
+                        thread.channel_type === undefined &&
+                        cleanTerm(thread.displayName).includes(searchTerm)
+                );
+            } else if (tab !== "main") {
                 threads = threads.filter(({ channel_type }) =>
                     this.tabToThreadType(tab).includes(channel_type)
                 );

--- a/addons/mail/static/src/core/web/messaging_menu_patch.xml
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.xml
@@ -25,6 +25,7 @@
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'main' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'main'">All</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'chat' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'chat'">Chats</button>
                         <button class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'channel' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'channel'">Channels</button>
+                        <button t-if="store.self.main_user_id?.notification_type === 'inbox'" class="o-mail-MessagingMenu-headerFilter btn btn-link px-2 py-1 m-1 lh-1" t-att-class="store.discuss.activeTab === 'inbox' ? 'fw-bold o-active shadow-sm' : 'text-muted'" type="button" role="tab" t-on-click="() => store.discuss.activeTab = 'inbox'">Inbox</button>
                         <button t-if="threads.length >= 20 and store.channels.status !== 'fetching'" class="btn btn-link py-1 rounded-0 text-muted" type="button" title="Quick search" t-on-click="toggleSearch"><i class="fa fa-fw fa-search"/></button>
                         <button t-if="store.channels.status === 'fetching'" class="btn btn-light py-1 rounded-0" disabled="true" type="button"><i class="fa fa-fw fa-circle-o-notch fa-spin"/></button>
                     </t>
@@ -99,6 +100,12 @@
                     <t t-set="itemIndex" t-value="itemIndex + 1"/>
                 </t>
             </t>
+        </xpath>
+        <xpath expr="//*[@name='threads']" position="after">
+            <div t-ref="loadMoreSentinel" class="o-mail-MessagingMenu-loadMore"
+                style="min-height: 1px;"
+                t-att-class="{'d-none': !!state.tabState[store.discuss.activeTab]?.[1]}"
+                t-on-click="loadMoreMessagingMenuData"/>
         </xpath>
     </t>
 </templates>


### PR DESCRIPTION
**Current behavior before PR:**

- Channels were loaded all at once in the messaging menu, causing performance issues.
- Read notifications gets disappeared and were only accessible from Discuss history.

**Desired behavior after PR is merged:**

- New inbox tab in messaging menu which displays unread & read notifications  
- All tabs (main, channels, chat, inbox) implement lazy loading and fetch threads in batches as user scrolls  
- Inbox tab is only visible to users with notification preference set to handle in odoo


task-[4458377](https://www.odoo.com/odoo/project/1519/tasks/4458377)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
