### PR TITLE
[FIX] web: OwlError when clicking on any Cash or Bank journal entry - Issue #212395

### DIFF
--- a/addons/web/static/src/views/fields/binary/binary_field.xml
+++ b/addons/web/static/src/views/fields/binary/binary_field.xml
@@ -53,7 +53,7 @@
         <t t-elif="props.record.resId and props.record.data[props.name]">
             <a class="o_form_uri" href="#" t-on-click.prevent="onFileDownload">
                 <span class="fa fa-download me-2" />
-                <t t-if="fileName" t-esc="fileName" />
+                <t t-if="props.record.data[props.fileNameField]" t-esc="props.record.data[props.fileNameField]" />
             </a>
         </t>
     </t>

--- a/doc/cla/individual/benakrab.md
+++ b/doc/cla/individual/benakrab.md
@@ -1,0 +1,11 @@
+France, 2025-06-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mustapha Ben 15079009+Benakrab@users.noreply.github.com https://github.com/Benakrab


### PR DESCRIPTION
Steps to Reproduce:
--------------------
- POS module
- Open a session
- Perform a Cash In operation
- Close the Session
- Go to the Invoicing module, select Configuration/Journals and click on the Cash Journal associated with the POS already been used to perform the Cash In operation
- Click on Journal Entries. Here is a list of the entries. Click on any entry.
- Same issue for Bank operations

Cause:
-------
When clicking on the journal entry link, a binary field, which is `needed_terms`, is computed. This field triggers the `binary_field.xml` view which contains two main blocks: the first one checks if the `props` are not 'readonly', which is false in our case. So, this block is ignored and the second one is executed. This second block tries to get the `fileName` property which returns a `Proxy Object` instead of a string.

Solution:
-------------
Replace `fileName` by `props.record.data[props.fileNameField]`

Closes #212395


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
