### PR TITLE
[FIX] l10n_tr_nilvera_einvoice: traceback after edi fetch refactor

### DIFF
--- a/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
+++ b/addons/l10n_tr_nilvera_einvoice/models/account_journal.py
@@ -11,7 +11,6 @@ class AccountJournal(models.Model):
         self.filtered(
             lambda j: j.is_nilvera_journal and
                       j.l10n_tr_nilvera_api_key and
-                      j.l10n_tr_nilvera_api_key.raw_value and
                       j.type == 'purchase'
         ).show_fetch_in_einvoices_button = True
 
@@ -21,7 +20,6 @@ class AccountJournal(models.Model):
         super()._compute_show_refresh_out_einvoices_status_button()
         self.filtered(
             lambda j: j.l10n_tr_nilvera_api_key and
-                      j.l10n_tr_nilvera_api_key.raw_value and
                       j.type == 'sale'
         ).show_refresh_out_einvoices_status_button = True
 


### PR DESCRIPTION
5d69408548b30671b968c3c1ae1e8f444ac2d82e introduced overrides for the generic EDI fetch/update logic. It mistakenly copied a condition from the XML layer that checked `.raw_value` on the API key field. This caused a traceback when accessing the accounting dashboard.

No task-ID
