### PR TITLE
[FIX] website_event_exhibitor: fix missing prop error in debug mode.

### DIFF
--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.js
@@ -10,6 +10,7 @@ export class ExhibitorConnectClosedDialog extends Component {
     static components = { Dialog };
     static props = {
         sponsorId: Number,
+        close: Function,
     };
 
     setup() {


### PR DESCRIPTION
Steps to reproduce:
1. Open Event > any upcoming event
2. make sure to check website submenu and showcase exhibitors
3. Create a sponsor with the exhibitor type and publish the website
4. Open private window in browser and go to exhibitor page by
5. Go to Events > Modfied Event > Exhibitor submenu
6. Turn on debug mode
7. Now click on more info button inside the exhibitor card

Issue:
- Invalid prop 'close' is used but not passed.

Solution:
- Add close prop in ExhibitorConnectClosedDialog

Backport of https://github.com/odoo/odoo/commit/a8a0e3b7a36e743aa24c51f96f1947e3bcaa5a5f

opw-4737183