### PR TITLE
[FIX] l10n_din5008: fix IBN number on PDF footer

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -137,7 +137,7 @@
                     <div class="company_details">
                         <table class="table-borderless">
                             <tr>
-                                <td colspan="4">
+                                <td colspan="3">
                                     <ul class="list-inline">
                                         <li t-if="company.company_details"><span t-field="company.company_details"/></li>
                                     </ul>
@@ -156,11 +156,11 @@
                                         <li>HRB Nr: <span t-field="company.company_registry"/></li>
                                     </ul>
                                 </td>
-                                <td colspan="2" t-if="company.partner_id.bank_ids">
+                                <td colspan="3" t-if="company.partner_id.bank_ids">
                                     <ul class="list-inline">
                                         <t t-foreach="company.partner_id.bank_ids[:2]" t-as="bank">
                                             <li><span t-field="bank.bank_id.name"/></li>
-                                            <li>IBAN: <span t-field="bank.acc_number"/></li>
+                                            <li class="text-nowrap">IBAN: <span t-field="bank.acc_number"/></li>
                                             <li>BIC: <span t-field="bank.bank_id.bic"/></li>
                                         </t>
                                     </ul>


### PR DESCRIPTION
### Before this commit:
The `IBAN number` in the PDF footer is currently broken and displayed across multiple lines.
![image](https://github.com/user-attachments/assets/136a6bb2-3781-46ed-b384-e0c3ea6157a4)

### After this commit:
Fix it by updating the CSS classes to ensure proper alignment and a cleaner UI layout.
![image](https://github.com/user-attachments/assets/1f6cb17f-5012-41cf-b3b3-7223f26aa64b)

> Task-4822070

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
