### PR TITLE
[IMP] core: clear the transaction cache

### DIFF
--- a/odoo/orm/environments.py
+++ b/odoo/orm/environments.py
@@ -575,6 +575,9 @@ class Transaction:
         self.field_data_patches.clear()
         self.field_dirty.clear()
         self.tocompute.clear()
+        for env in self.envs:
+            env.cr.cache.clear()
+            break  # all envs of the transaction share the same cursor
 
     def reset(self) -> None:
         """ Reset the transaction.  This clears the transaction, and reassigns

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -514,7 +514,7 @@ class Cursor(BaseCursor):
         if not self._obj:
             return
 
-        del self.cache
+        self.cache.clear()
 
         # advanced stats only at logging.DEBUG level
         self.print_log()


### PR DESCRIPTION
When clearing the transaction, we should clear the local cache of the transaction as well. This cache is used to store data local to the database transaction.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
