### PR TITLE
[FIX] web: calendar: avoid rerender when not needed

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -73,7 +73,7 @@ export class CalendarCommonRenderer extends Component {
             this.fc.api.scrollToTime(`${luxon.DateTime.local().hour - 2}:00:00`)
         );
 
-        const fullCalendarRenderDebounced = useDebounced(() => this.fc.api.render(), 100, {
+        const fullCalendarRenderDebounced = useDebounced(() => this.fc.api.updateSize(), 100, {
             immediate: true,
         });
         const fullCalendarResizeObserver = new ResizeObserver(fullCalendarRenderDebounced);


### PR DESCRIPTION
This commit optimize a previous fix as in this fix we always rerender the FullCalendar when the parent's sizing element was changed, but it's not optimal as we can call `updateSize` instead of `render`.

Doc:
> render
> Will initially render a calendar, or if it is already rendered, will rerender it.
>
> ---
> updateSize
> Immediately forces the calendar to readjusts its size.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
