### PR TITLE
[FIX] iap: Prevent traceback on empty error message

### DIFF
--- a/addons/iap/static/src/js/insufficient_credit_error_handler.js
+++ b/addons/iap/static/src/js/insufficient_credit_error_handler.js
@@ -2,6 +2,7 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 
 const { Component, onWillStart } = owl;
 
@@ -37,15 +38,23 @@ class InsufficientCreditDialog extends Component {
 InsufficientCreditDialog.components = { Dialog };
 InsufficientCreditDialog.template = "iap.InsufficientCreditDialog";
 
-function insufficientCreditHandler(env, error, originalError) {
+export function insufficientCreditHandler(env, error, originalError) {
     if (!originalError) {
         return false;
     }
     const { data } = originalError;
     if (data && data.name === "odoo.addons.iap.tools.iap_tools.InsufficientCreditError") {
-        env.services.dialog.add(InsufficientCreditDialog, {
-            errorData: JSON.parse(data.message),
-        });
+        if(!data.message){
+            env.services.dialog.add(AlertDialog,{
+                title: "Insufficient Credit Error",
+                body: "Insufficient credit to perform this service.",
+            });
+        }
+        else { 
+            env.services.dialog.add(InsufficientCreditDialog, {
+                errorData: JSON.parse(data.message),
+            });
+        }
         return true;
     }
     return false;

--- a/addons/iap/static/tests/iap_credits_test.js
+++ b/addons/iap/static/tests/iap_credits_test.js
@@ -1,0 +1,37 @@
+/** @odoo-module **/
+
+import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { insufficientCreditHandler } from "../src/js/insufficient_credit_error_handler";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+
+QUnit.module("iap", (hooks) => {
+    let env;
+
+    hooks.beforeEach(async () => {
+        env = await makeTestEnv();
+        env.services.dialog = {
+            add: (Component, props) => {
+                env.__dialogComponent = Component;
+                env.__dialogProps = props;
+            },
+        };
+    });
+
+    QUnit.test("displays AlertDialog when data.message is missing", async (assert) => {
+        const originalError = {
+            data: {
+                name: "odoo.addons.iap.tools.iap_tools.InsufficientCreditError",
+                // no `message` field
+            },
+        };
+
+        const handled = insufficientCreditHandler(env, {}, originalError);
+
+        assert.ok(handled, "Error should be handled");
+        assert.strictEqual(env.__dialogComponent, AlertDialog, "Should render AlertDialog");
+        assert.deepEqual(env.__dialogProps, {
+            title: "Insufficient Credit Error",
+            body: "Insufficient credit to perform this service.",
+        }, "Dialog should have correct title and body");
+    });
+});


### PR DESCRIPTION
**Problem**
=================
Calling `JSON.parse` on an empty or missing `message` in `InsufficientCreditError` caused a frontend traceback.

**Steps to reproduce**
======================
1. Install `l10n_br_avatax`
2. Enable debug mode
3. Set AvaTax Brazil API ID and Key to `'a'` in Accounting Settings
4. Create an invoice for "BR Company Customer"
5. Add "Regular Consumable Product" with "Automatic Tax Mapping..." fiscal position
6. Click **Compute Taxes**

**Issue**
==========
`data.message` is empty → `JSON.parse('')` throws.

**Fix**
========
Show an `AlertDialog` with a default message when `data.message` is missing.

**Result**
===========
User sees a proper alert instead.

opw-4784600

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
