### PR TITLE
[FIX] website: fix image tools options on image field

### DIFF
--- a/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
+++ b/addons/website/static/src/builder/plugins/image/image_tool_option_plugin.js
@@ -38,6 +38,7 @@ class ImageToolOptionPlugin extends Plugin {
             withSequence(IMAGE_TOOL, {
                 OptionComponent: ImageToolOption,
                 selector: "img",
+                exclude: "[data-oe-type='image'] > img",
             }),
             withSequence(ALIGNMENT_STYLE_PADDING, {
                 template: "website.ImageAndFaOption",


### PR DESCRIPTION
Since the refactoring of the Website Builder options, unwanted image options are now available on product images and other image fields in edit mode.

This commit excludes image fields from the image tool options, such as the image shape option.

task-4367641