### PR TITLE
[FIX] analytic: ensure scrollable analytic distribution table on mobile view

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.xml
@@ -25,7 +25,7 @@
                     </div>
                 </div>
             </div>
-            <div class="popover-body p-2 table-responsive">
+            <div class="popover-body p-2 table-responsive" style="max-width: 100vw;">
                 <span t-if="!allPlans.length">No analytic plans found</span>
                 <table t-else="" class="o_list_table table table-sm table-hover o_analytic_table mb-2 table-striped">
                     <t t-set="totals" t-value="planTotals()"/>


### PR DESCRIPTION
The analytic distribution table is not scrollable on mobile devices, resulting in hidden content and an unusable layout when there is horizontal overflow due to many columns.
We added style="max-width: 100vw;" to table-responsive wrapper to enable horizontal scrolling on smaller screens.

Steps to Reproduce:
1. Install the Expenses and Accounting modules.
2. Go to Settings → Search for Analytic Accounting → Enable it. 
3. Add multiple analytic plans with sufficient data to cause horizontal overflow. 
4. Navigate to Expenses → Open any record.
5. Open Inspect in your browser → Switch to mobile view. 
6. Click on Analytic Distribution.

<details><summary>Images</summary>
<p>

before FIX:

![image](https://github.com/user-attachments/assets/ee0668af-76aa-4a3f-85e3-9133b58c2832)

after FIX:
![image](https://github.com/user-attachments/assets/88124899-da08-4c27-a6f9-4f6e3b6af05f)
</p>
</details> 

Ticket [link](https://www.odoo.com/odoo/project/967/tasks/4805590)
opw-4805590
