### PR TITLE
[IMP] point_of_sale: remove set maximum difference setting

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -113,7 +113,6 @@ class PosConfig(models.Model):
     is_margins_costs_accessible_to_every_user = fields.Boolean(string='Margins & Costs', default=False,
         help='When disabled, only PoS manager can view the margin and cost of product among the Product info.')
     cash_control = fields.Boolean(string='Advanced Cash Control', compute='_compute_cash_control', help="Check the amount of the cashbox at opening and closing.")
-    set_maximum_difference = fields.Boolean('Set Maximum Difference', help="Set a maximum difference allowed between the expected and counted money during the closing of the session.")
     receipt_header = fields.Text(string='Receipt Header', help="A short text that will be inserted as a header in the printed receipt.")
     receipt_footer = fields.Text(string='Receipt Footer', help="A short text that will be inserted as a footer in the printed receipt.")
     basic_receipt = fields.Boolean(string='Basic Receipt', help="Print basic ticket without prices. Can be used for gifts.")
@@ -164,10 +163,6 @@ class PosConfig(models.Model):
     is_posbox = fields.Boolean("PosBox")
     is_header_or_footer = fields.Boolean("Custom Header & Footer")
     module_pos_hr = fields.Boolean(help="Show employee login screen")
-    amount_authorized_diff = fields.Float('Amount Authorized Difference',
-        help="This field depicts the maximum difference allowed between the ending balance and the theoretical cash when "
-             "closing a session, for non-POS managers. If this maximum is reached, the user will have an error message at "
-             "the closing of his session saying that he needs to contact his manager.")
     payment_method_ids = fields.Many2many('pos.payment.method', string='Payment Methods', default=lambda self: self._default_payment_methods(), copy=False)
     company_has_template = fields.Boolean(string="Company has chart of accounts", compute="_compute_company_has_template")
     current_user_id = fields.Many2one('res.users', string='Current Session Responsible', compute='_compute_current_session_user')

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -791,7 +791,6 @@ class PosSession(models.Model):
                 'type': pm.type,
             } for pm in non_cash_payment_method_ids],
             'is_manager': self.env.user.has_group("point_of_sale.group_pos_manager"),
-            'amount_authorized_diff': self.config_id.amount_authorized_diff if self.config_id.set_maximum_difference else None
         }
 
     def _create_picking_at_end_of_session(self):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -58,7 +58,6 @@ class ResConfigSettings(models.TransientModel):
     pos_printer_ids = fields.Many2many(related='pos_config_id.printer_ids', readonly=False)
 
     pos_allowed_pricelist_ids = fields.Many2many('product.pricelist', compute='_compute_pos_allowed_pricelist_ids')
-    pos_amount_authorized_diff = fields.Float(related='pos_config_id.amount_authorized_diff', readonly=False)
     pos_available_pricelist_ids = fields.Many2many('product.pricelist', string='Available Pricelists', compute='_compute_pos_pricelist_id', readonly=False, store=True)
     pos_cash_control = fields.Boolean(related='pos_config_id.cash_control')
     pos_cash_rounding = fields.Boolean(related='pos_config_id.cash_rounding', readonly=False, string="Cash Rounding (PoS)")

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -98,7 +98,6 @@ class ResConfigSettings(models.TransientModel):
     pos_route_id = fields.Many2one(related='pos_config_id.route_id', readonly=False)
     pos_selectable_categ_ids = fields.Many2many('pos.category', compute='_compute_pos_selectable_categ_ids')
     pos_sequence_id = fields.Many2one(related='pos_config_id.sequence_id')
-    pos_set_maximum_difference = fields.Boolean(related='pos_config_id.set_maximum_difference', readonly=False)
     pos_ship_later = fields.Boolean(related='pos_config_id.ship_later', readonly=False)
     pos_tax_regime_selection = fields.Boolean(related='pos_config_id.tax_regime_selection', readonly=False)
     pos_tip_product_id = fields.Many2one('product.product', string='Tip Product', compute='_compute_pos_tip_product_id', readonly=False, store=True)

--- a/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
+++ b/addons/point_of_sale/static/src/app/components/popups/closing_popup/closing_popup.js
@@ -25,7 +25,6 @@ export class ClosePosPopup extends Component {
         "default_cash_details",
         "non_cash_payment_methods",
         "is_manager",
-        "amount_authorized_diff",
         "close",
     ];
 
@@ -100,27 +99,18 @@ export class ClosePosPopup extends Component {
             await this.closeSession();
             return;
         }
-        if (this.hasUserAuthority()) {
-            const response = await ask(this.dialog, {
-                title: _t("Payments Difference"),
-                body: _t(
-                    "The money counted doesn't match what we expected. Want to log the difference for the books?"
-                ),
-                confirmLabel: _t("Proceed Anyway"),
-                cancelLabel: _t("Discard"),
-            });
-            if (response) {
-                return this.closeSession();
-            }
-            return;
-        }
-        this.dialog.add(ConfirmationDialog, {
+        const response = await ask(this.dialog, {
             title: _t("Payments Difference"),
             body: _t(
-                "The maximum difference allowed is %s.\nPlease contact your manager to accept the closing difference.",
-                this.env.utils.formatCurrency(this.props.amount_authorized_diff)
+                "The money counted doesn't match what we expected. Want to log the difference for the books?"
             ),
+            confirmLabel: _t("Proceed Anyway"),
+            cancelLabel: _t("Discard"),
         });
+        if (response) {
+            return this.closeSession();
+        }
+        return;
     }
     async cancel() {
         if (this.canCancel()) {
@@ -177,13 +167,6 @@ export class ClosePosPopup extends Component {
             ...Object.keys(this.state.payments).map((id) =>
                 Math.abs(this.getDifference(parseInt(id)))
             )
-        );
-    }
-    hasUserAuthority() {
-        return (
-            this.props.is_manager ||
-            this.props.amount_authorized_diff == null ||
-            this.getMaxDifference() <= this.props.amount_authorized_diff
         );
     }
     canCancel() {

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -107,13 +107,6 @@
                                                 invisible="not group_cash_rounding"/>
                                     </div>
                                 </setting>
-                                <setting help="Set a maximum difference allowed between the expected and counted money during the closing of the session">
-                                    <field name="pos_set_maximum_difference" />
-                                    <div class="content-group mt16" invisible="not pos_set_maximum_difference">
-                                        <label for="pos_amount_authorized_diff" string="Authorized Difference" class="fw-normal me-1"/>
-                                        <field name="pos_amount_authorized_diff"/>
-                                    </div>
-                                </setting>
                                 <setting id="iface_tipproduct" title="This product is used as reference on customer receipts." string="Tips" help="Accept customer tips or convert their change to a tip" documentation="/applications/sales/point_of_sale/restaurant/tips.html">
                                     <field name="pos_iface_tipproduct"/>
                                     <div class="content-group" invisible="not pos_iface_tipproduct">


### PR DESCRIPTION
Following this commit:
====
- `Set Maximum Difference` setting from configuration is been removed as the warning is still shown while closing the register.

task-4824252
Upgrade PR - https://github.com/odoo/upgrade/pull/7771

