### PR TITLE
[FIX] web: close datepicker when owner is destroyed

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_hook.js
+++ b/addons/web/static/src/core/datetime/datetime_hook.js
@@ -16,12 +16,13 @@ export function useDateTimePicker(hookParams) {
         });
     }
     const inputRefs = [useRef("start-date"), useRef("end-date")];
-    const createPopover = hookParams.createPopover ?? usePopover;
+    if (!hookParams.createPopover) {
+        hookParams.createPopover = usePopover;
+    }
     const getInputs = () => inputRefs.map((ref) => ref?.el);
     const { computeBasePickerProps, state, open, focusIfNeeded, enable } = datetimePicker.create(
         hookParams,
-        getInputs,
-        createPopover
+        getInputs
     );
     onWillRender(computeBasePickerProps);
     useEffect(enable, getInputs);

--- a/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_hook.test.js
@@ -143,3 +143,54 @@ test("value is not updated if it did not change", async () => {
     expect(getShortDate(pickerProps.value)).toBe("2023-07-07");
     expect.verifySteps(["2023-07-07"]);
 });
+
+test("close popover when owner component is unmounted", async() => {
+    class Child extends Component {
+        static components = { DateTimeInput };
+        static props = [];
+        static template = xml`
+            <div>
+                <input type="text" class="datetime_hook_input" t-ref="start-date"/>
+            </div>
+        `;
+
+        setup() {
+            useDateTimePicker({
+                pickerProps: {
+                    value: [false, false],
+                    type: "date",
+                    range: true,
+                }
+            });
+        }
+    }
+
+    const { resolve: hidePopover, promise } = Promise.withResolvers();
+
+    class DateTimeToggler extends Component {
+        static components = { Child };
+        static props = [];
+        static template = xml`<Child t-if="!state.hidden"/>`;
+
+        setup() {
+            this.state = useState({
+                hidden: false,
+            });
+            promise.then(() => {
+                this.state.hidden = true;
+            });
+        }
+    }
+
+    await mountWithCleanup(DateTimeToggler);
+
+    await click("input.datetime_hook_input");
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(1);
+
+    // we can't simply add a button because `useClickAway` will be triggered, thus closing the popover properly
+    hidePopover();
+    await animationFrame();
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(0);
+});


### PR DESCRIPTION
Steps to reproduce
==================

- Go to project
- Open a project
- Open a task
- Click on the deadline field
- Go to the previous page using the browser back button

=> The datepicker stays open

Cause of the issue
==================

`datetimePicker.create` was called using three parameters. But since bb1f912f04fbc4b1efe57847bceffce5895ced9b, it only accepts two.

Solution
========

`createPopover` should be added to the `hookParams`

This allows the popover to be closed when the owner component is
destroyed.

https://github.com/odoo/odoo/blob/bb1f912f04fbc4b1efe57847bceffce5895ced9b/addons/web/static/src/core/popover/popover_hook.js#L65

opw-4811594