### PR TITLE
[FIX] html_builder, *: always activate the stored target on undo/redo + Fix carousels

### DIFF
--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -115,8 +115,8 @@ export class BuilderOptionsPlugin extends Plugin {
             this.target = target;
         }
         if (!this.target || !this.target.isConnected) {
-            this.lastContainers = this.lastContainers.filter((c) => c.element.isConnected);
-            this.target = this.lastContainers.at(-1)?.element;
+            const connectedContainers = this.lastContainers.filter((c) => c.element.isConnected);
+            this.target = connectedContainers.at(-1)?.element;
         }
 
         const newContainers = this.computeContainers(this.target);

--- a/addons/html_builder/static/src/core/builder_options_plugin.js
+++ b/addons/html_builder/static/src/core/builder_options_plugin.js
@@ -2,7 +2,7 @@ import { Plugin } from "@html_editor/plugin";
 import { uniqueId } from "@web/core/utils/functions";
 import { isRemovable } from "./remove_plugin";
 import { isClonable } from "./clone_plugin";
-import { getElementsWithOption } from "@html_builder/utils/utils";
+import { getElementsWithOption, isElementInViewport } from "@html_builder/utils/utils";
 import { shouldEditableMediaBeEditable } from "@html_builder/utils/utils_css";
 
 export class BuilderOptionsPlugin extends Plugin {
@@ -308,6 +308,10 @@ export class BuilderOptionsPlugin extends Plugin {
                 targetEl = revertedStep.extraStepInfos.nextTarget;
             }
             this.updateContainers(targetEl, { forceUpdate: true });
+            // Scroll to the target if not visible.
+            if (!isElementInViewport(targetEl)) {
+                targetEl.scrollIntoView({ behavior: "smooth", block: "center" });
+            }
         }
     }
 

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -357,7 +357,9 @@ export class CarouselOptionPlugin extends Plugin {
 
             const activeImageEl = editingCarouselElement.querySelector(".carousel-item.active img");
             this.dependencies.history.addStep();
-            this.dependencies["builder-options"].updateContainers(activeImageEl, { force: true });
+            this.dependencies["builder-options"].updateContainers(activeImageEl, {
+                forceUpdate: true,
+            });
         }
     }
 }

--- a/addons/website/static/src/builder/plugins/carousel_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/carousel_option_plugin.js
@@ -4,9 +4,14 @@ import { registry } from "@web/core/registry";
 import { CarouselItemHeaderMiddleButtons } from "./carousel_item_header_buttons";
 import { renderToElement } from "@web/core/utils/render";
 
+const carouselWrapperSelector =
+    ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper";
+const carouselControlsSelector =
+    ".carousel-control-prev, .carousel-control-next, .carousel-indicators";
+
 export class CarouselOptionPlugin extends Plugin {
     static id = "carouselOption";
-    static dependencies = ["clone", "history", "remove", "builder-options", "builderActions"];
+    static dependencies = ["clone", "history", "builder-options", "builderActions"];
     static shared = ["slide", "addSlide", "removeSlide"];
 
     resources = {
@@ -47,15 +52,14 @@ export class CarouselOptionPlugin extends Plugin {
         },
         builder_actions: this.getActions(),
         on_cloned_handlers: this.onCloned.bind(this),
-        on_will_clone_handlers: this.onWillClone.bind(this),
         on_snippet_dropped_handlers: this.onSnippetDropped.bind(this),
-        normalize_handlers: this.normalize.bind(this),
         on_reorder_items_handlers: this.reorderCarouselItems.bind(this),
         before_save_handlers: () => {
             const proms = [];
+            // Restore all the carousels so their first slide is the active one.
             for (const carouselEl of this.editable.querySelectorAll(".carousel")) {
-                const firstItem = carouselEl.querySelector(".carousel-item");
-                if (firstItem.classList.contains("active")) {
+                const firstItemEl = carouselEl.querySelector(".carousel-item");
+                if (firstItemEl.classList.contains("active")) {
                     continue;
                 }
                 proms.push(this.slide(carouselEl, 0));
@@ -77,17 +81,7 @@ export class CarouselOptionPlugin extends Plugin {
                     this.slideCarousel(editingElement, direction),
             },
             toggleControllers: {
-                apply: ({ editingElement }) => {
-                    const carouselEl = editingElement.closest(".carousel");
-                    const indicatorsWrapEl = carouselEl.querySelector(".carousel-indicators");
-                    const areControllersHidden =
-                        carouselEl.classList.contains("s_carousel_arrows_hidden") &&
-                        indicatorsWrapEl.classList.contains("s_carousel_indicators_hidden");
-                    carouselEl.classList.toggle(
-                        "s_carousel_controllers_hidden",
-                        areControllersHidden
-                    );
-                },
+                apply: ({ editingElement }) => this.toggleControllers(editingElement),
             },
             toggleCardImg: {
                 apply: ({ editingElement }) => this.toggleCardImg(editingElement),
@@ -104,6 +98,25 @@ export class CarouselOptionPlugin extends Plugin {
         };
     }
 
+    /**
+     * Adds a custom class if all controllers are hidden.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
+    toggleControllers(editingElement) {
+        const carouselEl = editingElement.closest(".carousel");
+        const indicatorsEl = carouselEl.querySelector(".carousel-indicators");
+        const areControllersHidden =
+            carouselEl.classList.contains("s_carousel_arrows_hidden") &&
+            indicatorsEl.classList.contains("s_carousel_indicators_hidden");
+        carouselEl.classList.toggle("s_carousel_controllers_hidden", areControllersHidden);
+    }
+
+    /**
+     * Toggles the card images.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
     toggleCardImg(editingElement) {
         const carouselEl = editingElement.closest(".carousel");
         const cardEls = carouselEl.querySelectorAll(".card");
@@ -114,53 +127,79 @@ export class CarouselOptionPlugin extends Plugin {
     }
 
     getTitleExtraInfo(editingElement) {
-        const itemsEls = [...editingElement.parentElement.children];
-        const activeIndex = itemsEls.indexOf(editingElement);
-
-        const updatedText = ` (${activeIndex + 1}/${itemsEls.length})`;
+        const itemEls = [...editingElement.parentElement.children];
+        const activeIndex = itemEls.indexOf(editingElement);
+        // Updates the slide counter.
+        const updatedText = ` (${activeIndex + 1}/${itemEls.length})`;
         return updatedText;
     }
 
+    /**
+     * Adds a slide.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
     async addSlide(editingElement) {
-        const activeCarouselItem = editingElement.querySelector(".carousel-item.active");
-        this.dependencies.clone.cloneElement(activeCarouselItem);
+        // Clone the active item and remove the "active" class.
+        const activeItemEl = editingElement.querySelector(".carousel-item.active");
+        const newItemEl = this.dependencies.clone.cloneElement(activeItemEl, {
+            activateClone: false,
+        });
+        newItemEl.classList.remove("active");
 
+        // Show the controllers (now that there is always more than one item).
+        const controlEls = editingElement.querySelectorAll(carouselControlsSelector);
+        controlEls.forEach((controlEl) => {
+            controlEl.classList.remove("d-none");
+        });
+
+        // Add the new indicator.
+        const indicatorsEl = editingElement.querySelector(".carousel-indicators");
+        const newIndicatorEl = this.document.createElement("button");
+        newIndicatorEl.setAttribute("data-bs-target", "#" + editingElement.id);
+        newIndicatorEl.setAttribute("aria-label", _t("Carousel indicator"));
+        indicatorsEl.appendChild(newIndicatorEl);
+
+        // Slide to the new item.
         await this.slide(editingElement, "next");
-        this.dependencies.history.addStep();
-        this.dependencies["builder-options"].updateContainers(
-            editingElement.querySelector(".carousel-item.active")
-        );
     }
 
-    async removeSlide(editingCarouselElement) {
-        const toRemoveCarouselItemEl =
-            editingCarouselElement.querySelector(".carousel-item.active");
-        const toRemoveIndicatorEl = editingCarouselElement.querySelector(
-            ".carousel-indicators > .active"
-        );
-        const itemsEls = [...editingCarouselElement.querySelectorAll(".carousel-item")];
+    /**
+     * Removes the current slide.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
+    async removeSlide(editingElement) {
+        const itemEls = [...editingElement.querySelectorAll(".carousel-item")];
+        const newLength = itemEls.length - 1;
+        if (newLength > 0) {
+            const activeItemEl = editingElement.querySelector(".carousel-item.active");
+            const activeIndicatorEl = editingElement.querySelector(
+                ".carousel-indicators > .active"
+            );
+            // Slide to the previous item.
+            await this.slide(editingElement, "prev");
 
-        if (itemsEls.length > 1) {
-            // Slide to the previous item
-            await this.slide(editingCarouselElement, "prev");
+            // Remove the carousel item and the indicator.
+            activeItemEl.remove();
+            activeIndicatorEl.remove();
 
-            // Remove the carousel item and the indicator
-            this.dependencies.remove.removeElement(toRemoveCarouselItemEl);
-            this.dependencies.remove.removeElement(toRemoveIndicatorEl);
-
-            this.dependencies.history.addStep();
-            this.dependencies["builder-options"].updateContainers(
-                editingCarouselElement.querySelector(".carousel-item.active")
+            // Hide the controllers if there is only one slide left.
+            const controlEls = editingElement.querySelectorAll(carouselControlsSelector);
+            controlEls.forEach((controlEl) =>
+                controlEl.classList.toggle("d-none", newLength === 1)
             );
         }
     }
 
+    /**
+     * Slides the carousel.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     * @param {String} direction "prev" or "next".
+     */
     async slideCarousel(editingElement, direction) {
         await this.slide(editingElement, direction);
-        this.dependencies.history.addStep();
-        this.dependencies["builder-options"].updateContainers(
-            editingElement.querySelector(".carousel-item.active")
-        );
     }
 
     /**
@@ -189,14 +228,18 @@ export class CarouselOptionPlugin extends Plugin {
                     // Setting the active indicator manually, as Bootstrap could
                     // not do it because the `data-bs-slide-to` attribute is not
                     // here in edit mode anymore.
-                    const activeSlide = editingElement.querySelector(".carousel-item.active");
-                    const indicatorsEl = editingElement.querySelector(".carousel-indicators");
-                    const activeIndex = [...activeSlide.parentElement.children].indexOf(
-                        activeSlide
+                    const itemEls = editingElement.querySelectorAll(".carousel-item");
+                    const activeItemEl = editingElement.querySelector(".carousel-item.active");
+                    const activeIndex = [...itemEls].indexOf(activeItemEl);
+                    const indicatorEls = editingElement.querySelectorAll(
+                        ".carousel-indicators > *"
                     );
-                    const activeIndicatorEl = [...indicatorsEl.children][activeIndex];
+                    const activeIndicatorEl = [...indicatorEls][activeIndex];
                     activeIndicatorEl.classList.add("active");
                     activeIndicatorEl.setAttribute("aria-current", "true");
+
+                    // Activate the active item.
+                    this.dependencies["builder-options"].setNextTarget(activeItemEl);
 
                     resolve();
                 }, 0.2 * slideDuration);
@@ -214,49 +257,24 @@ export class CarouselOptionPlugin extends Plugin {
         });
     }
 
-    onWillClone({ originalEl }) {
-        if (originalEl.matches(".carousel-item")) {
-            const editingCarousel = originalEl.closest(".carousel");
-
-            const indicatorsEl = editingCarousel.querySelector(".carousel-indicators");
-            this.controlEls = editingCarousel.querySelectorAll(
-                ".carousel-control-prev, .carousel-control-next, .carousel-indicators"
-            );
-            this.controlEls.forEach((control) => {
-                control.classList.remove("d-none");
-            });
-
-            const newIndicatorEl = this.document.createElement("button");
-            newIndicatorEl.setAttribute("data-bs-target", "#" + editingCarousel.id);
-            newIndicatorEl.setAttribute("aria-label", _t("Carousel indicator"));
-            indicatorsEl.appendChild(newIndicatorEl);
-        }
-    }
-
     onCloned({ cloneEl }) {
-        if (
-            cloneEl.matches(
-                ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper"
-            )
-        ) {
+        if (cloneEl.matches(carouselWrapperSelector)) {
             this.assignUniqueID(cloneEl);
-        }
-        if (cloneEl.matches(".carousel-item")) {
-            // Need to remove editor data from the clone so it gets its own.
-            cloneEl.classList.remove("active");
         }
     }
 
     onSnippetDropped({ snippetEl }) {
-        if (
-            snippetEl.matches(
-                ".s_carousel_wrapper, .s_carousel_intro_wrapper, .s_carousel_cards_wrapper"
-            )
-        ) {
+        if (snippetEl.matches(carouselWrapperSelector)) {
             this.assignUniqueID(snippetEl);
         }
     }
 
+    /**
+     * Creates a unique ID for the carousel and reassign data-attributes that
+     * depend on it.
+     *
+     * @param {HTMLElement} editingElement the carousel element.
+     */
     assignUniqueID(editingElement) {
         const id = "myCarousel" + Date.now();
         editingElement.querySelector(".carousel").setAttribute("id", id);
@@ -270,36 +288,6 @@ export class CarouselOptionPlugin extends Plugin {
                 el.setAttribute("href", "#" + id);
             }
         });
-    }
-    normalize(root) {
-        const carousel = root.closest(".carousel");
-        const allCarousels = [...root.querySelectorAll(".carousel")];
-        if (carousel) {
-            allCarousels.push(carousel);
-        }
-        this.fixWrongHistoryOnCarousels(allCarousels);
-    }
-    /**
-     * This fix is exists to workaround a bug:
-     * - add slide
-     * - undo
-     * - redo
-     * => the active class of the carousel item and therefore it looks like the carrousel is empty.
-     *
-     * @todo: find the root cause and remove this fix.
-     */
-    fixWrongHistoryOnCarousels(carousels) {
-        for (const carousel of carousels) {
-            const carouselItems = carousel.querySelectorAll(".carousel-item");
-            const activeCarouselItems = carousel.querySelectorAll(".carousel-item.active");
-            if (!activeCarouselItems.length) {
-                carouselItems[0].classList.add("active");
-                const indicatorsEl = carousel.querySelector(".carousel-indicators");
-                const activeIndicatorEl = [...indicatorsEl.children][0];
-                activeIndicatorEl.classList.add("active");
-                activeIndicatorEl.setAttribute("aria-current", "true");
-            }
-        }
     }
 
     reorderCarouselItems({ elementToReorder, position, optionName }) {

--- a/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/options/gallery_element_option_plugin.js
@@ -20,17 +20,42 @@ export class GalleryElementOptionPlugin extends Plugin {
     getActions() {
         return {
             setGalleryElementPosition: {
-                apply: ({ editingElement, value: position }) => {
-                    const optionName = editingElement.classList.contains("carousel-item")
+                apply: ({ editingElement: activeItemEl, value: position }) => {
+                    const optionName = activeItemEl.classList.contains("carousel-item")
                         ? "Carousel"
                         : "GalleryImageList";
 
-                    // Carousel and gallery image list are both managed by the same handler
-                    this.dispatchTo("on_reorder_items_handlers", {
-                        elementToReorder: editingElement,
-                        position: position,
-                        optionName: optionName,
-                    });
+                    // Get the items to reorder.
+                    const itemEls = [];
+                    for (const getGalleryItems of this.getResource("get_gallery_items_handlers")) {
+                        itemEls.push(...getGalleryItems(activeItemEl, optionName));
+                    }
+
+                    // Reorder the items.
+                    const oldPosition = itemEls.indexOf(activeItemEl);
+                    if (oldPosition === 0 && position === "prev") {
+                        position = "last";
+                    } else if (oldPosition === itemEls.length - 1 && position === "next") {
+                        position = "first";
+                    }
+                    itemEls.splice(oldPosition, 1);
+                    switch (position) {
+                        case "first":
+                            itemEls.unshift(activeItemEl);
+                            break;
+                        case "prev":
+                            itemEls.splice(Math.max(oldPosition - 1, 0), 0, activeItemEl);
+                            break;
+                        case "next":
+                            itemEls.splice(oldPosition + 1, 0, activeItemEl);
+                            break;
+                        case "last":
+                            itemEls.push(activeItemEl);
+                            break;
+                    }
+
+                    // Update the DOM with the new items order.
+                    this.dispatchTo("reorder_items_handlers", activeItemEl, itemEls, optionName);
                 },
             },
         };

--- a/addons/website/static/tests/builder/builder_option.test.js
+++ b/addons/website/static/tests/builder/builder_option.test.js
@@ -17,7 +17,7 @@ function expectOptionContainerToInclude(editor, elem) {
 
 defineWebsiteModels();
 
-test("Undo/Redo correctly restore the container target", async () => {
+test("Undo/Redo correctly restores the stored container target", async () => {
     addActionOption({
         customAction: {
             apply: ({ editingElement }) => {
@@ -29,27 +29,105 @@ test("Undo/Redo correctly restore the container target", async () => {
         selector: ".test-options-target",
         template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
     });
-    const { getEditor } = await setupWebsiteBuilder(`
-        <div class="test-options-target target1">
+    await setupWebsiteBuilder(`
+        <div data-name="Target 1" class="test-options-target target1">
             Homepage
         </div>
-        <div class="test-options-target target2">
+        <div data-name="Target 2" class="test-options-target target2">
             Homepage2
         </div>
 
     `);
-    const editor = getEditor();
 
     await contains(":iframe .target1").click();
-    expectOptionContainerToInclude(editor, queryOne(":iframe .target1"));
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
     await contains("[data-action-id='customAction']").click();
     await contains(":iframe .target2").click();
-    expectOptionContainerToInclude(editor, queryOne(":iframe .target2"));
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
 
     await contains(".o-snippets-top-actions .fa-undo").click();
-    expectOptionContainerToInclude(editor, queryOne(":iframe .target1"));
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
     await contains(".o-snippets-top-actions .fa-repeat").click();
-    expectOptionContainerToInclude(editor, queryOne(":iframe .target2"));
+    expect(".options-container").toHaveCount(0);
+});
+
+test("Undo/Redo multiple actions always restores the action container target", async () => {
+    addActionOption({
+        customAction: {
+            apply: ({ editingElement }) => {
+                editingElement.classList.add("test");
+            },
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
+    await setupWebsiteBuilder(`
+        <div data-name="Target 1" class="test-options-target target1">
+            Homepage
+        </div>
+        <div data-name="Target 2" class="test-options-target target2">
+            Homepage2
+        </div>
+
+    `);
+
+    await contains(":iframe .target1").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
+    await contains("[data-action-id='customAction']").click();
+    await contains(":iframe .target2").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+    await contains("[data-action-id='customAction']").click();
+    expect(":iframe .test-options-target.test").toHaveCount(2);
+    // Undo everything.
+    await contains(".o-snippets-top-actions .fa-undo").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+    await contains(".o-snippets-top-actions .fa-undo").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
+    expect(":iframe .test-options-target.test").toHaveCount(0);
+    // Redo everything.
+    await contains(".o-snippets-top-actions .fa-repeat").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
+    await contains(".o-snippets-top-actions .fa-repeat").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+    expect(":iframe .test-options-target.test").toHaveCount(2);
+});
+
+test("Undo/Redo an action that activates another target restores the old one on undo and the new one on redo", async () => {
+    let editor;
+    addActionOption({
+        customAction: {
+            apply: ({ editingElement }) => {
+                editingElement.classList.add("test");
+                editor.shared["builder-options"].setNextTarget(editingElement.nextElementSibling);
+            },
+        },
+    });
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderButton action="'customAction'">Test</BuilderButton>`,
+    });
+    const { getEditor } = await setupWebsiteBuilder(`
+        <div data-name="Target 1" class="test-options-target target1">
+            Homepage
+        </div>
+        <div data-name="Target 2" class="test-options-target target2">
+            Homepage2
+        </div>
+
+    `);
+    editor = getEditor();
+
+    await contains(":iframe .target1").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
+    await contains("[data-action-id='customAction']").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
+    // Undo everything.
+    await contains(".o-snippets-top-actions .fa-undo").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 1");
+    await contains(".o-snippets-top-actions .fa-repeat").click();
+    expect(".options-container").toHaveAttribute("data-container-title", "Target 2");
 });
 
 test("Container fallback to a valid ancestor if target dissapear", async () => {

--- a/addons/website/static/tests/builder/custom_tab/misc.test.js
+++ b/addons/website/static/tests/builder/custom_tab/misc.test.js
@@ -407,6 +407,7 @@ test("no need to define 'isApplied' method for custom action if the widget alrea
 });
 
 test("useDomState callback shouldn't be called when the editingElement is removed", async () => {
+    let editor;
     let count = 0;
     class TestOption extends Component {
         static template = xml`<div class="test_option">test</div>`;
@@ -426,12 +427,26 @@ test("useDomState callback shouldn't be called when the editingElement is remove
         editableOnly: false,
         Component: TestOption,
     });
+    addOption({
+        selector: "*",
+        template: xml`<BuilderButton action="'addTestSnippet'">Add</BuilderButton>`,
+    });
+    addActionOption({
+        addTestSnippet: {
+            apply: ({ editingElement }) => {
+                const testEl = document.createElement("div");
+                testEl.classList.add("s_test", "alert-info");
+                testEl.textContent = "test";
+                editingElement.after(testEl);
+                editor.shared["builder-options"].setNextTarget(testEl);
+            },
+        },
+    });
 
-    const { getEditor } = await setupWebsiteBuilder(`<div></div>`);
-    const editor = getEditor();
-    setContent(editor.editable, '<div class="s_test alert-info">a</div>');
-    editor.shared.history.addStep();
-    await contains(":iframe .s_test").click();
+    const { getEditor } = await setupWebsiteBuilder(`<div class="s_dummy">Hello</div>`);
+    editor = getEditor();
+    await contains(":iframe .s_dummy").click();
+    await contains("[data-action-id='addTestSnippet']").click();
     expect(".options-container .test_option").toHaveCount(1);
     expect.verifySteps(["useDomState 0"]);
 

--- a/addons/website/static/tests/builder/website_builder/carousel_item.test.js
+++ b/addons/website/static/tests/builder/website_builder/carousel_item.test.js
@@ -1,85 +1,17 @@
 import { expect, test } from "@odoo/hoot";
 import { contains } from "@web/../tests/web_test_helpers";
-import { defineWebsiteModels, dummyBase64Img, setupWebsiteBuilder } from "../website_helpers";
-import { queryOne, waitFor } from "@odoo/hoot-dom";
+import { defineWebsiteModels, setupWebsiteBuilderWithSnippet } from "../website_helpers";
+import { waitFor } from "@odoo/hoot-dom";
 
 defineWebsiteModels();
 
-test("reorder carousel item should update container title", async () => {
-    const { getEditor } = await setupWebsiteBuilder(
-        `
-        <section class="s_carousel_intro_wrapper p-0">
-            <div class="s_carousel_intro s_carousel_default carousel carousel-dark" data-bs-ride="true" data-bs-interval="10000">
-                <div class="carousel-inner">
-                    <div class="s_carousel_intro_item carousel-item active" data-name="Slide">
-                        <div class="container">
-                            <div class="row o_grid_mode">
-                                <div data-name="Block">
-                                    <h1>Slide header 1</h1>
-                                </div>
-                                <div data-name="Block">
-                                    <p class="lead">Slide</p>
-                                </div>
-                                <div class="o_grid_item o_grid_item_image" data-name="Block">
-                                    <img src='${dummyBase64Img}' alt="" class="img img-fluid first_img">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="s_carousel_intro_item carousel-item" data-name="Slide">
-                        <div class="container">
-                            <div class="row o_grid_mode">
-                                <div data-name="Block">
-                                    <h1>Slide header 2</h1>
-                                </div>
-                                <div data-name="Block">
-                                    <p class="lead">slide 2</p>
-                                </div>
-                                <div class="o_grid_item o_grid_item_image" data-name="Block">
-                                    <img src='${dummyBase64Img}' alt="" class="img img-fluid">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="s_carousel_intro_item carousel-item" data-name="Slide">
-                        <div class="container">
-                            <div class="row o_grid_mode">
-                                <div data-name="Block">
-                                    <h1>Slide header 3</h1>
-                                </div>
-                                <div data-name="Block">
-                                    <p class="lead">slide 3</p>
-                                </div>
-                                <div class="o_grid_item o_grid_item_image" data-name="Block">
-                                    <img src='${dummyBase64Img}' alt="" class="img img-fluid">
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="o_horizontal_controllers container o_not_editable" contenteditable="false">
-                    <div class="o_horizontal_controllers_row row">
-                        <div class="o_arrows_wrapper">
-                            <button class="carousel-control-prev o_not_editable o_we_no_overlay" aria-label="Previous" title="Previous" contenteditable="false">
-                                <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                                <span class="visually-hidden">Previous</span>
-                            </button>
-                            <button class="carousel-control-next o_not_editable o_we_no_overlay" aria-label="Next" title="Next" contenteditable="false">
-                                <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                                <span class="visually-hidden">Next</span>
-                            </button>
-                        </div>
-                        <div class="s_carousel_indicators_numbers carousel-indicators o_we_no_overlay">
-                            <button type="button" class="active" aria-label="Carousel indicator"></button>
-                            <button type="button" aria-label="Carousel indicator"></button>
-                            <button type="button" aria-label="Carousel indicator"></button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        `
-    );
+test("Reordering a carousel item should update the container title", async () => {
+    const { getEditor, getEditableContent } = await setupWebsiteBuilderWithSnippet("s_carousel");
+    // Add a class on the first slide to identify it.
+    const editableEl = getEditableContent();
+    const firstItemEl = editableEl.querySelector(".carousel-item");
+    firstItemEl.classList.add("first-slide");
+
     const editor = getEditor();
     const builderOptions = editor.shared["builder-options"];
     const expectOptionContainerToInclude = (elem) => {
@@ -88,25 +20,13 @@ test("reorder carousel item should update container title", async () => {
         );
     };
 
-    await contains(":iframe .first_img").click();
+    await contains(":iframe .first-slide").click();
     await waitFor("[data-action-value='next']");
     expect("[data-container-title='Slide (1/3)']").toHaveCount(1);
-    expect("[data-container-title='Slide (2/3)']").toHaveCount(0);
-    expect("[data-container-title='Slide (3/3)']").toHaveCount(0);
-    expect("[data-action-value='next']").toHaveCount(1);
     await contains("[data-action-value='next']").click();
-
-    // the container title should be updated after reordering
-    expectOptionContainerToInclude(queryOne(":iframe .first_img"));
-    expect("[data-container-title='Slide (1/3)']").toHaveCount(0);
+    expectOptionContainerToInclude(firstItemEl);
     expect("[data-container-title='Slide (2/3)']").toHaveCount(1);
-    expect("[data-container-title='Slide (3/3)']").toHaveCount(0);
-
-    expect("[data-action-value='next']").toHaveCount(1);
     await contains("[data-action-value='next']").click();
-
-    expectOptionContainerToInclude(queryOne(":iframe .first_img"));
-    expect("[data-container-title='Slide (1/3)']").toHaveCount(0);
-    expect("[data-container-title='Slide (2/3)']").toHaveCount(0);
+    expectOptionContainerToInclude(firstItemEl);
     expect("[data-container-title='Slide (3/3)']").toHaveCount(1);
 });


### PR DESCRIPTION
[FIX] html_builder, *: always activate the stored target on undo/redo

*: html_editor

This commit fixes the behavior when restoring the containers when
undoing/redoing, by really storing the `extraStepInfos` in the step.
More precisely, on undo/redo, if the reverted step had some infos in it
(i.e. in `extraStepInfos`), they are kept when adding the step. This
allows to always have the mutations associated to the element on which
they apply (i.e. `currentTarget`), and therefore to activate the right
containers afterwards.

This commit also adds a way to ask to activate a specific element after
adding the current step, by using the `setNextTarget` shared function
of the `builder-options` plugin. This function adds the next target in
the current step `extraStepInfos`, so the containers are updated with it
when the step is added.

The tests are also adapted and simplified, and new tests are also added.

task-4367641

---
[FIX] html_builder, *: fix containers behavior when target disappears

*: website

This commit fixes the containers behavior when the target disappears.

Indeed, `this.lastContainers` was directly updated with the elements
still connected in the DOM, and then the target was set to the element
of the last container. So, when computing the containers of the new
target, the new containers were therefore the same as the old ones
(stored in `this.lastContainers`), which made them satisfy the condition
to not update them. The signal telling that they changed (i.e. the
`change_current_options_containers_listeners` resource) was then never
dispatched, making the options of the deleted target still be present in
the builder sidebar.

This commit fixes that by not updating directly `this.lastContainers`
and simply set the target to the last connected element, to then let the
containers be correctly updated after recomputing them.

task-4367641

---
[IMP] html_builder: scroll to the restored containers target if needed

This commit makes the page scroll to the target (if not in the viewport)
when restoring its options containers on undo/redo.

task-4367641

---
[FIX] website: review carousel options and clean the code

This commit fixes various things about the carousel options:

- Remove the normalize resource: the issue it was fixing does in fact
not happen, making this code useless.

- Hide the carousel controllers when removing a slide, if there is only
one slide left.

- Put all the code concerning the addition of a slide in the `addSlide`
function instead of using the clone resources, making it easier to
follow the flow.

- Not use the `remove` plugin `removeElement` shared function when
removing a slide and its indicator, as we do not want to go up to the
parent and so on, we simply want to delete the element.

- Remove the hack of "adding a step and then updating the containers" to
activate the active slide, as it is not correct and will add multiple
steps for one operation. Instead, use the `setNextTarget` shared
function of the `builder-options` plugin. It allows to always have the
right slide counter, no matter how much we undo/redo.

- Add some comments and docstrings.

- Use better variable names (to uniformize and simplify them).

- Clean the code.

task-4367641

---
[FIX] website: extract common code about reordering gallery items

This commit extracts the common code of `reorderGalleryItems` and
`reorderCarouselItems` to actually use `gallery_element_option_plugin`.

In addition, it also cleans the code a bit and properly activates the
next active item, by using the `setNextTarget` shared function instead
of adding a step and then updating the containers during the option.
This allows the slide counter to always properly update after a
reordering and after an undo/redo.

A notable change is that the "Image Gallery" does not slide to the
active slide anymore but updates it manually. It was mainly done for the
sake of a better UX (there is no point in sliding to the same image) but
also to not have the misalignment issue between the image and the
overlay anymore (this is caused by the fact that the `slid` BS event is
triggered too soon, so the handler should have added a delay. This will
be fixed later).

This commit also modifies the test, to adapt it to the changes and to
simplify it.

task-4367641