### PR TITLE
[IMP] web: FormViewDialog: add canExpand props

### DIFF
--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.js
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.js
@@ -24,6 +24,7 @@ export class FormViewDialog extends Component {
         viewId: { type: [Number, Boolean], optional: true },
         preventCreate: { type: Boolean, optional: true },
         preventEdit: { type: Boolean, optional: true },
+        canExpand: { type: Boolean, optional: true },
         isToMany: { type: Boolean, optional: true },
         size: Dialog.props.size,
     };
@@ -31,6 +32,7 @@ export class FormViewDialog extends Component {
         onRecordSaved: () => {},
         preventCreate: false,
         preventEdit: false,
+        canExpand: true,
         isToMany: false,
     };
 
@@ -46,6 +48,10 @@ export class FormViewDialog extends Component {
             : "web.FormViewDialog.ToOne.buttons";
 
         this.currentResId = this.props.resId;
+
+        if (this.props.canExpand) {
+            this.onExpandCallback = this.onExpand.bind(this);
+        }
 
         this.viewProps = {
             type: "form",

--- a/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
+++ b/addons/web/static/src/views/view_dialogs/form_view_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.FormViewDialog">
-    <Dialog size="props.size" title="props.title" withBodyPadding="false" modalRef="modalRef" onExpand.bind="onExpand">
+    <Dialog size="props.size" title="props.title" withBodyPadding="false" modalRef="modalRef" onExpand="onExpandCallback">
       <View t-props="viewProps"/>
       <t t-set-slot="footer">
         <t t-if="props.preventEdit and props.preventCreate">

--- a/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
+++ b/addons/web/static/tests/views/view_dialogs/form_view_dialog.test.js
@@ -482,6 +482,19 @@ test("expand button with save and new", async () => {
     ]);
 });
 
+test("FormViewDialog with canExpand set to false", async () => {
+    Partner._views["form,false"] = /* xml */ `<form><field name="foo"/></form>`;
+    Partner._records = [];
+    await mountWithCleanup(WebClient);
+    getService("dialog").add(FormViewDialog, {
+        resModel: "partner",
+        canExpand: false,
+    });
+    await animationFrame();
+    expect(".o_dialog .o_form_view").toHaveCount(1);
+    expect(".o_dialog .modal-header .o_expand_button").toHaveCount(0);
+});
+
 test.tags("desktop");
 test("close dialog with escape after modifying a field with onchange (no blur)", async () => {
     Partner._views["form,false"] = `<form><field name="foo"/></form>`;


### PR DESCRIPTION
This props allows to prevent from rendering the expand button on the top right corner of the dialog, which opens the record in a main form view. For some reasons, this was requested for a task in hr_holidays.

task~4784553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
