### PR TITLE
[FIX] website: countdown colors setup

### DIFF
--- a/addons/web/static/src/core/utils/colors.js
+++ b/addons/web/static/src/core/utils/colors.js
@@ -201,7 +201,7 @@ export function convertRgbaToCSSColor(r, g, b, a) {
  *          - blue [0, 255] (integer)
  *          - opacity [0, 100.0] (float)
  */
-export function convertCSSColorToRgba(cssColor) {
+export function convertCSSColorToRgba(cssColor = "") {
     // Check if cssColor is a rgba() or rgb() color
     const rgba = cssColor.match(/^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d+(?:\.\d+)?))?\)$/);
     if (rgba) {

--- a/addons/website/static/tests/interactions/snippets/countdown.test.js
+++ b/addons/website/static/tests/interactions/snippets/countdown.test.js
@@ -137,6 +137,31 @@ test("countdown is stopped correctly", async () => {
     expect(queryAll(".s_countdown_end_redirect_message")).toHaveLength(0);
 });
 
+test("Countdown snippet exists, when the colors are not defined", async () => {
+    const countdownEl = `<section class="s_countdown pt48 pb48"
+            data-display="dhms"
+            data-end-action="nothing"
+            data-size="175"
+            data-layout="circle"
+            data-layout-background="none"
+            data-progress-bar-style="surrounded"
+            data-progress-bar-weight="thin"
+            id="countdown-section"
+            data-end-time="1749351790.469224">
+                <div class="container">
+                    <div class="s_countdown_canvas_wrapper"
+                    style="
+                        display: flex;
+                        justify-content: center;
+                        align-items: center;">
+                    </div>
+                </div>
+            </section>`;
+    const { core } = await startInteractions(countdownEl);
+    expect(".o_error_dialog").toHaveCount(0);
+    expect(core.interactions).toHaveLength(1);
+});
+
 test("past date: redirect end message is shown", async () => {
     await startInteractions(getTemplate({ endAction: "redirect", endTime: 1 }));
     await tick();


### PR DESCRIPTION
Steps to reproduce the error:
1. Start editing
2. Drop countdown snippet
3. Click on any of the color options (Text Color or Progress Bar Color)
4. Hover the reset button 

As a result, we get an error and the countdown is missing.
This PR follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb

Related to task-4367641