### PR TITLE
[FIX] core: allow underscore in extension

### DIFF
--- a/odoo/addons/base/tests/test_mimetypes.py
+++ b/odoo/addons/base/tests/test_mimetypes.py
@@ -135,6 +135,7 @@ class test_guess_mimetype(BaseCase):
         self.assertEqual(get_extension('filename.Abc'), '.abc')
         self.assertEqual(get_extension('filename.scss'), '.scss')
         self.assertEqual(get_extension('filename.torrent'), '.torrent')
+        self.assertEqual(get_extension('filename.ab_c'), '.ab_c')
         self.assertEqual(get_extension('.htaccess'), '')
         # enough to suppose that extension is present and don't suffix the filename
         self.assertEqual(get_extension('filename.tar.gz'), '.gz')

--- a/odoo/tools/mimetypes.py
+++ b/odoo/tools/mimetypes.py
@@ -209,12 +209,14 @@ def neuter_mimetype(mimetype, user):
         return 'text/plain'
     return mimetype
 
+
+_extension_pattern = re.compile(r'\w+')
 def get_extension(filename):
     # A file has no extension if it has no dot (ignoring the leading one
     # of hidden files) or that what follow the last dot is not a single
     # word, e.g. "Mr. Doe"
     _stem, dot, ext = filename.lstrip('.').rpartition('.')
-    if not dot or not ext.isalnum():
+    if not dot or not _extension_pattern.fullmatch(ext):
         return ''
 
     # Assume all 4-chars extensions to be valid extensions even if it is


### PR DESCRIPTION
Step to reproduce;
- install documents
- upload a parasolid file, it has extension `x_t`
- download it

Observation: if a file is uploaded  with file named as `file.x_t`,  it will be downloaded as `file.x_t.txt`

Issue:
currently, the `get_extension` method only allow alphanumeric values for extension, which do not consider extension having '_'

https://github.com/odoo/odoo/blob/15fd3f62769b137cb9a0625f47b333424b851a27/odoo/tools/mimetypes.py#L212-L218

when such file is downloaded, `_get_stream_from` appends extra extension to the filename, depending upon its mimetype.

https://github.com/odoo/odoo/blob/15fd3f62769b137cb9a0625f47b333424b851a27/odoo/addons/base/models/ir_binary.py#L148-L150

Fix:
instead of `isalnum()`, use a regex that allows alphanumeric and underscore in extension.


opw-4801263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
