### PR TITLE
[FIX] hr_holidays: fix leave type _compute_valid

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -198,7 +198,6 @@ class HrLeaveType(models.Model):
         allocation_by_leave_type = dict(self.env['hr.leave.allocation']._read_group(
             domain=Domain([
                 ('holiday_status_id', 'in', self.filtered(lambda leave_type: leave_type.requires_allocation).ids),
-                ('allocation_type', '=', 'accrual'),
                 ('employee_id', '=', employee_id),
                 ('date_from', '<=', date_from),
                 '|',
@@ -210,7 +209,7 @@ class HrLeaveType(models.Model):
         ))
         for leave_type in self:
             if leave_type.requires_allocation:
-                allocations = allocation_by_leave_type.get(leave_type.id, self.env['hr.leave.allocation'])
+                allocations = allocation_by_leave_type.get(leave_type, self.env['hr.leave.allocation'])
                 allowed_excess = leave_type.max_allowed_negative if leave_type.allows_negative else 0
                 allocations = allocations.filtered(lambda alloc:
                     alloc.allocation_type == 'accrual'


### PR DESCRIPTION
This PR fixes two issues in the `_compute_valid` method of the `hr.leave.type` model. The `('allocation_type', '=', 'accrual')` was removed from the domain, as it limited the valid allocations to type `accrual` only, which is not the intended behavior. The `leave_type.id` was changed to `leave_type`, since the key type in `allocation_by_leave_type` is a recordset, not an integer.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
