### PR TITLE
[FIX] l10n_ro_edi_stock: remove country restriction for carrier partner

### DIFF
--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -435,8 +435,6 @@ class Picking(models.Model):
         partner = data['transport_partner_id']
         missing_carrier_partner_fields = []
 
-        if partner.country_id.code != 'RO':
-            errors.append(_("The delivery carrier partner has to be located in Romania."))
 
         if not partner.vat:
             missing_carrier_partner_fields.append(_("VAT"))

--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -435,7 +435,6 @@ class Picking(models.Model):
         partner = data['transport_partner_id']
         missing_carrier_partner_fields = []
 
-
         if not partner.vat:
             missing_carrier_partner_fields.append(_("VAT"))
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The system enforced a strict check that the delivery carrier partner must be located in Romania. This was limiting for companies that work with international carriers or operate across borders.

Current behavior before PR:
Delivery carriers not based in Romania triggered an error and could not be used in the delivery process.

Desired behavior after PR is merged:
Delivery carriers can now be located in any country. This provides greater flexibility in managing logistics and integrating international shipping partners.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
