### PR TITLE
[FIX] account_peppol: Fix unclear user error message

### DIFF
--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -159,8 +159,7 @@ class ResConfigSettings(models.TransientModel):
         ):
             error_msg = _(
                 "A participant with these details has already been registered on the network. "
-                "If you have previously registered to an alternative Peppol service, please deregister from that service, "
-                "or request a migration key before trying again. "
+                "If you have previously registered to a Peppol service, please deregister."
             )
 
             if isinstance(participant_info, str):


### PR DESCRIPTION
Context: Migration keys in the context of Peppol are keys that are used to transfer a Peppol participant from one SMP (a service provider by simplification, like Odoo) to another.

Problem: The error fixed in this commit is raised when we detect the Peppol Identification/Peppol Address is already on the Peppol Network. It mentions the migration key while it can also be raised when the identification is already used on our own SMP, which makes the migration mention irrelevant and confusing.

Moreover, migration keys are actually handled by very few provider. Generally, the way to go is to unregister from the SMP you want to leave, to be able to register on a new one.

task-no
