### PR TITLE
[FIX] {im, website}_livechat: new session in test chatbot

### DIFF
--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.js
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.js
@@ -44,6 +44,13 @@ export class FeedbackPanel extends Component {
         this.state.rating = rating;
     }
 
+    get allowNewSession() {
+        return (
+            this.store.livechat_rule?.action !== "hide_button" &&
+            this.livechatService.options.channel_id
+        );
+    }
+
     onClickSendFeedback() {
         rpc("/im_livechat/feedback", {
             reason: this.state.feedback,

--- a/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
+++ b/addons/im_livechat/static/src/embed/common/feedback_panel/feedback_panel.xml
@@ -26,7 +26,7 @@
         </div>
         <div class="d-flex gap-2 justify-content-center">
             <button class="btn btn-outline-secondary" t-on-click="props.onClickClose">Close</button>
-            <button t-if="store.livechat_rule?.action !== 'hide_button'" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
+            <button t-if="allowNewSession" class="btn btn-outline-secondary" t-on-click="props.onClickNewSession">New Session</button>
         </div>
     </div>
 </div>

--- a/addons/im_livechat/static/src/embed/common/livechat_button.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_button.js
@@ -36,6 +36,10 @@ export class LivechatButton extends Component {
     }
 
     get isShown() {
-        return this.store.livechat_available && this.store.activeLivechats.length === 0;
+        return (
+            this.store.livechat_available &&
+            this.store.activeLivechats.length === 0 &&
+            this.livechatService.options.channel_id
+        );
     }
 }

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_test_page_tour.js
@@ -53,5 +53,32 @@ registry.category("web_tour.tours").add("website_livechat_chatbot_test_page_tour
             trigger: messagesContain("Please find documentation at"),
             run: () => {},
         },
+        {
+            trigger: ".o-livechat-root:shadow [title='Close Chat Window (ESC)']",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains('Yes, leave conversation')",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow p:contains('Did we correctly answer your question?')",
+            async run() {
+                await contains("button", { target: this.anchor.getRootNode(), text: "Close" });
+                await contains("button", {
+                    target: this.anchor.getRootNode(),
+                    text: "New Session",
+                    count: 0,
+                });
+            },
+        },
+        {
+            trigger: ".o-livechat-root:shadow button:contains('Close')",
+            run: "click",
+        },
+        {
+            trigger: ".o-livechat-root:shadow .o-mail-ChatHub:not(:visible)",
+            content: "Livechat Button should not be visible",
+        },
     ],
 });


### PR DESCRIPTION
Before this commit, clicking the `New Session` button after a test chatbot session ended would throw an error because it required a Livechat Channel ID, which isn't available on the test chatbot page.

This commit fixes the issue by hiding the `New Session` and `Livechat` buttons when the chatbot is opened in test mode, preventing errors related to missing Channel IDs.

Task-4781464


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
