### PR TITLE
[FIX] mail: some discuss style minor fixed

### DIFF
--- a/addons/mail/static/src/core/common/message_card_list.scss
+++ b/addons/mail/static/src/core/common/message_card_list.scss
@@ -1,8 +1,14 @@
-.o-mail-MessageCardList .card-body {
-    background-color: var(--mail-MessageCardList-cardBodyBg, $o-view-background-color);
+.o-mail-MessageCardList {
+    .card {
+        --border-opacity: .35;
+    }
 
-    &:hover .o-mail-MessageCard-jump {
-        opacity: 100 !important;
+    .card-body {
+        background-color: var(--mail-MessageCardList-cardBodyBg, $o-view-background-color);
+    
+        &:hover .o-mail-MessageCard-jump {
+            opacity: 100 !important;
+        }
     }
 }
 

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -31,6 +31,10 @@
     margin-bottom: 0;
 }
 
+.o-mail-Message:not(:has(.o-mail-MessageReaction)) + .o-mail-NotificationMessage {
+    margin-top: map-get($spacers, 1);
+}
+
 .o-mail-NotificationMessage:has(.o_hide_author) {
     & .o-mail-NotificationMessage-author {
         display: none!important;

--- a/addons/mail/static/src/core/public_web/discuss.scss
+++ b/addons/mail/static/src/core/public_web/discuss.scss
@@ -85,5 +85,5 @@
 }
 
 .o_web_client:has(.o-mail-Discuss) .o_control_panel {
-    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, 0)};
+    --ControlPanel-border-bottom: #{$border-width} solid #{rgba($border-color, .25)};
 }


### PR DESCRIPTION
1.  lower opacity on pinned message cards
2. show low opacity separator above discuss app
3. better spacing between msg bubble and next msg notification