### PR TITLE
[FIX] sale_project: clickable COGS project dashboard item

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -264,6 +264,17 @@ class Project(models.Model):
                 action['res_id'] = res_id
             return action
 
+        if section_name == 'cost_of_goods_sold':
+            action = {
+                'name': _('Cost of Goods Sold Items'),
+                'type': 'ir.actions.act_window',
+                'res_model': 'account.move.line',
+                'views': [[False, 'tree'], [False, 'form']],
+                'domain': [('move_id', '=', res_id), ('display_type', '=', 'cogs')],
+                'context': {'create': False, 'edit': False},
+            }
+            return action
+
         return super().action_profitability_items(section_name, domain, res_id)
 
     @api.depends('sale_order_id.invoice_status', 'tasks.sale_order_id.invoice_status')


### PR DESCRIPTION
**Current behavior:**
COGS dashboard items in a project's profitability report do not open any details when clicked on.

**Expected behavior:**
This should open a detailed view for an invoice linked via the analytic account on the project.

**Steps to reproduce:**
1. Create a service product that generates a project on sale, on the project template set a specific analytic account

2. Create another product with real time valuation and assign the COGS account on the product category's expense account

3. Sell some of the service product and the auto val product in the same order, deliver it -> generate invoice & post it

4. In the project's settings, open the profitability report and click on the `Cost of Goods Sold` dashboard item

**Cause of the issue:**
There is no action set up to return for this section, as it was just added in: 0fbc592

**Fix:**
Add an action to return the account move line records with COGS display type for the invoice record in question (in the request's `res_id`).

opw-4813885