### PR TITLE
[FIX] purchase: remove redundant uom field from purchase view

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -301,7 +301,6 @@
                                     <field name="product_qty" class="oe_inline" readonly="state != 'draft'"/>
                                 </button>
                                 <label for="product_uom_id" string="" class="oe_inline"/>
-                                <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
                                 <field name="product_uom_id" options="{'no_open': True, 'no_create': True, 'quantity_field': 'product_qty'}" groups="uom.group_uom" widget="many2one_uom" readonly="state != 'draft'" class="flex-grow-0" style="width:auto!important"/>
                                 <span class='fw-bold text-nowrap'>To Produce</span>
                                 <button type="object" name="action_product_forecast_report" title="Forecast Report" icon="fa-area-chart" invisible="forecasted_issue"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -245,7 +245,6 @@
                                     <field name="currency_id" column_invisible="True"/>
                                     <field name="state" column_invisible="True"/>
                                     <field name="product_type" column_invisible="True"/>
-                                    <field name="product_uom_id" column_invisible="True" groups="!uom.group_uom"/>
                                     <field name="invoice_lines" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <field

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -188,6 +188,8 @@ class TestCreatePicking(ProductVariantsCommon):
 
         self.assertEqual(self.product_id_1.uom_id.id, uom_unit.id)
 
+        self.env.user.group_ids += self.env.ref('uom.group_uom')
+
         # buy a dozen
         po_form = Form(self.env['purchase.order'])
         po_form.partner_id = self.partner_id

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -53,7 +53,6 @@
                                 widget="many2one_uom"
                                 readonly="product_uom_readonly"
                                 required="not display_type"/>
-                            <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
                             <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
                             <field name="order_partner_id" invisible="1"/>
                         </group>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -527,7 +527,6 @@
                                         <label for="product_uom_qty"/>
                                         <div class="o_row" name="ordered_qty">
                                             <field name="product_uom_qty"/>
-                                            <field name="product_uom_id" invisible="1" groups="!uom.group_uom"/>
                                             <field
                                                 name="product_uom_id"
                                                 force_save="1"
@@ -672,7 +671,6 @@
                                     decoration-bf="(not display_type and invoice_status == 'to invoice')"
                                     column_invisible="parent.state != 'sale'"
                                     optional="show"/>
-                                <field name="product_uom_id" column_invisible="True" groups="!uom.group_uom"/>
                                 <field
                                     name="product_uom_id"
                                     force_save="1"

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -136,7 +136,6 @@
                     <field name="picking_type_entire_packs" invisible="1"/>
                     <field name="display_assign_serial" invisible="1"/>
                     <field name="display_import_lot" invisible="1"/>
-                    <field name="product_uom" invisible="1" groups="!uom.group_uom"/>
                     <field name="picking_code" invisible="1"/>
                     <field name="has_tracking" invisible="1"/>
                     <field name="show_quant" invisible="1"/>
@@ -184,7 +183,6 @@
                     <field name="result_package_id" column_invisible="True"/>
                     <field name="tracking" column_invisible="True"/>
                     <field name="picking_type_id" column_invisible="True"/>
-                    <field name="product_uom_id" column_invisible="True" groups="!uom.group_uom"/>
                     <field name="quant_id"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', parent.location_id)]"
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'list_view_ref': 'stock.view_stock_quant_tree', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': True}"

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -292,7 +292,6 @@
                                     <field name="product_qty" readonly="1" column_invisible="True"/>
                                     <field name="quantity" string="Quantity" readonly="not is_quantity_done_editable" column_invisible="parent.state=='draft'" decoration-danger="product_uom_qty and quantity > product_uom_qty and parent.state not in ['done', 'cancel']"/>
                                     <field name="product_uom" readonly="state != 'draft' and not additional" options="{'no_open': True, 'no_create': True}" widget="many2one_uom" groups="uom.group_uom"/>
-                                    <field name="product_uom" groups="!uom.group_uom" column_invisible="True"/>
                                     <field name="picked" optional="hide" column_invisible="parent.state=='draft'"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         column_invisible="parent.state == 'draft'"

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -13,7 +13,6 @@
                         options="{'no_open': 1, 'no_create': 1}" class="fw-bold"/> is
                     <field name="forecasted_quantity"/>
                     <field class="ps-1" name="forecast_uom_id" groups="uom.group_uom" readonly="1"/>
-                    <field name="forecast_uom_id" groups="!uom.group_uom" invisible="1"/>
                 </p>
                 <group>
                     <group>
@@ -24,7 +23,6 @@
                         <label for="quantity"/>
                         <div class="o_row">
                             <field name="quantity" />
-                            <field name="product_uom_id" groups="!uom.group_uom" invisible="1"/>
                             <field name="product_uom_id"
                                 groups="uom.group_uom"
                                 widget="many2one_uom"


### PR DESCRIPTION
This commit removes the unnecessary copy of `product_uom_id` field on `purchase_order_line` list view in `purchase_order` form view. Previously, the view had the same field twice: one invisible in case the user doesn't have the uom group, and another one only visible if the user has the group. The first one is not needed, because the view automatically loads the field if it's needed as a dependency in any other field. This also led to an issue with "Studio", where a user was not able to change the column label, because the name change only affected the first occurrence of the field (which was the invisible one).

Task-4818427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
