### PR TITLE
[FIX] stock: append move origin to picking instead of clearing

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1402,7 +1402,14 @@ Please change the quantity done or the rounding precision of your unit of measur
         if any(picking.partner_id != m.partner_id for m in self):
             vals['partner_id'] = False
         if any(picking.origin != m.origin for m in self):
-            vals['origin'] = False
+            current_origins = set(picking.origin.split(',') + [False]) if picking.origin else {False}
+            vals['origin'] = picking.origin
+            for move in self:
+                if move.origin not in current_origins:
+                    if not vals['origin']:
+                        vals['origin'] = move.origin
+                    else:
+                        vals['origin'] += f',{move.origin}'
         return vals
 
     def _assign_picking_post_process(self, new=False):

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -414,10 +414,10 @@ class TestOldRules(TestStockCommon):
         self.assertEqual(picking_pick.partner_id.id, procurement_group1.partner_id.id)
         self.assertEqual(picking_pick.origin, move1.group_id.name)
 
-        # second out move, the "pick" picking should have lost its partner and origin
+        # second out move, the "pick" picking should have lost its partner and have its origin updated
         move2._action_confirm()
         self.assertEqual(picking_pick.partner_id.id, False)
-        self.assertEqual(picking_pick.origin, False)
+        self.assertEqual(picking_pick.origin, f'{move1.group_id.name},{move2.group_id.name}')
 
     def test_fixed_procurement_01(self):
         """ Run a procurement for 5 products when there are only 4 in stock then
@@ -601,10 +601,10 @@ class TestOldRules(TestStockCommon):
         self.assertEqual(picking_pick.partner_id.id, procurement_group1.partner_id.id)
         self.assertEqual(picking_pick.origin, move1.group_id.name)
 
-        # second out move, the "pick" picking should have lost its partner and origin
+        # second out move, the "pick" picking should have lost its partner and have its origin updated
         move2._action_confirm()
         self.assertEqual(picking_pick.partner_id.id, False)
-        self.assertEqual(picking_pick.origin, False)
+        self.assertEqual(picking_pick.origin, f'{move1.group_id.name},{move2.group_id.name}')
 
     def test_propagate_cancel_in_pull_setup(self):
         """


### PR DESCRIPTION
**Current behavior:**
During the assignment of a picking, if any of its moves have an origin that does not match its own, the origin will be cleared altogether.

**Expected behavior:**
The different origin should be appended to the existing origin string (as is done in batch replenishment, for example).

**Steps to reproduce:**
1. Create 2 products, create a secondary warehouse

2. Create an orderpoint for each product, make the route on both of them the (first?) pointed to by `resupply_route_ids` on the primary warehouse

3. Set `qty_to_order` 1 on each of the orderpoints, and one at a time click the 'Order' button

4. The move generated for each replenishment action will ultimately be added to a single picking -> in the end see that its `origin` field is cleared

**Cause of the issue:**
We currently decide to clear the picking origin during assignment if any of its moves have a different origin.

**Fix:**
Instead, append the different origin string to the picking.

opw-4749519