### PR TITLE
[FIX] website, website_livechat: remove im_status from visitor banner

### DIFF
--- a/addons/website/static/src/common/website_visitor_model.js
+++ b/addons/website/static/src/common/website_visitor_model.js
@@ -13,8 +13,6 @@ export class WebsiteVisitor extends Record {
     country_id = fields.One("res.country");
     /** @type {string} */
     display_name;
-    /** @type {boolean} */
-    is_connected;
     lang_id = fields.One("res.lang");
     partner_id = fields.One("Persona");
     website_id = fields.One("website");

--- a/addons/website/static/tests/mock_server/mock_models/website_visitor.js
+++ b/addons/website/static/tests/mock_server/mock_models/website_visitor.js
@@ -32,7 +32,7 @@ export class WebsiteVisitor extends models.ServerModel {
         const Website = this.env["website"];
 
         for (const visitor of this.browse(ids)) {
-            const [data] = this._read_format(visitor.id, ["display_name", "is_connected"]);
+            const [data] = this._read_format(visitor.id, ["display_name"]);
             data.country_id = mailDataHelpers.Store.one(ResCountry.browse(visitor.country_id));
             data.history = visitor.history;
             data.lang_id = mailDataHelpers.Store.one(ResLang.browse(visitor.lang_id));

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -44,9 +44,8 @@ class DiscussChannel(models.Model):
                     Store.One("country_id", ["code"]),
                     "display_name",
                     "history",
-                    "is_connected",
                     Store.One("lang_id", ["name"]),
-                    Store.One("partner_id", [Store.One("country_id", ["code"]), "im_status"]),
+                    Store.One("partner_id", [Store.One("country_id", ["code"])]),
                     Store.One("website_id", ["name"]),
                 ],
                 predicate=lambda channel: channel.livechat_visitor_id

--- a/addons/website_livechat/static/src/web/thread_patch.xml
+++ b/addons/website_livechat/static/src/web/thread_patch.xml
@@ -9,7 +9,6 @@
                 </div>
                 <div>
                     <div class="d-flex align-items-baseline">
-                        <ImStatus t-if="visitor.is_connected" className="'me-1'" persona="visitor.partner_id"/>
                         <span class="me-2 fw-bolder" t-esc="visitor.display_name"/>
                         <img t-if="visitor.country" class="me-2 o_country_flag align-self-center" t-att-src="visitor.country.flagUrl" t-att-alt="visitor.country.code or visitor.country.name"/>
                         <span t-if="visitor.lang_id" class="me-2">

--- a/addons/website_livechat/static/tests/thread_patch.test.js
+++ b/addons/website_livechat/static/tests/thread_patch.test.js
@@ -24,7 +24,6 @@ test("Rendering of visitor banner", async () => {
     const visitorId = pyEnv["website.visitor"].create({
         country_id,
         history: "Home → Contact",
-        is_connected: true,
         lang_id,
         website_id,
     });
@@ -50,7 +49,6 @@ test("Rendering of visitor banner", async () => {
             }`
         )}']`
     );
-    await contains(".o-website_livechat-VisitorBanner .o-mail-ImStatus");
     await contains(".o_country_flag[data-src='/base/static/img/country_flags/be.png']");
     await contains(".o-website_livechat-VisitorBanner span", {
         text: `Website Visitor #${visitorId}`,
@@ -69,7 +67,6 @@ test("Livechat with non-logged visitor should show visitor banner", async () => 
         country_id,
         display_name: "Visitor #11",
         history: "Home → Contact",
-        is_connected: true,
         lang_id,
         website_id,
     });
@@ -99,7 +96,6 @@ test("Livechat with logged visitor should show visitor banner", async () => {
         country_id,
         display_name: "Visitor #11",
         history: "Home → Contact",
-        is_connected: true,
         lang_id,
         partner_id,
         website_id,

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -280,7 +280,6 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
                         "display_name": f"Website Visitor #{self.visitor.id}",
                         "history": "",
                         "id": self.visitor.id,
-                        "is_connected": True,
                         "lang_id": self.env.ref("base.lang_en").id,
                         "partner_id": False,
                         "website_id": self.env.ref("website.default_website").id,


### PR DESCRIPTION
The website visitor model has been defined since #208848. Previously, the website visitor was a persona with type `visitor`, but now it is only related to the persona via the partner_id field. That PR changed the visitor banner template to show the im_status of the visitor's partner_id, which is incorrect because the visitor could be a guest and not a partner. Therefore, the flow easily crashes when the partner_id is unavailable.

One possible solution is to change the persona to the correct one, which would allow the im_status to work properly. However, this im_status is very close to the thread header im_status, which comes from its correspondent. Therefore, they are conceptually the same. Having two im_status so close together doesn't make sense, since there is no added value in showing it twice. This commit removes the im_status from the visitor banner to avoid displaying it twice. It also removes the `is_connected` value from the website visitor model, which was only used to display the im_status.

Before:

![image](https://github.com/user-attachments/assets/5e3b3784-4629-4448-9932-eb7022042ab2)

After:

![image](https://github.com/user-attachments/assets/83d75c15-e926-4e66-b765-be305dddae69)
