### PR TITLE
[FIX] account: fix _search_placeholder_code

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -401,11 +401,14 @@ class AccountAccount(models.Model):
                     record.placeholder_code = f'{code} ({company.name})'
 
     def _search_placeholder_code(self, operator, value):
-        if operator != '=ilike':
+        if operator not in ('=ilike', 'in'):
             return NotImplemented
         query = Query(self.env, 'account_account')
         placeholder_code_sql = self.env['account.account']._field_to_sql('account_account', 'placeholder_code', query)
-        query.add_where(SQL("%s ILIKE %s", placeholder_code_sql, value))
+        if operator == 'in':
+            query.add_where(SQL("%s IN %s", placeholder_code_sql, tuple(value)))
+        else:
+            query.add_where(SQL("%s ILIKE %s", placeholder_code_sql, value))
         return [('id', 'in', query)]
 
     @api.depends_context('company')


### PR DESCRIPTION
The web client considers the `account.account.placeholder_code` field to be groupable since there is an implementation inside _field_to_sql. However, grouping by this field results in a NotImplementedError because the search method doesn't implement equality. Equality is necessary because since the '__extra_domain' returned from `formatted_read_group` contains a leaf, such as `('placeholder_code', '=', ...)`.

Add the equality implementation to the search method. A test will be added later to the master branch in a later PR that found the issue https://github.com/odoo/odoo/pull/133224.


https://github.com/odoo/enterprise/pull/86626