### PR TITLE
[FIX] l10n_in: reload fiscal position data for branch company

### DIFF
--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -129,3 +129,10 @@ class ResConfigSettings(models.TransientModel):
                 'views': [[self.env.ref('base.view_company_form').id, 'form']],
             }
             raise RedirectWarning(_("Please enter a GST number in company."), action, _("Go to Company"))
+
+    def reload_template(self):
+        super().reload_template()
+        if self.country_code == 'IN':
+            branch_companies = self.company_id.child_ids
+            if branch_companies:
+                branch_companies._update_l10n_in_fiscal_position()


### PR DESCRIPTION
In commit https://github.com/odoo/odoo/commit/bd6cd2d4a84f22d2adc27c962f81903dc284569e, the issue related to mapping taxes with fiscal positions of branch companies was resolved. However, for existing databases, the taxes are not automatically mapped with the fiscal positions of branch companies. To address this, the fiscal position data for branch companies also needs to be reloaded.

With this PR, when reloading chart template data for the parent company, the fiscal position data for all branch companies will now also be reloaded to ensure proper tax mapping.
