### PR TITLE
[FIX] pos_loyalty: Buy X Get Y multiple reward

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/models/pos_order.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order.js
@@ -1267,9 +1267,9 @@ patch(PosOrder.prototype, {
                     }
                 }
                 if (factor === 0) {
-                    freeQty = Math.floor(
-                        (remainingPoints / reward.required_points) * reward.reward_product_qty
-                    );
+                    freeQty =
+                        Math.floor(remainingPoints / reward.required_points) *
+                        reward.reward_product_qty;
                 } else {
                     const correction = shouldCorrectRemainingPoints
                         ? this._getPointsCorrection(reward.program_id)

--- a/addons/pos_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_store.js
@@ -404,9 +404,13 @@ patch(PosStore.prototype, {
         }
         const potentialRewards = this.getPotentialFreeProductRewards();
         const rewardsToApply = [];
+        const quantity = vals.qty;
         for (const reward of potentialRewards) {
             for (const reward_product_id of reward.reward.reward_product_ids) {
-                if (reward_product_id.id == product.id) {
+                if (
+                    reward_product_id.id == product.id &&
+                    (quantity === undefined || quantity === reward.potentialQty)
+                ) {
                     rewardsToApply.push(reward);
                 }
             }

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_reward_button_tour.js
@@ -156,6 +156,23 @@ registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_2", {
         ].flat(),
 });
 
+registry.category("web_tour.tours").add("test_loyalty_free_product_rewards_3", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+
+            ProductScreen.clickDisplayedProduct("Desk Organizer"),
+            ProductScreen.clickNumpad("6"),
+            PosLoyalty.isRewardButtonHighlighted(true, true),
+            PosLoyalty.claimReward("Desk Organizer x2"),
+            ProductScreen.selectedOrderlineHas("Desk Organizer", "8.00", "40.80"),
+            PosLoyalty.hasRewardLine("Desk Organizer x2", "-10.20", "2.00"),
+            PosLoyalty.orderTotalIs("30.60"),
+            PosLoyalty.finalizeOrder("Cash", "30.60"),
+        ].flat(),
+});
+
 registry.category("web_tour.tours").add("PosLoyaltySpecificDiscountTour", {
     steps: () =>
         [

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -434,6 +434,47 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.assertEqual(free_product.pos_order_count, 1)
 
+    def test_loyalty_free_product_rewards_3(self):
+        self.env['loyalty.program'].search([]).write({'active': False})
+        free_product = self.env['loyalty.program'].create({
+            'name': 'Buy X Take Y desk_organizer(s)',
+            'program_type': 'buy_x_get_y',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [(0, 0, {
+                'product_ids': self.desk_organizer,
+                'reward_point_amount': 1,
+                'reward_point_mode': 'order',
+                'minimum_qty': 3,
+            }), (0, 0, {
+                'product_ids': self.desk_organizer,
+                'reward_point_amount': 2,
+                'reward_point_mode': 'order',
+                'minimum_qty': 6,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'product',
+                'reward_product_id': self.desk_organizer.id,
+                'reward_product_qty': 1,
+                'required_points': 1,
+                'description': 'Desk Organizer x1',
+            }), (0, 0, {
+                'reward_type': 'product',
+                'reward_product_id': self.desk_organizer.id,
+                'reward_product_qty': 2,
+                'required_points': 2,
+                'description': 'Desk Organizer x2',
+            })],
+        })
+
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('stock.group_stock_user').id),
+            ]
+        })
+        self.start_pos_tour("test_loyalty_free_product_rewards_3")
+        self.assertEqual(free_product.pos_order_count, 1)
+
     def test_pos_loyalty_tour_max_amount(self):
         """Test the loyalty program with a maximum amount and product with different taxe."""
 


### PR DESCRIPTION
In Point of sale "Buy X Get Y" promotion program may offer multiple rewards that can be selected manually.
However, in this case the promotion is applied inconsistently with respect to the same promotion on a sales order

Steps to reproduce:
- Have a promo program like follows:
  - Program Type: Buy X Get Y
  - Condition 1:
    - Minimum quantity: 12
    - Grant: 1 credit per order
    - Product: [PRODUCT]
  - Condition 2:
    - Minimum quantity: 14
    - Grant: 2 credit per order
    - Product: [PRODUCT]
  - Reward 1:
    - In exchange of: 1 credit
    - Product: [PRODUCT]
    - Quantity rewarded: 1
  - Reward 2:
    - In exchange of: 2 credit
    - Product: [PRODUCT]
    - Quantity rewarded: 2
    - Description: "PRODUCT x2"
- Open POS Session
- Add [Product]
- Via Numpad change quantity to 14
- Click Reward button
- Select "PRODUCT x2"

Issue:
Existing POS order line quantity is raised from 14 to 17. No reward line is added to the order.

Cause:
This occurs because:
1. The reward quantity is not correctly computed in case of multi-quantity reward
2. The reward is selected based on the reward product, so in case of multiple reward with the same product, we should apply the reward with the correct quantity

opw-4563825

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
