### PR TITLE
[FIX] account: relax constraints on recently merged feature

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2384,7 +2384,7 @@ class AccountMove(models.Model):
                 tax=False,
                 hard=True,
             )
-            if violated_lock_dates:
+            if not self.env.su and violated_lock_dates:
                 message = _("You cannot add/modify entries prior to and inclusive of: %(lock_date_info)s.",
                             lock_date_info=self.env['res.company']._format_lock_dates(violated_lock_dates))
                 raise UserError(message)

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -1272,6 +1272,8 @@ class AccountMoveLine(models.Model):
         return True
 
     def _check_reconciliation(self):
+        if self.env.su:
+            return
         for line in self:
             if line.matched_debit_ids or line.matched_credit_ids:
                 raise UserError(_("You cannot do this modification on a reconciled journal entry. "

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -790,8 +790,6 @@ class ResPartner(models.Model):
         res = super().write(vals)
         moves_sudo = self.sudo().env['account.move'].search([('partner_id', 'in', self.ids)])
         if moves_sudo and 'parent_id' in vals:
-            if not self.env.user.has_group('account.group_account_user'):
-                raise UserError(_("You do not have permission to mark this partner as the main commercial partner."))
             parent_vat = self.env['res.partner'].browse(vals['parent_id']).vat
             if vals['parent_id'] and {parent_vat} != set(self.mapped('vat')):
                 raise UserError(_("You cannot set a partner as an invoicing address of another if they have a different %(vat_label)s.", vat_label=self.vat_label))


### PR DESCRIPTION
commit 3941972dc7bba3e9a3d4497b312ff7f86a497157 restricted the change of commercial entity on a partner having existing accounting entries to accountants only. This has been debated and ruled as too restrictive. Also all the checks that could failed (fiscal lock date, existing reconciliation made) are now totally by-passed as it would just made the feature unusable and we've set up some checks prior to make sure it was safe

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
