### PR TITLE
[FIX] html_editor, web: avoid traceback for date-type dynamic fields

### DIFF
--- a/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
@@ -64,8 +64,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
                 close: this.onClose.bind(this),
                 validate: this.onValidate.bind(this),
                 resModel: resModel,
-                canFollowRelationFor: (field, followRelations) =>
-                    (field.relation && followRelations) || field.type === "properties",
+                followRelation: (field) => field.relation || field.type === "properties",
             },
         });
     }

--- a/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder_plugin.js
@@ -64,6 +64,8 @@ export class DynamicPlaceholderPlugin extends Plugin {
                 close: this.onClose.bind(this),
                 validate: this.onValidate.bind(this),
                 resModel: resModel,
+                canFollowRelationFor: (field, followRelations) =>
+                    (field.relation && followRelations) || field.type === "properties",
             },
         });
     }

--- a/addons/html_editor/static/tests/dynamic_placeholder.test.js
+++ b/addons/html_editor/static/tests/dynamic_placeholder.test.js
@@ -59,3 +59,21 @@ test("inserted value from dynamic placeholder should contain the data-oe-t-inlin
 
     expect("t[data-oe-t-inline]").toHaveCount(1);
 });
+
+test("Should not show `__date` fields for dynamic placeholders", async () => {
+    const { editor } = await setupEditor("<p>test[]</p>", {
+        config: {
+            Plugins: [...MAIN_PLUGINS, ...DYNAMIC_PLACEHOLDER_PLUGINS],
+            dynamicPlaceholderResModel: "res.users",
+        },
+    });
+    onRpc("/web/dataset/call_kw/res.users/mail_get_partner_fields", () => ["partner_id"]);
+
+    await insertText(editor, "/dynamicplaceholder");
+    await press("Enter");
+    await animationFrame();
+
+    expect(
+        'li[data-name="write_date"] > .o_model_field_selector_popover_item_relation'
+    ).toHaveCount(0);
+});

--- a/addons/web/static/src/core/expression_editor/expression_editor.js
+++ b/addons/web/static/src/core/expression_editor/expression_editor.js
@@ -80,7 +80,7 @@ export class ExpressionEditor extends Component {
                 readonly: false,
                 filter: (fieldDef) => fieldDef.name in this.filteredFields,
                 showDebugInput: false,
-                followRelations: false,
+                followRelations: () => false,
                 isDebugMode: this.isDebugMode,
             }),
             isSupported: (value) => [0, 1].includes(value) || value in this.filteredFields,

--- a/addons/web/static/src/core/model_field_selector/model_field_selector.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.js
@@ -20,7 +20,7 @@ export class ModelFieldSelector extends Component {
         update: { type: Function, optional: true },
         filter: { type: Function, optional: true },
         sort: { type: Function, optional: true },
-        followRelations: { type: Boolean, optional: true },
+        followRelations: { type: Function, optional: true },
         showDebugInput: { type: Boolean, optional: true },
     };
     static defaultProps = {
@@ -29,7 +29,7 @@ export class ModelFieldSelector extends Component {
         isDebugMode: false,
         showSearchInput: true,
         update: () => {},
-        followRelations: true,
+        followRelations: () => true,
     };
 
     setup() {

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -113,8 +113,7 @@ export class ModelFieldSelectorPopover extends Component {
         close: Function,
         filter: { type: Function, optional: true },
         sort: { type: Function, optional: true },
-        followRelations: { type: Boolean, optional: true },
-        canFollowRelationFor: { type: Function, optional: true },
+        followRelation: { type: Function, optional: true },
         showDebugInput: { type: Boolean, optional: true },
         isDebugMode: { type: Boolean, optional: true },
         path: { optional: true },
@@ -126,7 +125,6 @@ export class ModelFieldSelectorPopover extends Component {
     static defaultProps = {
         filter: (value) => value.searchable && value.type != "json",
         isDebugMode: false,
-        followRelations: true,
     };
 
     setup() {
@@ -171,14 +169,14 @@ export class ModelFieldSelectorPopover extends Component {
     }
 
     canFollowRelationFor(fieldDef) {
-        if (typeof this.props.canFollowRelationFor === "function") {
-            return this.props.canFollowRelationFor(fieldDef, this.props.followRelation);
+        const followRelation = this.props.followRelations
+            ? this.props.followRelations(fieldDef)
+            : null;
+        if ([true, false].includes(followRelation)) {
+            return followRelation;
         }
         if (fieldDef.type === "properties") {
             return true;
-        }
-        if (!this.props.followRelations) {
-            return false;
         }
         return (
             fieldDef.relation ||

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -114,6 +114,7 @@ export class ModelFieldSelectorPopover extends Component {
         filter: { type: Function, optional: true },
         sort: { type: Function, optional: true },
         followRelations: { type: Boolean, optional: true },
+        canFollowRelationFor: { type: Function, optional: true },
         showDebugInput: { type: Boolean, optional: true },
         isDebugMode: { type: Boolean, optional: true },
         path: { optional: true },
@@ -170,6 +171,9 @@ export class ModelFieldSelectorPopover extends Component {
     }
 
     canFollowRelationFor(fieldDef) {
+        if (typeof this.props.canFollowRelationFor === "function") {
+            return this.props.canFollowRelationFor(fieldDef, this.props.followRelation);
+        }
         if (fieldDef.type === "properties") {
             return true;
         }

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -28,7 +28,7 @@ export class DynamicPlaceholderPopover extends Component {
     static components = {
         ModelFieldSelectorPopover,
     };
-    static props = ["resModel", "validate", "close"];
+    static props = ["resModel", "validate", "close", "canFollowRelationFor?"];
 
     setup() {
         useAutofocus();

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -28,7 +28,7 @@ export class DynamicPlaceholderPopover extends Component {
     static components = {
         ModelFieldSelectorPopover,
     };
-    static props = ["resModel", "validate", "close", "canFollowRelationFor?"];
+    static props = ["resModel", "validate", "close", "followRelation"];
 
     setup() {
         useAutofocus();

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
@@ -52,14 +52,13 @@
             <ModelFieldSelectorPopover
                 close.bind="closeFieldSelector"
                 filter.bind="filter"
-                followRelations="true"
+                followRelation="props.followRelation"
                 isDebugMode="!!env.debug"
                 path="state.path"
                 resModel="props.resModel"
                 readProperty="true"
                 showSearchInput="true"
                 update.bind="setPath"
-                canFollowRelationFor="props.canFollowRelationFor"
             />
         </t>
     </t>

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
@@ -59,6 +59,7 @@
                 readProperty="true"
                 showSearchInput="true"
                 update.bind="setPath"
+                canFollowRelationFor="props.canFollowRelationFor"
             />
         </t>
     </t>

--- a/addons/web/static/src/views/fields/field_selector/field_selector_field.js
+++ b/addons/web/static/src/views/fields/field_selector/field_selector_field.js
@@ -13,7 +13,7 @@ export class FieldSelectorField extends Component {
         ...standardFieldProps,
         resModel: { type: String, optional: true },
         onlySearchable: { type: Boolean, optional: true },
-        followRelations: { type: Boolean, optional: true },
+        followRelations: { type: Function, optional: true },
     };
 
     filter(fieldDef) {
@@ -70,7 +70,7 @@ export const fieldSelectorField = {
     ],
     extractProps({ options }, dynamicInfo) {
         return {
-            followRelations: options.follow_relations ?? true,
+            followRelations: () => options.follow_relations ?? true,
             onlySearchable: exprToBoolean(options.only_searchable),
             resModel: options.model,
         };

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -393,7 +393,7 @@ test("can follow relations", async () => {
             readonly: false,
             path: "",
             resModel: "partner",
-            followRelations: true, // default
+            followRelations: () => true, // default
             update(path) {
                 expect(path).toBe("product_id");
             },
@@ -428,7 +428,7 @@ test("cannot follow relations", async () => {
             readonly: false,
             path: "",
             resModel: "partner",
-            followRelations: false,
+            followRelations: () => false,
             update(path) {
                 expect(path).toBe("product_id");
             },


### PR DESCRIPTION
Problem:
After commit 8787987dce631d196ceac388465bf7f227f6c5c5, adding a dynamic placeholder with a field of type `__date` (e.g., `datetime.day_of_month`) in the HTML editor causes a traceback on save.

Solution:
Hide dynamic fields of type `__date` in the HTML editor, as was done in previous versions, to prevent usage that leads to traceback.

Steps to reproduce:
1. Open a new email template.
2. Type "/Dynamic placeholder".
3. Add a field pointing to `datetime.day_of_month`.
4. Save the template. → A traceback occurs.

opw-4812898

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
