### PR TITLE
[FIX] mail, portal: improve mail/view redirections

### DIFF
--- a/addons/crm/controllers/main.py
+++ b/addons/crm/controllers/main.py
@@ -4,7 +4,6 @@ import logging
 
 from odoo.addons.mail.controllers.mail import MailController
 from odoo import http
-from odoo.http import request
 
 _logger = logging.getLogger(__name__)
 
@@ -19,7 +18,7 @@ class CrmController(http.Controller):
                 record.action_set_won_rainbowman()
             except Exception:
                 _logger.exception("Could not mark crm.lead as won")
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('crm.lead', res_id)
         return redirect
 
     @http.route('/lead/case_mark_lost', type='http', auth='user', methods=['GET'])
@@ -30,7 +29,7 @@ class CrmController(http.Controller):
                 record.action_set_lost()
             except Exception:
                 _logger.exception("Could not mark crm.lead as lost")
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('crm.lead', res_id)
         return redirect
 
     @http.route('/lead/convert', type='http', auth='user', methods=['GET'])
@@ -41,5 +40,5 @@ class CrmController(http.Controller):
                 record.convert_opportunity(record.partner_id)
             except Exception:
                 _logger.exception("Could not convert crm.lead to opportunity")
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('crm.lead', res_id)
         return redirect

--- a/addons/hr_holidays/controllers/main.py
+++ b/addons/hr_holidays/controllers/main.py
@@ -14,7 +14,7 @@ class HrHolidaysController(http.Controller):
             try:
                 record.action_approve()
             except Exception:
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('hr.leave', res_id)
         return redirect
 
     @http.route('/leave/refuse', type='http', auth='user', methods=['GET'])
@@ -24,7 +24,7 @@ class HrHolidaysController(http.Controller):
             try:
                 record.action_refuse()
             except Exception:
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('hr.leave', res_id)
         return redirect
 
     @http.route('/allocation/validate', type='http', auth='user', methods=['GET'])
@@ -34,7 +34,7 @@ class HrHolidaysController(http.Controller):
             try:
                 record.action_approve()
             except Exception:
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('hr.leave.allocation', res_id)
         return redirect
 
     @http.route('/allocation/refuse', type='http', auth='user', methods=['GET'])
@@ -44,5 +44,5 @@ class HrHolidaysController(http.Controller):
             try:
                 record.action_refuse()
             except Exception:
-                return MailController._redirect_to_messaging()
+                return MailController._redirect_to_generic_fallback('hr.leave.allocation', res_id)
         return redirect

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -93,7 +93,9 @@ class MailController(http.Controller):
         # the record has a window redirection: check access rights
         if uid is not None:
             if not RecordModel.with_user(uid).check_access_rights('read', raise_exception=False):
-                return cls._redirect_to_messaging()
+                return cls._redirect_to_generic_fallback(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
             try:
                 # We need here to extend the "allowed_company_ids" to allow a redirection
                 # to any record that the user can access, regardless of currently visible
@@ -117,7 +119,9 @@ class MailController(http.Controller):
                     cids = cids + [suggested_company.id]
                     record_sudo.with_user(uid).with_context(allowed_company_ids=cids).check_access_rule('read')
             except AccessError:
-                return cls._redirect_to_messaging()
+                return cls._redirect_to_generic_fallback(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
             else:
                 record_action = record_sudo._get_access_action(access_uid=uid)
         else:

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -136,9 +136,25 @@ class MailController(http.Controller):
         # the record has an URL redirection: use it directly
         if record_action['type'] == 'ir.actions.act_url':
             return request.redirect(record_action['url'])
-        # other choice: act_window (no support of anything else currently)
+        # anything else than an act_window is not supported
         elif not record_action['type'] == 'ir.actions.act_window':
             return cls._redirect_to_messaging()
+
+        # backend act_window: when not logged, unless really readable as public,
+        # user is going to be redirected to login -> keep mail/view as redirect
+        # in that case. In case of readable record, we consider this might be
+        # a customization and we do not change the behavior in stable
+        if uid is None or request.env.user._is_public():
+            has_access = record_sudo.with_user(request.env.user).check_access_rights('read', raise_exception=False)
+            if has_access:
+                try:
+                    record_sudo.with_user(request.env.user).check_access_rule('read')
+                except AccessError:
+                    has_access = False
+            if not has_access:
+                return cls._redirect_to_login_with_mail_view(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
 
         url_params = {
             'model': model,

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -122,22 +122,11 @@ class MailController(http.Controller):
                 record_action = record_sudo._get_access_action(access_uid=uid)
         else:
             record_action = record_sudo._get_access_action()
-            if suggested_company:
-                cids = [suggested_company.id]
+            # we have an act_url (probably a portal link): we need to retry being logged to check access
             if record_action['type'] == 'ir.actions.act_url' and record_action.get('target_type') != 'public':
-                url_params = {
-                    'model': model,
-                    'id': res_id,
-                    'active_id': res_id,
-                    'action': record_action.get('id'),
-                }
-                if cids:
-                    url_params['cids'] = cids[0]
-                view_id = record_sudo.get_formview_id()
-                if view_id:
-                    url_params['view_id'] = view_id
-                url = '/web/login?redirect=#%s' % url_encode(url_params)
-                return request.redirect(url)
+                return cls._redirect_to_login_with_mail_view(
+                    model, res_id, access_token=access_token, **kwargs,
+                )
 
         record_action.pop('target_type', None)
         # the record has an URL redirection: use it directly

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -17,9 +17,31 @@ class MailController(http.Controller):
     _cp_path = '/mail'
 
     @classmethod
+    def _redirect_to_generic_fallback(cls, model, res_id, access_token=None, **kwargs):
+        if request.session.uid is None:
+            return cls._redirect_to_login_with_mail_view(
+                model, res_id, access_token=access_token, **kwargs,
+            )
+        return cls._redirect_to_messaging()
+
+    @classmethod
     def _redirect_to_messaging(cls):
         url = '/web#%s' % url_encode({'action': 'mail.action_discuss'})
         return request.redirect(url)
+
+    @classmethod
+    def _redirect_to_login_with_mail_view(cls, model, res_id, access_token=None, **kwargs):
+        url_base = '/mail/view'
+        url_params = request.env['mail.thread']._notify_get_action_link_params(
+            'view', **{
+                'model': model,
+                'res_id': res_id,
+                'access_token': access_token,
+                **kwargs,
+            }
+        )
+        mail_view_url = f'{url_base}?{url_encode(url_params, sort=True)}'
+        return request.redirect(f'/web/login?{url_encode({"redirect": mail_view_url})}')
 
     @classmethod
     def _check_token(cls, token):
@@ -54,14 +76,18 @@ class MailController(http.Controller):
 
         # no model / res_id, meaning no possible record -> redirect to login
         if not model or not res_id or model not in request.env:
-            return cls._redirect_to_messaging()
+            return cls._redirect_to_generic_fallback(
+                model, res_id, access_token=access_token, **kwargs,
+            )
 
         # find the access action using sudo to have the details about the access link
         RecordModel = request.env[model]
         record_sudo = RecordModel.sudo().browse(res_id).exists()
         if not record_sudo:
             # record does not seem to exist -> redirect to login
-            return cls._redirect_to_messaging()
+            return cls._redirect_to_generic_fallback(
+                model, res_id, access_token=access_token, **kwargs,
+            )
 
         suggested_company = record_sudo._get_mail_redirect_suggested_company()
         # the record has a window redirection: check access rights

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -56,12 +56,12 @@ class MailController(http.Controller):
         comparison = cls._check_token(token)
         if not comparison:
             _logger.warning('Invalid token in route %s', request.httprequest.url)
-            return comparison, None, cls._redirect_to_messaging()
+            return comparison, None, cls._redirect_to_generic_fallback(model, res_id)
         try:
             record = request.env[model].browse(res_id).exists()
         except Exception:
             record = None
-            redirect = cls._redirect_to_messaging()
+            redirect = cls._redirect_to_generic_fallback(model, res_id)
         else:
             redirect = cls._redirect_to_record(model, res_id)
         return comparison, record, redirect

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -159,7 +159,7 @@ class MailController(http.Controller):
 
         if cids:
             url_params['cids'] = ','.join([str(cid) for cid in cids])
-        url = '/web?#%s' % url_encode(url_params)
+        url = '/web?#%s' % url_encode(url_params, sort=True)
         return request.redirect(url)
 
     @http.route('/mail/view', type='http', auth='public')

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -272,6 +272,6 @@ class MailController(mail.MailController):
                             url = urls.url_parse(url)
                             url_params = url.decode_query()
                             url_params.update([("pid", pid), ("hash", hash)])
-                            url = url.replace(query=urls.url_encode(url_params)).to_url()
+                            url = url.replace(query=urls.url_encode(url_params, sort=True)).to_url()
                         return request.redirect(url)
         return super(MailController, cls)._redirect_to_record(model, res_id, access_token=access_token, **kwargs)

--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -237,6 +237,13 @@ class PortalChatter(http.Controller):
 class MailController(mail.MailController):
 
     @classmethod
+    def _redirect_to_generic_fallback(cls, model, res_id, access_token=None, **kwargs):
+        # Generic fallback for a share user is the customer portal
+        if request.session.uid and request.env.user.share:
+            return request.redirect('/my')
+        return super()._redirect_to_generic_fallback(model, res_id, access_token=access_token, **kwargs)
+
+    @classmethod
     def _redirect_to_record(cls, model, res_id, access_token=None, **kwargs):
         """ If the current user doesn't have access to the document, but provided
         a valid access token, redirect them to the front-end view.

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -296,7 +296,7 @@ class TestMultiCompanySetup(TestMailCommon, TestRecipients):
         )
 
 
-@tagged('-at_install', 'post_install', 'multi_company')
+@tagged('-at_install', 'post_install', 'multi_company', 'mail_controller')
 class TestMultiCompanyRedirect(TestMailCommon, HttpCase):
 
     @classmethod
@@ -408,7 +408,7 @@ class TestMultiCompanyRedirect(TestMailCommon, HttpCase):
                     self.assertNotIn('cids', decoded_fragment)
 
 
-@tagged("-at_install", "post_install", "multi_company")
+@tagged("-at_install", "post_install", "multi_company", "mail_controller")
 class TestMultiCompanyThreadData(TestMailCommon, HttpCase):
     @classmethod
     def setUpClass(cls):

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -337,8 +337,7 @@ class TestMultiCompanyRedirect(TestMailCommon, HttpCase):
                     path = url_parse(response.url).path
                     self.assertEqual(path, '/web/login')
                     decoded_fragment = url_decode(url_parse(response.url).fragment)
-                    self.assertTrue("cids" in decoded_fragment)
-                    self.assertEqual(decoded_fragment['cids'], str(mc_record.company_id.id))
+                    self.assertNotIn("cids", decoded_fragment)
                 else:
                     user = self.env['res.users'].browse(self.session.uid)
                     self.assertEqual(user.login, login)
@@ -388,24 +387,18 @@ class TestMultiCompanyRedirect(TestMailCommon, HttpCase):
                     self.assertTrue("cids" in decoded_fragment)
                     self.assertEqual(decoded_fragment['cids'], str(user_company.id))
 
-        # when being not logged, cids should be added based on
-        # '_get_mail_redirect_suggested_company'
-        self.authenticate(None, None)
+        # when being not logged, cids should not be added as redirection after
+        # logging will be 'mail/view' again
         for test_record in nothreads:
-            with self.subTest(record_name=test_record.name, user_company=user_company):
-                self.user_admin.write({'company_id': user_company.id})
+            with self.subTest(record_name=test_record.name):
+                self.authenticate(None, None)
                 response = self.url_open(
                     f'/mail/view?model={test_record._name}&res_id={test_record.id}',
                     timeout=15
                 )
                 self.assertEqual(response.status_code, 200)
-
                 decoded_fragment = url_decode(url_parse(response.url).fragment)
-                if test_record.company_id:
-                    self.assertIn('cids', decoded_fragment)
-                    self.assertEqual(decoded_fragment['cids'], str(test_record.company_id.id))
-                else:
-                    self.assertNotIn('cids', decoded_fragment)
+                self.assertNotIn('cids', decoded_fragment)
 
 
 @tagged("-at_install", "post_install", "multi_company", "mail_controller")

--- a/addons/test_mail_full/__init__.py
+++ b/addons/test_mail_full/__init__.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
+from . import controllers
 from . import models
 from . import tests

--- a/addons/test_mail_full/controllers/__init__.py
+++ b/addons/test_mail_full/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import portal

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+
+
+class PortalTest(http.Controller):
+    """Implements some test portal routes (ex.: for viewing a record)."""
+
+    @http.route('/my/test_portal/<int:res_id>', type='http', auth='public', methods=['GET'])
+    def test_portal_record_view(self, res_id, access_token=None, **kwargs):
+        return request.make_response(f'Record view of test_portal {res_id} ({access_token}, {kwargs})')
+
+    @http.route('/test_portal/public_type/<int:res_id>', type='http', auth='public', methods=['GET'])
+    def test_public_record_view(self, res_id):
+        return request.make_response(f'Testing public controller for {res_id}')

--- a/addons/test_mail_full/controllers/portal.py
+++ b/addons/test_mail_full/controllers/portal.py
@@ -1,5 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from odoo import http
 from odoo.http import request
 

--- a/addons/test_mail_full/models/test_mail_models_mail.py
+++ b/addons/test_mail_full/models/test_mail_models_mail.py
@@ -16,9 +16,10 @@ class MailTestPortal(models.Model):
 
     name = fields.Char()
     partner_id = fields.Many2one('res.partner', 'Customer')
+    user_id = fields.Many2one(comodel_name='res.users', string="Salesperson")
 
     def _compute_access_url(self):
-        self.access_url = False
+        super()._compute_access_url()
         for record in self.filtered('id'):
             record.access_url = '/my/test_portal/%s' % self.id
 
@@ -38,6 +39,30 @@ class MailTestPortalNoPartner(models.Model):
         self.access_url = False
         for record in self.filtered('id'):
             record.access_url = '/my/test_portal_no_partner/%s' % self.id
+
+
+class MailTestPortalPublicAccessAction(models.Model):
+    """ Test 'public' target_type access action """
+    _description = 'Portal Public Access Action'
+    _name = 'mail.test.portal.public.access.action'
+    _inherit = 'mail.test.portal'
+
+    def _compute_access_url(self):
+        super()._compute_access_url()
+        for record in self.filtered('id'):
+            record.access_url = f'/test_portal/public_type/{record.id}'
+
+    def _get_access_action(self, access_uid=None, force_website=False):
+        # Test 'public' target type for portal / public people
+        if self.env.user.share or force_website:
+            return {
+                'type': 'ir.actions.act_url',
+                'url': self.access_url,
+                'target': 'self',
+                'target_type': 'public',
+                'res_id': self.id,
+            }
+        return super()._get_access_action(access_uid=access_uid, force_website=force_website)
 
 
 class MailTestRating(models.Model):

--- a/addons/test_mail_full/security/ir.model.access.csv
+++ b/addons/test_mail_full/security/ir.model.access.csv
@@ -1,8 +1,10 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_mail_test_portal_all,mail.test.portal.all,model_mail_test_portal,,1,0,0,0
+access_mail_test_portal_all,mail.test.portal.all,model_mail_test_portal,,0,0,0,0
 access_mail_test_portal_user,mail.test.portal.user,model_mail_test_portal,base.group_user,1,1,1,1
 access_mail_test_portal_no_partner_all,mail.test.portal.no.partner.all,model_mail_test_portal_no_partner,,1,0,0,0
 access_mail_test_portal_no_partner_user,mail.test.portal.no.partner.user,model_mail_test_portal_no_partner,base.group_user,1,1,1,1
+access_mail_test_portal_public_access_action_portal,mail.test.portal.public.access.action.portal,model_mail_test_portal_public_access_action,base.group_portal,1,0,0,0
+access_mail_test_portal_public_access_action_user,mail.test.portal.public.access.action.user,model_mail_test_portal_public_access_action,base.group_user,1,1,1,1
 access_mail_test_rating_all,mail.test.rating.all,model_mail_test_rating,,0,0,0,0
 access_mail_test_rating_portal,mail.test.rating.portal,model_mail_test_rating,base.group_portal,1,0,0,0
 access_mail_test_rating_user,mail.test.rating.user,model_mail_test_rating,base.group_user,1,1,1,1

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -242,12 +242,12 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
         # prepare result URLs on self to ease tests
         # ------------------------------------------------------------
         cls.portal_web_url = f'{base_url}/my/test_portal/{cls.record_portal.id}'
-        cls.portal_web_url_with_token = f'{base_url}/my/test_portal/{cls.record_portal.id}?{url_encode({"access_token": cls.record_portal.access_token, "pid": cls.customer.id, "hash": cls.record_portal_hash})}'
+        cls.portal_web_url_with_token = f'{base_url}/my/test_portal/{cls.record_portal.id}?{url_encode({"access_token": cls.record_portal.access_token, "pid": cls.customer.id, "hash": cls.record_portal_hash}, sort=True)}'
         cls.public_act_url_share = f'{base_url}/test_portal/public_type/{cls.record_public_act_url.id}'
-        cls.internal_backend_local_url = f'/web#{url_encode({"model": cls.record_internal._name, "id": cls.record_internal.id, "active_id": cls.record_internal.id, "cids": cls.company_admin.id})}'
-        cls.portal_backend_local_url = f'/web#{url_encode({"model": cls.record_portal._name, "id": cls.record_portal.id, "active_id": cls.record_portal.id, "cids": cls.company_admin.id})}'
-        cls.read_backend_local_url = f'/web#{url_encode({"model": cls.record_read._name, "id": cls.record_read.id, "active_id": cls.record_read.id, "cids": cls.company_admin.id})}'
-        cls.public_act_url_backend_local_url = f'/web#{url_encode({"model": cls.record_public_act_url._name, "id": cls.record_public_act_url.id, "active_id": cls.record_public_act_url.id, "cids": cls.company_admin.id})}'
+        cls.internal_backend_local_url = f'/web#{url_encode({"model": cls.record_internal._name, "id": cls.record_internal.id, "active_id": cls.record_internal.id, "cids": cls.company_admin.id}, sort=True)}'
+        cls.portal_backend_local_url = f'/web#{url_encode({"model": cls.record_portal._name, "id": cls.record_portal.id, "active_id": cls.record_portal.id, "cids": cls.company_admin.id}, sort=True)}'
+        cls.read_backend_local_url = f'/web#{url_encode({"model": cls.record_read._name, "id": cls.record_read.id, "active_id": cls.record_read.id, "cids": cls.company_admin.id}, sort=True)}'
+        cls.public_act_url_backend_local_url = f'/web#{url_encode({"model": cls.record_public_act_url._name, "id": cls.record_public_act_url.id, "active_id": cls.record_public_act_url.id, "cids": cls.company_admin.id}, sort=True)}'
         cls.discuss_local_url = '/web#action=mail.action_discuss'
 
     def test_assert_initial_data(self):
@@ -331,7 +331,7 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
             # std url, read record -> redirect to my with parameters being record portal action parameters (???)
             (
                 'Access record (no customer portal)', self.record_read_url_base,
-                f'{self.test_base_url}/my#{url_encode({"model": self.record_read._name, "id": self.record_read.id, "active_id": self.record_read.id, "cids": self.company_admin.id})}',
+                f'{self.test_base_url}/my#{url_encode({"model": self.record_read._name, "id": self.record_read.id, "active_id": self.record_read.id, "cids": self.company_admin.id}, sort=True)}',
             ),
             # std url, no access to record -> redirect to my with discuss action (???)
             (
@@ -403,7 +403,7 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
             # std url, no access to record -> redirect to login, with just some mail/view params kept (???)
             (
                 'No access record (internal)', self.record_internal_url_base,
-                f'{login_url}#{url_encode(odoo_internal_params)}',
+                f'{login_url}#{url_encode(odoo_internal_params, sort=True)}',
             ),
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
@@ -411,7 +411,7 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
             ),
             (
                 'No access record (portal can read, no customer portal)', self.record_read_url_base,
-                f'{login_url}#{url_encode(odoo_read_params)}',
+                f'{login_url}#{url_encode(odoo_read_params, sort=True)}',
             ),
             # public_type act_url -> share users are redirected to frontend url
             (

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -314,7 +314,7 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
     def test_portal_access_logged(self):
         """ Check portal behavior when accessing mail/view, notably check token
         support and propagation. """
-        my_discuss_url = f'{self.test_base_url}/my#action=mail.action_discuss'
+        my_url = f'{self.test_base_url}/my'
 
         self.authenticate(self.env.user.login, self.env.user.login)
         for url_name, url, exp_url in [
@@ -323,43 +323,43 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
                 "No access (portal enabled), token", self.record_portal_url_auth,
                 self.portal_web_url_with_token,
             ),
-            # invalid token -> ko -> redirect to my with discuss action (???)
+            # invalid token -> ko -> redirect to my
             (
                 "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
-                my_discuss_url,
+                my_url,
             ),
             # std url, read record -> redirect to my with parameters being record portal action parameters (???)
             (
                 'Access record (no customer portal)', self.record_read_url_base,
                 f'{self.test_base_url}/my#{url_encode({"model": self.record_read._name, "id": self.record_read.id, "active_id": self.record_read.id, "cids": self.company_admin.id}, sort=True)}',
             ),
-            # std url, no access to record -> redirect to my with discuss action (???)
+            # std url, no access to record -> redirect to my
             (
                 'No access record (internal)', self.record_internal_url_base,
-                my_discuss_url,
+                my_url,
             ),
-            # missing token -> redirect to my with discuss action (???)
+            # missing token -> redirect to my
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
-                my_discuss_url,
+                my_url,
             ),
             # public_type act_url -> share users are redirected to frontend url
             (
                 "Public with act_url -> frontend url", self.record_public_act_url_base,
                 self.public_act_url_share
             ),
-            # not existing -> redirect to my with discuss action (???)
+            # not existing -> redirect to my
             (
                 'Not existing record (internal)', self.record_internal_url_no_exists,
-                my_discuss_url,
+                my_url,
             ),
             (
                 'Not existing record (portal enabled)', self.record_portal_url_no_exists,
-                my_discuss_url,
+                my_url,
             ),
             (
                 'Not existing model', self.record_url_no_model,
-                my_discuss_url,
+                my_url,
             ),
         ]:
             with self.subTest(name=url_name, url=url):

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -378,11 +378,6 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
             'id': self.record_internal.id,
             'active_id': self.record_internal.id,
         }
-        odoo_portal_params = {
-            'model': self.record_portal._name,
-            'id': self.record_portal.id,
-            'active_id': self.record_portal.id,
-        }
         odoo_read_params = {
             'model': self.record_read._name,
             'id': self.record_read.id,
@@ -395,19 +390,20 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
                 "No access (portal enabled), token", self.record_portal_url_auth,
                 self.portal_web_url_with_token,
             ),
-            # invalid token -> ko -> redirect to login with a redirect with just some mail/view params kept (???)
+            # invalid token -> ko -> redirect to login with redirect to original link, will be rejected after login
             (
                 "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
-                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_auth_wrong_token.replace(self.test_base_url, "")})}',
             ),
             # std url, no access to record -> redirect to login, with just some mail/view params kept (???)
             (
                 'No access record (internal)', self.record_internal_url_base,
                 f'{login_url}#{url_encode(odoo_internal_params, sort=True)}',
             ),
+            # std url, no access to record but portal -> redirect to login, original (local) URL kept as redirection post login to try again (even if faulty)
             (
                 'No access record (portal enabled)', self.record_portal_url_base,
-                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_base.replace(self.test_base_url, "")})}',
             ),
             (
                 'No access record (portal can read, no customer portal)', self.record_read_url_base,

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -373,16 +373,6 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
         support and propagation. """
         self.authenticate(None, None)
         login_url = f'{self.test_base_url}/web/login'
-        odoo_internal_params = {
-            'model': self.record_internal._name,
-            'id': self.record_internal.id,
-            'active_id': self.record_internal.id,
-        }
-        odoo_read_params = {
-            'model': self.record_read._name,
-            'id': self.record_read.id,
-            'active_id': self.record_read.id,
-        }
 
         for url_name, url, exp_url in [
             # valid token -> ok -> redirect to portal URL
@@ -395,10 +385,10 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
                 "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
                 f'{login_url}?{url_encode({"redirect": self.record_portal_url_auth_wrong_token.replace(self.test_base_url, "")})}',
             ),
-            # std url, no access to record -> redirect to login, with just some mail/view params kept (???)
+            # std url, no access to record -> redirect to login with redirect to original link, will be rejected after login
             (
                 'No access record (internal)', self.record_internal_url_base,
-                f'{login_url}#{url_encode(odoo_internal_params, sort=True)}',
+                f'{login_url}?{url_encode({"redirect": self.record_internal_url_base.replace(self.test_base_url, "")})}',
             ),
             # std url, no access to record but portal -> redirect to login, original (local) URL kept as redirection post login to try again (even if faulty)
             (
@@ -407,7 +397,7 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
             ),
             (
                 'No access record (portal can read, no customer portal)', self.record_read_url_base,
-                f'{login_url}#{url_encode(odoo_read_params, sort=True)}',
+                f'{login_url}?{url_encode({"redirect": self.record_read_url_base.replace(self.test_base_url, "")})}',
             ),
             # public_type act_url -> share users are redirected to frontend url
             (

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -418,18 +418,18 @@ class TestPortalFlow(TestMailFullCommon, HttpCase):
                 "Public with act_url -> frontend url", self.record_public_act_url_base,
                 self.public_act_url_share
             ),
-            # not existing -> redirect to login, with a parameter for messaging (???)
+            # not existing -> redirect to login, original (internal) URL kept as redirection post login to try again (even if faulty)
             (
                 'Not existing record (internal)', self.record_internal_url_no_exists,
-                f'{login_url}#action=mail.action_discuss',
+                f'{login_url}?{url_encode({"redirect": self.record_internal_url_no_exists.replace(self.test_base_url, "")})}',
             ),
             (
                 'Not existing record (portal enabled)', self.record_portal_url_no_exists,
-                f'{login_url}#action=mail.action_discuss',
+                f'{login_url}?{url_encode({"redirect": self.record_portal_url_no_exists.replace(self.test_base_url, "")})}',
             ),
             (
                 'Not existing model', self.record_url_no_model,
-                f'{login_url}#action=mail.action_discuss',
+                f'{login_url}?{url_encode({"redirect": self.record_url_no_model.replace(self.test_base_url, "")})}',
             ),
         ]:
             with self.subTest(name=url_name, url=url):

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from werkzeug.urls import url_parse, url_decode
-
+from werkzeug.urls import url_parse, url_decode, url_encode
 import json
 
 from odoo import http
 from odoo.addons.test_mail_full.tests.common import TestMailFullCommon
 from odoo.addons.test_mail_sms.tests.common import TestSMSRecipients
+from odoo.exceptions import AccessError
 from odoo.tests import tagged, users
 from odoo.tests.common import HttpCase
+from odoo.tools import mute_logger
 
 
 @tagged('portal')
@@ -26,54 +27,8 @@ class TestPortal(HttpCase, TestMailFullCommon, TestSMSRecipients):
         self.record_portal._portal_ensure_token()
 
 
-@tagged('-at_install', 'post_install', 'portal')
+@tagged('-at_install', 'post_install', 'portal', 'mail_controller')
 class TestPortalControllers(TestPortal):
-
-    def test_redirect_to_records(self):
-        """ Test redirection of portal-enabled records """
-        # Test Case 0: as anonymous, cannot access, redirect to web/login
-        response = self.url_open('/mail/view?model=%s&res_id=%s' % (
-            self.record_portal._name,
-            self.record_portal.id), timeout=15)
-
-        path = url_parse(response.url).path
-        self.assertEqual(path, '/web/login')
-
-        # Test Case 1: as admin, can access record
-        self.authenticate(self.user_admin.login, self.user_admin.login)
-        response = self.url_open('/mail/view?model=%s&res_id=%s' % (
-            self.record_portal._name,
-            self.record_portal.id), timeout=15)
-
-        self.assertEqual(response.status_code, 200)
-
-        fragment = url_parse(response.url).fragment
-        params = url_decode(fragment)
-        self.assertEqual(params['cids'], '%s' % self.user_admin.company_id.id)
-        self.assertEqual(params['id'], '%s' % self.record_portal.id)
-        self.assertEqual(params['model'], self.record_portal._name)
-
-    def test_redirect_to_records_norecord(self):
-        """ Check specific use case of missing model, should directly redirect
-        to login page. """
-        for model, res_id in [
-                (False, self.record_portal.id),
-                ('', self.record_portal.id),
-                (self.record_portal._name, False),
-                (self.record_portal._name, ''),
-                (False, False),
-                ('wrong.model', self.record_portal.id),
-                (self.record_portal._name, -4),
-            ]:
-            response = self.url_open(
-                '/mail/view?model=%s&res_id=%s' % (model, res_id),
-                timeout=15
-            )
-            path = url_parse(response.url).path
-            self.assertEqual(
-                path, '/web/login',
-                'Failed with %s - %s' % (model, res_id)
-            )
 
     def test_portal_avatar_with_access_token(self):
         mail_record = self.env['mail.message'].create({
@@ -195,6 +150,314 @@ class TestPortalControllers(TestPortal):
 
         self.assertIn('Test', message.body)
         self.assertEqual(message.author_id, self.partner_2)
+
+
+@tagged('-at_install', 'post_install', 'portal', 'mail_controller')
+class TestPortalFlow(TestMailFullCommon, HttpCase):
+    """ Test shared links, mail/view links and redirection (backend, customer
+    portal or frontend for specific addons). """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.customer = cls.env['res.partner'].create({
+            'country_id': cls.env.ref('base.fr').id,
+            'email': 'mdelvaux34@example.com',
+            'lang': 'en_US',
+            'mobile': '+33639982325',
+            'name': 'Mathias Delvaux',
+            'phone': '+33353011823',
+        })
+        # customer portal enabled
+        cls.record_portal = cls.env['mail.test.portal'].create({
+            'name': 'Test Portal Record',
+            'partner_id': cls.customer.id,
+            'user_id': cls.user_admin.id,
+        })
+        # internal only
+        cls.record_internal = cls.env['mail.test.track'].create({
+            'name': 'Test Internal Record',
+        })
+        # readable (aka portal can read but no specific action)
+        cls.record_read = cls.env['mail.test.simple'].create({
+            'name': 'Test Readable Record',
+        })
+        # 'public' target_type act_url (e.g. blog, forum, ...) -> redirection to a public page
+        cls.record_public_act_url = cls.env['mail.test.portal.public.access.action'].create({
+            'name': 'Public ActUrl',
+        })
+
+        cls.mail_template = cls.env['mail.template'].create({
+            'auto_delete': True,
+            'body_html': '<p>Hello <t t-out="object.partner_id.name"/>, your quotation is ready for review.</p>',
+            'email_from': '{{ (object.user_id.email_formatted or user.email_formatted) }}',
+            'model_id': cls.env.ref('test_mail_full.model_mail_test_portal').id,
+            'name': 'Quotation template',
+            'partner_to': '{{ object.partner_id.id }}',
+            'subject': 'Your quotation "{{ object.name }}"',
+        })
+        cls._create_portal_user()
+
+        # prepare access URLs on self to ease tests
+        # ------------------------------------------------------------
+        base_url = cls.record_portal.get_base_url()
+        cls.test_base_url = base_url
+
+        cls.record_internal_url_base = f'{base_url}/mail/view?model={cls.record_internal._name}&res_id={cls.record_internal.id}'
+        cls.record_portal_url_base = f'{base_url}/mail/view?model={cls.record_portal._name}&res_id={cls.record_portal.id}'
+        cls.record_read_url_base = f'{base_url}/mail/view?model={cls.record_read._name}&res_id={cls.record_read.id}'
+        cls.record_public_act_url_base = f'{base_url}/mail/view?model={cls.record_public_act_url._name}&res_id={cls.record_public_act_url.id}'
+
+        max_internal_id = cls.env['mail.test.track'].search([], order="id desc", limit=1).id
+        max_portal_id = cls.env['mail.test.portal'].search([], order="id desc", limit=1).id
+        max_read_id = cls.env['mail.test.simple'].search([], order="id desc", limit=1).id
+        max_public_act_url_id = cls.env['mail.test.portal.public.access.action'].search([], order="id desc", limit=1).id
+        cls.record_internal_url_no_exists = f'{base_url}/mail/view?model={cls.record_internal._name}&res_id={max_internal_id + 1}'
+        cls.record_portal_url_no_exists = f'{base_url}/mail/view?model={cls.record_portal._name}&res_id={max_portal_id + 1}'
+        cls.record_read_url_no_exists = f'{base_url}/mail/view?model={cls.record_read._name}&res_id={max_read_id + 1}'
+        cls.record_public_act_url_url_no_exists = f'{base_url}/mail/view?model={cls.record_public_act_url._name}&res_id={max_public_act_url_id + 1}'
+
+        cls.record_url_no_model = f'{cls.record_portal.get_base_url()}/mail/view?model=this.should.not.exists&res_id=1'
+
+        # find portal + auth data url
+        for group_name, group_func, group_data in cls.record_portal.sudo()._notify_get_recipients_groups(False):
+            if group_name == 'portal_customer' and group_func(cls.customer):
+                cls.record_portal_url_auth = group_data['button_access']['url']
+                break
+        else:
+            raise AssertionError('Record access URL not found')
+        # build altered access_token URL for testing security
+        parsed_url = url_parse(cls.record_portal_url_auth)
+        query_params = url_decode(parsed_url.query)
+        cls.record_portal_hash = query_params['hash']
+        cls.record_portal_url_auth_wrong_token = parsed_url.replace(
+            query=url_encode({
+                **query_params,
+                'access_token': query_params['access_token'].translate(
+                    str.maketrans('0123456789abcdef', '9876543210fedcba')
+                )
+            }, sort=True)
+        ).to_url()
+
+        # prepare result URLs on self to ease tests
+        # ------------------------------------------------------------
+        cls.portal_web_url = f'{base_url}/my/test_portal/{cls.record_portal.id}'
+        cls.portal_web_url_with_token = f'{base_url}/my/test_portal/{cls.record_portal.id}?{url_encode({"access_token": cls.record_portal.access_token, "pid": cls.customer.id, "hash": cls.record_portal_hash})}'
+        cls.public_act_url_share = f'{base_url}/test_portal/public_type/{cls.record_public_act_url.id}'
+        cls.internal_backend_local_url = f'/web#{url_encode({"model": cls.record_internal._name, "id": cls.record_internal.id, "active_id": cls.record_internal.id, "cids": cls.company_admin.id})}'
+        cls.portal_backend_local_url = f'/web#{url_encode({"model": cls.record_portal._name, "id": cls.record_portal.id, "active_id": cls.record_portal.id, "cids": cls.company_admin.id})}'
+        cls.read_backend_local_url = f'/web#{url_encode({"model": cls.record_read._name, "id": cls.record_read.id, "active_id": cls.record_read.id, "cids": cls.company_admin.id})}'
+        cls.public_act_url_backend_local_url = f'/web#{url_encode({"model": cls.record_public_act_url._name, "id": cls.record_public_act_url.id, "active_id": cls.record_public_act_url.id, "cids": cls.company_admin.id})}'
+        cls.discuss_local_url = '/web#action=mail.action_discuss'
+
+    def test_assert_initial_data(self):
+        """ Test some initial values. Test that record_access_url is a valid URL
+        to view the record_portal and that record_access_url_wrong_token only differs
+        from record_access_url by a different access_token. """
+        self.record_internal.with_user(self.user_employee).check_access_rule('read')
+        self.record_portal.with_user(self.user_employee).check_access_rule('read')
+        self.record_read.with_user(self.user_employee).check_access_rule('read')
+
+        with self.assertRaises(AccessError):
+            self.record_internal.with_user(self.user_portal).check_access_rights('read')
+        with self.assertRaises(AccessError):
+            self.record_portal.with_user(self.user_portal).check_access_rights('read')
+        self.record_read.with_user(self.user_portal).check_access_rights('read')
+
+        self.assertNotEqual(self.record_portal_url_auth, self.record_portal_url_auth_wrong_token)
+        url_params = []
+        for url in (
+            self.record_portal_url_auth, self.record_portal_url_auth_wrong_token,
+        ):
+            with self.subTest(url=url):
+                parsed = url_parse(url)
+                self.assertEqual(parsed.path, '/mail/view')
+                params = url_decode(parsed.query)
+                url_params.append(params)
+                # Note that pid, hash and auth_signup_token are not tested by this test but may be present in the URL (config).
+                self.assertEqual(params.get('model'), 'mail.test.portal')
+                self.assertEqual(int(params.get('res_id')), self.record_portal.id)
+                self.assertTrue(params.get('access_token'))
+        self.assertNotEqual(url_params[0]['access_token'], url_params[1]['access_token'])
+        self.assertEqual(
+            {k: v for k, v in url_params[0].items() if k != 'access_token'},
+            {k: v for k, v in url_params[1].items() if k != 'access_token'},
+            'URLs should be the same, except for access token'
+        )
+
+    @users('employee')
+    def test_employee_access(self):
+        """ Check internal employee behavior when accessing mail/view """
+        self.authenticate(self.env.user.login, self.env.user.login)
+        for url_name, url, exp_url in [
+            # accessible records
+            ("Internal record mail/view", self.record_internal_url_base, self.internal_backend_local_url),
+            ("Portal record mail/view", self.record_portal_url_base, self.portal_backend_local_url),
+            ("Portal readable record mail/view", self.record_read_url_base, self.read_backend_local_url),
+            ("Public with act_url", self.record_public_act_url_base, self.public_act_url_backend_local_url),
+            # even with token -> backend
+            ("Portal record with token", self.record_portal_url_auth, self.portal_backend_local_url),
+            # invalid token is not an issue for employee -> backend, has access
+            ("Portal record with wrong token", self.record_portal_url_auth_wrong_token, self.portal_backend_local_url),
+            # not existing -> redirect to discuss
+            ("Not existing record (internal)", self.record_internal_url_no_exists, self.discuss_local_url),
+            ("Not existing record (portal enabled)", self.record_portal_url_no_exists, self.discuss_local_url),
+            ("Not existign model", self.record_url_no_model, self.discuss_local_url),
+        ]:
+            with self.subTest(name=url_name, url=url):
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertURLEqual(res.url, exp_url)
+
+    @mute_logger('werkzeug')
+    @users('portal_test')
+    def test_portal_access_logged(self):
+        """ Check portal behavior when accessing mail/view, notably check token
+        support and propagation. """
+        my_discuss_url = f'{self.test_base_url}/my#action=mail.action_discuss'
+
+        self.authenticate(self.env.user.login, self.env.user.login)
+        for url_name, url, exp_url in [
+            # valid token -> ok -> redirect to portal URL
+            (
+                "No access (portal enabled), token", self.record_portal_url_auth,
+                self.portal_web_url_with_token,
+            ),
+            # invalid token -> ko -> redirect to my with discuss action (???)
+            (
+                "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
+                my_discuss_url,
+            ),
+            # std url, read record -> redirect to my with parameters being record portal action parameters (???)
+            (
+                'Access record (no customer portal)', self.record_read_url_base,
+                f'{self.test_base_url}/my#{url_encode({"model": self.record_read._name, "id": self.record_read.id, "active_id": self.record_read.id, "cids": self.company_admin.id})}',
+            ),
+            # std url, no access to record -> redirect to my with discuss action (???)
+            (
+                'No access record (internal)', self.record_internal_url_base,
+                my_discuss_url,
+            ),
+            # missing token -> redirect to my with discuss action (???)
+            (
+                'No access record (portal enabled)', self.record_portal_url_base,
+                my_discuss_url,
+            ),
+            # public_type act_url -> share users are redirected to frontend url
+            (
+                "Public with act_url -> frontend url", self.record_public_act_url_base,
+                self.public_act_url_share
+            ),
+            # not existing -> redirect to my with discuss action (???)
+            (
+                'Not existing record (internal)', self.record_internal_url_no_exists,
+                my_discuss_url,
+            ),
+            (
+                'Not existing record (portal enabled)', self.record_portal_url_no_exists,
+                my_discuss_url,
+            ),
+            (
+                'Not existing model', self.record_url_no_model,
+                my_discuss_url,
+            ),
+        ]:
+            with self.subTest(name=url_name, url=url):
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertURLEqual(res.url, exp_url)
+
+    @mute_logger('werkzeug')
+    def test_portal_access_not_logged(self):
+        """ Check customer behavior when accessing mail/view, notably check token
+        support and propagation. """
+        self.authenticate(None, None)
+        login_url = f'{self.test_base_url}/web/login'
+        odoo_internal_params = {
+            'model': self.record_internal._name,
+            'id': self.record_internal.id,
+            'active_id': self.record_internal.id,
+        }
+        odoo_portal_params = {
+            'model': self.record_portal._name,
+            'id': self.record_portal.id,
+            'active_id': self.record_portal.id,
+        }
+        odoo_read_params = {
+            'model': self.record_read._name,
+            'id': self.record_read.id,
+            'active_id': self.record_read.id,
+        }
+
+        for url_name, url, exp_url in [
+            # valid token -> ok -> redirect to portal URL
+            (
+                "No access (portal enabled), token", self.record_portal_url_auth,
+                self.portal_web_url_with_token,
+            ),
+            # invalid token -> ko -> redirect to login with a redirect with just some mail/view params kept (???)
+            (
+                "No access (portal enabled), invalid token", self.record_portal_url_auth_wrong_token,
+                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+            ),
+            # std url, no access to record -> redirect to login, with just some mail/view params kept (???)
+            (
+                'No access record (internal)', self.record_internal_url_base,
+                f'{login_url}#{url_encode(odoo_internal_params)}',
+            ),
+            (
+                'No access record (portal enabled)', self.record_portal_url_base,
+                f'{login_url}?redirect=#{url_encode(odoo_portal_params)}',
+            ),
+            (
+                'No access record (portal can read, no customer portal)', self.record_read_url_base,
+                f'{login_url}#{url_encode(odoo_read_params)}',
+            ),
+            # public_type act_url -> share users are redirected to frontend url
+            (
+                "Public with act_url -> frontend url", self.record_public_act_url_base,
+                self.public_act_url_share
+            ),
+            # not existing -> redirect to login, with a parameter for messaging (???)
+            (
+                'Not existing record (internal)', self.record_internal_url_no_exists,
+                f'{login_url}#action=mail.action_discuss',
+            ),
+            (
+                'Not existing record (portal enabled)', self.record_portal_url_no_exists,
+                f'{login_url}#action=mail.action_discuss',
+            ),
+            (
+                'Not existing model', self.record_url_no_model,
+                f'{login_url}#action=mail.action_discuss',
+            ),
+        ]:
+            with self.subTest(name=url_name, url=url):
+                res = self.url_open(url)
+                self.assertEqual(res.status_code, 200)
+                self.assertURLEqual(res.url, exp_url)
+
+    def test_redirect_to_records_norecord(self):
+        """ Check specific use case of missing model, should directly redirect
+        to login page. """
+        for model, res_id in [
+            (False, self.record_portal.id),
+            ('', self.record_portal.id),
+            (self.record_portal._name, False),
+            (self.record_portal._name, ''),
+            (False, False),
+            ('wrong.model', self.record_portal.id),
+            (self.record_portal._name, -4),
+        ]:
+            response = self.url_open(
+                '/mail/view?model=%s&res_id=%s' % (model, res_id),
+                timeout=15
+            )
+            path = url_parse(response.url).path
+            self.assertEqual(
+                path, '/web/login',
+                'Failed with %s - %s' % (model, res_id)
+            )
 
 
 @tagged('portal')


### PR DESCRIPTION


Global purpose is to make mail/view controller more resilient by
improving redirections when not having access to the record.

Notably
 * correctly route internal users to discuss, portal users to /my
   and unlogged users to login;
 * keep original mail/view route when performing redirection after
   login so that we try the routing again;
 * fix various issues in redirect computation, such as lost access
   token parameter or partial reconstruction of URLs;

Improve test coverage.

Task-4685166