### PR TITLE
[FIX] sale_crm: default_user_id during SO confirmation

### DIFF
--- a/addons/sale_crm/models/sale_order.py
+++ b/addons/sale_crm/models/sale_order.py
@@ -12,4 +12,4 @@ class SaleOrder(models.Model):
         domain="[('type', '=', 'opportunity'), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
 
     def action_confirm(self):
-        return super(SaleOrder, self.with_context({k:v for k,v in self._context.items() if k != 'default_tag_ids'})).action_confirm()
+        return super(SaleOrder, self.with_context({k: v for k, v in self._context.items() if k not in ['default_tag_ids', 'default_user_id']})).action_confirm()


### PR DESCRIPTION
Steps to reproduce:
When creating or confirming an SO when navigating from a crm.lead, the default_user_id gets set in the context and never gets removed.

- Let's consider if we create an SO and confirm it from a crm.lead with a user_id (Salesperson) set
- This user_id will populate subsequent records

Current behavior before PR:
For opw-4713198, quality.check records were being created with a user_id (Responsible) set, even though the quality_state was still in the "To Do" (None) stage.

Desired behavior after PR is merged:
The default_user_id context gets cleared once we confirm the SO

Caused by:
https://github.com/odoo/odoo/pull/79352

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr