### PR TITLE
[FIX] pos_loyalty: prevent error when reference ids not found on module loading

### DIFF
--- a/addons/pos_loyalty/data/pos_loyalty_demo.xml
+++ b/addons/pos_loyalty/data/pos_loyalty_demo.xml
@@ -7,7 +7,7 @@
             <field name="program_type">next_order_coupons</field>
             <field name="trigger">auto</field>
             <field name="applies_on">future</field>
-            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main')])]"/>
+            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main', raise_if_not_found=False)])]"/>
             <field name="portal_visible">True</field>
             <field name="portal_point_name">Coupon point(s)</field>
         </record>
@@ -25,15 +25,15 @@
         </record>
 
         <record id="loyalty.3_cabinets_plus_1_free" model="loyalty.program">
-            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main')])]" />
+            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main', raise_if_not_found=False)])]" />
         </record>
 
         <record id="loyalty.10_percent_with_code" model="loyalty.program">
-            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main')])]" />
+            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main', raise_if_not_found=False)])]" />
         </record>
 
         <record id="loyalty.10_percent_coupon" model="loyalty.program">
-            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main')])]" />
+            <field name="pos_config_ids" eval="[(6,0,[ref('point_of_sale.pos_config_main', raise_if_not_found=False)])]" />
         </record>
 
         <function name="create" model="loyalty.generate.wizard">


### PR DESCRIPTION
Currently, an error may occur if a referenced record ID is not found during XML data loading. This can happen in various scenarios, including:
- While loading demo data during module installation.
- When an exception interrupts demo data loading, it prevents remaining data from being processed.
- When demo data is being loaded while the module is simultaneously being uninstalled in another session.

**Steps to Reproduce:**
- Install all the modules without demo data.
- Go to settings and manually load the demo data.
- If a user error occurs during this process, the demo data load will fail and raise an error.

**Error:**
`Could not eval([(4, ref('mrp.product_product_computer_desk'))]) for product_ids in {"lang":null}`

This commit applies `raise_if_not_found=False` to XML references in `eval`, preventing errors when the referenced external ids are missing.

Related-enterprise-PR: https://github.com/odoo/enterprise/pull/86681

Sentry - 3935871751