### PR TITLE
[FIX] website: improve date/datetime picker behavior on mobile

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -131,6 +131,9 @@ import wUtils from '@website/js/utils';
                         value: defaultValue && DateTime.fromSeconds(parseInt(defaultValue)),
                     },
                 }).enable();
+                // Disable virtual keyboard to fix popover display issues on
+                // small screens
+                input.setAttribute("inputmode", "none");
             }
             this.$allDates.addClass('s_website_form_datepicker_initialized');
 

--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -100,6 +100,11 @@
             background-color: darken($o-gray-200, 4.5%);
         }
     }
+    @include media-breakpoint-down(md) {
+        .datetimepicker-input{
+            caret-color: transparent;
+        }
+    }
 }
 
 body:not(.editor_enable) .s_website_form[data-vcss="001"] {


### PR DESCRIPTION
Before this commit:
- The cursor was shown inside the date/datetime input field on mobile,
  which triggered the keyboard unnecessarily and degraded the user
  experience.

Steps to reproduce:
1. Add a form snippet.
2. Add a Date/Datetime field.
3. Click on the Date field.
   - The virtual keyboard appears and the datepicker popover may be
     clipped or partially hidden.

After this commit:
- The virtual keyboard is now prevented from opening on date/datetime 
  inputs, and the text cursor within these fields is also hidden.

task-[4745714](https://www.odoo.com/odoo/project/974/tasks/4745714)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
