### PR TITLE
[FIX] hr_holidays: fix allocation domain in leave type _compute_valid

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -158,7 +158,6 @@ class HolidaysType(models.Model):
             if holiday_type.requires_allocation == 'yes':
                 allocations = self.env['hr.leave.allocation'].search([
                     ('holiday_status_id', '=', holiday_type.id),
-                    ('allocation_type', '=', 'accrual'),
                     ('employee_id', '=', employee_id),
                     ('date_from', '<=', date_from),
                     '|',


### PR DESCRIPTION
This commit fixes an issue in the `_compute_valid` method of the `hr.leave.type` model. The `('allocation_type', '=', 'accrual')` was removed from the domain, as it limited the valid allocations to type `accrual` only, which is not the intended behavior

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
