### PR TITLE
[FIX] website, html_builder: implement nav-item "move" overlay buttons

### DIFF
--- a/addons/html_builder/static/src/core/clone_plugin.js
+++ b/addons/html_builder/static/src/core/clone_plugin.js
@@ -3,12 +3,12 @@ import { withSequence } from "@html_editor/utils/resource";
 import { _t } from "@web/core/l10n/translation";
 import { isElementInViewport } from "@html_builder/utils/utils";
 import { isRemovable } from "./remove_plugin";
-import { isMovable } from "./move_plugin";
 
 const clonableSelector = "a.btn:not(.oe_unremovable)";
 
 export function isClonable(el) {
-    return el.matches(clonableSelector) || (isRemovable(el) && isMovable(el));
+    // TODO and isDraggable
+    return el.matches(clonableSelector) || isRemovable(el);
 }
 
 export class ClonePlugin extends Plugin {

--- a/addons/html_builder/static/src/core/move_plugin.js
+++ b/addons/html_builder/static/src/core/move_plugin.js
@@ -25,10 +25,7 @@ const moveUpOrDown = {
 };
 
 const moveLeftOrRight = {
-    selector: [
-        ".row:not(.s_col_no_resize) > div",
-        ".nav-item", // TODO specific plugin
-    ].join(", "),
+    selector: [".row:not(.s_col_no_resize) > div"].join(", "),
     exclude: ".s_showcase .row .row > div",
 };
 
@@ -202,8 +199,6 @@ export class MovePlugin extends Plugin {
      * @param {String} direction "prev" or "next"
      */
     onMoveClick(direction) {
-        // TODO nav-item ? (=> specific plugin)
-        // const isNavItem = this.overlayTarget.classList.contains("nav-item");
         let hasMobileOrder = !!this.overlayTarget.style.order;
         const siblingEls = this.overlayTarget.parentNode.children;
 

--- a/addons/website/static/src/builder/plugins/collapse_plugin.js
+++ b/addons/website/static/src/builder/plugins/collapse_plugin.js
@@ -13,6 +13,7 @@ export class CollapsePlugin extends Plugin {
                 dropLockWithin: ".accordion",
             },
         ],
+        is_movable_selector: { selector: ".s_accordion .accordion-item", direction: "vertical", noScroll: true },
     };
 
     setup() {

--- a/addons/website/static/src/builder/plugins/options/navtabs_header_buttons.js
+++ b/addons/website/static/src/builder/plugins/options/navtabs_header_buttons.js
@@ -10,9 +10,12 @@ export class NavTabsHeaderMiddleButtons extends Component {
     };
 
     setup() {
-        this.state = useDomState((editingElement) => ({
-            tabEls: editingElement.querySelectorAll(".s_tabs_nav .nav-item"),
-        }));
+        this.state = useDomState((editingElement) => {
+            const navEl = editingElement.querySelector(".nav");
+            return {
+                tabEls: navEl.querySelectorAll(".nav-item"),
+            }
+        });
 
         this.callOperation = useOperation();
     }

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_boxed_option_plugin.js
@@ -34,6 +34,7 @@ class PriceListBoxedOptionPlugin extends Plugin {
             selector: ".s_pricelist_boxed_item",
             dropNear: ".s_pricelist_boxed_item",
         },
+        is_movable_selector: { selector: ".s_pricelist_boxed_item", direction: "vertical" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/pricelist_cafe_plugin.js
@@ -40,6 +40,7 @@ class PriceListCafePlugin extends Plugin {
             selector: ".s_pricelist_cafe_item",
             dropNear: ".s_pricelist_cafe_item",
         },
+        is_movable_selector: { selector: ".s_pricelist_cafe_item", direction: "vertical" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/pricelist_option/product_catalog_plugin.js
@@ -34,6 +34,7 @@ class ProductCatalogOptionPlugin extends Plugin {
             selector: ".s_product_catalog_dish",
             dropNear: ".s_product_catalog_dish",
         },
+        is_movable_selector: { selector: ".s_product_catalog_dish", direction: "vertical" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/timeline_list_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/timeline_list_option_plugin.js
@@ -25,6 +25,7 @@ class TimelineListOptionPlugin extends Plugin {
             selector: ".s_timeline_list_row",
             dropNear: ".s_timeline_list_row",
         },
+        is_movable_selector: { selector: ".s_timeline_list_row", direction: "vertical" },
     };
 }
 

--- a/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/timeline_option_plugin.js
@@ -39,6 +39,7 @@ class TimelineOptionPlugin extends Plugin {
         get_overlay_buttons: withSequence(0, {
             getButtons: this.getActiveOverlayButtons.bind(this),
         }),
+        is_movable_selector: { selector: ".s_timeline_row", direction: "vertical" },
     };
 
     getActiveOverlayButtons(target) {

--- a/addons/website/static/src/builder/plugins/separator_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/separator_option_plugin.js
@@ -16,6 +16,7 @@ class SeparatorOptionPlugin extends Plugin {
             dropNear: "p, h1, h2, h3, blockquote, .s_hr",
         },
         so_content_addition_selector: [".s_hr"],
+        is_movable_selector: { selector: ".s_hr", direction: "vertical" },
     };
 }
 registry.category("website-plugins").add(SeparatorOptionPlugin.id, SeparatorOptionPlugin);

--- a/addons/website/static/src/builder/plugins/timeline_images_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/timeline_images_option_plugin.js
@@ -25,6 +25,7 @@ class TimelineImagesOptionPlugin extends Plugin {
             selector: ".s_timeline_images_row",
             dropNear: ".s_timeline_images_row",
         },
+        is_movable_selector: { selector: ".s_timeline_images_row", direction: "vertical" },
     };
 }
 


### PR DESCRIPTION
[FIX] website, html_builder: implement nav-item "move" overlay buttons

This commit implements the "move" overlay buttons off the nav-items.
They work differently as they have to sync with their tab pane, which is
why they need their own.

task-4367641

---
[FIX] website, html_builder: review the `move` plugin

This commit improves the `move_plugin` code:

- Add the `is_movable_selector` resource to get the selectors of the
  movable elements. It allows to have the resources in the different
  option plugins, instead of duplicating these selectors across multiple
  files. We use it like this:
  ```js
    is_movable_selector: {
      selector: selector,
      exclude: exclude,
      direction: direction,
      noScroll: true,
    },
  ```
  where
    - `selector` is the movable elements selector,
    - `exclude` is the selector of elements to exclude,
    - `direction` is either `"vertical"` or `"horizontal"`: it allows to
      specify if the arrows are up/down or left/right respectively,
    - `noScroll` is a boolean specifying that the page should not scroll
      to make the element visible after moving it. The page scrolls by
      default so we only need this parameter if we do not want it to, in
      which case we have to set it to `true`.

- Scroll to the moved element, unless specified otherwise (see previous
point).

- Clean the code to simplify it.

- Use the `is_movable_selector` resource in the different option
plugins.

task-4367641

---
[FIX] website: consider nested tabs in "Tabs" snippet and fix ids

This commit fixes the `NavTabs` options by also considering tabs inside
tabs. Indeed, the "Tabs" snippet can be dropped inside another "Tabs"
snippet tab, so nested tabs should be considered too.

It also removes the normalize resource: indeed, the ids should be
generated only when the snippet was dropped or cloned, so there is no
need to re-generate the ids at each change.

It also removes the use of the `remove` and `clone` plugins when not
necessary.

task-4367641