### PR TITLE
[FIX] website: repair link_to_document tour

### DIFF
--- a/addons/website/static/tests/tours/link_to_document.js
+++ b/addons/website/static/tests/tours/link_to_document.js
@@ -22,6 +22,17 @@ const unpatchStep = {
     run: () => unpatch(),
 };
 
+function showLinkPopover(linkEl) {
+    const doc = linkEl.ownerDocument;
+    const selection = doc.getSelection();
+    const range = doc.createRange();
+    selection.removeAllRanges();
+    range.setStart(linkEl.childNodes[0], 0);
+    range.setEnd(linkEl.childNodes[0], 0);
+    doc.dispatchEvent(new Event("focus"));
+    selection.addRange(range);
+}
+
 /**
  * The purpose of this tour is to check the Linktools to create a link to an
  * uploaded document.
@@ -41,31 +52,52 @@ registerWebsitePreviewTour(
         {
             content: "Click on button Start Now",
             trigger: ":iframe #wrap .s_banner a:nth-child(1)",
+            run: ({ anchor }) => {
+                showLinkPopover(anchor);
+            },
+        },
+        {
+            content: "Click on edit link",
+            trigger: ".o-we-linkpopover .o_we_edit_link",
             run: "click",
+        },
+        {
+            content: "Make upload button appear by emptying the link input",
+            trigger: ".o_we_href_input_link",
+            run: ({ anchor }) => {
+                anchor.value = "";
+                anchor.dispatchEvent(new Event("input"));
+            },
         },
         patchStep,
         {
-            content: "Click on link to an uploaded document",
-            trigger: ".o_url_input .o_we_user_value_widget.fa.fa-upload",
+            content: "Click on upload button",
+            trigger: ".o_we_href_input_link + span button",
+            run: "click",
+        },
+        {
+            content: "Click on apply",
+            trigger: ".o_we_apply_link",
             run: "click",
         },
         {
             content: "Check if a document link is created",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link[href^='/web/content']",
+            trigger: ":iframe #wrap .s_banner a[href^='/web/content']",
         },
         unpatchStep,
-        {
-            content: "Check if by default the option auto-download is enabled",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link[href$='download=true']",
-        },
-        {
-            content: "Deactivate direct download",
-            trigger: ".o_switch > we-checkbox[name='direct_download']",
-            run: "click",
-        },
-        {
-            content: "Check if auto-download is disabled",
-            trigger: ":iframe #wrap .s_banner .oe_edited_link:not([href$='download=true'])",
-        },
+        // TODO: reimplement these steps if the auto-download option comes back
+        // {
+        //     content: "Check if by default the option auto-download is enabled",
+        //     trigger: ":iframe #wrap .s_banner .oe_edited_link[href$='download=true']",
+        // },
+        // {
+        //     content: "Deactivate direct download",
+        //     trigger: ".o_switch > we-checkbox[name='direct_download']",
+        //     run: "click",
+        // },
+        // {
+        //     content: "Check if auto-download is disabled",
+        //     trigger: ":iframe #wrap .s_banner .oe_edited_link:not([href$='download=true'])",
+        // },
     ]
 );

--- a/addons/website/tests/test_attachment.py
+++ b/addons/website/tests/test_attachment.py
@@ -41,7 +41,6 @@ class TestWebsiteAttachment(odoo.tests.HttpCase):
     def test_02_image_quality(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'website_image_quality', login="admin")
 
-    @unittest.skip
     def test_03_link_to_document(self):
         text = b'Lorem Ipsum'
         self.env['ir.attachment'].create({


### PR DESCRIPTION
Steps to reproduce:
    Run the test_03_link_to_document test

Current behavior before PR:
    The test fails miserably because the tour click event  does not trigger a selectionchange event

Desired behavior after PR is merged:
    The tour is fixed by manually triggering a selectionchange event as well as a focus event
