### PR TITLE
[FIX] mail: lower opacity on pinned message cards

### DIFF
--- a/addons/mail/static/src/core/common/message_card_list.scss
+++ b/addons/mail/static/src/core/common/message_card_list.scss
@@ -1,8 +1,14 @@
-.o-mail-MessageCardList .card-body {
-    background-color: var(--mail-MessageCardList-cardBodyBg, $o-view-background-color);
+.o-mail-MessageCardList {
+    .card {
+        --border-opacity: .35;
+    }
 
-    &:hover .o-mail-MessageCard-jump {
-        opacity: 100 !important;
+    .card-body {
+        background-color: var(--mail-MessageCardList-cardBodyBg, $o-view-background-color);
+    
+        &:hover .o-mail-MessageCard-jump {
+            opacity: 100 !important;
+        }
     }
 }
 


### PR DESCRIPTION
Was using default `.border-secondary` which is too strong compared to other discuss items.