### PR TITLE
[FIX] hr_holidays: open employee's time off

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -753,8 +753,7 @@
             'search_default_waiting_for_me_manager': 2,
             'search_default_current_year': 3,
             'hide_employee_name': 1,
-            }
-        </field>
+            }</field>
         <field name="domain">[('employee_id.company_id', 'in', allowed_company_ids)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">


### PR DESCRIPTION
It's currently impossible to open the employee's time off

To reproduce the issue:
1. Open an employee form
2. Click on the smart button "Time Off"

Error: it leads to an "Odoo Server Error"

Clicking on the smart button leads to
https://github.com/odoo/odoo/blob/944c11e61abead4f5157a7a7cb7b1f536bc14411/addons/hr_holidays/models/hr_employee.py#L33-L35 Where we eval this:
https://github.com/odoo/odoo/blob/4ad41c7fc98b3aa183d1da3d7a01831cd300f76d/addons/hr_holidays/views/hr_leave_views.xml#L751-L757 However, since `</field>` doesn't come right after the closing bracket `}`, the end of the field value contains a new empty line. As a result, when evaluating it, it gives an error:
```
{IndentationError}IndentationError('unexpected indent', [...]
```

Considering that
- The use case must be fixed asap (luckily the bug is not on prod yet, cf merge date of [1])
- Stable versions

We have decided to locally fix the issue. However, as discussed with the ORM team, a better/generic fix should be brought on master.

[1] 4ad41c7fc98b3aa183d1da3d7a01831cd300f76d
