### PR TITLE
[FIX] html_editor: fix paragraph selection on triple click with <br>

### DIFF
--- a/addons/html_editor/static/tests/selection.test.js
+++ b/addons/html_editor/static/tests/selection.test.js
@@ -70,6 +70,18 @@ test("correct selection after triple click with bold", async () => {
     expect(getContent(el)).toBe("<p>[abc<strong>d]</strong></p><p>efg</p>");
 });
 
+test("correct selection after triple click in multi-line block (1)", async () => {
+    const { el } = await setupEditor("<p>[]abc<br>efg</p>", {});
+    await tripleClick(queryFirst("p").firstChild);
+    expect(getContent(el)).toBe("<p>[abc<br>efg]</p>");
+});
+
+test("correct selection after triple click in multi-line block (2)", async () => {
+    const { el } = await setupEditor("<p>block1</p><p>[]block2<br>block2</p><p>block3</p>", {});
+    await tripleClick(queryFirst("p").nextSibling.firstChild); // we triple click inside block2
+    expect(getContent(el)).toBe("<p>block1</p><p>[block2<br>block2]</p><p>block3</p>");
+});
+
 test("fix selection P in the beggining being a direct child of the editable p after selection", async () => {
     const { el } = await setupEditor("<div>a</div>[]<p>b</p>");
     expect(getContent(el)).toBe(`<div class="o-paragraph">a</div><p>[]b</p>`);

--- a/addons/html_editor/static/tests/tags.test.js
+++ b/addons/html_editor/static/tests/tags.test.js
@@ -502,6 +502,7 @@ describe("to blockquote", () => {
             focusNode: anchorNode.nextSibling,
             focusOffset: 0,
         });
+        await manuallyDispatchProgrammaticEvent(anchorNode, "click", { detail: 6 });
         await tick();
         expect(getContent(el)).toBe("<p>[abcd]</p><p>Plop</p>");
 


### PR DESCRIPTION
Problem:
When a paragraph contains a `<br>` element, triple-clicking on any line does not select the entire paragraph — only the clicked line is selected.

Solution:
Ensure that on triple click, the selection expands to include the entire block, regardless of inline breaks like `<br>`.

Steps to reproduce:
- Open the Todo app.
- Add a paragraph of text.
- Use `Shift+Enter` to insert a line break (`<br>`).
- Add text on the second line.
- Triple-click on the second line. → Only the second line is selected, not the full paragraph.

opw-4825816

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
