### PR TITLE
[FIX] point_of_sale: load account.move model

### DIFF
--- a/addons/point_of_sale/models/account_move.py
+++ b/addons/point_of_sale/models/account_move.py
@@ -5,7 +5,8 @@ from odoo import fields, models, api
 
 
 class AccountMove(models.Model):
-    _inherit = 'account.move'
+    _name = 'account.move'
+    _inherit = ['account.move', 'pos.load.mixin']
 
     pos_order_ids = fields.One2many('pos.order', 'account_move')
     pos_payment_ids = fields.One2many('pos.payment', 'account_move_id')
@@ -14,6 +15,14 @@ class AccountMove(models.Model):
         help="The pos order that was reverted after closing the session to create an invoice for it.")
     pos_session_ids = fields.One2many("pos.session", "move_id", "POS Sessions")
     pos_order_count = fields.Integer(compute="_compute_origin_pos_count", string='POS Order Count')
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return ['id', 'name', 'state']
+
+    @api.model
+    def _load_pos_data_domain(self, data):
+        return ['|', ('pos_order_ids', '!=', False), ('pos_payment_ids', '!=', False)]
 
     @api.depends('pos_order_ids')
     def _compute_origin_pos_count(self):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -139,7 +139,7 @@ class PosSession(models.Model):
             'pos.category', 'pos.bill', 'res.company', 'account.tax', 'account.tax.group', 'product.template', 'product.product', 'product.attribute', 'product.attribute.custom.value',
             'product.template.attribute.line', 'product.template.attribute.value', 'product.template.attribute.exclusion', 'product.combo', 'product.combo.item', 'res.users', 'res.partner', 'product.uom',
             'decimal.precision', 'uom.uom', 'res.country', 'res.country.state', 'res.lang', 'product.pricelist', 'product.pricelist.item', 'product.category',
-            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module']
+            'account.cash.rounding', 'account.fiscal.position', 'account.fiscal.position.tax', 'stock.picking.type', 'res.currency', 'pos.note', 'product.tag', 'ir.module.module', 'account.move']
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/security/point_of_sale_security.xml
+++ b/addons/point_of_sale/security/point_of_sale_security.xml
@@ -77,7 +77,7 @@
         <field name="name">Invoice POS User</field>
         <field name="model_id" ref="account.model_account_move" />
         <field name="groups" eval="[(4, ref('group_pos_user'))]"/>
-        <field name="domain_force">[('pos_order_ids', '!=', False)]</field>
+        <field name="domain_force">['|', ('pos_order_ids', '!=', False), ('pos_payment_ids', '!=', False)]</field>
     </record>
     <record id="rule_invoice_line_pos_user" model="ir.rule">
         <field name="name">Invoice Line POS User</field>


### PR DESCRIPTION
Steps to reproduce
- install `l10n_pe_edi_pos` module
- open a pos session
- create a order, when checking out, tick `invoice` checkbox
- pay and complete the order
- go to order menu, from top-right hamburger  button
- select the previously completed order, apply for refund 
Observation: you are navigated to Order screen
Expectation: A dialog for reason should open first

Issue
- after this commit odoo/odoo@3a09ea7 and https://github.com/odoo/enterprise/commit/e3e84bb `account_move` field is used instead of `invoiced` state of order. But the `account_move` field is always undefined at frontend.
- This is due to fact that when pos_order is fulfilled from [`syncAllOrders`](https://github.com/odoo/odoo/blob/saas-18.2/addons/point_of_sale/static/src/app/services/pos_store.js#L1227) function, a call to [missingRecursive](https://github.com/odoo/odoo/blob/saas-18.2/addons/point_of_sale/static/src/app/services/data_service.js#L553) is made, as `account.move` model is never loaded, it is unable to link it to appropriate model and results to `undefined`
- we lose the field i.e its data here: https://github.com/odoo/odoo/blob/f2421a625a7179787fbbe34af80642ffa60aada6/addons/point_of_sale/static/src/app/models/data_service.js#L479-L485

Fix
- load `account.move` model at init


opw-4744785


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
