### PR TITLE
[IMP] spreadsheet_edition: add numeric global filter

### DIFF
--- a/addons/spreadsheet/static/src/@types/global_filter.d.ts
+++ b/addons/spreadsheet/static/src/@types/global_filter.d.ts
@@ -83,17 +83,17 @@ declare module "@spreadsheet" {
     type RelationDefaultValue = RelationValue | CurrentUser;
 
     interface NumericUnaryValue {
-        operator: "=" | "!=" | "<" | ">";
-        operand: number;
+        operator: "=" | "!=" | ">" | "<";
+        targetValue: number;
     }
 
     interface NumericRangeValue {
-        operator: "between" | "not_between";
-        min: number;
-        max: number;
+        operator: "between";
+        minimumValue: number;
+        maximumValue: number;
     }
 
-    export type NumericValue = NumericUnaryValue | NumericRangeValue | SetValue;
+    export type NumericValue = NumericUnaryValue | NumericRangeValue;
 
     interface TextInValue {
         operator: "in" | "not in";
@@ -156,6 +156,13 @@ declare module "@spreadsheet" {
         domainOfAllowedValues?: DomainListRepr | string;
     }
 
+    export interface NumericGlobalFilter {
+        type: "numeric";
+        id: string;
+        label: string;
+        defaultValue?: NumericValue;
+    }
+
     export interface BooleanGlobalFilter {
         type: "boolean";
         id: string;
@@ -163,6 +170,6 @@ declare module "@spreadsheet" {
         defaultValue?: SetValue;
     }
 
-    export type GlobalFilter = TextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter;
-    export type CmdGlobalFilter = CmdTextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter;
+    export type GlobalFilter = TextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter | NumericGlobalFilter;
+    export type CmdGlobalFilter = CmdTextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter | BooleanGlobalFilter | SelectionGlobalFilter | NumericGlobalFilter;
 }

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -17,6 +17,7 @@ import {
     isSetOperator,
     getDefaultValue,
 } from "@spreadsheet/global_filters/helpers";
+import { NumericFilterValue } from "../numeric_filter_value/numeric_filter_value";
 
 const { ValidationMessages } = components;
 
@@ -28,6 +29,7 @@ export class FilterValue extends Component {
         MultiRecordSelector,
         SelectionFilterValue,
         ValidationMessages,
+        NumericFilterValue,
     };
     static props = {
         filter: Object,
@@ -115,6 +117,42 @@ export class FilterValue extends Component {
         this.props.setGlobalFilterValue(id, { operator, strings: value });
     }
 
+    onTargetValueNumericInput(id, value) {
+        const operator = this.filterValue?.operator ?? this.getDefaultOperator();
+        const newFilterValue = {
+            operator,
+            targetValue: value,
+        };
+        this.props.setGlobalFilterValue(id, newFilterValue);
+    }
+
+    reorderValues(min, max) {
+        if (min > max) {
+            const tmp = min;
+            min = max;
+            max = tmp;
+        }
+        return { minimumValue: min, maximumValue: max };
+    }
+
+    onMinimumValueNumericInput(id, value) {
+        const operator = this.filterValue?.operator ?? this.getDefaultOperator();
+        const newFilterValue = {
+            operator,
+            ...this.reorderValues(value, this.filterValue?.maximumValue),
+        };
+        this.props.setGlobalFilterValue(id, newFilterValue);
+    }
+
+    onMaximumValueNumericInput(id, value) {
+        const operator = this.filterValue?.operator ?? this.getDefaultOperator();
+        const newFilterValue = {
+            operator,
+            ...this.reorderValues(this.filterValue?.minimumValue, value),
+        };
+        this.props.setGlobalFilterValue(id, newFilterValue);
+    }
+
     onBooleanInput(id, value) {
         if (Array.isArray(value) && value.length === 0) {
             this.clear(id);
@@ -138,10 +176,7 @@ export class FilterValue extends Component {
             this.clear(id);
         } else {
             const operator = this.filterValue?.operator ?? this.getDefaultOperator();
-            this.props.setGlobalFilterValue(
-                id,
-                { operator, ids: resIds },
-            );
+            this.props.setGlobalFilterValue(id, { operator, ids: resIds });
         }
     }
 

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -22,6 +22,26 @@
                 <DateFilterValue value="filterValue"
                                  update.bind="(value) => this.onDateInput(filter.id, value)"/>
             </div>
+            <div t-if="filter.type === 'numeric'" class="w-100 d-flex align-items-center"
+                 t-att-class="filterValue?.operator === 'between' ? 'justify-content-between' : ''">
+                <t t-if="filterValue?.operator === 'between'">
+                    <NumericFilterValue
+                        value="filterValue.minimumValue"
+                        onValueChanged="(value) => this.onMinimumValueNumericInput(filter.id, value)"
+                    />
+                    <i class="fa fa-long-arrow-right mx-2"/>
+                    <NumericFilterValue
+                        value="filterValue.maximumValue"
+                        onValueChanged="(value) => this.onMaximumValueNumericInput(filter.id, value)"
+                    />
+                </t>
+                <t t-else="">
+                    <NumericFilterValue
+                        value="filterValue.targetValue"
+                        onValueChanged="(value) => this.onTargetValueNumericInput(filter.id, value)"
+                    />
+                </t>
+            </div>
             <span t-elif="filter.type === 'relation'" class="w-100">
                 <MultiRecordSelector
                     t-if="isValid"

--- a/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filters_search_dialog/filters_search_dialog.js
@@ -77,7 +77,7 @@ export class FiltersSearchDialog extends Component {
     }
 
     setGlobalFilterValue(node, value) {
-        if (!value && node.globalFilter.type !== "date") {
+        if (value == undefined && node.globalFilter.type !== "date") {
             // preserve the operator.
             node.value = {
                 ...node.value,

--- a/addons/spreadsheet/static/src/global_filters/components/numeric_filter_value/numeric_filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/numeric_filter_value/numeric_filter_value.js
@@ -1,0 +1,41 @@
+/** @ts-check */
+
+import { Component, useRef } from "@odoo/owl";
+import { useNumpadDecimal } from "@web/views/fields/numpad_decimal_hook";
+import { parseFloat } from "@web/views/fields/parsers";
+
+export class NumericFilterValue extends Component {
+    static template = "spreadsheet.NumericFilterValue";
+    static props = {
+        onValueChanged: Function,
+        value: { type: [Number, String], optional: true },
+    };
+
+    setup() {
+        useNumpadDecimal();
+        this.inputRef = useRef("numpadDecimal");
+    }
+
+    onChange(value) {
+        let numericValue;
+        if (value === undefined || value === "") {
+            numericValue = undefined;
+        } else {
+            try {
+                numericValue = parseFloat(value);
+                // eslint-disable-next-line no-unused-vars
+            } catch (e) {
+                numericValue = 0;
+            }
+        }
+        this.props.onValueChanged(numericValue);
+        // If the user enters a non-numeric string, we default the value to 0.
+        // However, if the same invalid input is entered again, the component
+        // doesn't re-render because the prop value hasn't changed. To ensure
+        // the input reflects the correct state, we manually set the input
+        // element's value to 0.
+        if (numericValue === 0 && this.inputRef?.el) {
+            this.inputRef.el.value = 0;
+        }
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/numeric_filter_value/numeric_filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/numeric_filter_value/numeric_filter_value.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="spreadsheet.NumericFilterValue">
+        <input
+            type="text"
+            t-ref="numpadDecimal"
+            class="o_input o-global-filter-numeric-value text-truncate"
+            t-att-value="props.value ?? ''"
+            t-on-change="(e) => this.onChange(e.target.value)"
+            inputmode="decimal"
+        />
+    </t>
+</templates>

--- a/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/filter_value_component.test.js
@@ -271,5 +271,26 @@ test("selection filter", async function () {
     await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
     await contains("input").click();
     await contains("a:first").click();
-    expect(model.getters.getGlobalFilterValue("42")).toEqual({ operator: "in", selectionValues: ["after"]});
+    expect(model.getters.getGlobalFilterValue("42")).toEqual({
+        operator: "in",
+        selectionValues: ["after"],
+    });
+});
+
+test("numeric filter", async function () {
+    const env = await makeMockEnv();
+    const model = new Model({}, { custom: { odooDataProvider: new OdooDataProvider(env) } });
+    await addGlobalFilter(model, {
+        id: "42",
+        type: "numeric",
+        label: "Numeric Filter",
+        defaultValue: { operator: "=", targetValue: 1998 },
+    });
+    await mountFilterValueComponent({ model, filter: model.getters.getGlobalFilter("42") });
+    await contains("input").edit(1998);
+    await contains("input").press("Enter");
+    expect(model.getters.getGlobalFilterValue("42")).toEqual(
+        { operator: "=", targetValue: 1998 },
+        { message: "value is set" }
+    );
 });

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_core_view.test.js
@@ -109,6 +109,57 @@ test("Value of selection filter", () => {
     expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
 });
 
+test("Value of numeric filter", () => {
+    const model = new Model();
+    addGlobalFilterWithoutReload(model, {
+        id: "1",
+        type: "numeric",
+        label: "Numeric Filter",
+        defaultValue: { operator: "=", targetValue: 10 },
+    });
+
+    let result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: { operator: "=", targetValue: false },
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: { operator: "=", targetValue: "value" },
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: { operator: "=", targetValue: "5" },
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "1",
+        value: { operator: "=", targetValue: "" },
+    });
+    expect(result.isSuccessful).toBe(false);
+    expect(result.reasons).toEqual(["InvalidValueTypeCombination"]);
+
+    result = addGlobalFilterWithoutReload(model, {
+        id: "2",
+        type: "numeric",
+        label: "Default value is a number",
+        defaultValue: { operator: "=", targetValue: 99 },
+    });
+    expect(result.isSuccessful).toBe(true);
+
+    result = setGlobalFilterValueWithoutReload(model, {
+        id: "2",
+    });
+    expect(result.isSuccessful).toBe(true);
+});
+
 test("Value of date filter", () => {
     const model = new Model();
     addGlobalFilterWithoutReload(model, {

--- a/addons/spreadsheet/static/tests/global_filters/numeric_filter_value.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/numeric_filter_value.test.js
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { keyDown } from "@odoo/hoot-dom";
+import {
+    makeMockEnv,
+    contains,
+    mountWithCleanup,
+    patchWithCleanup,
+} from "@web/../tests/web_test_helpers";
+import { defineSpreadsheetModels } from "@spreadsheet/../tests/helpers/data";
+import { getTemplate } from "@web/core/templates";
+import { NumericFilterValue } from "@spreadsheet/global_filters/components/numeric_filter_value/numeric_filter_value";
+import { localization } from "@web/core/l10n/localization";
+
+describe.current.tags("desktop");
+defineSpreadsheetModels();
+
+async function mountNumericFilterValue(env, props) {
+    await mountWithCleanup(NumericFilterValue, { props, env, getTemplate });
+}
+
+test("numeric filter with no default value prop", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        onValueChanged: (value) => {
+            expect(value).toEqual(1998);
+            expect.step("update");
+        },
+    });
+    expect.verifySteps([]);
+    expect(".o_input").toHaveText("");
+    await contains("input").edit(1998);
+    await contains("input").press("Enter");
+    expect.verifySteps(["update"]);
+    expect(".o_input").toHaveValue(1998);
+});
+
+test("numeric filter with default value prop", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        value: 1999,
+        onValueChanged: () => {},
+    });
+    expect(".o_input").toHaveValue(1999);
+});
+
+test("change value of numeric filter with default value prop", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        value: 1999,
+        onValueChanged: (value) => {
+            expect(value).toEqual(2000);
+            expect.step("update");
+        },
+    });
+    expect.verifySteps([]);
+    expect(".o_input").toHaveValue(1999);
+    await contains("input").edit(2000);
+    await contains("input").press("Enter");
+    expect.verifySteps(["update"]);
+    expect(".o_input").toHaveValue(2000);
+});
+
+test("clearing numeric filter input should not reset its value to 0", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        value: 1998,
+        onValueChanged: (value) => {
+            expect(value).toEqual(undefined);
+            expect.step("reset");
+        },
+    });
+    await contains("input").edit("");
+    await contains("input").press("Enter");
+    expect.verifySteps(["reset"]);
+    expect(".o_input").toHaveValue("");
+});
+
+test("setting a string value to numeric filter input should reset its value to 0", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        value: undefined,
+        onValueChanged: (value) => {
+            expect(value).toEqual(0);
+            expect.step("reset");
+        },
+    });
+    await contains("input").edit("hola");
+    await contains("input").press("Enter");
+    expect.verifySteps(["reset"]);
+    expect(".o_input").toHaveValue(0);
+});
+
+test("numeric filter input value is correctly parsed based on localization", async function () {
+    const env = await makeMockEnv();
+    patchWithCleanup(localization, {
+        decimalPoint: ",",
+        thousandsSep: ".",
+    });
+    await mountNumericFilterValue(env, {
+        onValueChanged: (value) => {
+            expect(value).toEqual(40048789.87);
+            expect.step("parsed");
+        },
+    });
+    await contains("input").edit("40.048.789,87");
+    await contains("input").press("Enter");
+    expect.verifySteps(["parsed"]);
+});
+
+test("numeric filter input should insert localized decimal separator when numpad decimal key is pressed", async function () {
+    const env = await makeMockEnv();
+    patchWithCleanup(localization, {
+        decimalPoint: ",",
+        thousandsSep: ".",
+    });
+    await mountNumericFilterValue(env, {
+        onValueChanged: (value) => {
+            expect(value).toEqual(0.12);
+            expect.step("parsed");
+        },
+    });
+    await contains("input").focus();
+    await keyDown(".", { code: "NumpadDecimal" });
+    await keyDown("1", { code: "Digit1" });
+    await keyDown("2", { code: "Digit2" });
+    expect(".o_input").toHaveValue(",12");
+    const input = document.querySelector(".o_input");
+    input.dispatchEvent(new Event("change"));
+    expect.verifySteps(["parsed"]);
+});
+
+test("default value is saved after saving and editing again", async function () {
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        value: 2001,
+        onValueChanged: () => {},
+    });
+    expect(".o_input").toHaveValue(2001);
+    await mountNumericFilterValue(env, {
+        onValueChanged: () => {},
+    });
+    expect(".o_input").toHaveText("");
+});
+
+test("default value does not disappear when pressing enter", async function () {
+    let savedValue = null;
+    const env = await makeMockEnv();
+    await mountNumericFilterValue(env, {
+        onValueChanged: (value) => {
+            savedValue = value;
+        },
+    });
+    await contains("input").edit("2024");
+    await contains("input").press("Enter");
+    expect(savedValue).toEqual(2024);
+
+    expect(".o_input").toHaveValue(2024);
+});


### PR DESCRIPTION
This commit introduces numeric global filters feature for spreadsheet dashboards, allowing users to filter data based
on numeric values. At this stage, only the equal (=) operator is supported. Future improvements may extend this to include other domain operators.

Task: [4032933](https://www.odoo.com/odoo/project/2328/tasks/4032933)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
