### PR TITLE
[FIX] spreadsheet: correctly compute month/quarter value for filters

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -50,23 +50,23 @@ function pivotPeriodToFilterValue(timeRange, value) {
                 yearOffset,
             };
         case "month": {
-            const month = value.includes("/") ? Number.parseInt(value.split("/")[0]) : -1;
+            const month = value.includes("/") ? Number.parseInt(value.split("/")[0]) - 1 : -1;
             if (!(month in monthsOptions)) {
                 return { yearOffset, period: undefined };
             }
             return {
                 yearOffset,
-                period: monthsOptions[month - 1].id,
+                period: monthsOptions[month].id,
             };
         }
         case "quarter": {
-            const quarter = value.includes("/") ? Number.parseInt(value.split("/")[0]) : -1;
+            const quarter = value.includes("/") ? Number.parseInt(value.split("/")[0]) - 1 : -1;
             if (!(quarter in FILTER_DATE_OPTION.quarter)) {
                 return { yearOffset, period: undefined };
             }
             return {
                 yearOffset,
-                period: FILTER_DATE_OPTION.quarter[quarter - 1],
+                period: FILTER_DATE_OPTION.quarter[quarter],
             };
         }
     }
@@ -460,7 +460,9 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
                             }
                         }
                         // A group by value of "none"
-                        if (value === false) break;
+                        if (value === false) {
+                            break;
+                        }
                         if (JSON.stringify(currentValue) !== `[${value}]`) {
                             transformedValue = [value];
                         }


### PR DESCRIPTION
Steps to reproduce:
- Create a dashboard with a pivot table with a date field and a global filter on it. Ensure that the date field is set to "Month" in the pivot table and at least a value for the month of December is present.
- Open the dashboard
- Click on the "December" value in the pivot => Only the year is selected in the global filter, not the month.

Same thing happens when the date field is set to quarter and the value Q4 is selected.

Task: 4844417

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
