### PR TITLE
[FIX] mass_mailing: fix separator alignment in email editor

### DIFF
--- a/addons/mass_mailing/static/src/snippets/s_hr/000.scss
+++ b/addons/mass_mailing/static/src/snippets/s_hr/000.scss
@@ -5,7 +5,11 @@
         padding: 0;
         border: 0;
         border-top: 1px solid currentColor;
-        margin: auto;
         color: inherit;
+        margin-top: auto;
+        margin-bottom: auto;
+        &:not(.ms-auto):not(.me-auto) {
+            margin-inline: auto;
+        }
     }
 }


### PR DESCRIPTION
Problem:
When trying to align a separator to the left or right in the email editor using `ms-auto` or `me-auto`, it remains centered instead of aligning as intended.

Cause:
A global `margin: auto` rule was applied to all `hr` elements, overriding the directional margin utilities (`ms-auto`, `me-auto`), preventing correct alignment.

Solution:
Restrict `margin: auto` to only apply on `hr` elements that do *not* have `ms-auto` or `me-auto` classes. This preserves default centering while allowing explicit left or right alignment.

Steps to reproduce:
- Open Email Marketing and add a "Separator" to an email.
- Try to align the separator to the left or right. → The separator remains centered instead of aligning properly.

opw-4805194

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
