### PR TITLE
[FIX] website_event: restore flexibility options

### DIFF
--- a/addons/website_event/static/src/website_builder/event_page_option.xml
+++ b/addons/website_event/static/src/website_builder/event_page_option.xml
@@ -16,6 +16,28 @@
             <BuilderSelectItem actionParam="{views: ['website_event.opt_event_description_cover_hidden']}">Hidden (visitor only)</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
+    <BuilderContext action="'websiteConfig'">
+        <BuilderRow label.translate="Fixed Sidebar">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_fixed_sidebar']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Registration" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_registration_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Dates" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_dates_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Calendar links" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_calendar_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Location" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_location_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Organizer" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_organizer_block']}"/>
+        </BuilderRow>
+        <BuilderRow label.translate="Share" level="1">
+            <BuilderCheckbox actionParam="{views: ['website_event.opt_event_share_block']}"/>
+        </BuilderRow>
+    </BuilderContext>
 </t>
 </templates>
-


### PR DESCRIPTION
Restore missing website event page options that were lost following the introduction of the new website builder.

Options restored are the "Fixed Sidebar" and all the side bar blocks visibility options ( see odoo/odoo#198005 )

related: odoo/odoo#187419

Task-4841011


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
