### PR TITLE
[FIX] account: allow payment register branches

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -5,6 +5,7 @@ from odoo.tests import tagged, Form, users
 from odoo import fields, Command
 
 from dateutil.relativedelta import relativedelta
+from itertools import product
 
 
 @tagged('post_install', '-at_install')
@@ -169,6 +170,12 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'company_id': cls.branch.id,
             'company_ids': [Command.set(cls.branch.ids)],
         })
+
+    @classmethod
+    def get_wizard_available_journals(cls, wizard):
+        return wizard.available_journal_ids.filtered_domain([
+            *cls.env['account.journal']._check_company_domain(wizard.company_id),
+        ])
 
     def test_register_payment_single_batch_grouped_keep_open_lower_amount(self):
         ''' Pay 800.0 with 'open' as payment difference handling on two customer invoices (1000 + 2000). '''
@@ -1523,62 +1530,139 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertEqual(wizard.amount, 39.50)
 
-    def test_group_payment_method_with_branch(self):
-        # create a new branch
-        self.env.company.write({
-            'child_ids': [
-                Command.create({'name': 'Branch A'}),
-                Command.create({'name': 'Branch B'}),
-            ],
-        })
-        self.cr.precommit.run()  # load the CoA
+    def test_payment_with_branch(self):
+        """
+        Test register payment with branches when different receivable accounts are used in each branch with combinations of invoices and selected companies
+        """
+        def test_register_payment_flow(cases):
+            for group_payment, case in product((False, True), cases):
+                invoices, selected_companies, expected_companies, expected_pmnt_comp, should_raise = case.values()
+                with self.subTest(invoices=invoices.mapped('name'), selected_companies=selected_companies.mapped('name')):
+                    wizard = self.env['account.payment.register'].with_context(allowed_company_ids=selected_companies.ids, active_model='account.move', active_ids=invoices.ids).create({'group_payment': group_payment})
+                    available_journals = self.get_wizard_available_journals(wizard)
+                    self.assertEqual(available_journals.company_id, expected_companies)
+                    if should_raise:
+                        with self.assertRaisesRegex(UserError, 'Incompatible companies on records:'):
+                            wizard._create_payments()
+                    else:
+                        payments = wizard._create_payments()
+                        self.assertEqual(payments.company_id, expected_pmnt_comp)
+                        invoices.line_ids.filtered(lambda l: l.display_type == 'payment_term').remove_move_reconcile()
 
-        # create an invoice on the new branch
+        # create a new branch
+        self.setup_company_data("New Branch", parent_id=self.env.company.id)
+        branches = self.env.company.child_ids
+        self.user_branch.company_ids = branches
+
+        # PART 1: Basic cases
+        # create invoices on branches
         branch_invoices = self.env['account.move']
-        for idx, branch in enumerate(self.env.company.child_ids):
+        for branch in branches:
             self.env["account.journal"].create({
                 'code': 'TEST',
                 'company_id': branch.id,
                 'name': f'{branch.name} journal',
                 'type': 'bank',
             })
-            receivable_account = self.env['account.account'].create({
-                'name': 'Receivable Account',
-                'code': f'{idx}234567',
-                'account_type': 'asset_receivable',
-                'reconcile': True,
-                'company_id': branch.id,
-            })
-            self.partner_a.with_company(branch).write({
-                'property_account_receivable_id': receivable_account.id,
-            })
             branch_invoices |= self.init_invoice('out_invoice', products=self.product_a, company=branch)
 
         parent_invoice = self.init_invoice('out_invoice', products=self.product_a)
-        (branch_invoices | parent_invoice).action_post()
+        other_company_invoice = self.init_invoice('out_invoice', products=self.product_a, company=self.company_data_2['company'])
+        (branch_invoices | parent_invoice | other_company_invoice).action_post()
 
-        # branch1 + parent
-        case1 = branch_invoices[0] + parent_invoice
-        # branch1 + branch2
-        case2 = branch_invoices
-        # branch1 + branch2 + parent
-        case3 = branch_invoices + parent_invoice
+        # test first branches invoices with branch user
+        with self.with_user('user_branch'):
+            with self.assertRaisesRegex(UserError, 'branches without access to parent company.'):
+                self.env['account.payment.register'].with_context(allowed_company_ids=branches.ids, active_model='account.move', active_ids=branch_invoices.ids).create({})
 
-        wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=case1.ids).create({})
-        # When user select branch + parent, allow only parent company journals
-        self.assertTrue(wizard.journal_id.company_id == self.env.company)
+        # test also with two differents companies
+        with (self.assertRaisesRegex(UserError, 'for entries belonging to different companies.')):
+            for group_payment in [False, True]:
+                self.env['account.payment.register'].with_context(
+                    allowed_company_ids=(self.env.company + self.company_data_2['company']).ids,
+                    active_model='account.move',
+                    active_ids=(parent_invoice + other_company_invoice).ids
+                ).create({'group_payment': group_payment})
 
-        # When user select sibling companies, group payments are not allowed
-        with self.assertRaises(UserError, msg="You can't create payments for entries belonging to different branches."):
-            self.env['account.payment.register'].with_context(active_model='account.move', active_ids=case2.ids).create({})
+        cases = [
+            {
+                'invoices': branch_invoices[0] + parent_invoice,
+                'selected_companies': (self.branch + self.env.company),
+                'expected_companies': self.env.company,
+                'expected_pmnt_comp': self.env.company,
+                'should_raise': False,
+            },
+            {
+                'invoices': branch_invoices,
+                'selected_companies': branches,
+                'expected_companies': self.env.company,
+                'expected_pmnt_comp': self.env.company,
+                'should_raise': False,
+            },
+            {
+                'invoices': branch_invoices + parent_invoice,
+                'selected_companies': self.env.company._accessible_branches(),
+                'expected_companies': self.env.company,
+                'expected_pmnt_comp': self.env.company,
+                'should_raise': False,
+            },
+            {
+                'invoices': branch_invoices[0],
+                'selected_companies': self.branch,
+                'expected_companies': (self.env.company + self.branch),
+                'expected_pmnt_comp': self.branch,
+                'should_raise': False,
+            },
+            {
+                'invoices': branch_invoices,
+                'selected_companies': self.env.company._accessible_branches(),
+                'expected_companies': self.env.company,
+                'expected_pmnt_comp': self.env.company,
+                'should_raise': False,
+            },
+        ]
 
-        wizard = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=case3.ids).create({})
-        available_journals = wizard.available_journal_ids.filtered_domain([
-            *self.env['account.journal']._check_company_domain(wizard.company_id),
-            ('type', 'in', ('bank', 'cash')),
-        ])
-        # When user select 2+ branches and parent company allow to create payment on the parent journal
-        self.assertEqual(available_journals.company_id, self.env.company)
+        test_register_payment_flow(cases)
+
+        # PART 2: Test the same cases with different receivable accounts for each branch
+        # An error should be raised as the receivable account doesn't belong to the wizard's company, except for the case where we register payment only for one branch
+        branch_invoices.button_draft()
+        for branch in branches:
+            receivable_account = self.company_data['default_account_receivable'].with_company(branch).copy({'company_id': branch.id})
+            branch_invoice = branch_invoices.filtered(lambda inv: inv.company_id == branch)
+            # To mock the situation where the partner has his own receivable account depending on the branch
+            branch_invoice.line_ids.filtered(lambda l: l.display_type == 'payment_term').account_id = receivable_account
+        branch_invoices.action_post()
+        new_cases = [
+            {
+                'invoices': branch_invoices[0] + parent_invoice,
+                'expected_pmnt_comp': False,
+                'should_raise': True,
+            },
+            {
+                'invoices': branch_invoices,
+                'expected_pmnt_comp': False,
+                'should_raise': True,
+            },
+            {
+                'invoices': branch_invoices + parent_invoice,
+                'expected_pmnt_comp': False,
+                'should_raise': True,
+            },
+            {
+                'invoices': branch_invoices[0],
+                'expected_pmnt_comp': self.branch,
+                'should_raise': False,
+            },
+            {
+                'invoices': branch_invoices,
+                'expected_pmnt_comp': False,
+                'should_raise': True,
+            },
+        ]
+        cases = [{**case, **new_case} for case, new_case in zip(cases, new_cases)]
+
+        test_register_payment_flow(cases)
 
     def test_epd_and_cash_rounding(self):
         cash_rounding = self.env['account.cash.rounding'].create({


### PR DESCRIPTION
Currently, we prevent user to register payment for invoices
belonging to different branches.
With this commit, when trying to register payments for
two invoices belonging to different branches, we register it as
parent company.

Steps:

- Have a main company with 2 branch
- Create and confirm one invoice for each branch
- Select both branches in company selector
- From the invoice list view, select the 2 invoices
- Try to register payment
-> Error: "You can't create payments for entries belonging to different branches."

opw-4563936
