### PR TITLE
[IMP] mail: human-readable error on bad record single-id insert

### DIFF
--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -298,6 +298,11 @@ export class Record {
             if (typeof data === "object" && data !== null) {
                 store._.updateFields(record, data);
             } else {
+                if (Array.isArray(record.Model.id)) {
+                    throw new Error(
+                        `Cannot insert "${data}" on model "${record.Model.getName()}": this model doesn't support single-id data!`
+                    );
+                }
                 // update on single-id data
                 store._.updateFields(record, { [record.Model.id]: data });
             }

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -213,6 +213,13 @@ export class RecordListInternal {
         const inverse = getInverse(recordList);
         const targetModel = getTargetModel(recordList);
         if (typeof val !== "object") {
+            if (Array.isArray(recordList._store[targetModel].id)) {
+                throw new Error(
+                    `Cannot insert "${val}" on relational field "${recordList._.owner.Model.getName()}/${
+                        recordList._.name
+                    }": target model "${targetModel}" doesn't support single-id data!`
+                );
+            }
             // single-id data
             val = { [recordList._store[targetModel].id]: val };
         }

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -31,6 +31,8 @@ export class Store extends Record {
         this._.ERRORS.push(err);
     }
 
+    warnErrors = true;
+
     /** @param {() => any} fn */
     MAKE_UPDATE(fn) {
         this._.UPDATE++;
@@ -175,9 +177,11 @@ export class Store extends Record {
             }
             this._.UPDATE--;
             if (this._.ERRORS.length) {
-                console.warn("Store data insert aborted due to following errors:");
-                for (const err of this._.ERRORS) {
-                    console.warn(err);
+                if (this.warnErrors) {
+                    console.warn("Store data insert aborted due to following errors:");
+                    for (const err of this._.ERRORS) {
+                        console.warn(err);
+                    }
                 }
                 const [error1] = this._.ERRORS;
                 this._.ERRORS = [];


### PR DESCRIPTION
Before this commit, when using a single-id data insertion on
a Model that doesn't support it, it throws the following
error message:

```
TypeError: can't convert symbol to string
```

This happens because the model doesn't support single-id
data syntax, e.g. `message.author = 1` for setting persona
with id "1". A persona needs both id and type because a
partner and guest can have same id but differs only by the
type.

For information, the error message tries to convert symbol
to string because the id or non-single id Models is an array
that contains the field names and the special AND/OR symbols.

With this commit, the message error explicitly names the model
and field with problematic value being attempted to insert, and
also mentions this is a failed attempt to use single-id data
syntax that is unsupported on the target model.