### PR TITLE
[FIX] html_editor: do not pad lists without markers

### DIFF
--- a/addons/html_editor/static/src/main/list/list.scss
+++ b/addons/html_editor/static/src/main/list/list.scss
@@ -2,12 +2,6 @@ li p {
     margin-bottom: 0px;
 }
 
-.odoo-editor-editable {
-    ol, ul {
-        padding-inline-start: 2rem;
-    }
-}
-
 // Checklist
 ul.o_checklist {
     > li {


### PR DESCRIPTION
**Problem**
Before this commit, all the 'ol' and 'ul' elements inside .odoo-editor-editable are padded on their left to accomodate for the presence of list markers, even when the marker is not present [1]. Thus, lists with 'list-style: none' have an unnecessary extra padding visible only during editing. See for example:
- nav menu when in mobile mode,
- hamburger menu,
- s_pricelist snippets,
- s_product_catalog snippet.

**Solution**
After a chat with @dmo-odoo and @walidsahli, we decided to entirely remove the CSS rule, because the bug described in [1] does not seem to be reproducible anymore, and there is already a default `padding-left` applied to lists with markers.

**Note**
A possible alternative solution would be to apply `padding-inline-start` only to `ol` and `ul` elements containing markers (`:has(li::marker)`), thus not affecting lists having `list-style: none`.

[1] odoo@8d0cd62
