### PR TITLE
[FIX] *: add transparent grayscale to the color picker

### DIFF
--- a/addons/html_builder/static/src/builder.scss
+++ b/addons/html_builder/static/src/builder.scss
@@ -111,6 +111,7 @@
     width: $o-we-sidebar-content-field-colorpicker-size;
     height: $o-we-sidebar-content-field-colorpicker-size;
     border: $o-we-sidebar-content-field-border-width solid $o-we-bg-darkest;
+    background: unset;
     border-radius: 10rem;
     cursor: pointer;
 

--- a/addons/html_builder/static/src/builder.variables.scss
+++ b/addons/html_builder/static/src/builder.variables.scss
@@ -362,6 +362,7 @@ $o-transparent-grays: (
     'white-85': rgba(white, 0.85),
 ) !default;
 $o-gray-color-palettes: () !default;
+$o-gray-color-palettes: map-merge($o-transparent-grays, $o-gray-color-palettes);
 $o-gray-color-palette-name: '' !default;
 
 // Color combinations

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -104,11 +104,13 @@ export class BuilderColorPicker extends Component {
         ...basicContainerBuilderComponentProps,
         noTransparency: { type: Boolean, optional: true },
         enabledTabs: { type: Array, optional: true },
+        grayscales: { type: Object, optional: true },
         unit: { type: String, optional: true },
         title: { type: String, optional: true },
         getUsedCustomColors: { type: Function, optional: true },
         selectedTab: { type: String, optional: true },
         defaultColor: { type: String, optional: true },
+        defaultOpacity: { type: Number, optional: true },
     };
     static defaultProps = {
         enabledTabs: ["theme", "gradient", "custom"],
@@ -139,6 +141,8 @@ export class BuilderColorPicker extends Component {
                 showRgbaField: true,
                 noTransparency: this.props.noTransparency,
                 enabledTabs: this.props.enabledTabs,
+                grayscales: this.props.grayscales,
+                defaultOpacity: this.props.defaultOpacity,
                 className: "o-hb-colorpicker",
             },
             {

--- a/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
+++ b/addons/html_builder/static/src/core/building_blocks/builder_colorpicker.js
@@ -46,11 +46,13 @@ export function useColorPickerBuilderComponent() {
         const { actionId, actionParam } = actionWithGetValue;
         const actionValue = getAction(actionId).getValue({ editingElement, params: actionParam });
         return {
+            mode: actionParam.mainParam || actionId,
             selectedColor: actionValue || comp.props.defaultColor,
             selectedColorCombination: comp.env.editor.shared.color.getColorCombination(
                 editingElement,
                 actionParam
             ),
+            getTargetedElements: () => [editingElement],
         };
     }
     function getColor(colorValue) {

--- a/addons/html_builder/static/src/plugins/background_option/background_option.xml
+++ b/addons/html_builder/static/src/plugins/background_option/background_option.xml
@@ -33,8 +33,24 @@
         <ImageFormatOption level="2" computeMaxDisplayWidth="this.computeMaxDisplayWidth"/>
         <!-- Color filter -->
         <BuilderRow t-if="this.showColorFilter()" label.translate="Color Filter" level="2">
-            <!-- TODO handle data-opacity="0.5" -->
-            <BuilderColorPicker action="'selectFilterColor'" enabledTabs="['custom', 'gradient']" selectedTab="'gradient'"/>
+            <BuilderColorPicker
+                action="'selectFilterColor'"
+                defaultOpacity="50"
+                enabledTabs="['custom', 'gradient']"
+                grayscales="{
+                    'transparent': [
+                        'black-75',
+                        'black-50',
+                        'black-25',
+                        'black-15',
+                        'white-25',
+                        'white-50',
+                        'white-75',
+                        'white-85'
+                    ],
+                    'solid': [],
+                }"
+                selectedTab="'gradient'"/>
         </BuilderRow>
         <BackgroundShapeOption t-if="props.withShapes"/>
     </t>

--- a/addons/html_editor/static/src/main/font/color_plugin.js
+++ b/addons/html_editor/static/src/main/font/color_plugin.js
@@ -132,6 +132,10 @@ export class ColorPlugin extends Plugin {
             applyColorResetPreview: this.applyColorResetPreview.bind(this),
             colorPrefix: mode === "color" ? "text-" : "bg-",
             onClose: () => this.dependencies.selection.focusEditable(),
+            getTargetedElements: () => {
+                const nodes = this.dependencies.selection.getTargetedNodes().filter(isTextNode);
+                return nodes.map((node) => closestElement(node));
+            },
         };
     }
 

--- a/addons/html_editor/static/src/main/font/color_selector.js
+++ b/addons/html_editor/static/src/main/font/color_selector.js
@@ -22,6 +22,7 @@ export class ColorSelector extends Component {
         applyColorPreview: Function,
         applyColorResetPreview: Function,
         getUsedCustomColors: Function,
+        getTargetedElements: Function,
         colorPrefix: { type: String },
         enabledTabs: { type: Array, optional: true },
         themeColorPrefix: { type: String, optional: true },
@@ -49,6 +50,8 @@ export class ColorSelector extends Component {
                 this.state.defaultTab = this.getCorrespondingColorTab(
                     selectedColors[this.props.mode]
                 );
+                this.state.getTargetedElements = this.props.getTargetedElements;
+                this.state.mode = this.props.mode;
             },
             [this.props.getSelectedColors()]
         );

--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -128,9 +128,12 @@ export class LinkPopover extends Component {
             stripDomain: true,
         });
 
+        const getTargetedElements = () => [this.props.linkElement];
         this.customTextColorState = useState({
             selectedColor: computedStyle.color || DEFAULT_CUSTOM_TEXT_COLOR,
             defaultTab: "solid",
+            getTargetedElements,
+            mode: "color",
         });
         this.customTextResetPreviewColor = this.customTextColorState.selectedColor;
         this.customFillColorState = useState({
@@ -141,11 +144,15 @@ export class LinkPopover extends Component {
                 computedStyle.backgroundColor ||
                 DEFAULT_CUSTOM_FILL_COLOR,
             defaultTab: "solid",
+            getTargetedElements,
+            mode: "background-color",
         });
         this.customFillResetPreviewColor = this.customFillColorState.selectedColor;
         this.customBorderColorState = useState({
             selectedColor: computedStyle.borderColor || DEFAULT_CUSTOM_TEXT_COLOR,
             defaultTab: "solid",
+            getTargetedElements,
+            mode: "border-color",
         });
         this.customBorderResetPreviewColor = this.customBorderColorState.selectedColor;
 

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -50,7 +50,9 @@ export class ColorPicker extends Component {
             shape: {
                 selectedColor: String,
                 selectedColorCombination: { type: String, optional: true },
+                getTargetedElements: { type: Function, optional: true },
                 defaultTab: String,
+                mode: { type: String, optional: true },
             },
         },
         getUsedCustomColors: Function,
@@ -81,6 +83,8 @@ export class ColorPicker extends Component {
         this.DEFAULT_GRADIENT_COLORS = DEFAULT_GRADIENT_COLORS;
         this.grayscales = Object.assign({}, DEFAULT_GRAYSCALES);
         this.grayscales = Object.assign(this.grayscales, this.props.grayscales);
+        this.DEFAULT_THEME_COLOR_VARS = DEFAULT_THEME_COLOR_VARS;
+        this.defaultColorSet = this.getDefaultColorSet();
         this.root = useRef("root");
 
         this.defaultColor = this.props.state.selectedColor;
@@ -134,6 +138,7 @@ export class ColorPicker extends Component {
     applyColor(color) {
         this.state.currentCustomColor = color;
         this.props.applyColor(color);
+        this.defaultColorSet = this.getDefaultColorSet();
     }
 
     onColorApply(ev) {
@@ -211,6 +216,55 @@ export class ColorPicker extends Component {
         }
     }
 
+    getDefaultColorSet() {
+        if (!this.props.state.getTargetedElements || !this.props.state.mode) {
+            return;
+        }
+        const targetedEls = this.props.state.getTargetedElements();
+        let defaultColors = this.props.enabledTabs.includes("solid")
+            ? this.DEFAULT_THEME_COLOR_VARS
+            : [];
+        for (const grayscale of Object.values(this.grayscales)) {
+            defaultColors = defaultColors.concat(grayscale);
+        }
+
+        const extractColorFromClasses = (targetedEls, prefix, defaultColors) => {
+            for (const el of targetedEls) {
+                for (const className of el.classList) {
+                    const match = className.match(new RegExp(`^${prefix}-(.+)$`));
+                    if (match && defaultColors.includes(match[1])) {
+                        return match[1];
+                    }
+                }
+            }
+            return false;
+        };
+        switch (this.props.state.mode) {
+            case "color":
+                return extractColorFromClasses(targetedEls, "text", defaultColors);
+            case "background-color":
+            case "backgroundColor":
+                return extractColorFromClasses(targetedEls, "bg", defaultColors);
+            case "selectFilterColor": {
+                const filterEls = targetedEls
+                    .map((el) => el.querySelector(".o_we_bg_filter"))
+                    .filter((el) => el !== null);
+                return extractColorFromClasses(filterEls, "bg", defaultColors);
+            }
+            default: {
+                for (const el of targetedEls) {
+                    const color = el.dataset[this.props.state.mode];
+                    if (
+                        defaultColors.includes(color) ||
+                        defaultColors.includes(this.props.state.mode)
+                    ) {
+                        return color;
+                    }
+                }
+                return false;
+            }
+        }
+    }
     toggleGradientPicker() {
         this.state.showGradientPicker = !this.state.showGradientPicker;
     }

--- a/addons/web/static/src/core/color_picker/color_picker.js
+++ b/addons/web/static/src/core/color_picker/color_picker.js
@@ -1,7 +1,7 @@
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
 import { CustomColorPicker } from "@web/core/color_picker/custom_color_picker/custom_color_picker";
 import { usePopover } from "@web/core/popover/popover_hook";
-import { isCSSColor, isColorGradient } from "@web/core/utils/colors";
+import { applyOpacityToGradient, isCSSColor, isColorGradient } from "@web/core/utils/colors";
 import { cookie } from "@web/core/browser/cookie";
 import { GradientPicker } from "./gradient_picker/gradient_picker";
 import { POSITION_BUS } from "../position/position_hook";
@@ -28,6 +28,10 @@ const DEFAULT_GRADIENT_COLORS = [
     "linear-gradient(135deg, rgb(222, 222, 222) 0%, rgb(69, 69, 69) 100%)",
     "linear-gradient(135deg, rgb(255, 222, 202) 0%, rgb(202, 115, 69) 100%)",
 ];
+
+const DEFAULT_GRAYSCALES = {
+    solid: ["black", "900", "800", "600", "400", "200", "100", "white"],
+};
 
 export const DEFAULT_THEME_COLOR_VARS = [
     "o-color-1",
@@ -57,20 +61,26 @@ export class ColorPicker extends Component {
         colorPrefix: { type: String },
         themeColorPrefix: { type: String, optional: true },
         showRgbaField: { type: Boolean, optional: true },
+        defaultOpacity: { type: Number, optional: true },
+        grayscales: { type: Object, optional: true },
         noTransparency: { type: Boolean, optional: true },
         close: { type: Function, optional: true },
         className: { type: String, optional: true },
     };
     static defaultProps = {
         close: () => {},
+        defaultOpacity: 100,
         enabledTabs: ["solid", "gradient", "custom"],
         showRgbaField: false,
         themeColorPrefix: "",
     };
+    applyOpacityToGradient = applyOpacityToGradient;
 
     setup() {
         this.DEFAULT_COLORS = DEFAULT_COLORS;
         this.DEFAULT_GRADIENT_COLORS = DEFAULT_GRADIENT_COLORS;
+        this.grayscales = Object.assign({}, DEFAULT_GRAYSCALES);
+        this.grayscales = Object.assign(this.grayscales, this.props.grayscales);
         this.root = useRef("root");
 
         this.defaultColor = this.props.state.selectedColor;

--- a/addons/web/static/src/core/color_picker/color_picker.scss
+++ b/addons/web/static/src/core/color_picker/color_picker.scss
@@ -34,14 +34,26 @@
 }
 
 .o_gradient_color_button {
-  border-width: 0px;
+    border-width: 0px;
+    background: unset;
+
+    &:hover, &:focus {
+        background: unset;
+    }
+}
+
+.o_custom_gradient_button[style*="background-image"] {
+    background: unset;
 }
 
 .o_custom_gradient_button,
 .o_color_button {
+    @extend %o-preview-alpha-background;
+
     &:focus,
     &:hover {
         outline: solid $o-enterprise-action-color;
+        z-index: 1;
         transition: transform 0.1s ease-out;
     }
 }

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -71,17 +71,16 @@
                 t-on-focusin="onColorFocusin"
                 t-on-focusout="onColorFocusout">
                 <div class="o_colorpicker_section">
-                    <button data-color="o-color-1" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-1)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-3" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-3)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-2" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-2)" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-4" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-4); grid-column: 5;" class="btn p-0 o_color_button"/>
-                    <button data-color="o-color-5" t-attf-style="background-color: var(--{{props.themeColorPrefix}}o-color-5)" class="btn p-0 o_color_button"/>
+                    <t t-foreach="DEFAULT_THEME_COLOR_VARS" t-as="color" t-key="color">
+                        <button t-att-data-color="color" t-att-class="{'selected': color === defaultColorSet}" 
+                            t-att-style="`background-color: var(--${props.themeColorPrefix + color})` + (color_index === 3 ? '; grid-column: 5' : '')" class="btn p-0 o_color_button"/>
+                    </t>
                 </div>
 
                 <div class="o_color_section">
                     <t t-foreach="DEFAULT_COLORS" t-as="line" t-key="line_index">
                         <t t-foreach="line" t-as="color" t-key="color_index">
-                            <button class="o_color_button btn p-0" t-att-class="{'selected': color === this.state.currentCustomColor.toUpperCase()}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
+                            <button class="o_color_button btn p-0" t-att-class="{'selected': color === this.state.currentCustomColor.toUpperCase() and !defaultColorSet}" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                         </t>
                     </t>
                 </div>
@@ -93,12 +92,12 @@
                     <t t-foreach="this.usedCustomColors" t-as="color" t-key="color_index">
                         <button t-if="color !== this.state.currentCustomColor?.toLowerCase()" class="o_color_button btn p-0" t-att-data-color="color" t-attf-style="background-color: {{color}}"/>
                     </t>
-                    <button class="o_color_button btn p-0 selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
+                    <button t-if="!defaultColorSet" class="o_color_button btn p-0" t-att-class="{'selected': defaultColorSet === false}" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>
                 <t t-foreach="Object.values(this.grayscales)" t-as="grayscaleColors" t-key="grayscaleColors">
                     <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
                         <t t-foreach="grayscaleColors" t-as="color" t-key="color">
-                            <button t-att-data-color="color" class="o_color_button btn p-0" t-att-class="{'selected': color === defaultColor}" t-attf-style="background-color: var(--{{color}})" />
+                            <button t-att-data-color="color" class="o_color_button btn p-0" t-att-class="{'selected': color === defaultColorSet}" t-attf-style="background-color: var(--{{color}})" />
                         </t>
                     </div>
                 </t>

--- a/addons/web/static/src/core/color_picker/color_picker.xml
+++ b/addons/web/static/src/core/color_picker/color_picker.xml
@@ -95,33 +95,37 @@
                     </t>
                     <button class="o_color_button btn p-0 selected" t-att-data-color="this.state.currentCustomColor" t-attf-style="background-color: {{this.state.currentCustomColor}}"/>
                 </div>
-                <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
-                    <button data-color="black" class="btn p-0 o_color_button bg-black"></button>
-                    <button data-color="900" class="o_color_button btn p-0" style="background-color: var(--900)"></button>
-                    <button data-color="800" class="o_color_button btn p-0" style="background-color: var(--800)"></button>
-                    <button data-color="600" class="o_color_button btn p-0" style="background-color: var(--600)"></button>
-                    <button data-color="400" class="o_color_button btn p-0" style="background-color: var(--400)"></button>
-                    <button data-color="200" class="o_color_button btn p-0" style="background-color: var(--200)"></button>
-                    <button data-color="100" class="o_color_button btn p-0" style="background-color: var(--100)"></button>
-                    <button data-color="white" class="o_color_button btn p-0 bg-white"></button>
-                </div>
+                <t t-foreach="Object.values(this.grayscales)" t-as="grayscaleColors" t-key="grayscaleColors">
+                    <div class="o_colorpicker_section" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
+                        <t t-foreach="grayscaleColors" t-as="color" t-key="color">
+                            <button t-att-data-color="color" class="o_color_button btn p-0" t-att-class="{'selected': color === defaultColor}" t-attf-style="background-color: var(--{{color}})" />
+                        </t>
+                    </div>
+                </t>
                 <CustomColorPicker
-                    selectedColor = "this.state.currentCustomColor"
+                    selectedColor="this.state.currentCustomColor"
                     onColorSelect.bind="(color) => this.applyColor(color.hex)"
                     onColorPreview.bind="onCustomColorPreview"
                     showRgbaField="props.showRgbaField"
-                    noTransparency="props.noTransparency" />
+                    noTransparency="props.noTransparency"
+                    defaultOpacity="props.defaultOpacity" />
             </div>
         </t>
         <t t-if="state.activeTab==='gradient'">
             <t t-set="currentGradient" t-value="getCurrentGradientColor()" />
-            <div class="o_colorpicker_sections p-2" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
-                <t t-foreach="this.DEFAULT_GRADIENT_COLORS" t-as="gradient" t-key="gradient">
-                    <button class="w-50 m-0 o_color_button o_gradient_color_button btn p-0" t-att-class="{'selected': currentGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
+            <div class="o_colorpicker_sections p-2 d-grid gap-1" style="grid-template-columns: 1fr 1fr;" t-on-click="onColorApply" t-on-mouseover="onColorHover" t-on-mouseout="onColorHoverOut" t-on-focusin="onColorFocusin" t-on-focusout="onColorHoverOut">
+                <t t-set="gradientsWithOpacity" t-value="
+                    this.DEFAULT_GRADIENT_COLORS.map((gradient) => applyOpacityToGradient(gradient, this.props.defaultOpacity))" />
+                <t t-foreach="gradientsWithOpacity"
+                    t-as="gradient" t-key="gradient">
+                    <button class="w-100 m-0 o_color_button o_gradient_color_button btn p-0" t-att-class="{'selected': currentGradient?.includes(gradient)}" t-attf-style="background-image: #{gradient};" t-att-data-color="gradient"/>
                 </t>
             </div>
             <div class="px-2">
-                <button t-attf-style="background-image: {{ currentGradient }};" class="w-50 border btn mb-2 o_custom_gradient_button" t-att-class="{'selected': currentGradient and !this.DEFAULT_GRADIENT_COLORS.includes(currentGradient)}" t-att-data-color="currentGradient" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">Custom</button>
+                <button t-attf-style="{{ currentGradient ? `background-image: ${currentGradient}` : '' }};"
+                    class="w-50 border btn mb-2 o_custom_gradient_button" t-att-class="{'selected': currentGradient and !gradientsWithOpacity.includes(currentGradient)}" t-att-data-color="currentGradient" t-on-click="this.toggleGradientPicker" title="Define a custom gradient">
+                    Custom
+                </button>
                 <GradientPicker t-if="state.showGradientPicker" onGradientChange.bind="applyColor" selectedGradient="getCurrentGradientColor()"/>
             </div>
         </t>

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -99,11 +99,9 @@ export class CustomColorPicker extends Component {
             useExternalListener(doc, "pointerup", this.onPointerUp.bind(this));
         }
         onMounted(async () => {
-            const defaultCssColor = this.props.selectedColor
-                ? this.props.selectedColor
-                : this.props.defaultColor;
             const rgba =
-                convertCSSColorToRgba(defaultCssColor) || convertCSSColorToRgba(DEFAULT_COLOR);
+                convertCSSColorToRgba(this.props.selectedColor) ||
+                convertCSSColorToRgba(this.props.defaultColor);
             if (rgba) {
                 this._updateRgba(rgba.red, rgba.green, rgba.blue, rgba.opacity);
             }

--- a/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
+++ b/addons/web/static/src/core/color_picker/custom_color_picker/custom_color_picker.js
@@ -29,10 +29,12 @@ export class CustomColorPicker extends Component {
         onColorPreview: { type: Function, optional: true },
         onInputEnter: { type: Function, optional: true },
         showRgbaField: { type: Boolean, optional: true },
+        defaultOpacity: { type: Number, optional: true },
     };
     static defaultProps = {
         document: window.document,
         defaultColor: DEFAULT_COLOR,
+        defaultOpacity: 100,
         noTransparency: false,
         stopClickPropagation: false,
         onColorSelect: () => {},
@@ -45,6 +47,15 @@ export class CustomColorPicker extends Component {
         this.pickerFlag = false;
         this.sliderFlag = false;
         this.opacitySliderFlag = false;
+        if (this.props.defaultOpacity > 0 && this.props.defaultOpacity <= 1) {
+            this.props.defaultOpacity *= 100;
+        }
+        if (this.props.defaultColor.length <= 7) {
+            const opacityHex = Math.round((this.props.defaultOpacity / 100) * 255)
+                .toString(16)
+                .padStart(2, "0");
+            this.props.defaultColor += opacityHex;
+        }
         this.colorComponents = {};
         this.uniqueId = uniqueId("colorpicker");
         this.selectedHexValue = "";
@@ -270,7 +281,7 @@ export class CustomColorPicker extends Component {
         // Remove full transparency in case some lightness is added
         const opacity = a || this.colorComponents.opacity;
         if (opacity < 0.1 && (r > 0.1 || g > 0.1 || b > 0.1)) {
-            a = 100;
+            a = this.props.defaultOpacity;
         }
 
         const hex = convertRgbaToCSSColor(r, g, b, a);
@@ -307,7 +318,7 @@ export class CustomColorPicker extends Component {
         // Remove full transparency in case some lightness is added
         let a = this.colorComponents.opacity;
         if (a < 0.1 && l > 0.1) {
-            a = 100;
+            a = this.props.defaultOpacity;
         }
 
         const rgb = convertHslToRgb(h, s, l);

--- a/addons/web/static/src/core/utils/colors.js
+++ b/addons/web/static/src/core/utils/colors.js
@@ -1,4 +1,18 @@
 /**
+ * Adds opacity to the gradient
+ *
+ * @static
+ * @param {string} gradient - css gradient string
+ * @param {number} opacity - [0, 1] {float}
+ * @returns {string} - gradient string with opacity
+ */
+export function applyOpacityToGradient(gradient, opacity = 100) {
+    if (opacity === 100) {
+        return gradient;
+    }
+    return gradient.replace(/rgb\(([^)]+)\)/g, `rgba($1, ${opacity / 100.0})`);
+}
+/**
  * Converts RGB color components to HSL components.
  *
  * @static

--- a/addons/web/static/src/scss/utils.scss
+++ b/addons/web/static/src/scss/utils.scss
@@ -89,6 +89,7 @@
         z-index: -1;
         background: inherit; // Inherit all background properties
         border-radius: inherit;
+        box-shadow: inherit;
     }
 }
 

--- a/addons/website/static/src/builder/plugins/options/map_option.xml
+++ b/addons/website/static/src/builder/plugins/options/map_option.xml
@@ -39,7 +39,21 @@
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow label.translate="Color Filter">
-        <BuilderColorPicker styleAction="'background-color'" applyTo="'.s_map_color_filter'"/>
+        <BuilderColorPicker styleAction="'background-color'" applyTo="'.s_map_color_filter'" defaultOpacity="50"
+                enabledTabs="['custom', 'gradient']"
+                grayscales="{
+                    'transparent': [
+                        'black-75',
+                        'black-50',
+                        'black-25',
+                        'black-15',
+                        'white-25',
+                        'white-50',
+                        'white-75',
+                        'white-85'
+                    ],
+                    'solid': [],
+                }"/>
     </BuilderRow>
     <BuilderRow label.translate="Description">
         <BuilderCheckbox action="'mapDescription'"/>

--- a/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
+++ b/addons/website/static/tests/builder/custom_tab/builder_components/builder_colorpicker.test.js
@@ -203,6 +203,21 @@ test("should revert preview on escape", async () => {
     expect(":iframe .test-options-target").toHaveStyle({ "background-color": "rgba(0, 0, 0, 0)" });
 });
 
+test("should mark default color as selected when it is selected", async () => {
+    addOption({
+        selector: ".test-options-target",
+        template: xml`<BuilderColorPicker enabledTabs="['custom']" styleAction="'background-color'"/>`,
+    });
+    await setupWebsiteBuilder(`<div class="test-options-target">b</div>`);
+    await contains(":iframe .test-options-target").click();
+    expect(".options-container").toBeDisplayed();
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    await contains(".o-overlay-item [data-color='900']").click();
+    expect(":iframe .test-options-target").toHaveClass("bg-900");
+    await contains(".we-bg-options-container .o_we_color_preview").click();
+    expect(".o-overlay-item [data-color='900']").toHaveClass("selected");
+});
+
 test("should apply transparent color if no color is defined", async () => {
     addActionOption({
         customAction: class extends BuilderAction {

--- a/addons/website/static/tests/tours/snippet_background_edition.js
+++ b/addons/website/static/tests/tours/snippet_background_edition.js
@@ -164,7 +164,7 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 // Check the current color palette selection + Change the bg color
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc2",
-    checkBg: backgroundColors[0].hex,
+    checkBg: backgroundColors[0].code,
     changeType: 'bg',
     change: backgroundColors[1].code,
     finalSelector: `:iframe .${snippets[0].id}.o_cc2.bg-${backgroundColors[1].code}:not(.bg-${backgroundColors[0].code})`,
@@ -174,8 +174,8 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 // again. It should keep the bg color class.
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc2",
-    checkBg: backgroundColors[1].hex,
-    checkNoBg: backgroundColors[0].hex,
+    checkBg: backgroundColors[1].code,
+    checkNoBg: backgroundColors[0].code,
     changeType: 'cc',
     change: "o_cc4",
     finalSelector: `:iframe .${snippets[0].id}.o_cc4:not(.o_cc2).bg-${backgroundColors[1].code}`,
@@ -185,7 +185,7 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc4",
     checkNoCC: "o_cc2",
-    checkBg: backgroundColors[1].hex,
+    checkBg: backgroundColors[1].code,
     changeType: 'gradient',
     change: gradients[0],
     finalSelector: `:iframe .${snippets[0].id}.o_cc4:not(.bg-${backgroundColors[1].code})[style*="background-image: ${gradients[0]}"]`,
@@ -194,7 +194,7 @@ changeOption("Text - Image", "button[data-action-id='toggleBgImage']"),
 // Check the current color palette status + Replace the gradient
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc4",
-    checkNoBg: backgroundColors[1].hex,
+    checkNoBg: backgroundColors[1].code,
     checkGradient: gradients[0],
     changeType: 'gradient',
     change: gradients[1],
@@ -365,7 +365,7 @@ switchTo('gradient'),
 // Re-add a gradient
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc1",
-    checkBg: backgroundColors[1].hex,
+    checkBg: backgroundColors[1].code,
     checkNoGradient: gradients[0],
     changeType: 'gradient',
     change: gradients[1],
@@ -386,7 +386,7 @@ switchTo('gradient'),
 // Final check of color selection and removing the image
 ...checkAndUpdateBackgroundColor({
     checkCC: "o_cc1",
-    checkNoBg: backgroundColors[1].hex,
+    checkNoBg: backgroundColors[1].code,
     checkGradient: gradients[1],
 }),
 // Now removing all colors via the 'None' button (note: colorpicker still opened)


### PR DESCRIPTION
*: html_builder, html_editor, web, website
Previously, color filter default colors and gradients were set to 100% opacity, making them ineffective as overlays. This caused two issues: 
- Default colors didn't have the checkered transparency pattern in the color picker as in 18.3
- Fully opaque colors blocked the underlying image

Steps to reproduce the original issue:
1. Open website and start editing
2. Drop any snippet with an image background and click on it
3. Click on the color filter option color picker

The default colors and gradients appear solid and hide the background when applied. This commit introduces default 50% opacity to create functional semi-transparent overlays.
As well as this, this PR fixes the problem when, after selecting the default color in the color picker, the color wasn't marked as selected.
This PR follows [the html_builder refactoring].

[the html_builder refactoring]: odoo/odoo@9fe45e2b7ddb 

Related to task-4367641