### PR TITLE
[FIX] website: single line format/resolution in image format option

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_select.xml
+++ b/addons/html_builder/static/src/core/building_blocks/builder_select.xml
@@ -8,8 +8,8 @@
         <div t-ref="root" class="w-100" style="overflow: hidden;">
             <div t-att-class="'d-none ' + props.className" t-ref="content"><WithIgnoreItem><t t-slot="default" /></WithIgnoreItem></div>
             <Dropdown state="this.dropdown">
-                <button class="btn btn-primary text-start o-dropdown-caret" t-ref="button" t-att-id="props.id"
-                    style="width: 100%; overflow: hidden; text-overflow: ellipsis;">
+                <button class="btn btn-primary text-start o-dropdown-caret w-100 overflow-hidden" t-ref="button" t-att-id="props.id"
+                    style="min-width: 0; text-overflow: ellipsis;">
                     <t t-slot="fixedButton"/>
                 </button>
                 <t t-set-slot="content">

--- a/addons/website/static/src/builder/plugins/image/image_format_option.xml
+++ b/addons/website/static/src/builder/plugins/image/image_format_option.xml
@@ -6,8 +6,10 @@
         <BuilderSelect>
             <t t-foreach="state.formats" t-as="format" t-key="format.id">
                 <BuilderSelectItem className="'o_we_badge_at_end'" action="'setImageFormat'" actionParam="format">
-                    <t t-esc="format.label"/>
-                    <span class="badge rounded-pill text-bg-dark" t-out="format.mimetype.split('/')[1]"/>
+                    <div class="w-100 d-flex justify-content-between overflow-hidden">
+                        <t t-out="format.label"/>
+                        <span class="badge text-bg-dark ms-2 top-0" t-out="format.mimetype.split('/')[1]"/>
+                    </div>
                 </BuilderSelectItem>
             </t>
         </BuilderSelect>


### PR DESCRIPTION
Steps to reproduce:
	1. Go to the website builder
	2. Click on an image
	3. Click on the format dropdown option

Before fix: Each select item has two lines: one with the resolution and one with the format
After fix: The format and resolution of a given select item share the same line
