### PR TITLE
[FIX] pos_self_order: use session test_mode instead of relying on timeout

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -4,6 +4,7 @@ import { Component, onMounted, onWillStart, onWillUnmount, useRef } from "@odoo/
 import { useSelfOrder } from "@pos_self_order/app/self_order_service";
 import { useService } from "@web/core/utils/hooks";
 import { LanguagePopup } from "@pos_self_order/app/components/language_popup/language_popup";
+import { session } from "@web/session";
 
 export class LandingPage extends Component {
     static template = "pos_self_order.LandingPage";
@@ -34,9 +35,12 @@ export class LandingPage extends Component {
                 const carousel = new Carousel(this.carouselRef.el);
 
                 // prevent traceback when no image is set
-                this.carouselInterval = setInterval(() => {
-                    carousel.next();
-                }, 5000);
+                this.carouselInterval = setInterval(
+                    () => {
+                        carousel.next();
+                    },
+                    session.test_mode ? 100 : 5000
+                );
             }
         });
 

--- a/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
+++ b/addons/pos_self_order/static/tests/tours/utils/landing_page_util.js
@@ -40,10 +40,9 @@ export function checkCarouselAutoPlaying() {
     return {
         content: `Check that the slideshow is working`,
         trigger: `.carousel-item.active`,
-        timeout: 5600,
         async run() {
             const firstSlideHtml = document.querySelector(".carousel-item.active")?.outerHTML;
-            await delay(5000);
+            await delay(150);
             const currentSlideHtml = document.querySelector(".carousel-item.active")?.outerHTML;
             if (firstSlideHtml === currentSlideHtml) {
                 throw new Error(


### PR DESCRIPTION
In this commit:
===============
- We use session.test_mode instead of relying on a timeout while testing the carousel in all self-ordering modes in test_self_order_pos_landing_page_carousel

Runbot error: 226322

