### PR TITLE
[IMP] mail, project: cleanup project sharing suggestions

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_hook.js
+++ b/addons/mail/static/src/core/common/suggestion_hook.js
@@ -3,10 +3,12 @@ import { ConnectionAbortedError } from "@web/core/network/rpc";
 import { useService } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
 
+export const DELAY_FETCH = 250;
+
 class UseSuggestion {
     constructor(comp) {
         this.comp = comp;
-        this.fetchSuggestions = useDebounced(this.fetchSuggestions.bind(this), 250);
+        this.fetchSuggestions = useDebounced(this.fetchSuggestions.bind(this), DELAY_FETCH);
         useEffect(
             () => {
                 this.update();

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -2111,4 +2111,12 @@ class ProjectTask(models.Model):
             [("id", "in", followers.partner_id.ids)],
         ])
         partners = self.env["res.partner"].sudo()._search_mention_suggestions(domain, limit)
-        return Store(partners).get_result()
+        return (
+            Store()
+            .add(
+                self,
+                {"limitedMentions": Store.Many(partners, ["email", "im_status", "name"])},
+                as_thread=True,
+            )
+            .get_result()
+        )

--- a/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
+++ b/addons/project/static/src/project_sharing/chatter/suggestion_service_patch.js
@@ -5,15 +5,16 @@ import { patch } from "@web/core/utils/patch";
 patch(SuggestionService.prototype, {
     async fetchPartnersRoles(term, thread, { abortSignal } = {}) {
         if (thread.model === "project.task") {
-            const suggestedPartners = await this.makeOrmCall(
-                "project.task",
-                "get_mention_suggestions",
-                [thread.id],
-                { search: term },
-                { abortSignal }
+            this.store.insert(
+                await this.makeOrmCall(
+                    "project.task",
+                    "get_mention_suggestions",
+                    [thread.id],
+                    { search: term },
+                    { abortSignal }
+                )
             );
-            this.store.insert(suggestedPartners);
-            thread.limitedMentions = suggestedPartners["res.partner"];
+            return;
         }
         return super.fetchPartnersRoles(...arguments);
     },

--- a/addons/project/static/tests/tours/project_sharing_tour.js
+++ b/addons/project/static/tests/tours/project_sharing_tour.js
@@ -1,3 +1,4 @@
+import { delay } from "@odoo/hoot-dom";
 import { registry } from "@web/core/registry";
 import { stepUtils } from "@web_tour/tour_service/tour_utils";
 
@@ -224,6 +225,13 @@ registry.category("web_tour.tours").add("portal_project_sharing_chatter_mention_
         { trigger: "table > tbody > tr a:has(span:contains(Project Sharing))", run: "click" },
         { trigger: ".o_project_sharing" },
         { trigger: ".o_kanban_record:contains('Test Task')", run: "click" },
+        { trigger: ".o-mail-Composer-input", run: "edit @xxx" },
+        {
+            trigger: "body:not(:has(.o-mail-Composer-suggestion))",
+            run: async () => {
+                await delay(odoo.loader.modules.get("@mail/core/common/suggestion_hook").DELAY_FETCH);
+            },
+        },
         { trigger: ".o-mail-Composer-input", run: "edit @Georges" },
         { trigger: ".o-mail-Composer-suggestion:contains('Georges')" },
     ],


### PR DESCRIPTION
This change cleans up the code related to getting suggestions in a project sharing environment. It ensures that the server-side data is properly formatted as store data, making it possible to insert it directly into the client-side store. This change also removes the extra rpc during the get suggestions process in project sharing. This extra rpc comes from the lack of a proper return, so calling the super happens even if it's not needed.

