### PR TITLE
[FIX] account: support Greek letters in journal sequence prefixes

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3840,7 +3840,8 @@ class AccountMove(models.Model):
             reference will be 'RF67 INV0 0003 7'.
         """
         self.ensure_one()
-        return format_structured_reference_iso(f'{self.journal_id.code}{str(self.id).zfill(6)}')
+        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() else self.journal_id.id
+        return format_structured_reference_iso(f'{journal_identifier}{str(self.id).zfill(6)}')
 
     def _get_invoice_reference_euro_partner(self):
         """ This computes the reference based on the RF Creditor Reference.
@@ -3854,9 +3855,10 @@ class AccountMove(models.Model):
             be used.
         """
         self.ensure_one()
+        journal_identifier = self.journal_id.code if self.journal_id.code.isascii() else self.journal_id.id
         partner_ref = self.partner_id.ref
         partner_ref_nr = re.sub(r'\D', '', partner_ref or '')[-21:] or str(self.partner_id.id)[-21:]
-        partner_ref_nr = f'{self.journal_id.code}{partner_ref_nr}'[-21:]
+        partner_ref_nr = f'{journal_identifier}{partner_ref_nr}'[-21:]
         return format_structured_reference_iso(partner_ref_nr)
 
     def _get_invoice_reference_number_invoice(self):

--- a/addons/account/tools/structured_reference.py
+++ b/addons/account/tools/structured_reference.py
@@ -23,7 +23,7 @@ def format_structured_reference_iso(number):
     The Creditor Reference is an international standard (ISO 11649).
     Example: `123456789` -> `RF18 1234 5678 9`
     """
-    check_digits = mod_97_10.calc_check_digits('{}RF'.format(number))
+    check_digits = mod_97_10.calc_check_digits(f"{number}RF")
     return 'RF{} {}'.format(
         check_digits,
         ' '.join(''.join(x) for x in zip_longest(*[iter(str(number))]*4, fillvalue=''))


### PR DESCRIPTION
**Issue**
Using a Greek letter in the journal's sequence prefix causes a traceback error when confirming an invoice

**Steps to Reproduce**
1. Install the Accounting module
2. Navigate to Accounting > Configuration > Journals
3. Open the Sales journal
4. Under the Advanced Settings tab, set the communication standard to "European"
5. Set the sequence prefix to include Greek letters (e.g., "TΠY")
6. Create and confirm a new invoice
7. Observe the traceback error

**Root Cause**
The prefix is used in calculating the `check_digits` via a base-36 to base-10 conversion. This conversion fails for Greek characters, which are not valid in base-36, leading to an exception

**Fix**
Greek letters in the prefix are transliterated to their Latin equivalents before performing the checksum calculation, ensuring compatibility with the base-36 conversion logic

Opw-4813790
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
