### PR TITLE
[Fix] website: Unnecessary new line in alert snippet

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -76,6 +76,7 @@ export class Builder extends Component {
                 "SeparatorPlugin",
                 "StarPlugin",
                 "BannerPlugin",
+                "MoveNodePlugin",
             ]
         );
         const corePlugins = this.props.isTranslation ? [] : CORE_PLUGINS;

--- a/addons/website/views/snippets/s_alert.xml
+++ b/addons/website/views/snippets/s_alert.xml
@@ -2,9 +2,9 @@
 <odoo>
 
 <template id="s_alert" name="Alert">
-    <div class="s_alert s_alert_md alert alert-info w-100 clearfix" role="alert" data-vcss="001">
+    <div class="s_alert s_alert_md alert alert-info w-100 clearfix o-contenteditable-false" role="alert" data-vcss="001">
         <i class="fa fa-lg fa-info-circle fa-stack d-flex align-items-center justify-content-center me-3 p-2 rounded-1 s_alert_icon"/>
-        <div class="s_alert_content">
+        <div class="s_alert_content o-contenteditable-true">
             <p>Explain the benefits you offer. <br/>Don't write about products or services here, write about solutions.</p>
         </div>
     </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fixed new line in alert snippet

Current behavior before PR: An extra new line was visible in edit mode when adding an alert snippet.

Desired behavior after PR is merged: The new line is removed.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
