### PR TITLE
[FIX] point_of_sale: display pos order line discount

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -753,7 +753,8 @@ export class PosOrder extends Base {
                         orderLine.get_all_prices().priceWithTax;
                     if (
                         orderLine.display_discount_policy() === "without_discount" &&
-                        !(orderLine.price_type === "manual")
+                        !(orderLine.price_type === "manual") &&
+                        orderLine.discount == 0
                     ) {
                         sum +=
                             (orderLine.get_taxed_lst_unit_price() -


### PR DESCRIPTION
### Problem:
The discount display policy in POS invoices is designed to hide discounts when a pricelist with a percentage-based discount is applied to its items. However, if an additional discount is added directly to a POS order line, it will not be shown in the total.

Additionally, if one of the lines has a manually modified price, the total will incorrectly reflect that line's discount.

### How to reproduce:
    * Add a percentage discount to one of the products in the pricelist
    * Order two products and add a percentage discount to both
    * Modify the price of the order line for one of them
    * Complete the order (the printed invoice total discount is the total discount of the manually modified line)

opw-4776259

