### PR TITLE
[IMP] tests: allow to add test_tags at runtime

### DIFF
--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -13,7 +13,8 @@ from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo import tools
 
-@tagged('odoo2google')
+
+@tagged('odoo2google', 'is_query_count')
 @patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
 class TestSyncOdoo2Google(TestSyncGoogle):
 

--- a/addons/mail/tests/test_mail_channel_as_guest.py
+++ b/addons/mail/tests/test_mail_channel_as_guest.py
@@ -6,7 +6,7 @@ from odoo.addons.base.tests.common import HttpCaseWithUserPortal, HttpCaseWithUs
 from odoo.addons.mail.tests.common import mail_new_test_user
 
 
-@odoo.tests.tagged('-at_install', 'post_install')
+@odoo.tests.tagged('-at_install', 'post_install', 'is_tour')
 class TestMailPublicPage(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     """Checks that the invite page redirects to the channel and that all
     modules load correctly on the welcome and channel page when authenticated as various users"""

--- a/addons/website/tests/test_website_visitor.py
+++ b/addons/website/tests/test_website_visitor.py
@@ -26,7 +26,7 @@ class MockVisitor(common.BaseCase):
             yield
 
 
-@tagged('-at_install', 'post_install', 'website_visitor')
+@tagged('-at_install', 'post_install', 'website_visitor', 'is_query_count')
 class WebsiteVisitorTests(MockVisitor, HttpCaseWithUserDemo):
 
     def setUp(self):

--- a/addons/website_crm/tests/test_website_visitor.py
+++ b/addons/website_crm/tests/test_website_visitor.py
@@ -9,7 +9,7 @@ from odoo.tests import tagged
 from odoo.tests.common import users
 
 
-@tagged('website_visitor')
+@tagged('website_visitor', 'is_query_count')
 class TestWebsiteVisitor(TestCrmCommon, WebsiteVisitorTests):
 
     def setUp(self):

--- a/addons/website_event/tests/test_event_visitor.py
+++ b/addons/website_event/tests/test_event_visitor.py
@@ -9,7 +9,7 @@ from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests import tagged
 
 
-@tagged('website_visitor')
+@tagged('website_visitor', 'is_query_count')
 class TestEventVisitor(TestEventOnlineCommon, WebsiteVisitorTests):
 
     def test_clean_inactive_visitors_event(self):

--- a/addons/website_event_track/tests/test_website_visitor.py
+++ b/addons/website_event_track/tests/test_website_visitor.py
@@ -8,7 +8,7 @@ from odoo.addons.website_event.tests.common import TestEventOnlineCommon
 from odoo.tests import tagged
 
 
-@tagged('website_visitor')
+@tagged('website_visitor', 'is_query_count')
 class WebsiteVisitorTestsEventTrack(TestEventOnlineCommon, WebsiteVisitorTests):
 
     def test_clean_inactive_visitors_event_track(self):

--- a/odoo/addons/base/tests/test_test_suite.py
+++ b/odoo/addons/base/tests/test_test_suite.py
@@ -29,6 +29,9 @@ if sys.version_info >= (3, 8):
         def test_test_suite(self):
             """ Check that OdooSuite handles unittest.TestCase correctly. """
 
+        def get_method_additional_tags(self, method):
+            return []
+
 
 class TestRunnerLoggingCommon(TransactionCase):
     """

--- a/odoo/addons/test_main_flows/tests/test_flow.py
+++ b/odoo/addons/test_main_flows/tests/test_flow.py
@@ -87,13 +87,15 @@ class BaseTestUi(odoo.tests.HttpCase):
 
         self.start_tour("/web", 'main_flow_tour', login="admin", timeout=180)
 
-@odoo.tests.tagged('post_install', '-at_install')
+
+@odoo.tests.tagged('post_install', '-at_install', 'is_tour')
 class TestUi(BaseTestUi):
 
     def test_01_main_flow_tour(self):
         self.main_flow_tour()
 
-@odoo.tests.tagged('post_install', '-at_install')
+
+@odoo.tests.tagged('post_install', '-at_install', 'is_tour')
 class TestUiMobile(BaseTestUi):
 
     browser_size = '375x667'

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -251,6 +251,8 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
         super().__init__(methodName)
         self.addTypeEqualityFunc(etree._Element, self.assertTreesEqual)
         self.addTypeEqualityFunc(html.HtmlElement, self.assertTreesEqual)
+        if methodName != 'runTest':
+            self.test_tags = self.test_tags | set(self.get_method_additional_tags(getattr(self, methodName)))
 
     def run(self, result):
         testMethod = getattr(self, self._testMethodName)
@@ -719,6 +721,13 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
             raise BadRequest(
                 'Request ignored during test as it does not contain the required cookie.'
             )
+
+    def get_method_additional_tags(self, test_method):
+        """override this method to add additional tags based on test method
+        :test_method str: an inspectable test method name
+        :return list: a list of tags to add
+        """
+        return []
 
 savepoint_seq = itertools.count()
 
@@ -2024,6 +2033,9 @@ class HttpCase(TransactionCase):
         """Wrapper for `browser_js` to start the given `tour_name` with the
         optional delay between steps `step_delay`. Other arguments from
         `browser_js` can be passed as keyword arguments."""
+        if not 'is_tour' in self.test_tags:
+            # change it into warning in master
+            self._logger.info('start_tour was called from a test not tagged `is_tour`')
         step_delay = ', %s' % step_delay if step_delay else ''
         code = kwargs.pop('code', "odoo.startTour('%s'%s)" % (tour_name, step_delay))
         ready = kwargs.pop('ready', "odoo.__DEBUG__.services['web_tour.tour'].tours['%s'].ready" % tour_name)
@@ -2039,6 +2051,15 @@ class HttpCase(TransactionCase):
             return sup.profile(description=request.httprequest.full_path)
         return profiler.Nested(_profiler, patch('odoo.http.Request._get_profiler_context_manager', route_profiler))
 
+    def get_method_additional_tags(self, test_method):
+        """
+        guess if the test_methods is a tour and adds an `is_tour` tag on the test
+        """
+        additional_tags = super().get_method_additional_tags(test_method)
+        method_source = inspect.getsource(test_method)
+        if 'self.start_tour' in method_source:
+            additional_tags.append('is_tour')
+        return additional_tags
 
 # kept for backward compatibility
 class HttpSavepointCase(HttpCase):

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -470,6 +470,9 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
 
             The second form is convenient when used with :func:`users`.
         """
+        if not 'is_query_count' in self.test_tags:
+            # change into warning in master
+            self._logger.info('assertQueryCount is used but the test is not tagged `is_query_count`')
         if self.warm:
             # mock random in order to avoid random bus gc
             with patch('random.random', lambda: 1):
@@ -723,11 +726,13 @@ class BaseCase(case.TestCase, metaclass=MetaCase):
             )
 
     def get_method_additional_tags(self, test_method):
-        """override this method to add additional tags based on test method
-        :test_method str: an inspectable test method name
-        :return list: a list of tags to add
+        """Guess if the test_methods is a query_count and adds an `is_query_count` tag on the test
         """
-        return []
+        additional_tags = []
+        method_source = inspect.getsource(test_method) if test_method else ''
+        if 'self.assertQueryCount' in method_source:
+            additional_tags.append('is_query_count')
+        return additional_tags
 
 savepoint_seq = itertools.count()
 


### PR DESCRIPTION
This commit add the possibility to automatically add test-tag on a test
method at runtime. A generic method `get_method_additional_tags` is
added on `BaseCase` test class. That method can be overridden to return
a list of test-tags that will be added on the test methods.

With this mechanism, the `HttpCase` class override this method to
add a `is_tour` test-tag when the `start_tour` method is used in the
test method. Also, the `start_tour` method will now emit a warning when
the method is called without being tagged `is_tour`. That way, all the
tours can now be started with the `is_tour` test-tag.
