### PR TITLE
[FIX] point_of_sale: fix report closing difference

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1085,7 +1085,7 @@ class PosSession(models.Model):
         destination_account = self._get_receivable_account(payment_method)
 
         account_payment = self.env['account.payment'].with_context(pos_payment=True).create({
-            'amount': abs(amounts['amount']) + diff_amount,
+            'amount': abs(amounts['amount']),
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,
             'destination_account_id': destination_account.id,

--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -171,9 +171,11 @@ class ReportSaleDetails(models.AbstractModel):
                             payment['count'] = True
                         elif payment['id'] in account_payments.mapped('pos_payment_method_id.id'):
                             account_payment = account_payments.filtered(lambda p: p.pos_payment_method_id.id == payment['id'])
+                            profit_line = account_payment.move_id.line_ids.filtered(lambda l: l.account_id == account_payment.journal_id.profit_account_id)
+                            loss_line = account_payment.move_id.line_ids.filtered(lambda l: l.account_id == account_payment.journal_id.loss_account_id)
                             payment['final_count'] = payment['total']
-                            payment['money_counted'] = sum(account_payment.mapped('amount_signed'))
-                            payment['money_difference'] = payment['money_counted'] - payment['final_count']
+                            payment['money_difference'] = -loss_line.amount_currency if loss_line else profit_line.amount_currency
+                            payment['money_counted'] = sum(account_payment.mapped('amount_signed')) + payment['money_difference']
                             payment['cash_moves'] = []
                             if payment['money_difference'] > 0:
                                 move_name = 'Difference observed during the counting (Profit)'

--- a/addons/point_of_sale/tests/test_report_session.py
+++ b/addons/point_of_sale/tests/test_report_session.py
@@ -264,36 +264,3 @@ class TestReportSession(TestPoSCommon):
             bank_payment_method_diffs={self.bank_pm1.id: -20})
         report = self.env['report.point_of_sale.report_saledetails'].get_sale_details(session_ids=[session1_id])
         self.assertEqual(report['payments'][1]['money_difference'], -20)
-
-        self.bank_pm1.outstanding_account_id = False
-        self.config.open_ui()
-
-        session2_id = self.config.current_session_id.id
-        order2 = self.env['pos.order'].create({
-            'company_id': self.env.company.id,
-            'session_id': session2_id,
-            'partner_id': self.partner_a.id,
-            'lines': [(0, 0, {
-                'name': "OL/0001",
-                'product_id': self.product1.id,
-                'price_unit': 100,
-                'discount': 0,
-                'qty': 1,
-                'tax_ids': [[6, False, [self.tax1.id]]],
-                'price_subtotal': 100,
-                'price_subtotal_incl': 100,
-            })],
-            'pricelist_id': self.config.pricelist_id.id,
-            'amount_paid': 100.0,
-            'amount_total': 100.0,
-            'amount_tax': 10.0,
-            'amount_return': 0.0,
-            'last_order_preparation_change': '{}',
-            'to_invoice': False,
-        })
-
-        self.make_payment(order2, self.bank_pm1, 100)
-
-        self.config.current_session_id.action_pos_session_closing_control(bank_payment_method_diffs={self.bank_pm1.id: -20})
-        report = self.env['report.point_of_sale.report_saledetails'].get_sale_details(session_ids=[session2_id])
-        self.assertEqual(report['payments'][1]['money_difference'], -20)


### PR DESCRIPTION
When a PoS session was closed with a closing difference, the report was not correctly updated to reflect the closing difference for bank payment methods

Steps to reproduce:
-------------------
* Open PoS session
* Make a sale with a bank payment method
* Close the session with a closing difference
* Open the sales detail report
> Observation: The report does not show the closing difference for the
bank payment method

Note:
----------------
The previous test was testing a payment method with no outstanding account set on it. This is not a real use case, as the outstanding should always be set.

opw-4494656