### PR TITLE
[FIX] mail: mark thread read on scroll to bottom (focus on thread)

### DIFF
--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusout="onFocusout">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusin="onFocusin" t-on-focusout="onFocusout">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -3,6 +3,7 @@ import {
     click,
     contains,
     defineMailModels,
+    focus,
     isInViewportOf,
     openDiscuss,
     patchUiSize,
@@ -150,6 +151,8 @@ test("remove banner when scrolling to bottom", async () => {
     await start();
     await openDiscuss(channelId);
     await contains(".o-mail-Message", { count: 30 });
+    await contains(".o-mail-Composer.o-focused");
+    await focus(".o-mail-Thread");
     await contains(".o-mail-Thread-banner", { text: "50 new messages" });
     await tick(); // wait for the scroll to first unread to complete
     await scroll(".o-mail-Thread", "bottom");


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/211720

PR above backport behaviour of (un)read conversations, i.e. mark as read on scroll bottom, new message separator, and unread message banner.

One of the improvements are made possible thanks to adding concept of thread focused (without composer), which allow to mark as read even when focusing the thread without composer.

The backport made a mistake in omitting onFocusin on thread in template, which made it not possible to mark as read on scroll bottom with just focus on thread.

This commit fixes it by adding in template. Handler was already there. Test for scroll to bottom that marks unread is adapted to focus the thread without composer.

