### PR TITLE
[FIX] mail: exclude completed activities from the list when accessed via the clock icon

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -213,6 +213,8 @@ class MailActivityMixin(models.AbstractModel):
     def _search_activity_user_id(self, operator, operand):
         if isinstance(operand, bool) and ((operator == '=' and not operand) or (operator == '!=' and operand)):
             return [('activity_ids', '=', False)]
+        if self.env.context.get('exclude_done_activities'):
+            return [('activity_ids', 'any', [('active', '=', True), ('user_id', operator, operand)])]
         return [('activity_ids', 'any', [('active', 'in', [True, False]), ('user_id', operator, operand)])]
 
     @api.model

--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -63,6 +63,7 @@ export class ActivityMenu extends Component {
             // Necessary because activity_ids of mail.activity.mixin has auto_join
             // So, duplicates are faking the count and "Load more" doesn't show up
             force_search_count: 1,
+            exclude_done_activities: true,
         };
         if (group.model === "mail.activity") {
             this.action


### PR DESCRIPTION
When clicking on the clock icon to view scheduled activities, the system currently displays all activities, including those already marked as done. This clutters the view and makes it difficult for users to focus on pending tasks.

Related commit: https://github.com/odoo/odoo/commit/5f4add917a55f62c024a7a79c9240dc628a9f14f




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
