### PR TITLE
[FIX] tools: Enhance json_default to safely decode bytes with backsla…

### DIFF
--- a/odoo/tools/json.py
+++ b/odoo/tools/json.py
@@ -69,5 +69,5 @@ def json_default(obj):
     if isinstance(obj, ReadonlyDict):
         return dict(obj)
     if isinstance(obj, bytes):
-        return obj.decode()
+        return obj.decode(errors='backslashreplace')
     return str(obj)


### PR DESCRIPTION
…shreplace

Modified the json_default function to decode bytes using errors='backslashreplace'. This prevents UnicodeDecodeErrors when encountering invalid byte sequences and ensures robust JSON serialization.

Description of the issue/feature this PR addresses:

It get a traceback when reading rawfile of file (like .pdf, .png etc.)

https://github.com/odoo/odoo/issues/205510

Current behavior before PR:

Raise a traceback when wrong char were find in bytes object

Desired behavior after PR is merged:

Replace the wrong char with backslash and there for no traceback raised

CLA Signed : https://github.com/odoo/odoo/pull/212690

