### PR TITLE
[FIX] website_sale: add order information in the payment form

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1849,6 +1849,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
     def _get_shop_payment_values(self, order, **kwargs):
         checkout_page_values = {
+            'sale_order': order,
             'website_sale_order': order,
             'errors': self._get_shop_payment_errors(order),
             'partner': order.partner_invoice_id,


### PR DESCRIPTION
Before this commit, sale_order information were used in some payment form but only website_sale_order was available.
This would cause issue in overrides.

task 4808806




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
