### PR TITLE
[FIX] pos_sale: settle SO with notes and section and product tracked

### DIFF
--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -85,8 +85,7 @@ patch(PosStore.prototype, {
             sale_order.order_line.map((l) => l.id),
         ]);
 
-        for (let i = 0; i < sale_order.order_line.length; ++i) {
-            const line = sale_order.order_line[i];
+        for (const line of sale_order.order_line) {
             if (line.display_type === "line_note") {
                 if (previousProductLine) {
                     const previousNote = previousProductLine.customer_note;
@@ -122,7 +121,7 @@ patch(PosStore.prototype, {
             const newLine = await this.addLineToCurrentOrder(newLineValues, {}, false);
             previousProductLine = newLine;
 
-            const converted_line = converted_lines[i];
+            const converted_line = converted_lines.find((l) => l.id === line.id);
             if (
                 newLine.get_product().tracking !== "none" &&
                 (this.pickingType.use_create_lots || this.pickingType.use_existing_lots) &&

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -1192,13 +1192,19 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         sale_order = self.env['sale.order'].create({
             'partner_id': partner_test.id,
-            'order_line': [(0, 0, {
-                'product_id': product.id,
-                'name': product.name,
-                'product_uom_qty': 2,
-                'product_uom': product.uom_id.id,
-                'price_unit': product.lst_price,
-            })],
+            'order_line': [
+                (0, 0, {
+                    'name': 'section line',
+                    'display_type': 'line_section',
+                }),
+                (0, 0, {
+                    'product_id': product.id,
+                    'name': product.name,
+                    'product_uom_qty': 2,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.lst_price,
+                })
+            ],
         })
         sale_order.action_confirm()
         self.main_pos_config.open_ui()


### PR DESCRIPTION
Currently, when you try to settle a SO in POS which has sections/notes before the product line (producted tracked), a traceback will appear and the amount to settle will be set to 0.

Steps to reproduce:
-------------------
* Crete a product tracked by SN
* Create a SO, the first line should be a section line and the second the product newly created
* Open pos session
* Try to settle the SO
> Observation: Traceback, when closing the traceback, the line on the
pos order has an amount of 0.

Why the fix:
------------
This commit https://github.com/odoo/odoo/commit/4c0fdfe23c6302929bf05f2223f41b7ac5587e66 didn't take into account that `read_converted` could potentially return less data than the number of sale order lines (sections and notes).

Thus using a loop invariant to track the converted_line related to the SO line does not make sense. In our example above, `i=1` when reaching the product line but `converted_lines` only had one element. In this case, `sale_order.order_line[1]` is related to `converted_lines[0]`.

opw-4800339