### PR TITLE
[FIX] project:  Ensure parent task is set for new sub-tasks

### DIFF
--- a/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_one2many_field.js
@@ -11,11 +11,12 @@ export class SubtaskOne2ManyField extends X2ManyField {
     };
 
     getFormActionContext() {
+        const defaultValueKeys = Object.keys(this.props.context).filter((key) => key.startsWith('default_'));
         return pick(
             this.props.context,
             "active_test",
-            "default_project_id",
-            "propagate_not_active"
+            "propagate_not_active",
+            ...defaultValueKeys,
         );
     }
 }


### PR DESCRIPTION
Previously, when creating a sub-task via "task form view > create a sub-task > 
view > new task", the 'Parent Task' field was empty. 

Now, the parent task's reference is correctly included in the creation flow,
ensuring the 'Parent Task' field is properly pre-filled.

task-4797845

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
