### PR TITLE
[IMP] web: list: select more records by clicking on rows

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -110,6 +110,10 @@ export class StaticList extends DataPoint {
         return this.config.resIds;
     }
 
+    get selection() {
+        return [];
+    }
+
     // -------------------------------------------------------------------------
     // Public
     // -------------------------------------------------------------------------

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -96,7 +96,7 @@ export class ListRenderer extends Component {
     static useMagicColumnWidths = true;
     static LONG_TOUCH_THRESHOLD = 400;
     static components = { DropdownItem, Field, ViewButton, CheckBox, Dropdown, Pager, Widget };
-    static defaultProps = { hasSelectors: false, cycleOnTab: true };
+    static defaultProps = { allowSelectors: false, cycleOnTab: true };
     static props = [
         "activeActions?",
         "list",
@@ -608,7 +608,7 @@ export class ListRenderer extends Component {
 
     get aggregates() {
         let values;
-        if (this.props.list.selection && this.props.list.selection.length) {
+        if (this.props.list.selection.length) {
             values = this.props.list.selection.map((r) => r.data);
         } else if (this.props.list.isGrouped) {
             values = this.props.list.groups.map((g) => g.aggregates);
@@ -1109,14 +1109,15 @@ export class ListRenderer extends Component {
         if (ev.target.special_click) {
             return;
         }
-        const recordAfterResequence = async () => {
-            const recordIndex = this.props.list.records.indexOf(record);
-            await this.resequencePromise;
-            // row might have changed record after resequence
-            record = this.props.list.records[recordIndex] || record;
-        };
 
-        if ((this.props.list.model.multiEdit && record.selected) || this.isInlineEditable(record)) {
+        const multiEdit = this.props.list.model.multiEdit;
+        const hasSelection = !!this.props.list.selection.length;
+        if (hasSelection && this.canSelectRecord && (!multiEdit || !record.selected)) {
+            this.toggleRecordSelection(record);
+        } else if (
+            (multiEdit && record.selected) ||
+            (this.isInlineEditable(record) && !hasSelection)
+        ) {
             if (record.isInEdition && this.editedRecord === record) {
                 const cell = this.tableRef.el.querySelector(
                     `.o_selected_row td[name='${column.name}']`
@@ -1129,7 +1130,10 @@ export class ListRenderer extends Component {
                 this.focusCell(column);
                 this.cellToFocus = null;
             } else {
-                await recordAfterResequence();
+                const recordIndex = this.props.list.records.indexOf(record);
+                await this.resequencePromise;
+                // row might have changed record after resequence
+                record = this.props.list.records[recordIndex] || record;
                 await this.props.list.enterEditMode(record);
                 this.cellToFocus = { column, record };
                 if (
@@ -2108,7 +2112,7 @@ export class ListRenderer extends Component {
      */
     ignoreEventInSelectionMode(ev) {
         const { list } = this.props;
-        if (this.env.isSmall && list.selection && list.selection.length) {
+        if (this.env.isSmall && list.selection.length) {
             // in selection mode, only selection is allowed.
             ev.stopPropagation();
             ev.preventDefault();
@@ -2121,7 +2125,7 @@ export class ListRenderer extends Component {
      */
     onClickCapture(record, ev) {
         const { list } = this.props;
-        if (this.env.isSmall && list.selection && list.selection.length) {
+        if (this.env.isSmall && list.selection.length) {
             ev.stopPropagation();
             ev.preventDefault();
             this.toggleRecordSelection(record);

--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -46,7 +46,6 @@
     .o_list_table {
         --table-bg: #{$o-view-background-color};
 
-
         // We need this to be collapse because we want to add a border on the rows
         // for sale order/invoice lines of type section.
         border-collapse: collapse;
@@ -183,6 +182,10 @@
                     flex-wrap: nowrap !important;
                 }
             }
+        }
+
+        &:has(.o_data_row_selected) {
+            user-select: none;
         }
 
         tfoot {
@@ -388,7 +391,6 @@
         }
 
         .o_data_row.o_selected_row > .o_data_cell {
-
             > .o_field_widget:not(.o_readonly_modifier):not(.o_invisible_modifier) {
                 width: 100%;
                 .o_input {

--- a/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_avatar_field.test.js
@@ -169,8 +169,7 @@ test("widget many2many_tags_avatar in list view", async () => {
     await contains(".o_control_panel_main_buttons .o_list_button_save").click();
     expect(".o_data_row:eq(0) .o_field_many2many_tags_avatar .o_avatar img").toHaveCount(2);
 
-    // Select the first row and enter edit mode on the x2many field.
-    await contains(".o_data_row:nth-child(1) .o_list_record_selector input").click();
+    // Edit first row
     await contains(".o_data_row:nth-child(1) .o_data_cell").click();
 
     // Only the first row should have tags with delete buttons.
@@ -191,8 +190,7 @@ test("widget many2many_tags_avatar list view - don't crash on keyboard navigatio
             `,
     });
 
-    // Select the 2nd row and enter edit mode on the x2many field.
-    await contains(".o_data_row:nth-child(2) .o_list_record_selector input").click();
+    // Edit second row
     await contains(".o_data_row:nth-child(2) .o_data_cell").click();
 
     // Pressing left arrow should focus on the right-most (second) tag.

--- a/addons/web/static/tests/views/fields/many2many_tags_field.test.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field.test.js
@@ -325,10 +325,11 @@ test("Many2ManyTagsField in list view on desktop", async () => {
     expect(".o_colorlist").toHaveCount(0);
 
     await contains(".o_list_record_selector:eq(1)").click();
+    expect(".o_data_row_selected").toHaveCount(1);
     await contains(".o_field_many2many_tags .badge :nth-child(1)").click();
-    expect.verifySteps(["selectRecord"]);
+    expect(".o_data_row_selected").toHaveCount(0);
+    expect.verifySteps([]);
     await animationFrame();
-
     expect(".o_colorlist").toHaveCount(0);
 });
 

--- a/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_avatar_field.test.js
@@ -250,7 +250,6 @@ test("click on many2one_avatar in an editable list view (editable top)", async (
             </list>`,
     });
 
-    await contains(".o_data_row:eq(0) .o_list_record_selector input").click();
     await contains(".o_data_row .o_data_cell [name='user_id']").click();
     expect(".o_data_row:eq(0)").toHaveClass("o_selected_row");
 

--- a/addons/web/static/tests/views/fields/many2one_field.test.js
+++ b/addons/web/static/tests/views/fields/many2one_field.test.js
@@ -873,10 +873,6 @@ test("focus tracking on a many2one in a list", async () => {
             </list>`,
     });
 
-    // Select two records
-    await contains(".o_data_row:eq(0) .o_list_record_selector input").click();
-    await contains(".o_data_row:eq(1) .o_list_record_selector input").click();
-
     await contains(".o_data_row .o_data_cell").click();
     expect(".o_data_row .o_data_cell input").toBeFocused();
 
@@ -951,12 +947,12 @@ test("empty readonly many2one field", async () => {
 
 test("empty many2one field with no result", async () => {
     patchWithCleanup(Many2XAutocomplete.prototype, {
-        getCreationContext(value){
+        getCreationContext(value) {
             expect(value).toBe("");
             const context = super.getCreationContext(value);
             expect(context[`default_${this.props.nameCreateField}`]).toBe(undefined);
             return context;
-        }
+        },
     });
     class M2O extends models.Model {
         m2o = fields.Many2one({ relation: "m2o" });

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -2797,7 +2797,6 @@ test(`editing a record should change same record in other groups when grouped by
     await contains(`.o_group_header:eq(1)`).click(); // open Value 2 group
     expect(queryAllTexts(`.o_list_char`)).toEqual(["yop", "blip", "blip", "yop", "blip"]);
 
-    await contains(`.o_data_row .o_list_record_selector input`).click();
     await contains(`.o_data_row .o_data_cell`).click();
     await contains(`.o_data_row .o_list_char input`).edit("xyz");
     await contains(`.o_list_view`).click();
@@ -10772,7 +10771,7 @@ test(`editable list view: contexts with multiple edit`, async () => {
 });
 
 test.tags("desktop");
-test(`editable list view: single edition with selected records`, async () => {
+test(`list view editable and multi editable: click on row with selected records`, async () => {
     await mountView({
         resModel: "foo",
         type: "list",
@@ -10781,12 +10780,10 @@ test(`editable list view: single edition with selected records`, async () => {
 
     // Select first record
     await contains(`.o_data_row .o_list_record_selector input`).click();
-
-    // Edit the second
+    expect(".o_data_row_selected").toHaveCount(1);
+    // Click on a cell of the second record
     await contains(`.o_data_row:eq(1) .o_data_cell`).click();
-    await contains(`.o_data_cell input`).edit("oui", { confirm: false });
-    await contains(`.o_list_button_save`).click();
-    expect(queryAllTexts(`.o_data_cell`)).toEqual(["yop", "oui", "gnap", "blip"]);
+    expect(".o_data_row_selected").toHaveCount(2);
 });
 
 test.tags("desktop");
@@ -11309,9 +11306,6 @@ test(`editable list view: mousedown on "Discard", mouseup somewhere else (no mul
         `,
     });
 
-    // select two records
-    await contains(`.o_data_row:eq(0) .o_list_record_selector input`).click();
-    await contains(`.o_data_row:eq(1) .o_list_record_selector input`).click();
     await contains(`.o_data_row:eq(0) .o_data_cell:eq(0)`).click();
     await contains(`.o_data_row [name=foo] input`).edit("oof", { confirm: false });
     await pointerDown(`.o_list_button_discard`);
@@ -11698,10 +11692,11 @@ test(`editable readonly list view: navigation`, async () => {
     await contains(`.o_data_row:eq(2) [name=foo]`).click();
     expect(`.o_selected_row`).toHaveCount(0);
 
-    // Clicking on an unselected record while no row is being edited will open the record
-    expect.verifySteps([]);
+    // Clicking on an unselected record while no row is being edited will select it
+    expect(`.o_data_row_selected`).toHaveCount(2);
     await contains(`.o_data_row:eq(2) [name=foo]`).click();
-    expect.verifySteps([`resId: 3`]);
+    expect(`.o_data_row_selected`).toHaveCount(3);
+    expect.verifySteps([]);
 });
 
 test.tags("desktop");
@@ -11779,8 +11774,10 @@ test(`editable readonly list view: navigation in grouped list`, async () => {
     expect(`.o_selected_row`).toHaveCount(0);
 
     // Click again should select the clicked record
+    expect(`.o_data_row_selected`).toHaveCount(2);
     await contains(`.o_data_row:eq(3) [name=foo]`).click();
-    expect.verifySteps(["resId: 3"]);
+    expect(`.o_data_row_selected`).toHaveCount(3);
+    expect.verifySteps([]);
 });
 
 test.tags("desktop");

--- a/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/select_create_dialog.test.js
@@ -757,6 +757,36 @@ test("SelectCreateDialog: default props, create a record on desktop", async () =
     expect.verifySteps(["onSelected 4"]);
 });
 
+test.tags("desktop");
+test("SelectCreateDialog: click on row once in selection", async () => {
+    Partner._views["list"] = `<list><field name="name"/></list>`;
+    Partner._views["search"] = `
+        <search>
+            <filter name="bar" help="Bar" domain="[('bar', '=', True)]"/>
+        </search>`;
+    await mountWithCleanup(WebClient);
+
+    getService("dialog").add(SelectCreateDialog, {
+        onSelected: (resIds) => expect.step(`onSelected ${resIds}`),
+        resModel: "partner",
+    });
+    await animationFrame();
+
+    expect(".o_dialog").toHaveCount(1);
+    expect(".o_dialog .o_list_view .o_data_row").toHaveCount(3);
+    expect(".o_dialog .o_selection_box").toHaveCount(0);
+
+    await contains(".o_data_row .o_list_record_selector").click();
+    expect(".o_dialog .o_data_row_selected").toHaveCount(1);
+
+    await contains(".o_data_row:eq(1) .o_data_cell").click();
+    expect(".o_dialog .o_data_row_selected").toHaveCount(2);
+
+    await contains(".o_dialog footer .btn-primary").click();
+    expect(".o_dialog").toHaveCount(0);
+    expect.verifySteps(["onSelected 1,2"]);
+});
+
 test.tags("mobile");
 test("SelectCreateDialog: default props, create a record on mobile", async () => {
     Partner._views["search"] = /* xml */ `


### PR DESCRIPTION
In a list view, select a record by clicking on the checkbox.
From this point, we entered the selection mode. Before
this commit, clicking on a row (not its checkbox), would behave
the same way as if no other record was selected (e.g. open the
record in form view, switch it in edition in editable lists...),
thus ignoring the fact that some records are already selected.

In SelectCreateDialog, clicking on a record after selecting some
records would close the dialog, with that clicked record as only
selection.

With this commit, once in selection mode, more records can be
selected by clicking on their row, not only their checkbox.

task~4830114