### PR TITLE
[FIX] event: Prevent emails from going out for cancelled events

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -262,7 +262,8 @@ You receive this email because you are:
         schedulers = self.search([
             ('event_id.active', '=', True),
             ('mail_done', '=', False),
-            ('scheduled_date', '<=', fields.Datetime.now())
+            ('scheduled_date', '<=', fields.Datetime.now()),
+            ('event_id.stage_id', '!=', self.env.ref('event.event_stage_cancelled').id)
         ])
 
         for scheduler in schedulers:

--- a/addons/event/tests/test_event_flow.py
+++ b/addons/event/tests/test_event_flow.py
@@ -112,6 +112,17 @@ class TestEventFlow(EventCase):
             test_reg1.state, 'draft',
             'Event: new registration should not be confirmed with auto_confirmation parameter being False')
 
+        # Flow for cancelling the event and making sure no emails go out
+        test_event.update({'stage_id': self.env.ref('event.event_stage_cancelled').id})
+
+        scheduler = self.env['event.mail'].sudo().search([
+            ('event_id', '=', test_event.id),
+            ('interval_type', '=', 'before_event'),
+            ('interval_unit', '=', 'hours')
+        ])
+        self.env['event.mail'].schedule_communications()
+        self.assertFalse(scheduler.mail_count_done)
+
     @mute_logger('odoo.addons.event.models.event_mail')
     def test_event_missed_mail_template(self):
         """ Check that error on mail sending is ignored if corresponding mail template was deleted """


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
When the cron job that sends out emails for events gets sent out, there is no check to differentiate between events that are still scheduled and events that are cancelled. This causes the cron job to query cancelled events and add any communication attached to the list of emails to be sent out. This fix adds an extra check to filter out the events that are cancelled when scheduling the emails getting sent out.

opw - 4589819

### Steps to reproduce on runbot:
1. Create an event and add a reminder on the event
2. Set the begin date on the event to be an hour from now
3. Cancel the event
4. Reset the cron job for Event: Mail Scheduler to be close to current time or run manually
5. Check the emails in the technical menu to see the email sent out

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
