### PR TITLE
[FIX][16.0] product: fix type in product filter

### DIFF
--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -173,7 +173,7 @@
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <group expand="1" string="Group By">
-                    <filter string="Product Type" name="type" context="{'group_by':'type'}"/>
+                    <filter string="Product Type" name="type" context="{'group_by':'detailed_type'}"/>
                     <filter string="Product Category" name="categ_id" context="{'group_by':'categ_id'}"/>
                 </group>
             </search>


### PR DESCRIPTION
### Reason
- In Product module, there are two type of product types : type and detailed_type. While they share similar names, they filter different results. The type field only filters consumables and services, whereas detailed_type have type + more specific categories such as Clothing, Electronics, Furniture,...etc making it more relevant for users.

- I suggest change the default filter to detailed_type to avoid confusion. Since users are likely to rely on this filter frequently, it should be set as the default not type.

Description of the issue/feature this PR addresses:

Current behavior before PR:
-Filter by type:

![image](https://github.com/user-attachments/assets/4a05878a-a3fc-4a3e-ba56-ce3bfbd4ffdc)


Desired behavior after PR is merged:
-Filter by detailed_type:

![image](https://github.com/user-attachments/assets/d0b15eef-77c5-42d5-b72c-9bf021572ef1)



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
