### PR TITLE
[FIX] mail: no chat hub options in discuss app without chat hub use

### DIFF
--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -103,16 +103,19 @@ export class ChatHub extends Component {
         return counter;
     }
 
+    /** @deprecated */
     get displayConversations() {
-        return this.chatHub.opened.length + this.chatHub.folded.length > 0 && !this.chatHub.compact;
+        return this.chatHub.showConversations && !this.chatHub.compact;
     }
 
+    /** @deprecated */
     get isShown() {
         return true;
     }
 
+    /** @deprecated */
     shouldDisplayChatWindow(cw) {
-        return this.isShown || this.ui.isSmall;
+        return cw.canShow;
     }
 
     expand() {

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -6,14 +6,14 @@
 
         <t t-set="visibleChatWindows" t-value="chatHub.compact ? chatHub.opened.filter(({ bypassCompact }) => bypassCompact) : chatHub.opened "/>
         <t t-foreach="visibleChatWindows" t-as="cw" t-key="cw.localId">
-            <ChatWindow chatWindow="cw" t-if="shouldDisplayChatWindow(cw)" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>
+            <ChatWindow chatWindow="cw" t-if="cw.canShow" right="chatHub.BUBBLE_START + chatHub.BUBBLE + (chatHub.BUBBLE_OUTER*2) + (visibleChatWindows.length - cw_index - 1) * (chatHub.WINDOW + chatHub.WINDOW_INBETWEEN * 2)"/>
         </t>
         <div class="o-mail-ChatHub-bubbles position-fixed d-flex flex-column align-content-start justify-content-end align-items-center" t-attf-style="top: {{position.top}}; left: {{position.left}}; right: {{position.right}}; bottom: {{position.bottom}}" t-att-class="{ 'o-liftUp': busMonitoring.hasConnectionIssues, 'o-mobile': isMobileOS }" t-ref="bubbles">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
-                <Dropdown t-if="displayConversations or position.dragged" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
+                <Dropdown t-if="(chatHub.showConversations and !chatHub.compact) or position.dragged" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
                     <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn oi oi-ellipsis-h bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
                     <t t-set-slot="content">
-                        <t t-if="displayConversations">
+                        <t t-if="chatHub.showConversations and !chatHub.compact">
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
                             <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
                         </t>
@@ -23,7 +23,7 @@
                 <t t-if="store.chatHub.compact" t-call="mail.ChatHub.compactButton"/>
                 <t t-else="">
                     <t t-foreach="chatHub.folded.slice(0, chatHub.maxFolded)" t-as="cw" t-key="cw.localId">
-                        <ChatBubble t-if="shouldDisplayChatWindow(cw)" chatWindow="cw"/>
+                        <ChatBubble t-if="cw.canShow" chatWindow="cw"/>
                     </t>
                     <div class="o-mail-ChatHub-extraActions"/>
                     <t t-if="chatHub.folded.length > chatHub.maxFolded" t-call="mail.ChatHub.hiddenButton"/>

--- a/addons/mail/static/src/core/common/chat_hub_model.js
+++ b/addons/mail/static/src/core/common/chat_hub_model.js
@@ -48,6 +48,8 @@ export class ChatHub extends Record {
             }
         },
     });
+    canShowOpened = fields.Many("ChatWindow");
+    canShowFolded = fields.Many("ChatWindow");
     /** From left to right. Right-most will actually be folded */
     opened = fields.Many("ChatWindow", {
         inverse: "hubAsOpened",
@@ -143,6 +145,12 @@ export class ChatHub extends Record {
             })
         );
     }
+
+    showConversations = fields.Attr(false, {
+        compute() {
+            return this.canShowOpened.length + this.canShowFolded.length > 0;
+        },
+    });
 }
 
 ChatHub.register();

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -16,6 +16,24 @@ export class ChatWindow extends Record {
     fromMessagingMenu = false;
     hubAsOpened = fields.One("ChatHub", { inverse: "opened" });
     hubAsFolded = fields.One("ChatHub", { inverse: "folded" });
+    hubAsCanShowOpened = fields.One("ChatHub", {
+        inverse: "canShowOpened",
+        /** @this {import("models").ChatWindow} */
+        compute() {
+            if (this.canShow && this.hubAsOpened) {
+                return this.store.chatHub;
+            }
+        },
+    });
+    hubAsCanShowFolded = fields.One("ChatHub", {
+        inverse: "canShowFolded",
+        /** @this {import("models").ChatWindow} */
+        compute() {
+            if (this.canShow && this.hubAsFolded) {
+                return this.store.chatHub;
+            }
+        },
+    });
 
     get displayName() {
         return this.thread?.displayName;
@@ -23,6 +41,16 @@ export class ChatWindow extends Record {
 
     get isOpen() {
         return Boolean(this.hubAsOpened);
+    }
+
+    canShow = fields.Attr(true, {
+        compute() {
+            return this.computeCanShow();
+        },
+    });
+
+    computeCanShow() {
+        return !this.store.discuss?.isActive || this.store.env.services.ui.isSmall;
     }
 
     async close(options = {}) {

--- a/addons/mail/static/src/core/public_web/chat_hub_patch.js
+++ b/addons/mail/static/src/core/public_web/chat_hub_patch.js
@@ -1,8 +1,0 @@
-import { patch } from "@web/core/utils/patch";
-import { ChatHub } from "@mail/core/common/chat_hub";
-
-patch(ChatHub.prototype, {
-    get isShown() {
-        return super.isShown && !this.store.discuss.isActive;
-    },
-});

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -676,6 +676,19 @@ test("chat window: composer state conservation on toggle discuss", async () => {
     await contains(".o-mail-Composer-input", { value: "XDU for the win !" });
 });
 
+test("don't show chat hub options when discuss is open", async () => {
+    const pyEnv = await startServer();
+    pyEnv["discuss.channel"].create({});
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await click(".o-mail-NotificationItem");
+    await contains(".o-mail-ChatWindow");
+    await contains(".o-mail-ChatHub [title='Chat Options']");
+    await openDiscuss();
+    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o-mail-ChatHub [title='Chat Options']", { count: 0 });
+});
+
 test("chat window: scroll conservation on toggle discuss", async () => {
     const pyEnv = await startServer();
     const channelId = pyEnv["discuss.channel"].create({});


### PR DESCRIPTION
Before this commit, when accessing discuss app with some chat windows or bubbles in desktop, it was showing the chat hub options in the bottom right.

This happens of some spaghetti code with addition of `ai` module that requires to show sometimes chat window in discuss app: Visibility of chat hub was strictly not shown in desktop before this AI feature, but now the chat hub condition is more complex.

The new feature was added with minimal change to code, but this uses getter that were poorly named and made it hard to see overall condition for the actual showing of chat hub items, including the option button.

This commit fixes the issue by making the "options" button aware of whether some chat windows or bubbles are shown, through a new field `ChatHub.showConversations`.

To remedy a bit with spaghetti code, some code have been moved to models and new fields use consistent wording "show". rather than (should)Display(ed).

To follow stable policy, old getters have been flagged deprecated and are rewired to the new code.

https://github.com/odoo/enterprise/pull/86732