### PR TITLE
[FIX] base_import: csv default encoding

### DIFF
--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -685,6 +685,7 @@ export class BaseImportModel {
                 type: "select",
                 value: "",
                 options: [
+                    "iso-8859-1",
                     "utf-8",
                     "utf-16",
                     "windows-1252",


### PR DESCRIPTION
Steps:
- Import a csv file with a special accent character like : ï

Actual result:
- First load of the file will not load the character properly
- Persisting the import will use the wrong character

Expected result:
- File is loaded properly with the right encoding on first try (based on Odoo 16: `iso-8859-1`)

Workaround:
- Load file with another encoding format, ignore error
- then, load file with the correct encoding

opw-4839903