### PR TITLE
[FIX] website: ensure edit mode is fully ready before running tour steps

### DIFF
--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -100,7 +100,7 @@ export function changeColumnSize(position = "right") {
 export function changeImage(snippet, position = "bottom") {
     return [
         {
-            trigger: "body :iframe .odoo-editor-editable",
+            trigger: ".o_builder_sidebar_open",
         },
         {
             trigger: snippet.id ? `#wrapwrap .${snippet.id} img` : snippet,
@@ -245,7 +245,7 @@ export function clickOnEditAndWaitEditMode(position = "bottom") {
         run: "click",
     }, {
         content: "Check that we are in edit mode",
-        trigger: ".o_website_preview :iframe .odoo-editor-editable",
+        trigger: ".o_builder_sidebar_open",
     }];
 }
 
@@ -268,7 +268,7 @@ export function clickOnEditAndWaitEditModeInTranslatedPage(position = "bottom") 
         run: "click",
     }, {
         content: "Check that we are in edit mode",
-        trigger: ".o_website_preview :iframe .odoo-editor-editable",
+        trigger: ".o_builder_sidebar_open",
     }];
 }
 
@@ -359,7 +359,7 @@ export function clickOnText(snippet, element, position = "bottom") {
 export function insertSnippet(snippet, { position = "bottom", ignoreLoading = false } = {}) {
     const blockEl = snippet.groupName || snippet.name;
     const insertSnippetSteps = [{
-        trigger: ".o_website_preview :iframe .odoo-editor-editable",
+        trigger: ".o_builder_sidebar_open",
         noPrepend: true,
     }];
     const snippetIDSelector = snippet.id ? `[data-snippet-id="${snippet.id}"]` : `[data-snippet-id^="${snippet.customID}_"]`;
@@ -500,7 +500,7 @@ export function registerWebsitePreviewTour(name, options, steps) {
             if (options.edition) {
                 tourSteps.unshift({
                     content: "Wait for the edit mode to be started",
-                    trigger: ".o_website_preview :iframe .odoo-editor-editable",
+                    trigger: ".o_builder_sidebar_open",
                     timeout: 30000,
                 });
             } else {


### PR DESCRIPTION
Previously, when running tours that triggered plugin-related actions (e.g., opening the link popover) immediately after entering Edit mode, those actions sometimes failed to execute because the editor wasn't fully initialized yet.

This commit updates the `clickOnEditAndWaitEditMode` tour helper to use a more reliable readiness check. It previously waited for the `.odoo-editor-editable` class, but that class can appear before the editor is fully ready, leading to race conditions in tours.

We now wait for the builder sidebar to open instead, which happens slightly later and offers a more accurate signal that the editor is fully initialized.