### PR TITLE
[FIX] html_editor: properly detect format across blocks

### DIFF
--- a/addons/html_editor/static/src/utils/dom_info.js
+++ b/addons/html_editor/static/src/utils/dom_info.js
@@ -15,7 +15,7 @@ export function isEmpty(el) {
 }
 
 export function isEmptyTextNode(node) {
-    return node.nodeType === Node.TEXT_NODE && node.nodeValue.length === 0;
+    return node.nodeType === Node.TEXT_NODE && node.textContent.trim().length === 0;
 }
 
 /**

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -225,6 +225,55 @@ test("should make a few characters bold inside table (bold)", async () => {
     });
 });
 
+test("should make two paragraphs (separated with whitespace) bold", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: bold,
+        contentAfter: `
+            <p><strong>[abc</strong></p>
+            <p><strong>def]</strong></p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) not bold", async () => {
+    await testEditor({
+        contentBefore: `
+            <p><strong>[abc</strong></p>
+            <p><strong>def]</strong></p>
+        `,
+        stepFunction: bold,
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) bold, then not bold", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: async (editor) => {
+            bold(editor);
+            expect(getContent(editor.editable)).toBe(`
+            <p><strong>[abc</strong></p>
+            <p><strong>def]</strong></p>
+        `);
+            bold(editor);
+        },
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
 test("should insert a span zws when toggling a formatting command twice", () =>
     testEditor({
         contentBefore: `<p>[]<br></p>`,

--- a/addons/html_editor/static/tests/format/italic.test.js
+++ b/addons/html_editor/static/tests/format/italic.test.js
@@ -92,6 +92,55 @@ test("should make a selection ending with italic text fully italic", async () =>
     });
 });
 
+test("should make two paragraphs (separated with whitespace) italic", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: italic,
+        contentAfter: `
+            <p><em>[abc</em></p>
+            <p><em>def]</em></p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) not italic", async () => {
+    await testEditor({
+        contentBefore: `
+            <p><em>[abc</em></p>
+            <p><em>def]</em></p>
+        `,
+        stepFunction: italic,
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) italic, then not italic", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: async (editor) => {
+            italic(editor);
+            expect(getContent(editor.editable)).toBe(`
+            <p><em>[abc</em></p>
+            <p><em>def]</em></p>
+        `);
+            italic(editor);
+        },
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
 test("should get ready to type in italic", async () => {
     await testEditor({
         contentBefore: `<p>ab[]cd</p>`,

--- a/addons/html_editor/static/tests/format/underline.test.js
+++ b/addons/html_editor/static/tests/format/underline.test.js
@@ -96,6 +96,55 @@ test("should make a selection ending with underline text fully underline", async
     });
 });
 
+test("should make two paragraphs (separated with whitespace) underline", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: underline,
+        contentAfter: `
+            <p><u>[abc</u></p>
+            <p><u>def]</u></p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) not underline", async () => {
+    await testEditor({
+        contentBefore: `
+            <p><u>[abc</u></p>
+            <p><u>def]</u></p>
+        `,
+        stepFunction: underline,
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
+test("should make two paragraphs (separated with whitespace) underline, then not underline", async () => {
+    await testEditor({
+        contentBefore: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+        stepFunction: async (editor) => {
+            underline(editor);
+            expect(getContent(editor.editable)).toBe(`
+            <p><u>[abc</u></p>
+            <p><u>def]</u></p>
+        `);
+            underline(editor);
+        },
+        contentAfter: `
+            <p>[abc</p>
+            <p>def]</p>
+        `,
+    });
+});
+
 test("should get ready to type in underline", async () => {
     await testEditor({
         contentBefore: `<p>ab[]cd</p>`,

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -229,6 +229,18 @@ test("toolbar format buttons should react to format change", async () => {
     expect(".btn[name='bold']").toHaveClass("active");
 });
 
+test("toolbar format buttons should react to format change across blocks (with whitespace)", async () => {
+    await setupEditor(`
+        <p>[abc</p>
+        <p>def]</p>
+        `);
+    await waitFor(".o-we-toolbar");
+    expect(".btn[name='bold']").not.toHaveClass("active");
+    await contains(".btn[name='bold']").click();
+    await animationFrame();
+    expect(".btn[name='bold']").toHaveClass("active");
+});
+
 test("toolbar disable link button when selection cross blocks", async () => {
     await setupEditor("<div>[<div>a<p>b</p></div>]</div>");
     await waitFor(".o-we-toolbar");


### PR DESCRIPTION
When selecting across blocks, the selection sometimes includes whitespace text nodes that have space and newline characters. When these were included, the format of the selection failed to be detected. As a result the format didn't show in the toolbar and it couldn't be removed.

task-4840889

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
