### PR TITLE
[IMP] web: change m2x avatar assign icon

### DIFF
--- a/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
+++ b/addons/web/static/src/views/fields/many2many_tags_avatar/many2many_tags_avatar_field.xml
@@ -43,7 +43,7 @@
         <xpath expr="//t[@t-foreach='visibleTags']" position="before">
             <t t-if="canDisplayQuickAssignAvatar">
                 <a t-on-click.stop.prevent="openPopover" tabIndex="-1" href="#" data-tooltip="Assign"
-                   aria-label="Assign" class="o_quick_assign fa fa-pencil o_m2m_avatar btn-link d-flex align-items-center text-dark" role="button"/>
+                   aria-label="Assign" class="o_quick_assign fa o_m2m_avatar btn-link d-flex align-items-center text-dark" t-attf-class="{{ props.tags.length ? 'fa-pencil' : 'fa-user-plus' }}" role="button"/>
             </t>
         </xpath>
     </t>

--- a/addons/web/static/src/views/fields/many2one/many2one.xml
+++ b/addons/web/static/src/views/fields/many2one/many2one.xml
@@ -9,7 +9,7 @@
             <t t-elif="!props.readonly">
                 <span class="o_avatar o_m2o_avatar">
                     <a class="o_quick_assign btn-link d-flex align-items-center text-dark" href="#" role="button" tabIndex="-1" aria-label="Assign" data-tooltip="Assign" t-on-click.stop.prevent="(e) => this.openAssignPopover(e.currentTarget)">
-                        <i class="fa fa-pencil"/>
+                        <i class="fa fa-user-plus"/>
                     </a>
                 </span>
             </t>


### PR DESCRIPTION
This commit is a half revert of a previous change on the icon of the m2x assign button. When there is no assignee, the "fa-pencil" icon looks confusing. It induces that we will edit the record, not the assignees. So now, we display the "fa-user-plus" as before but when there is no assignee and the "fa-pencil" when there is at least one assignee.

task-4801337