### PR TITLE
[FIX] account: avoid raising error when it's not needed

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -787,21 +787,18 @@ class ResPartner(models.Model):
         )
 
     def write(self, vals):
-        if 'parent_id' not in vals:
-            return super().write(vals)
-
-        if not self.env.user.has_group('account.group_account_user'):
-            raise UserError(_("You do not have permission to mark this partner as the main commercial partner."))
-        parent_vat = self.env['res.partner'].browse(vals['parent_id']).vat
-        if vals['parent_id'] and {parent_vat} != set(self.mapped('vat')):
-            raise UserError(_("You cannot set a partner as an invoicing address of another if they have a different %(vat_label)s.", vat_label=self.vat_label))
-
         res = super().write(vals)
-        self._compute_commercial_partner()
-        moves = self.env['account.move'].search([('partner_id', 'in', self.ids)])
-        if moves:
+        moves_sudo = self.sudo().env['account.move'].search([('partner_id', 'in', self.ids)])
+        if moves_sudo and 'parent_id' in vals:
+            if not self.env.user.has_group('account.group_account_user'):
+                raise UserError(_("You do not have permission to mark this partner as the main commercial partner."))
+            parent_vat = self.env['res.partner'].browse(vals['parent_id']).vat
+            if vals['parent_id'] and {parent_vat} != set(self.mapped('vat')):
+                raise UserError(_("You cannot set a partner as an invoicing address of another if they have a different %(vat_label)s.", vat_label=self.vat_label))
+
+            self._compute_commercial_partner()
             for partner in self:
-                moves.filtered(lambda m: m.partner_id == partner)['commercial_partner_id'] = partner.commercial_partner_id.id
+                moves_sudo.filtered(lambda m: m.partner_id == partner)['commercial_partner_id'] = partner.commercial_partner_id.id
                 partner._message_log(body=_("The commercial partner has been updated for all related accounting entries."))
         return res
 


### PR DESCRIPTION
commit 0a9c5fcfb9eb1b3532cd67e22b218f255f793091 introduced an automatic way to fix accounting entries when the commercial partner of a res.patrner would change. Only accountants should be doing that, but the error should be raised only if there exist some accounting entries

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
