### PR TITLE
[IMP] orm: in model class operations, use classes instead of recordsets

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -846,7 +846,8 @@ class IrModelFields(models.Model):
                     rel_name = field.relation_table or (is_model and model._fields[field.name].relation)
                     tables_to_drop.add(rel_name)
             if field.state == 'manual' and is_model:
-                pop_field(model, field.name)
+                model_cls = self.env.registry[model._name]
+                pop_field(model_cls, field.name)
 
         if tables_to_drop:
             # drop the relation tables that are not used by other fields
@@ -922,7 +923,7 @@ class IrModelFields(models.Model):
             if field:
                 self.env._field_dirty.pop(field)
         # remove fields from registry, and check that views are not broken
-        fields = [pop_field(self.env[record.model], record.name) for record in records]
+        fields = [pop_field(self.env.registry[record.model], record.name) for record in records]
         domain = Domain.OR([('arch_db', 'like', record.name)] for record in records)
         views = self.env['ir.ui.view'].search(domain)
         try:
@@ -2407,7 +2408,7 @@ class IrModelData(models.Model):
                         # the field is shared across registries; don't modify it
                         Field = type(field)
                         field_ = Field(_base_fields__=(field, Field(prefetch=False)))
-                        add_field(self.env[ir_field.model], ir_field.name, field_)
+                        add_field(self.env.registry[ir_field.model], ir_field.name, field_)
                         field_.setup(model)
                         has_shared_field = True
         if has_shared_field:


### PR DESCRIPTION
The current implementation iterates over `env` instead of `registry`, then almost everytime retrieves the class in the registry.  This is not efficient and leads to many calls to `env[...]`, which instanciates models for nothing.
    
This commit changes the iteration to use the registry and the model classes directly, instanciating a model with an `env` ony when needed. Note that in most cases, the `env` could be removed by replacing some methods by class methods or hardcoded logic.

This work was initially made in #211658 but was extracted here.