### PR TITLE
[FIX] bus: increase websocket subscription timeout in tests

### DIFF
--- a/addons/bus/static/tests/bus_test_helpers.js
+++ b/addons/bus/static/tests/bus_test_helpers.js
@@ -95,7 +95,7 @@ viewsRegistry.category("form").add(
 
 // should be enough to decide whether or not notifications/channel
 // subscriptions... are received.
-const TIMEOUT = 500;
+const TIMEOUT = 2000;
 
 //-----------------------------------------------------------------------------
 // Exports


### PR DESCRIPTION
The test "Message shows up even if channel data is incomplete" can occasionally fail, most likely due to high CPU usage. The websocket subscription check is timing out too early.

Increase the timeout, as done in 18.1, to reduce the likelihood of such failures.

runbot-224044