### PR TITLE
[FIX] mail: show low opacity separator above discuss app

### DIFF
--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -85,5 +85,5 @@
 }
 
 .o_web_client:has(.o-mail-Discuss) .o_control_panel {
-    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, 0)};
+    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .25)};
 }


### PR DESCRIPTION
The default separator color of control panel is too strong, which doesn't fit well in discuss app that has a lot of items that needs enough attention.

This was overridden to remove it completely, but now that many work as been done to adjust the right balance of color in discuss app, this separator can be shown at a reduced opacity.