### PR TITLE
[FIX] account_edi_ubl_cii: Xrechnung BuyerReference field placeholder

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_xrechnung.py
@@ -24,6 +24,8 @@ class AccountEdiXmlUBLDE(models.AbstractModel):
         # EXTENDS account.edi.xml.ubl_bis3
         vals = super()._export_invoice_vals(invoice)
         vals['vals']['customization_id'] = 'urn:cen.eu:en16931:2017#compliant#urn:xeinkauf.de:kosit:xrechnung_3.0'
+        if not vals['vals'].get('buyer_reference'):
+            vals['vals']['buyer_reference'] = 'N/A'
         return vals
 
     def _export_invoice_constraints(self, invoice, vals):


### PR DESCRIPTION
Issue:
The BuyerReference field in Xrechnung is only mandatory to be filled with the appropriate company reference for DE B2G invoices, but not having the company reference resuts in the field being absent entirely from the document for B2C and B2B invoices, which results in the document being rejected.
Solution:
If the BuyerReference is not filled, it is set to 'N/A' instead of being left absent from the document.
Addresses ticket-4715709
task-4756812

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
