### PR TITLE
[FIX] pos*: open config with register default

### DIFF
--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -190,16 +190,10 @@ export class PosStore extends WithLazyGetterTrap {
     }
 
     get defaultPage() {
-        let openOrder = this.models["pos.order"].find((o) => o.state === "draft");
-
-        if (!openOrder) {
-            openOrder = this.addNewOrder();
-        }
-
         return {
             page: "ProductScreen",
             params: {
-                orderUuid: openOrder?.uuid,
+                orderUuid: this.openOrder.uuid,
             },
         };
     }
@@ -1240,6 +1234,9 @@ export class PosStore extends WithLazyGetterTrap {
         } else {
             return this.addNewOrder();
         }
+    }
+    get openOrder() {
+        return this.models["pos.order"].find((o) => o.state === "draft") || this.addNewOrder();
     }
     getEmptyOrder() {
         const orders = this.models["pos.order"].filter(

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -28,17 +28,23 @@ patch(PosStore.prototype, {
             ? { page: "LoginScreen", params: {} }
             : this.defaultPage;
     },
-    get defaultPage() {
-        const screen = super.defaultPage;
+    get openOrder() {
         if (this.config.module_pos_restaurant) {
-            const screens = {
-                register: "ProductScreen",
-                tables: "FloorScreen",
-            };
-            screen.page = screens[this.config.default_screen];
-            screen.params = {};
+            return (
+                this.models["pos.order"].find((o) => o.state === "draft" && o.isDirectSale) ||
+                this.addNewOrder()
+            );
         }
-        return screen;
+        return super.openOrder;
+    },
+    get defaultPage() {
+        if (this.config.module_pos_restaurant && this.config.default_screen === "tables") {
+            return {
+                page: "FloorScreen",
+                params: {},
+            };
+        }
+        return super.defaultPage;
     },
     get idleTimeout() {
         return [

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -671,3 +671,13 @@ registry.category("web_tour.tours").add("test_customer_alone_saved", {
             ProductScreen.customerIsSelected("Deco Addict"),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_open_default_register_screen_config", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            Chrome.endTour(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -589,3 +589,11 @@ class TestFrontend(TestFrontendCommon):
         Tests that when a customer is set, it will be saved and not be reset even if this is the only thing that changed in the order
         """
         self.start_tour(f"/pos/ui?config_id={self.main_pos_config.id}", 'test_customer_alone_saved', login="pos_user")
+
+    def test_open_default_register_screen_config(self):
+        """
+        Tests that the default register screen is opened when the config is set to do so
+        """
+        self.pos_config.write({'default_screen': 'register'})
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('test_open_default_register_screen_config')


### PR DESCRIPTION
pos*: point_of_sale, pos_restaurant

When opening a config with register as the default screen, the pos was bugging as the screen was waiting for the orderUuid as params but it was never set. This is now fixed by adding an empty order if there is none and giving it as params when navigating to the default screen.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
