### PR TITLE
[IMP] mrp: show component qty in product BoMs

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -712,6 +712,12 @@ class MrpBomLine(models.Model):
         compute='_compute_child_line_ids')
     attachments_count = fields.Integer('Attachments Count', compute='_compute_attachments_count')
     tracking = fields.Selection(related='product_id.tracking')
+    bom_code = fields.Char(related='bom_id.code')
+    bom_type = fields.Selection(related='bom_id.type')
+    bom_product_id = fields.Many2one(related='bom_id.product_id')
+    bom_product_tmpl_id = fields.Many2one(related='bom_id.product_tmpl_id')
+    bom_product_qty = fields.Float(related='bom_id.product_qty', string="BoM Quantity")
+    bom_product_uom_id = fields.Many2one(related='bom_id.uom_id', string="BoM Unit")
 
     _bom_qty_zero = models.Constraint(
         'CHECK (product_qty>=0)',
@@ -812,6 +818,16 @@ class MrpBomLine(models.Model):
     def action_add_from_catalog(self):
         bom = self.env['mrp.bom'].browse(self.env.context.get('order_id'))
         return bom.with_context(child_field='bom_line_ids').action_add_from_catalog()
+
+    def action_open_parent_bom(self, *args):
+        return {
+            'res_model': 'mrp.bom',
+            'type': 'ir.actions.act_window',
+            'views': [[False, 'form']],
+            'view_mode': 'form',
+            'res_id': self.bom_id.id,
+            'target': 'current',
+        }
 
     def _get_product_catalog_lines_data(self, default=False, **kwargs):
         if self and not default:

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -78,8 +78,14 @@ class ProductTemplate(models.Model):
 
     def action_used_in_bom(self):
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_form_action")
-        action['domain'] = [('bom_line_ids.product_tmpl_id', '=', self.id)]
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_line_action_used_in_boms")
+        action['domain'] = [('product_tmpl_id', '=', self.id)]
+        action['context'] = {
+            'component_variant_count': len(
+                self.product_variant_ids.filtered(lambda variant: variant.bom_line_ids)
+            ),
+            'search_default_bom_active': True,
+        }
         return action
 
     def _compute_mrp_product_qty(self):
@@ -241,8 +247,14 @@ class ProductProduct(models.Model):
 
     def action_used_in_bom(self):
         self.ensure_one()
-        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_form_action")
-        action['domain'] = [('bom_line_ids.product_id', '=', self.id)]
+        action = self.env["ir.actions.actions"]._for_xml_id("mrp.mrp_bom_line_action_used_in_boms")
+        action['domain'] = [('product_id', '=', self.id)]
+        action['context'] = {
+            'component_variant_count': len(
+                self.product_tmpl_id.product_variant_ids.filtered(lambda variant: variant.bom_line_ids)
+            ),
+            'search_default_bom_active': True,
+        }
         return action
 
     def _compute_mrp_product_qty(self):

--- a/addons/mrp/views/mrp_bom_views.xml
+++ b/addons/mrp/views/mrp_bom_views.xml
@@ -283,6 +283,56 @@
             </field>
         </record>
 
+        <record id="mrp_bom_line_action_used_in_boms" model="ir.actions.act_window">
+            <field name="name">Used in BoM</field>
+            <field name="res_model">mrp.bom.line</field>
+            <field name="path">used_in_boms</field>
+            <field name="domain">[]</field>
+            <field name="view_mode">list</field>
+        </record>
+
+        <record id="mrp_bom_line_view_list" model="ir.ui.view">
+            <field name="name">mrp.bom.line.view.list</field>
+            <field name="model">mrp.bom.line</field>
+            <field name="arch" type="xml">
+                <list create="False" delete="False" action="action_open_parent_bom" type="object">
+                    <field name="bom_product_tmpl_id"/>
+                    <field name="bom_code" optional="show"/>
+                    <field name="bom_type"/>
+                    <field name="bom_product_id" groups="product.group_product_variant" optional="hide"/>
+                    <field name="bom_product_template_attribute_value_ids" widget="many2many_tags" options="{'no_create': True}" groups="product.group_product_variant"/>
+                    <field name="bom_product_qty" string="Quantity" optional="hide"/>
+                    <field name="bom_product_uom_id" string="Unit" groups="uom.group_uom" optional="hide"/>
+                    <field name="product_id" string="Component Variant" column_invisible="context.get('component_variant_count') == 1"/>
+                    <field name="product_qty" string="Component Quantity" optional="hide" width="130px"/>
+                    <field name="uom_id" string="Component Unit" groups="uom.group_uom" optional="hide"/>
+                    <field name="company_id" groups="base.group_multi_company" optional="show"/>
+                </list>
+            </field>
+        </record>
+
+        <record id="mrp_bom_line_view_search" model="ir.ui.view">
+            <field name="name">mrp.bom.line.view.search</field>
+            <field name="model">mrp.bom.line</field>
+            <field name="arch" type="xml">
+                <search string="Search BoM Line">
+                    <field name="bom_code" string="Bill of Materials" filter_domain="['|', ('bom_code', 'ilike', self), ('bom_product_tmpl_id', 'ilike', self)]"/>
+                    <field name="bom_product_tmpl_id" string="Product"/>
+                    <filter string="Manufacturing" name="normal" domain="[('bom_type', '=', 'normal')]"/>
+                    <filter string="Kit" name="phantom" domain="[('bom_type', '=', 'phantom')]"/>
+                    <separator/>
+                    <filter string="Active" name="bom_active" domain="[('bom_id.active', '=', True)]"/>
+                    <filter string="Archived" name="bom_inactive" domain="[('bom_id.active', '=', False)]"/>
+                    <group>
+                        <filter string="BoM" name="group_by_bom" context="{'group_by': 'bom_id'}"/>
+                        <filter string="Product" name="group_by_product" context="{'group_by': 'bom_product_tmpl_id'}"/>
+                        <filter string="BoM Type" name="group_by_type" context="{'group_by': 'bom_type'}"/>
+                        <filter string="Unit" name="group_by_unit_of_measure" context="{'group_by': 'uom_id'}"/>
+                   </group>
+                </search>
+            </field>
+        </record>
+
         <menuitem id="menu_mrp_bom_form_action"
             action="mrp_bom_form_action"
             parent="menu_mrp_bom"


### PR DESCRIPTION
To avoid checking each BoM individually, the "Used In" list of BoMs will
now display the quantity and UoM of currently viewed component.

Task: 4788617
Related: https://github.com/odoo/enterprise/pull/92623



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
