### PR TITLE
[FIX] base: malaysian address display state name

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1013,6 +1013,7 @@
             <field name="code">my</field>
             <field name="currency_id" ref="MYR" />
             <field eval="60" name="phone_code" />
+            <field eval="'%(street)s\n%(street2)s\n%(city)s %(state_name)s %(zip)s\n%(country_name)s'"  name="address_format" />
         </record>
         <record id="mz" model="res.country">
             <field name="name">Mozambique</field>


### PR DESCRIPTION
Current behaviour:
---
When displaying a malaysian address on an invoice, the state code is shown.

Street 12
Cityname KTN 12345
Malaysia

In 17.0 and after, KTN is replaced by MY-03
(and other state codes) per ISO standards
KUL -> MY-14, PHG -> MY-06, etc.
https://github.com/odoo/odoo/commit/a8204fcf6f919cfa85411f96c11c247e1d0a6f35

Expected behaviour:
---
The state name should be displayed instead.

Street 12
Cityname Kelantan 12345
Malaysia

Steps to reproduce:
---
1. Go to Contacts
2. Create a new contact
3. Set country as Malaysia, and choose a state
4. Go to Invoice, create one
5. Select new malaysian contact
6. State code in address instead of name

Fix:
---
Added a custom address_format in res_country_data.xml

opw-4762300

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
