### PR TITLE
[FIX] mrp: prevent error when user remove date in productivity losses

### DIFF
--- a/addons/mrp/models/mrp_workcenter.py
+++ b/addons/mrp/models/mrp_workcenter.py
@@ -521,6 +521,8 @@ class MrpWorkcenterProductivity(models.Model):
 
     @api.onchange('duration')
     def _duration_changed(self):
+        if not self.date_end:
+            return
         self.date_start = self.date_end - timedelta(minutes=self.duration)
         self._loss_type_change()
 

--- a/addons/mrp/tests/test_oee.py
+++ b/addons/mrp/tests/test_oee.py
@@ -2,10 +2,12 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta, time
+from freezegun import freeze_time
 from pytz import timezone, utc
 
 from odoo import fields
 from odoo.addons.mrp.tests.common import TestMrpCommon
+from odoo.tests import Form
 
 
 class TestOee(TestMrpCommon):
@@ -17,6 +19,22 @@ class TestOee(TestMrpCommon):
             'loss_id': loss_reason.id,
             'description': loss_reason.name
         })
+
+    @freeze_time('2025-05-30')
+    def test_unset_end_date(self):
+        with Form(self.env['mrp.workcenter.productivity']) as workcenter_productivity:
+            # Set the end date to tomorrow
+            workcenter_productivity.date_end = datetime(2025, 5, 31, 12, 0, 0)
+            # Unset the end date
+            workcenter_productivity.date_end = False
+            self.assertFalse(workcenter_productivity.date_end)
+            self.assertEqual(workcenter_productivity.duration, 0.0, "The duration should be 0.0 when the end date is unset.")
+
+            workcenter_productivity.workcenter_id = self.workcenter_1
+            workcenter_productivity.date_end = datetime(2025, 5, 31, 12, 0, 0)
+            workcenter_productivity.date_start = datetime(2025, 5, 30, 12, 0, 0)
+            workcenter_productivity.save()
+            self.assertEqual(workcenter_productivity.duration, 1440.0)
 
     def test_wrokcenter_oee(self):
         """  Test case workcenter oee. """


### PR DESCRIPTION
If the `End Date` is already defined and the user removes that date in the form view of productivity losses, an error is generated.

Steps to reproduce:
---
- Install the `mrp` module
- Manufacturing > Configuration > Work Centers > Open any of the Work Centers
- In the form view of Work Center, click on the `Lost` stat button
- Open a new Productivity Loss form, set a future date in `End Date`, click elsewhere, then clear the `End Date`

Traceback:
---
`TypeError: unsupported operand type(s) for -: 'bool' and 'datetime.timedelta'`

If the end date is missing, we will return from the method

sentry-6641245276

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
