### PR TITLE
[IMP] im_livechat, *: cleanup get_session

### DIFF
--- a/addons/crm_livechat/tests/test_chatbot_lead.py
+++ b/addons/crm_livechat/tests/test_chatbot_lead.py
@@ -171,7 +171,6 @@ class CrmChatbotCase(chatbot_common.CrmChatbotCase):
 
     def _play_session_with_lead(self):
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'Test Visitor',
             'channel_id': self.livechat_channel.id,
             'chatbot_script_id': self.chatbot_script.id,
         })

--- a/addons/crm_livechat/tests/test_crm_lead.py
+++ b/addons/crm_livechat/tests/test_crm_lead.py
@@ -30,7 +30,6 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
         """ Test customer set on lead: not if public, guest if not public """
         # public: should not be set as customer
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'Visitor',
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
@@ -48,7 +47,6 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
         self.assertFalse(self.env.ref('base.public_user').active)
 
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'Visitor',
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
@@ -71,7 +69,6 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
         # portal: should be set as customer
         self.authenticate("user_portal", "user_portal")
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'Visitor',
             'channel_id': self.livechat_channel.id,
             'persisted': True,
         })
@@ -104,8 +101,7 @@ class TestLivechatLead(HttpCase, TestCrmCommon):
         self.livechat_channel.user_ids = bob_operator
         self.env["mail.presence"]._update_presence(bob_operator)
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {"anonymous_name": "Visitor", "channel_id": self.livechat_channel.id},
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         message = channel.message_post(

--- a/addons/im_livechat/controllers/cors/main.py
+++ b/addons/im_livechat/controllers/cors/main.py
@@ -28,11 +28,11 @@ class CorsLivechatController(LivechatController):
 
     @route("/im_livechat/cors/get_session", methods=["POST"], type="jsonrpc", auth="public", cors="*")
     def cors_get_session(
-        self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs
+        self, channel_id, previous_operator_id=None, chatbot_script_id=None, persisted=True, **kwargs
     ):
         force_guest_env(kwargs.pop("guest_token", ""), raise_if_not_found=False)
         return self.get_session(
-            channel_id, anonymous_name, previous_operator_id, chatbot_script_id, persisted, **kwargs
+            channel_id, previous_operator_id, chatbot_script_id, persisted, **kwargs
         )
 
     @route("/im_livechat/cors/init", type="jsonrpc", auth="public", cors="*")

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -115,7 +115,6 @@ export class LivechatService {
             "/im_livechat/get_session",
             {
                 channel_id: this.options.channel_id,
-                anonymous_name: this.options.default_username ?? _t("Visitor"),
                 chatbot_script_id:
                     originThread?.chatbot?.script.id ??
                     this.store.livechat_rule?.chatbot_script_id?.id,

--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -102,7 +102,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
     await waitForSteps([
         `/im_livechat/get_session - ${JSON.stringify({
             channel_id: livechatChannelId,
-            anonymous_name: "Visitor",
             previous_operator_id: null,
             persisted: false,
         })}`,
@@ -122,7 +121,6 @@ test("Only necessary requests are made when creating a new chat", async () => {
             stepsBefore: [
                 `/im_livechat/get_session - ${JSON.stringify({
                     channel_id: livechatChannelId,
-                    anonymous_name: "Visitor",
                     previous_operator_id: operatorPartnerId,
                     persisted: true,
                 })}`,

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -51,7 +51,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
 
     def test_chatbot_steps(self):
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            'anonymous_name': 'Test Visitor',
             'chatbot_script_id': self.chatbot_script.id,
             'channel_id': self.livechat_channel.id,
         })
@@ -117,7 +116,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Test Visitor",
                 "channel_id": self.livechat_channel.id,
                 "chatbot_script_id": self.chatbot_script.id,
             },
@@ -142,7 +140,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Test Visitor",
                 "channel_id": self.livechat_channel.id,
                 "chatbot_script_id": self.chatbot_script.id,
             },
@@ -512,7 +509,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Test Visitor",
                 "chatbot_script_id": self.chatbot_script.id,
                 "channel_id": self.livechat_channel.id,
             },

--- a/addons/im_livechat/tests/test_cors_livechat.py
+++ b/addons/im_livechat/tests/test_cors_livechat.py
@@ -24,7 +24,6 @@ class TestCorsLivechat(HttpCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/cors/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": self.livechat_channel.id,
                 "persisted": True,
             },
@@ -39,7 +38,6 @@ class TestCorsLivechat(HttpCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/cors/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": self.livechat_channel.id,
                 "persisted": True,
             },
@@ -53,7 +51,6 @@ class TestCorsLivechat(HttpCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/cors/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": self.livechat_channel.id,
                 "persisted": True,
             },
@@ -71,7 +68,6 @@ class TestCorsLivechat(HttpCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/cors/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": self.livechat_channel.id,
                 "persisted": True,
             },

--- a/addons/im_livechat/tests/test_discuss_channel.py
+++ b/addons/im_livechat/tests/test_discuss_channel.py
@@ -10,11 +10,7 @@ class TestDiscussChannel(TestImLivechatCommon, MailCase):
             self.env, "bob_user", groups="base.group_user,im_livechat.im_livechat_group_manager"
         )
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
         )
         chat = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertFalse(chat.livechat_end_dt)
@@ -25,11 +21,7 @@ class TestDiscussChannel(TestImLivechatCommon, MailCase):
 
     def test_human_operator_failure_states(self):
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
         )
         chat = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertFalse(chat.chatbot_current_step_id)  # assert there is no chatbot
@@ -54,11 +46,7 @@ class TestDiscussChannel(TestImLivechatCommon, MailCase):
         )
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "anonymous_name": "Visitor",
-                "chatbot_script_id": chatbot_script.id,
-                "channel_id": self.livechat_channel.id,
-            },
+            {"chatbot_script_id": chatbot_script.id, "channel_id": self.livechat_channel.id},
         )
         chat = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertTrue(chat.chatbot_current_step_id)  # assert there is a chatbot
@@ -82,10 +70,7 @@ class TestDiscussChannel(TestImLivechatCommon, MailCase):
         """Test that a livechat note is sent to the internal user bus."""
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            {"channel_id": self.livechat_channel.id},
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(
@@ -113,10 +98,7 @@ class TestDiscussChannel(TestImLivechatCommon, MailCase):
         """Test that a livechat status is sent to the internal user bus."""
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            {"channel_id": self.livechat_channel.id},
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         with self.assertBus(

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -35,13 +35,12 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             data = self.make_jsonrpc_request(
                 "/im_livechat/get_session",
                 {
-                    "anonymous_name": "Visitor 22",
                     "previous_operator_id": operator.partner_id.id,
                     "channel_id": self.livechat_channel.id,
                 },
             )["store_data"]
         channel_info = data["discuss.channel"][0]
-        self.assertEqual(channel_info['anonymous_name'], "Visitor 22")
+        self.assertEqual(channel_info['anonymous_name'], "Visitor")
         self.assertEqual(channel_info["country_id"], belgium.id)
         self.assertEqual(data["res.country"], [{"code": "BE", "id": belgium.id, "name": "Belgium"}])
 
@@ -99,12 +98,11 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         # ensure visitor info are correct with real user
         self.authenticate(test_user.login, self.password)
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
-            'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
             'channel_id': self.livechat_channel.id,
         })["store_data"]
         channel_info = data["discuss.channel"][0]
-        self.assertFalse(channel_info['anonymous_name'])
+        self.assertEqual(channel_info['anonymous_name'], "Roger")
         self.assertEqual(channel_info["country_id"], belgium.id)
         self.assertEqual(data["res.country"], [{"code": "BE", "id": belgium.id, "name": "Belgium"}])
         operator_member_domain = [
@@ -210,7 +208,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         operator = self.operators[0]
         self.authenticate(operator.login, self.password)
         data = self.make_jsonrpc_request('/im_livechat/get_session', {
-            'anonymous_name': 'whatever',
             'previous_operator_id': operator.partner_id.id,
             'channel_id': self.livechat_channel.id,
         })["store_data"]
@@ -221,7 +218,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         ]
         operator_member = self.env['discuss.channel.member'].search(operator_member_domain)
         self.assertEqual(channel_info['livechat_operator_id'], operator.partner_id.id)
-        self.assertFalse(channel_info['anonymous_name'])
+        self.assertEqual(channel_info['anonymous_name'], "Michel")
         self.assertEqual(channel_info['country_id'], False)
         self.assertEqual(
             data["res.partner"],
@@ -294,8 +291,7 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         discuss_channels = []
         for _i in range(5):
             data = self.make_jsonrpc_request(
-                "/im_livechat/get_session",
-                {"anonymous_name": "Anonymous", "channel_id": self.livechat_channel.id},
+                "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
             )
             discuss_channels.append(data["store_data"]["discuss.channel"][0])
             # send a message to mark this channel as 'active'
@@ -307,7 +303,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "whatever",
                 "channel_id": self.livechat_channel.id,
                 "previous_operator_id": operator.partner_id.id,
             },
@@ -324,7 +319,9 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertIn(channel.id, channel_ids, "channel should be fetched by operator on new page")
 
     def test_read_channel_unpined_for_operator_after_one_day(self):
-        data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
+        )
         member_of_operator = self.env["discuss.channel.member"].search(
             [
                 ("channel_id", "=", data["channel_id"]),
@@ -339,7 +336,9 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
         self.assertTrue(member_of_operator.channel_id.livechat_end_dt)
 
     def test_unread_channel_not_unpined_for_operator_after_autovacuum(self):
-        data = self.make_jsonrpc_request('/im_livechat/get_session', {'anonymous_name': 'visitor', 'channel_id': self.livechat_channel.id})
+        data = self.make_jsonrpc_request(
+            "/im_livechat/get_session", {"channel_id": self.livechat_channel.id}
+        )
         member_of_operator = self.env["discuss.channel.member"].search(
             [
                 ("channel_id", "=", data["channel_id"]),

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -27,7 +27,7 @@ class TestImLivechatReport(TestImLivechatCommon):
         ):
             channel_id = self.make_jsonrpc_request(
                 "/im_livechat/get_session",
-                {"anonymous_name": "Anonymous", "channel_id": self.livechat_channel.id},
+                {"channel_id": self.livechat_channel.id},
             )["channel_id"]
 
         channel = self.env['discuss.channel'].browse(channel_id)

--- a/addons/im_livechat/tests/test_member_history.py
+++ b/addons/im_livechat/tests/test_member_history.py
@@ -16,11 +16,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             },
         )
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "anonymous_name": "Visitor",
-                "channel_id": livechat_channel.id,
-            },
+            "/im_livechat/get_session", {"channel_id": livechat_channel.id}
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 2)
@@ -50,7 +46,6 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Test Visitor",
                 "chatbot_script_id": self.chatbot_script.id,
                 "channel_id": self.livechat_channel.id,
             },
@@ -88,11 +83,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
             },
         )
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "anonymous_name": "Visitor",
-                "channel_id": livechat_channel.id,
-            },
+            "/im_livechat/get_session", {"channel_id": livechat_channel.id}
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         self.assertEqual(len(channel.channel_member_ids.livechat_member_history_ids), 2)
@@ -138,7 +129,7 @@ class TestLivechatMemberHistory(TestGetOperatorCommon, chatbot_common.ChatbotCas
         )
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {"anonymous_name": "Visitor", "channel_id": livechat_channel.id},
+            {"channel_id": livechat_channel.id},
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         og_history = channel.channel_member_ids.livechat_member_history_ids.filtered(

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -61,7 +61,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": self.livechat_channel.id,
                 "chatbot_script_id": self.chatbot_script.id,
                 "persisted": True,
@@ -128,7 +127,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             self.make_jsonrpc_request(
                 "/im_livechat/get_session",
                 {
-                    "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
                     "channel_id": im_livechat_channel.id,
                 },
@@ -239,7 +237,6 @@ class TestImLivechatMessage(ChatbotCase, MailCommon):
             self.make_jsonrpc_request(
                 "/im_livechat/get_session",
                 {
-                    "anonymous_name": "anon 1",
                     "previous_operator_id": self.users[0].partner_id.id,
                     "channel_id": im_livechat_channel.id,
                 },

--- a/addons/im_livechat/tests/test_session_history.py
+++ b/addons/im_livechat/tests/test_session_history.py
@@ -13,7 +13,6 @@ class TestImLivechatSessionHistory(TestImLivechatCommon):
         self.authenticate(None, None)
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
             "channel_id": self.livechat_channel.id,
-            "anonymous_name": "Visitor",
             "previous_operator_id": operator.partner_id.id
         })
         channel = self.env["discuss.channel"].browse(data["channel_id"])

--- a/addons/im_livechat/tests/test_transcript.py
+++ b/addons/im_livechat/tests/test_transcript.py
@@ -9,10 +9,7 @@ class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo):
     def test_download_transcript(self):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            {"channel_id": self.livechat_channel.id},
         )
         res = self.url_open(f"/im_livechat/download_transcript/{data['channel_id']}")
         self.assertEqual(res.status_code, 200)
@@ -22,10 +19,7 @@ class TestImLivechatTranscript(TestImLivechatCommon, HttpCaseWithUserDemo):
         self.authenticate("demo", "demo")
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "channel_id": self.livechat_channel.id,
-                "anonymous_name": "Visitor",
-            },
+            {"channel_id": self.livechat_channel.id},
         )
         chat = self.env["discuss.channel"].browse(data["channel_id"])
         self.authenticate(None, None)

--- a/addons/im_livechat/tests/test_upload_attachment.py
+++ b/addons/im_livechat/tests/test_upload_attachment.py
@@ -17,7 +17,6 @@ class TestUploadAttachment(HttpCase):
         data = self.make_jsonrpc_request(
             "/im_livechat/get_session",
             {
-                "anonymous_name": "Visitor",
                 "channel_id": livechat_channel.id,
                 "persisted": True,
             },

--- a/addons/im_livechat/tests/test_user_livechat_username.py
+++ b/addons/im_livechat/tests/test_user_livechat_username.py
@@ -15,12 +15,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
             }
         )
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {
-                "anonymous_name": "Visitor",
-                "channel_id": livechat_channel.id,
-                "persisted": True,
-            },
+            "/im_livechat/get_session", {"channel_id": livechat_channel.id, "persisted": True}
         )
         john.partner_id.user_livechat_username = "ELOPERADOR"
         channel = self.env["discuss.channel"].browse(data["channel_id"])
@@ -37,8 +32,7 @@ class TestUserLivechatUsername(TestGetOperatorCommon):
             {"name": "Livechat Channel", "user_ids": [john.id]}
         )
         data = self.make_jsonrpc_request(
-            "/im_livechat/get_session",
-            {"anonymous_name": "Visitor", "channel_id": livechat_channel.id},
+            "/im_livechat/get_session", {"channel_id": livechat_channel.id}
         )
         channel = self.env["discuss.channel"].browse(data["channel_id"])
         message = channel.message_post(body="Hello, How can I help you?")

--- a/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
+++ b/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
@@ -3,12 +3,12 @@
 from dateutil.relativedelta import relativedelta
 
 from odoo import Command, fields
-from odoo.tests.common import tagged
+from odoo.tests.common import HttpCase, tagged
 from odoo.addons.mail.tests.common import MailCommon
 
 
 @tagged("post_install", "-at_install")
-class TestLivechatHrHolidays(MailCommon):
+class TestLivechatHrHolidays(HttpCase, MailCommon):
     """Tests for bridge between im_livechat and hr_holidays modules."""
 
     @classmethod
@@ -47,8 +47,6 @@ class TestLivechatHrHolidays(MailCommon):
                 "user_ids": [Command.link(self.user_employee.id)],
             }
         )
-        self.env["discuss.channel"].create(
-            livechat_channel._get_livechat_discuss_channel_vals(anonymous_name="Visitor")
-        )
+        self.make_jsonrpc_request("/im_livechat/get_session", {"channel_id": livechat_channel.id})
         self.assertEqual(self.user_employee.im_status, "leave_online")
         self.assertFalse(livechat_channel.available_operator_ids)

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -239,7 +239,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             self.make_jsonrpc_request(
                 "/im_livechat/get_session",
                 {
-                    "anonymous_name": "anon 1",
                     "channel_id": self.im_livechat_channel.id,
                     "previous_operator_id": self.users[0].partner_id.id,
                 },
@@ -255,7 +254,6 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 self.make_jsonrpc_request(
                     "/im_livechat/get_session",
                     {
-                        "anonymous_name": "anon 2",
                         "channel_id": self.im_livechat_channel.id,
                         "previous_operator_id": self.users[0].partner_id.id,
                     },
@@ -923,7 +921,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_1:
             return {
-                "anonymous_name": False,
+                "anonymous_name": "test1",
                 "avatar_cache_key": channel.avatar_cache_key,
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.in").id,
@@ -957,7 +955,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
             }
         if channel == self.channel_livechat_2:
             return {
-                "anonymous_name": "anon 2",
+                "anonymous_name": "Visitor",
                 "avatar_cache_key": channel.avatar_cache_key,
                 "channel_type": "livechat",
                 "country_id": self.env.ref("base.be").id,
@@ -983,7 +981,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "member_count": 2,
                 "message_needaction_counter_bus_id": bus_last_id,
                 "message_needaction_counter": 0,
-                "name": "anon 2 Ernest Employee",
+                "name": "Visitor Ernest Employee",
                 "parent_channel_id": False,
                 "requested_by_operator": False,
                 "rtc_session_ids": [["ADD", []]],
@@ -1539,7 +1537,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "body": ["markup", "<p>test</p>"],
                 "create_date": create_date,
                 "date": date,
-                "default_subject": "anon 2 Ernest Employee",
+                "default_subject": "Visitor Ernest Employee",
                 "email_from": False,
                 "id": last_message.id,
                 "incoming_email_cc": False,
@@ -1555,7 +1553,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
                 "pinned_at": False,
                 "rating_id": False,
                 "reactions": [],
-                "record_name": "anon 2 Ernest Employee",
+                "record_name": "Visitor Ernest Employee",
                 "res_id": channel.id,
                 "scheduledDatetime": False,
                 "starred": False,
@@ -1827,7 +1825,7 @@ class TestDiscussFullPerformance(HttpCase, MailCommon):
         if channel == self.channel_livechat_1:
             return {**common_data, "display_name": "test1 Ernest Employee"}
         if channel == self.channel_livechat_2:
-            return {**common_data, "display_name": "anon 2 Ernest Employee"}
+            return {**common_data, "display_name": "Visitor Ernest Employee"}
         return {}
 
     def _res_for_user(self, user):

--- a/addons/website_livechat/controllers/main.py
+++ b/addons/website_livechat/controllers/main.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http, _
+from odoo import _
 from odoo.http import request
 from odoo.addons.im_livechat.controllers.main import LivechatController
 
@@ -11,11 +10,3 @@ class WebsiteLivechat(LivechatController):
     def _get_guest_name(self):
         visitor_sudo = request.env["website.visitor"]._get_visitor_from_request()
         return _('Visitor #%d', visitor_sudo.id) if visitor_sudo else super()._get_guest_name()
-
-    @http.route()
-    def get_session(self, channel_id, anonymous_name, previous_operator_id=None, chatbot_script_id=None, persisted=True):
-        """ Override to use visitor name instead of 'Visitor' whenever a visitor start a livechat session. """
-        visitor_sudo = request.env['website.visitor']._get_visitor_from_request()
-        if visitor_sudo:
-            anonymous_name = _('Visitor #%s', visitor_sudo.id)
-        return super().get_session(channel_id, anonymous_name, previous_operator_id=previous_operator_id, chatbot_script_id=chatbot_script_id, persisted=persisted)

--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -6,10 +6,8 @@ from odoo import api, models
 class Im_LivechatChannel(models.Model):
     _inherit = 'im_livechat.channel'
 
-    def _get_livechat_discuss_channel_vals(self, anonymous_name, previous_operator_id=None, chatbot_script=None, user_id=None, country_id=None, lang=None):
-        discuss_channel_vals = super()._get_livechat_discuss_channel_vals(
-            anonymous_name, previous_operator_id, chatbot_script, user_id=user_id, country_id=country_id, lang=lang
-        )
+    def _get_livechat_discuss_channel_vals(self, chatbot_script=None, agent=None):
+        discuss_channel_vals = super()._get_livechat_discuss_channel_vals(chatbot_script, agent)
         if not discuss_channel_vals:
             return False
         visitor_sudo = self.env['website.visitor']._get_visitor_from_request()

--- a/addons/website_livechat/tests/common.py
+++ b/addons/website_livechat/tests/common.py
@@ -55,10 +55,7 @@ class TestLivechatCommon(MailCommon, TransactionCaseWithUserDemo):
         self.livechat_base_url = self.livechat_channel.get_base_url()
 
         self.open_chat_url = f"{self.livechat_base_url}/im_livechat/get_session"
-        self.open_chat_params = {'params': {
-            'channel_id': self.livechat_channel.id,
-            'anonymous_name': "Wrong Name"
-        }}
+        self.open_chat_params = {"params": {"channel_id": self.livechat_channel.id}}
 
         self.send_feedback_url = f"{self.livechat_base_url}/im_livechat/feedback"
         self.leave_session_url = f"{self.livechat_base_url}/im_livechat/visitor_leave_session"

--- a/addons/website_livechat/tests/test_fw_operator.py
+++ b/addons/website_livechat/tests/test_fw_operator.py
@@ -65,7 +65,6 @@ class TestFwOperator(ChatbotCase, HttpCase, TestLivechatCommon):
 
     def test_chatbot_trigger_blocked_after_forward_to_operator(self):
         data = self.make_jsonrpc_request("/im_livechat/get_session", {
-            "anonymous_name": "Visitor #1",
             "channel_id": self.livechat_channel.id,
             "chatbot_script_id": self.chatbot_fw_script.id
         })

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -384,10 +384,7 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         self.target_visitor = None
         channel_info = self.make_jsonrpc_request(
             "/im_livechat/get_session",
-            {
-                "anonymous_name": "whatever",
-                "channel_id": self.livechat_channel.id,
-            },
+            {"channel_id": self.livechat_channel.id},
         )["store_data"]["discuss.channel"][0]
         self.assertEqual(channel_info["livechat_visitor_id"], False)
 


### PR DESCRIPTION
*: crm_livechat, mail, test_discuss_full, website_livechat

This commit removes the anonymous_name param from the get_session route and uses
 the user or guest name in the relevant flows instead. It also cleans up the
 process of getting livechat channel values when getting the session.

part of task-4675719

Related to odoo/enterprise#86640
