### PR TITLE
[FIX] mail: spacing between msg bubble and next msg notification

### DIFF
--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -31,6 +31,10 @@
     margin-bottom: 0;
 }
 
+.o-mail-Message:not(:has(.o-mail-MessageReaction)) + .o-mail-NotificationMessage {
+    margin-top: map-get($spacers, 1);
+}
+
 .o-mail-NotificationMessage:has(.o_hide_author) {
     & .o-mail-NotificationMessage-author {
         display: none!important;


### PR DESCRIPTION
Before this commit, visual of a message without reactions just above a notification like "started a live conference" looked slightly off.

This comes from lack of spacing between them.

This commit fixes the issue by specifically adding minimal spacing in-between message without reaction and the notification in the message list.

The spacing of message bubbles and notification is intentionally small to be efficient with space and add only when desired. When a message has a reaction, there's already bottom spacing so there's no need to add even more. As a reminder, the bottom spacing on reaction helps to see which message this reaction it is attached to.

![Screenshot 2025-05-28 at 17 14 10](https://github.com/user-attachments/assets/0a9dc502-8fff-4484-a858-1c9c15e4b934)
