### PR TITLE
[FIX] repair: fix error when removing product from parts in repair order

### DIFF
--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -44,6 +44,9 @@ The following topics are covered by this module:
         'web.assets_backend': [
             'repair/static/src/**/*',
         ],
+        'web.assets_tests': [
+            'repair/static/tests/tours/*.js',
+        ],
     },
     'license': 'LGPL-3',
 }

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -316,7 +316,7 @@ class Repair(models.Model):
     @api.depends('move_ids.quantity', 'move_ids.product_uom_qty', 'move_ids.product_uom.rounding')
     def _compute_has_uncomplete_moves(self):
         for repair in self:
-            repair.has_uncomplete_moves = any(float_compare(move.quantity, move.product_uom_qty, precision_rounding=move.product_uom.rounding) < 0 for move in repair.move_ids)
+            repair.has_uncomplete_moves = any(move.product_uom and float_compare(move.quantity, move.product_uom_qty, precision_rounding=move.product_uom.rounding) < 0 for move in repair.move_ids)
 
     @api.depends('move_ids', 'state', 'move_ids.product_uom_qty')
     def _compute_unreserve_visible(self):

--- a/addons/repair/static/tests/tours/repair_order.js
+++ b/addons/repair/static/tests/tours/repair_order.js
@@ -1,0 +1,47 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('test_repair_without_product_in_parts', {
+
+    steps: () => [
+    {
+        content: "Click product_id field",
+        trigger: "div[name='move_ids'] .o_data_row td.o_data_cell[name=product_id]",
+        run: "click",
+    },
+    {
+        content: "Unset the product",
+        trigger: "div[name=move_ids] div[name=product_id] input",
+        run: "edit",
+    },
+    {
+        content: "Click partner field",
+        trigger: ".o_field_widget[name=partner_id] input",
+        run: "click",
+    },
+    // Note: Selecting the partner is only to trigger the compute;
+    // this could be done by modifying any other field.
+    {
+        content: "Select partner",
+        trigger: ".ui-menu-item > a:contains('A Partner')",
+        run: "click",
+    },
+    {
+        content: "Click the product field",
+        trigger: "div[name=move_ids] .o_field_widget[name=product_id] input",
+        run: "edit [1234] A Product",
+    },
+    {
+        content: "Select a product",
+        trigger:".ui-menu-item > a:contains('[1234] A Product')",
+        run: "click",
+    },
+    {
+        content: "Save the repair order",
+        trigger: ".o_form_button_save",
+        run: "click",
+    },
+    {
+        content: "wait for save completion",
+        trigger: ".o_form_saved",
+    },
+]});


### PR DESCRIPTION
When User removes the product from parts in repair order and tries to change
the partner, A traceback will appear.

Steps to reproduce the error:
- Install ``repair`` module
- Create new repair order > Add a line > Add a product in parts > Save
- Remove product from parts > change customer > Save

Traceback:
```
AssertionError: precision_rounding must be positive, got 0.0
```

https://github.com/odoo/odoo/blob/122dece7eeedbf670254aebd2a2d69642b381547/addons/repair/models/repair.py#L319 When user removes the product from parts, ``precision_rounding`` becomes 0.0
Which results in the above traceback.

sentry-6650889934

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
