### PR TITLE
[FIX] sale_mrp: spread sol total price amoung kit component

### DIFF
--- a/addons/sale_mrp/models/stock_move.py
+++ b/addons/sale_mrp/models/stock_move.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from collections import defaultdict
+
 from odoo import models
+from odoo.tools.float_utils import float_is_zero, float_round
 
 
 class StockMove(models.Model):
@@ -18,8 +21,28 @@ class StockMoveLine(models.Model):
 
     def _compute_sale_price(self):
         kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        sale_line_exploded_list_price = defaultdict(float)
         for move_line in kit_lines:
-            unit_price = move_line.product_id.list_price
-            qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)
-            move_line.sale_price = unit_price * qty
+            if move_line.move_id.sale_line_id:
+                unit_price = move_line.product_id.list_price
+                qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.move_id.sale_line_id.product_uom)
+                sale_line_exploded_list_price[move_line.move_id.sale_line_id] += unit_price * qty
+        sale_line_price_deviation = defaultdict(float)
+        for move_line in kit_lines:
+            sol = move_line.move_id.sale_line_id
+            if sale_line_exploded_list_price[sol]:
+                qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, sol.product_uom)
+                price_percentage = move_line.product_id.list_price * qty / sale_line_exploded_list_price[sol]
+                exact_price = price_percentage * sol.price_total
+                move_line.sale_price = float_round(exact_price, precision_rounding=sol.currency_id.rounding)
+                sale_line_price_deviation[sol] += exact_price - move_line.sale_price
+            else:
+                unit_price = move_line.product_id.list_price
+                qty = move_line.product_uom_id._compute_quantity(move_line.qty_done, move_line.product_id.uom_id)
+                move_line.sale_price = unit_price * qty
+        # check if the rounding error is relevant and add to the first related move_line if needed
+        for sol in sale_line_price_deviation:
+            if not float_is_zero(sale_line_price_deviation[sol], precision_rounding=sol.currency_id.rounding):
+                move_line = (sol.move_ids.move_line_ids & kit_lines)[0]
+                move_line.sale_price = float_round(move_line.sale_price + sale_line_price_deviation[sol], precision_rounding=sol.currency_id.rounding)
         super(StockMoveLine, self - kit_lines)._compute_sale_price()


### PR DESCRIPTION
### Issue:

Confirming a sale order with a line for a kit product will create and explode a delivery move for the kit component. However, the computation of the sale price of move lines related to the kit component is currently based solely on the generic `lst_price` of the component set on its product form rather than dividing the price of the related line properly. Since this sale_price is used on deliveries can influence the shipping cost of certain carrier e.g:
https://github.com/odoo/enterprise/blob/74bb47e01b57d670a06781a5c6458a0aa4f0d23e/delivery_dhl_rest/models/dhl_request.py#L186
it is important to refine the computation of that value in case the sale price of the kit product (with taxes) do not coincide with the sum of the cost of its components.

### Steps to reproduce:

- Create a kit product with lst_price 50 eur and a Kit bom:
    - 10 x COMP (storable product with lst_price: 10 eur)
- Create and confirm an SO for 1 kit product
#### > the sale_price of the delivery move line is set to 100 eur.

opw-4798375
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
