### PR TITLE
[FIX] website: two fixes for mega menu

### DIFF
--- a/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
+++ b/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
@@ -17,6 +17,7 @@ const MegaMenuDropdownEdit = (I) => class extends I {
     };
 
     setup() {
+        super.setup();
         const hasMegaMenu = this.el.querySelector(".o_mega_menu_toggle");
         if (hasMegaMenu) {
             const bsDropdown = window.Dropdown.getOrCreateInstance(".o_mega_menu_toggle");

--- a/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
+++ b/addons/website/static/src/interactions/dropdown/mega_menu_dropdown.edit.js
@@ -7,11 +7,13 @@ const MegaMenuDropdownEdit = (I) => class extends I {
         ".o_mega_menu_toggle": {
             ...this.dynamicContent[".o_mega_menu_toggle"],
             "t-on-shown.bs.dropdown": () => {
-                // Focus the mega menu to show its options. Pointerup is
+                // Focus the mega menu to show its options. Click is
                 // listened to in BuilderOptionsPlugin to call updateContainers.
-                document
-                    .querySelector(".o_mega_menu")
-                    .dispatchEvent(new PointerEvent("pointerup", { bubbles: true }));
+                this.waitForTimeout(() => {
+                        document
+                            .querySelector(".o_mega_menu")
+                            .dispatchEvent(new PointerEvent("click", { bubbles: true }));
+                });
             },
         },
     };


### PR DESCRIPTION
The two commits fix two problems related to mega menus in editing mode. See individual commit messages.
The first commit fixes the traceback error reported in the pad:
> [BVR] Add a mega menu > go to mobile view > open the menu > Click the mega menu > Traceback (Cannot read properties of undefined (reading 'indexOf') at EI.moveMegaMenu) This also happens with other steps.