### PR TITLE
[FIX] test_base_automation: run should not return anything

### DIFF
--- a/addons/test_base_automation/static/tests/tour/base_automation_tour.js
+++ b/addons/test_base_automation/static/tests/tour/base_automation_tour.js
@@ -470,8 +470,8 @@ registry.category("web_tour.tours").add("test_form_view_model_id", {
         },
         {
             trigger: ".o_field_widget[name='trigger']",
-            run() {
-                return waitUntil(() => {
+            async run() {
+                await waitUntil(() => {
                     const triggerGroups = Array.from(this.anchor.querySelectorAll("optgroup"));
                     return triggerGroups.map((el) => el.getAttribute("label")).join(" // ") === "Values Updated // Timing Conditions // Custom // External" &&
                         triggerGroups.map((el) => el.innerText).join(" // ") === "Stage is set toUser is setTag is addedPriority is set to // Based on date fieldAfter creationAfter last update // On createOn create and editOn deletionOn UI change // On webhook";
@@ -576,8 +576,8 @@ registry.category("web_tour.tours").add("test_form_view_mail_triggers", {
         },
         {
             trigger: ".o_field_widget[name='trigger']",
-            run() {
-                return waitUntil(() => {
+            async run() {
+                await waitUntil(() => {
                     const textLabels = Array.from(this.anchor.querySelectorAll("select optgroup"))
                         .map((el) => el.label)
                         .join(", ");


### PR DESCRIPTION
In this commit, we ensure that run function of assertions helpers return nothing. When a run function return a non-null value, macro stops.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
