### PR TITLE
[FIX] pos_self_order: remove invalid key from tour

### DIFF
--- a/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
+++ b/addons/pos_self_order/static/tests/tours/self_order_kiosk_tour.js
@@ -166,7 +166,6 @@ registry.category("web_tour.tours").add("test_self_order_kiosk_combo_sides", {
 });
 
 registry.category("web_tour.tours").add("self_order_pricelist", {
-    test: true,
     steps: () => [
         Utils.checkIsNoBtn("My Order"),
         Utils.clickBtn("Order Now"),


### PR DESCRIPTION
The test for the self-order feature was failing due to a validation error in the web_tour registry. The issue comes from the use of an unrecognized key 'test' in the tour configuration of 'self_order_pricelist'.

This change removes the invalid 'test' key from the tour definition.
