### PR TITLE
[PERF] core: _get_attrs OrderedDict

### DIFF
--- a/odoo/orm/fields.py
+++ b/odoo/orm/fields.py
@@ -16,7 +16,7 @@ from psycopg2.extras import Json as PsycopgJson
 from odoo.exceptions import AccessError, MissingError
 from odoo.tools import Query, SQL, sql
 from odoo.tools.constants import PREFETCH_MAX
-from odoo.tools.misc import SENTINEL, OrderedSet, ReadonlyDict, Sentinel, unique
+from odoo.tools.misc import SENTINEL, ReadonlyDict, Sentinel, unique
 
 from .domains import NEGATIVE_CONDITION_OPERATORS, Domain
 from .utils import COLLECTION_TYPES, SQL_OPERATORS, SUPERUSER_ID, expand_ids
@@ -428,7 +428,8 @@ class Field(typing.Generic[T]):
         attrs['model_name'] = model_class._name
         attrs['name'] = name
         attrs['_module'] = modules[-1] if modules else None
-        attrs['_modules'] = tuple(OrderedSet(modules))
+        # the following is faster than calling unique or using OrderedSet
+        attrs['_modules'] = tuple(unique(modules) if len(modules) > 1 else modules)
 
         # initialize ``self`` with ``attrs``
         if name == 'state':


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Using `OrderedDict` is slower than `unique`. Since the setup is done for each field, using misc is noticable at startup and we have very often only 1 module in the list.

Performance:
```
In [1]: def x():
   ...:     class X(odoo.models.Model):
   ...:         name = odoo.fields.Char()
   ...:         age = odoo.fields.Integer()
   ...:         _module = 'odoo.addons.abc'
   ...:         _name = 'x'


BEFORE:
In [3]: %timeit x()
31.8 μs ± 396 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

AFTER:
In [5]: %timeit x()
29.6 μs ± 166 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

We have more than 1 module in `modules` only around 2% of the time.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
