### PR TITLE
[FIX] point_of_sale: fix selectOrder test step

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -37,7 +37,7 @@
                             <table t-if="!ui.isSmall"  class="table table-striped table-hover">
                                 <tbody>
                                     <t t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
-                                        <tr class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}"
+                                        <tr class="order-row" t-attf-class="{{ isHighlighted(order) ? 'highlight active': '' }}" t-att-order-tracking-number="order.tracking_number"
                                             t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() => order.uiState.locked ? ()=>{} : this._setOrder(order)" >
                                             <td>
                                                 <div class="fs-6 fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
@@ -89,7 +89,7 @@
                             </table>
                             <t t-if="ui.isSmall" t-foreach="_filteredOrderList" t-as="order" t-key="order.uuid">
                                 <div class="mobileOrderList order-row d-flex flex-row ps-1" t-attf-class="{{ isHighlighted(order) ? 'highlight': '' }}"
-                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" >
+                                    t-on-click="() => this.onClickOrder(order)" t-on-dblclick="() =>  order.uiState.locked ? ()=>{} : this._setOrder(order)" t-att-order-tracking-number="order.tracking_number"> 
                                     <div class="p-2">
                                             <div class="fw-bolder"><t t-esc="this.pos.getDate(order.date_order)"></t></div>
                                             <div class="small text-muted"><t t-esc="this.pos.getTime(order.date_order)"></t></div>

--- a/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/pos_cash_rounding_tour.js
@@ -39,7 +39,7 @@ registry
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
 
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -97,7 +97,7 @@ registry
                     Chrome.clickOrders(),
                     TicketScreen.selectFilter("Active"),
                     TicketScreen.selectFilter("Paid"),
-                    TicketScreen.selectOrder("0001"),
+                    TicketScreen.selectOrder("001"),
                     TicketScreen.confirmRefund(),
 
                     ProductScreen.checkTaxAmount("-2.05"),
@@ -159,7 +159,7 @@ registry
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
 
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -221,7 +221,7 @@ registry
                     Chrome.clickOrders(),
                     TicketScreen.selectFilter("Active"),
                     TicketScreen.selectFilter("Paid"),
-                    TicketScreen.selectOrder("0001"),
+                    TicketScreen.selectOrder("001"),
                     TicketScreen.confirmRefund(),
 
                     ProductScreen.checkTaxAmount("-2.05"),
@@ -282,7 +282,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -339,7 +339,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -397,7 +397,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -454,7 +454,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.03"),
@@ -511,7 +511,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.03"),
@@ -569,7 +569,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),
@@ -627,7 +627,7 @@ registry
                 Chrome.clickOrders(),
                 TicketScreen.selectFilter("Active"),
                 TicketScreen.selectFilter("Paid"),
-                TicketScreen.selectOrder("0001"),
+                TicketScreen.selectOrder("001"),
                 TicketScreen.confirmRefund(),
 
                 ProductScreen.checkTaxAmount("-2.05"),

--- a/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/ticket_screen_util.js
@@ -9,10 +9,15 @@ export function clickDiscard() {
         run: "click",
     };
 }
-export function selectOrder(orderName) {
+/**
+ * Selects an order based on its tracking number.
+ * @param {string} orderTrackingNumber.
+ *
+ **/
+export function selectOrder(orderTrackingNumber) {
     return [
         {
-            trigger: `.ticket-screen .order-row:contains("${orderName}")`,
+            trigger: `.ticket-screen .order-row[order-tracking-number="${orderTrackingNumber}"]`,
             run: "click",
         },
     ];

--- a/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/split_bill_screen_tour.js
@@ -101,7 +101,7 @@ registry.category("web_tour.tours").add("SplitBillScreenTour2", {
             SplitBillScreen.clickButton("Split"),
             ProductScreen.totalAmountIs("4.0"),
             Chrome.clickOrders(),
-            TicketScreen.selectOrder("2B"),
+            TicketScreen.selectOrder("002"),
             TicketScreen.loadSelectedOrder(),
             Order.hasLine({ productName: "Coca-Cola", quantity: "1" }),
             Order.hasLine({ productName: "Water", quantity: "1" }),


### PR DESCRIPTION
Modified the selectOrder function to specifically target the order-row that contains the tracking_number being passed to the function. Also updated a step in SplitBillScreenTour to align with the changes in selectOrder.

Enterprise PR: https://github.com/odoo/enterprise/pull/88795
runbot-163111	
