### PR TITLE
[FIX] purchase: convert bill amount when adding downpayment

### DIFF
--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -118,3 +118,19 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             {'account_id': accrued_wizard.account_id.id, 'debit': 0, 'credit': 235.0},
         ])
         self.assertFalse(self.env['account.move'].search(accrued_wizard.create_entries()['domain']).line_ids.filtered(lambda l: l.is_downpayment))
+
+    def test_downpayment_exchange_rate(self):
+        self.env['res.currency.rate'].create({'currency_id': self.other_currency.id, 'rate': 1.5})
+
+        po = self.init_purchase(products=[self.product_order])
+        po.button_confirm()
+        self.init_invoice('in_invoice', amounts=[100.00], post=True, currency=self.other_currency)
+
+        match_lines = self.env['purchase.bill.line.match'].search([('partner_id', '=', self.partner_a.id)])
+        action = match_lines.action_add_to_po()
+
+        wizard = self.env['bill.to.po.wizard'].with_context({**action['context'], 'active_ids': match_lines.ids}).create({})
+        wizard.action_add_downpayment()
+
+        po_dp_line = po.order_line.filtered(lambda l: l.display_type != 'line_section' and l.is_downpayment)
+        self.assertEqual(po_dp_line.price_unit, 66.67)

--- a/addons/purchase/wizard/bill_to_po_wizard.py
+++ b/addons/purchase/wizard/bill_to_po_wizard.py
@@ -48,13 +48,16 @@ class BillToPO(models.TransientModel):
             self.purchase_order_id = self.env['purchase.order'].create({
                 'partner_id': lines_to_convert.partner_id.id,
             })
+        po_currency = self.purchase_order_id.currency_id
+        company = self.purchase_order_id.company_id
+        date = self.purchase_order_id.date_order or fields.Date.today()
         line_vals = [
             {
                 'name': _("Down Payment (ref: %(ref)s)", ref=aml.display_name),
                 'product_qty': 0.0,
                 'product_uom': aml.product_uom_id.id,
                 'is_downpayment': True,
-                'price_unit': aml.price_unit,
+                'price_unit': aml.currency_id._convert(aml.price_unit, po_currency, company, date) if aml.currency_id != po_currency else aml.price_unit,
                 'taxes_id': aml.tax_ids,
                 'order_id': self.purchase_order_id.id,
             }


### PR DESCRIPTION
Users can create a downpayment bill directly from the purchase order
or create a bill separately and then associate it with the original
purchase order.
However, in the latter case, the bill amount won't take into account
the currency.

Steps to reproduce:
- Create a purchase order for a partner in company currency
- Create a bill in foreign currency for the same partner
- Click "Purchase Matching" smart button
- Select PO and BILL > Add to PO > Add Down Payment

Issue: Downpayment will be added into the PO without taking into account
the different currency

opw-4716949