### PR TITLE
[FIX] mrp_subcontracting: create backorder on incomplete subcontracted delivery

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -59,8 +59,8 @@ class StockMove(models.Model):
         return res
 
     def _compute_picked(self):
-       subcontracted_moves = self.filtered(lambda m: m.is_subcontract)
-       super(StockMove, self - subcontracted_moves)._compute_picked()
+        subcontracted_moves = self.filtered(lambda m: m.is_subcontract and float_compare(m.product_uom_qty, m.quantity, precision_rounding=m.product_uom.rounding) != 0)
+        super(StockMove, self - subcontracted_moves)._compute_picked()
 
     def _set_quantity_done(self, qty):
         to_set_moves = self


### PR DESCRIPTION
Issue
-----
In barcode processing reception of subcontracted products doesn't create a back order for the remaining products.

Steps to reproduce
-----
- Create 2 products, one subcontracted and one storable
- Create a purchase order for the 2 products & confirm it
- Go to barcode and open the delivery
- Only validate the reception of the subcontracted product

--> No backorder is created for the remaining product, it is considered received

Cause
-----
Commit db8b33e changed the compute of the move's picked status to not update for subcontracted moves. So the move line has picked set to True but not the move itself.

When we validate the operation in barcode, we go through this pre hook https://github.com/odoo/odoo/blob/1d256123da587d625c0527ca3a18cd82e7161df5/addons/stock/models/stock_picking.py#L1193

Since the move has a quantity but picked is still False, the full picking is being picked at once

https://github.com/odoo/odoo/blob/1d256123da587d625c0527ca3a18cd82e7161df5/addons/stock/models/stock_picking.py#L1206-L1207

-----
Ticket:
opw-4726229
