### PR TITLE
[FIX] website: restore original IDs and add missing t-if conditions

### DIFF
--- a/addons/website/static/src/builder/plugins/header_navbar_option.xml
+++ b/addons/website/static/src/builder/plugins/header_navbar_option.xml
@@ -45,7 +45,7 @@
         <BuilderButtonGroup>
             <BuilderNumberInput action="'customizeWebsiteVariable'" actionParam="'header-font-size'" unit="'px'" saveUnit="'rem'"/>
             <BuilderColorPicker action="'customizeWebsiteVariable'" actionParam="'header-text-color'"/>
-            <BuilderSelect action="'websiteConfig'" id="'header_alignment_opt'">
+            <BuilderSelect action="'websiteConfig'" t-if="!hasSomeViews(['website.template_header_sales_three', 'website.template_header_vertical'])" id="'header_alignment_opt'">
                 <BuilderSelectItem
                     actionParam="{
                         views: [],
@@ -71,7 +71,7 @@
             </BuilderSelect>
         </BuilderButtonGroup>
     </BuilderRow>
-    <BuilderRow label.translate="Link Style" t-if="hasSomeViews(['website.template_header_default', 'website.template_header_boxed', 'website.template_header_vertical', 'website.template_header_search', 'website.template_header_sales_one', 'website.template_header_sales_two', 'website.template_header_sales_three', 'website.template_header_sales_four'])">
+    <BuilderRow label.translate="Link Style" t-if="!hasSomeViews(['website.template_header_hamburger', 'website.template_header_stretch', 'website.template_header_sidebar'])">
         <BuilderSelect action="'websiteConfig'">
             <BuilderSelectItem
                 id="'option_header_navbar_links_default'"
@@ -139,7 +139,7 @@
             >Secondary</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
-    <BuilderRow label.translate="Sub Menus">
+    <BuilderRow label.translate="Sub Menus" t-if="!hasSomeViews(['website.template_header_hamburger'])">
         <BuilderSelect action="'websiteConfig'">
             <BuilderSelectItem
                 id="header_dropdown_on_click_opt"

--- a/addons/website/static/src/builder/plugins/options/card_image_option.xml
+++ b/addons/website/static/src/builder/plugins/options/card_image_option.xml
@@ -7,7 +7,7 @@
         <!-- Image position -->
             <BuilderButtonGroup action="'setCoverImagePosition'">
                 <BuilderButton
-                    id="'card_img_top_option'"
+                    id="'card_img_top_opt'"
                     classAction="'o_card_img_top'"
                     actionParam="'card-img-top'"
                     iconImg="'/website/static/src/img/snippets_options/pos_top.svg'"
@@ -49,12 +49,12 @@
             <BuilderSelect applyTo="'.o_card_img_wrapper'">
                 <BuilderSelectItem id="'card_img_default_ratio_option'" classAction="''">Image default</BuilderSelectItem>
                 <BuilderSelectItem classAction="'ratio ratio-1x1'">Square</BuilderSelectItem>
-                <t t-if="isActiveItem('card_img_top_option')">
+                <t t-if="isActiveItem('card_img_top_opt')">
                     <BuilderSelectItem classAction="'ratio ratio-4x3'">Landscape - 4/3</BuilderSelectItem>
                     <BuilderSelectItem classAction="'ratio ratio-16x9'">Wide - 16/9</BuilderSelectItem>
                     <BuilderSelectItem classAction="'ratio ratio-21x9'">Ultrawide - 21/9</BuilderSelectItem>
                     <BuilderSelectItem
-                        id="'card_img_custom_ratio_option'"
+                        id="'image_ratio_custom_opt'"
                         classAction="'ratio o_card_img_ratio_custom'">
                         Custom
                     </BuilderSelectItem>
@@ -63,7 +63,7 @@
         </BuilderRow>
 
         <!-- Custom ratio control -->
-        <BuilderRow t-if="isActiveItem('card_img_custom_ratio_option')" label.translate="Custom Ratio" level="2">
+        <BuilderRow t-if="isActiveItem('image_ratio_custom_opt')" label.translate="Custom Ratio" level="2">
             <BuilderRange
                 styleAction="'--card-img-aspect-ratio'"
                 min="8"
@@ -74,7 +74,7 @@
         </BuilderRow>
 
         <!-- Width -->
-        <BuilderRow t-if="!isActiveItem('card_img_top_option')" label.translate="Width" level="1">
+        <BuilderRow t-if="!isActiveItem('card_img_top_opt')" label.translate="Width" level="1">
             <!-- Bootstrap default column size -->
             <t t-set="colSize" t-value="8.33333333"/>
             <BuilderRange

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -7,6 +7,7 @@
         <BuilderSelect action="'reloadComposite'">
             <BuilderSelectItem
                 title.translate="Default"
+                id="'header_default_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -22,6 +23,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Hamburger menu"
+                id="'header_hamburger_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -37,6 +39,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Rounded box menu"
+                id="'header_boxed_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -52,6 +55,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Stretch menu"
+                id="'header_stretch_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -67,6 +71,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Vertical"
+                id="'header_vertical_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -82,6 +87,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu with Search bar"
+                id="'header_search_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -97,6 +103,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 1"
+                id="'header_sales_one_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -112,6 +119,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 2"
+                id="'header_sales_two_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -127,6 +135,7 @@
             </BuilderSelectItem>
             <BuilderSelectItem
                 title.translate="Menu - Sales 3"
+                id="'header_sales_three_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -141,7 +150,8 @@
                 <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_three.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
-                title.translate="Menu - Sales "
+                title.translate="Menu - Sales 4"
+                id="'header_sales_four_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',
@@ -156,8 +166,8 @@
                 <Img attrs="{style:'width:150px;'}" src="'/website/static/src/img/snippets_options/header_template_sales_four.svg'"/>
             </BuilderSelectItem>
             <BuilderSelectItem
-                id="'header_sidebar_opt'"
                 title.translate="Sidebar"
+                id="'header_sidebar_opt'"
                 actionParam="[
                     {
                         action: 'websiteConfig',

--- a/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option.xml
@@ -8,8 +8,8 @@
     </BuilderRow>
     <BuilderRow label.translate="Mode" t-if="!this.state.isSlideShow">
         <BuilderSelect>
-            <BuilderSelectItem id="'image_gallery_grid_id'" action="'setImageGalleryLayout'" actionParam="'grid'">Grid</BuilderSelectItem>
-            <BuilderSelectItem id="'image_gallery_masonry_id'" action="'setImageGalleryLayout'" actionParam="'masonry'">Masonry</BuilderSelectItem>
+            <BuilderSelectItem id="'grid_mode_opt'" action="'setImageGalleryLayout'" actionParam="'grid'">Grid</BuilderSelectItem>
+            <BuilderSelectItem id="'masonry_mode_opt'" action="'setImageGalleryLayout'" actionParam="'masonry'">Masonry</BuilderSelectItem>
             <BuilderSelectItem action="'setImageGalleryLayout'" actionParam="'nomode'">Float</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
@@ -19,7 +19,7 @@
         <BuilderRange action="'setClassRange'" actionParam="['o_spc-none','o_spc-small','o_spc-medium','o_spc-big']" max="3"/>
     </BuilderRow>
 
-    <BuilderRow label.translate="Columns" t-if="isActiveItem('image_gallery_grid_id') || isActiveItem('image_gallery_masonry_id')">
+    <BuilderRow label.translate="Columns" t-if="isActiveItem('grid_mode_opt') || isActiveItem('masonry_mode_opt')">
         <BuilderSelect>
             <t t-foreach="[1,2,3,4,6,12]" t-as="column" t-key="column">
                 <BuilderSelectItem action="'setImageGalleryColumns'" actionParam="column"><t t-esc="column"/></BuilderSelectItem>

--- a/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
+++ b/addons/website/static/src/builder/plugins/options/progress_bar_option.xml
@@ -17,10 +17,10 @@
         <BuilderColorPicker applyTo="'.progress-bar'" styleAction="'background-color'"/>
     </BuilderRow>
     <BuilderRow label.translate="Striped">
-        <BuilderCheckbox id="'striped_option'" classAction="'progress-bar-striped'" applyTo="'.progress-bar'"/>
+        <BuilderCheckbox id="'progress_striped_opt'" classAction="'progress-bar-striped'" applyTo="'.progress-bar'"/>
     </BuilderRow>
     <BuilderRow label.translate="Animated" level="1">
-        <BuilderCheckbox classAction="'progress-bar-animated'" t-if="this.isActiveItem('striped_option')" applyTo="'.progress-bar'"/>
+        <BuilderCheckbox classAction="'progress-bar-animated'" t-if="this.isActiveItem('progress_striped_opt')" applyTo="'.progress-bar'"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.js
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.js
@@ -17,6 +17,6 @@ export class ScrollButtonOption extends BaseOptionComponent {
     }
 
     showHeightField() {
-        return this.state.heightFieldEnabled && this.isActiveItem("fit_content_opt");
+        return this.state.heightFieldEnabled && this.isActiveItem("minheight_auto_opt");
     }
 }

--- a/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
+++ b/addons/website/static/src/builder/plugins/options/scroll_button_option.xml
@@ -4,7 +4,7 @@
 <t t-name="website.ScrollButtonOption">
     <BuilderRow label="this.state.heightLabel">
         <BuilderButtonGroup action="'scrollButtonSectionHeightClassAction'">
-            <BuilderButton id="'fit_content_opt'" actionParam="''" title.translate="Fit content">Auto</BuilderButton>
+            <BuilderButton id="'minheight_auto_opt'" actionParam="''" title.translate="Fit content">Auto</BuilderButton>
             <BuilderButton actionParam="'o_half_screen_height'" title.translate="Half screen">50%</BuilderButton>
             <BuilderButton id="'full_height_opt'" actionParam="'o_full_screen_height'" title.translate="Full screen">100%</BuilderButton>
         </BuilderButtonGroup>


### PR DESCRIPTION
This commit reverts specific IDs to their original values, which were inadvertently changed during the website refactor [1]. This ensures consistency and simplifies future maintenance.

Additionally, missing `t-if` conditions that were overlooked in the refactor have been re-added to ensure correct rendering logic.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641