### PR TITLE
[FIX] Selected employee can't be archived

### DIFF
--- a/addons/hr_timesheet/tests/__init__.py
+++ b/addons/hr_timesheet/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_timesheet
 from . import test_project_task_quick_create
 from . import test_portal_timesheet
 from . import test_project_project
+from . import test_employee_delete_wizard

--- a/addons/hr_timesheet/tests/test_employee_delete_wizard.py
+++ b/addons/hr_timesheet/tests/test_employee_delete_wizard.py
@@ -1,0 +1,26 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo.addons.hr.tests.common import TestHrCommon
+
+
+class TestEmployeeDeleteWizard(TestHrCommon):
+    def setUp(self):
+        super().setUp()
+
+    def test_delete_wizard_single_employee_with_timesheet(self):
+        """ Test the deletion wizard in the case of a single employee """
+        employee_A = self.env['hr.employee'].create([
+            {
+                'name': 'Employee A',
+                'user_id': False,
+                'work_email': 'employee_A@example.com',
+            }
+        ])
+
+        delete_wizard = self.env['hr.employee.delete.wizard'].create({
+            'employee_ids': [employee_A.id],
+        })
+
+        returned_action_Record = delete_wizard.action_archive()
+
+        self.assertEqual(returned_action_Record['context']['active_ids'], [employee_A.id], "Employee should have been selected")
+        self.assertEqual(returned_action_Record['context']['employee_termination'], True, "Employee Termination should have been set")

--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
@@ -40,7 +40,7 @@ class HrEmployeeDeleteWizard(models.TransientModel):
             'view_mode': 'form',
             'target': 'new',
             'context': {
-                'active_id': self.employee_ids.id,
+                'active_ids': self.employee_ids.ids,
                 'employee_termination': True,
             }
         }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This pr addresses the issue of the `HrDepartureWizard` attempting to archive an employee that was not initially selected.

Current behavior before PR:
The `HrDepartureWizard`'s `employee_ids` field is filled with a different employee id than the selected employee, also sometimes may be assigned a non existing id.

Desired behavior after PR is merged:
The mentioned field is filled with the id of the selected employee.

Solved by:
Setting the `active_ids` context field within action `action_archive` of `HrEmployeeDeleteWizard`.

The related subtask: 
https://www.odoo.com/odoo/project/1251/tasks/4844003