### PR TITLE
[FIX] account: add constraint to validate regex in reconcile model

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -141,6 +141,15 @@ class AccountReconcileModel(models.Model):
 
     line_ids = fields.One2many('account.reconcile.model.line', 'model_id', copy=True)
 
+    @api.constrains('match_label', 'match_label_param')
+    def _check_match_label_param(self):
+        for record in self:
+            if record.match_label == 'match_regex':
+                try:
+                    re.compile(record.match_label_param)
+                except re.error:
+                    raise UserError(_('The regex is not valid'))
+
     @api.depends('mapped_partner_id', 'match_label', 'match_partner_ids', 'trigger')
     def _compute_can_be_proposed(self):
         for model in self:


### PR DESCRIPTION
Currently, an error occurs when saving a reconciliation form with an invalid regex (e.g., `[` ) in the `Label Parameter` field, while the `Label` is set to `Match Regex`.

**Steps to produce:**
- Install the `accountant` module (without demo data).
- Navigate to: `Accounting > Bank > Models (under Reconciliation)`.
- Open any reconcile model, set `Label` to `Match Regex` and `Label Parameter` to `'['` and save.
- Load demo data and open the bank transactions.

**Error:**
`InvalidRegularExpression: invalid regular expression: brackets [] not balanced`

**Root Cause:**
Currently, there is no constraint on the `Label Parameter` field. when Label is set to `match_regex`, which allows saving invalid regex.

This commit ensures user cannot set an invalid regex in the Label Parameter.

sentry - 6638289601