### PR TITLE
[FIX] account: do not mark copied invoices as modified

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3186,7 +3186,7 @@ class AccountMove(models.Model):
     def create(self, vals_list):
         if any('state' in vals and vals.get('state') == 'posted' for vals in vals_list):
             raise UserError(_('You cannot create a move already in the posted state. Please create a draft move and post it after.'))
-        container = {'records': self}
+        container = {'records': self.browse()}
         with self._check_balanced(container):
             with ExitStack() as exit_stack, self._sync_dynamic_lines(container):
                 for vals in vals_list:

--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -4389,6 +4389,12 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         self.assertEqual(invoice_1.journal_id.id, invoices_duplicate[0]['journal_id'])
         self.assertEqual(invoice_2.journal_id.id, invoices_duplicate[1]['journal_id'])
 
+    def test_invoice_copy_not_is_modified(self):
+        # Create is an api.model method, and shouldn't modify self even if set.
+        invoice = self.init_invoice('in_invoice', products=self.product_a + self.product_b, post=True)
+        invoice.copy()
+        self.assertFalse(invoice.is_manually_modified)
+
     def test_before_initial_rate(self):
         def invoice(date):
             return self.init_invoice(


### PR DESCRIPTION
Steps to reproduce:
* create an invoice
* duplicate it

Result:
The invoice was marked as manually modified

Expected:
It should remain in the exact same state as before
