### PR TITLE
[MOV] website: move MockRequest to http_routing.tests.common

### DIFF
--- a/addons/http_routing/tests/__init__.py
+++ b/addons/http_routing/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import common
 from . import test_res_lang

--- a/addons/http_routing/tests/common.py
+++ b/addons/http_routing/tests/common.py
@@ -1,0 +1,113 @@
+import contextlib
+from unittest.mock import MagicMock, Mock, patch
+
+import werkzeug.urls
+from werkzeug.exceptions import NotFound
+from werkzeug.test import EnvironBuilder
+
+import odoo.http
+from odoo.tests import HOST, HttpCase
+from odoo.tools import DotDict, config, frozendict
+
+
+@contextlib.contextmanager
+def MockRequest(
+    env, *, path='/mockrequest', routing=True, multilang=True,
+    context=frozendict(), cookies=frozendict(), country_code=None,
+    website=None, remote_addr=HOST, environ_base=None, url_root=None,
+):
+    """Mock of the ``http.request``.
+
+    NOTE: If you only use ``request.env`` in your code, you can replace it by
+    ``self.env`` and don't need to use this class.
+    It is in this module, because website adds properties which are not defined
+    in base module.
+    """
+    lang_code = context.get('lang', env.context.get('lang', 'en_US'))
+    env = env(context=dict(context, lang=lang_code))
+    if HttpCase.http_port():
+        base_url = HttpCase.base_url()
+    else:
+        base_url = f"http://{HOST}:{config['http_port']}"
+    request = Mock(
+        # request
+        httprequest=Mock(
+            host='localhost',
+            path=path,
+            app=odoo.http.root,
+            environ=dict(
+                EnvironBuilder(
+                    path=path,
+                    base_url=base_url,
+                    environ_base=environ_base,
+                ).get_environ(),
+                REMOTE_ADDR=remote_addr,
+            ),
+            cookies=cookies,
+            referrer='',
+            remote_addr=remote_addr,
+            url_root=url_root,
+            args=[],
+        ),
+        type='http',
+        future_response=odoo.http.FutureResponse(),
+        params={},
+        redirect=env['ir.http']._redirect,
+        session=DotDict(
+            odoo.http.get_default_session(),
+            context={'lang': ''},
+            force_website_id=website and website.id,
+        ),
+        geoip=odoo.http.GeoIP('127.0.0.1'),
+        db=env.registry.db_name,
+        env=env,
+        registry=env.registry,
+        cr=env.cr,
+        uid=env.uid,
+        context=env.context,
+        cookies=cookies,
+        lang=env['res.lang']._get_data(code=lang_code),
+        website=website,
+        render=lambda *a, **kw: '<MockResponse>',
+    )
+    if url_root is not None:
+        request.httprequest.url = werkzeug.urls.url_join(url_root, path)
+    if website:
+        request.website_routing = website.id
+    if country_code:
+        try:
+            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
+        except TypeError:
+            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
+
+    # The following code mocks match() to return a fake rule with a fake
+    # 'routing' attribute (routing=True) or to raise a NotFound
+    # exception (routing=False).
+    #
+    #   router = odoo.http.root.get_db_router()
+    #   rule, args = router.bind(...).match(path)
+    #   # arg routing is True => rule.endpoint.routing == {...}
+    #   # arg routing is False => NotFound exception
+    router = MagicMock()
+    match = router.return_value.bind.return_value.match
+    if routing:
+        match.return_value[0].routing = {
+            'type': 'http',
+            'website': True,
+            'multilang': multilang
+        }
+    else:
+        match.side_effect = NotFound
+
+    def update_context(**overrides):
+        request.env = request.env(context=dict(request.context, **overrides))
+        request.context = request.env.context
+
+    request.update_context = update_context
+
+    with contextlib.ExitStack() as s:
+        odoo.http._request_stack.push(request)
+        s.callback(odoo.http._request_stack.pop)
+        s.enter_context(patch('odoo.http.root.get_db_router', router))
+
+        yield request

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -220,7 +220,7 @@ class TestPDFQuoteBuilder(SaleManagementCommon):
         if 'website' not in self.env:
             self.skipTest("Module `website` not found")
         else:
-            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+            from odoo.addons.http_routing.tests.common import MockRequest  # noqa: PLC0415
 
         # Upload document without Sale Order Template
         with (
@@ -249,7 +249,7 @@ class TestPDFQuoteBuilder(SaleManagementCommon):
         if 'website' not in self.env:
             self.skipTest("Module `website` not found")
         else:
-            from odoo.addons.website.tools import MockRequest  # noqa: PLC0415
+            from odoo.addons.http_routing.tests.common import MockRequest  # noqa: PLC0415
 
         # Upload a document for a Sale Order Template without company id
         self.empty_order_template.company_id = False

--- a/addons/survey/tests/test_survey_results.py
+++ b/addons/survey/tests/test_survey_results.py
@@ -4,7 +4,7 @@ import json
 
 from odoo.addons.survey.controllers.main import Survey
 from odoo.addons.survey.tests import common
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 
 
 class TestSurveyResults(common.TestSurveyResultsCommon):

--- a/addons/test_website/tests/test_fuzzy.py
+++ b/addons/test_website/tests/test_fuzzy.py
@@ -5,7 +5,7 @@ import logging
 import psycopg2
 
 from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 import odoo.tests
 from odoo.tests.common import TransactionCase
 

--- a/addons/test_website/tests/test_views_during_module_operation.py
+++ b/addons/test_website/tests/test_views_during_module_operation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests import standalone
 
 

--- a/addons/web/tests/test_reports.py
+++ b/addons/web/tests/test_reports.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch
 
 import odoo.tests
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.exceptions import UserError
 from odoo.http import root
 from odoo.tools import mute_logger

--- a/addons/website/tests/common.py
+++ b/addons/website/tests/common.py
@@ -1,9 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import base64
+
+from odoo.fields import Command
 from odoo.tests import HttpCase
 from odoo.tools import file_open
-from odoo.fields import Command
 
 
 class HttpCaseWithWebsiteUser(HttpCase):

--- a/addons/website/tests/test_fuzzy.py
+++ b/addons/website/tests/test_fuzzy.py
@@ -1,14 +1,17 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
-from lxml import etree
 import re
+
+from lxml import etree
 from markupsafe import Markup
 
-from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import distance, MockRequest
 import odoo.tests
 from odoo.tests.common import TransactionCase
+
+from odoo.addons.website.controllers.main import Website
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website.tools import distance
 
 _logger = logging.getLogger(__name__)
 

--- a/addons/website/tests/test_get_current_website.py
+++ b/addons/website/tests/test_get_current_website.py
@@ -2,7 +2,7 @@
 import json
 
 from odoo import Command
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests import tagged
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 

--- a/addons/website/tests/test_lang_url.py
+++ b/addons/website/tests/test_lang_url.py
@@ -4,7 +4,7 @@ import json
 import lxml.html
 from urllib.parse import urlparse
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests import HttpCase, tagged
 
 

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -5,7 +5,7 @@ from lxml import html
 from unittest.mock import Mock, patch
 from werkzeug.urls import url_parse
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests import common
 
 

--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -4,7 +4,7 @@ from lxml import html
 from unittest.mock import patch
 
 from odoo.addons.website.controllers.main import Website
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.fields import Command
 from odoo.http import root
 from odoo.tests import common, HttpCase, tagged

--- a/addons/website/tests/test_qweb.py
+++ b/addons/website/tests/test_qweb.py
@@ -2,7 +2,7 @@
 
 from odoo import http
 from odoo.addons.base.tests.common import TransactionCaseWithUserDemo
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests.common import TransactionCase
 
 

--- a/addons/website/tests/test_redirect.py
+++ b/addons/website/tests/test_redirect.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.exceptions import ValidationError
 from odoo.tests import TransactionCase, tagged
 

--- a/addons/website/tests/test_res_users.py
+++ b/addons/website/tests/test_res_users.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import Command
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.exceptions import ValidationError
 from odoo.service.model import retrying
 from odoo.tests.common import TransactionCase, new_test_user

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -5,9 +5,8 @@ from lxml import html
 from werkzeug.urls import url_encode
 
 from odoo.tests import HttpCase, tagged
-from odoo.addons.website.tools import MockRequest, create_image_attachment
-from odoo.tests.common import HOST
-from odoo.tools import config
+from odoo.addons.http_routing.tests.common import MockRequest
+from odoo.addons.website.tools import create_image_attachment
 import unittest
 
 _logger = logging.getLogger(__name__)

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from odoo.http import request
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 from odoo.addons.website.controllers.form import WebsiteForm
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.tests.common import tagged, TransactionCase
 import unittest
 

--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -1,117 +1,11 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import contextlib
 import re
+
 import werkzeug.urls
 from lxml import etree
-from unittest.mock import Mock, MagicMock, patch
 
-from werkzeug.exceptions import NotFound
-from werkzeug.test import EnvironBuilder
+from odoo.tools.misc import hmac
 
-import odoo.http
-from odoo.tools.misc import hmac, DotDict, frozendict
-
-HOST = '127.0.0.1'
-
-
-@contextlib.contextmanager
-def MockRequest(
-    env, *, path='/mockrequest', routing=True, multilang=True,
-    context=frozendict(), cookies=frozendict(), country_code=None,
-    website=None, remote_addr=HOST, environ_base=None, url_root=None,
-):
-    # TODO move MockRequest to a package in addons/web/tests
-    from odoo.tests.common import HttpCase  # noqa: PLC0415
-    lang_code = context.get('lang', env.context.get('lang', 'en_US'))
-    env = env(context=dict(context, lang=lang_code))
-    if HttpCase.http_port():
-        base_url = HttpCase.base_url()
-    else:
-        base_url = f"http://{HOST}:{odoo.tools.config['http_port']}"
-    request = Mock(
-        # request
-        httprequest=Mock(
-            host='localhost',
-            path=path,
-            app=odoo.http.root,
-            environ=dict(
-                EnvironBuilder(
-                    path=path,
-                    base_url=base_url,
-                    environ_base=environ_base,
-                ).get_environ(),
-                REMOTE_ADDR=remote_addr,
-            ),
-            cookies=cookies,
-            referrer='',
-            remote_addr=remote_addr,
-            url_root=url_root,
-            args=[],
-        ),
-        type='http',
-        future_response=odoo.http.FutureResponse(),
-        params={},
-        redirect=env['ir.http']._redirect,
-        session=DotDict(
-            odoo.http.get_default_session(),
-            context={'lang': ''},
-            force_website_id=website and website.id,
-        ),
-        geoip=odoo.http.GeoIP('127.0.0.1'),
-        db=env.registry.db_name,
-        env=env,
-        registry=env.registry,
-        cr=env.cr,
-        uid=env.uid,
-        context=env.context,
-        cookies=cookies,
-        lang=env['res.lang']._get_data(code=lang_code),
-        website=website,
-        render=lambda *a, **kw: '<MockResponse>',
-    )
-    if url_root is not None:
-        request.httprequest.url = werkzeug.urls.url_join(url_root, path)
-    if website:
-        request.website_routing = website.id
-    if country_code:
-        try:
-            request.geoip._city_record = odoo.http.geoip2.models.City(['en'], country={'iso_code': country_code})
-        except TypeError:
-            request.geoip._city_record = odoo.http.geoip2.models.City({'country': {'iso_code': country_code}})
-
-    # The following code mocks match() to return a fake rule with a fake
-    # 'routing' attribute (routing=True) or to raise a NotFound
-    # exception (routing=False).
-    #
-    #   router = odoo.http.root.get_db_router()
-    #   rule, args = router.bind(...).match(path)
-    #   # arg routing is True => rule.endpoint.routing == {...}
-    #   # arg routing is False => NotFound exception
-    router = MagicMock()
-    match = router.return_value.bind.return_value.match
-    if routing:
-        match.return_value[0].routing = {
-            'type': 'http',
-            'website': True,
-            'multilang': multilang
-        }
-    else:
-        match.side_effect = NotFound
-
-    def update_context(**overrides):
-        request.env = request.env(context=dict(request.context, **overrides))
-        request.context = request.env.context
-
-    request.update_context = update_context
-
-    with contextlib.ExitStack() as s:
-        odoo.http._request_stack.push(request)
-        s.callback(odoo.http._request_stack.pop)
-        s.enter_context(patch('odoo.http.root.get_db_router', router))
-
-        yield request
-
-# Fuzzy matching tools
 
 def distance(s1="", s2="", limit=4):
     """
@@ -150,6 +44,7 @@ def distance(s1="", s2="", limit=4):
         p, d = d, p
     return p[l1] if p[l1] <= limit else -1
 
+
 def similarity_score(s1, s2):
     """
     Computes a score that describes how much two strings are matching.
@@ -168,6 +63,7 @@ def similarity_score(s1, s2):
     score -= dist / len(s1)
     score -= len(set1.symmetric_difference(s2)) / (len(s1) + len(s2))
     return score
+
 
 def text_from_html(html_fragment, collapse_whitespace=False):
     """
@@ -193,8 +89,9 @@ def text_from_html(html_fragment, collapse_whitespace=False):
 
     content = ' '.join(tree.itertext())
     if collapse_whitespace:
-        content = re.sub('\\s+', ' ', content).strip()
+        content = re.sub(r'\s+', ' ', content).strip()
     return content
+
 
 def get_base_domain(url, strip_www=False):
     """

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -3,7 +3,7 @@ import json
 
 from odoo.exceptions import UserError
 from odoo.tests.common import users, HttpCase, tagged
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_blog.tests.common import TestWebsiteBlogCommon
 from odoo.addons.mail.controllers.thread import ThreadController
 

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -12,7 +12,7 @@ from odoo.tools import mute_logger
 from odoo.addons.base.tests.common import HttpCase
 from odoo.addons.crm.tests.common import TestCrmCommon
 from odoo.addons.mail.tests.common import mail_new_test_user
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_crm_partner_assign.controllers.main import (
     WebsiteAccount,
     WebsiteCrmPartnerAssign,

--- a/addons/website_event/tests/test_event_internals.py
+++ b/addons/website_event/tests/test_event_internals.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from odoo.fields import Datetime as FieldsDatetime
 from odoo.tests.common import users
 from odoo.addons.website.tests.test_website_visitor import MockVisitor
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_event.controllers.main import WebsiteEventController
 from odoo.addons.event.tests.common import EventCase
 

--- a/addons/website_event/tests/test_fuzzy.py
+++ b/addons/website_event/tests/test_fuzzy.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 from odoo.http import request
 from odoo.tests import tagged
 
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website.tests.test_fuzzy import TestAutoComplete
-from odoo.addons.website.tools import MockRequest
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/website_forum/tests/test_forum_controller.py
+++ b/addons/website_forum/tests/test_forum_controller.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_forum.controllers.website_forum import WebsiteForum
 from odoo.addons.website_forum.tests.common import KARMA, TestForumCommon
 

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -6,7 +6,7 @@ import odoo.tests
 from odoo.tools import html2plaintext
 import unittest
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_hr_recruitment.controllers.main import WebsiteHrRecruitment
 
 @odoo.tests.tagged('post_install', '-at_install')

--- a/addons/website_project/tests/test_project_portal_access.py
+++ b/addons/website_project/tests/test_project_portal_access.py
@@ -6,7 +6,7 @@ from odoo.tests import HttpCase
 
 from odoo.addons.mail.controllers.thread import ThreadController
 from odoo.addons.project.tests.test_project_sharing import TestProjectSharingCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 
 
 class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):

--- a/addons/website_sale/tests/common.py
+++ b/addons/website_sale/tests/common.py
@@ -7,7 +7,7 @@ from odoo.tools import lazy
 
 from odoo.addons.delivery.tests.common import DeliveryCommon
 from odoo.addons.product.tests.common import ProductCommon
-from odoo.addons.website.tools import MockRequest as websiteMockRequest
+from odoo.addons.http_routing.tests.common import MockRequest as websiteMockRequest
 from odoo.addons.website_sale.models.website import (
     CART_SESSION_CACHE_KEY,
     FISCAL_POSITION_SESSION_CACHE_KEY,

--- a/addons/website_sale/tests/test_website_editor.py
+++ b/addons/website_sale/tests/test_website_editor.py
@@ -7,7 +7,7 @@ from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 

--- a/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
+++ b/addons/website_sale/tests/test_website_sale_reorder_from_portal.py
@@ -4,7 +4,7 @@ from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install')

--- a/addons/website_sale/tests/test_website_sale_snippets.py
+++ b/addons/website_sale/tests/test_website_sale_snippets.py
@@ -4,7 +4,7 @@ import logging
 
 from odoo.tests import HttpCase, tagged
 
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 
 
 _logger = logging.getLogger(__name__)

--- a/addons/website_sale/tests/test_website_sequence.py
+++ b/addons/website_sale/tests/test_website_sequence.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 from odoo.tools import SQL
 
 from odoo.addons.base.tests.common import BaseCommon
-from odoo.addons.website.tools import MockRequest
+from odoo.addons.http_routing.tests.common import MockRequest
 
 
 @tagged('post_install', '-at_install')


### PR DESCRIPTION
`MockRequest` is used for testing. When running odoo, we should not have this class nor import unittest framework.

odoo/enterprise#86717
odoo/design-themes#1095
odoo/upgrade#7775

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
