### PR TITLE
[FIX] point_of_sale: singleton error when refund many products on _compute_total_cost()

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1533,8 +1533,8 @@ class PosOrderLine(models.Model):
             product = line.product_id
             if line._is_product_storable_fifo_avco() and stock_moves:
                 product_cost = product._compute_average_price(0, line.qty, line._get_stock_moves_to_consider(stock_moves, product))
-                if (product.cost_currency_id.is_zero(product_cost) and self.order_id.shipping_date and self.refunded_orderline_id):
-                    product_cost = self.refunded_orderline_id.total_cost / self.refunded_orderline_id.qty
+                if (product.cost_currency_id.is_zero(product_cost) and line.order_id.shipping_date and line.refunded_orderline_id):
+                    product_cost = line.refunded_orderline_id.total_cost / line.refunded_orderline_id.qty
             else:
                 product_cost = product.standard_price
             line.total_cost = line.qty * product.cost_currency_id._convert(

--- a/doc/cla/individual/darkel61.md
+++ b/doc/cla/individual/darkel61.md
@@ -1,0 +1,11 @@
+Venezuela, 2025-05-30
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Henry Yu ddhenry809@hotmail.com https://github.com/darkel61


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When you create a refund order, and there's many products theres an error

Current behavior before PR: Error, this is the traceback.
```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/models.py", line 5896, in ensure_one
    _id, = self._ids
ValueError: too many values to unpack (expected 1)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 1803, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 152, in retrying
    result = func()
  File "/home/odoo/src/odoo/odoo/http.py", line 1831, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/odoo/http.py", line 2035, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 772, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 29, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 21, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 484, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 469, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/addons/point_of_sale/wizard/pos_payment.py", line 70, in check
    order._process_saved_order(False)
  File "/home/odoo/src/odoo/addons/point_of_sale/models/pos_order.py", line 184, in _process_saved_order
    self._compute_total_cost_in_real_time()
  File "/home/odoo/src/odoo/addons/point_of_sale/models/pos_order.py", line 412, in _compute_total_cost_in_real_time
    lines._compute_total_cost(stock_moves)
  File "/home/odoo/src/odoo/addons/point_of_sale/models/pos_order.py", line 1537, in _compute_total_cost
    product_cost = self.refunded_orderline_id.total_cost / self.refunded_orderline_id.qty
  File "/home/odoo/src/odoo/odoo/fields.py", line 1148, in __get__
    record.ensure_one()
  File "/home/odoo/src/odoo/odoo/models.py", line 5899, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: pos.order.line(16923, 16924, 16925)
```
Desired behavior after PR is merged:
No traceback error?


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
