### PR TITLE
[FIX] l10n_jo_edi: improve HTTP 403 error message

### DIFF
--- a/addons/l10n_jo_edi/i18n/l10n_jo_edi.pot
+++ b/addons/l10n_jo_edi/i18n/l10n_jo_edi.pot
@@ -1,0 +1,416 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_jo_edi
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-05-30 12:49+0000\n"
+"PO-Revision-Date: 2025-05-30 12:49+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "%s To set: Configuration > Settings > Electronic Invoicing (Jordan)"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.view_move_form
+msgid ""
+"<span class=\"mx-1\"><b>Warning</b>: this invoice cannot be sent to "
+"JoFotara.</span>"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.report_invoice_document
+msgid "<strong class=\"text-center\">JoFotara QR Code</strong>"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Access forbidden. Please verify your JoFotara credentials."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.res_config_settings_view_form
+msgid "Activity Number"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Activity number (Sequence of income source) is missing.\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Client ID is missing.\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.res_config_settings_view_form
+msgid "Configure your JoFotara credentials here"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.view_move_form
+msgid "Download XML"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "E-invoice (JoFotara) submitted successfully."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.res_config_settings_view_form
+msgid "Electronic Invoicing (Jordan)"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/wizard/account_move_send.py:0
+#, python-format
+msgid "Errors when submitting the JoFotara e-invoice:"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Invalid request: %s"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_uuid
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_uuid
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_uuid
+msgid "Invoice UUID"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_config_settings__l10n_jo_edi_client_identifier
+msgid "JoFotara Client ID"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.res_config_settings_view_form
+msgid "JoFotara Credentials"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_error
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_error
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_error
+msgid "JoFotara Error"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_config_settings__l10n_jo_edi_secret_key
+msgid "JoFotara Secret Key"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_state
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_state
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_state
+msgid "JoFotara State"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "JoFotara portal cannot process %s VAT with non-digit characters in it\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"JoFotara portal cannot process negative quantity nor negative price on "
+"invoice lines"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_xml_attachment_id
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_xml_attachment_id
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_xml_attachment_id
+msgid "Jordan E-Invoice XML"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_xml_attachment_file
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_xml_attachment_file
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_xml_attachment_file
+msgid "Jordan E-Invoice XML File"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_computed_xml
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_computed_xml
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_computed_xml
+msgid "Jordan E-Invoice computed XML File"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_company__l10n_jo_edi_client_identifier
+msgid "Jordan EINV Client ID"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_company__l10n_jo_edi_secret_key
+msgid "Jordan EINV Secret Key"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_error
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move__l10n_jo_edi_error
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_payment__l10n_jo_edi_error
+msgid "Jordan: Error details."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_xml_attachment_id
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move__l10n_jo_edi_xml_attachment_id
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_payment__l10n_jo_edi_xml_attachment_id
+msgid "Jordan: e-invoice XML."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_computed_xml
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move__l10n_jo_edi_computed_xml
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_payment__l10n_jo_edi_computed_xml
+msgid ""
+"Jordan: technical field computing e-invoice XML data, useful at submission "
+"failure scenarios."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_xml_attachment_file
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move__l10n_jo_edi_xml_attachment_file
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_payment__l10n_jo_edi_xml_attachment_file
+msgid "Jordan: technical field holding the e-invoice XML data."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move_send__l10n_jo_edi_is_visible
+msgid ""
+"Jordan: technical field to determine if the option to submit a Jordanian "
+"electronic invoice is visible."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_is_needed
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move__l10n_jo_edi_is_needed
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_payment__l10n_jo_edi_is_needed
+msgid ""
+"Jordan: technical field to determine if this invoice is eligible to be "
+"e-invoiced."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,help:l10n_jo_edi.field_account_move_send__l10n_jo_edi_is_enabled
+msgid "Jordan: used to determine whether to submit this e-invoice."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model_terms:ir.ui.view,arch_db:l10n_jo_edi.account_move_send_form
+msgid "Jordanian e-invoicing (JoFotara) was enabled"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_is_needed
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_is_needed
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_is_needed
+msgid "L10N Jo Edi Is Needed"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move_send__l10n_jo_edi_is_visible
+msgid "L10N Jo Edi Is Visible"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"No taxes are allowed on invoice lines for taxpayers unregistered in the "
+"sales tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"One general tax per invoice line is expected for taxpayers registered in the"
+" sales tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid ""
+"One special and one general tax per invoice line is expected for taxpayers "
+"registered in the special tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Please use \"Reversal of\" to link this credit note with an Invoice\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__l10n_jo_edi_qr
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__l10n_jo_edi_qr
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__l10n_jo_edi_qr
+msgid "QR"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields.selection,name:l10n_jo_edi.selection__res_company__l10n_jo_edi_taxpayer_type__sales
+msgid "Registered in the sales tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields.selection,name:l10n_jo_edi.selection__res_company__l10n_jo_edi_taxpayer_type__special
+msgid "Registered in the special sales tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Request failed: %s"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Request time out! Please try again."
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_bank_statement_line__reversed_entry_id
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move__reversed_entry_id
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_payment__reversed_entry_id
+msgid "Reversal of"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Secret key is missing.\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_account_move_send__l10n_jo_edi_is_enabled
+msgid "Send JoFotara e-invoice"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields.selection,name:l10n_jo_edi.selection__account_move__l10n_jo_edi_state__sent
+msgid "Sent"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_company__l10n_jo_edi_sequence_income_source
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_config_settings__l10n_jo_edi_sequence_income_source
+msgid "Sequence of Income Source"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_account_tax
+msgid "Tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_company__l10n_jo_edi_taxpayer_type
+#: model:ir.model.fields,field_description:l10n_jo_edi.field_res_config_settings__l10n_jo_edi_taxpayer_type
+msgid "Taxpayer type"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "Taxpayer type is missing.\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/account_move.py:0
+#, python-format
+msgid "The following errors have to be fixed in order to create an XML:\n"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields.selection,name:l10n_jo_edi.selection__account_move__l10n_jo_edi_state__to_send
+msgid "To Send"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model,name:l10n_jo_edi.model_account_edi_xml_ubl_21_jo
+msgid "UBL 2.1 (JoFotara)"
+msgstr ""
+
+#. module: l10n_jo_edi
+#: model:ir.model.fields.selection,name:l10n_jo_edi.selection__res_company__l10n_jo_edi_taxpayer_type__income
+msgid "Unregistered in the sales tax"
+msgstr ""
+
+#. module: l10n_jo_edi
+#. odoo-python
+#: code:addons/l10n_jo_edi/models/ir_attachment.py:0
+#, python-format
+msgid ""
+"You cannot delete this Invoice PDF as it has been submitted to JoFotara"
+msgstr ""

--- a/addons/l10n_jo_edi/models/account_move.py
+++ b/addons/l10n_jo_edi/models/account_move.py
@@ -152,7 +152,10 @@ class AccountMove(models.Model):
             return _("Invalid request: %s", e)
 
         if not response.ok:
-            return _("Request failed: %s", response.content.decode())
+            content = response.content.decode()
+            if response.status_code == 403:
+                content = _("Access forbidden. Please verify your JoFotara credentials.")
+            return _("Request failed: %s", content)
         dict_response = response.json()
         self.l10n_jo_edi_qr = str(dict_response.get('EINV_QR', ''))
         self.invoice_pdf_report_id.res_field = False


### PR DESCRIPTION
Improve the error message when the response is HTTP 403. Currently, the content is empty for such errors, making it difficult to identify the source of the problem for users.

Step to reproduce:
- Try to send an invoice with wrong credentials.
- The error message is empty, making it hard to understand what went wrong.

Error message before this commit:
![image](https://github.com/user-attachments/assets/52296dbe-7aff-4efb-ace4-6e882b60a5fa)


After:
![image](https://github.com/user-attachments/assets/23ae92d4-1c23-4bd2-8169-a88add306f28)


Also added the missing .pot file.

opw-4823950
opw-4628908

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
