### PR TITLE
[FIX] html_editor: locally running some editor tests

### DIFF
--- a/addons/html_editor/static/tests/list/list_font_size.test.js
+++ b/addons/html_editor/static/tests/list/list_font_size.test.js
@@ -1,5 +1,5 @@
 import { testEditor } from "../_helpers/editor";
-import { test } from "@odoo/hoot";
+import { test, before } from "@odoo/hoot";
 import {
     setFontSize,
     splitBlock,
@@ -8,8 +8,16 @@ import {
 } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
 
+before(() => {
+    return document.fonts.add(new FontFace(
+        "Roboto",
+        "url(/web/static/fonts/google/Roboto/Roboto-Regular.ttf)",
+    )).ready;
+});
+
 test("should apply font-size to completely selected list item", async () => {
     await testEditor({
+        styleContent: ':root { font: 14px Roboto }',
         contentBefore: "<ol><li>[abc]</li><li>def</li></ol>",
         stepFunction: setFontSize("56px"),
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[abc]</li><li>def</li></ol>`,
@@ -125,6 +133,7 @@ test("should carry font-size of list item to paragraph (4)", async () => {
 
 test("should keep list item font-size on toggling list twice", async () => {
     await testEditor({
+        styleContent: 'ol { font: 14px Roboto }',
         contentBefore:
             '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 32px;">def]</li></ol>',
         stepFunction: (editor) => {
@@ -146,6 +155,7 @@ test("should change font-size of a list item", async () => {
 
 test("should change font-size of a list item (2)", async () => {
     await testEditor({
+        styleContent: 'ol { font: 14px Roboto }',
         contentBefore:
             '<ol><li style="font-size: 18px;">[abc</li><li style="font-size: 18px;">ghi]</li></ol>',
         stepFunction: setFontSize("32px"),
@@ -184,7 +194,8 @@ test("should pad list based on font-size", async () => {
 
 test("should pad list based on font-size (2)", async () => {
     await testEditor({
-        contentBefore: `<span style="font-size: 56px;">[a]</span>`,
+        styleContent: 'ol { font: 14px Roboto }',
+        contentBefore: `<span style="font-size: 56px">[a]</span>`,
         stepFunction: toggleOrderedList,
         contentAfter: `<ol style="padding-inline-start: 60px;"><li style="font-size: 56px;">[]a</li></ol>`,
     });

--- a/addons/html_editor/static/tests/list/outdent.test.js
+++ b/addons/html_editor/static/tests/list/outdent.test.js
@@ -1,15 +1,23 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { describe, expect, test, before } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { bold, deleteBackward, keydownShiftTab } from "../_helpers/user_actions";
 import { getContent } from "../_helpers/selection";
 
+before(() => {
+    return document.fonts.add(new FontFace(
+        "Roboto",
+        "url(/web/static/fonts/google/Roboto/Roboto-Regular.ttf)",
+    )).ready;
+});
+
 describe("Regular list", () => {
     test("should remove the list-style when outdent the list", async () => {
         await testEditor({
+            styleContent: "ul { font: 14px Roboto }",
             contentBefore: unformat(`
                     <ul>
-                        <li style="list-style: cambodian;">
+                        <li style="list-style: upper-latin;">
                             <ul>
                                 <li>a[b]c</li>
                             </ul>
@@ -18,7 +26,7 @@ describe("Regular list", () => {
             stepFunction: keydownShiftTab,
             contentAfter: unformat(`
                     <ul>
-                        <li style="list-style: cambodian;"></li>
+                        <li style="list-style: upper-latin;"></li>
                         <li>a[b]c</li>
                     </ul>`),
         });

--- a/addons/html_editor/static/tests/list/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/list/paragraph_break.test.js
@@ -1,10 +1,17 @@
-import { describe, test } from "@odoo/hoot";
+import { describe, test, before } from "@odoo/hoot";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { insertText, splitBlock } from "../_helpers/user_actions";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
+
+before(() => {
+    return document.fonts.add(new FontFace(
+        "Roboto",
+        "url(/web/static/fonts/google/Roboto/Roboto-Regular.ttf)",
+    )).ready;
+});
 
 describe("Selection collapsed", () => {
     describe("Ordered", () => {
@@ -384,15 +391,16 @@ describe("Selection collapsed", () => {
 
             test("should keep the list-style when add li", async () => {
                 await testEditor({
+                    styleContent: "ul { font: 14px Roboto }",
                     contentBefore: unformat(`
-                            <ul style="font-size: 14px; font-family: sans-serif;">
-                                <li style="list-style: cambodian;">a[]</li>
+                            <ul>
+                                <li style="list-style: upper-latin;">a[]</li>
                             </ul>`),
                     stepFunction: splitBlock,
                     contentAfter: unformat(`
-                        <ul style="font-size: 14px; font-family: sans-serif; padding-inline-start: 36px;">
-                            <li style="list-style: cambodian;">a</li>
-                            <li style="list-style: cambodian;">[]<br></li>
+                        <ul>
+                            <li style="list-style: upper-latin;">a</li>
+                            <li style="list-style: upper-latin;">[]<br></li>
                         </ul>`),
                 });
             });

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1720,7 +1720,7 @@ which leads to stray network requests and inconsistencies."""
         # endGroup, assert, profile, profileEnd, count, timeEnd
     }
 
-    def take_screenshot(self, prefix='sc_'):
+    def take_screenshot(self, prefix='sc_') -> Future[dict]:
         def handler(f):
             try:
                 base_png = f.result(timeout=0)['data']


### PR DESCRIPTION
odoo/odoo#202688 updated the handling of list padding, however it hard-coded padding sizes. Those sizes can vary slightly depending on font selection (as different fonts have slightly different character dimensions). So depending on the local setup / environment, tests at issue may always fail.

Add a content cleaner property to `testEditor`, and use it to nuke the `inline-padding-start` property in various tests.
