### PR TITLE
[FIX] mail: fix non deterministic presence test

### DIFF
--- a/addons/mail/static/src/core/common/persona_model.js
+++ b/addons/mail/static/src/core/common/persona_model.js
@@ -50,7 +50,10 @@ export class Persona extends Record {
         compute() {
             if (
                 this.type === "guest" ||
-                (this.type === "partner" && this.im_status !== "im_partner" && !this.is_public)
+                (this.type === "partner" &&
+                    this.im_status !== "im_partner" &&
+                    this.im_status !== "bot" &&
+                    !this.is_public)
             ) {
                 return this._store;
             }

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -2,12 +2,14 @@
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
-import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
+import { busService } from "@bus/services/bus_service";
 import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
-import { patchDate, triggerHotkey } from "@web/../tests/helpers/utils";
+import { nextTick, patchDate, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
+import { registry } from "@web/core/registry";
+import { Deferred } from "@web/core/utils/concurrency";
 
 QUnit.module("discuss");
 
@@ -25,37 +27,50 @@ QUnit.test("Member list and settings menu are exclusive", async () => {
     await contains(".o-discuss-ChannelMemberList", { count: 0 });
 });
 
-QUnit.test("subscribe to known partner presences", async () => {
+QUnit.test("subscribe to presence channels according to store data", async (assert) => {
+    const busServiceStartDeferred = new Deferred();
+    registry.category("services").add(
+        "bus_service",
+        {
+            dependencies: busService.dependencies,
+            start() {
+                const ogAPI = busService.start(...arguments);
+                patchWithCleanup(ogAPI, {
+                    async start() {
+                        await busServiceStartDeferred;
+                        return super.start();
+                    },
+                });
+                return ogAPI;
+            },
+        },
+        { force: true }
+    );
     patchWebsocketWorkerWithCleanup({
-        // Force update doesn't matter in this test and is non-deterministic, since the subscription
-        // content depends on whether add_channels runs first (both are debounced).
-        _forceUpdateChannels() {},
         _sendToServer({ event_name, data }) {
             if (event_name === "subscribe") {
                 step(`subscribe - [${data.channels}]`);
             }
         },
     });
-    const pyEnv = await startServer();
-    const bobPartnerId = pyEnv["res.partner"].create({
-        name: "Bob",
-        user_ids: [Command.create({ name: "bob" })],
-    });
-    const later = luxon.DateTime.now().plus({ seconds: 2 });
-    patchDate(later.year, later.month, later.day, later.hour, later.minute, later.second);
-    const { openDiscuss } = await start();
-    await openDiscuss();
-    const expectedPresences = [
-        `odoo-presence-res.partner_${pyEnv.odoobotId}`,
-        `odoo-presence-res.partner_${pyEnv.currentPartnerId}`,
-    ];
-    await assertSteps([`subscribe - [${expectedPresences.join(",")}]`]);
-    await click(".o-mail-DiscussSidebar i[title='Start a conversation']");
-    await insertText(".o-discuss-ChannelSelector input", "bob");
-    await click(".o-discuss-ChannelSelector-suggestion");
-    await triggerHotkey("Enter");
-    expectedPresences.push(`odoo-presence-res.partner_${bobPartnerId}`);
-    await assertSteps([`subscribe - [${expectedPresences.join(",")}]`]);
+    const { env } = await start();
+    const store = env.services["mail.store"];
+    assert.notOk(env.services.bus_service.isActive);
+    // Should not subscribe to presences as bus service is not started.
+    await nextTick();
+    await assertSteps([]);
+    // Starting the bus should subscribe to known presence channels.
+    busServiceStartDeferred.resolve();
+    await assertSteps([`subscribe - [odoo-presence-res.partner_${store.self.id}]`]);
+    // Discovering new presence channels should refresh the subscription.
+    store["Persona"].insert({ id: 5000, type: "partner", name: "Partner 5000" });
+    await assertSteps([
+        `subscribe - [odoo-presence-res.partner_${store.self.id},odoo-presence-res.partner_5000]`,
+    ]);
+    store["Persona"].insert({ id: 1, type: "guest" });
+    await assertSteps([
+        `subscribe - [odoo-presence-mail.guest_1,odoo-presence-res.partner_${store.self.id},odoo-presence-res.partner_5000]`,
+    ]);
 });
 
 QUnit.test("bus subscription is refreshed when channel is joined", async () => {


### PR DESCRIPTION
The `subscribe to known partner presences` test ensures a bus subscription is sent when a new partner (whose presence needs tracking) is discovered. However, this test is prone to race conditions due to non-deterministic subscription timing:

- `addChannels` is debounced and called once at the beginning (for the current user from session data), and again after `init_messaging`. This means the timing of the RPC affects the number of subscriptions: 1 if it's fast enough to fall within the first call, or 2 otherwise.

- `forceUpdateChannel` is also debounced, so the final subscription depends on how these debounces overlap.

Ultimately, the test only aims to verify that discovering a new partner or guest adds their presence to the subscription. Using the full flow introduces unnecessary points of failure.

This commit rewrites the test to use `store.insert` instead, giving more control over the flow while preserving the test's intent.

fixes runbot-161223,182043,182044

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
