### PR TITLE
[FIX] web: restrict drag & drop in grouped list views

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_group_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_group_list.js
@@ -4,6 +4,8 @@ import { Domain } from "@web/core/domain";
 import { DynamicList } from "./dynamic_list";
 import { getGroupServerValue } from "./utils";
 
+export const MOVABLE_RECORD_TYPES = ["char", "boolean", "integer", "selection", "many2one"];
+
 /**
  * @typedef {import("./record").Record} RelationalRecord
  */

--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -8,17 +8,17 @@ import { evaluateExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable_owl";
+import { MOVABLE_RECORD_TYPES } from "@web/model/relational_model/dynamic_group_list";
 import { isNull } from "@web/views/utils";
 import { ColumnProgress } from "@web/views/view_components/column_progress";
 import { useBounceButton } from "@web/views/view_hook";
+import { KanbanColumnExamplesDialog } from "./kanban_column_examples_dialog";
 import { KanbanColumnQuickCreate } from "./kanban_column_quick_create";
 import { KanbanHeader } from "./kanban_header";
 import { KanbanRecord } from "./kanban_record";
 import { KanbanRecordQuickCreate } from "./kanban_record_quick_create";
-import { KanbanColumnExamplesDialog } from "./kanban_column_examples_dialog";
 
 const DRAGGABLE_GROUP_TYPES = ["many2one"];
-const MOVABLE_RECORD_TYPES = ["char", "boolean", "integer", "selection", "many2one"];
 
 function validateColumnQuickCreateExamples(data) {
     const { allowedGroupBys = [], examples = [], foldField = "" } = data;

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -394,11 +394,10 @@ export class ListRenderer extends Component {
         if (!this.props.list.canResequence() || this.props.readonly) {
             return false;
         }
-        const groupByField = this.props.list.groupByField;
-        if (groupByField && !this.isMovableField(groupByField)) {
+        const { groupBy, groupByField, handleField, orderBy } = this.props.list;
+        if (groupBy?.length > 1 || (groupByField && !this.isMovableField(groupByField))) {
             return false;
         }
-        const { handleField, orderBy } = this.props.list;
         return !orderBy.length || (orderBy.length && orderBy[0].name === handleField);
     }
 

--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -3,12 +3,14 @@ import { CheckBox } from "@web/core/checkbox/checkbox";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { localization } from "@web/core/l10n/localization";
 import { Pager } from "@web/core/pager/pager";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useBus, useService } from "@web/core/utils/hooks";
 import { useSortable } from "@web/core/utils/sortable_owl";
 import { getTabableElements } from "@web/core/utils/ui";
+import { AGGREGATABLE_FIELD_TYPES, combineModifiers } from "@web/model/relational_model/utils";
 import { Field, getPropertyFieldInfo } from "@web/views/fields/field";
 import { getTooltipInfo } from "@web/views/fields/field_tooltip";
 import {
@@ -16,25 +18,24 @@ import {
     getClassNameFromDecoration,
     getFormattedValue,
 } from "@web/views/utils";
-import { AGGREGATABLE_FIELD_TYPES, combineModifiers } from "@web/model/relational_model/utils";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { useBounceButton } from "@web/views/view_hook";
 import { Widget } from "@web/views/widgets/widget";
-import { localization } from "@web/core/l10n/localization";
 import { useMagicColumnWidths } from "./column_width_hook";
 
 import {
     Component,
     onMounted,
     onPatched,
-    status,
     onWillPatch,
     onWillRender,
+    status,
     useExternalListener,
     useRef,
 } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
 import { exprToBoolean } from "@web/core/utils/strings";
+import { MOVABLE_RECORD_TYPES } from "@web/model/relational_model/dynamic_group_list";
 
 /**
  * @typedef {import('@web/model/relational_model/dynamic_list').DynamicList} DynamicList
@@ -393,6 +394,10 @@ export class ListRenderer extends Component {
         if (!this.props.list.canResequence() || this.props.readonly) {
             return false;
         }
+        const groupByField = this.props.list.groupByField;
+        if (groupByField && !this.isMovableField(groupByField)) {
+            return false;
+        }
         const { handleField, orderBy } = this.props.list;
         return !orderBy.length || (orderBy.length && orderBy[0].name === handleField);
     }
@@ -447,6 +452,10 @@ export class ListRenderer extends Component {
             return true;
         }
         return false;
+    }
+
+    isMovableField(field) {
+        return MOVABLE_RECORD_TYPES.includes(field.type);
     }
 
     focusCell(column, forward = true) {

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10239,6 +10239,26 @@ test(`editable grouped list with handle widget`, async () => {
     });
 });
 
+test(`editable grouped list with handle widget (group by date)`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list editable="top" default_order="int_field">
+                <field name="int_field" widget="handle"/>
+                <field name="amount" widget="float" digits="[5,0]"/>
+            </list>
+        `,
+        groupBy: ["date"],
+    });
+    expect(`.o_group_header`).toHaveCount(2);
+    await contains(`.o_group_header:first`).click();
+    await contains(`.o_group_header:last`).click();
+    expect(`.o_group_header:first`).toHaveText("January 2017 (1)\n 1,200");
+    expect(`.o_group_header:last`).toHaveText("None (3)\n 800");
+    expect(`.o_field_handle:first span`).not.toBeEnabled();
+});
+
 test(`editable target, handle widget locks and unlocks on sort`, async () => {
     // resequence makes sense on a sequence field, not on arbitrary fields
     Foo._records[0].int_field = 0;

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -10259,6 +10259,26 @@ test(`editable grouped list with handle widget (group by date)`, async () => {
     expect(`.o_field_handle:first span`).not.toBeEnabled();
 });
 
+test(`editable grouped list with handle widget (multiple group by)`, async () => {
+    await mountView({
+        resModel: "foo",
+        type: "list",
+        arch: `
+            <list editable="top" default_order="int_field">
+                <field name="int_field" widget="handle"/>
+                <field name="amount" widget="float" digits="[5,0]"/>
+            </list>
+        `,
+        groupBy: ["bar", "foo"],
+    });
+    expect(`.o_group_header`).toHaveCount(2);
+    await contains(`.o_group_header:first`).click();
+    await contains(`.o_group_header:eq(1)`).click(); // sub group
+    expect(`.o_group_header:first`).toHaveText("No (1)\n 0");
+    expect(`.o_group_header:eq(1)`).toHaveText("blip (1)\n 0");
+    expect(`.o_field_handle:first span`).not.toBeEnabled();
+});
+
 test(`editable target, handle widget locks and unlocks on sort`, async () => {
     // resequence makes sense on a sequence field, not on arbitrary fields
     Foo._records[0].int_field = 0;


### PR DESCRIPTION
First commit fixes an issue that allowed users to drag and drop records between groups in list views where such behavior was not appropriate (such as when grouped by date).

Drag and drop is now properly restricted to:
- Ungrouped list views
- List views grouped by fields of type: char, boolean, integer, selection, or many2one

Second commit removes the ability to drag and drop records in list view when there are multiple groups since it would trigger a traceback.

task-4828407
