### PR TITLE
Fix l10n_es_edi_sii visibility changes

### DIFF
--- a/addons/l10n_es_edi_sii/views/account_move_views.xml
+++ b/addons/l10n_es_edi_sii/views/account_move_views.xml
@@ -10,9 +10,16 @@
                     <field name="l10n_es_registration_date" attrs="{'readonly': [('state', '=', 'posted')], 'invisible': [('country_code', '!=', 'ES')]}"/>
                     <field name="l10n_es_edi_csv" invisible="1"/>
                 </xpath>
-                <field name="ref" position="attributes">
-                    <attribute name="attrs">{'readonly': [('l10n_es_edi_csv', '!=', False)]}</attribute>
-                </field>
+                <xpath expr="//field[@name='ref'][@nolabel='1']" position="attributes">
+                    <attribute name="attrs">
+                        {'invisible':[('move_type', 'not in', ('in_invoice', 'in_receipt', 'in_refund'))], 'readonly': [('l10n_es_edi_csv', '!=', False)]}
+                    </attribute>
+                </xpath>
+                <xpath expr="//field[@name='ref'][not(@nolabel)]" position="attributes">
+                    <attribute name="attrs">
+                        {'invisible':[('move_type', 'in', ('in_invoice', 'in_receipt', 'in_refund', 'out_invoice', 'out_refund'))], 'readonly': [('l10n_es_edi_csv', '!=', False)]}
+                    </attribute>
+                </xpath>
             </field>
         </record>
     </data>


### PR DESCRIPTION
Take into account that the ref field  is present twice in the view and that when changint  the visibility of the field  both appearances must be taken into  account in order not to botch  the rendering of account moves.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Installing l10n_es_edi_sii botches the rendering of th einvoices and in general moves. This happens because the patched field is present twice in the base view and both instances should be patched.

Desired behavior after PR is merged:

Invoices and moves render correctly.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
