### PR TITLE
[IMP] account: Allow order of bank account in the partner form

### DIFF
--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.js
@@ -2,6 +2,7 @@ import {
     many2ManyTagsFieldColorEditable,
     Many2ManyTagsFieldColorEditable,
 } from "@web/views/fields/many2many_tags/many2many_tags_field";
+import { useService } from "@web/core/utils/hooks";
 import { registry } from "@web/core/registry";
 import { TagsList } from "@web/core/tags_list/tags_list";
 import { _t } from "@web/core/l10n/translation";
@@ -12,6 +13,7 @@ export class FieldMany2ManyTagsBanksTagsList extends TagsList {
 }
 
 export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
+    static template = "account.FieldMany2ManyTagsBanks";
     static components = {
         ...FieldMany2ManyTagsBanks.components,
         TagsList: FieldMany2ManyTagsBanksTagsList,
@@ -19,6 +21,7 @@ export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
 
     setup() {
         super.setup();
+        this.actionService = useService("action");
         onMounted(async () => {
             // Needed when you create a partner (from a move for example), we want the partner to be saved to be able
             // to have it as account holder
@@ -35,6 +38,17 @@ export class FieldMany2ManyTagsBanks extends Many2ManyTagsFieldColorEditable {
             allowOutPayment: record.data?.allow_out_payment,
         };
     }
+
+    openBanksListView() {
+        this.actionService.doAction({
+            type: "ir.actions.act_window",
+            name: _t("Banks"),
+            res_model: this.relation,
+            views: [[false, "list"], [false, "form"]],
+            domain: this.getDomain(),
+            target: "current",
+        });
+    }
 }
 
 export const fieldMany2ManyTagsBanks = {
@@ -47,6 +61,11 @@ export const fieldMany2ManyTagsBanks = {
             name: "allow_out_payment_field",
             type: "boolean",
         },
+        {
+            label: _t("No search more"),
+            name: "no_search_more",
+            type: "boolean",
+        },
     ],
     additionalClasses: [
         ...(many2ManyTagsFieldColorEditable.additionalClasses || []),
@@ -57,6 +76,13 @@ export const fieldMany2ManyTagsBanks = {
             ...many2ManyTagsFieldColorEditable.relatedFields({ options }),
             { name: options.allow_out_payment_field, type: "boolean", readonly: false },
         ];
+    },
+    extractProps({ attrs, options, string }, dynamicInfo) {
+        const noSearchMore = Boolean(options.no_search_more);
+        return {
+            ...many2ManyTagsFieldColorEditable.extractProps({ attrs, options, string }, dynamicInfo),
+            noSearchMore,
+        };
     },
 };
 

--- a/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.xml
+++ b/addons/account/static/src/components/many2many_tags_banks/many2many_tags_banks.xml
@@ -5,4 +5,18 @@
             <i t-if="tag.allowOutPayment" class="ms-1 fa fa-unlock"/>
         </xpath>
     </t>
+
+    <t t-name="account.FieldMany2ManyTagsBanks" t-inherit="web.Many2ManyTagsField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_field_many2many_selection')]" position="inside">
+            <button
+                aria-label="Internal link"
+                class="btn btn-link text-action o_dropdown_button px-1 py-0 oi oi-arrow-right"
+                data-tooltip="Internal link"
+                draggable="false"
+                tabindex="-1"
+                type="button"
+                t-on-click="this.openBanksListView"
+            />
+        </xpath>
+    </t>
 </templates>

--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -240,7 +240,7 @@
                         <field name="show_credit_limit" invisible="1"/>
                         <group>
                             <group string="General" name="general" groups="account.group_account_invoice,account.group_account_readonly">
-                                <field name="bank_ids" context="{'default_partner_id': id}" domain="[('partner_id','=', id)]" widget="many2many_tags_banks" options="{'color_field': 'color', 'allow_out_payment_field': 'allow_out_payment', 'edit_tags': True}"/>
+                                <field name="bank_ids" context="{'default_partner_id': id}" domain="[('partner_id','=', id)]" widget="many2many_tags_banks" options="{'color_field': 'color', 'allow_out_payment_field': 'allow_out_payment', 'edit_tags': True, 'no_search_more': True}"/>
                                 <field name="property_account_receivable_id" required="True"/>
                                 <field name="property_account_payable_id" required="True"/>
                                 <field name="autopost_bills" groups="account.group_account_invoice,account.group_account_readonly"/>


### PR DESCRIPTION
In the partner bank account selection, it was not possible to order accounts.
This is a crucial feature because the first account was used by default in many parts of odoo.
This commit solves this issue by adding access to banks list view, where the user can change banks as desired.

task-4830220




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
