### PR TITLE
[FIX] test_website_modules: test_01_configurator_flow tour

### DIFF
--- a/addons/test_website_modules/static/tests/tours/configurator_flow.js
+++ b/addons/test_website_modules/static/tests/tours/configurator_flow.js
@@ -91,19 +91,21 @@ registry.category("web_tour.tours").add("configurator_flow", {
         // Online catalog screen
         {
             content: "Choose a shop page style",
-            trigger: ".theme_preview",
+            trigger: ".o_configurator_screen:contains(online catalog) .theme_preview",
             run: "click",
         },
         // Product page Screen
         {
             content: "Choose a product page style",
-            trigger: ".theme_preview",
+            trigger: ".o_configurator_screen:contains(product page) .theme_preview",
             run: "click",
+        },
+        {
+            trigger: ".o_website_loader_container",
         },
         {
             content: "Wait until the configurator is finished",
             trigger: ".o_website_preview[data-view-xmlid='website.homepage']",
-            timeout: 30000,
         },
         {
             content: "check menu and footer links are correct",


### PR DESCRIPTION
In this commit we fix the tour test_01_configurator_flow by precising selector of two steps that has the same selector.

runbot-error-id~190622

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
