### PR TITLE
[FIX] l10n_es: fix "is simplified" recomputation

### DIFF
--- a/addons/l10n_es/models/account_move.py
+++ b/addons/l10n_es/models/account_move.py
@@ -8,7 +8,10 @@ class AccountMove(models.Model):
     l10n_es_is_simplified = fields.Boolean("Is Simplified",
                                            compute="_compute_l10n_es_is_simplified", readonly=False, store=True)
 
-    @api.depends('partner_id', 'amount_total_signed')
+    # Note: We depend on 'line_ids.balance' instead of 'amount_total_signed' directly.
+    # Otherwise the field is recomputed when the 'state' changes (since 'amount_total_signed' depends on it);
+    # the recomputation would i.e. happen when confirming the invoice and override any manual edits of the field.
+    @api.depends('partner_id', 'line_ids.balance')
     def _compute_l10n_es_is_simplified(self):
         simplified_partner = self.env.ref('l10n_es.partner_simplified', raise_if_not_found=False)
         for move in self:


### PR DESCRIPTION
Currently the "Is Simplified" field (`l10n_es_is_simplified`)
is recomputed when the state of the move changes.
I.e. this can lead to to issues when confirming invoices with
the "Is Simplified" checked. When the invoice has a
partner (not the simplified one) and the total amount exceeds 400€
the "Is Simplified" is set to `False`.
(The same thing could also happen when cancelling a simplified invoice)

Technically the reason for the recomputation is a `depends` on `amount_total_signed`,
which itself depends on `state`.
After this fix we depend on `line_ids.balance` instead.
This way we avoid the dependency on `state` but still recompute when
the amounts on the invoice are changed. (The `amount_total_signed` is
just the sum of the `balance` of all the lines).

task: None (found / needed for task-3745982)