### PR TITLE
[FIX] hr_expense: remove work email constraint while posting expense

### DIFF
--- a/addons/hr_expense/models/hr_expense_sheet.py
+++ b/addons/hr_expense/models/hr_expense_sheet.py
@@ -698,12 +698,6 @@ class HrExpenseSheet(models.Model):
                 "Please specify if the expenses for this report were paid by the company, or the employee"
             ))
 
-        missing_email_employees = self.filtered(lambda sheet: not sheet.employee_id.work_email).employee_id
-        if missing_email_employees:
-            action = self.env['ir.actions.actions']._for_xml_id('hr.open_view_employee_list_my')
-            action['domain'] = [('id', 'in', missing_email_employees.ids)]
-            raise RedirectWarning(_("The work email of some employees is missing. Please add it on the employee form"), action, _("Show missing work email employees"))
-
     def _do_submit(self):
         self.approval_state = 'submit'
         self.sudo().activity_update()

--- a/addons/hr_expense/tests/test_expenses.py
+++ b/addons/hr_expense/tests/test_expenses.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
-from odoo.exceptions import RedirectWarning, UserError, ValidationError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tests import tagged, Form
 from odoo.tools.misc import format_date
 
@@ -1220,24 +1220,6 @@ class TestExpenses(TestExpenseCommon):
                 lambda att: att.checksum in sheet.expense_line_ids.attachment_ids.mapped('checksum')
             ).unlink()
             assert_attachments_are_synced(sheet, sheet_attachment, sheet_has_attachment)
-
-    def test_expense_sheet_with_employee_of_no_work_email(self):
-        """
-        Should raise a RedirectWarning when the selected employee in the sheet doesn't have a work email.
-        """
-        # Create two employees with no work email
-        employee = self.env["hr.employee"].create([
-            {
-                'name': "Test Employee1"
-            },
-        ])
-        # Create an expense with the above created employees
-        expense = self.create_expense({'employee_id': employee.id})
-        sheet = expense._create_sheets_from_expense()
-
-        sheet.action_submit_sheet()
-        with self.assertRaises(RedirectWarning):
-            sheet.action_approve_expense_sheets()
 
     def test_create_report_name(self):
         """


### PR DESCRIPTION
- removed work email constraint while posting the expense as the partner 
  is now created without the need of work email

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
