### PR TITLE
[FIX] test_http: more reliable tests

### DIFF
--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -134,7 +134,7 @@ class TestHttp(http.Controller):
     @http.route('/test_http/<model("test_http.galaxy"):galaxy>/<model("test_http.stargate"):gate>', auth='user', readonly=True)
     def stargate(self, galaxy, gate):
         if not gate.exists():
-            raise UserError("The goa'uld destroyed the gate")
+            raise UserError("The goauld destroyed the gate")
 
         return http.request.render('test_http.tmpl_stargate', {
             'gate': gate

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import html
 from http import HTTPStatus
 
 import odoo
@@ -70,7 +69,7 @@ class TestHttpModels(TestHttpBase):
         milky_way = self.env.ref('test_http.milky_way')
         res = self.url_open(f'/test_http/{milky_way.id}/9999')  # unknown gate
         self.assertEqual(res.status_code, 400)
-        self.assertIn("The goa'uld destroyed the gate", html.unescape(res.text))
+        self.assertIn("The goauld destroyed the gate", res.text)
 
     def test_models4_stargate_setname(self):
         milky_way = self.env.ref('test_http.milky_way')

--- a/odoo/addons/test_http/tests/test_webjson.py
+++ b/odoo/addons/test_http/tests/test_webjson.py
@@ -1,6 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import html
+from http import HTTPStatus
 from base64 import b64encode
+from urllib.parse import parse_qs, urlsplit
 
 from datetime import date
 
@@ -262,12 +264,13 @@ class TestHttpWebJson_1(TestHttpBase):
             env['test_http.stargate']
                 .web_search_read(domain, {'name': {}, 'sgc_designation': {}})
         )
-        # we should find one redirect with the domain in the URL
-        [hist] = res.history
-        self.assertEqual(hist.status_code, 307)
-        str_domain = str(domain).replace(' ', '+')
-        self.assertIn("limit=80", res.url)
-        self.assertIn(f"domain={str_domain}", res.url)
+        self.assertEqual(len(res.history), 1, "should had been redirected")
+        self.assertEqual(res.history[0].status_code, HTTPStatus.TEMPORARY_REDIRECT)
+        self.assertEqual(parse_qs(urlsplit(res.url).query), {
+            'domain': ["[('name', 'ilike', 'earth')]"],
+            'offset': ['0'],
+            'limit': ['80'],
+        })
 
     def test_webjson_pivot(self):
         env = self.authenticate_demo()


### PR DESCRIPTION
**[FIX] test_http: make test_webjson_list_args reliable**

The domain in the query-string is quoted by werkzeug, but there are
multiple possible equivalent quoting strategy and the test sometimes
fails because it is quoted differently. The test is not about testing
the different quoting strategy, use a proper url parser to make the test
more resilient.

**[FIX] test_http: more reliable test_models3**

The quote in the returned text sometimes get escaped, sometimes not,
sometimes with a different QP code. Remove the quote, since the test is
not about them, to make the test more reliable.
