### PR TITLE
[IMP] iot_base: add iot box id to device controller

### DIFF
--- a/addons/iot_base/static/src/device_controller.js
+++ b/addons/iot_base/static/src/device_controller.js
@@ -6,12 +6,13 @@ import { uniqueId } from "@web/core/utils/functions";
 export class DeviceController {
     /**
      * @param {import("@iot_base/network_utils/longpolling").IoTLongpolling} iotLongpolling
-     * @param {{ iot_ip: string, identifier: string, manual_measurement: string }} deviceInfo - Representation of an iot device
+     * @param {{ iot_ip: string, identifier: string, iot_id: Object, manual_measurement: string }} deviceInfo - Representation of an iot device
      */
     constructor(iotLongpolling, deviceInfo) {
         this.id = uniqueId('listener-');
         this.iotIp = deviceInfo.iot_ip;
         this.identifier = deviceInfo.identifier;
+        this.iotId = deviceInfo.iot_id.id;
         this.manual_measurement = deviceInfo.manual_measurement;
         this.iotLongpolling = iotLongpolling;
     }


### PR DESCRIPTION
We added the iot box id to the device controller object in order to ease the transition from the `iot_longpolling` service to the `iot_http` one.

Enterprise PR: odoo/enterprise#86596
Task: 4824066
