### PR TITLE
[FIX] account_move: add 'Error' status to E-Factura selection

### DIFF
--- a/addons/l10n_ro_edi/models/account_move.py
+++ b/addons/l10n_ro_edi/models/account_move.py
@@ -13,6 +13,7 @@ class AccountMove(models.Model):
     l10n_ro_edi_state = fields.Selection(
         selection=[
             ('invoice_sent', 'Sent'),
+            ('invoice_sending_failed', 'Error'),
             ('invoice_validated', 'Validated'),
         ],
         string='E-Factura Status',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 add missing 'Error' status to E-Factura selection

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
