### PR TITLE
[FIX] mail, html_editor: sync editor when attachment is removed

### DIFF
--- a/addons/html_editor/static/src/main/link/link_plugin.js
+++ b/addons/html_editor/static/src/main/link/link_plugin.js
@@ -515,8 +515,11 @@ export class LinkPlugin extends Plugin {
                     ...props,
                     isImage: false,
                     linkEl: this.linkElement,
-                    onApply: (url, label, classes) => {
+                    onApply: (url, label, classes, attachmentId) => {
                         this.linkElement.href = url;
+                        if (attachmentId) {
+                            this.linkElement.dataset.attachmentId = attachmentId;
+                        }
                         if (cleanZWChars(this.linkElement.innerText) === label) {
                             this.overlay.close();
                             this.dependencies.selection.setSelection(

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -108,7 +108,12 @@ export class LinkPopover extends Component {
         this.state.url = deducedUrl
             ? this.correctLink(deducedUrl)
             : this.correctLink(this.state.url);
-        this.props.onApply(this.state.url, this.state.label, this.state.classes);
+        this.props.onApply(
+            this.state.url,
+            this.state.label,
+            this.state.classes,
+            this.state.attachmentId
+        );
     }
     onClickEdit() {
         this.state.editing = true;
@@ -303,6 +308,7 @@ export class LinkPopover extends Component {
         this.props.onUpload?.(attachment);
         this.state.url = getURL(attachment, { download: true, unique: true, accessToken: true });
         this.state.label ||= attachment.name;
+        this.state.attachmentId = attachment.id;
     }
 
     isAttachmentUrl() {

--- a/addons/html_editor/static/src/main/media/file_plugin.js
+++ b/addons/html_editor/static/src/main/media/file_plugin.js
@@ -75,7 +75,7 @@ export class FilePlugin extends Plugin {
             unique: true,
             accessToken: true,
         });
-        const { name: filename, mimetype } = attachment;
-        return renderStaticFileBox(filename, mimetype, url);
+        const { name: filename, mimetype, id } = attachment;
+        return renderStaticFileBox(filename, mimetype, url, id);
     }
 }

--- a/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/document_selector.js
@@ -81,14 +81,20 @@ export class DocumentSelector extends FileSelector {
     }
 
     static renderFileElement(attachment, downloadUrl) {
-        return renderStaticFileBox(attachment.name, attachment.mimetype, downloadUrl);
+        return renderStaticFileBox(
+            attachment.name,
+            attachment.mimetype,
+            downloadUrl,
+            attachment.id
+        );
     }
 }
 
-export function renderStaticFileBox(filename, mimetype, downloadUrl) {
+export function renderStaticFileBox(filename, mimetype, downloadUrl, id) {
     const rootSpan = document.createElement("span");
     rootSpan.classList.add("o_file_box");
     rootSpan.contentEditable = false;
+    rootSpan.dataset.attachmentId = id;
     const bannerElement = renderToElement("html_editor.StaticFileBox", {
         fileModel: { filename, mimetype, downloadUrl },
     });

--- a/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
+++ b/addons/html_editor/static/src/main/media/media_dialog/image_selector.js
@@ -132,8 +132,13 @@ export class ImageSelector extends FileSelector {
         const domain = super.attachmentsDomain;
         domain.push(["mimetype", "in", IMAGE_MIMETYPES]);
         if (!this.props.useMediaLibrary) {
-            domain.push("|", ["url", "=", false],
-                "!", "|", ["url", "=ilike", "/html_editor/shape/%"], ["url", "=ilike", "/web_editor/shape/%"],
+            domain.push(
+                "|",
+                ["url", "=", false],
+                "!",
+                "|",
+                ["url", "=ilike", "/html_editor/shape/%"],
+                ["url", "=ilike", "/web_editor/shape/%"]
             );
         }
         domain.push("!", ["name", "=like", "%.crop"]);
@@ -334,10 +339,11 @@ export class ImageSelector extends FileSelector {
             .concat(savedMedia)
             .map((attachment) => {
                 // Color-customize dynamic SVGs with the theme colors
-                if (attachment.image_src && (
-                    attachment.image_src.startsWith("/html_editor/shape/") ||
-                    attachment.image_src.startsWith("/web_editor/shape/")
-                )) {
+                if (
+                    attachment.image_src &&
+                    (attachment.image_src.startsWith("/html_editor/shape/") ||
+                        attachment.image_src.startsWith("/web_editor/shape/"))
+                ) {
                     const colorCustomizedURL = new URL(
                         attachment.image_src,
                         window.location.origin
@@ -371,6 +377,7 @@ export class ImageSelector extends FileSelector {
                 }
                 imageEl.src = src;
                 imageEl.alt = attachment.description || "";
+                imageEl.dataset.attachmentId = attachment.id;
                 return imageEl;
             })
         );

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -1019,7 +1019,7 @@ describe("upload file via link popover", () => {
         await animationFrame();
         // Created link has the correct href and label
         expect(cleanLinkArtifacts(getContent(el))).toBe(
-            `<p><a href="${expectedUrl}">file.txt[]</a></p>`
+            `<p><a href="${expectedUrl}" data-attachment-id="1">file.txt[]</a></p>`
         );
     });
 

--- a/addons/mail/static/src/chatter/web/form_controller.js
+++ b/addons/mail/static/src/chatter/web/form_controller.js
@@ -1,11 +1,16 @@
 import { createDocumentFragmentFromContent } from "@mail/utils/common/html";
 
-import { useSubEnv } from "@odoo/owl";
+import { EventBus, useSubEnv } from "@odoo/owl";
 
 import { x2ManyCommands } from "@web/core/orm_service";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { FormController } from "@web/views/form/form_controller";
+
+FormController.props = {
+    ...FormController.props,
+    fullComposerBus: { type: EventBus, optional: true },
+};
 
 patch(FormController.prototype, {
     setup() {

--- a/addons/mail/static/src/chatter/web/mail_composer_form.js
+++ b/addons/mail/static/src/chatter/web/mail_composer_form.js
@@ -11,14 +11,13 @@ export class MailComposerFormController extends formView.Controller {
         ...formView.Controller.props,
         fullComposerBus: { type: EventBus, optional: true },
     };
+    static defaultProps = { fullComposerBus: new EventBus() };
     setup() {
         super.setup();
         toRaw(this.env.dialogData).model = "mail.compose.message";
-        if (this.props.fullComposerBus) {
-            useSubEnv({
-                fullComposerBus: this.props.fullComposerBus,
-            });
-        }
+        useSubEnv({
+            fullComposerBus: this.props.fullComposerBus,
+        });
     }
 }
 

--- a/addons/mail/static/src/core/web/mail_composer_attachment_list.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_list.js
@@ -2,7 +2,7 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import {
     many2ManyBinaryField,
-    Many2ManyBinaryField
+    Many2ManyBinaryField,
 } from "@web/views/fields/many2many_binary/many2many_binary_field";
 
 export class MailComposerAttachmentList extends Many2ManyBinaryField {
@@ -23,6 +23,9 @@ export class MailComposerAttachmentList extends Many2ManyBinaryField {
         if (attachment) {
             await this.attachmentUploadService.unlink(attachment);
         }
+        this.env.fullComposerBus.trigger("ATTACHMENT_REMOVED", {
+            id: attachment.id,
+        });
     }
 }
 

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -5,6 +5,7 @@ import { useBus } from "@web/core/utils/hooks";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MentionPlugin } from "./mention_plugin";
 import { SIGNATURE_CLASS } from "@html_editor/main/signature_plugin";
+import { fillEmpty } from "@html_editor/utils/dom";
 
 export class HtmlComposerMessageField extends HtmlMailField {
     setup() {
@@ -26,6 +27,17 @@ export class HtmlComposerMessageField extends HtmlMailField {
                 const textValue = elContent.innerText.replace(/(\t|\n)+/g, "\n");
                 elContent.remove();
                 ev.detail.onSaveContent(textValue, emailAddSignature);
+            });
+            useBus(this.env.fullComposerBus, "ATTACHMENT_REMOVED", (ev) => {
+                const attachmentElements = this.editor.editable.querySelectorAll(
+                    `[data-attachment-id="${ev.detail.id}"]`
+                );
+                attachmentElements.forEach((element) => {
+                    const parent = element.parentElement;
+                    element.remove();
+                    fillEmpty(parent);
+                });
+                this.editor.shared.history.addStep();
             });
         }
     }

--- a/addons/mail/static/tests/composer/html_composer_message_field.test.js
+++ b/addons/mail/static/tests/composer/html_composer_message_field.test.js
@@ -3,7 +3,7 @@ import { insertText } from "@html_editor/../tests/_helpers/user_actions";
 import { FileSelector } from "@html_editor/main/media/media_dialog/file_selector";
 import { uploadService } from "@html_editor/main/media/media_dialog/upload_progress_toast/upload_service";
 import { HtmlComposerMessageField } from "@mail/views/web/fields/html_composer_message_field/html_composer_message_field";
-import { beforeEach, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import {
     manuallyDispatchProgrammaticEvent,
     press,
@@ -11,6 +11,7 @@ import {
     queryAllTexts,
     queryOne,
     waitFor,
+    waitForNone,
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame } from "@odoo/hoot-mock";
 import {
@@ -21,8 +22,9 @@ import {
     mountViewInDialog,
     onRpc,
     patchWithCleanup,
+    serverState,
 } from "@web/../tests/web_test_helpers";
-import { defineMailModels, mailModels } from "../mail_test_helpers";
+import { defineMailModels, mailModels, openFormView, start } from "../mail_test_helpers";
 
 // Need this hack to use the arch in mountView(...)
 mailModels.MailComposeMessage._views = {};
@@ -195,4 +197,91 @@ test("mention a channel", async () => {
     await press("a");
     await animationFrame();
     expect.verifySteps(["get_mention_suggestions: a"]);
+});
+
+describe("Remove attachments", () => {
+    beforeEach(() => {
+        mailModels.MailComposeMessage._views = {
+            "form,false": `
+            <form js_class="mail_composer_form">
+                <field name="body" type="html" widget="html_composer_message"/>
+                <field name="attachment_ids" widget="mail_composer_attachment_list"/>
+            </form>`,
+        };
+    });
+
+    test("should remove file from html editor if removed from attachment list", async () => {
+        mockService("uploadLocalFiles", {
+            async upload() {
+                expect.step("File Uploaded");
+                return [{ id: 1, name: "file.txt", public: true, checksum: "123" }];
+            },
+        });
+        await start();
+        await openFormView("res.partner", serverState.partnerId);
+        await contains("button:contains('Log note')").click();
+        await contains("button[title='Full composer']").click();
+        await waitFor(".odoo-editor-editable");
+        const anchorNode = queryOne(".odoo-editor-editable div.o-paragraph");
+        setSelection({ anchorNode, anchorOffset: 0 });
+        await insertText(htmlEditor, "/file");
+        await press("Enter");
+        await expect.waitForSteps(["File Uploaded"]);
+        await waitFor("[name='attachment_ids'] a:contains('file.txt')");
+        await waitFor(".odoo-editor-editable .o_file_box:has(a:contains('file.txt'))");
+        await contains("[name='attachment_ids'] button:has(i.fa-times)").click();
+        await waitForNone("[name='attachment_ids'] a:contains('file.txt')");
+        await waitForNone(".odoo-editor-editable .o_file_box:has(a:contains('file.txt'))");
+    });
+
+    test("should remove image from html editor if removed from attachment list", async () => {
+        patchWithCleanup(FileSelector.prototype, {
+            async onUploaded() {
+                await super.onUploaded(...arguments);
+                expect.step("Image Uploaded");
+            },
+        });
+        onRpc("/html_editor/attachment/add_data", () => ({
+            id: 1,
+            name: "test.jpg",
+            description: false,
+            mimetype: "image/jpeg",
+            checksum: "7951a43bbfb08fd742224ada280913d1897b89ab",
+            url: false,
+            type: "binary",
+            res_id: 0,
+            res_model: "mail.compose.message",
+            public: false,
+            access_token: false,
+            image_src: "/web/image/1-a0e63e61/test.jpg",
+            image_width: 1,
+            image_height: 1,
+            original_id: false,
+        }));
+        onRpc("/web/dataset/call_kw/ir.attachment/generate_access_token", () => [
+            "129a52e1-6bf2-470a-830e-8e368b022e13",
+        ]);
+
+        await start();
+        await openFormView("res.partner", serverState.partnerId);
+        await contains("button:contains('Log note')").click();
+        await contains("button[title='Full composer']").click();
+        await waitFor(".odoo-editor-editable");
+        const anchorNode = queryOne(".odoo-editor-editable div.o-paragraph");
+        setSelection({ anchorNode, anchorOffset: 0 });
+        await insertText(htmlEditor, "/image");
+        await press("Enter");
+        await animationFrame();
+        const fileInput = queryOne(".o_select_media_dialog input.d-none.o_file_input");
+        Object.defineProperty(fileInput, "files", {
+            value: [new File([], "test.jpg", { type: "image/jpeg" })],
+        });
+        manuallyDispatchProgrammaticEvent(fileInput, "change");
+        await expect.waitForSteps(["Image Uploaded"]);
+        await waitFor("[name='attachment_ids'] a:contains('test.jpg')");
+        await waitFor(".odoo-editor-editable img[data-attachment-id='1']");
+        await contains("[name='attachment_ids'] button:has(i.fa-times)").click();
+        await waitForNone("[name='attachment_ids'] a:contains('test.jpg')");
+        await waitForNone(".odoo-editor-editable img[data-attachment-id='1']");
+    });
 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

Attachments like files and images removed from the mail attachment list were still present in the editor, resulting in broken links and 404 errors.

Desired behavior after PR is merged:

Removing an attachment from the list also removes its reference from the editor.

task-4794954

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
