### PR TITLE
[FIX] point_of_sale: internal note on KOT

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1664,7 +1664,7 @@ export class PosStore extends WithLazyGetterTrap {
             tracking_number: order.tracking_number,
             preset_name: order.preset_id?.name || "",
             employee_name: order.employee_id?.name || order.user_id?.name,
-            internal_note: order.internal_note,
+            internal_note: this.getStrNotes(order.internal_note),
             general_customer_note: order.general_customer_note,
             changes: {
                 title: "",
@@ -1745,7 +1745,7 @@ export class PosStore extends WithLazyGetterTrap {
             }
 
             if (orderChange.internal_note || orderChange.general_customer_note) {
-                orderData.changes = {};
+                orderData.changes = { title: "", data: [] };
                 const result = await this.printOrderChanges(orderData, printer);
                 if (!result.successful) {
                     unsuccedPrints.push(printer.config.name);

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -27,7 +27,7 @@
             <!-- Receipt Body -->
             <div class="pos-receipt-body pb-5">
                 <t t-set="hasDataChanges" t-value="data.changes.data or data.changes.groupedData" />
-                <div t-if="hasDataChanges" class="new-changes w-100">
+                <div t-if="hasDataChanges?.length" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong t-esc="data.changes.title" />
                     </div>
@@ -45,13 +45,13 @@
                         </div>
                     </t>
                 </div>
-                <div t-if="data.internal_note and !hasDataChanges" class="new-changes w-100" t-att-class="{'mb-3': data.general_customer_note}">
+                <div t-if="data.internal_note and !hasDataChanges?.length" class="new-changes w-100" t-att-class="{'mb-3': data.general_customer_note}">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>INTERNAL NOTE</strong>
                     </div>
                     <div class="text-center" style="font-size: 109%;" t-esc="data.internal_note" />
                 </div>
-                <div t-if="data.general_customer_note and !hasDataChanges" class="new-changes w-100">
+                <div t-if="data.general_customer_note and !hasDataChanges?.length" class="new-changes w-100">
                     <div class="pos-receipt-title text-center w-100">
                         <strong>CUSTOMER NOTE</strong>
                     </div>

--- a/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
+++ b/addons/point_of_sale/static/tests/pos/tours/utils/preparation_receipt_util.js
@@ -2,7 +2,7 @@
 
 import { renderToElement } from "@web/core/utils/render";
 
-export function generatePreparationReceiptElement() {
+export function generatePreparationChanges() {
     const order = posmodel.getOrder();
     const orderChange = posmodel.changesToOrder(
         order,
@@ -10,13 +10,16 @@ export function generatePreparationReceiptElement() {
         false
     );
 
-    const { orderData, changes } = posmodel.generateOrderChange(
+    return posmodel.generateOrderChange(
         order,
         orderChange,
         Array.from(posmodel.config.preparationCategories),
         false
     );
+}
 
+export function generatePreparationReceiptElement() {
+    const { orderData, changes } = generatePreparationChanges();
     orderData.changes = {
         title: "new",
         data: changes.new,

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -15,7 +15,11 @@ import { registry } from "@web/core/registry";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import { delay } from "@odoo/hoot-dom";
 import * as TextInputPopup from "@point_of_sale/../tests/generic_helpers/text_input_popup_util";
-import { generatePreparationReceiptElement } from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
+import {
+    generatePreparationChanges,
+    generatePreparationReceiptElement,
+} from "@point_of_sale/../tests/pos/tours/utils/preparation_receipt_util";
+import { renderToElement } from "@web/core/utils/render";
 
 const ProductScreen = { ...ProductScreenPos, ...ProductScreenResto };
 
@@ -411,6 +415,31 @@ registry.category("web_tour.tours").add("PreparationPrinterContent", {
                     }
                     if (rendered.innerHTML.includes("DUPLICATA!")) {
                         throw new Error("DUPLICATA! should not be present in printed receipt");
+                    }
+                },
+            },
+            Chrome.clickPlanButton(),
+            FloorScreen.clickTable("2"),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ...ProductScreen.clickSelectedLine("Water"),
+            ProductScreen.addInternalNote("To Serve"),
+            {
+                content: "Check if order preparation contains 'To Serve' order level internal note",
+                trigger: "body",
+                run: async () => {
+                    const changes = generatePreparationChanges();
+                    const rendered = renderToElement("point_of_sale.OrderChangeReceipt", {
+                        data: changes.orderData,
+                    });
+
+                    if (!rendered.innerHTML.includes("INTERNAL NOTE")) {
+                        throw new Error("'INTERNAL NOTE' not found in printed receipt");
+                    }
+                    if (!rendered.innerHTML.includes("To Serve")) {
+                        throw new Error("To Serve not found in printed receipt");
+                    }
+                    if (rendered.innerHTML.includes("colorIndex")) {
+                        throw new Error("colorIndex should not be displayed in printed receipt");
                     }
                 },
             },


### PR DESCRIPTION
Steps to reproduce:
-------------------------
- Install `pos_restaurant` and configure a kitchen printer.
- Open a session and create an order.
- Change the order level internal note.

Issue:
-------
- The KOT for order level internal note change was not properly printed.

Cause:
---------
- In backend we are storing the array of objects to obtain color of the note and without parsing string from that it was shown as it is.

FIX:
-----
- We have now parsed the note and sent the appropriate texts to print.
- The `orderData.change` was reset wrongly, instead of removing the
keys we just need to reset them.
- We have also corrected the condition to show INTERNAL & CUSTOMER
notes as hasDataChanges will be an array and only if we have something
changed than only we need that.

task: 4830054
