### PR TITLE
[IMP] netsvc: avoid importing bs4 when starting

### DIFF
--- a/odoo/_monkeypatches/bs4.py
+++ b/odoo/_monkeypatches/bs4.py
@@ -1,0 +1,8 @@
+import bs4
+import warnings
+
+
+def patch_module():
+    # ofxparse use an html parser to parse ofx xml files and triggers a warning since bs4 4.11.0
+    # https://github.com/jseutter/ofxparse/issues/170
+    warnings.filterwarnings('ignore', category=bs4.XMLParsedAsHTMLWarning)

--- a/odoo/netsvc.py
+++ b/odoo/netsvc.py
@@ -199,11 +199,10 @@ def init_logger():
     warnings.simplefilter('default', category=DeprecationWarning)
     # https://github.com/urllib3/urllib3/issues/2680
     warnings.filterwarnings('ignore', r'^\'urllib3.contrib.pyopenssl\' module is deprecated.+', category=DeprecationWarning)
-    # ofxparse use an html parser to parse ofx xml files and triggers a warning since bs4 4.11.0
-    # https://github.com/jseutter/ofxparse/issues/170
-    with contextlib.suppress(ImportError):
-        from bs4 import XMLParsedAsHTMLWarning
-        warnings.filterwarnings('ignore', category=XMLParsedAsHTMLWarning)
+    if bs4 := sys.modules.get('bs4'):
+        # avoid loading bs4 module during initialization; this filter is also
+        # monkeypatched if the import is done afterwards
+        warnings.filterwarnings('ignore', category=bs4.XMLParsedAsHTMLWarning)
     # ignore a bunch of warnings we can't really fix ourselves
     for module in [
         'babel.util', # deprecated parser module, no release yet


### PR DESCRIPTION
When setting-up logging, avoid importing bs4 (beautifulsoup) which is a quite large module. Add a hook to ignore the warnings if the module is imported.

![image](https://github.com/user-attachments/assets/85a4dd11-ecc6-4b63-a0a8-4ae903490853)

odoo/enterprise#86719


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
