### PR TITLE
[FIX] pos_sale: retain downpayment line tax with fiscal position in PoS

### DIFF
--- a/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
+++ b/addons/pos_sale/static/src/app/order_management_screen/sale_order_management_screen/sale_order_management_screen.js
@@ -192,13 +192,18 @@ export class SaleOrderManagementScreen extends ControlButtonsMixin(Component) {
                         continue;
                     }
 
+                    let taxIds = orderFiscalPos ? undefined : line.tax_id;
+                    if (line.product_id[0] === this.pos.config.down_payment_product_id[0]) {
+                        taxIds = line.tax_id;
+                    }
+
                     const line_values = {
                         pos: this.pos,
                         order: this.pos.get_order(),
                         product: this.pos.db.get_product_by_id(line.product_id[0]),
                         description: line.name,
                         price: line.price_unit,
-                        tax_ids: orderFiscalPos ? undefined : line.tax_id,
+                        tax_ids: taxIds,
                         price_manually_set: false,
                         price_type: "automatic",
                         sale_order_origin_id: clickedOrder,


### PR DESCRIPTION
Before this commit, when paying a sale order in PoS with a downpayment line and a fiscal position available in PoS, the negative downpayment line at the end did not retain its tax.

opw-4746761

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
