### PR TITLE
[IMP] core: lazy import reportlab and barcode

### DIFF
--- a/addons/l10n_ch/tests/test_ch_qr_code.py
+++ b/addons/l10n_ch/tests/test_ch_qr_code.py
@@ -1,10 +1,7 @@
-# -*- coding:utf-8 -*-
-
-from reportlab.graphics.barcode import createBarcodeDrawing
-
 from odoo import Command
 from odoo.tests import tagged
 from odoo.exceptions import UserError
+from odoo.tools.barcode import createBarcodeDrawing
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 

--- a/odoo/tools/barcode.py
+++ b/odoo/tools/barcode.py
@@ -1,21 +1,59 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+import functools
 import re
+from threading import RLock
+
+__all__ = ['check_barcode_encoding', 'createBarcodeDrawing', 'get_barcode_font']
+_barcode_init_lock = RLock()
 
 
-__all__ = ['check_barcode_encoding']
+# A lock occurs when the user wants to print a report having multiple barcode while the server is
+# started in threaded-mode. The reason is that reportlab has to build a cache of the T1 fonts
+# before rendering a barcode (done in a C extension) and this part is not thread safe.
+# This cached functions allows to lazily initialize the T1 fonts cache need for rendering of
+# barcodes in a thread-safe way.
+@functools.lru_cache(1)
+def _init_barcode():
+    with _barcode_init_lock:
+        try:
+            from reportlab.graphics import barcode  # noqa: PLC0415
+            from reportlab.pdfbase.pdfmetrics import TypeFace, getFont  # noqa: PLC0415
+            font_name = 'Courier'
+            available = TypeFace(font_name).findT1File()
+            if not available:
+                substitution_font = 'NimbusMonoPS-Regular'
+                fnt = getFont(substitution_font)
+                if fnt:
+                    font_name = substitution_font
+                    fnt.ascent = 629
+                    fnt.descent = -157
+            barcode.createBarcodeDrawing('Code128', value='foo', format='png', width=100, height=100, humanReadable=1, fontName=font_name).asString('png')
+        except ImportError:
+            raise
+        except Exception:  # noqa: BLE001
+            font_name = 'Courier'
+        return barcode, font_name
 
 
-def get_barcode_check_digit(numeric_barcode):
+def createBarcodeDrawing(codeName: str, **options):
+    barcode, _font = _init_barcode()
+    return barcode.createBarcodeDrawing(codeName, **options)
+
+
+def get_barcode_font():
+    """Get the barcode font for rendering."""
+    _barcode, font = _init_barcode()
+    return font
+
+
+def get_barcode_check_digit(numeric_barcode: str) -> int:
     """ Computes and returns the barcode check digit. The used algorithm
     follows the GTIN specifications and can be used by all compatible
     barcode nomenclature, like as EAN-8, EAN-12 (UPC-A) or EAN-13.
     https://www.gs1.org/sites/default/files/docs/barcodes/GS1_General_Specifications.pdf
     https://www.gs1.org/services/how-calculate-check-digit-manually
     :param numeric_barcode: the barcode to verify/recompute the check digit
-    :type numeric_barcode: str
     :return: the number corresponding to the right check digit
-    :rtype: int
     """
     # Multiply value of each position by
     # N1  N2  N3  N4  N5  N6  N7  N8  N9  N10 N11 N12 N13 N14 N15 N16 N17 N18
@@ -34,10 +72,9 @@ def get_barcode_check_digit(numeric_barcode):
     return (10 - total % 10) % 10
 
 
-def check_barcode_encoding(barcode, encoding):
+def check_barcode_encoding(barcode: str, encoding: str) -> bool:
     """ Checks if the given barcode is correctly encoded.
     :return: True if the barcode string is encoded with the provided encoding.
-    :rtype: bool
     """
     encoding = encoding.lower()
     if encoding == "any":

--- a/odoo/tools/pdf/__init__.py
+++ b/odoo/tools/pdf/__init__.py
@@ -10,20 +10,10 @@ from logging import getLogger
 from zlib import compress, decompress, decompressobj
 
 from PIL import Image, PdfImagePlugin
-from reportlab.lib import colors
-from reportlab.lib.units import cm
-from reportlab.lib.utils import ImageReader
-from reportlab.pdfgen import canvas
 
 from odoo.tools.arabic_reshaper import reshape
 from odoo.tools.parse_version import parse_version
-from odoo.tools.misc import file_open
-
-try:
-    import fontTools
-    from fontTools.ttLib import TTFont
-except ImportError:
-    TTFont = None
+from odoo.tools.misc import file_open, SENTINEL
 
 # ----------------------------------------------------------
 # PyPDF2 hack
@@ -227,15 +217,22 @@ def to_pdf_stream(attachment) -> io.BytesIO:
     _logger.warning("mimetype (%s) not recognized for %s", attachment.mimetype, attachment)
 
 
-def add_banner(pdf_stream, text=None, logo=False, thickness=2 * cm):
+def add_banner(pdf_stream, text=None, logo=False, thickness=SENTINEL):
     """ Add a banner on a PDF in the upper right corner, with Odoo's logo (optionally).
 
     :param pdf_stream (BytesIO):    The PDF stream where the banner will be applied.
     :param text (str):              The text to be displayed.
     :param logo (bool):             Whether to display Odoo's logo in the banner.
-    :param thickness (float):       The thickness of the banner in pixels.
+    :param thickness (float):       The thickness of the banner in pixels (default: 2cm).
     :return (BytesIO):              The modified PDF stream.
     """
+    from reportlab.lib import colors  # noqa: PLC0415
+    from reportlab.lib.utils import ImageReader  # noqa: PLC0415
+    from reportlab.pdfgen import canvas  # noqa: PLC0415
+
+    if thickness is SENTINEL:
+        from reportlab.lib.units import cm  # noqa: PLC0415
+        thickness = 2 * cm
 
     old_pdf = PdfFileReader(pdf_stream, strict=False, overwriteWarnings=False)
     packet = io.BytesIO()
@@ -507,7 +504,11 @@ class OdooPdfFileWriter(PdfFileWriter):
 
         # PDF/A needs the glyphs width array embedded in the pdf to be consistent with the ones from the font file.
         # But it seems like it is not the case when exporting from wkhtmltopdf.
-        if TTFont:
+        try:
+            import fontTools.ttLib  # noqa: PLC0415
+        except ImportError:
+            _logger.warning('The fonttools package is not installed. Generated PDF may not be PDF/A compliant.')
+        else:
             fonts = {}
             # First browse through all the pages of the pdf file, to get a reference to all the fonts used in the PDF.
             for page in pages:
@@ -521,7 +522,7 @@ class OdooPdfFileWriter(PdfFileWriter):
             for font in fonts.values():
                 font_file = font['/FontDescriptor']['/FontFile2']
                 stream = io.BytesIO(decompress(font_file._data))
-                ttfont = TTFont(stream)
+                ttfont = fontTools.ttLib.TTFont(stream)
                 font_upm = ttfont['head'].unitsPerEm
                 if parse_version(fontTools.__version__) < parse_version('4.37.2'):
                     glyphs = ttfont.getGlyphSet()._hmtx.metrics
@@ -534,8 +535,6 @@ class OdooPdfFileWriter(PdfFileWriter):
 
                 font[NameObject('/W')] = ArrayObject([NumberObject(1), ArrayObject(glyph_widths)])
                 stream.close()
-        else:
-            _logger.warning('The fonttools package is not installed. Generated PDF may not be PDF/A compliant.')
 
         outlines = self._root_object['/Outlines'].getObject()
         outlines[NameObject('/Count')] = NumberObject(1)


### PR DESCRIPTION
When starting, we don't need to have barcode and reportlab code loaded untile it is needed.
Gains: ~100ms.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
