### PR TITLE
[FIX] website: hide parallax option in dialog

### DIFF
--- a/addons/website/static/src/builder/plugins/options/background_option.xml
+++ b/addons/website/static/src/builder/plugins/options/background_option.xml
@@ -13,7 +13,7 @@
         </t>
     </xpath>
     <!-- TODO: change position of the xpath when snippet_options_image_optimization_widgets is converted -->
-    <xpath expr="//BackgroundShapeOption" position="after">
+    <xpath expr="//BackgroundShapeOption" position="before">
         <ParallaxOption/>
         <t t-call="website.BackgroundVideoOption"/>
     </xpath>

--- a/addons/website/static/src/builder/plugins/options/parallax_option.js
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.js
@@ -1,6 +1,12 @@
-import { BaseOptionComponent } from "@html_builder/core/utils";
-
+import { BaseOptionComponent, useDomState } from "@html_builder/core/utils";
 export class ParallaxOption extends BaseOptionComponent {
     static template = "website.ParallaxOption";
     static props = {};
+
+    setup() {
+        super.setup();
+        this.state = useDomState((el) => ({
+            InDialog: el.closest('.modal[role="dialog"]'),
+        }));
+    }
 }

--- a/addons/website/static/src/builder/plugins/options/parallax_option.xml
+++ b/addons/website/static/src/builder/plugins/options/parallax_option.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="website.ParallaxOption">
-    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id')" label.translate="Parallax" level="2" preview="false">
+    <BuilderRow t-if="isActiveItem('toggle_bg_image_id') and !isActiveItem('toggle_bg_video_id') and !this.state.InDialog" label.translate="Scroll Effect" level="2" preview="false">
         <BuilderSelect action="'setParallaxType'">
             <BuilderSelectItem actionValue="'none'">None</BuilderSelectItem>
             <BuilderSelectItem actionValue="'fixed'">Fixed</BuilderSelectItem>

--- a/addons/website/static/tests/builder/website_builder/background.test.js
+++ b/addons/website/static/tests/builder/website_builder/background.test.js
@@ -31,7 +31,7 @@ test("remove parallax changes editing element", async () => {
             <span class='s_parallax_bg oe_img_bg o_bg_img_center' style="background-image: ${backgroundImageUrl} !important;">aaa</span>
         </section>`);
     await contains(":iframe section").click();
-    await contains("[data-label='Parallax'] button.o-dropdown").click();
+    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
     await contains("[data-action-value='none']").click();
     await contains("[data-label='Position'] .dropdown-toggle").click();
     await contains("[data-action-value='repeat-pattern']").click();
@@ -45,5 +45,5 @@ async function setupWebsiteAndOpenParallaxOptions({ editingElClasses = "" } = {}
         <section ${editingElClass} style="background-image: ${backgroundImageUrl}; width: 500px; height:500px">
         </section>`);
     await contains(":iframe section").click();
-    await contains("[data-label='Parallax'] button.o-dropdown").click();
+    await contains("[data-label='Scroll Effect'] button.o-dropdown").click();
 }

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -20,7 +20,7 @@ registerWebsitePreviewTour("test_parallax", {
     content: "Check that the Cover snippet has the Blur filter on its background image",
     trigger: ":iframe .s_cover span[data-gl-filter='blur']",
 },
-...changeOptionInPopover("Cover", "Parallax", "None"),
+...changeOptionInPopover("Cover", "Scroll Effect", "None"),
 {
     content: "Check that the data related to the filter have been transferred to the new target",
     trigger: ":iframe .s_cover[data-gl-filter='blur']",
@@ -29,7 +29,7 @@ registerWebsitePreviewTour("test_parallax", {
     content: "Check that the 'o_modified_image_to_save' class has been transferred to the new target",
     trigger: ":iframe .s_cover.o_modified_image_to_save",
 },
-...changeOptionInPopover("Cover", "Parallax", "Fixed"),
+...changeOptionInPopover("Cover", "Scroll Effect", "Fixed"),
 {
     content: "Check that the 'o_modified_image_to_save' class has been deleted from the old target",
     trigger: ":iframe .s_cover:not(.o_modified_image_to_save)",
@@ -42,12 +42,12 @@ registerWebsitePreviewTour("test_parallax", {
     content: "Check that the data related to the filter have been transferred to the new target",
     trigger: ":iframe span.s_parallax_bg[data-gl-filter='blur']",
 },
-...changeOptionInPopover("Cover", "Parallax", "Parallax to Top"),
+...changeOptionInPopover("Cover", "Scroll Effect", "Parallax to Top"),
 {
     content: "Check that the option was correctly applied",
     trigger: ':iframe span.s_parallax_bg[style*=top][style*=bottom][style*=transform]',
 },
-...changeOptionInPopover("Cover", "Parallax", "Zoom In"),
+...changeOptionInPopover("Cover", "Scroll Effect", "Zoom In"),
 {
     content: "Check that the option was correctly applied",
     trigger: ':iframe span.s_parallax_bg[style*="transform: scale("]',


### PR DESCRIPTION
[FIX] website: hide parallax option in dialog

Steps to Reproduce :

- Enter edit mode.
- Drag and drop the s_popup snippet.
- The parallax option is visible in the background options.

Previously, the parallax option was visible when editing the background
image of a snippet inside a dialog, even though scrolling is not
possible in that context. This didn’t make sense, so this commit hides
the parallax option when the editing element is within a dialog.