### PR TITLE
[FIX] html_editor: node duplication on serialization

### DIFF
--- a/addons/html_editor/static/src/core/history_plugin.js
+++ b/addons/html_editor/static/src/core/history_plugin.js
@@ -1140,7 +1140,7 @@ export class HistoryPlugin extends Plugin {
                 result.attributes[node.attributes[i].name] = node.attributes[i].value;
             }
             for (const child of childrenToSerialize) {
-                if (!nodesToStripFromChildren.has(child.nodeId)) {
+                if (!nodesToStripFromChildren.has(this.nodeToIdMap.get(child))) {
                     const serializedChild = this._serializeNode(child, nodesToStripFromChildren);
                     if (serializedChild) {
                         result.children.push(serializedChild);

--- a/addons/html_editor/static/tests/collaboration.test.js
+++ b/addons/html_editor/static/tests/collaboration.test.js
@@ -263,9 +263,8 @@ test("wrapInlinesInBlocks should not create impossible mutations in a collaborat
     expect(getContent(e1.editable, { sortAttrs: true })).toBe(
         `<div class="oe_unbreakable"><p>myNode[]</p></div>`
     );
-    // TODO selection in collab should be handled better.
     expect(getContent(e2.editable, { sortAttrs: true })).toBe(
-        `<div class="oe_unbreakable">[]<p>myNode</p></div>`
+        `<div class="oe_unbreakable"><p>myNode[]</p></div>`
     );
 });
 test("should reset from snapshot", async () => {

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -2,7 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { parseHTML } from "@html_editor/utils/html";
 import { describe, expect, test } from "@odoo/hoot";
-import { click, pointerDown, pointerUp, press, queryOne } from "@odoo/hoot-dom";
+import { click, pointerDown, pointerUp, press, queryOne, microTick } from "@odoo/hoot-dom";
 import { animationFrame, mockUserAgent, tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
@@ -600,5 +600,40 @@ describe("destroy", () => {
         editor.destroy();
         await animationFrame();
         expect.verifySteps([]);
+    });
+});
+
+describe("serialization", () => {
+    test("node serialization should not duplicate nodes", async () => {
+        const { editor, el, plugins } = await setupEditor("<p>hello</p>");
+        const p = el.querySelector("p");
+        const textNode = p.firstChild;
+        // Mutation: add strong to p
+        const strong = editor.document.createElement("strong");
+        p.append(strong);
+        // Mutation: remove textNode
+        textNode.remove();
+        // Mutation: add textNode to strong
+        strong.append(textNode);
+
+        await microTick();
+
+        const historyPlugin = plugins.get("history");
+        const mutations = historyPlugin.currentStep.mutations;
+        const idToNode = (id) => historyPlugin.idToNodeMap.get(id);
+
+        expect(mutations.length).toBe(3);
+
+        // Serialized node should not have textNode as child, even though it
+        // current has it as child (otherwise it would duplicate it on unserialization)
+        let { nodeId, children } = mutations[0].node;
+        expect(idToNode(nodeId)).toBe(strong);
+        expect(children.length).toBe(0);
+
+        // 2nd and 3rd mutations: textNode is moved into strong
+        ({ nodeId } = mutations[1].node);
+        expect(idToNode(nodeId)).toBe(textNode);
+        ({ nodeId } = mutations[2].node);
+        expect(idToNode(nodeId)).toBe(textNode);
     });
 });


### PR DESCRIPTION
Since 18.0, we don't store `nodeId` on a `Node` anymore. The error fixed by this commmit led to failure of the mechanism in charge of avoiding duplication of nodes during serialization of history steps.

Steps to reproduce:
- Open the same project task in two tabs, so that collaboration is enabled.
- In one tab, type some text, select it, and make it bold.
- Notice that in the other tab the typed text is duplicated.

task-4825081

