### PR TITLE
[PERF] l10n_fr_pos_cert: optimize compute for bulk records

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -3,6 +3,7 @@
 from hashlib import sha256
 from json import dumps, loads
 import logging
+from collections import defaultdict
 
 from odoo import models, api, fields, release, _
 from odoo.exceptions import UserError
@@ -57,16 +58,26 @@ class pos_order(models.Model):
 
     @api.depends('l10n_fr_secure_sequence_number')
     def _compute_previous_order(self):
-        for order in self:
-            prev_order = self.search([('state', 'in', ['paid', 'done', 'invoiced']),
-                                                ('company_id', '=', order.company_id.id),
-                                                ('l10n_fr_secure_sequence_number', '!=', 0),
-                                                ('l10n_fr_secure_sequence_number', '=', order.l10n_fr_secure_sequence_number - 1)])
-            if prev_order and len(prev_order) != 1:
-                raise UserError(
-                    _('An error occurred when computing the inalterability. Impossible to get the unique previous posted point of sale order.'))
-            elif prev_order:
-                order.previous_order_id = prev_order
+        orders_by_company = defaultdict(list)
+        for order in self.filtered(lambda o: o.l10n_fr_secure_sequence_number):
+            orders_by_company[order.company_id.id].append(order)
+
+        for company_id, orders in orders_by_company.items():
+            prev_seq = [o.l10n_fr_secure_sequence_number - 1 for o in orders]
+            prev_orders = self.search([
+                ('state', 'in', ['paid', 'done', 'invoiced']),
+                ('company_id', '=', company_id),
+                ('l10n_fr_secure_sequence_number', 'in', prev_seq),
+            ])
+            prev_map = defaultdict(list)
+            for po in prev_orders:
+                prev_map[po.l10n_fr_secure_sequence_number].append(po)
+
+            for order in orders:
+                match = prev_map.get(order.l10n_fr_secure_sequence_number - 1, [])
+                if len(match) > 1:
+                    raise UserError(_('An error occurred when computing the inalterability. Impossible to get the unique previous posted point of sale order.'))
+                order.previous_order_id = match[0] if match else False
 
     def _get_new_hash(self):
         """ Returns the hash to write on pos orders when they get posted"""


### PR DESCRIPTION
**Patch description:**
- This commit addresses a perf issue in the `_compute_previous_order` compute of the `pos.order` model, which is particularly noticeable during db upgrade from `v17.0` to `v18.0` because field `previous_order_id` got introduced in `v18.0` or when installing the `l10n_fr_pos_cert` module on an existing db with many POS orders in `v18.0`.

- In both cases, the compute method is triggered for all `pos.order` records to assign the `previous_order_id`, causing significant delay due to per-record lookups.

**Example from a real DB with ~113k orders:**
```sql
apan_2840187=> select count(*) from pos_order;
 count
--------
 113342
(1 row)
```

**Observation:**
- Before the fix (compute took nearly 50 minutes):
```py
2025-05-29 06:31:12,587 28 INFO apan_2840187_18.0 odoo.modules.registry: module l10n_fr_pos_cert: creating or updating database tables
2025-05-29 06:31:12,799 28 INFO apan_2840187_18.0 odoo.models: Prepare computation of pos.order.previous_order_id
2025-05-29 07:17:37,855 28 INFO apan_2840187_18.0 odoo.modules.loading: loading l10n_fr_pos_cert/views/pos_views.xml
```

- After the fix (completed within 1 min):
```py
2025-05-30 06:56:59,510 24 INFO apan_2840187_18.0 odoo.modules.registry: module l10n_fr_pos_cert: creating or updating database tables
2025-05-30 06:56:59,584 24 INFO apan_2840187_18.0 odoo.models: Prepare computation of pos.order.previous_order_id
2025-05-30 06:57:12,531 24 INFO apan_2840187_18.0 odoo.modules.loading: loading l10n_fr_pos_cert/views/pos_views.xml
```

**Note:** The issue reported in the OPW was not originally about perf, but it was clearly exposed during the upgrade of the mentioned db.

opw-4812874
upg-2840187


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
