### PR TITLE
[FIX] mrp: ensure correct computation of byproducts

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1256,6 +1256,9 @@ class MrpProduction(models.Model):
             origin = '%s,%s' % (origin, self.name)
         return origin
 
+    def _mark_byproducts_as_produced(self):
+        self.move_byproduct_ids.picked = True
+
     def _set_qty_producing(self, pick_manual_consumption_moves=True):
         if self.product_id.tracking == 'serial':
             qty_producing_uom = self.product_uom_id._compute_quantity(self.qty_producing, self.product_id.uom_id, rounding_method='HALF-UP')
@@ -1266,7 +1269,12 @@ class MrpProduction(models.Model):
         # waiting for a preproduction move before assignement
         is_waiting = self.warehouse_id.manufacture_steps != 'mrp_one_step' and self.picking_ids.filtered(lambda p: p.picking_type_id == self.warehouse_id.pbm_type_id and p.state not in ('done', 'cancel'))
 
-        for move in (self.move_raw_ids.filtered(lambda m: not is_waiting or m.product_id.tracking == 'none') | self.move_finished_ids.filtered(lambda m: m.product_id != self.product_id)):
+        for move in (self.move_raw_ids.filtered(lambda m: not is_waiting or m.product_id.tracking == 'none') | self.move_byproduct_ids):
+            is_byproduct = move in self.move_byproduct_ids
+            # Never update already produced by-product moves.
+            if move.picked and is_byproduct:
+                continue
+
             # picked + manual means the user set the quantity manually
             if move.manual_consumption and move.picked:
                 continue
@@ -1277,7 +1285,7 @@ class MrpProduction(models.Model):
 
             new_qty = float_round((self.qty_producing - self.qty_produced) * move.unit_factor, precision_rounding=move.product_uom.rounding)
             move._set_quantity_done(new_qty)
-            if (not move.manual_consumption or pick_manual_consumption_moves) and move.quantity:
+            if (not move.manual_consumption or pick_manual_consumption_moves) and move.quantity and not is_byproduct:
                 move.picked = True
 
     def _should_postpone_date_finished(self, date_finished):
@@ -2165,7 +2173,7 @@ class MrpProduction(models.Model):
 
     def pre_button_mark_done(self):
         self._button_mark_done_sanity_checks()
-        productions_auto = set()
+        production_auto_ids = set()
         for production in self:
             if not float_is_zero(production.qty_producing, precision_rounding=production.product_uom_id.rounding):
                 production.move_raw_ids.filtered(
@@ -2173,12 +2181,15 @@ class MrpProduction(models.Model):
                 ).picked = True
                 continue
             if production._auto_production_checks():
-                productions_auto.add(production.id)
+                production_auto_ids.add(production.id)
             else:
                 return production.action_mass_produce()
 
-        for production in self.env['mrp.production'].browse(productions_auto):
+        productions_auto = self.env['mrp.production'].browse(production_auto_ids)
+        for production in productions_auto:
             production._set_quantities()
+        # Produce by-products also for not auto productions.
+        (self - productions_auto)._mark_byproducts_as_produced()
 
         consumption_issues = self._get_consumption_issues()
         if consumption_issues:
@@ -2756,6 +2767,7 @@ class MrpProduction(models.Model):
         else:
             self.qty_producing = self.product_qty - self.qty_produced
         self._set_qty_producing()
+        self._mark_byproducts_as_produced()
 
         for move in self.move_raw_ids:
             if move.state in ('done', 'cancel') or not move.product_uom_qty:

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -185,7 +185,6 @@ class TestMrpOrder(TestMrpCommon):
         mo.action_confirm()
         self.assertEqual(mo.workorder_ids.mapped('sequence'), [0, 1, 2, 100])
 
-
     @freeze_time('2022-06-28 08:00')
     def test_end_date(self):
         """ End date must be the day the MO is done (regardless of lead times)"""
@@ -1104,18 +1103,18 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(len(move_byproduct_1), 1)
         self.assertEqual(move_byproduct_1.product_uom_qty, 2.0)
         self.assertEqual(move_byproduct_1.quantity, 1)
-        self.assertTrue(move_byproduct_1.picked)
+        self.assertFalse(move_byproduct_1.picked)
 
         move_byproduct_2 = mo.move_finished_ids.filtered(lambda l: l.product_id == self.byproduct2)
         self.assertEqual(len(move_byproduct_2), 1)
         self.assertEqual(move_byproduct_2.product_uom_qty, 4.0)
         self.assertEqual(move_byproduct_2.quantity, 2)
-        self.assertTrue(move_byproduct_2.picked)
+        self.assertFalse(move_byproduct_2.picked)
 
         move_byproduct_3 = mo.move_finished_ids.filtered(lambda l: l.product_id == self.byproduct3)
         self.assertEqual(move_byproduct_3.product_uom_qty, 4.0)
         self.assertEqual(move_byproduct_3.quantity, 2.0)
-        self.assertTrue(move_byproduct_3.picked)
+        self.assertFalse(move_byproduct_3.picked)
         self.assertEqual(move_byproduct_3.product_uom, dozen)
 
         details_operation_form = Form(move_byproduct_1, view=self.env.ref('stock.view_stock_move_operations'))
@@ -1139,18 +1138,18 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(len(move_byproduct_1), 1)
         self.assertEqual(move_byproduct_1.product_uom_qty, 1.0)
         self.assertEqual(move_byproduct_1.quantity, 1)
-        self.assertTrue(move_byproduct_1.picked)
+        self.assertFalse(move_byproduct_1.picked)
 
         move_byproduct_2 = mo2.move_finished_ids.filtered(lambda l: l.product_id == self.byproduct2)
         self.assertEqual(len(move_byproduct_2), 1)
         self.assertEqual(move_byproduct_2.product_uom_qty, 2.0)
         self.assertEqual(move_byproduct_2.quantity, 2)
-        self.assertTrue(move_byproduct_2.picked)
+        self.assertFalse(move_byproduct_2.picked)
 
         move_byproduct_3 = mo2.move_finished_ids.filtered(lambda l: l.product_id == self.byproduct3)
         self.assertEqual(move_byproduct_3.product_uom_qty, 2.0)
         self.assertEqual(move_byproduct_3.quantity, 2.0)
-        self.assertTrue(move_byproduct_3.picked)
+        self.assertFalse(move_byproduct_3.picked)
         self.assertEqual(move_byproduct_3.product_uom, dozen)
 
         details_operation_form = Form(move_byproduct_1, view=self.env.ref('stock.view_stock_move_operations'))
@@ -1223,6 +1222,63 @@ class TestMrpOrder(TestMrpCommon):
                 break
         mo = mo_form.save()
         mo.button_mark_done()
+
+    def test_byproduct_update_produced(self):
+        """ Ensures that when the MO quantity to produce is updated, the
+        by-products quantity are updated aswell when they are not produced yet,
+        and the by-products quantity is NOT updated when already produced.
+        """
+        self.env.user.group_ids += self.env.ref('mrp.group_mrp_byproducts')
+        byproduct1, byproduct2 = self.env['product.product'].create([{
+            'name': f'byproduct{i}',
+            'is_storable': True,
+            'tracking': 'none',
+        } for i in [1, 2]])
+
+        self.bom_1.product_qty = 1
+        self.bom_1.byproduct_ids = [
+            Command.create({
+                'product_id': byproduct1.id,
+                'product_qty': 1.0,
+            }),
+            Command.create({
+                'product_id': byproduct2.id,
+                'product_qty': 1.0,
+            }),
+        ]
+
+        # Create a MO for 2 product_4
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_4
+        mo_form.bom_id = self.bom_1
+        mo_form.product_qty = 2
+        mo = mo_form.save()
+        mo.action_confirm()
+        self.assertRecordValues(mo.move_byproduct_ids, [
+            {'product_id': byproduct1.id, 'quantity': 2, 'picked': False},
+            {'product_id': byproduct2.id, 'quantity': 2, 'picked': False},
+        ])
+
+        # Update quantity to produce to 1 => Both by-product qty should be updated to 1 too.
+        mo_form = Form(mo)
+        mo_form.qty_producing = 1
+        mo = mo_form.save()
+        self.assertRecordValues(mo.move_byproduct_ids, [
+            {'product_id': byproduct1.id, 'quantity': 1, 'picked': False},
+            {'product_id': byproduct2.id, 'quantity': 1, 'picked': False},
+        ])
+
+        # Mark first by-product as produced and update MO qty to 2 => only
+        # second by-product qty should be updated to 2.
+        move_byproduct_1 = mo.move_finished_ids.filtered(lambda l: l.product_id == byproduct1)
+        move_byproduct_1.picked = True
+        mo_form = Form(mo)
+        mo_form.qty_producing = 2
+        mo = mo_form.save()
+        self.assertRecordValues(mo.move_byproduct_ids, [
+            {'product_id': byproduct1.id, 'quantity': 1, 'picked': True},
+            {'product_id': byproduct2.id, 'quantity': 2, 'picked': False},
+        ])
 
     def test_product_produce_duplicate_1(self):
         """ produce a finished product tracked by serial number 2 times with the
@@ -1994,7 +2050,6 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(mo.reservation_state, 'assigned')
         self.assertEqual(mo.components_availability, 'Available')
         check_availability_state('available')
-
 
     def test_immediate_validate_6(self):
         """In a production for a tracked product, clicking on mark as done without filling any quantities should


### PR DESCRIPTION
Currently, when we change the quantity for a MO, all byproduct quantities are updated regardless of whether the Produced checkbox is checked or not. With this commit, the byproduct quantities will be updated only when the Produced checkbox is not checked. Additionally, the checkbox will no longer be automatically picked when the quantity value is modified.

How to reproduce
================
1. Create a BoM with at least one by-product;
2. Create and confirm a MO using this BoM;
3. Update the by-product quantity and mark the move as produced;
4. Update the MO quantity to produce -> You can see the by-product quantity was updated, even if the move is already mark as produced.

task: 4314900

Enterprise PR: odoo/enterprise#86650