### PR TITLE
[16.0][FIX] stock_landed_costs: preserve sign for vendor refunds in landed cost

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -25,13 +25,14 @@ class AccountMove(models.Model):
         self.ensure_one()
         landed_costs_lines = self.line_ids.filtered(lambda line: line.is_landed_costs_line)
 
+        sign = -1 if self.move_type in ['in_refund'] else 1
         landed_costs = self.env['stock.landed.cost'].with_company(self.company_id).create({
             'vendor_bill_id': self.id,
             'cost_lines': [(0, 0, {
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
-                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
+                'price_unit': sign * l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date or fields.Date.context_today(l)),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -678,3 +678,74 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
 
         # 35 = Product price (10) + landed cost price (25)
         self.assertEqual(product.standard_price, 35)
+
+    def test_refund_landed_cost_creates_negative_valuation(self):
+        """Ensure landed cost created from a vendor refund is negative and reduces valuation."""
+        self.env.company.anglo_saxon_accounting = True
+        product = self.env['product.product'].create({
+            'name': 'product',
+            'type': 'product',
+            'purchase_method': 'purchase',
+            'categ_id': self.stock_account_product_categ.id,
+        })
+        product.categ_id.write({
+            'property_stock_account_input_categ_id': self.company_data['default_account_stock_in'].id,
+            'property_stock_account_output_categ_id': self.company_data['default_account_stock_out'].id,
+            'property_stock_valuation_account_id': self.company_data['default_account_stock_valuation'].id,
+            'property_valuation': 'real_time',
+            'property_cost_method': 'average',
+        })
+        landed_cost_product = self.landed_cost
+        landed_cost_product.write({
+            'landed_cost_ok': True,
+            'categ_id': product.categ_id.id,
+            'type': 'service',
+            'purchase_method': 'purchase',
+        })
+        po = self.env['purchase.order'].create({
+            'partner_id': self.supplier_id,
+            'order_line': [
+                Command.create({
+                    'product_id': product.id,
+                    'product_qty': 1,
+                    'price_unit': 100,
+                }),
+                Command.create({
+                    'product_id': landed_cost_product.id,
+                    'product_qty': 1,
+                    'price_unit': 20,
+                }),
+            ],
+        })
+        po.button_confirm()
+        picking = po.picking_ids
+        picking.move_ids.quantity_done = 1
+        picking.button_validate()
+        po.action_create_invoice()
+        bill = po.invoice_ids[0]
+        bill.invoice_date = fields.Date.today()
+        bill.action_post()
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(picking)
+        lc = lc_form.save()
+        lc.button_validate()
+        self.assertEqual(lc.amount_total, 20)
+        self.assertEqual(lc.stock_valuation_layer_ids.value, 20)
+        reverse_wizard = self.env['account.move.reversal'].with_context(active_model='account.move', active_ids=bill.ids).create({
+            'reason': 'Refund for landed cost',
+            'date': fields.Date.today(),
+            'refund_method': 'refund',
+            'journal_id': bill.journal_id.id,
+        })
+        reversal = reverse_wizard.reverse_moves()
+        reversed_move = self.env['account.move'].browse(reversal['res_id'])
+        reversed_move.invoice_date = fields.Date.today()
+        reversed_move.action_post()
+        action = reversed_move.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(picking)
+        lc = lc_form.save()
+        lc.button_validate()
+        self.assertEqual(lc.amount_total, -20)
+        self.assertEqual(lc.stock_valuation_layer_ids.value, -20)


### PR DESCRIPTION
Before this PR, creating a landed cost in the following scenario incorrectly increased the stock valuation instead of reducing it:

- Create a Purchase Order with a valuated product and a landed cost product in the order lines.
- Validate the receipt of the PO.
- Create the vendor bill from the PO and confirm it.
- Create a landed cost from the vendor bill by clicking "CREATE LANDED COSTS" and selecting the receipt in the landed cost.
- Validate the landed cost.
- Create a credit note from the vendor bill.
- Create a landed cost from the credit note by clicking "CREATE LANDED COSTS" and selecting the same receipt.
- Validate the landed cost.

In this scenario, the refund amount is treated as a positive landed cost, causing the stock valuation to increase again. This can lead to the landed cost being applied twice by mistake, overstating inventory value.

After this PR, the landed cost line amounts for credit notes are correctly set as negative, which reduces the stock valuation instead of increasing it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

OPW #4844792
@qrtl QT5401