### PR TITLE
[FIX] mail: Avoid creating multiple invoice documents

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2401,7 +2401,7 @@ class MailThread(models.AbstractModel):
         """ Ease tweaking attachment creation when processing them in posting
         process. Mainly meant for stable version, to be cleaned when reaching
         master. """
-        return self.env['ir.attachment'].sudo().create(values_list)
+        return self.env['ir.attachment'].sudo().with_context(no_document=True).create(values_list)
 
     def _process_attachments_for_template_post(self, mail_template):
         """ Model specific management of attachments used with template attachments


### PR DESCRIPTION
Previously, sending an invoice using the **Send & Print** button could lead to **two identical PDF documents** being saved in the **Documents** app.

This issue occurred because:
- The system was generating **one document** when creating the **PDF**, and
- A **second document** was created when sending the **email** with the same PDF attached.

### Steps to Reproduce

1. Go to **Settings → Files Centralization → Accounting → Journals**.
2. Configure a workspace for the journal.
3. Create an invoice.
4. Send the invoice via email using **Send & Print**.
5. Observe that **two documents** are created in the **Documents** app.

### After this Fix

- The document is now created **only once**, at the moment the invoice **PDF is generated**.
- Sending the invoice by email will **no longer create an additional document**, preventing duplication in the Documents app.

### References
- 📄 [Attachment creation during email sending (`message_post`)](https://github.com/odoo/odoo/blob/643318a345bddbe1cbf4aab39fb671cbe95997eb/addons/mail/models/mail_thread.py#L2371)  
- 📄 [Attachment creation during PDF generation (`_link_invoice_documents`)](https://github.com/odoo/odoo/blob/643318a345bddbe1cbf4aab39fb671cbe95997eb/addons/account/wizard/account_move_send.py#L680)

---

opw-4681311