### PR TITLE
[FIX] sale: helpers should not return anything

### DIFF
--- a/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/combo_configurator_tour_utils.js
@@ -1,4 +1,4 @@
-import { queryAll, queryValue, waitUntil } from '@odoo/hoot-dom';
+import { queryAll } from '@odoo/hoot-dom';
 
 function comboSelector(comboName) {
     return `
@@ -20,9 +20,12 @@ function assertComboCount(count) {
     return {
         content: `Assert that there are ${count} combos`,
         trigger: '.sale-combo-configurator-dialog',
-        run: () => queryAll(
-            '.sale-combo-configurator-dialog [name="sale_combo_configurator_title"]'
-        ).length === count,
+        run() {
+            const selector = `.sale-combo-configurator-dialog [name="sale_combo_configurator_title"]`;
+            if (queryAll(selector).length !== count) {
+                console.error(`Assertion failed`);
+            }
+        },
     };
 }
 
@@ -30,9 +33,12 @@ function assertComboItemCount(comboName, count) {
     return {
         content: `Assert that there are ${count} combo items in combo ${comboName}`,
         trigger: comboSelector(comboName),
-        run: () => queryAll(
-            `${comboSelector(comboName)} + .combo-item-grid .product-card`
-        ).length === count,
+        run() {
+            const selector = `${comboSelector(comboName)} + .combo-item-grid .product-card`;
+            if (queryAll(selector).length !== count) {
+                console.error(`Assertion failed`);
+            }
+        },
     };
 }
 
@@ -40,9 +46,12 @@ function assertSelectedComboItemCount(count) {
     return {
         content: `Assert that there are ${count} selected combo items`,
         trigger: '.sale-combo-configurator-dialog',
-        run: () => queryAll(
-            `.sale-combo-configurator-dialog .combo-item-grid .product-card.selected`
-        ).length === count,
+        run() {
+            const selector = `.sale-combo-configurator-dialog .combo-item-grid .product-card.selected`;
+            if (queryAll(selector).length !== count) {
+                console.error(`Assertion failed`);
+            }
+        },
     };
 }
 
@@ -86,12 +95,9 @@ function setQuantity(quantity) {
 }
 
 function assertQuantity(quantity) {
-    const quantitySelector = '.sale-combo-configurator-dialog input[name="sale_quantity"]';
     return {
         content: `Assert that the combo quantity is ${quantity}`,
-        trigger: quantitySelector,
-        run: async () =>
-            await waitUntil(() => queryValue(quantitySelector) === quantity, { timeout: 1000 }),
+        trigger: `.sale-combo-configurator-dialog input[name="sale_quantity"]:value(${quantity})`,
     };
 }
 


### PR DESCRIPTION
In this commit, we ensure that run function of assertions helpers return nothing. When a run function return a non-null value, macro stops.
This commit fixes this by removing callWithUnloadCheck from tour_automatic.
Currently, this tour works because callWithUnloadCheck overwrites the return value of run() {}

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
