### PR TITLE
[FIX] html_editor: correcly determine title indentation in /TOC

### DIFF
--- a/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content_manager.js
+++ b/addons/html_editor/static/src/others/embedded_components/core/table_of_content/table_of_content_manager.js
@@ -48,40 +48,19 @@ export class TableOfContentManager {
     }
 
     updateStructure() {
-        let currentDepthByTag = {};
-        let previousTag;
-        let previousDepth = -1;
         const container = this.getContainerEl();
         if (!container) {
             return;
         }
+        const tagDepthStack = [];
         this.structure.headings = this.fetchValidHeadings(container).map((heading) => {
-            let depth = HEADINGS.indexOf(heading.tagName);
-            if (depth !== previousDepth && heading.tagName === previousTag) {
-                depth = previousDepth;
-            } else if (depth > previousDepth) {
-                if (heading.tagName !== previousTag && HEADINGS.indexOf(previousTag) < depth) {
-                    depth = previousDepth + 1;
-                } else {
-                    depth = previousDepth;
-                }
-            } else if (depth < previousDepth) {
-                if (currentDepthByTag.hasOwnProperty(heading.tagName)) {
-                    depth = currentDepthByTag[heading.tagName];
-                }
+            while (tagDepthStack.at(-1) >= heading.tagName) {
+                tagDepthStack.pop();
             }
-
-            previousTag = heading.tagName;
-            previousDepth = depth;
-
-            // going back to 0 depth, wipe-out the 'currentDepthByTag'
-            if (depth === 0) {
-                currentDepthByTag = {};
-            }
-            currentDepthByTag[heading.tagName] = depth;
-
+            const depth = tagDepthStack.length;
+            tagDepthStack.push(heading.tagName);
             return {
-                depth: depth,
+                depth,
                 name: heading.innerText,
                 target: heading,
             };


### PR DESCRIPTION
Prior to this commit, headings indentation was inconsistent in some edge cases.

Example:
```
<h3>
<h2>
  <h3>
  <h2>
    <h3>
```
would appear instead of:
```
<h3>
<h2>
  <h3>
<h2>
  <h3>
```
Desired algorithm:
  - Indent heading by 1 unit to the right of the previous strictly lower heading, or no indent

task-4836337
