### PR TITLE
[FIX] mail: link mass mail attachments to records

### DIFF
--- a/addons/mail/wizard/mail_compose_message.py
+++ b/addons/mail/wizard/mail_compose_message.py
@@ -442,7 +442,7 @@ class MailComposer(models.TransientModel):
                 mail_values['attachment_ids'] = self.env['mail.thread'].with_context(attached_to=record)._message_post_process_attachments(
                     mail_values.pop('attachments', []),
                     attachment_ids,
-                    {'model': 'mail.message', 'res_id': 0}
+                    {'model': record._name, 'res_id': record.id}
                 )['attachment_ids']
 
                 # generate message_id directly; instead of letting mail_message create


### PR DESCRIPTION
In mass mode attachments are post-processed with
"mail.message, 0" as linked record.

The intent seems to have been to use post-processing to link the attachment to the target record instead.

For this we need to use "mail.compose.message, 0"

task-???
