### PR TITLE
[FIX] l10n_gcc_pos: avoid duplicate 'Served by' text in POS receipt

### DIFF
--- a/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -19,7 +19,7 @@
         </xpath>
         <xpath expr="//div[@t-esc='props.data.cashier']/.." position="after">
             <div t-if="props.data.is_gcc_country" t-translation="off">
-                <div>Served by / خدم بواسطة <t t-esc="props.data.cashier"/></div>
+                <div>Served by / خدم بواسطة <t t-esc="props.data.gcc_cashier"/></div>
             </div>
         </xpath>
     </t>

--- a/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
+++ b/addons/l10n_gcc_pos/static/src/overrides/pos_store.js
@@ -8,6 +8,7 @@ patch(PosStore.prototype, {
             is_gcc_country: ["SA", "AE", "BH", "OM", "QA", "KW"].includes(
                 this.company.country_id?.code
             ),
+            gcc_cashier: order?.getCashierName() || this.get_cashier()?.name,
         };
     },
 });


### PR DESCRIPTION
Steps to reproduce:
1. Install l10n_gcc_pos.
2. Set the company’s country to a GCC country.
3. Print a POS receipt.

Issue:
- The receipt displays the phrase 'Served by' multiple times first two hardcoded and third one from prefix due to the cashier prop already including the prefix 'Served by '.
- https://github.com/odoo/odoo/blob/f2dc7b5aaaf60d23e42e92f1ca0c6eed4ea13bf2/addons/l10n_gcc_pos/static/src/overrides/app/screens/receipt_screen/receipt/order_receipt.xml#L22

- Standard header data
https://github.com/odoo/odoo/blob/0f8546528566acbcd2dd2fc1a99ae148ea2a7895/addons/point_of_sale/static/src/app/store/pos_store.js#L2099-L2105

Solution:
- Replace cashier prop with gcc_cashier to return only the cashier’s name, without the 'Served by ' prefix. This avoids duplication and allows the template to handle translations consistently.

opw-4724578