### PR TITLE
[FIX] html_builder, web: show rgba controls in colorpicker of builder

### DIFF
--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -119,6 +119,7 @@ export class BuilderColorPicker extends Component {
                 applyColorResetPreview: onPreviewRevert,
                 getUsedCustomColors: this.props.getUsedCustomColors,
                 colorPrefix: "color-prefix-",
+                showRgbaField: true,
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
             },

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -54,6 +54,7 @@ export class ColorPicker extends Component {
         applyColorResetPreview: Function,
         enabledTabs: { type: Array, optional: true },
         colorPrefix: { type: String },
+        showRgbaField: { type: Boolean, optional: true },
         noTransparency: { type: Boolean, optional: true },
         close: { type: Function, optional: true },
         className: { type: String, optional: true },
@@ -61,6 +62,7 @@ export class ColorPicker extends Component {
     static defaultProps = {
         close: () => {},
         enabledTabs: ["solid", "gradient", "custom"],
+        showRgbaField: false,
     };
 
     setup() {

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -107,7 +107,7 @@
                     defaultColor="this.state.currentCustomColor"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
                     onColorPreview.bind="onColorPreview"
-                    showRgbaField="false"
+                    showRgbaField="props.showRgbaField"
                     noTransparency="props.noTransparency" />
             </div>
         </t>


### PR DESCRIPTION
The rgba controls in color picker of builder were not kept through initial website builder refactor

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2 task-4367641
