### PR TITLE
[FIX] hr_recruitment: added check for scenario data already loaded

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -376,8 +376,16 @@ class HrJob(models.Model):
         }
         return action
 
+    def has_recruitment_scenario_data(self):
+        return bool(self.env.ref('hr_recruitment.scenario_applicant_macm_enrique_cv', raise_if_not_found=False))
+
     @api.model
     def _action_load_recruitment_scenario(self):
+        if self.has_recruitment_scenario_data():
+            return {
+            "type": "ir.actions.client",
+            "tag": "reload",
+        }
 
         convert_file(
             self.sudo().env,


### PR DESCRIPTION
Currently, an error occurs when the user attempts load scenario data through a server action.

Steps to replicate:
- Go to `Server Actions > search `Load Demo Data` > Create contextual action`.
- Go to Recruitment > go to Job Positions form view > Run the server action twice, and you will get the error.

Error:
`ValueError: ParseError('while parsing /home/odoo/odoo18/community/addons/...')` `UniqueViolation: duplicate key value violates unique constraint 'documents_document_attachment_unique'`

This error occurs due to a unique  constraint on documents, which causes a uniqueness violation on ir.attachment [1] when attempting to import the same record twice.

This commit fixes the issue by checking if the scenario data has already been imported. If it has, the import is skipped to prevent uniqueness violation.

[1]-https://github.com/odoo/odoo/blob/4b4fb5b9a655db4d3b9adb8d6a875f01d27a4806/addons/hr_recruitment/data/scenarios/hr_recruitment_scenario.xml#L194

sentry-6636243614
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
