### PR TITLE
[FIX] html_editor: image transformation issues

### DIFF
--- a/addons/html_editor/static/src/main/media/image_transform_button.js
+++ b/addons/html_editor/static/src/main/media/image_transform_button.js
@@ -37,11 +37,6 @@ export class ImageTransformButton extends Component {
             }
             this.mouseDownInsideTransform = false;
         });
-        // When we click on any character the image is deleted and we need to close the image transform
-        // We handle this by selectionchange
-        useExternalListener(this.props.document, "selectionchange", (ev) => {
-            this.closeImageTransformation();
-        });
     }
 
     isNodeInsideTransform(node) {

--- a/addons/html_editor/static/src/main/media/image_transformation.js
+++ b/addons/html_editor/static/src/main/media/image_transformation.js
@@ -51,6 +51,16 @@ export class ImageTransformation extends Component {
         });
         useExternalListener(window, "mousemove", this.mouseMove);
         useExternalListener(window, "mouseup", this.mouseUp);
+        // When a character key is pressed and the image gets deleted,
+        // close the image transform via selectionchange.
+        useExternalListener(this.document, "selectionchange", () => this.props.destroy());
+        // Backspace/Delete don’t trigger selectionchange on image
+        // delete in Chrome, so we use keydown event.
+        useExternalListener(this.document, "keydown", (ev) => {
+            if (["Backspace", "Delete"].includes(ev.key)) {
+                this.props.destroy();
+            }
+        });
         useHotkey("escape", () => this.props.destroy());
         usePositionHook({ el: this.props.editable }, this.document, this.resetHandlers);
     }

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -4,7 +4,7 @@ import { animationFrame } from "@odoo/hoot-mock";
 import { contains } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setContent } from "./_helpers/selection";
-import { undo } from "./_helpers/user_actions";
+import { insertText, undo } from "./_helpers/user_actions";
 import { expectElementCount } from "./_helpers/ui_expectations";
 
 const base64Img =
@@ -328,6 +328,40 @@ test("Image transformation disappear on escape", async () => {
     await animationFrame();
     transfoContainers = document.querySelectorAll(".transfo-container");
     expect(transfoContainers.length).toBe(0);
+});
+
+test("Image transformation disappear on backspace/delete", async () => {
+    const { editor } = await setupEditor(`
+        <img class="img-fluid test-image" src="${base64Img}">
+    `);
+    click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    await contains(".o-we-toolbar div[name='image_transform'] button").click();
+    expect(".transfo-container").toHaveCount(1);
+    press("backspace");
+    await animationFrame();
+    expect(".transfo-container").toHaveCount(0);
+    undo(editor);
+    click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    await contains(".o-we-toolbar div[name='image_transform'] button").click();
+    expect(".transfo-container").toHaveCount(1);
+    press("delete");
+    await animationFrame();
+    expect(".transfo-container").toHaveCount(0);
+});
+
+test("Image transformation disappears on character key press", async () => {
+    const { editor } = await setupEditor(`
+        <img class="img-fluid test-image" src="${base64Img}">
+    `);
+    click("img.test-image");
+    await waitFor(".o-we-toolbar");
+    await contains(".o-we-toolbar div[name='image_transform'] button").click();
+    expect(".transfo-container").toHaveCount(1);
+    insertText(editor, "a");
+    await animationFrame();
+    expect(".transfo-container").toHaveCount(0);
 });
 
 test("Image transformation scalers position", async () => {


### PR DESCRIPTION
### Steps to reproduce:

- Insert an image into the editor.
- Open the Transformation controls for the image.
- Press the `Backspace` key to delete the image.
- The transformation overlay remains visible after the image is removed.

### Description of the issue/feature this PR addresses:

- In commit [1](https://github.com/odoo/odoo/commit/85698bf4f591fc9280f054b9a255a7d5ff4d1fe2), the `image_transform_button` component unmounted before `selectionchange` event could fire.  As a result, event listener was removed, and the transform container was not closed when the image was deleted.

Desired behavior after PR is merged:

- The `selectionchange` listener is now attached within the `image_transformation` component.
- A `keydown` listener is also added to explicitly handle Backspace and Delete keys, addressing the case where Chrome does not trigger `selectionchange` on image deletion.

task-4831728

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
