### PR TITLE
[FIX] hr_holidays: kanban view access

### DIFF
--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -142,7 +142,7 @@
                 </div>
            </xpath>
             <xpath expr="//li[@id='last_login']" position="inside">
-                <span t-if="record.current_leave_id.raw_value" style="font-size: 100%"
+                <span t-if="record.current_leave_id and record.current_leave_id.raw_value" style="font-size: 100%"
                         t-att-class="record.current_leave_state.raw_value=='validate'?'oe_kanban_button oe_kanban_color_3':'oe_kanban_button oe_kanban_color_2'"
                         t-att-title="luxon.DateTime.fromISO(record.leave_date_from.raw_value).toFormat('ccc d MMM') + ' - ' + luxon.DateTime.fromISO(record.leave_date_to.raw_value).toFormat('ccc d MMM')">
                     <field name="current_leave_id"/>


### PR DESCRIPTION
To reproduce:
=============
- install hr_holidays, mrp
- in settings remove all HR groups to Mitchell Admin
- in mrp settings enable **Work Orders** to have **Work Centers**
- open a work center config and enable **Requires Log In**
- switch to mobile view and refresh the page
- try to select **Allowed Employees** -> Traceback

Problem:
========
- in mobile view, the select of emplyees is using kanban view
- kanban view is overrided in hr_holidays to add some fields, as user doesn't have access to these fields, the kanban view is not rendered and the select is not working

Solution:
=========
- check if the field is accessible before trying to read it values in kanban view

opw-4741170
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
