### PR TITLE
[FIX] account: markdown tax name_search

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -636,14 +636,15 @@ class AccountTax(models.Model):
         return vals_list
 
     @api.depends('type_tax_use', 'tax_scope')
-    @api.depends_context('append_type_to_tax_name')
+    @api.depends_context('append_fields', 'append_type_to_tax_name')
     def _compute_display_name(self):
         type_tax_use = dict(self._fields['type_tax_use']._description_selection(self.env))
+        fields_to_include = set(self.env.context.get('append_fields') or [])
         for record in self:
             if name := record.name:
                 if self._context.get('append_type_to_tax_name'):
                     name += ' (%s)' % type_tax_use.get(record.type_tax_use)
-                if len(self.env.companies) > 1 and self.env.context.get('params', {}).get('model') == 'product.template':
+                if 'company_id' in fields_to_include and len(self.env.companies) > 1:
                     name += ' (%s)' % record.company_id.display_name
                 if record.country_id != record.company_id._accessible_branches()[:1].account_fiscal_country_id:
                     name += ' (%s)' % record.country_code

--- a/addons/account/views/product_view.xml
+++ b/addons/account/views/product_view.xml
@@ -10,8 +10,8 @@
                     <field name="default_code"/>
                     <field name="name"/>
                     <field name="list_price"/>
-                    <field name="taxes_id" widget="many2many_tags"/>
-                    <field name="supplier_taxes_id" widget="many2many_tags"/>
+                    <field name="taxes_id" widget="many2many_tags" context="{'append_fields': ['company_id']}"/>
+                    <field name="supplier_taxes_id" widget="many2many_tags" context="{'append_fields': ['company_id']}"/>
                     <field name="activity_exception_decoration" widget="activity_exception"/>
                 </list>
             </field>
@@ -85,6 +85,7 @@
                                 'search_default_sale': 1,
                                 'search_default_service': type == 'service',
                                 'search_default_goods': type == 'consu',
+                                'append_fields': ['company_id'],
                             }"
                         />
                         <field name="tax_string" class="oe_inline"/>
@@ -99,6 +100,7 @@
                             'search_default_purchase': 1,
                             'search_default_service': type == 'service',
                             'search_default_goods': type == 'consu',
+                            'append_fields': ['company_id'],
                         }"
                     />
                 </div>


### PR DESCRIPTION
Backport of some changes included here https://github.com/odoo/odoo/commit/2cf73ba8fe50288a0ea9d0ad4b8aeb51bc345740

The goal of this pr is to see for which company belongs each sale/purchase tax in a product when more than one company is selected.

This pr solves odoo task #4829985 and this issue https://github.com/odoo/odoo/issues/147673

Steps to reproduce:

1) Go to runbot odoo enterprise 18 instance and select companies "My Belgian Company" and "My Company (San Francisco)" taking position in "My Belgian Company".

2) Go to "Accounting / Customers / Products" and get into product with name "Bolt" and internal reference "CONS_89957". There is shown two taxes in "Sale Taxes" and "Purchase Taxes" fields but is not possible to distinguish for which company belongs each tax.

Current behavior:
It can not be distinguished whenever for which company belongs each customer tax in a product if more than one company is selected.

Expected behavior:
It can be distinguished whenever for which company belongs each customer tax in a product if more than one company is selected.

Task Adhoc side: 52262

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
