### PR TITLE
Moving a few fields from company form to settings

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -307,7 +307,7 @@
                                         </div>
                                     </div>
                                 </setting>
-                                <setting id="product_accounts" string="Product Accounts:">
+                                <setting id="product_accounts" string="Product Accounts:" company_dependent="1">
                                     <div class="content-group">
                                         <div class="row mt8">
                                             <label for="income_account_id" class="col-lg-5 o_light_label"/>

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -19,7 +19,7 @@
             <field name="arch" type="xml">
                 <group name="logistics" position="after">
                     <group string="Inventory Valuation">
-                        <field name="property_cost_method" required="True"/>
+                        <field name="property_cost_method" placeholder="Use company default"/>
                         <field name="property_valuation" groups="account.group_account_readonly,stock.group_stock_manager"/>
                     </group>
                 </group>


### PR DESCRIPTION
This commits allows the user to leave the `property_cost_field`
empty and it will then fallback to the company's cost method.

Added a warning when changing cost method to inform the user
the importance of the cost method and the criticality of changing it.

Task:4720952
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
