### PR TITLE
[FIX] point_of_sale: Fix error if category is missing

### DIFF
--- a/addons/point_of_sale/data/scenarios/bakery_data.xml
+++ b/addons/point_of_sale/data/scenarios/bakery_data.xml
@@ -38,7 +38,7 @@
 			<field name="image_1920" type="base64" file="point_of_sale/static/img/product_flour.png"/>
 			<field name="available_in_pos" eval="True"/>
 			<field name="to_weight" eval="True"/>
-			<field name="categ_id" ref="point_of_sale.product_category_food"/>
+			<field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
 			<field name="pos_categ_ids" eval="[(6, 0, [ref('pos_category_breads')])]" />
 		</record>
 		<record model="product.product" id="product_tiger_white_loaf">


### PR DESCRIPTION
Currently, an exception is generated when the system tries to find the product category for the newly added `product_flour` if all categories have been deleted manually before loading demo data.

Steps to reproduce:

1. Install the `point_of_sale` module without demo data.
2. Navigate to Inventory -> Configuration -> Categories.
3. Delete food categories.
4. Navigate to Point of Sale -> load sample of bakery
5. An error occurs.

Error:
```
ParseError
while parsing /home/odoo/src/odoo/saas-18.2/addons/product/data/product_demo.xml:30, somewhere inside
```
This issue occurs because `product_flour` also references a missing product category. As with previous products, this change ensures a fallback to avoid failure when no categories exist.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
