### PR TITLE
[FIX] hr_expense,web: prevent traceback when attaching receipt

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -554,6 +554,8 @@ class HrExpense(models.Model):
 
     def attach_document(self, **kwargs):
         """When an attachment is uploaded as a receipt, set it as the main attachment."""
+        if not self.has_access('write') or (self.sheet_id and not self.sheet_id.has_access('write')):
+            raise UserError(_("You don't have the rights to attach a document to a submitted expense. Please reset the expense report to draft first."))
         self._message_set_main_attachment_id(self.env["ir.attachment"].browse(kwargs['attachment_ids'][-1:]), force=True)
 
     @api.model


### PR DESCRIPTION
<b>Version:</b> - 18.0

<b>Steps to Reproduce:</b>
1. Log in as Admin.
2. Install the Expenses module.
4. Go to Users > Select or Create an internal user:
   - Create an Employee for the user (if not already done).
   - Ensure Expenses is set blank.
5. Log in with this user.
6. Go to Expenses > Create a new expense.
7. Add a name and total, click "Create Report", then "Submit to Manager".
8. Go back to the expense and attempt to attach a receipt.

<b>Issue:</b>
- A traceback is raised when trying to attach receipt after submitting the report.

**Cause:**
- When setting the main attachment, the method _message_set_main_attachment_id tries to filter on
mimetype assuming it's always a string. If the attachment has False value for mimetype, this leads to
AttributeError: 'bool' object has no attribute 'endswith'.

**Solution:**
- Safely check whether the attachment exists before calling _message_set_main_attachment_id. 
This avoids passing an empty recordset and prevents triggering the downstream error.


<b>opw-4760255</b>
