### PR TITLE
[IMP] website, website_sale: allow to switch style of header buttons

### DIFF
--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -396,6 +396,24 @@
                 resetViewArch: true,
             }"/>
     </BuilderRow>
+    <BuilderRow
+        label.translate="Background"
+        level="1"
+        action="'websiteConfig'"
+        t-if="isActiveItem('header_default_opt')
+              or isActiveItem('header_hamburger_opt')
+              or isActiveItem('header_boxed_opt')
+              or isActiveItem('header_vertical_opt')
+              or isActiveItem('header_sales_one_opt')
+              or isActiveItem('header_sales_two_opt')
+              or isActiveItem('header_sales_four_opt')
+              or isActiveItem('header_sidebar_opt')"
+        >
+        <BuilderCheckbox actionParam="{
+            views: ['!website.template_header_navlink_no_background'],
+            resetViewArch: true,
+        }"/>
+    </BuilderRow>
 </t>
 
 </templates>

--- a/addons/website/static/src/builder/plugins/options/header_option.xml
+++ b/addons/website/static/src/builder/plugins/options/header_option.xml
@@ -330,75 +330,71 @@
 </t>
 
 <t t-name="website.headerElementOption">
-    <BuilderRow label.translate="Elements" action="'websiteConfig'">
-        <div class="flex-grow-1">
-            <div class="d-flex mb-1">
-                <BuilderButton
-                    title.translate="Show/hide text element"
-                    className="'flex-grow-1 me-1'"
-                    actionParam="{
-                        views: ['website.header_text_element'],
-                        resetViewArch: true,
-                    }"
-                >
-                    <Img src="'/website/static/src/img/snippets_options/header_extra_element_text.svg'"/>
-                </BuilderButton>
-                <t t-set="language_ids" t-value="env.services.website.currentWebsite.language_ids || []"/>
-                <BuilderButton
-                    t-if="language_ids.length > 1"
-                    title.translate="Show/hide language selector"
-                    className="'flex-grow-1 me-1 fa fa-flag'"
-                    actionParam="{
-                        views: ['website.header_language_selector'],
-                        resetViewArch: true,
-                    }"
-                >
-                </BuilderButton>
-                <BuilderButton
-                    title.translate="Show/hide search bar"
-                    className="'fa fa-search flex-grow-1 me-1'"
-                    actionParam="{
-                        views: ['website.header_search_box'],
-                        resetViewArch: true,
-                    }"/>
-                <BuilderButton
-                    title.translate="Show/hide sign in button"
-                    className="'fa fa-sign-in flex-grow-1'"
-                    actionParam="{
-                        views: ['portal.user_sign_in'],
-                        resetViewArch: true,
-                    }"/>
-            </div>
-            <div class="d-flex">
-                <BuilderButton
-                    title.translate="Show/hide social links"
-                    className="'flex-grow-1 me-1'"
-                    actionParam="{
-                        views: ['website.header_social_links'],
-                        resetViewArch: true,
-                    }"
-                >
-                    <Img src="'/website/static/src/img/snippets_options/header_extra_element_social.svg'"/>
-                </BuilderButton>
-                <BuilderButton
-                    title.translate="Show/hide button"
-                    className="'flex-grow-1 me-1'"
-                    actionParam="{
-                        views: ['website.header_call_to_action'],
-                        resetViewArch: true,
-                    }"
-                >
-                    <Img src="'/website/static/src/img/snippets_options/header_extra_element_cta.svg'"/>
-                </BuilderButton>
-                <BuilderButton
-                    title.translate="Show/hide logo"
-                    className="'flex-grow-1'"
-                    actionParam="websiteLogoParams"
-                >
-                    <Img src="'/website/static/src/img/snippets_options/header_extra_element_logo.svg'"/>
-                </BuilderButton>
-            </div>
-        </div>
+    <BuilderRow label.translate="Header elements" action="'websiteConfig'">
+        <BuilderButton
+            title.translate="Show/hide logo"
+            className="'flex-grow-1'"
+            actionParam="websiteLogoParams"
+        >
+            <Img src="'/website/static/src/img/snippets_options/header_extra_element_logo.svg'"/>
+        </BuilderButton>
+        <BuilderButton
+            title.translate="Show/hide text element"
+            className="'flex-grow-1'"
+            actionParam="{
+                views: ['website.header_text_element'],
+                resetViewArch: true,
+            }"
+        >
+            <Img src="'/website/static/src/img/snippets_options/header_extra_element_text.svg'"/>
+        </BuilderButton>
+        <BuilderButton
+            title.translate="Show/hide button"
+            className="'flex-grow-1'"
+            actionParam="{
+                views: ['website.header_call_to_action'],
+                resetViewArch: true,
+            }"
+        >
+            <Img src="'/website/static/src/img/snippets_options/header_extra_element_cta.svg'"/>
+        </BuilderButton>
+        <t t-set="language_ids" t-value="env.services.website.currentWebsite.language_ids || []"/>
+        <BuilderButton
+            t-if="language_ids.length > 1"
+            title.translate="Show/hide language selector"
+            className="'fa fa-flag flex-grow-1'"
+            actionParam="{
+                views: ['website.header_language_selector'],
+                resetViewArch: true,
+            }"
+        >
+        </BuilderButton>
+    </BuilderRow>
+    <BuilderRow label.translate="Actions" action="'websiteConfig'">
+        <BuilderButton
+            title.translate="Show/hide search bar"
+            className="'fa fa-search flex-grow-1'"
+            actionParam="{
+                views: ['website.header_search_box'],
+                resetViewArch: true,
+            }"/>
+        <BuilderButton
+            title.translate="Show/hide social links"
+            className="'flex-grow-1'"
+            actionParam="{
+                views: ['website.header_social_links'],
+                resetViewArch: true,
+            }"
+        >
+            <Img src="'/website/static/src/img/snippets_options/header_extra_element_social.svg'"/>
+        </BuilderButton>
+        <BuilderButton
+            title.translate="Show/hide sign in button"
+            className="'fa fa-sign-in flex-grow-1'"
+            actionParam="{
+                views: ['portal.user_sign_in'],
+                resetViewArch: true,
+            }"/>
     </BuilderRow>
 </t>
 

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -313,6 +313,10 @@ body {
     }
 }
 
+.o_navlink_no_background .navbar-light {
+    --NavLinkWithBackground-bg-color: transparent;
+}
+
 .navbar {
 
     .navbar-collapse {
@@ -396,8 +400,14 @@ body {
 .o_navlink_background {
     background: var(--NavLinkWithBackground-bg-color, rgba(var(--#{$variable-prefix}emphasis-color-rgb), .05));
 
-    &:hover {
+    &:hover, .o_navlink_trigger_hover:hover & {
         background: var(--NavLinkWithBackground-bg-color--hover, rgba(var(--#{$variable-prefix}emphasis-color-rgb), .1));
+    }
+}
+
+.o_navlink_background, .o_navlink_trigger_hover {
+    &:focus-visible {
+        --#{$prefix}btn-focus-box-shadow: #{$nav-link-focus-box-shadow};
     }
 }
 

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -493,6 +493,12 @@
     </t>
 </template>
 
+<template id="template_header_navlink_no_background" inherit_id="website.layout" active="False">
+    <xpath expr="//header" position="attributes">
+        <attribute name="t-attf-class" add="o_navlink_no_background" separator=" "/>
+    </xpath>
+</template>
+
 <template id="template_header_mobile_position_left" inherit_id="website.template_header_mobile" active="False">
     <xpath expr="//t[@t-set='_side']" position="replace">
         <t t-set="_side" t-valuef="offcanvas-start"/>
@@ -633,14 +639,14 @@
                 <ul class="o_header_hamburger_right_col navbar-nav flex-row gap-2 align-items-center ms-auto">
                     <!-- Sign In -->
                     <t t-call="portal.placeholder_user_sign_in">
-                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn text-reset"/>
+                        <t t-set="_link_class" t-valuef="o_navlink_background btn text-reset"/>
                     </t>
                     <!-- User Dropdown -->
                     <t t-call="portal.user_dropdown">
                         <t t-set="_icon" t-value="true"/>
                         <t t-set="_item_class" t-valuef="dropdown"/>
                         <t t-set="_icon_class" t-valuef="fa-stack"/>
-                        <t t-set="_link_class" t-valuef="o_navlink_background_hover btn d-flex align-items-center rounded-circle p-1 pe-2 text-reset"/>
+                        <t t-set="_link_class" t-valuef="o_navlink_background btn d-flex align-items-center rounded-circle p-1 pe-2 text-reset"/>
                         <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                     </t>
                 </ul>
@@ -1153,8 +1159,8 @@
                                 <t t-set="_icon" t-value="true"/>
                                 <t t-set="_icon_class" t-valuef="fa-stack"/>
                                 <t t-set="_item_class" t-valuef="dropdown"/>
-                                <t t-set="_link_class" t-valuef="btn d-flex align-items-center border-0 fw-bold text-reset o_navlink_background_hover"/>
-                                <t t-set="_icon_wrap_class" t-value="'position-relative me-2 p-2 rounded-circle border bg-o-color-3'"/>
+                                <t t-set="_link_class" t-valuef="btn d-flex align-items-center border-0 fw-bold text-reset o_navlink_trigger_hover"/>
+                                <t t-set="_icon_wrap_class" t-value="'position-relative me-2 p-2 rounded-circle o_navlink_background transition-base'"/>
                                 <t t-set="_dropdown_menu_class" t-valuef="dropdown-menu-end"/>
                             </t>
                         </ul>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -173,13 +173,13 @@
 
     <template id="template_header_sidebar" inherit_id="website.template_header_sidebar">
         <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="after">
-            <div class="d-flex gap-1 ms-auto mb-0">
+            <ul class="list-unstyled d-flex gap-1 ms-auto mb-0">
                 <t t-call="website_sale.header_cart_link">
                     <t t-set="_icon" t-value="True"/>
                     <t t-set="_link_class" t-value="'o_navlink_background btn position-relative p-1 rounded-circle text-reset'"/>
                     <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 rounded-pill mt-n1 me-n1'"/>
                 </t>
-            </div>
+            </ul>
         </xpath>
     </template>
 

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -88,7 +88,7 @@
         <xpath expr="//t[@t-call='portal.placeholder_user_sign_in']" position="before">
             <t t-call="website_sale.header_cart_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-pill p-1 text-reset'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative rounded-pill p-1 text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded'"/>
             </t>
         </xpath>
@@ -141,8 +141,8 @@
             <t t-call="website_sale.header_cart_link">
                 <t t-set="_icon" t-value="True"/>
                 <t t-set="_text" t-value="True"/>
-                <t t-set="_icon_wrap_class" t-value="'position-relative me-2 rounded-circle border p-2 bg-o-color-3 o_border_contrast'"/>
-                <t t-set="_link_class" t-value="'btn d-flex align-items-center fw-bold text-reset o_navlink_background_hover'"/>
+                <t t-set="_icon_wrap_class" t-value="'o_navlink_background position-relative me-2 rounded-circle p-2 transition-base'"/>
+                <t t-set="_link_class" t-value="'o_navlink_trigger_hover btn d-flex align-items-center fw-bold text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
                 <t t-set="_text_class" t-value="'small'"/>
             </t>
@@ -165,7 +165,7 @@
         <xpath expr="//t[@t-call='website.placeholder_header_call_to_action']" position="before">
             <t t-call="website_sale.header_cart_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-pill p-1 text-reset'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative rounded-pill p-1 text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
             </t>
         </xpath>
@@ -173,10 +173,10 @@
 
     <template id="template_header_sidebar" inherit_id="website.template_header_sidebar">
         <xpath expr="//t[@t-call='website.placeholder_header_brand']" position="after">
-            <div class="d-flex ms-auto mb-0">
+            <div class="d-flex gap-1 ms-auto mb-0">
                 <t t-call="website_sale.header_cart_link">
                     <t t-set="_icon" t-value="True"/>
-                    <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative p-1 rounded-circle text-reset'"/>
+                    <t t-set="_link_class" t-value="'o_navlink_background btn position-relative p-1 rounded-circle text-reset'"/>
                     <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 rounded-pill mt-n1 me-n1'"/>
                 </t>
             </div>

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -136,6 +136,13 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
             $wishButton.toggleClass('d-none', !this.wishlistProductIDs.length);
         }
         $wishButton.find('.my_wish_quantity').text(this.wishlistProductIDs.length);
+        const wishlistQuantity = document.querySelector('.my_wish_quantity');
+        if (this.wishlistProductIDs.length != 0) {
+            wishlistQuantity.classList.remove('d-none');
+        }
+        else {
+            wishlistQuantity.classList.add('d-none');
+        }
     },
     /**
      * @private

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -93,7 +93,11 @@
                 <a href="/shop/wishlist" t-attf-class="#{_link_class}">
                     <div t-attf-class="#{_icon_wrap_class}">
                         <i t-if="_icon" class="fa fa-1x fa-heart fa-stack"/>
-                        <sup t-esc="wishcount" t-attf-class="my_wish_quantity o_animate_blink badge bg-primary #{_badge_class}"/>
+                        <sup
+                            t-out="wishcount"
+                            t-attf-class="my_wish_quantity o_animate_blink badge bg-primary
+                                          #{_badge_class} #{'d-none' if (wishcount == 0) else ''}"
+                        />
                     </div>
                     <span t-if="_text" t-attf-class="#{_text_class}">Wishlist</span>
                 </a>

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -134,7 +134,7 @@
         <xpath expr="//t[@t-call='website_sale.header_cart_link']" position="after">
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-pill p-1 text-reset'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative rounded-pill p-1 text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded'"/>
             </t>
         </xpath>
@@ -176,7 +176,7 @@
         <xpath expr="//t[@t-call='website_sale.header_cart_link']" position="after">
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'btn position-relative rounded-circle p-1 text-reset o_navlink_background'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative rounded-circle p-1 text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
             </t>
         </xpath>
@@ -187,8 +187,8 @@
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
                 <t t-set="_text" t-value="True"/>
-                <t t-set="_icon_wrap_class" t-value="'position-relative me-2 rounded-circle border p-2 bg-o-color-3 o_border_contrast'"/>
-                <t t-set="_link_class" t-value="'btn d-flex align-items-center fw-bold text-reset o_navlink_background_hover'"/>
+                <t t-set="_icon_wrap_class" t-value="'o_navlink_background position-relative me-2 rounded-circle p-2 transition-base'"/>
+                <t t-set="_link_class" t-value="'o_navlink_trigger_hover btn d-flex align-items-center fw-bold text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
                 <t t-set="_text_class" t-value="'small'"/>
             </t>
@@ -211,7 +211,7 @@
         <xpath expr="//t[@t-call='website_sale.header_cart_link']" position="after">
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative rounded-pill p-1 text-reset'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative rounded-pill p-1 text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
             </t>
         </xpath>
@@ -221,7 +221,7 @@
         <xpath expr="//t[@t-call='website_sale.header_cart_link']" position="after">
             <t t-call="website_sale_wishlist.header_wishlist_link">
                 <t t-set="_icon" t-value="True"/>
-                <t t-set="_link_class" t-value="'o_navlink_background_hover btn position-relative p-1 rounded-circle text-reset'"/>
+                <t t-set="_link_class" t-value="'o_navlink_background btn position-relative p-1 rounded-circle text-reset'"/>
                 <t t-set="_badge_class" t-value="'position-absolute top-0 end-0 mt-n1 me-n1 rounded-pill'"/>
             </t>
         </xpath>


### PR DESCRIPTION
### Adapt header template title 
Since [the refactoring of the website builder](https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2), the title of a header template wasn't correct.
This PR fixes this issue.

### Reorganise header elements feature
This PR reorganises the buttons in the "Elements" option, available
in the header, to make them easier to read.

### Allow to switch style of header buttons
Prior to this PR, some header templates used buttons with a slightly dark or white background, depending on the header background. This style could not be changed in the editor.
This PR adds a new option that allows the user to remove the background from these buttons to achieve a more minimalist style.

This feature works with the following headers templates:
- Default
- Hamburger
- Rounded
- Vertical
- Sales One
- Sales Two
- Sales Four
- Sidebar

### Wishlist button: hide count when list is empty
This PR hides the small count of the wishlist button in the header when the list is empty (previously it displayed "0").
The goal is to maintain consistency with the cart button.


### Fix e-commerce button in sidebar header
Before this PR, the options to show/hide the "Add to Cart" and "Wishlist" buttons had no effect on the "Sidebar" header template (only in edit mode).

Steps to reproduce:

- Install e-commerce.
- Enter edit mode and click the header.
- Change the header template to "Sidebar".
- In the header options, click the toggles to hide the "Add to Cart" or  "Wishlist" buttons if they are empty.
- Bug: nothing happens unless you save the page and exit edit mode.

This was caused by the editor's `liWithoutParentToP` function, which checks that a `<li>` element has a valid parent. It transforms `<li>` into `<p>` when there is no `<ul>` as parent.

This PR fixes the issue by wrapping the `<li>` elements that contain the 'Add to Cart' and 'Wishlist' buttons in a `<ul>`.

task-4840014

**Example:**


| | Preview |
|--------|--------|
| Editor Option| ![image](https://github.com/user-attachments/assets/be21b42b-d562-4663-8fea-7726325a8138) |
| Option OFF | ![Capture d’écran 2025-06-02 à 16 43 45](https://github.com/user-attachments/assets/c2aff099-55eb-4cc6-8edf-ecfae872e06f) |
| Option ON | ![Capture d’écran 2025-06-02 à 16 43 36](https://github.com/user-attachments/assets/d3d1f2be-7ed6-4ddc-bb4d-684f49c09f54) |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
