### PR TITLE
[FIX] project_purchase: fix error when opening dashboard of project

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -156,6 +156,8 @@ class ProjectProject(models.Model):
                     if purchase_line.invoice_lines:
                         for line in purchase_line.invoice_lines:
                             price_subtotal = line.currency_id._convert(line.price_subtotal, self.currency_id, self.company_id)
+                            if not line.analytic_distribution:
+                                continue
                             # an analytic account can appear several time in an analytic distribution with different repartition percentage
                             analytic_contribution = sum(
                                 percentage for ids, percentage in line.analytic_distribution.items()


### PR DESCRIPTION
When user tries to open the dashboard of project,
A traceback will appear.

Steps to reproduce the error:
- Install ``sale_management``, ``project_purchase`` and ``accountant`` modules
- Go to Settings > Enable Analytic Accounting
- Create Project A > Billable: True > Go to Settings >
  Select any analytic account in project(account_id)
- Make sure that bills are available
- Create A new PO > add any product > Other Information > Project: Project A >
  Confirm Order > Bill Matching > Select a line > Match > Bill will be created
- Remove Analytic from Invoice Lines of the bill
- Go to Project > click on dropdown menu of Project A > Dashboard

Traceback:
```
File "/home/odoo/src/odoo/addons/project_purchase/models/project_project.py", line 161, in _get_profitability_items
    percentage for ids, percentage in line.analytic_distribution.items()
AttributeError: 'bool' object has no attribute 'items'
```

https://github.com/odoo/odoo/blob/9cebb8c23d66a6aadd06bf0d806c65b67dc13ae7/addons/project_purchase/models/project_project.py#L161
When a user removes the analytic from the invoice lines of a bill,
``line.analytic_distribution`` becomes False,
So, It will lead to the above traceback.

sentry-6638122973

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
