### PR TITLE
[FIX] account: adding amount_currency in the key of discount

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1023,6 +1023,7 @@ class AccountMoveLine(models.Model):
             for line in self.move_id.line_ids
             if line.display_type == 'product'
             and (discount_allocation_account := line.move_id._get_discount_allocation_account())
+            and line.account_id != discount_allocation_account
             and (amount := line.currency_id.round(
                 line.move_id.direction_sign * line.quantity * line.price_unit * line.discount / 100
             ))


### PR DESCRIPTION
Problem:
  - When using the same account for both discount allocation and payment method, the system failed to distinguish between the two discount lines resulting in an imbalance during accounting entry generation.

Solution:
  - Added `amount_currency` as part of the key in the discount allocation logic to correctly differentiate between the positive and negative entries.

opw-4806356




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
