### PR TITLE
[IMP] website: add image size tag

### DIFF
--- a/addons/website/static/src/builder/plugins/background_option/background_image.xml
+++ b/addons/website/static/src/builder/plugins/background_option/background_image.xml
@@ -3,7 +3,8 @@
 
 <t t-name="website.BackgroundImageOption">
     <BuilderRow t-if="isActiveItem('toggle_bg_image_id')" label.translate="Image" level="1">
-        <BuilderButton preview="false" title.translate="Edit image" type="'success'" action="'replaceBgImage'"> Replace </BuilderButton>
+        <BuilderButton preview="false" title.translate="Edit image" action="'replaceBgImage'" type="'success'" className="'flex-grow-1'"> Replace </BuilderButton>
+        <ImageSizeTag/>
     </BuilderRow>
     <BuilderRow t-if="showMainColorPicker()" label.translate="Main Color" level="2">
         <t t-foreach="getColorPickerColorNames()" t-as="colorName" t-key="colorName_index">

--- a/addons/website/static/src/builder/plugins/background_option/background_image_option.js
+++ b/addons/website/static/src/builder/plugins/background_option/background_image_option.js
@@ -1,9 +1,11 @@
 import { BaseOptionComponent } from "@html_builder/core/utils";
 import { getBgImageURLFromEl, normalizeColor } from "@html_builder/utils/utils_css";
+import { ImageSizeTag } from "@website/builder/plugins/image/image_size_tag";
 
 export class BackgroundImageOption extends BaseOptionComponent {
     static template = "website.BackgroundImageOption";
     static props = {};
+    static components = { ImageSizeTag };
     setup() {
         // done here because we have direct access to the editing element
         // (which we don't have in the normalize of the current plugin)

--- a/addons/website/static/src/builder/plugins/image/image_size_tag.js
+++ b/addons/website/static/src/builder/plugins/image/image_size_tag.js
@@ -1,0 +1,26 @@
+import { Component, useState } from "@odoo/owl";
+import { useDomState } from "@html_builder/core/utils";
+import { loadImageDataURL, getImageSizeFromCache } from "@html_editor/utils/image_processing";
+import { KeepLast } from "@web/core/utils/concurrency";
+import { getImageSrc } from "@html_editor/utils/image";
+
+export class ImageSizeTag extends Component {
+    static template = "website.ImageSizeTag";
+    static props = {};
+    setup() {
+        this.keepLast = new KeepLast();
+        this.state = useState({ size: 0 });
+        useDomState((el) => this.updateImageSize(el));
+        this.updateImageSize(this.env.getEditingElement());
+    }
+
+    async updateImageSize(el) {
+        try {
+            const src = getImageSrc(el);
+            await this.keepLast.add(loadImageDataURL(src));
+            this.state.size = Math.round((getImageSizeFromCache(src) / 1024) * 10) / 10;
+        } catch {
+            // skip
+        }
+    }
+}

--- a/addons/website/static/src/builder/plugins/image/image_size_tag.xml
+++ b/addons/website/static/src/builder/plugins/image/image_size_tag.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="website.ImageSizeTag">
+        <span class="badge text-bg-dark" title="Size"><t t-out="state.size"/> KB</span>
+    </t>
+</templates>

--- a/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
@@ -16,6 +16,7 @@ import {
 import { ReplaceMediaOption, searchSupportedParentLinkEl } from "./replace_media_option";
 import { computeMaxDisplayWidth } from "./image_format_option";
 import { BuilderAction } from "@html_builder/core/builder_action";
+import { ImageSizeTag } from "./image_size_tag";
 
 export const REPLACE_MEDIA_SELECTOR = "img, .media_iframe_video, span.fa, i.fa";
 export const REPLACE_MEDIA_EXCLUDE =
@@ -33,6 +34,10 @@ class ImageToolOptionPlugin extends Plugin {
     ];
     static shared = ["canHaveHoverEffect"];
     resources = {
+        builder_header_middle_buttons: {
+            Component: ImageSizeTag,
+            selector: "img",
+        },
         builder_options: [
             withSequence(REPLACE_MEDIA, {
                 OptionComponent: ReplaceMediaOption,

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -7,6 +7,8 @@ import {
     queryAll,
     queryFirst,
     waitFor,
+    queryAllTexts,
+    waitUntil,
 } from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder, dummyBase64Img } from "./website_helpers";
@@ -59,6 +61,21 @@ test("image should not be draggable", async () => {
     });
 
     expect(events.get("dragstart").defaultPrevented).toBe(true);
+});
+
+test("click on Image should show image size tag in sidebar", async () => {
+    await setupWebsiteBuilder(`
+        <div class="test-options-target">
+            ${testImg}
+        </div>
+    `);
+    await contains(":iframe .test-options-target img").click();
+    await waitUntil(
+        () =>
+            queryAllTexts(".options-container span.badge.text-bg-dark[title='Size']")[0] ===
+            "42.9 KB",
+        { timeout: 2000 }
+    );
 });
 
 describe("Image format/optimize", () => {

--- a/addons/website/static/tests/builder/website_builder/animate_option.test.js
+++ b/addons/website/static/tests/builder/website_builder/animate_option.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { animationFrame, queryFirst } from "@odoo/hoot-dom";
-import { contains, onRpc } from "@web/../tests/web_test_helpers";
+import { contains, onRpc, patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder } from "../website_helpers";
+import { ImageSizeTag } from "@website/builder/plugins/image/image_size_tag";
 
 defineWebsiteModels();
 
@@ -230,6 +231,9 @@ test("animation=onHover should not be visible when the image has a wrong mimetyp
     expect(".o-dropdown--menu [data-action-value='onHover']").not.toHaveCount();
 });
 test("animation=onHover should not be visible when the image has a cors protected image", async () => {
+    patchWithCleanup(ImageSizeTag.prototype, {
+        updateImageSize() {},
+    });
     await setupWebsiteBuilder(`
         <div class="test-options-target">
             <img data-original-id="1" src='/web/image/0-redirect/foo.jpg'>


### PR DESCRIPTION
In the website builder in edit mode, when clicking on an image or an element with a background image there is no way of knowing its size.
This is why a tag to indicate the size of the image was added.
