### PR TITLE
[IMP] hr_holidays: Allow creating absence leaves overlapping with worked time leaves

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -139,6 +139,7 @@ class HrEmployee(models.Model):
             ('employee_id', 'in', self.ids),
             ('date_from', '<=', fields.Datetime.now()),
             ('date_to', '>=', fields.Datetime.now()),
+            ('holiday_status_id.time_type', '=', 'leave'),
             ('state', '=', 'validate'),
         ])
         leave_data = {}

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -275,6 +275,7 @@ class HrLeave(models.Model):
             ('date_from', '<', max(self.mapped('date_to'))),
             ('date_to', '>', min(self.mapped('date_from'))),
             ('employee_id', 'in', self.employee_id.ids),
+            ('holiday_status_id.allow_request_on_top', '=', False),
             ('state', 'not in', ['cancel', 'refuse']),
         ])
         self.filtered(lambda self: self.state in ['cancel', 'refuse']).dashboard_warning_message = False
@@ -969,6 +970,7 @@ Versions:
             'resource_id': self.employee_id.resource_id.id,
             'calendar_id': self.resource_calendar_id.id,
             'time_type': self.holiday_status_id.time_type,
+            'elligible_for_accrual_rate': self.holiday_status_id.elligible_for_accrual_rate,
         }
 
     def _create_resource_leave(self):

--- a/addons/hr_holidays/models/res_users.py
+++ b/addons/hr_holidays/models/res_users.py
@@ -62,7 +62,9 @@ class ResUsers(models.Model):
                             JOIN hr_leave ON hr_leave.user_id = res_users.id
                             AND hr_leave.state = 'validate'
                             AND res_users.active = 't'
-                            AND hr_leave.date_from <= %%s AND hr_leave.date_to >= %%s''' % field, (now, now))
+                            AND hr_leave.date_from <= %%s AND hr_leave.date_to >= %%s
+                            RIGHT JOIN hr_leave_type ON hr_leave.holiday_status_id = hr_leave_type.id
+                            AND hr_leave_type.time_type = 'leave';''' % field, (now, now))
         return [r[0] for r in self.env.cr.fetchall()]
 
     def _clean_leave_responsible_users(self):

--- a/addons/hr_holidays/models/resource.py
+++ b/addons/hr_holidays/models/resource.py
@@ -13,6 +13,8 @@ class ResourceCalendarLeaves(models.Model):
     _inherit = "resource.calendar.leaves"
 
     holiday_id = fields.Many2one("hr.leave", string='Time Off Request')
+    elligible_for_accrual_rate = fields.Boolean(string='Eligible for Accrual Rate', default=False,
+        help="If checked, this time off type will be taken into account for accruals computation.")
 
     @api.constrains('date_from', 'date_to', 'calendar_id')
     def _check_compare_dates(self):

--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -67,16 +67,21 @@ patch(HrPresenceStatusPill.prototype, patchHrPresenceStatusPill());
 
 const patchHrPresenceStatusPrivate = () => ({
     get label() {
-        return this.props.record.data.current_leave_id
-            ? this.props.record.data.current_leave_id.display_name + _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
-                {
-                    day: 'numeric',
-                    month: 'short',
-                    year: 'numeric',
-                }
-            )
-            : super.label;
-    },
+        if (this.props.record.data.current_leave_id){
+            let label = this.props.record.data.current_leave_id.display_name;
+            if (this.props.record.data.leave_date_to) {
+                label += _t(", back on ") + this.props.record.data['leave_date_to'].toLocaleString(
+                    {
+                        day: 'numeric',
+                        month: 'short',
+                        year: 'numeric',
+                    }
+                )
+            }
+            return label;
+        }
+        return super.label;
+    }
 });
 // Applies patch to hr_presence_status_private to display the time off type instead of default label
 patch(HrPresenceStatusPrivate.prototype, patchHrPresenceStatusPrivate());

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -64,7 +64,7 @@
                     <group>
                         <group>
                                 <field name="request_unit" widget="radio" options="{'horizontal': True}"/>
-                                <field name="time_type" required="1"/>
+                                <field name="time_type" required="1" string="Count as"/>
                                 <field name="responsible_ids"
                                     widget="many2many_tags"
                                     placeholder="Nobody to notify"
@@ -94,11 +94,15 @@
                                     <label for="include_public_holidays_in_duration" class="me-4"/>
                                     <label for="hide_on_dashboard" class="me-4"/>
                                     <label for="support_document" class="me-4" string="Require Supporting Document"/>
+                                    <label for="elligible_for_accrual_rate" class="me-4"/>
+                                    <label for="allow_request_on_top" class="me-4" invisible="time_type == 'leave'"/>
                                 </div>
                                 <div class="d-flex flex-column gap-1">
                                     <field name="include_public_holidays_in_duration" class="mb-2" nolabel="1"/>
                                     <field name="hide_on_dashboard" class="mb-2" nolabel="1"/>
                                     <field name="support_document" nolabel="1"/>
+                                    <field name="elligible_for_accrual_rate" nolabel="1" readonly="time_type != 'leave'"/>
+                                    <field name="allow_request_on_top" nolabel="1" invisible="time_type == 'leave'"/>
                                 </div>
                             </div>
                         </group>


### PR DESCRIPTION
This improvement enables the creation of absence type leaves on top of existing worked time leaves. Previously, such an overlap was restricted. With this change, users can now allocate an absence leave even when a worked time leave already exists for the same period.

Task: 4595936


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
