### PR TITLE
[FIX] stock: Fix neg_moves with location_dest taken from rule

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -222,6 +222,8 @@ class StockMove(models.Model):
             location_dest = False
             if move.picking_id:
                 location_dest = move.picking_id.location_dest_id
+            elif move.rule_id.location_dest_from_rule:
+                location_dest = move.rule_id.location_dest_id
             elif move.picking_type_id:
                 location_dest = move.picking_type_id.default_location_dest_id
             is_move_to_interco_transit = False

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -641,3 +641,37 @@ class TestOldRules(TestStockCommon):
         pick_move = move_chain.filtered(lambda m: m.picking_type_id == self.warehouse_3_steps.pick_type_id)
         pick_move.picking_id.action_cancel()
         self.assertEqual(move_chain.mapped('state'), ['cancel', 'cancel', 'cancel'])
+
+    def test_negative_move_with_take_loc_from_rule(self):
+        """
+        This test checks if t a negative move will be merged correctly when the loc_dest_id
+        is taken from the rule instead of the picking type.
+        """
+        rule = self.warehouse_1.reception_route_id.rule_ids.filtered(lambda r: r.action == 'pull')
+        new_loc = self.env['stock.location'].create({
+            'name': 'Shelf',
+            'usage': 'transit',
+            'location_id': rule.location_dest_id.id,
+        })
+        rule.write({
+            'location_dest_id': new_loc.id,
+        })
+        rule.location_dest_from_rule = True
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': rule.picking_type_id.id,
+            'location_dest_id': rule.location_dest_id.id,
+        })
+        pos_move = self.env['stock.move'].create({
+            'name': 'Positive move',
+            'product_id': self.product_1.id,
+            'product_uom_qty': 5.0,
+            'picking_id': picking.id,
+            'rule_id': rule.id,
+        })
+        pos_move._action_confirm()
+        neg_move = pos_move.copy({
+            'name': 'Negative move',
+            'product_uom_qty': -2.0,
+        })
+        neg_move._action_confirm()
+        self.assertEqual(picking.move_ids.product_uom_qty, 3.0)


### PR DESCRIPTION
Steps to reproduce:
- Install Sales and Stock
- Activate the multi-step routes setting
- Go to a Delivery route in the warehouse
- Change the `location_dest_id` of the operation type set on the rule
- Enable the "Location Dest. Taken from Rule" checkbox
- Ensure `rule.location_dest_id` and `operation_type.location_dest_id`
  are different
- Create a Sales Order (SO) for a product with quantity = 5 and confirm
- Change the SO line quantity to 3 and save

Issue:
A second picking is created with a move taking the product from
`rule.operation_type.location_dest_id -> rule.operation_type.
location_src_id` with quantity = -2.

This happens because the decrease in the SO quantity triggers a
negative move, and this move is not merged with the existing
positive move. Instead, a new move is created in the opposite
direction.

In `_merge_moves`:
https://github.com/odoo/odoo/blob/3c4275fb00255e519f01bf5547eff1db3a59d4b5/addons/stock/models/stock_move.py#L1191-L1193

It checks if the negative move has similar characteristics to the
existing positive moves. However, the `neg_key(neg_move)` differs in
`location_dest_id`, so the merge fails. This happens because the
negative move does **not** read the `location_dest_id` from the rule —
unlike the procurement, which **does** use the rule and therefore
creates positive moves with the correct destination.

When the negative move is created with the procurement, it initially
has the correct `location_dest_id`. But then:

https://github.com/odoo/odoo/blob/b984c72df398c4fe942d8894442e4e893ca0660e/addons/stock/models/stock_move.py#L1191
triggers `_compute_location_dest_id`, which doesn't consider the
`rule.location_dest_id` and defaults to `operation_type.
location_dest_id`, causing the merge to fail due to mismatched
destination_locations.

The positive move has read the correct value, because when it
was assigned to a picking, the picking has the correct destination
from the procurement. But for the neg_move it has picking None so
it maps to the operation_type without consdiering the location from
rule checkbox.

opw-4793171