### PR TITLE
[FIX] website: color picker reset button

### DIFF
--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -144,6 +144,32 @@ export class ColorPicker extends Component {
         }
         this.props.applyColorResetPreview();
     }
+
+    onColorResetApply() {
+        const color = "o-color-1";
+        this.applyColor(color);
+        this.props.close();
+    }
+
+    onColorResetHover(ev) {
+        const color = "o-color-1";
+        this.props.applyColorPreview(color);
+    }
+
+    onColorResetHoverOut() {
+        this.props.applyColorResetPreview();
+    }
+
+    onColorResetFocusin(ev) {
+        if (this.focusedColorBtn === ev.target) {
+            this.focusedColorBtn = null;
+            return;
+        }
+        this.onColorResetHover(ev);
+        this.focusedColorBtn = ev.target;
+        ev.target.focus();
+    }
+
     getTarget(ev) {
         const target = ev.target.closest(`[data-color]`);
         return this.root.el.contains(target) ? target : ev.target;

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -29,10 +29,10 @@
             <div class="flex-grow-1" />
             <button class="btn btn-sm btn-light fa fa-trash me-1"
                     title="Reset"
-                    t-on-click="onColorApply"
-                    t-on-mouseover="onColorHover"
-                    t-on-mouseout="onColorHoverOut"
-                    t-on-focusin="onColorFocusin"/>
+                    t-on-click="onColorResetApply"
+                    t-on-mouseover="onColorResetHover"
+                    t-on-mouseout="onColorResetHoverOut"
+                    t-on-focusin="onColorResetFocusin"/>
         </div>
         <t t-if="state.activeTab==='theme'">
             <div class="pt-2 px-2 pb-3 d-flex flex-column gap-1 o_cc_preview_wrapper"


### PR DESCRIPTION
The error occurs because of the missing functionality for a reset button Steps to reproduce the issue:
1. Open any colorpicker option
2. Hover the reset button We get an error and the element whose color we were changing is missing. The PR follows [the html_builder refactoring].

[the html_builder refactoring]: odoo@9fe45e2b7ddb

Related to task-4367641