### PR TITLE
[FIX] base_automation, mail: crash when clicking on envelope in chatter

### DIFF
--- a/addons/base_automation/tests/test_mail_composer.py
+++ b/addons/base_automation/tests/test_mail_composer.py
@@ -38,6 +38,7 @@ class TestMailFullComposer(MailCommon, HttpCase):
             "login": "nadu",
             "partner_id": user_partner.id
         })
+        partner.message_subscribe(partner_ids=[self.user_admin.partner_id.id])
         with self.mock_mail_app():
             self.start_tour(
                 f"/odoo/res.partner/{partner.id}",

--- a/addons/mail/static/src/core/common/notification_model.js
+++ b/addons/mail/static/src/core/common/notification_model.js
@@ -78,7 +78,7 @@ export class Notification extends Record {
 
     get isFollowerNotification() {
         return this.mail_message_id.thread.followers.some(
-            (follower) => follower.partner_id.id === this.persona.id
+            (follower) => follower.partner_id.id === this.res_partner_id.id
         );
     }
 

--- a/addons/mail/static/tests/tours/mail_composer_test_tour.js
+++ b/addons/mail/static/tests/tours/mail_composer_test_tour.js
@@ -140,7 +140,7 @@ registry.category("web_tour.tours").add("mail/static/tests/tours/mail_composer_t
         {
             content: "Check message has correct recipients",
             trigger:
-                ".o-mail-MessageNotificationPopover:contains('Not A Demo User (NotADemoUser@mail.com)\nJane (jane@example.com)')",
+                ".o-mail-MessageNotificationPopover:contains('Not A Demo User (NotADemoUser@mail.com)\nJane (jane@example.com)\nMitchell Admin (test.admin@test.example.com)')",
         },
         {
             content: "Check message contains the first attachment",

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -280,6 +280,7 @@ class TestMailComposerUI(MailCommon, HttpCase):
             "login": "nadu",
             "partner_id": user_partner.id
         })
+        partner.message_subscribe(partner_ids=[self.user_admin.partner_id.id])
         with self.mock_mail_app():
             self.start_tour(
                 f"/odoo/res.partner/{partner.id}",


### PR DESCRIPTION
**Current behavior before PR:**

Clicking on the envelope icon in the chatter after sending a message would cause a crash. This was due to the use of the outdated `persona` field name when checking followers, which had been renamed to `res_partner_id` [here](https://github.com/odoo/odoo/pull/210990).

**Desired behavior after PR is merged:**

The field name has been correctly updated from `persona` to `res_partner_id`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
