### PR TITLE
[FIX] pos_self_order: Allow cancelling self order

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -2,10 +2,12 @@
 import re
 import uuid
 from datetime import timedelta
-from odoo import http, fields
+from odoo import http, fields, _
 from odoo.http import request
 from odoo.tools import float_round
 from werkzeug.exceptions import NotFound, BadRequest, Unauthorized
+from odoo.exceptions import MissingError
+from odoo.tools import consteq
 
 class PosSelfOrderController(http.Controller):
     @http.route("/pos-self-order/process-new-order/<device_type>/", auth="public", type="json", website=True)
@@ -150,6 +152,19 @@ class PosSelfOrderController(http.Controller):
 
         pos_order.send_table_count_notification(pos_order.table_id)
         return pos_order._export_for_self_order()
+
+    @http.route('/pos-self-order/remove-order', auth='public', type='json', website=True)
+    def remove_order(self, access_token, order_id, order_access_token):
+        pos_config = self._verify_pos_config(access_token)
+        pos_order = pos_config.env['pos.order'].browse(order_id)
+
+        if not pos_order.exists() or not consteq(pos_order.access_token, order_access_token):
+            raise MissingError(_("Your order does not exist or has been removed"))
+
+        if pos_order.state != 'draft':
+            raise Unauthorized(_("You are not authorized to remove this order"))
+
+        pos_order.remove_from_ui([pos_order.id])
 
     @http.route('/pos-self-order/get-orders', auth='public', type='json', website=True)
     def get_orders_by_access_token(self, access_token, order_access_tokens):

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -6,6 +6,7 @@ import { useSelfOrder } from "@pos_self_order/app/self_order_service";
 import { PopupTable } from "@pos_self_order/app/components/popup_table/popup_table";
 import { _t } from "@web/core/l10n/translation";
 import { OrderWidget } from "@pos_self_order/app/components/order_widget/order_widget";
+import { CancelPopup } from "@pos_self_order/app/components/cancel_popup/cancel_popup";
 
 export class CartPage extends Component {
     static template = "pos_self_order.CartPage";
@@ -13,11 +14,20 @@ export class CartPage extends Component {
 
     setup() {
         this.selfOrder = useSelfOrder();
+        this.dialog = useService("dialog");
         this.router = useService("router");
         this.state = useState({
             selectTable: false,
             cancelConfirmation: false,
         });
+    }
+
+    get showCancelButton() {
+        return (
+            this.selfOrder.config.self_ordering_mode === "mobile" &&
+            this.selfOrder.config.self_ordering_pay_after === "each" &&
+            typeof this.selfOrder.currentOrder.id === "number"
+        );
     }
 
     get lines() {
@@ -34,6 +44,25 @@ export class CartPage extends Component {
         } else {
             return this.lines;
         }
+    }
+
+    async cancelOrder() {
+        this.dialog.add(CancelPopup, {
+            title: _t("Cancel order"),
+            confirm: async () => {
+                try {
+                    await this.selfOrder.rpc("/pos-self-order/remove-order", {
+                        access_token: this.selfOrder.access_token,
+                        order_id: this.selfOrder.currentOrder.id,
+                        order_access_token: this.selfOrder.currentOrder.access_token,
+                    });
+                    this.selfOrder.currentOrder.state = "cancel";
+                    this.router.navigate("default");
+                } catch (error) {
+                    this.selfOrder.handleErrorNotification(error);
+                }
+            },
+        });
     }
 
     getLineChangeQty(line) {

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -3,7 +3,10 @@
     <t t-name="pos_self_order.CartPage">
         <div class="order-cart-content d-flex flex-column flex-grow-1 justify-content-between overflow-y-auto">
             <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 p-3 w-100 bg-view border-bottom overflow-x-auto z-index-1">
-                <h1 class="mb-0 fw-bolder text-nowrap">Your Order</h1>
+                <h1 class="mb-0 fw-bolder text-nowrap overflow-hidden">Your Order</h1>
+                <button t-if="showCancelButton" t-on-click="() => this.cancelOrder()" class="btn btn-secondary px-3" type="button">
+                    <span>Cancel</span>
+                </button>
             </div>
             <div class="order-content flex-grow-1 overflow-auto pb-4">
                 <t t-foreach="linesToDisplay" t-as="line" t-key="line.uuid">

--- a/addons/pos_self_order/static/tests/helpers/cart_page.js
+++ b/addons/pos_self_order/static/tests/helpers/cart_page.js
@@ -66,3 +66,16 @@ export function checkCombo(comboName, products) {
 
     return steps;
 }
+
+export function cancelOrder() {
+    return [
+        {
+            content: `Click on 'Cancel' button`,
+            trigger: '.order-cart-content .btn:contains("Cancel")',
+        },
+        {
+            content: `Validate cancel popup`,
+            trigger: ".modal-dialog .btn:contains('Cancel Order')",
+        },
+    ];
+}

--- a/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
@@ -23,6 +23,10 @@ registry.category("web_tour.tours").add("self_mobile_each_table_takeaway_in", {
         Utils.clickBtn("Pay"),
         Utils.clickBtn("Ok"),
         Utils.checkIsNoBtn("Order Now"),
+        Utils.clickBtn("My Order"),
+        ...CartPage.cancelOrder(),
+        Utils.checkBtn("Order Now"),
+        Utils.checkBtn("My Orders"),
     ],
 });
 


### PR DESCRIPTION
Prior to this change, when users cancelled their payment, they remained stuck on their previous order. It was not possible to cancel the order from the basket page.

This change allows the user to cancel the order from the shopping cart page.

taskId: 4830007

