### PR TITLE
[FIX] hr_holidays: fix leave type _compute_valid

### DIFF
--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -210,7 +210,7 @@ class HrLeaveType(models.Model):
         ))
         for leave_type in self:
             if leave_type.requires_allocation:
-                allocations = allocation_by_leave_type.get(leave_type.id, self.env['hr.leave.allocation'])
+                allocations = allocation_by_leave_type.get(leave_type, self.env['hr.leave.allocation'])
                 allowed_excess = leave_type.max_allowed_negative if leave_type.allows_negative else 0
                 allocations = allocations.filtered(lambda alloc:
                     alloc.allocation_type == 'accrual'


### PR DESCRIPTION
This commit fixes an issue in the `_compute_valid` method of the `hr.leave.type` model. The `leave_type.id` was changed to `leave_type`, since the key type in `allocation_by_leave_type` is a recordset, not an integer.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
