### PR TITLE
[FIX/IMP] web, crm, mail: monetary aggregates in grouped view

### DIFF
--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -4,7 +4,7 @@
         <xpath expr="//div[hasclass('o_column_progress')]" position="attributes">
             <attribute name="class" remove="w-75" add="w-50" separator=" "/>
         </xpath>
-        <AnimatedNumber position="after">
+        <b t-else="" position="after">
             <t t-if="showRecurringRevenue">
                 <t t-set="rrmAggregate" t-value="getRecurringRevenueGroupAggregate(props.group)"/>
                 <AnimatedNumber
@@ -19,6 +19,6 @@
                     </t>
                 </AnimatedNumber>
             </t>
-        </AnimatedNumber>
+        </b>
     </t>
 </templates>

--- a/addons/mail/static/src/core/web/mail_column_progress.xml
+++ b/addons/mail/static/src/core/web/mail_column_progress.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
     <t t-name="mail.ColumnProgress" t-inherit="web.ColumnProgress" t-inherit-mode="primary">
-        <AnimatedNumber position="after">
+        <b t-else="" position="after">
             <t t-if="props.aggregateOn">
                 <span class="text-900 text-nowrap cursor-default"
                      t-att-title="props.aggregateOn.title">
                     /<span class="o_column_progress_aggregated_on" t-out="props.aggregateOn.value"/>
                 </span>
             </t>
-        </AnimatedNumber>
+        </b>
     </t>
 </templates>

--- a/addons/web/static/src/model/sample_server.js
+++ b/addons/web/static/src/model/sample_server.js
@@ -185,6 +185,8 @@ export class SampleServer {
                 group[name] = records.some((r) => Boolean(r[fieldName]));
             } else if (func === "bool_and") {
                 group[name] = records.every((r) => Boolean(r[fieldName]));
+            } else if (func === "array_agg_distinct") {
+                group[name] = unique(records.map((r) => r[fieldName]));
             } else {
                 throw new Error(`Aggregate "${func}" not implemented in SampleServer`);
             }

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -133,21 +133,20 @@ class ProgressBarState {
         let value = 0;
         if (!this.activeBars[group.serverValue]) {
             value = group.count;
-            if (aggregateField) {
-                value =
-                    _findGroup(this._aggregateValues, group.groupByField, group.serverValue)[
-                        aggregateField.name
-                    ] || 0;
+            if (value && aggregateField) {
+                value = _findGroup(this._aggregateValues, group.groupByField, group.serverValue)[
+                    aggregateField.name
+                ];
             }
         } else {
             value = this.activeBars[group.serverValue].count;
-            if (aggregateField) {
+            if (value && aggregateField) {
                 value =
-                    (this.activeBars[group.serverValue]?.aggregates &&
-                        this.activeBars[group.serverValue]?.aggregates[aggregateField.name]) ||
-                    0;
+                    this.activeBars[group.serverValue]?.aggregates &&
+                    this.activeBars[group.serverValue]?.aggregates[aggregateField.name];
             }
         }
+        value ??= false;
         return { title, value };
     }
 

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -1,4 +1,5 @@
 import { reactive } from "@odoo/owl";
+import { getCurrency } from "@web/core/currency";
 import { Domain } from "@web/core/domain";
 import { _t } from "@web/core/l10n/translation";
 import {
@@ -147,6 +148,16 @@ class ProgressBarState {
             }
         }
         value ??= false;
+        if (value && aggregateField.type === "monetary" && aggregateField.currency_field) {
+            const currencyId = group.aggregates[aggregateField.currency_field][0];
+            if (currencyId) {
+                return {
+                    title,
+                    value,
+                    currency: getCurrency(currencyId),
+                };
+            }
+        }
         return { title, value };
     }
 

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -220,7 +220,10 @@
                 </div>
             </th>
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-foreach="getAggregateColumns(group)" t-as="column" t-key="column.id" t-att-class="{'o_list_number': column.type === 'field'}">
-                <t t-if="column.type === 'field'" t-esc="formatAggregateValue(group, column)"/>
+                <t t-if="column.type === 'field'">
+                    <t t-set="groupAggregate" t-value="formatGroupAggregate(group, column)"/>
+                    <span t-esc="groupAggregate.value" t-att-data-tooltip="groupAggregate.help || ''"/>
+                </t>
             </td>
             <t t-set="groupPagerColspan" t-value="getGroupPagerCellColspan(group)"/>
             <th t-on-keydown="(ev) => this.onCellKeydown(ev, group)" t-if="groupPagerColspan > 0" t-att-colspan="groupPagerColspan"/>

--- a/addons/web/static/src/views/view_components/animated_number.xml
+++ b/addons/web/static/src/views/view_components/animated_number.xml
@@ -4,9 +4,9 @@
     <t t-name="web.AnimatedNumber">
         <div class="o_animated_number ms-2 text-900 text-nowrap cursor-default" t-att-class="state.value !== props.value and props.animationClass" t-att-title="props.title">
             <t t-slot="prefix"/>
-            <span t-if="props.currency and props.currency.position === 'before'" t-esc="props.currency.symbol" class="ms-1"/>
+            <b t-if="props.currency and props.currency.position === 'before'" t-esc="props.currency.symbol" class="me-1"/>
             <b t-esc="format(state.value)" />
-            <span t-if="props.currency and props.currency.position === 'after'" t-esc="props.currency.symbol" class="ms-1"/>
+            <b t-if="props.currency and props.currency.position === 'after'" t-esc="props.currency.symbol" class="ms-1"/>
         </div>
     </t>
 

--- a/addons/web/static/src/views/view_components/column_progress.js
+++ b/addons/web/static/src/views/view_components/column_progress.js
@@ -1,5 +1,6 @@
 import { Component } from "@odoo/owl";
 import { AnimatedNumber } from "./animated_number";
+import { _t } from "@web/core/l10n/translation";
 
 export class ColumnProgress extends Component {
     static components = {
@@ -18,5 +19,9 @@ export class ColumnProgress extends Component {
 
     async onBarClick(bar) {
         await this.props.onBarClicked(bar);
+    }
+
+    get invalidAggregateTooltip() {
+        return _t("Different currencies cannot be aggregated");
     }
 }

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -23,12 +23,14 @@
             </t>
         </div>
         <AnimatedNumber
+            t-if="props.aggregate.value !== false"
             value="props.aggregate.value"
             title="props.aggregate.title"
             duration="1000"
             currency="props.aggregate.currency"
             animationClass="props.aggregate.value > 999 ? 'o_animated_grow' : 'o_animated_grow_huge'"
         />
+        <b t-else="" class="pe-1" t-att-data-tooltip="invalidAggregateTooltip">—</b>
     </t>
 
 </templates>

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -134,7 +134,7 @@ class Partner extends models.Model {
             ["ghi", "GHI"],
         ],
     });
-    salary = fields.Monetary({ aggregator: "sum", currency_field: this.currency_id });
+    salary = fields.Monetary({ aggregator: "sum", currency_field: "currency_id" });
     currency_id = fields.Many2one({ relation: "res.currency" });
 
     _records = [
@@ -9423,6 +9423,7 @@ test("progress bar with false aggregate value", async () => {
     expect(".o_kanban_counter:first .o_animated_number").toHaveCount(0);
     expect(".o_kanban_counter:last .o_animated_number").toHaveCount(1);
 
+    expect(".o_kanban_counter:last .o_animated_number").toHaveText("$3,722");
     expect(".o_kanban_counter:first b").toHaveText("—");
     expect(".o_kanban_counter:first b").toHaveAttribute(
         "data-tooltip",


### PR DESCRIPTION
First commit fixes the display of totals in kanban progress bars when dealing with records using different currencies. Previously, invalid aggregate values were shown as 0, which could be misleading. They are now correctly displayed as '-' to indicate the absence of a valid total.

Second commit makes use of changes made in https://github.com/odoo/odoo/pull/199958 to display the currency of monetary field group aggregates in list and kanban view.

task-4794296