### PR TITLE
[FIX] account: fix early payment discount banner CSS

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -33,7 +33,7 @@
                     <field name="untrusted_bank_ids" invisible="1"/>
 
                     <div role="alert" class="alert alert-info" invisible="not hide_writeoff_section">
-                        <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
+                        <p class="m-0"><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
                     </div>
                     <div role="alert" class="alert alert-warning" invisible="untrusted_payments_count == 0">
                         <span class="fw-bold"><field name="untrusted_payments_count" class="oe_inline"/> out of <field name="total_payments_amount" class="oe_inline"/> payments will be skipped due to <button class="oe_link p-0 align-baseline" type="object" name="action_open_untrusted_bank_accounts">untrusted bank accounts</button>.</span>


### PR DESCRIPTION
Before this commit:
----
-The early payment discount message was not displayed correctly
 in versions 17.0 to 17.4.

UI before fix:
--- 
![image](https://github.com/user-attachments/assets/c1145828-700c-4e6e-b91e-17ca04583dee)


After this commit:
----
-The banner UI has been fixed by applying the correct CSS classes,
 ensuring proper alignment and consistent styling.

UI after fix:
---
![image](https://github.com/user-attachments/assets/01da3158-1c94-4751-8760-4bb29256e47d)

