### PR TITLE
[FIX] web: custom filter modal vs searchview dropdown menu

### DIFF
--- a/addons/web/static/tests/search/search_bar.test.js
+++ b/addons/web/static/tests/search/search_bar.test.js
@@ -1743,6 +1743,37 @@ test("dropdown menu last element is 'Add Custom Filter'", async () => {
     expect(".o_searchview_autocomplete .o-dropdown-item:last").toHaveText("Add Custom Filter");
 });
 
+test("dropdown menu elements should be 'below' the 'Add Custom Filter' modal", async () => {
+    await mountWithSearch(SearchBar, {
+        resModel: "partner",
+        searchMenuTypes: [],
+        searchViewId: false,
+        searchViewArch: `
+            <search>
+                <field name="foo"/>
+            </search>
+        `,
+    });
+    await editSearch("a");
+    await animationFrame();
+
+    await contains(".o_searchview_autocomplete .o-dropdown-item:last-child").click();
+    await animationFrame();
+
+    expect(".modal").toHaveCount(1);
+    expect(".modal header").toHaveText("Add Custom Filter");
+
+    const modalOverlay = queryFirst(".modal").closest(".o-overlay-item");
+    const dropdownOverlay = queryFirst(".o_searchview_autocomplete").closest(".o-overlay-item");
+
+    const modalOverlayZIndex = Number(getComputedStyle(modalOverlay).zIndex);
+    const dropdownOverlayZIndex = Number(getComputedStyle(dropdownOverlay).zIndex);
+
+    // Assert that the modal's overlay z-index is at least equal to the dropdown's overlay z-index
+    // This is to ensure that the modal appears on top of (in front of) the dropdown
+    expect(modalOverlayZIndex >= dropdownOverlayZIndex).toBe(true);
+});
+
 test("order by count resets when there is no group left", async () => {
     const searchBar = await mountWithSearch(SearchBar, {
         resModel: "partner",


### PR DESCRIPTION
Steps to reproduce:
- Install any module with exposed views (say sale_management) and the ai module.
- Open any list view (say the Quotations) and type something in the search bar.
- Dropdown menu items will appear and click "Custom Filter" button from the items.
- [ISSUE] The items are shown over the custom filter dialog.

The issue is caused by the custom rules introduced in the ai module and is fixed in the said module. https://github.com/odoo/enterprise/pull/86616

In this commit, we introduce a test to protect the backend interface to have this issue again.

