### PR TITLE
[FIX] web_editor: fix video alignment in website partner description

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -254,9 +254,8 @@ div.media_iframe_video {
     iframe {
         width: 100%;
         height: 100%;
-        @include o-position-absolute($top: 0);
+        @include o-position-absolute($top: 0, $left: 0, $right: 0);
         margin: 0 auto;
-        margin-left: -50%;
     }
     &.padding-small iframe {
         padding: 4px;


### PR DESCRIPTION
Problem:
When a video is added to the `website_description` field using the website editor, it appears visually shifted to the left (by 50%) when viewed from the Contacts page in the "Website Partner Full Description" field.

Cause:
The class `o-position-absolute` sets `left: auto` which was evaluated as `50%`, and`margin-left: -50%` was added to center absolutely positioned elements. However, this causes issues when rendered in `html_field` context, where `left: auto` evaluates to `0px`. As a result, the `-50%` margin shifts the video offscreen.

Solution:
Set both `left` and `right` to `0` in `.o-position-absolute` to ensure proper centering. Remove `margin-left: -50%` to prevent misalignment in non-editor contexts.

**Before**:
In website editor:
![image](https://github.com/user-attachments/assets/c8affa50-bc83-4f7f-ad24-df1c7dc882ca)
In contacts (html_field):
![image](https://github.com/user-attachments/assets/d77c23cf-7205-4ac4-943b-05c9291b3fe3)

**After**
In website editor:
![image](https://github.com/user-attachments/assets/814d3704-9f10-49f9-8b4d-04821c5ad5db)
In contacts (html_field):
![image](https://github.com/user-attachments/assets/816aec60-671f-468f-8d0a-0b1c5590f5cf)

Steps to reproduce:
- Go to Contacts > "Gemini Furniture".
- Add a video in the "Website Partner Full Description" field.
- Save and open the partner on the website (`partners/gemini-furniture-11`).
- Return to the Contacts page. → The video appears shifted 50% to the left.

opw-4752567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
