### PR TITLE
[FIX] html_builder: reload sidebar snippets after install

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -156,6 +156,7 @@ export class Builder extends Component {
         );
 
         this.snippetModel = useState(useService("html_builder.snippets"));
+        this.snippetModel.registerBeforeReload(this.save.bind(this));
 
         onWillStart(async () => {
             await this.snippetModel.load();
@@ -175,6 +176,7 @@ export class Builder extends Component {
         // });
         onWillDestroy(() => {
             this.editor.destroy();
+            this.snippetModel.unregisterBeforeReload();
             // actionService.setActionMode("current");
         });
 


### PR DESCRIPTION
Steps to reproduce:
1. Go to website builder
2. Click on install on some snippet of the option bar

Before fix: The corresponding module is installed, and nothing happens once it is done.
After fix: Now, we display a loading animation during the installation and once it is done the modifications are saved and the page is reloaded.
