### PR TITLE
[FIX] web: calendar: multi_create

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -243,6 +243,14 @@ export class CalendarModel extends Model {
      * @returns {Promise<*>}
      */
     async multiCreateRecords(dates) {
+        // Check required attribute of fields in form view
+        const isValid = await this.data.multiCreateRecord.checkValidity({
+            displayNotification: true,
+        });
+        if (!isValid) {
+            return;
+        }
+
         const records = [];
         const values = await this.data.multiCreateRecord.getChanges();
         const timeRange = this.data.multiCreateTimeRange;

--- a/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
@@ -86,9 +86,9 @@ export function useSquareSelection() {
     }
 
     function pointerDown(ev) {
-        const eventElement = ev.target.closest(".fc-event");
+        const avoidElement = ev.target.closest(".fc-event, .fc-more-cell, .fc-more-popover");
         const targetElement = ev.target.closest(".fc-day:not(.fc-col-header-cell)");
-        if (eventElement || !targetElement) {
+        if (avoidElement || !targetElement) {
             return;
         }
         document.activeElement?.blur(); // Force blur on activeElement to force update value

--- a/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
+++ b/addons/web/static/src/views/calendar/hooks/square_selection_hook.js
@@ -118,7 +118,9 @@ export function useSquareSelection() {
             drawHighlight();
             return;
         }
-        await onSquareSelection(state.currentSelectionElement);
+        if (state.currentSelectionElement.length > 0) {
+            await onSquareSelection(state.currentSelectionElement);
+        }
         clearState();
         drawHighlight();
     }

--- a/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_multi_create.test.js
@@ -690,3 +690,53 @@ test("multi_create: test popover in all mode", async () => {
     await animationFrame();
     expect(".o_popover").toHaveCount(1);
 });
+
+test.tags("desktop");
+test("multi_create: avoid trigger add/del event on specific element", async () => {
+    function makeEvents(numberOfEvent) {
+        return [...Array(numberOfEvent).keys()].map((i) => ({
+            id: i,
+            name: `event ${i}`,
+            date_start: "2019-03-13",
+            type: 1,
+            user_id: 1,
+        }));
+    }
+    Event._records = makeEvents(6);
+
+    onRpc("event", "create", ({ args: [records] }) => {
+        for (const record of records) {
+            expect.step(`${record.name}_${record.date_start}`);
+        }
+    });
+
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+    });
+
+    await click(".fc-event[data-event-id='1']");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_popover").toHaveCount(1);
+
+    await click(".o_calendar_button_today");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_popover").toHaveCount(0);
+
+    await click(".fc-more-cell a");
+    await animationFrame();
+    expect(".fc-more-popover").toHaveCount(1);
+    expect.verifySteps([]);
+
+    await click(".fc-popover-title");
+    await animationFrame();
+    expect(".fc-more-popover").toHaveCount(1);
+    expect.verifySteps([]);
+
+    await click(".fc-popover-close");
+    await animationFrame();
+    expect(".fc-more-popover").toHaveCount(0);
+    expect.verifySteps([]);
+});


### PR DESCRIPTION
**[FIX] web: calendar: multi_create: avoid add/del when click on "X more"**

FullCalendar when there is a certain amount of event in the same cell
(month view) it adds a link to show the remaining events not displayed
in the cell.

When we have added the multi_create feature we have forgotten this use
case and so when we click on the "X more" link in add/del mode we
trigger the `onSquareSelection` function.

This commit fixes this issue.

Steps to reproduce:
* Go to event
* Select a record (or create a new one)
* Check the "Multiple Slots" option in the form
* Click on the "Slots" "stat button"
* In the calendar view create a bunch of event on the same day
* When the "X more" link appears click on it
=> Bug a new event was created

---
**[FIX] web: calendar: multi_create: check required field before add**

In multi_create mode we can set a linked from view to set the values of
some fields when we create a bunch of event.

Before this commit if a fields had the required attribute, the events
will be created ignoring the fact that the field is required.

This commit fixes this issue.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
