### PR TITLE
[FIX] web: prevent unit test from failing with high cpu usage

### DIFF
--- a/addons/web/static/tests/views/fields/image_field_tests.js
+++ b/addons/web/static/tests/views/fields/image_field_tests.js
@@ -12,6 +12,8 @@ import {
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { pagerNext } from "@web/../tests/search/helpers";
 
+const { DateTime } = luxon;
+
 const MY_IMAGE =
     "iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==";
 const PRODUCT_IMAGE =
@@ -923,7 +925,9 @@ QUnit.module("Fields", (hooks) => {
             });
 
             const initialUnique = Number(getUnique(target.querySelector(".o_field_image img")));
-            assert.ok(initialUnique - 1486375200000 < 100);
+            assert.ok(
+                DateTime.fromMillis(initialUnique).hasSame(DateTime.fromISO("2017-02-06"), "days")
+            );
 
             await editInput(target, ".o_field_widget[name='foo'] input", "grrr");
 
@@ -952,9 +956,8 @@ QUnit.module("Fields", (hooks) => {
 
             await clickSave(target);
 
-            assert.ok(
-                Number(getUnique(target.querySelector(".o_field_image img"))) - 1486638000000 < 100
-            );
+            const unique = Number(getUnique(target.querySelector(".o_field_image img")));
+            assert.ok(DateTime.fromMillis(unique).hasSame(DateTime.fromISO("2017-02-09"), "days"));
         }
     );
 });


### PR DESCRIPTION
Steps to reproduce
==================

- Open the JS unit test page
- Enable the "Mid-tier mobile" option in the devtools in order to have a 4X CPU slowdown
- Run the test "url should not use the record last updated date when the field is related"

=> It fails

Cause of the issue
==================

We check that a timestamp generated after a patchDate is at most 100ms after. When we have a high CPU usage or a slow CPU, it can happen that the value is more than 100ms after.

Solution
========

The test simply needs to check that the date is either the `2017-02-06` or the `2017-02-09`.
We can use the luxon function `a.hasSame(b, "days")`

runbot-115469