### PR TITLE
[FIX] product_expiry: prioritize default user for lot expiry alerts

### DIFF
--- a/addons/product_expiry/tests/test_stock_lot.py
+++ b/addons/product_expiry/tests/test_stock_lot.py
@@ -685,3 +685,78 @@ class TestStockLot(TestStockCommon):
         delivery.action_confirm()
 
         self.assertAlmostEqual(delivery.move_line_ids[0].expiration_date, expiration_date, delta=delta)
+
+    def test_assign_lot_expiry_alert_to_default_user(self):
+        """ Test lot expiry alert is assigned to the default user of the activity type """
+
+        # User A will be the Default User on the activity type
+        default_user, responsible_user = self.env['res.users'].create([
+            {
+                'name': 'User A (Default)',
+                'login': 'user_a_test',
+            },
+            {
+                'name': 'User B (Responsible)',
+                'login': 'user_b_test',
+            }
+        ])
+
+        activity_type = self.env.ref('product_expiry.mail_activity_type_alert_date_reached')
+        activity_type.default_user_id = default_user.id
+
+        product = self.ProductObj.create({
+            'name': 'Product AAA',
+            'type': 'product',
+            'tracking': 'lot',
+            'company_id': self.env.company.id,
+            'responsible_id': responsible_user.id,
+        })
+
+        # create a new lot with with alert date in the past
+        lot = self.LotObj.create({
+            'name': 'Lot 1 ProductAAA',
+            'product_id': product.id,
+            'alert_date': fields.Date.to_string(datetime.today() - relativedelta(days=15)),
+            'company_id': self.env.company.id,
+        })
+
+        picking_in = self.PickingObj.create({
+            'picking_type_id': self.picking_type_in,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+            'state': 'draft',
+        })
+
+        qty = 33
+
+        move = self.MoveObj.create({
+            'name': product.name,
+            'product_id': product.id,
+            'product_uom_qty': qty,
+            'product_uom': product.uom_id.id,
+            'picking_id': picking_in.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+        })
+
+        picking_in.action_confirm()
+        # Replace pack operation of incoming shipments.
+        picking_in.action_assign()
+        move.move_line_ids.quantity = qty
+        move.move_line_ids.lot_id = lot.id
+
+        # Transfer Incoming Shipment.
+        move.picked = True
+        picking_in._action_done()
+
+        # run scheduled tasks
+        self.env['stock.lot']._alert_date_exceeded()
+
+        # check a new activity has been created for correct user
+        mail_activity = self.env['mail.activity'].search([
+            ('activity_type_id', '=', activity_type.id),
+            ('res_model_id', '=', self.env.ref('stock.model_stock_lot').id),
+            ('res_id', '=', lot.id)
+        ])
+        self.assertEqual(len(mail_activity), 1, 'No activity created or more than one activity created when there should be one')
+        self.assertEqual(mail_activity.user_id, default_user, "Activity was not assigned to the Default User.")


### PR DESCRIPTION
The "Alert Date Reached" activity was not correctly assigning the activity to the "Default User" specified in the `mail.activity.type` settings. This did not align with user expectations that the activity type's default user should be primarily considered.

To reproduce the issue:
1. Configure a "Default User" (e.g., User A) for the Alert Date Reached activity type.
2. Create a product tracked by lots. Ensure its "Responsible User" (on the product's Inventory tab) is either not set or is a different user (e.g., User B).
3. Receive the product with a lot number and set its alert date to be in the past.
4. Trigger the scheduler for checking lot expirations (via Operations > Run Scheduler).
5. The generated "Alert Date Reached" activity would be assigned to User B (if set) or the superuser, incorrectly ignoring User A.

This commit rectifies this behavior by modifying the user assignment logic for these lot expiry alerts. The new priority for determining the assignee is:
1. The "Default User" configured on the "Alert Date Reached" activity type.
2. If no default user is set on the activity type, then the "Responsible User" defined on the related product.
3. If neither is set, the activity is assigned to SUPERUSER.

[opw-4640027](https://www.odoo.com/odoo/project.task/4640027)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr