### PR TITLE
[FIX] account_edi_ubl_cii: Added alphabetic codes to SchemeID

### DIFF
--- a/addons/account_edi_ubl_cii/models/res_partner.py
+++ b/addons/account_edi_ubl_cii/models/res_partner.py
@@ -125,6 +125,11 @@ class ResPartner(models.Model):
             ('9955', "9955 - Swedish VAT number"),
             ('9957', "9957 - French VAT number"),
             ('9959', "9959 - Employer Identification Number (EIN, USA)"),
+            ('AN', "AN - O.F.T.P. (ODETTE File Transfer Protocol)"),
+            ('AQ', "AQ - X.400 address for mail text"),
+            ('AS', "AS - AS2 exchange"),
+            ('AU', "AU - File Transfer Protocol"),
+            ('EM', "EM - Electronic mail"),
         ]
     )
     hide_peppol_fields = fields.Boolean(compute='_compute_hide_peppol_fields')


### PR DESCRIPTION
Before this commit, creating bills through uploading XMLs with alphabetic codes in SchemeID was causing an error.
This happened because these codes were not allowed in partner peppol_eas selection field.
This commit adds these alphabetic codes as indicated in this reference sheet:
https://ec.europa.eu/digital-building-blocks/sites/download/attachments/467108974/Electronic%20Address%20Scheme%20Code%20list%20-%20version%205%20-%20published.xlsx?version=1&modificationDate=1639417211464&api=v2

task-4823915




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
