### PR TITLE
[FIX] mail: correct spacing of message action with expand icon

### DIFF
--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -222,9 +222,9 @@
         'ms-n2': isMobileOS and (isAlignedRight and props.asCard or !isAlignedRight and !props.asCard),
         'mt-n3': isMobileOS and props.asCard,
         'mt-n1': isMobileOS and !props.asCard,
-        'px-1 py-0': !isMobileOS,
-        'rounded-start-1': !isMobileOS and isReverse,
-        'rounded-end-1': !isMobileOS and !isReverse,
+        'p-0': !isMobileOS,
+        'rounded-start-1 me-n1': !isMobileOS and isReverse,
+        'rounded-end-1 ms-n1': !isMobileOS and !isReverse,
     }">
         <i class="oi oi-large oi-ellipsis-v" t-att-class="{ 'order-1': props.isInChatWindow, 'fa-fw': isMobileOS }" tabindex="1"/>
     </button>


### PR DESCRIPTION
Before this commit, message action spacing was too big next to the "expand / ..." icon.

This comes from new icon `.oi-ellipsis-v` which has a smaller visual by default and thus needs bigger size scale `.oi-large` to match font-awesome icons. Due to this bigger scaling, the horizontal spacing if quite big.

This commit fixes the issue by removing extra `px-1` on the button that was relevant with `.fa-ellipsis-v` that had thin width. Even with this removal, the spacing is still to big, so an extra `ms-n1`/`me-n1` is added to make the proper spacing.

Before / After
![Screenshot 2025-05-28 at 13 31 53](https://github.com/user-attachments/assets/f52ef584-fb32-4bbe-a3df-fd8b1c1f66a1) ![Screenshot 2025-05-28 at 13 31 05](https://github.com/user-attachments/assets/38e8a91a-dd76-48cd-b1d6-59e72fc2a2c7)
