### PR TITLE
[FIX] html_builder, *: fix "Newsletter Form" drop behavior

### DIFF
--- a/addons/html_builder/static/src/utils/utils.js
+++ b/addons/html_builder/static/src/utils/utils.js
@@ -88,15 +88,19 @@ export function isVisible(el) {
  * @param {HTMLElement} rootEl
  * @param {String} selector
  * @param {String} exclude
+ * @param {String} applyTo
  * @returns {Array}
  */
-export function getElementsWithOption(rootEl, selector, exclude = false) {
+export function getElementsWithOption(rootEl, selector, exclude = false, applyTo = false) {
     let matchingEls = [...rootEl.querySelectorAll(selector)];
     if (rootEl.matches(selector)) {
         matchingEls.unshift(rootEl);
     }
     if (exclude) {
         matchingEls = matchingEls.filter((editingEl) => !editingEl.matches(exclude));
+    }
+    if (applyTo) {
+        matchingEls = matchingEls.flatMap((editingEl) => [...editingEl.querySelectorAll(applyTo)]);
     }
     return matchingEls;
 }

--- a/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.inside.scss
+++ b/addons/website_mass_mailing/static/src/website_builder/mailing_list_subscribe_option.inside.scss
@@ -1,6 +1,9 @@
-.o_enable_preview {
-    display: block !important;
-}
-.o_disable_preview {
-    display: none !important;
+.s_newsletter_subscribe_form {
+    .o_enable_preview {
+        display: block !important;
+    }
+
+    .o_disable_preview {
+        display: none !important;
+    }
 }


### PR DESCRIPTION
*: website_mass_mailing

This commit properly cancels the drop of a Newsletter snippet when no
mailing list exists and the dialog is cancelled. Indeed, it was removing
the element manually, instead of using the provided mechanism, i.e.
returning `true` in the `onSnippetDropped` handler. This caused some
uncommitted mutations to stay after cancelling the dialog.

A notable change is that the entire snippet is now removed, instead of
only the "Newsletter Form". It is more correct, as adding the form later
would not result in the intended options behavior anyway.

The CSS rules were also modified to make them more specific to the
"Newsletter Form".

The code was also cleaned a bit.

task-4367641