### PR TITLE
[FIX] web(site): error dialog displayed when unloading page

### DIFF
--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -45,18 +45,7 @@ export class UncaughtCorsError extends UncaughtError {
 
 export const errorService = {
     start(env) {
-        let isUnloadingPage = false;
-        window.addEventListener("beforeunload", () => {
-            isUnloadingPage = true;
-            // restore after 30 seconds
-            setTimeout(() => (isUnloadingPage = false), 30000);
-        });
-
         function handleError(uncaughtError, retry = true) {
-            if (isUnloadingPage) {
-                uncaughtError.event.preventDefault();
-                return;
-            }
             let originalError = uncaughtError;
             while (originalError instanceof Error && "cause" in originalError) {
                 originalError = originalError.cause;

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -121,6 +121,7 @@
         ],
         'web.assets_frontend': [
             ('replace', 'web/static/src/legacy/js/public/public_root_instance.js', 'website/static/src/js/content/website_root_instance.js'),
+            'website/static/src/core/errors/beforeunload_error_handler.js',
             'website/static/src/scss/website.scss',
             'website/static/src/scss/website.ui.scss',
             'website/static/src/js/utils.js',

--- a/addons/website/static/src/core/errors/beforeunload_error_handler.js
+++ b/addons/website/static/src/core/errors/beforeunload_error_handler.js
@@ -1,0 +1,30 @@
+/** @odoo-module **/
+
+import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
+
+const errorHandlerRegistry = registry.category("error_handlers");
+
+let isUnloadingPage = false;
+window.addEventListener("beforeunload", () => {
+    isUnloadingPage = true;
+    // restore after 10 seconds
+    browser.setTimeout(() => (isUnloadingPage = false), 10000);
+});
+
+/**
+ * Handles the errors trigger after the before unload event.
+ *
+ * @param {OdooEnv} env
+ * @param {UncaughError} error
+ * @returns {boolean}
+ */
+function beforeUnloadHandler(env, error) {
+    if (isUnloadingPage) {
+        error.event.preventDefault();
+        return true;
+    }
+    return false;
+}
+
+errorHandlerRegistry.add("beforeUnloadHandler", beforeUnloadHandler, { sequence: 1 });


### PR DESCRIPTION

Because the `location.assign` method also triggers a `beforeunload`
event, the `error_service` doesn't handle errors when downloading a file
with the action target `download` (for example download vCard). See [1]
for more details about the original fix.

task-4457865

[1]: https://github.com/odoo/odoo/commit/e96d3aa6d9181d83e34cefd9fe205f37df2e317c
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
