### PR TITLE
[FIX] stock: prevent page refresh after multi-print

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1184,6 +1184,7 @@ class Picking(models.Model):
                 'type': 'ir.actions.client',
                 'tag': 'do_multi_print',
                 'params': {
+                    'noReload': True,
                     'reports': report_actions,
                     'anotherAction': another_action,
                 }

--- a/addons/stock/static/src/client_actions/multi_print.js
+++ b/addons/stock/static/src/client_actions/multi_print.js
@@ -30,7 +30,7 @@ async function doMultiPrint(env, action) {
     } else if (action.params.onClose) {
         // handle special cases such as barcode
         action.params.onClose()
-    } else {
+    } else if (!action.params.noReload) {
         return env.services.action.doAction("reload_context");
     }
 }


### PR DESCRIPTION
Steps to reproduce the bug:
- Enable multi-step routes.
- Go to Inventory > Configuration > Operation Types:
    - Open Delivery Orders. - In the Hardware tab, enable “Delivery Slip”.

- Create a delivery order with any product.
- Confirm and validate the delivery.

Problem:
The delivery slip is correctly printed, but the page is unnecessarily refreshed causing the user to lose their route history. This happens because the “do_multi_print” function is called without the “another_action” parameter being set.
As a result, the “reload_context” action is triggered, which leads to a page refresh.

Solution:
Add a new parameter “noReload: true” when calling “do_multi_print” to prevent the page refresh explicitly.

opw-4801963
