### PR TITLE
[FIX] html_builder, website: reload builder after installing module

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -33,6 +33,7 @@ export class Builder extends Component {
         closeEditor: { type: Function },
         reloadEditor: { type: Function, optional: true },
         onEditorLoad: { type: Function, optional: true },
+        installSnippetModule: { type: Function, optional: true },
         snippetsName: { type: String },
         toggleMobile: { type: Function },
         overlayRef: { type: Function },
@@ -92,6 +93,8 @@ export class Builder extends Component {
                 closeEditor: async () => {
                     await this.props.closeEditor();
                 },
+                installSnippetModule: async (snippet) =>
+                    this.props.installSnippetModule(snippet, this.save.bind(this)),
                 resources: {
                     trigger_dom_updated: () => {
                         editorBus.trigger("DOM_UPDATED");
@@ -132,7 +135,6 @@ export class Builder extends Component {
         this.props.onEditorLoad(this.editor);
 
         this.snippetModel = useState(useService("html_builder.snippets"));
-        this.snippetModel.registerBeforeReload(this.save.bind(this));
 
         onWillStart(async () => {
             await this.snippetModel.load();
@@ -167,7 +169,6 @@ export class Builder extends Component {
         onWillDestroy(() => {
             this.editor.destroy();
             this.editableEl.removeEventListener("dragstart", this.onDragStart);
-            this.snippetModel.unregisterBeforeReload();
             // actionService.setActionMode("current");
         });
 
@@ -216,6 +217,10 @@ export class Builder extends Component {
     }
 
     async save() {
+        this.editor.shared.operation.next(this._save.bind(this), { withLoadingEffect: false });
+    }
+
+    async _save() {
         this.isSaving = true;
         // TODO: handle the urgent save and the fail of the save operation
         const snippetMenuEl = this.builder_sidebarRef.el;

--- a/addons/html_builder/static/src/sidebar/block_tab.js
+++ b/addons/html_builder/static/src/sidebar/block_tab.js
@@ -59,42 +59,48 @@ export class BlockTab extends Component {
                 const baseSectionEl = snippet.content.cloneNode(true);
                 this.state.ongoingInsertion = true;
                 await new Promise((resolve) => {
-                    this.snippetModel.openSnippetDialog(snippet, {
-                        onSelect: (snippet) => {
-                            snippetEl = snippet.content.cloneNode(true);
+                    this.snippetModel.openSnippetDialog(
+                        snippet,
+                        {
+                            onSelect: (snippet) => {
+                                snippetEl = snippet.content.cloneNode(true);
 
-                            // Add the dropzones corresponding to a section and
-                            // make them invisible.
-                            const selectors = this.shared.dropzone.getSelectors(baseSectionEl);
-                            const dropzoneEls = this.shared.dropzone.activateDropzones(selectors);
-                            this.editable
-                                .querySelectorAll(".oe_drop_zone")
-                                .forEach((dropzoneEl) => dropzoneEl.classList.add("invisible"));
+                                // Add the dropzones corresponding to a section and
+                                // make them invisible.
+                                const selectors = this.shared.dropzone.getSelectors(baseSectionEl);
+                                const dropzoneEls =
+                                    this.shared.dropzone.activateDropzones(selectors);
+                                this.editable
+                                    .querySelectorAll(".oe_drop_zone")
+                                    .forEach((dropzoneEl) => dropzoneEl.classList.add("invisible"));
 
-                            // Find the dropzone closest to the center of the
-                            // viewport and not located in the top quarter of
-                            // the viewport.
-                            const iframeWindow = this.document.defaultView;
-                            const viewPortCenterPoint = {
-                                x: iframeWindow.innerWidth / 2,
-                                y: iframeWindow.innerHeight / 2,
-                            };
-                            const validDropzoneEls = dropzoneEls.filter(
-                                (el) => el.getBoundingClientRect().top >= viewPortCenterPoint.y / 2
-                            );
-                            const closestDropzoneEl =
-                                closest(validDropzoneEls, viewPortCenterPoint) ||
-                                dropzoneEls.at(-1);
+                                // Find the dropzone closest to the center of the
+                                // viewport and not located in the top quarter of
+                                // the viewport.
+                                const iframeWindow = this.document.defaultView;
+                                const viewPortCenterPoint = {
+                                    x: iframeWindow.innerWidth / 2,
+                                    y: iframeWindow.innerHeight / 2,
+                                };
+                                const validDropzoneEls = dropzoneEls.filter(
+                                    (el) =>
+                                        el.getBoundingClientRect().top >= viewPortCenterPoint.y / 2
+                                );
+                                const closestDropzoneEl =
+                                    closest(validDropzoneEls, viewPortCenterPoint) ||
+                                    dropzoneEls.at(-1);
 
-                            // Insert the selected snippet.
-                            closestDropzoneEl.after(snippetEl);
-                            this.shared.dropzone.removeDropzones();
-                            return snippetEl;
+                                // Insert the selected snippet.
+                                closestDropzoneEl.after(snippetEl);
+                                this.shared.dropzone.removeDropzones();
+                                return snippetEl;
+                            },
+                            onClose: () => {
+                                resolve();
+                            },
                         },
-                        onClose: () => {
-                            resolve();
-                        },
-                    });
+                        this.env.editor
+                    );
                 });
 
                 if (snippetEl) {
@@ -129,22 +135,26 @@ export class BlockTab extends Component {
         // Open the snippet dialog.
         let selectedSnippetEl;
         await new Promise((resolve) => {
-            this.snippetModel.openSnippetDialog(snippet, {
-                onSelect: (snippet) => {
-                    selectedSnippetEl = snippet.content.cloneNode(true);
-                    hookEl.replaceWith(selectedSnippetEl);
-                    return selectedSnippetEl;
+            this.snippetModel.openSnippetDialog(
+                snippet,
+                {
+                    onSelect: (snippet) => {
+                        selectedSnippetEl = snippet.content.cloneNode(true);
+                        hookEl.replaceWith(selectedSnippetEl);
+                        return selectedSnippetEl;
+                    },
+                    onClose: () => {
+                        if (!selectedSnippetEl) {
+                            hookEl.remove();
+                        }
+                        this.snippetModel.snippetStructures.forEach(
+                            (snippet) => delete snippet.isExcluded
+                        );
+                        resolve();
+                    },
                 },
-                onClose: () => {
-                    if (!selectedSnippetEl) {
-                        hookEl.remove();
-                    }
-                    this.snippetModel.snippetStructures.forEach(
-                        (snippet) => delete snippet.isExcluded
-                    );
-                    resolve();
-                },
-            });
+                this.env.editor
+            );
         });
 
         if (selectedSnippetEl) {

--- a/addons/html_builder/static/src/sidebar/snippet.js
+++ b/addons/html_builder/static/src/sidebar/snippet.js
@@ -22,4 +22,11 @@ export class Snippet extends Component {
                 .classList.toggle("visually-hidden-focusable", ev.type !== "mouseover");
         }
     }
+
+    onClickInstall() {
+        this.props.snippetModel.installSnippetModule(
+            this.props.snippet,
+            this.env.editor.config.installSnippetModule
+        );
+    }
 }

--- a/addons/html_builder/static/src/sidebar/snippet.xml
+++ b/addons/html_builder/static/src/sidebar/snippet.xml
@@ -18,7 +18,7 @@
             <button
                 t-if="snippet.isInstallable"
                 class="o_install_btn btn btn-success btn-lg position-absolute start-50 bottom-50 translate-middle-x visually-hidden-focusable z-1"
-                t-on-click="() => props.snippetModel.installSnippetModule(snippet)"
+                t-on-click="onClickInstall"
                 >
                 Install
             </button>

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -13,6 +13,7 @@ export class AddSnippetDialog extends Component {
         selectSnippet: { type: Function },
         snippetModel: { type: Object },
         close: { type: Function },
+        installSnippetModule: { type: Function },
     };
 
     setup() {
@@ -33,6 +34,7 @@ export class AddSnippetDialog extends Component {
                 this.props.close();
             },
             snippetModel: this.props.snippetModel,
+            installSnippetModule: this.props.installSnippetModule,
         };
 
         let root;

--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -7,21 +7,15 @@ import { AddSnippetDialog } from "./add_snippet_dialog";
 import { registry } from "@web/core/registry";
 import { user } from "@web/core/user";
 import { markup } from "@odoo/owl";
-import { RPCError } from "@web/core/network/rpc";
-import { redirect } from "@web/core/utils/urls";
 
 export class SnippetModel extends Reactive {
     constructor(services, { snippetsName, context }) {
         super();
         this.orm = services.orm;
         this.dialog = services.dialog;
-        this.notification = services.notification;
         this.snippetsName = snippetsName;
-        this.websiteService = services.website;
-        this.uiService = services.ui;
         this.context = context;
         this.loadProm = null;
-        this.beforeReload = null;
 
         this.snippetsByCategory = {
             snippet_groups: [],
@@ -83,58 +77,16 @@ export class SnippetModel extends Reactive {
         return this.snippetsByCategory[category].find((snippet) => snippet.name === name);
     }
 
-    registerBeforeReload(func) {
-        this.beforeReload = func;
-    }
-
-    unregisterBeforeReload() {
-        this.beforeReload = null;
-    }
-
-    installSnippetModule(snippet) {
-        // TODO: Should be the app name, not the snippet name ... Maybe both ?
-        const bodyText = _t("Do you want to install %s App?", snippet.title);
+    installSnippetModule(snippet, installSnippetModule) {
+        const bodyText = _t("Do you want to install %s App?", snippet.moduleDisplayName);
         const linkText = _t("More info about this app.");
         const linkUrl =
             "/odoo/action-base.open_module_tree/" + encodeURIComponent(snippet.moduleId);
 
         this.dialog.add(ConfirmationDialog, {
-            title: _t("Install %s", snippet.title),
-            body: markup`${bodyText}\n<a href="${linkUrl}" target="_blank">${linkText}</a>`,
-            confirm: () => {
-                this.uiService.block();
-                (async () => {
-                    try {
-                        await this.orm.call("ir.module.module", "button_immediate_install", [
-                            [Number(snippet.moduleId)],
-                        ]);
-                        if (this.beforeReload) {
-                            await this.beforeReload();
-                        }
-                        const currentPath = encodeURIComponent(window.location.pathname);
-                        const websiteId = this.websiteService.currentWebsite.id;
-                        redirect(
-                            `/odoo/action-website.website_preview?website_id=${encodeURIComponent(
-                                websiteId
-                            )}&path=${currentPath}&enable_editor=1`
-                        );
-                    } catch (e) {
-                        if (e instanceof RPCError) {
-                            const message = _t("Could not install module %(title)s", {
-                                title: snippet.title,
-                            });
-                            this.notification.add(message, {
-                                type: "danger",
-                                sticky: true,
-                            });
-                            return;
-                        }
-                        throw e;
-                    } finally {
-                        this.uiService.unblock();
-                    }
-                })();
-            },
+            title: _t("Install %s", snippet.moduleDisplayName),
+            body: markup`${bodyText}\n<a href="${linkUrl}" target="_blank"><i class="oi oi-arrow-right me-1"></i>${linkText}</a>`,
+            confirm: async () => installSnippetModule(snippet),
             confirmLabel: _t("Save and Install"),
             cancel: () => {},
         });
@@ -149,8 +101,9 @@ export class SnippetModel extends Reactive {
      * @param {Object} - `onSelect` called when a snippet is selected. Must return
      *     an HTMLElement.
      *                 - `onClose` called when the dialog is closed.
+     * @param {Object} editor
      */
-    openSnippetDialog(snippet, { onSelect, onClose }) {
+    openSnippetDialog(snippet, { onSelect, onClose }, editor) {
         this.dialog.add(
             AddSnippetDialog,
             {
@@ -160,6 +113,7 @@ export class SnippetModel extends Reactive {
                     const newSnippetEl = onSelect(...args);
                     this.updateSnippetContent(newSnippetEl);
                 },
+                installSnippetModule: editor.config.installSnippetModule,
             },
             { onClose }
         );
@@ -212,6 +166,7 @@ export class SnippetModel extends Reactive {
                     Object.assign(snippet, {
                         moduleId,
                         isInstallable: !!moduleId,
+                        moduleDisplayName: snippetEl.dataset.moduleDisplayName,
                     });
                 }
                 if (snippetEl.dataset.oeForbidSanitize) {
@@ -424,12 +379,11 @@ export class SnippetModel extends Reactive {
 }
 
 registry.category("services").add("html_builder.snippets", {
-    dependencies: ["orm", "dialog", "website", "notification", "ui"],
+    dependencies: ["orm", "dialog", "website"],
 
-    start(env, { orm, dialog, website, notification, ui }) {
-        const services = { orm, dialog, website, notification, ui };
+    start(env, { orm, dialog, website }) {
+        const services = { orm, dialog, website };
         const context = {
-            website_id: website.currentWebsite?.id,
             lang: website.currentWebsite?.metadata.lang,
             user_lang: user.context.lang,
         };

--- a/addons/html_builder/static/src/snippets/snippet_viewer.js
+++ b/addons/html_builder/static/src/snippets/snippet_viewer.js
@@ -19,6 +19,7 @@ export class SnippetViewer extends Component {
         selectSnippet: { type: Function },
         hasSearchResults: Function,
         snippetModel: { type: Object },
+        installSnippetModule: { type: Function },
     };
 
     setup() {
@@ -86,7 +87,7 @@ export class SnippetViewer extends Component {
 
     onClick(snippet) {
         if (snippet.moduleId) {
-            this.props.snippetModel.installSnippetModule(snippet);
+            this.props.snippetModel.installSnippetModule(snippet, this.props.installSnippetModule);
         } else {
             this.props.selectSnippet(snippet);
         }

--- a/addons/website/static/src/builder/website_builder.js
+++ b/addons/website/static/src/builder/website_builder.js
@@ -2,6 +2,7 @@ import { Builder } from "@html_builder/builder";
 import { BuilderOptionsPlugin } from "@html_builder/core/builder_options_plugin_translate";
 import { CORE_PLUGINS as CORE_BUILDER_PLUGINS } from "@html_builder/core/core_plugins";
 import { DisableSnippetsPlugin } from "@html_builder/core/disable_snippets_plugin_translation";
+import { OperationPlugin } from "@html_builder/core/operation_plugin";
 import { SavePlugin } from "@html_builder/core/save_plugin";
 import { SetupEditorPlugin } from "@html_builder/core/setup_editor_plugin";
 import { VisibilityPlugin } from "@html_builder/core/visibility_plugin";
@@ -27,6 +28,7 @@ const TRANSLATION_PLUGINS = [
     TranslationPlugin,
     WebsiteVisibilityPlugin,
     HighlightPlugin,
+    OperationPlugin,
 ];
 
 export class WebsiteBuilder extends Component {
@@ -70,7 +72,7 @@ export class WebsiteBuilder extends Component {
             if (this.editor && !editableEl) {
                 editableEl = closestElement(
                     this.editor.shared.selection.getEditableSelection().anchorNode,
-                    "[data-oe-model]",
+                    "[data-oe-model]"
                 );
             }
             if (!editableEl) {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -17,6 +17,7 @@ import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ResizablePanel } from "@web/core/resizable_panel/resizable_panel";
+import { RPCError } from "@web/core/network/rpc";
 import { Deferred } from "@web/core/utils/concurrency";
 import { uniqueId } from "@web/core/utils/functions";
 import { useChildRef, useService } from "@web/core/utils/hooks";
@@ -175,6 +176,7 @@ export class WebsiteBuilderClientAction extends Component {
             reloadEditor: this.reloadEditor.bind(this),
             snippetsName: "website.snippets",
             toggleMobile: this.toggleMobile.bind(this),
+            installSnippetModule: this.installSnippetModule.bind(this),
             overlayRef: this.overlayRef,
             iframeLoaded: this.iframeLoaded,
             isMobile: this.websiteContext.isMobile,
@@ -455,6 +457,40 @@ export class WebsiteBuilderClientAction extends Component {
             await this.loadAssetsEditBundle();
         }
         this.ui.unblock();
+    }
+
+    reloadWebClient() {
+        const currentPath = encodeURIComponent(window.location.pathname);
+        const websiteId = this.websiteService.currentWebsite.id;
+        redirect(
+            `/odoo/action-website.website_preview?website_id=${encodeURIComponent(
+                websiteId
+            )}&path=${currentPath}&enable_editor=1`
+        );
+    }
+
+    async installSnippetModule(snippet, beforeInstall) {
+        this.dialog.closeAll();
+        try {
+            this.ui.block();
+            await beforeInstall();
+            await this.orm.call("ir.module.module", "button_immediate_install", [
+                [parseInt(snippet.moduleId)],
+            ]);
+            this.reloadWebClient();
+        } catch (e) {
+            if (e instanceof RPCError) {
+                const message = _t("Could not install module %s", snippet.moduleDisplayName);
+                this.notification.add(message, {
+                    type: "danger",
+                    sticky: true,
+                });
+                return;
+            }
+            throw e;
+        } finally {
+            this.ui.unblock();
+        }
     }
 
     preparePublicRootReady() {

--- a/addons/website/static/tests/builder/block_tab/snippet_groups.test.js
+++ b/addons/website/static/tests/builder/block_tab/snippet_groups.test.js
@@ -70,14 +70,14 @@ test("install an app from snippet group", async () => {
     await setupWebsiteBuilder("<div><p>Text</p></div>", {
         snippets: {
             snippet_groups: [
-                '<div name="A" data-module-id="111" data-oe-thumbnail="a.svg"><section class="s_snippet_group" data-snippet="s_snippet_group"></section></div>',
+                '<div name="A" data-module-id="111" data-module-display-name="module_A" data-oe-thumbnail="a.svg"><section class="s_snippet_group" data-snippet="s_snippet_group"></section></div>',
             ],
         },
     });
     await click(`.o-snippets-menu #snippet_groups .o_snippet .btn.o_install_btn`);
     await animationFrame();
     expect(".modal").toHaveCount(1);
-    expect(".modal-body").toHaveText("Do you want to install A App?\nMore info about this app.");
+    expect(".modal-body").toHaveText("Do you want to install module_A App?\nMore info about this app.");
 
     await contains(".modal .btn-primary:contains('Save and Install')").click();
     expect.verifySteps([`button_immediate_install`]);
@@ -91,12 +91,14 @@ test("install an app from snippet structure", async () => {
     const snippetsDescription = () => [
         {
             name: "Test 1",
+            moduleDisplayName: "Test 1 module",
             groupName: "a",
             content: getBasicSection("Yop"),
             moduleId: 111,
         },
         {
             name: "Test 2",
+            moduleDisplayName: "Test 2 module",
             groupName: "a",
             content: getBasicSection("Hello"),
         },
@@ -129,7 +131,7 @@ test("install an app from snippet structure", async () => {
     );
     await animationFrame();
     expect(".o_dialog:not(:has(.o_inactive_modal)) .modal-body").toHaveText(
-        "Do you want to install Test 1 App?\nMore info about this app."
+        "Do you want to install Test 1 module App?\nMore info about this app."
     );
 
     await contains(

--- a/addons/website/static/tests/builder/website_helpers.js
+++ b/addons/website/static/tests/builder/website_helpers.js
@@ -388,9 +388,10 @@ export function getSnippetStructure({
     groupName,
     imagePreview = "",
     moduleId = "",
+    moduleDisplayName = "",
 }) {
     keywords = keywords.join(", ");
-    return `<div name="${name}" data-oe-snippet-id="123" data-o-image-preview="${imagePreview}" data-oe-keywords="${keywords}" data-o-group="${groupName}"  data-module-id="${moduleId}">${content}</div>`;
+    return `<div name="${name}" data-oe-snippet-id="123" data-o-image-preview="${imagePreview}" data-oe-keywords="${keywords}" data-o-group="${groupName}" data-module-id="${moduleId}" data-module-display-name="${moduleDisplayName}">${content}</div>`;
 }
 
 export function getInnerContent({


### PR DESCRIPTION
This was forgotten in the website refactor [1].

The builder was not reloading after installing a new module via the "Install" button on a snippet.

The install module dialog was showing the snippet name and not module name, because of a forgotten recent change [2].

Adapted tests to check presence of the module name and not snippet name.

Steps to reproduce:
- Install website
- Click install on a snippet that's missing its module (e.g. Donation button)
- Install module dialog appears
- Dialog should show the module name
- Builder should reload after clicking on "Save and Install"

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
[2]: https://github.com/odoo/odoo/commit/dd33ab018db7aa0fe7ad5e636636b75aaadd5d7a

Related to task-4367641
Related to task-4434981