### PR TITLE
[IMP] l10n_it_edi: remove many2one ir.attachment field

### DIFF
--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -46,11 +46,11 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         self.assertEqual((invoice1 + invoice2).mapped('sending_data'), [False, False])
         self.assertEqual(1, len(self.get_attachments(invoice1.id)))
         self.assertTrue(invoice1.invoice_pdf_report_id)
-        self.assertFalse(invoice1.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice1.l10n_it_edi_attachment_file)
         self.assertFalse(invoice1.is_being_sent)
         self.assertEqual(1, len(self.get_attachments(invoice2.id)))
         self.assertTrue(invoice2.invoice_pdf_report_id)
-        self.assertFalse(invoice2.l10n_it_edi_attachment_id)
+        self.assertFalse(invoice2.l10n_it_edi_attachment_file)
         self.assertFalse(invoice2.is_being_sent)
 
     def test_invoice_multi_with_l10n_it_edi_xml_export(self):
@@ -72,11 +72,11 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         self.assertEqual((invoice1 + invoice2).mapped('sending_data'), [False, False])
         self.assertEqual(2, len(self.get_attachments(invoice1.id)))
         self.assertTrue(invoice1.invoice_pdf_report_id)
-        self.assertTrue(invoice1.l10n_it_edi_attachment_id)
+        self.assertTrue(invoice1.l10n_it_edi_attachment_file)
         self.assertFalse(invoice1.is_being_sent)
         self.assertEqual(2, len(self.get_attachments(invoice2.id)))
         self.assertTrue(invoice2.invoice_pdf_report_id)
-        self.assertTrue(invoice2.l10n_it_edi_attachment_id)
+        self.assertTrue(invoice2.l10n_it_edi_attachment_file)
         self.assertFalse(invoice2.is_being_sent)
 
     def test_invoice_with_cig_or_cup_or_both(self):

--- a/addons/l10n_it_edi/views/l10n_it_view.xml
+++ b/addons/l10n_it_edi/views/l10n_it_view.xml
@@ -83,7 +83,7 @@
         <field name="arch" type="xml">
             <field name="status_in_payment" position="before">
                 <field name="l10n_it_edi_transaction" optional="hide"/>
-                <field name="l10n_it_edi_attachment_id" optional="hide"/>
+                <field name="l10n_it_edi_attachment_name" optional="hide"/>
                 <field name="l10n_it_edi_state" optional="hide"/>
             </field>
         </field>
@@ -96,7 +96,7 @@
         <field name="arch" type="xml">
             <xpath expr="//search/field[@name='journal_id']" position="after">
                 <field name="l10n_it_edi_transaction" groups="base.group_no_one"/>
-                <field name="l10n_it_edi_attachment_id" groups="base.group_no_one"/>
+                <field name="l10n_it_edi_attachment_name" groups="base.group_no_one"/>
                 <field name="l10n_it_edi_state" groups="base.group_no_one"/>
             </xpath>
         </field>
@@ -118,7 +118,6 @@
                 </xpath>
                 <xpath expr="//sheet" position="before">
                     <field name="l10n_it_edi_is_self_invoice" invisible="1"/>
-                    <field name="l10n_it_edi_attachment_id" invisible="1"/>
                     <div class="alert alert-warning" role="alert"
                         invisible="not l10n_it_edi_header 
                                    or state == 'draft'
@@ -147,8 +146,9 @@
                         invisible="move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund') or country_code != 'IT'">
                         <group>
                             <group>
+                                <field name="l10n_it_edi_attachment_name" invisible="1"/>
                                 <field name="l10n_it_edi_transaction" groups="base.group_no_one" readonly="1"/>
-                                <field name="l10n_it_edi_attachment_id" groups="base.group_no_one" readonly="1"/>
+                                <field name="l10n_it_edi_attachment_file" widget="binary" filename="l10n_it_edi_attachment_name" groups="base.group_no_one" readonly="1"/>
                                 <field name="l10n_it_stamp_duty" readonly="state != 'draft'"/>
                                 <field name="l10n_it_ddt_id" readonly="state != 'draft'" invisible="move_type not in ('out_invoice', 'out_refund')"/>
                                 <field name="l10n_it_document_type"


### PR DESCRIPTION
This is part of a general change for all the many2one ir.attachment fields to binary in order to avoid security issues as the former would allow access to all ir.attachment records.

In l10n_it_edi, we remove the l10n_it_edi_attachment_id and adapt the use of the existing l10n_it_edi_attachment_field, so only this binary field is used. The field l10n_it_edi_attachment_name is added, so it can be used in views.

task-4771720

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
