### PR TITLE
[FIX] web_editor: ignore toolbar update if iframe no longer in DOM

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3241,6 +3241,10 @@ export class OdooEditor extends EventTarget {
         }
 
         const sel = this.document.getSelection();
+        if (sel === null) {
+            // The iframe is no longer in the document => no need to do anything.
+            return;
+        }
         if (!hasTableSelection(this.editable)) {
             if (this.editable.classList.contains('o_col_resize') || this.editable.classList.contains('o_row_resize')) {
                 show = false;


### PR DESCRIPTION
This commit fixes this [runbot error](https://runbot.odoo.com/odoo/runbot.build.error/75847) which is triggered by a toolbar method called at an incorrect time in some instances.
Sometimes the method could be called after the form view was exited. Which means that the iframe used by the mailing editor could trigger the method even though it is no longer in the DOM.
This leads to a call to getSelection on a document that could no longer be displayed/present in the DOM.

To fix this issue, when the selection returned by the document is null (this.document no longer on the DOM), the method returns directly.

task-4829204

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
