### PR TITLE
[IMP] website_crm_partner_assign: Enable and adapt some tours

### DIFF
--- a/addons/website/static/tests/tours/snippet_images_wall.js
+++ b/addons/website/static/tests/tours/snippet_images_wall.js
@@ -20,11 +20,11 @@ const preventRaceConditionSteps = [{
 
 const selectSignImageStep = [
     {
-        trigger: ".o_we_customize_panel:not(:has(.snippet-option-GalleryElement))",
+        trigger: ".o_customize_tab:not(:has([data-label='Re-order']))",
     },
     {
         content: "Click on image 14",
-        trigger: ":iframe .s_image_gallery img[data-original-src*='library_image_14']",
+        trigger: ":iframe .s_image_gallery img[src*='library_image_14']",
         run: "click",
     },
 ];
@@ -63,11 +63,11 @@ registerWebsitePreviewTour("snippet_images_wall", {
         ...selectSignImageStep,
 {
     content: "Click on add a link",
-    trigger: ".snippet-option-ReplaceMedia we-button[data-set-link]",
+    trigger: "div[data-label='Media'] button[data-action-id='setLink']",
     run: "click",
 }, {
     content: "Change the link of the image",
-    trigger: ".snippet-option-ReplaceMedia [data-set-url] input",
+    trigger: "div[data-label='Your URL'] div[data-action-id='setUrl'] input",
     // TODO: This should not be needed, but there seems to be an odd behavior
     // with the input not properly blurring when clicking on the reorder
     // buttons. However this is also the case in older versions. It
@@ -76,45 +76,45 @@ registerWebsitePreviewTour("snippet_images_wall", {
     run: "edit /contactus && click body",
 }, {
     content: "Click on move to previous",
-    trigger: ".snippet-option-GalleryElement we-button[data-position='prev']",
+    trigger: "div[data-label='Re-order'] button[data-action-value='prev']",
     run: "click",
 }, {
     content: "Check if sign is in second column",
-    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(2):has(a[href='/contactus'] img[data-index='1'][data-original-src*='library_image_14'])",
+    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(2):has(img[data-index='1'][src*='library_image_14'])",
 },
 ...reselectSignImageSteps,
 {
     content: "Click on move to first",
-    trigger: ".snippet-option-GalleryElement we-button[data-position='first']",
+    trigger: "div[data-label='Re-order'] button[data-action-value='first']",
     run: "click",
 }, {
     content: "Check if sign is in first column",
-    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(1):has(img[data-index='0'][data-original-src*='library_image_14'])",
+    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(1):has(img[data-index='0'][src*='library_image_14'])",
 },
 ...reselectSignImageSteps,
 {
     content: "Click on move to previous",
-    trigger: ".snippet-option-GalleryElement we-button[data-position='prev']",
+    trigger: "div[data-label='Re-order'] button[data-action-value='prev']",
     run: "click",
 }, {
     content: "Check if sign is in third column",
-    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(img[data-index='5'][data-original-src*='library_image_14'])",
+    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(img[data-index='5'][src*='library_image_14'])",
 },
 ...reselectSignImageSteps,
 {
     content: "Click on move to next",
-    trigger: ".snippet-option-GalleryElement we-button[data-position='next']",
+    trigger: "div[data-label='Re-order'] button[data-action-value='next']",
     run: "click",
 }, {
     content: "Check if sign is in first column",
-    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(1):has(img[data-index='0'][data-original-src*='library_image_14'])",
+    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(1):has(img[data-index='0'][src*='library_image_14'])",
 },
 ...reselectSignImageSteps,
 {
     content: "Click on move to last",
-    trigger: ".snippet-option-GalleryElement we-button[data-position='last']",
+    trigger: "div[data-label='Re-order'] button[data-action-value='last']",
     run: "click",
 }, {
     content: "Check layout",
-    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(img[data-index='5'][data-original-src*='library_image_14'])",
+    trigger: ":iframe .s_image_gallery .o_masonry_col:nth-child(3):has(img[data-index='5'][src*='library_image_14'])",
 }]);

--- a/addons/website/tests/test_snippets.py
+++ b/addons/website/tests/test_snippets.py
@@ -113,7 +113,6 @@ class TestSnippets(HttpCase):
         })
         self.start_tour(self.env['website'].get_client_action_url('/'), 'snippet_popup_display_on_click', login='admin')
 
-    @unittest.skip
     def test_12_snippet_images_wall(self):
         self.start_tour('/', 'snippet_images_wall', login='admin')
 

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -101,7 +101,7 @@ registerWebsitePreviewTour('website_hr_recruitment_tour_edit_form', {
     run: "click",
 }, {
     content: 'Add a new field',
-    trigger: 'we-button[data-add-field]',
+    trigger: 'div[data-container-title="Field"] button.o_we_bg_brand_primary',
     run: "click",
 },
 ...clickOnSave(),
@@ -154,6 +154,6 @@ registerWebsitePreviewTour('model_required_field_should_have_action_name', {
     run: "click",
 }, {
     content: "Select model-required field",
-    trigger: "we-customizeblock-options we-alert > span:not(:contains(undefined))",
+    trigger: ".options-container .alert > span:not(:contains(undefined))",
 }
 ]);

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -11,8 +11,6 @@ from odoo.addons.website_hr_recruitment.controllers.main import WebsiteHrRecruit
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
-    # TODO master-mysterious-egg fix error
-    @unittest.skip("prepare mysterious-egg for merging")
     def test_tour(self):
         job_guru = self.env['hr.job'].create({
             'name': 'Guru',


### PR DESCRIPTION
test_03_reditor_not_salesman test was previously disabled, enabled the tour again.

This commit updates the tour steps to align with the new DOM and re-enables the associated test.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
