### PR TITLE
[FIX] l10n_it_edi: allow only branches with different VAT/CF to create their own proxy user

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -4,13 +4,12 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-17 09:50+0000\n"
-"PO-Revision-Date: 2024-01-15 23:04+0000\n"
+"POT-Creation-Date: 2025-06-12 15:49+0000\n"
+"PO-Revision-Date: 2025-06-12 15:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
@@ -19,12 +18,12 @@ msgstr ""
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
 msgid "<b>CIG: </b>"
-msgstr "<b>CIG: </b>"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
 msgid "<b>CUP: </b>"
-msgstr "<b>CUP: </b>"
+msgstr ""
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.report_invoice_document
@@ -65,14 +64,23 @@ msgstr ""
 "<span class=\"o_form_label\">\n"
 "                                Modalità fattura elettronica\n"
 "                            </span>\n"
-"                            <span class=\"fa fa-lg fa-building-o\" title=\"I "
-"valori indicati di seguito sono specifici per l'azienda.\"/>"
+"                            <span class=\"fa fa-lg fa-building-o\" title=\"I valori indicati di seguito sono specifici per l'azienda.\"/>"
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">\n"
+"                        This branch shares the same VAT number and Codice Fiscale as its parent company. Select the parent company to configure the EDI settings.\n"
+"                    </span>"
+msgstr ""
+"<span class=\"o_form_label\">\n"
+"                        Questa filiale condivide la stessa partita IVA e Codice Fiscale della società madre. Selezionare la società madre per configurare le impostazioni EDI.\n"
+"                    </span>"
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
 msgid "<span class=\"o_form_label\">Allow Odoo to process invoices</span>"
-msgstr ""
-"<span class=\"o_form_label\">Consenti a Odoo di inviare le fatture</span>"
+msgstr "<span class=\"o_form_label\">Consenti a Odoo di inviare le fatture</span>"
 
 #. module: l10n_it_edi
 #: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
@@ -605,6 +613,11 @@ msgid "PEC e-mail"
 msgstr "E-mail PEC"
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__company_parent_id
+msgid "Parent Company"
+msgstr "Società madre"
+
+#. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "Partner not found, useful informations from XML file:"
@@ -665,7 +678,8 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_edi_proxy_user.py:0
 msgid ""
-"Please fill your codice fiscale to be able to receive invoices from FatturaPA"
+"Please fill your codice fiscale to be able to receive invoices from "
+"FatturaPA"
 msgstr ""
 "Per favore, inserisci il codice fiscale per poter ricevere le fatture da "
 "FatturaPA"
@@ -856,6 +870,14 @@ msgstr "Test (sperimentale)"
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "The Origin Document Date cannot be in the future."
 msgstr "La Data Documento Origine non può essere nel futuro."
+
+#. module: l10n_it_edi
+#. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+msgid ""
+"The amount_total %(current_total)s is different than PrezzoTotale "
+"%(expected_total)s for '%(move_name)s'"
+msgstr "L'importo totale %(current_total)s è diverso dal PrezzoTotale %(expected_total)s per '%(move_name)s'"
 
 #. module: l10n_it_edi
 #. odoo-python
@@ -1141,6 +1163,11 @@ msgid "Unknown error"
 msgstr "Errore sconosciuto"
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__use_root_proxy_user
+msgid "Use Root Proxy User"
+msgstr "Utilizzare l'utente proxy root"
+
+#. module: l10n_it_edi
 #: model:ir.model.fields,help:l10n_it_edi.field_account_bank_statement_line__l10n_it_edi_header
 #: model:ir.model.fields,help:l10n_it_edi.field_account_move__l10n_it_edi_header
 msgid ""
@@ -1265,8 +1292,8 @@ msgstr ""
 #. module: l10n_it_edi
 #: model:ir.model.fields.selection,name:l10n_it_edi.selection__res_company__l10n_it_tax_system__rf10
 msgid ""
-"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata "
-"al DPR 640/72 (art.74, c.6, DPR 633/72)"
+"[RF10] Intrattenimenti, giochi e altre attività di cui alla tariffa allegata"
+" al DPR 640/72 (art.74, c.6, DPR 633/72)"
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 18.0\n"
+"Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-06 11:37+0000\n"
-"PO-Revision-Date: 2025-01-06 11:37+0000\n"
+"POT-Creation-Date: 2025-06-12 15:48+0000\n"
+"PO-Revision-Date: 2025-06-12 15:48+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -59,6 +59,14 @@ msgid ""
 "                                Fattura Elettronica mode\n"
 "                            </span>\n"
 "                            <span class=\"fa fa-lg fa-building-o\" title=\"Values set here are company-specific.\"/>"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model_terms:ir.ui.view,arch_db:l10n_it_edi.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">\n"
+"                        This branch shares the same VAT number and Codice Fiscale as its parent company. Select the parent company to configure the EDI settings.\n"
+"                    </span>"
 msgstr ""
 
 #. module: l10n_it_edi
@@ -563,6 +571,11 @@ msgid "PEC e-mail"
 msgstr ""
 
 #. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__company_parent_id
+msgid "Parent Company"
+msgstr ""
+
+#. module: l10n_it_edi
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "Partner not found, useful informations from XML file:"
@@ -805,6 +818,14 @@ msgstr ""
 
 #. module: l10n_it_edi
 #. odoo-python
+#: code:addons/l10n_it_edi/models/account_move.py:0
+msgid ""
+"The amount_total %(current_total)s is different than PrezzoTotale "
+"%(expected_total)s for '%(move_name)s'"
+msgstr ""
+
+#. module: l10n_it_edi
+#. odoo-python
 #: code:addons/l10n_it_edi/models/res_config_settings.py:0
 msgid ""
 "The company has already registered with the service as 'Test' or 'Official',"
@@ -1022,6 +1043,11 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_it_edi/models/account_move.py:0
 msgid "Unknown error"
+msgstr ""
+
+#. module: l10n_it_edi
+#: model:ir.model.fields,field_description:l10n_it_edi.field_res_config_settings__use_root_proxy_user
+msgid "Use Root Proxy User"
 msgstr ""
 
 #. module: l10n_it_edi

--- a/addons/l10n_it_edi/models/account_edi_proxy_user.py
+++ b/addons/l10n_it_edi/models/account_edi_proxy_user.py
@@ -31,5 +31,5 @@ class AccountEdiProxyClientUser(models.Model):
 
     def _register_proxy_user(self, company, proxy_type, edi_mode):
         if proxy_type == 'l10n_it_edi':
-            company = company.root_id
+            company = company._l10n_it_get_edi_company()
         return super()._register_proxy_user(company, proxy_type, edi_mode)

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -538,7 +538,7 @@ class AccountMove(models.Model):
             importo_totale_documento += values['base_amount_currency']
             importo_totale_documento += values['tax_amount_currency']
 
-        company = self.company_id.root_id
+        company = self.company_id._l10n_it_get_edi_company()
         partner = self.commercial_partner_id
         sender = company
         buyer = partner if not is_self_invoice else company

--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -114,7 +114,8 @@ class ResCompany(models.Model):
     @api.depends("account_edi_proxy_client_ids")
     def _compute_l10n_it_edi_proxy_user_id(self):
         for company in self:
-            company.l10n_it_edi_proxy_user_id = company.root_id.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
+            edi_company = company._l10n_it_get_edi_company()
+            company.l10n_it_edi_proxy_user_id = edi_company.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
 
     def _l10n_it_edi_export_check(self):
         checks = {
@@ -158,3 +159,14 @@ class ResCompany(models.Model):
         for company in self:
             if not company.l10n_it_has_tax_representative:
                 company.l10n_it_tax_representative_partner_id = False
+
+    def _l10n_it_get_edi_company(self):
+        self.ensure_one()
+        if (
+            self.root_id.id != self.id
+            and self.l10n_it_codice_fiscale == self.root_id.l10n_it_codice_fiscale
+            and self.vat == self.root_id.vat
+        ):
+            return self.root_id
+        else:
+            return self

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
             <xpath expr="//block[@id='account_vendor_bills']" position="after">
-                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT' or company_parent_id" id='account_edi'>
+                <block title="Italian Electronic Invoicing" invisible="country_code != 'IT' or use_root_proxy_user" id='account_edi'>
                     <setting id="italian_edi">
                         <div class="group-content">
                             <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
@@ -43,9 +43,9 @@
                         </div>
                     </setting>
                 </block>
-                <block title="Italian Electronic Invoicing" invisible="(country_code != 'IT') or not company_parent_id" id='account_edi_branch'>
+                <block title="Italian Electronic Invoicing" invisible="(country_code != 'IT') or not use_root_proxy_user" id='account_edi_branch'>
                     <span class="o_form_label">
-                        Branches use the EDI settings of their main company
+                        This branch shares the same VAT number and Codice Fiscale as its parent company. Select the parent company to configure the EDI settings.
                     </span>
                 </block>
             </xpath>


### PR DESCRIPTION
Companies (typically branches) whose VAT or Codice Fiscale differs from their parent (root) company are now allowed to create their own EDI proxy user.

This ensures that only independent legal entities are assigned individual proxy users, while subsidiaries sharing the same VAT/CF use the root company's proxy configuration.

no-task
