### PR TITLE
[FIX] html_editor: update powerButtons after undo restores embedded video

### DIFF
--- a/addons/html_editor/static/src/main/power_buttons_plugin.js
+++ b/addons/html_editor/static/src/main/power_buttons_plugin.js
@@ -54,6 +54,7 @@ export class PowerButtonsPlugin extends Plugin {
     resources = {
         layout_geometry_change_handlers: this.updatePowerButtons.bind(this),
         selectionchange_handlers: this.updatePowerButtons.bind(this),
+        post_mount_component_handlers: this.updatePowerButtons.bind(this),
     };
 
     setup() {

--- a/addons/html_editor/static/src/others/embedded_component_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_component_plugin.js
@@ -170,9 +170,10 @@ export class EmbeddedComponentPlugin extends Plugin {
         // just before adding the root rendered html.
         const fiber = root.node.fiber;
         const fiberComplete = fiber.complete;
-        fiber.complete = function () {
+        fiber.complete = () => {
             host.replaceChildren();
-            fiberComplete.call(this);
+            fiberComplete.call(fiber);
+            this.dispatchTo("post_mount_component_handlers");
         };
         const info = {
             root,


### PR DESCRIPTION
Steps to Reproduce:

1. Insert a video using the /video command.
2. Place the cursor on the new line below the video.
3. Press Backspace to delete the video.
4. Press Ctrl + Z to undo the deletion.
5. Observe that the `Type / for commands` hint and the magic buttons appear misaligned on different lines.

Current behavior before PR:

- After undoing video removal, the video block is remounted and at that time powerButtons position updates but iframe loads after that.
- PowerButtons update runs too early when video height is zero, causing misalignment.

Desired behavior after PR is merged:

- Introduce `post_mount_component_handlers` dispatched after each component mount completes.
- PowerButtonsPlugin uses this to update positions after the video and iframe are fully ready.
- Ensures powerButtons and hint paragraph stay correctly aligned after undo restores video.

task-4832484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
