### PR TITLE
[FIX] base_automation: restrict base.automation from model selection

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -81,7 +81,7 @@ class BaseAutomation(models.Model):
     name = fields.Char(string="Automation Rule Name", required=True, translate=True)
     description = fields.Html(string="Description")
     model_id = fields.Many2one(
-        "ir.model", string="Model", domain=[("field_id", "!=", False)], required=True, ondelete="cascade",
+        "ir.model", string="Model", domain=[("field_id", "!=", False), ("model", "!=", "base.automation")], required=True, ondelete="cascade",
         help="Model on which the automation rule runs."
     )
     model_name = fields.Char(related="model_id.model", string="Model Name", readonly=True, inverse="_inverse_model_name")


### PR DESCRIPTION
The system will crash with an error when we create an automation rule using the **Automation Rule** model and set the trigger to **On Save**. After saving, if we edit that rule and change the model to **Lead/Opportunity** and set the trigger to **Stage is set to** = NEW, and then save the rule again, the system will encounter an error.

**Steps to Produce:-**
1. Install **CRM** and **Automation Rules**.
2. **Settings > Technical > Automation > Automation Rules**.
3. Create a new rule using the **Automation Rule** model.
4. In trigger select **On Save** then **Save** the rule.
5. Then change the model to **LEAD/OPPORTUNITY)** and in trigger set **stage is set to**.
6. Try to **Save** the rule.

**Error:-**
`ValueError: Invalid field in filter of base.automation: [('stage_id', '=', 1)]`

**Solution:-**
- Disable the option to display the Automation Rule in the selection.

**Sentry - 6641811582**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
