### PR TITLE
[FIX] website_crm_partner_assign: allow filtering on all countries in /partners

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -48,8 +48,8 @@
                 </button>
                 <div class="dropdown-menu">
                     <t t-foreach="countries" t-as="country" t-if="country['country_id']">
-                        <a t-attf-href="/partners#{ current_grade and '/grade/%s' % slug(current_grade) or ''}#{country['country_id'][0] and '/country/%s' % slug(country['country_id']) or '' }?#{ keep_query('search', (country['country_id'][0] == 0 and 'country_all' or ''), 'industry')}"
-                        class="dropdown-item d-flex justify-content-between">
+                        <t t-set='all_countries' t-value="dict(country_all=1) if country['country_id'][0] == 0 else {} "/>
+                        <a t-attf-href="/partners#{ current_grade and '/grade/%s' % slug(current_grade) or ''}#{country['country_id'][0] and '/country/%s' % slug(country['country_id']) or '' }?#{ keep_query('search', 'industry', **all_countries)}" class="dropdown-item d-flex justify-content-between">
                             <t t-out="country['country_id'][1]"/>&amp;nbsp;&amp;nbsp;
                             <span class="badge text-white bg-secondary rounded-pill px-2 py-1" t-esc="country['country_id_count']"/>
                         </a>


### PR DESCRIPTION
Before this commit, if GeoIP was enabled and no country was provided, the geolocation was used automatically. As a result, it was not possible to view partners from all countries.

Now, we restore the previous logic by explicitly passing a parameter to show all countries.

Note: On runbot, no difference is visible since GeoIP is not enabled.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
