### PR TITLE
[FIX] mail: prevent template attachments to be deleted from composer

### DIFF
--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -236,9 +236,9 @@ class TestComposerForm(TestMailComposer):
         composer_form.template_id = template_1
         self.assertEqual(len(composer_form.attachment_ids), 4)
         report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
-        self.assertEqual(len(report_attachments), 2)
+        self.assertEqual(len(report_attachments), 4)
         tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(*report_attachments)
-        self.assertEqual(tpl_attachments, template_1_attachments)
+        self.assertFalse(tpl_attachments, "template attchment shouldn't be used directly")
 
         # change template: 0 static (attachment_ids) and 1 dynamic (report)
         composer_form.template_id = template_2
@@ -252,9 +252,9 @@ class TestComposerForm(TestMailComposer):
         composer_form.template_id = template_1
         self.assertEqual(len(composer_form.attachment_ids), 4)
         report_attachments = [att for att in composer_form.attachment_ids if att not in template_1_attachments]
-        self.assertEqual(len(report_attachments), 2)
+        self.assertEqual(len(report_attachments), 4)
         tpl_attachments = composer_form.attachment_ids[:] - self.env['ir.attachment'].concat(*report_attachments)
-        self.assertEqual(tpl_attachments, template_1_attachments)
+        self.assertFalse(tpl_attachments, "template attchment shouldn't be used directly (2)")
 
         # reset template
         composer_form.template_id = self.env['mail.template']
@@ -603,9 +603,9 @@ class TestComposerInternals(TestMailComposer):
                 if composition_mode == 'comment' and not batch:
                     self.assertEqual(len(composer.attachment_ids), 5)
                     for attach in attachs:
-                        self.assertIn(attach, composer.attachment_ids)
+                        self.assertNotIn(attach, composer.attachment_ids, "Template attachment should be copied, not used directly.")
                     generated = composer.attachment_ids - attachs
-                    self.assertEqual(len(generated), 2, 'MailComposer: should have 2 additional attachments for reports')
+                    self.assertEqual(len(generated), 5, 'MailComposer: should have 5 additional attachments for reports')
                     self.assertEqual(
                         sorted(generated.mapped('name')),
                         sorted([f'TestReport for {self.test_record.name}.html', f'TestReport2 for {self.test_record.name}.html']))


### PR DESCRIPTION
Removing an attachment (coming from a mail template) in the mail
composer wrongly removes it from the template.

- Edit the "Sales: Send Quotation" mail template, add it an attachment
- Go to a draft quotation
- Click on "Send", it will open the mail composer which will use the template. You should see the file you added on the template.
- Now, remove that file from the composer. For instance, for this client you don't want to send it, or you want to replace it or whatever.
- The mail attachment has also been deleted from the template, not only from the current mail.
- Note that you don't need to send it, just deleting it in the composer is enough to have it removed on the template.

Many refactoring were made in `mail` between Odoo 17 and 18, breaking this flow.

Another solution would be to change that in JS side, somehow managing to call `delete()` and not `remove()` in `/mail/[..]/attachment_model.js`. The caller is in `unlink()` in `/mail/[..]/attachment_upload_service.js` which is itself called by `onFileRemove()` from
`/mail/[..]/mail_composer_attachment_list.js`.

That would've kept using the same attachment record as the one in the template without removing it from the template when it's removed from the composer.

The python solution seems more straightforward and since it's creating new attachment no other bugs should arise.

Finally, note that "ghost" attachment are garbage collected through the `_gc_lost_attachments()` autovacuum method, looking for attachment having `res_id=0` and `mail.compose.message` as model.

task-4748058
