### PR TITLE
[FIX] web: condition tree: virtual operators for complex paths

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector_operator_editor.js
@@ -45,7 +45,7 @@ export function getDomainDisplayedOperators(fieldDef, params = {}) {
                 ">",
                 "<",
                 "between",
-                "is_not_between",
+                "not_between",
                 ...("allowExpressions" in params && !params.allowExpressions
                     ? []
                     : ["next", "not_next", "last", "not_last"]),
@@ -61,7 +61,7 @@ export function getDomainDisplayedOperators(fieldDef, params = {}) {
                 ">",
                 "<",
                 "between",
-                "is_not_between",
+                "not_between",
                 "ilike",
                 "not ilike",
                 "set",
@@ -89,7 +89,7 @@ export function getDomainDisplayedOperators(fieldDef, params = {}) {
         case "date_option":
         case "datetime_option":
         case "time_option":
-            return ["=", "!=", ">", "<", "between", "is_not_between", "set", "not_set"];
+            return ["=", "!=", ">", "<", "between", "not_between", "set", "not_set"];
         case undefined:
             return ["="];
         default:

--- a/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor_operator_editor.js
@@ -8,7 +8,7 @@ const EXPRESSION_VALID_OPERATORS = [
     "today",
     "not_today",
     "between",
-    "is_not_between",
+    "not_between",
     "last",
     "not_last",
     "next",

--- a/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_operator_editor.js
@@ -39,7 +39,7 @@ const OPERATOR_DESCRIPTIONS = {
     next: _t("next"),
 
     // virtual operators (equivalent to a couple (<,>))
-    is_not_between: _t("not between"),
+    not_between: _t("not between"),
     not_last: _t("not last"),
     not_next: _t("not next"),
 

--- a/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
+++ b/addons/web/static/src/core/tree_editor/tree_editor_value_editors.js
@@ -164,7 +164,7 @@ function getPartialValueEditorInfo(fieldDef, operator, params = {}) {
         case "ilike":
         case "not ilike":
             return STRING_EDITOR;
-        case "is_not_between":
+        case "not_between":
         case "between": {
             const editorInfo = getValueEditorInfo(fieldDef, "=");
             const { defaultValue } = getValueEditorInfo(fieldDef, "=", {

--- a/addons/web/static/src/core/tree_editor/utils.js
+++ b/addons/web/static/src/core/tree_editor/utils.js
@@ -216,7 +216,7 @@ function _getConditionDescription(node, getFieldDef, getPathDescription, display
     let join;
     let addParenthesis = Array.isArray(value);
     switch (operator) {
-        case "is_not_between":
+        case "not_between":
         case "between":
             join = _t("and");
             addParenthesis = false;

--- a/addons/web/static/tests/core/tree_editor/between_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/between_operator.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
+
+import {
+    applyTransformations,
+    condition,
+    connector,
+    expression,
+    FULL_VIRTUAL_OPERATORS_ELIMINATION,
+    FULL_VIRTUAL_OPERATORS_INTRODUCTION,
+} from "@web/core/tree_editor/condition_tree";
+
+describe.current.tags("headless");
+
+const options = {
+    getFieldDef: (name) => {
+        if (name === "m2o") {
+            return { type: "many2one" };
+        }
+        if (name === "m2o.datetime_2" || name === "datetime_1") {
+            return { type: "datetime" };
+        }
+        if (name === "m2o.int_2" || name === "int_1") {
+            return { type: "integer" };
+        }
+        return null;
+    },
+};
+
+test("between operator: introduction/elimination", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            tree_py: connector("&", [condition("int_1", ">=", 1), condition("int_1", "<=", 2)]),
+            tree: condition("int_1", "between", [1, 2]),
+        },
+        {
+            tree_py: connector(
+                "&",
+                [condition("int_1", ">=", 1), condition("int_1", "<=", 2)],
+                true
+            ),
+            tree: condition("int_1", "between", [1, 2], true),
+        },
+        {
+            tree_py: connector("&", [
+                condition("m2o.int_2", ">=", 1),
+                condition("m2o.int_2", "<=", 2),
+            ]),
+            tree: connector("&", [
+                condition("m2o.int_2", ">=", 1),
+                condition("m2o.int_2", "<=", 2),
+            ]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("&", [condition("int_2", ">=", 1), condition("int_2", "<=", 2)])
+            ),
+            tree: condition("m2o.int_2", "between", [1, 2]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("&", [condition("int_2", ">=", 1), condition("int_2", "<=", 2)]),
+                true
+            ),
+            tree: condition("m2o", "any", condition("int_2", "between", [1, 2]), true),
+        },
+        {
+            tree_py: connector("&", [
+                condition("datetime_1", ">=", 1),
+                condition("datetime_1", "<=", 2),
+            ]),
+            tree: condition("datetime_1", "between", [1, 2]),
+        },
+        {
+            tree_py: connector(
+                "&",
+                [condition("datetime_1", ">=", 1), condition("datetime_1", "<=", 2)],
+                true
+            ),
+            tree: condition("datetime_1", "between", [1, 2], true),
+        },
+        {
+            tree_py: connector("&", [
+                condition("m2o.datetime_2", ">=", 1),
+                condition("m2o.datetime_2", "<=", 2),
+            ]),
+            tree: connector("&", [
+                condition("m2o.datetime_2", ">=", 1),
+                condition("m2o.datetime_2", "<=", 2),
+            ]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("&", [condition("datetime_2", ">=", 1), condition("datetime_2", "<=", 2)])
+            ),
+            tree: condition("m2o.datetime_2", "between", [1, 2]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("&", [
+                    condition("datetime_2", ">=", 1),
+                    condition("datetime_2", "<=", 2),
+                ]),
+                true
+            ),
+            tree: condition("m2o", "any", condition("datetime_2", "between", [1, 2]), true),
+        },
+        {
+            tree_py: connector("&", [
+                condition(expression("path"), ">=", 1),
+                condition(expression("path"), "<=", 2),
+            ]),
+            tree: connector("&", [
+                condition(expression("path"), ">=", 1),
+                condition(expression("path"), "<=", 2),
+            ]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("&", [
+                    condition(expression("path"), ">=", 1),
+                    condition(expression("path"), "<=", 2),
+                ])
+            ),
+            tree: condition(
+                "m2o",
+                "any",
+                connector("&", [
+                    condition(expression("path"), ">=", 1),
+                    condition(expression("path"), "<=", 2),
+                ])
+            ),
+        },
+    ];
+    for (const { tree_py, tree } of toTest) {
+        expect(applyTransformations(FULL_VIRTUAL_OPERATORS_INTRODUCTION, tree_py, options)).toEqual(
+            tree
+        );
+        expect(applyTransformations(FULL_VIRTUAL_OPERATORS_ELIMINATION, tree)).toEqual(tree_py);
+    }
+});

--- a/addons/web/static/tests/core/tree_editor/condition_tree.test.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree.test.js
@@ -54,22 +54,6 @@ test("domainFromTree", async () => {
             result: `[("foo", "=ilike", "%hello")]`,
         },
         {
-            tree: condition("foo", "between", [1, 3]),
-            result: `["&", ("foo", ">=", 1), ("foo", "<=", 3)]`,
-        },
-        {
-            tree: condition("foo", "between", [1, expression("uid")], true),
-            result: `["!", "&", ("foo", ">=", 1), ("foo", "<=", uid)]`,
-        },
-        {
-            tree: condition("foo", "is_not_between", [1, expression("uid")]),
-            result: `["|", ("foo", "<", 1), ("foo", ">", uid)]`,
-        },
-        {
-            tree: condition("foo", "is_not_between", [1, 3], true),
-            result: `["!", "|", ("foo", "<", 1), ("foo", ">", 3)]`,
-        },
-        {
             tree: condition("foo", "next", [1, "weeks", "date"]),
             result: `["&", ("foo", ">=", context_today().strftime("%Y-%m-%d")), ("foo", "<=", (context_today() + relativedelta(weeks = 1)).strftime("%Y-%m-%d"))]`,
         },
@@ -104,35 +88,6 @@ test("domainFromTree", async () => {
         {
             tree: condition("foo", "not_next", [1, "weeks", "date"], true),
             result: `["!", "|", ("foo", "<", context_today().strftime("%Y-%m-%d")), ("foo", ">", (context_today() + relativedelta(weeks = 1)).strftime("%Y-%m-%d"))]`,
-        },
-        {
-            tree: condition("date.__time", "=", false),
-            result: `["&", "&", ("date.hour_number", "=", False), ("date.minute_number", "=", False), ("date.second_number", "=", False)]`,
-        },
-        {
-            tree: condition("date.__time", "!=", false),
-            result: `["|", "|", ("date.hour_number", "!=", False), ("date.minute_number", "!=", False), ("date.second_number", "!=", False)]`,
-        },
-        {
-            tree: condition("date.__time", "=", "01:15:24"),
-            result: `["&", "&", ("date.hour_number", "=", 1), ("date.minute_number", "=", 15), ("date.second_number", "=", 24)]`,
-        },
-        {
-            tree: condition("date.__time", "!=", "01:15:24"),
-            result: `["|", "|", ("date.hour_number", "!=", 1), ("date.minute_number", "!=", 15), ("date.second_number", "!=", 24)]`,
-        },
-        {
-            tree: condition("date.__time", "between", ["01:15:24", "22:06:56"]),
-            result: `[
-                "&",
-                    "|", "|",
-                            ("date.hour_number", ">=", 1),
-                            "&", ("date.hour_number", "=", 1), ("date.minute_number", ">=", 15),
-                            "&", "&", ("date.hour_number", "=", 1), ("date.minute_number", "=", 15), ("date.second_number", ">=", 24),
-                    "|", "|",
-                            ("date.hour_number", "<=", 22),
-                            "&", ("date.hour_number", "=", 22), ("date.minute_number", "<=", 6),
-                            "&", "&", ("date.hour_number", "=", 22), ("date.minute_number", "=", 6), ("date.second_number", "<=", 56)]`,
         },
     ];
     for (const { tree, result } of toTest) {
@@ -180,21 +135,6 @@ test("domainFromTree . treeFromDomain", async () => {
         },
         {
             domain: `["!", "|", ("foo", "<", 1), ("foo", ">", uid)]`,
-        },
-        {
-            domain: `["&", "&", ("date.hour_number", "=", False), ("date.minute_number", "=", False), ("date.second_number", "=", False)]`,
-        },
-        {
-            domain: `["&", "&", ("date.hour_number", "!=", False), ("date.minute_number", "!=", False), ("date.second_number", "!=", False)]`,
-        },
-        {
-            domain: `["&", "&", ("date.hour_number", "=", 1), ("date.minute_number", "=", 15), ("date.second_number", "=", 24)]`,
-        },
-        {
-            domain: `["|", "|", ("date.hour_number", "!=", 1), ("date.minute_number", "!=", 15), ("date.second_number", "!=", 24)]`,
-        },
-        {
-            domain: `["&", "&", "&", "&", "&", ("date.hour_number", ">=", 1), ("date.minute_number", ">=", 15), ("date.second_number", ">=", 24), ("date.hour_number", "<=", 22), ("date.minute_number", "<=", 6), ("date.second_number", "<=", 56)]`,
         },
     ];
     for (const { domain, result } of toTest) {
@@ -576,7 +516,7 @@ test("treeFromExpression", () => {
         },
         {
             expression: `foo < 1 or foo > 3`,
-            result: condition("foo", "is_not_between", [1, 3]),
+            result: condition("foo", "not_between", [1, 3]),
         },
         {
             expression: `date_field >= context_today().strftime("%Y-%m-%d") and date_field <= (context_today() + relativedelta(years = 1)).strftime("%Y-%m-%d")`,
@@ -1068,7 +1008,7 @@ test("evaluation . expressionFromTree = contains . domainFromTree", () => {
         condition("y", "=", false),
         condition("foo", "between", [1, 3]),
         condition("foo", "between", [1, expression("uid")], true),
-        condition("foo", "is_not_between", [1, 3]),
+        condition("foo", "not_between", [1, 3]),
         condition("datefield", "next", [1, "weeks", "date"]),
         condition("datetimefield", "last", [1, "years", "datetime"]),
         condition("datetimefield", "not_last", [1, "years", "datetime"]),

--- a/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
+++ b/addons/web/static/tests/core/tree_editor/condition_tree_editor_test_helpers.js
@@ -1,6 +1,12 @@
 import { queryAll, queryAllTexts, queryOne, queryText, queryValue } from "@odoo/hoot-dom";
 import { contains, fields, models } from "@web/../tests/web_test_helpers";
 
+import { Domain } from "@web/core/domain";
+
+export function formatDomain(str) {
+    return new Domain(str).toString();
+}
+
 /**
  * @typedef {import("@odoo/hoot-dom").FillOptions} FillOptions
  * @typedef {import("@odoo/hoot-dom").Target} Target

--- a/addons/web/static/tests/core/tree_editor/datetime_options.test.js
+++ b/addons/web/static/tests/core/tree_editor/datetime_options.test.js
@@ -1,0 +1,490 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
+import { formatDomain } from "@web/../tests/core/tree_editor/condition_tree_editor_test_helpers";
+
+import {
+    condition,
+    connector,
+    domainFromTree,
+    treeFromDomain,
+} from "@web/core/tree_editor/condition_tree";
+
+describe.current.tags("headless");
+
+const options = {
+    getFieldDef: (name) => {
+        if (name === "m2m") {
+            return { type: "many2many" };
+        }
+        if (name === "m2m.datetime_2" || name === "datetime_1") {
+            return { type: "datetime" };
+        }
+        if (name === "m2m.datetime_2.__time" || name === "datetime_1.__time") {
+            return { type: "datetime_option" };
+        }
+        if (name === "m2m.datetime_2.__date" || name === "datetime_1.__date") {
+            return { type: "datetime_option" };
+        }
+        return null;
+    },
+};
+
+test("datetime options: =", async () => {
+    await makeMockEnv();
+
+    const toTest = [
+        {
+            domain: `["&", "&", ("datetime_1.hour_number", "=", 1), ("datetime_1.minute_number", "=", 15), ("datetime_1.second_number", "=", 24)]`,
+            tree: condition("datetime_1.__time", "=", "01:15:24"),
+        },
+        {
+            domain: `["&", "&", ("m2m.datetime_2.hour_number", "=", 1), ("m2m.datetime_2.minute_number", "=", 15), ("m2m.datetime_2.second_number", "=", 24)]`,
+            tree: connector("&", [
+                condition("m2m.datetime_2.hour_number", "=", 1),
+                condition("m2m.datetime_2.minute_number", "=", 15),
+                condition("m2m.datetime_2.second_number", "=", 24),
+            ]),
+        },
+        {
+            domain: `[("m2m", "any", ["&", "&", ("datetime_2.hour_number", "=", 1), ("datetime_2.minute_number", "=", 15), ("datetime_2.second_number", "=", 24)])]`,
+            tree: condition("m2m.datetime_2.__time", "=", "01:15:24"),
+        },
+        {
+            domain: `["!", ("m2m", "any", ["&", "&", ("datetime_2.hour_number", "=", 1), ("datetime_2.minute_number", "=", 15), ("datetime_2.second_number", "=", 24)])]`,
+            tree: condition("m2m", "any", condition("datetime_2.__time", "=", "01:15:24"), true),
+        },
+        {
+            domain: `["&", "&", ("datetime_1.year_number", "=", 2025), ("datetime_1.month_number", "=", 6), ("datetime_1.day_of_month", "=", 4)]`,
+            tree: condition("datetime_1.__date", "=", "2025-06-04"),
+        },
+        {
+            domain: `["&", "&", ("m2m.datetime_2.year_number", "=", 2025), ("m2m.datetime_2.month_number", "=", 6), ("m2m.datetime_2.day_of_month", "=", 4)]`,
+            tree: connector("&", [
+                condition("m2m.datetime_2.year_number", "=", 2025),
+                condition("m2m.datetime_2.month_number", "=", 6),
+                condition("m2m.datetime_2.day_of_month", "=", 4),
+            ]),
+        },
+        {
+            domain: `[("m2m", "any", ["&", "&", ("datetime_2.year_number", "=", 2025), ("datetime_2.month_number", "=", 6), ("datetime_2.day_of_month", "=", 4)])]`,
+            tree: condition("m2m.datetime_2.__date", "=", "2025-06-04"),
+        },
+        {
+            domain: `["!", ("m2m", "any", ["&", "&", ("datetime_2.year_number", "=", 2025), ("datetime_2.month_number", "=", 6), ("datetime_2.day_of_month", "=", 4)])]`,
+            tree: condition("m2m", "any", condition("datetime_2.__date", "=", "2025-06-04"), true),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: !=", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `["|", "|", ("datetime_1.hour_number", "!=", 1), ("datetime_1.minute_number", "!=", 15), ("datetime_1.second_number", "!=", 24)]`,
+            tree: condition("datetime_1.__time", "!=", "01:15:24"),
+        },
+        {
+            domain: `["|", "|", ("m2m.datetime_2.hour_number", "!=", 1), ("m2m.datetime_2.minute_number", "!=", 15), ("m2m.datetime_2.second_number", "!=", 24)]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.hour_number", "!=", 1),
+                condition("m2m.datetime_2.minute_number", "!=", 15),
+                condition("m2m.datetime_2.second_number", "!=", 24),
+            ]),
+        },
+        {
+            domain: `[("m2m", "any", ["|", "|", ("datetime_2.hour_number", "!=", 1), ("datetime_2.minute_number", "!=", 15), ("datetime_2.second_number", "!=", 24)])]`,
+            tree: condition("m2m.datetime_2.__time", "!=", "01:15:24"),
+        },
+        {
+            domain: `["!", ("m2m", "any", ["|", "|", ("datetime_2.hour_number", "!=", 1), ("datetime_2.minute_number", "!=", 15), ("datetime_2.second_number", "!=", 24)])]`,
+            tree: condition("m2m", "any", condition("datetime_2.__time", "!=", "01:15:24"), true),
+        },
+        {
+            domain: `["|", "|", ("datetime_1.year_number", "!=", 2025), ("datetime_1.month_number", "!=", 6), ("datetime_1.day_of_month", "!=", 4)]`,
+            tree: condition("datetime_1.__date", "!=", "2025-06-04"),
+        },
+        {
+            domain: `["|", "|", ("m2m.datetime_2.year_number", "!=", 2025), ("m2m.datetime_2.month_number", "!=", 6), ("m2m.datetime_2.day_of_month", "!=", 4)]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.year_number", "!=", 2025),
+                condition("m2m.datetime_2.month_number", "!=", 6),
+                condition("m2m.datetime_2.day_of_month", "!=", 4),
+            ]),
+        },
+        {
+            domain: `[("m2m", "any", ["|", "|", ("datetime_2.year_number", "!=", 2025), ("datetime_2.month_number", "!=", 6), ("datetime_2.day_of_month", "!=", 4)])]`,
+            tree: condition("m2m.datetime_2.__date", "!=", "2025-06-04"),
+        },
+        {
+            domain: `["!", ("m2m", "any", ["|", "|", ("datetime_2.year_number", "!=", 2025), ("datetime_2.month_number", "!=", 6), ("datetime_2.day_of_month", "!=", 4)])]`,
+            tree: condition("m2m", "any", condition("datetime_2.__date", "!=", "2025-06-04"), true),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: >", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `[
+                "|","|",
+                    ("datetime_1.hour_number",">",1),
+                    "&",("datetime_1.hour_number","=",1),("datetime_1.minute_number",">",15),
+                    "&","&",("datetime_1.hour_number","=",1),("datetime_1.minute_number","=",15),("datetime_1.second_number",">",24)
+            ]`,
+            tree: condition("datetime_1.__time", ">", "01:15:24"),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("m2m.datetime_2.hour_number",">",1),
+                    "&",("m2m.datetime_2.hour_number","=",1),("m2m.datetime_2.minute_number",">",15),
+                    "&","&",("m2m.datetime_2.hour_number","=",1),("m2m.datetime_2.minute_number","=",15),("m2m.datetime_2.second_number",">",24)
+            ]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.hour_number", ">", 1),
+                connector("&", [
+                    condition("m2m.datetime_2.hour_number", "=", 1),
+                    condition("m2m.datetime_2.minute_number", ">", 15),
+                ]),
+                connector("&", [
+                    condition("m2m.datetime_2.hour_number", "=", 1),
+                    condition("m2m.datetime_2.minute_number", "=", 15),
+                    condition("m2m.datetime_2.second_number", ">", 24),
+                ]),
+            ]),
+        },
+        {
+            domain: `[
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.hour_number",">",1),
+                        "&",("datetime_2.hour_number","=",1),("datetime_2.minute_number",">",15),
+                        "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number",">",24)
+                ])
+            ]`,
+            tree: condition("m2m.datetime_2.__time", ">", "01:15:24"),
+        },
+        {
+            domain: `[
+                "!",
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.hour_number",">",1),
+                        "&",("datetime_2.hour_number","=",1),("datetime_2.minute_number",">",15),
+                        "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number",">",24)
+                ])
+            ]`,
+            tree: condition("m2m", "any", condition("datetime_2.__time", ">", "01:15:24"), true),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("datetime_1.year_number",">",2025),
+                    "&",("datetime_1.year_number","=",2025),("datetime_1.month_number",">",6),
+                    "&","&",("datetime_1.year_number","=",2025),("datetime_1.month_number","=",6),("datetime_1.day_of_month",">",4)
+            ]`,
+            tree: condition("datetime_1.__date", ">", "2025-06-04"),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("m2m.datetime_2.year_number",">",2025),
+                    "&",("m2m.datetime_2.year_number","=",2025),("m2m.datetime_2.month_number",">",6),
+                    "&","&",("m2m.datetime_2.year_number","=",2025),("m2m.datetime_2.month_number","=",6),("m2m.datetime_2.day_of_month",">",4)
+            ]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.year_number", ">", 2025),
+                connector("&", [
+                    condition("m2m.datetime_2.year_number", "=", 2025),
+                    condition("m2m.datetime_2.month_number", ">", 6),
+                ]),
+                connector("&", [
+                    condition("m2m.datetime_2.year_number", "=", 2025),
+                    condition("m2m.datetime_2.month_number", "=", 6),
+                    condition("m2m.datetime_2.day_of_month", ">", 4),
+                ]),
+            ]),
+        },
+        {
+            domain: `[
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.year_number",">",2025),
+                        "&",("datetime_2.year_number","=",2025),("datetime_2.month_number",">",6),
+                        "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month",">",4)
+                ])
+            ]`,
+            tree: condition("m2m.datetime_2.__date", ">", "2025-06-04"),
+        },
+        {
+            domain: `[
+                "!",
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.year_number",">",2025),
+                        "&",("datetime_2.year_number","=",2025),("datetime_2.month_number",">",6),
+                        "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month",">",4)
+                ])
+            ]`,
+            tree: condition("m2m", "any", condition("datetime_2.__date", ">", "2025-06-04"), true),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: <", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `[
+                "|","|",
+                    ("datetime_1.hour_number","<",1),
+                    "&",("datetime_1.hour_number","=",1),("datetime_1.minute_number","<",15),
+                    "&","&",("datetime_1.hour_number","=",1),("datetime_1.minute_number","=",15),("datetime_1.second_number","<",24)
+            ]`,
+            tree: condition("datetime_1.__time", "<", "01:15:24"),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("m2m.datetime_2.hour_number","<",1),
+                    "&",("m2m.datetime_2.hour_number","=",1),("m2m.datetime_2.minute_number","<",15),
+                    "&","&",("m2m.datetime_2.hour_number","=",1),("m2m.datetime_2.minute_number","=",15),("m2m.datetime_2.second_number","<",24)
+            ]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.hour_number", "<", 1),
+                connector("&", [
+                    condition("m2m.datetime_2.hour_number", "=", 1),
+                    condition("m2m.datetime_2.minute_number", "<", 15),
+                ]),
+                connector("&", [
+                    condition("m2m.datetime_2.hour_number", "=", 1),
+                    condition("m2m.datetime_2.minute_number", "=", 15),
+                    condition("m2m.datetime_2.second_number", "<", 24),
+                ]),
+            ]),
+        },
+        {
+            domain: `[
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.hour_number","<",1),
+                        "&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","<",15),
+                        "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number","<",24)
+                ])
+            ]`,
+            tree: condition("m2m.datetime_2.__time", "<", "01:15:24"),
+        },
+        {
+            domain: `[
+                "!",
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.hour_number","<",1),
+                        "&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","<",15),
+                        "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number","<",24)
+                ])
+            ]`,
+            tree: condition("m2m", "any", condition("datetime_2.__time", "<", "01:15:24"), true),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("datetime_1.year_number","<",2025),
+                    "&",("datetime_1.year_number","=",2025),("datetime_1.month_number","<",6),
+                    "&","&",("datetime_1.year_number","=",2025),("datetime_1.month_number","=",6),("datetime_1.day_of_month","<",4)
+            ]`,
+            tree: condition("datetime_1.__date", "<", "2025-06-04"),
+        },
+        {
+            domain: `[
+                "|","|",
+                    ("m2m.datetime_2.year_number","<",2025),
+                    "&",("m2m.datetime_2.year_number","=",2025),("m2m.datetime_2.month_number","<",6),
+                    "&","&",("m2m.datetime_2.year_number","=",2025),("m2m.datetime_2.month_number","=",6),("m2m.datetime_2.day_of_month","<",4)
+            ]`,
+            tree: connector("|", [
+                condition("m2m.datetime_2.year_number", "<", 2025),
+                connector("&", [
+                    condition("m2m.datetime_2.year_number", "=", 2025),
+                    condition("m2m.datetime_2.month_number", "<", 6),
+                ]),
+                connector("&", [
+                    condition("m2m.datetime_2.year_number", "=", 2025),
+                    condition("m2m.datetime_2.month_number", "=", 6),
+                    condition("m2m.datetime_2.day_of_month", "<", 4),
+                ]),
+            ]),
+        },
+        {
+            domain: `[
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.year_number","<",2025),
+                        "&",("datetime_2.year_number","=",2025),("datetime_2.month_number","<",6),
+                        "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month","<",4)
+                ])
+            ]`,
+            tree: condition("m2m.datetime_2.__date", "<", "2025-06-04"),
+        },
+        {
+            domain: `[
+                "!",
+                ("m2m", "any", [
+                    "|","|",
+                        ("datetime_2.year_number","<",2025),
+                        "&",("datetime_2.year_number","=",2025),("datetime_2.month_number","<",6),
+                        "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month","<",4)
+                ])
+            ]`,
+            tree: condition("m2m", "any", condition("datetime_2.__date", "<", "2025-06-04"), true),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: between", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `[
+                "&",
+                    "|",
+                        "|","|",
+                            ("datetime_1.hour_number",">",1),
+                            "&",("datetime_1.hour_number","=",1),("datetime_1.minute_number",">",15),
+                            "&","&",("datetime_1.hour_number","=",1),("datetime_1.minute_number","=",15),("datetime_1.second_number",">",24),
+                        "&","&",("datetime_1.hour_number","=",1),("datetime_1.minute_number","=",15),("datetime_1.second_number","=",24),
+                    "|",
+                        "|","|",
+                            ("datetime_1.hour_number","<",22),
+                            "&",("datetime_1.hour_number","=",22),("datetime_1.minute_number","<",6),
+                            "&","&",("datetime_1.hour_number","=",22),("datetime_1.minute_number","=",6),("datetime_1.second_number","<",56),
+                        "&","&",("datetime_1.hour_number","=",22),("datetime_1.minute_number","=",6),("datetime_1.second_number","=",56)
+            ]`,
+            tree: condition("datetime_1.__time", "between", ["01:15:24", "22:06:56"]),
+        },
+        {
+            domain: `[
+                "&",
+                    "|",
+                        "|","|",
+                            ("datetime_1.year_number",">",2025),
+                            "&",("datetime_1.year_number","=",2025),("datetime_1.month_number",">",6),
+                            "&","&",("datetime_1.year_number","=",2025),("datetime_1.month_number","=",6),("datetime_1.day_of_month",">",4),
+                        "&","&",("datetime_1.year_number","=",2025),("datetime_1.month_number","=",6),("datetime_1.day_of_month","=",4),
+                    "|",
+                        "|","|",
+                            ("datetime_1.year_number","<",2026),
+                            "&",("datetime_1.year_number","=",2026),("datetime_1.month_number","<",6),
+                            "&","&",("datetime_1.year_number","=",2026),("datetime_1.month_number","=",6),("datetime_1.day_of_month","<",27),
+                        "&","&",("datetime_1.year_number","=",2026),("datetime_1.month_number","=",6),("datetime_1.day_of_month","=",27)
+            ]`,
+            tree: condition("datetime_1.__date", "between", ["2025-06-04", "2026-06-27"]),
+        },
+        {
+            domain: `[
+                (
+                    "m2m",
+                    "any",
+                    [
+                        "&",
+                            "|",
+                                "|","|",
+                                    ("datetime_2.hour_number",">",1),
+                                    "&",("datetime_2.hour_number","=",1),("datetime_2.minute_number",">",15),
+                                    "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number",">",24),
+                                "&","&",("datetime_2.hour_number","=",1),("datetime_2.minute_number","=",15),("datetime_2.second_number","=",24),
+                            "|",
+                                "|","|",
+                                    ("datetime_2.hour_number","<",22),
+                                    "&",("datetime_2.hour_number","=",22),("datetime_2.minute_number","<",6),
+                                    "&","&",("datetime_2.hour_number","=",22),("datetime_2.minute_number","=",6),("datetime_2.second_number","<",56),
+                                "&","&",("datetime_2.hour_number","=",22),("datetime_2.minute_number","=",6),("datetime_2.second_number","=",56)
+                    ]
+                )
+            ]`,
+            tree: condition("m2m.datetime_2.__time", "between", ["01:15:24", "22:06:56"]),
+        },
+        {
+            domain: `[
+                (
+                    "m2m",
+                    "any",
+                    [
+                        "&",
+                            "|",
+                                "|","|",
+                                    ("datetime_2.year_number",">",2025),
+                                    "&",("datetime_2.year_number","=",2025),("datetime_2.month_number",">",6),
+                                    "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month",">",4),
+                                "&","&",("datetime_2.year_number","=",2025),("datetime_2.month_number","=",6),("datetime_2.day_of_month","=",4),
+                            "|",
+                                "|","|",
+                                    ("datetime_2.year_number","<",2026),
+                                    "&",("datetime_2.year_number","=",2026),("datetime_2.month_number","<",6),
+                                    "&","&",("datetime_2.year_number","=",2026),("datetime_2.month_number","=",6),("datetime_2.day_of_month","<",27),
+                                "&","&",("datetime_2.year_number","=",2026),("datetime_2.month_number","=",6),("datetime_2.day_of_month","=",27)
+                    ]
+                )
+            ]`,
+            tree: condition("m2m.datetime_2.__date", "between", ["2025-06-04", "2026-06-27"]),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: set", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `["|", "|", ("datetime_1.hour_number", "!=", False), ("datetime_1.minute_number", "!=", False), ("datetime_1.second_number", "!=", False)]`,
+            tree: condition("datetime_1.__time", "set", false),
+        },
+        {
+            domain: `["|", "|", ("datetime_1.year_number", "!=", False), ("datetime_1.month_number", "!=", False), ("datetime_1.day_of_month", "!=", False)]`,
+            tree: condition("datetime_1.__date", "set", false),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});
+
+test("datetime options: not_set", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            domain: `["&", "&", ("datetime_1.hour_number", "=", False), ("datetime_1.minute_number", "=", False), ("datetime_1.second_number", "=", False)]`,
+            tree: condition("datetime_1.__time", "not_set", false),
+        },
+        {
+            domain: `["&", "&", ("datetime_1.year_number", "=", False), ("datetime_1.month_number", "=", False), ("datetime_1.day_of_month", "=", False)]`,
+            tree: condition("datetime_1.__date", "not_set", false),
+        },
+    ];
+    for (const { domain, tree } of toTest) {
+        expect(treeFromDomain(domain, options)).toEqual(tree);
+        expect(domainFromTree(tree)).toEqual(formatDomain(domain));
+    }
+});

--- a/addons/web/static/tests/core/tree_editor/not_between_operator.test.js
+++ b/addons/web/static/tests/core/tree_editor/not_between_operator.test.js
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "@odoo/hoot";
+
+import { makeMockEnv } from "@web/../tests/web_test_helpers";
+
+import {
+    applyTransformations,
+    condition,
+    connector,
+    expression,
+    FULL_VIRTUAL_OPERATORS_ELIMINATION,
+    FULL_VIRTUAL_OPERATORS_INTRODUCTION,
+} from "@web/core/tree_editor/condition_tree";
+
+describe.current.tags("headless");
+
+const options = {
+    getFieldDef: (name) => {
+        if (name === "m2o") {
+            return { type: "many2one" };
+        }
+        if (name === "m2o.datetime_2" || name === "datetime_1") {
+            return { type: "datetime" };
+        }
+        if (name === "m2o.int_2" || name === "int_1") {
+            return { type: "integer" };
+        }
+        return null;
+    },
+};
+
+test("not_between operator: introduction/elimination", async () => {
+    await makeMockEnv();
+    const toTest = [
+        {
+            tree_py: connector("|", [condition("int_1", "<", 1), condition("int_1", ">", 2)]),
+            tree: condition("int_1", "not_between", [1, 2]),
+        },
+        {
+            tree_py: connector("|", [condition("int_1", "<", 1), condition("int_1", ">", 2)], true),
+            tree: condition("int_1", "not_between", [1, 2], true),
+        },
+        {
+            tree_py: connector("|", [
+                condition("m2o.int_2", "<", 1),
+                condition("m2o.int_2", ">", 2),
+            ]),
+            tree: connector("|", [condition("m2o.int_2", "<", 1), condition("m2o.int_2", ">", 2)]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("|", [condition("int_2", "<", 1), condition("int_2", ">", 2)])
+            ),
+            tree: condition("m2o.int_2", "not_between", [1, 2]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("|", [condition("int_2", "<", 1), condition("int_2", ">", 2)]),
+                true
+            ),
+            tree: condition("m2o", "any", condition("int_2", "not_between", [1, 2]), true),
+        },
+
+        {
+            tree_py: connector("|", [
+                condition("datetime_1", "<", 1),
+                condition("datetime_1", ">", 2),
+            ]),
+            tree: condition("datetime_1", "not_between", [1, 2]),
+        },
+        {
+            tree_py: connector(
+                "|",
+                [condition("datetime_1", "<", 1), condition("datetime_1", ">", 2)],
+                true
+            ),
+            tree: condition("datetime_1", "not_between", [1, 2], true),
+        },
+        {
+            tree_py: connector("|", [
+                condition("m2o.datetime_2", "<", 1),
+                condition("m2o.datetime_2", ">", 2),
+            ]),
+            tree: connector("|", [
+                condition("m2o.datetime_2", "<", 1),
+                condition("m2o.datetime_2", ">", 2),
+            ]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("|", [condition("datetime_2", "<", 1), condition("datetime_2", ">", 2)])
+            ),
+            tree: condition("m2o.datetime_2", "not_between", [1, 2]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("|", [condition("datetime_2", "<", 1), condition("datetime_2", ">", 2)]),
+                true
+            ),
+            tree: condition("m2o", "any", condition("datetime_2", "not_between", [1, 2]), true),
+        },
+
+        {
+            tree_py: connector("|", [
+                condition(expression("path"), "<", 1),
+                condition(expression("path"), ">", 2),
+            ]),
+            tree: connector("|", [
+                condition(expression("path"), "<", 1),
+                condition(expression("path"), ">", 2),
+            ]),
+        },
+        {
+            tree_py: condition(
+                "m2o",
+                "any",
+                connector("|", [
+                    condition(expression("path"), "<", 1),
+                    condition(expression("path"), ">", 2),
+                ])
+            ),
+            tree: condition(
+                "m2o",
+                "any",
+                connector("|", [
+                    condition(expression("path"), "<", 1),
+                    condition(expression("path"), ">", 2),
+                ])
+            ),
+        },
+    ];
+    for (const { tree_py, tree } of toTest) {
+        expect(applyTransformations(FULL_VIRTUAL_OPERATORS_INTRODUCTION, tree_py, options)).toEqual(
+            tree
+        );
+        expect(applyTransformations(FULL_VIRTUAL_OPERATORS_ELIMINATION, tree)).toEqual(tree_py);
+    }
+});


### PR DESCRIPTION
Several virtual operators are complex combinaisons of basic operators. For example "between" is a conjuction of ">=" and "<=":
```py
[("int", "between", [1, 3])]
```
is translated into
```py
["&", ("int", ">=", 1), ("int", "<=", 3)].
```

Bug:

```py
[("partner_ids.int", "between", [1, 3])]
```
is also translated into
```py
["&", ("partner_ids.int", ">=", 1), ("partner_ids.int", "<=", 3)]
```
a short cut for
```py
[
    "&",
        ("partner_ids", "any", [("int", ">=", 1)]),
        ("partner_ids", "any", [("int", "<=", 3)])
]
```
while it should be translated into
```py
[("partner_ids", "any", ["&", ("int", ">=", 1), ("int", "<=", 3)])].
```
Indeed "any" and "&" do not commute.

Here we fix this kind of problems for virtual operators like between that are combinaisons of basic operators.