### PR TITLE
[FIX] web: Hoot - cleanup queryAll error messages

### DIFF
--- a/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
+++ b/addons/web/static/lib/hoot/tests/hoot-dom/dom.test.js
@@ -16,6 +16,7 @@ import {
     queryAll,
     queryAllRects,
     queryAllTexts,
+    queryFirst,
     queryOne,
     queryRect,
     waitFor,
@@ -892,6 +893,9 @@ describe(parseUrl(import.meta.url), () => {
                 </div>
             `);
 
+            expect(() => queryFirst("invalid:pseudo-selector")).toThrow();
+            // Perform in-between valid query with custom pseudo selectors
+            expect(queryFirst(".modal:visible:contains('Tung Tung Tung Sahur')")).toBe(null);
             expect(() => queryOne(".tralalero:contains(Tralala):visible:scrollable:first")).toThrow(
                 `found 0 elements instead of 1: 0 matching ".tralalero:contains(Tralala):visible:scrollable:first" (1 element with text "Tralala" > 1 visible element > 0 scrollable elements > 0 first elements)`
             );


### PR DESCRIPTION
Before this commit, 'queryX' functions in Hoot would supposedly cleanup internal global variables on error thrown by the helpers. However, this only took into account the errors explicitly thrown, and NOT those that were thrown by other methods/native code, such as invalid native query selectors.

This commit introduces a new internal method to "guard" exposed 'queryX' helpers, to properly cleanup internal variables on any error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
