### PR TITLE
[ADD] pos_self_order_pine_labs: enable kiosk order payment with pine labs

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -385,7 +385,7 @@ class PosConfig(models.Model):
         return self.self_ordering_url
 
     def _supported_kiosk_payment_terminal(self):
-        return ['adyen', 'razorpay', 'stripe']
+        return ['adyen', 'razorpay', 'stripe', 'pine_labs']
 
     def has_valid_self_payment_method(self):
         """ Checks if the POS config has a valid payment method (terminal or online). """

--- a/addons/pos_self_order_pine_labs/__init__.py
+++ b/addons/pos_self_order_pine_labs/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/addons/pos_self_order_pine_labs/__manifest__.py
+++ b/addons/pos_self_order_pine_labs/__manifest__.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    "name": "POS Self Order Pine Labs",
+    "version": "1.0",
+    "summary": "An addon for the Self Order App (KIOSK) that allows customers to pay using the Pine Labs POS Terminal.",
+    "category": "Sales/Point Of Sale",
+    "depends": ["pos_pine_labs", "pos_self_order"],
+    "auto_install": True,
+    "assets": {
+        "pos_self_order.assets": [
+            "pos_self_order_pine_labs/static/src/**/*",
+        ],
+    },
+    "author": "Odoo IN Pvt Ltd",
+    "license": "LGPL-3",
+}

--- a/addons/pos_self_order_pine_labs/controllers/__init__.py
+++ b/addons/pos_self_order_pine_labs/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import orders

--- a/addons/pos_self_order_pine_labs/controllers/orders.py
+++ b/addons/pos_self_order_pine_labs/controllers/orders.py
@@ -1,0 +1,49 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.addons.pos_self_order.controllers.orders import PosSelfOrderController
+from werkzeug.exceptions import NotFound
+
+
+class PosSelfOrderPineLabsController(PosSelfOrderController):
+    @http.route('/pos-self-order/pine-labs-fetch-payment-status/', auth='public', type='jsonrpc')
+    def pine_labs_fetch_payment_status(self, access_token, order_id, payment_data, payment_method_id):
+        pos_config = self._verify_pos_config(access_token)
+        order = pos_config.env['pos.order'].browse(order_id)
+        payment_method = pos_config.env['pos.payment.method'].browse(payment_method_id)
+
+        if not order.exists() or not payment_method.exists() or order.config_id.id != pos_config.id:
+            raise NotFound()
+
+        pine_labs_status_response = payment_method.pine_labs_fetch_payment_status(payment_data)
+        if pine_labs_status_response.get('status') == "TXN APPROVED":
+            data = pine_labs_status_response.get('data')
+            order.add_payment({
+                'amount': order.amount_total,
+                'payment_method_id': payment_method.id,
+                'cardholder_name': data.get('Card Holder Name'),
+                'transaction_id': data.get('TransactionLogId'),
+                'payment_status': 'done',
+                'pos_order_id': order.id,
+                'payment_method_authcode': data.get('ApprovalCode'),
+                'card_brand': data.get('Card Type'),
+                'payment_method_issuer_bank': data.get('Acquirer Name'),
+                'card_no': data.get('Card Number') and data.get('Card Number')[-4:],
+                'payment_method_payment_mode': data.get('PaymentMode'),
+                'payment_ref_no': payment_data.get('payment_ref_no'),
+                'pine_labs_plutus_transaction_ref': pine_labs_status_response.get('plutusTransactionReferenceID'),
+            })
+            order.action_pos_order_paid()
+            order._send_payment_result('Success')
+        return pine_labs_status_response
+
+    @http.route("/pos-self-order/pine-labs-cancel-transaction/", auth="public", type="jsonrpc")
+    def pine_labs_cancel_transaction(self, access_token, order_id, payment_data, payment_method_id):
+        pos_config = self._verify_pos_config(access_token)
+        order = pos_config.env['pos.order'].browse(order_id)
+        payment_method = pos_config.env['pos.payment.method'].browse(payment_method_id)
+
+        if not order.exists() or not payment_method.exists() or order.config_id.id != pos_config.id:
+            raise NotFound()
+
+        return payment_method.pine_labs_cancel_payment_request(payment_data)

--- a/addons/pos_self_order_pine_labs/models/__init__.py
+++ b/addons/pos_self_order_pine_labs/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import pos_payment_method

--- a/addons/pos_self_order_pine_labs/models/pos_payment_method.py
+++ b/addons/pos_self_order_pine_labs/models/pos_payment_method.py
@@ -1,0 +1,32 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import uuid
+
+from odoo import api, models
+from odoo.fields import Domain
+
+
+class PosPaymentMethod(models.Model):
+    _inherit = 'pos.payment.method'
+
+    def _payment_request_from_kiosk(self, order):
+        if self.use_payment_terminal != 'pine_labs':
+            return super()._payment_request_from_kiosk(order)
+        reference_prefix = order.config_id.name.replace(' ', '')
+        # We need to provide the amount in paisa since Pine Labs processes amounts in paisa.
+        # The conversion rate between INR and paisa is set as 1 INR = 100 paisa.
+        data = {
+            'amount': order.amount_total * 100,
+            'transactionNumber': f'{reference_prefix}/Order/{order.id}/{uuid.uuid4().hex}',
+            'sequenceNumber': '1'
+        }
+        payment_response = self.pine_labs_make_payment_request(data)
+        payment_response['payment_ref_no'] = data['transactionNumber']
+        return payment_response
+
+    @api.model
+    def _load_pos_self_data_domain(self, data, config):
+        domain = super()._load_pos_self_data_domain(data, config)
+        if data['pos.config'][0]['self_ordering_mode'] == 'kiosk':
+            domain = Domain.OR([[('use_payment_terminal', '=', 'pine_labs'), ('id', 'in', config.payment_method_ids.ids)], domain])
+        return domain

--- a/addons/pos_self_order_pine_labs/static/src/app/pages/payment_page.js
+++ b/addons/pos_self_order_pine_labs/static/src/app/pages/payment_page.js
@@ -1,0 +1,16 @@
+import { patch } from "@web/core/utils/patch";
+import { PaymentPage } from "@pos_self_order/app/pages/payment_page/payment_page";
+
+patch(PaymentPage.prototype, {
+    async startPayment() {
+        const paymentMethod = this.selfOrder.models["pos.payment.method"].find(
+            (p) => p.id === this.state.paymentMethodId
+        );
+        if (paymentMethod.use_payment_terminal === "pine_labs") {
+            this.selfOrder.paymentError = false;
+            await this.selfOrder.pineLabs.startPayment(this.selfOrder.currentOrder);
+        } else {
+            await super.startPayment(...arguments);
+        }
+    },
+});

--- a/addons/pos_self_order_pine_labs/static/src/app/pine_labs.js
+++ b/addons/pos_self_order_pine_labs/static/src/app/pine_labs.js
@@ -1,0 +1,159 @@
+import { rpc } from "@web/core/network/rpc";
+
+const REQUEST_TIMEOUT = 5000;
+const INACTIVITY_TIMEOUT = 110000;
+
+export class PineLabsError extends Error {}
+
+export class PineLabs {
+    constructor(...args) {
+        this.setup(...args);
+    }
+
+    setup(pineLabsPaymentMethod, access_token, pos_config, errorCallback) {
+        this.pineLabsPaymentMethod = pineLabsPaymentMethod;
+        this.access_token = access_token;
+        this.pos_config = pos_config;
+        this.errorCallback = errorCallback;
+        this.savedOrder = false;
+        this.pollingTimeout = null;
+        this.inactivityTimeout = null;
+        this.paymentStopped = false;
+    }
+
+    async startPayment(order) {
+        const paymentRequestResponse = await this.processPayment(order);
+        if (paymentRequestResponse) {
+            await this.paymentPolling(this.savedOrder);
+        }
+        this.removePaymentHandler(["plutusTransactionReferenceID", "paymentRefNo"]);
+    }
+
+    async processPayment(order) {
+        try {
+            const initialResponse = await rpc(`/kiosk/payment/${this.pos_config.id}/kiosk`, {
+                order: order.serializeForORM(),
+                access_token: this.access_token,
+                payment_method_id: this.pineLabsPaymentMethod.id,
+            });
+            if (initialResponse) {
+                this.savedOrder = initialResponse.order[0];
+                return this.handlePineLabsResponse(initialResponse.payment_status);
+            }
+        } catch (error) {
+            this.errorCallback(error);
+            return false;
+        }
+    }
+
+    async cancelPayment(order) {
+        try {
+            // We need to provide the amount in paisa since Pine Labs processes amounts in paisa.
+            // The conversion rate between INR and paisa is set as 1 INR = 100 paisa.
+            const data = {
+                plutusTransactionReferenceID: localStorage.getItem("plutusTransactionReferenceID"),
+                amount: order.amount_total * 100,
+            };
+            const cancelResponse = await rpc("/pos-self-order/pine-labs-cancel-transaction/", {
+                access_token: this.access_token,
+                order_id: order.id,
+                payment_data: data,
+                payment_method_id: this.pineLabsPaymentMethod.id,
+            });
+
+            if (cancelResponse) {
+                // Successfully cancelled the transaction
+                if (cancelResponse.notification) {
+                    this.errorCallback(new PineLabsError(cancelResponse.notification, "warning"));
+                    return true;
+                }
+                return this.handlePineLabsResponse(cancelResponse);
+            }
+        } catch (error) {
+            this.errorCallback(error);
+            return false;
+        }
+    }
+
+    /**
+     * Polls Pine Labs payment status at regular intervals (5 seconds)
+     * until a payment is approved, a timeout occurs, or the transaction is stopped.
+     *
+     * This ensures that we handle both successful and failed payments gracefully
+     * by continuously checking the status until a final state is reached.
+     */
+    async paymentPolling(order) {
+        const data = {
+            plutusTransactionReferenceID: localStorage.getItem("plutusTransactionReferenceID"),
+            payment_ref_no: localStorage.getItem("paymentRefNo"),
+        };
+        this.stopInactivePayment().then(() => (this.paymentStopped = true));
+        const fetchPaymentStatus = async (resolve, reject) => {
+            try {
+                clearTimeout(this.pollingTimeout);
+                // This transaction will automatically cancel if inactive for more than 90 seconds.
+                if (this.paymentStopped) {
+                    await this.cancelPayment(order);
+                    return resolve(false);
+                }
+
+                const statusResponse = await rpc(
+                    "/pos-self-order/pine-labs-fetch-payment-status/",
+                    {
+                        access_token: this.access_token,
+                        order_id: order.id,
+                        payment_data: data,
+                        payment_method_id: this.pineLabsPaymentMethod.id,
+                    }
+                );
+                if (statusResponse?.status === "TXN APPROVED") {
+                    return resolve(true);
+                }
+                if (statusResponse?.error) {
+                    this.handlePineLabsResponse(statusResponse);
+                    return resolve(false);
+                }
+
+                this.pollingTimeout = setTimeout(
+                    fetchPaymentStatus,
+                    REQUEST_TIMEOUT,
+                    resolve,
+                    reject
+                );
+            } catch (error) {
+                this.errorCallback(error);
+                return resolve(false);
+            }
+        };
+        return new Promise(fetchPaymentStatus);
+    }
+
+    handlePineLabsResponse(response) {
+        if (response.error) {
+            this.errorCallback(new PineLabsError(response.error));
+            return false;
+        }
+        response.plutusTransactionReferenceID &&
+            localStorage.setItem(
+                "plutusTransactionReferenceID",
+                response.plutusTransactionReferenceID
+            );
+        response.payment_ref_no && localStorage.setItem("paymentRefNo", response.payment_ref_no);
+        return true;
+    }
+
+    stopInactivePayment() {
+        return new Promise(
+            (resolve) => (this.inactivityTimeout = setTimeout(resolve, INACTIVITY_TIMEOUT))
+        );
+    }
+
+    removePaymentHandler(payment_data) {
+        payment_data.forEach((data) => {
+            localStorage.removeItem(data);
+        });
+        clearTimeout(this.pollingTimeout);
+        clearTimeout(this.inactivityTimeout);
+        this.paymentStopped = false;
+    }
+}

--- a/addons/pos_self_order_pine_labs/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order_pine_labs/static/src/app/services/self_order_service.js
@@ -1,0 +1,49 @@
+import { patch } from "@web/core/utils/patch";
+import { SelfOrder } from "@pos_self_order/app/services/self_order_service";
+import { PineLabs, PineLabsError } from "@pos_self_order_pine_labs/app/pine_labs";
+import { _t } from "@web/core/l10n/translation";
+
+patch(SelfOrder.prototype, {
+    async setup() {
+        await super.setup(...arguments);
+
+        const pineLabsPaymentMethod = this.models["pos.payment.method"].find(
+            (p) => p.use_payment_terminal === "pine_labs"
+        );
+
+        if (pineLabsPaymentMethod) {
+            this.pineLabs = new PineLabs(
+                pineLabsPaymentMethod,
+                this.access_token,
+                this.config,
+                this.handlePineLabsError.bind(this)
+            );
+        }
+    },
+
+    filterPaymentMethods(pms) {
+        const filteredPaymentMethods = super.filterPaymentMethods(...arguments);
+        const pineLabsPaymentMethods = pms.filter(
+            (rec) => rec.use_payment_terminal === "pine_labs"
+        );
+        return [...new Set([...filteredPaymentMethods, ...pineLabsPaymentMethods])];
+    },
+
+    handlePineLabsError(error, type) {
+        this.paymentError = true;
+        this.handleErrorNotification(error, type);
+    },
+
+    handleErrorNotification(error, type = "danger") {
+        if (error instanceof PineLabsError) {
+            this.notification.add(
+                _t(`Pine Labs Error: %(errorMessage)s`, { errorMessage: error.message || "" }),
+                {
+                    type: type,
+                }
+            );
+        } else {
+            super.handleErrorNotification(...arguments);
+        }
+    },
+});


### PR DESCRIPTION
*: pos_self_order

In this commit:
===========
- Added support for processing kiosk orders through the Pine Labs payment terminal.
- Kiosk users can now complete payments using the Pine Labs terminal, enhancing the self-service checkout experience.

task-4791562
