### PR TITLE
[FIX] website: center carousel in edit mode 

### DIFF
--- a/addons/website/static/src/builder/plugins/options/image_gallery_option.inside.scss
+++ b/addons/website/static/src/builder/plugins/options/image_gallery_option.inside.scss
@@ -1,5 +1,5 @@
 .s_image_gallery {
-    &:has(.img) .o_empty_gallery_alert {
+    &:has(.img) .container:has(.o_empty_gallery_alert) {
         display: none;
     }
     .o_empty_gallery_alert {


### PR DESCRIPTION
Steps to Reproduce :

 - Enter edit mode.
 - Drag and drop the s_image_gallery snippet.
 - Change the Min-Height option to 100%.
 - Notice that the carousel is not centered

Cause:
An empty div (intended to display a placeholder when no images are
present) was still being rendered even when the carousel contained
images. This affected the layout and caused misalignment.

Solution:
Update the CSS rule to hide the placeholder when the carousel has
images, ensuring proper centering in edit mode.
