### PR TITLE
[FIX] website: prevent logout from website builder

### DIFF
--- a/addons/html_editor/static/src/main/link/link_popover.js
+++ b/addons/html_editor/static/src/main/link/link_popover.js
@@ -323,6 +323,13 @@ export class LinkPopover extends Component {
             this.state.previewIcon.value = "fa-question-circle-o";
             return;
         }
+        if (this.isLogoutUrl()) {
+            // The session ends if we fetch this url, so the preview is hardcoded
+            this.resetPreview();
+            this.state.urlTitle = _t("Logout");
+            this.state.previewIcon.value = "fa-sign-out";
+            return;
+        }
         if (this.isAttachmentUrl()) {
             const { name, mimetype } = await this.props.getAttachmentMetadata(this.state.url);
             this.resetPreview();
@@ -455,6 +462,9 @@ export class LinkPopover extends Component {
         this.onChange();
     }
 
+    isLogoutUrl() {
+        return !!this.state.url.match(/\/web\/session\/logout\b/);
+    }
     isAttachmentUrl() {
         return !!this.state.url.match(/\/web\/content\/\d+/);
     }

--- a/addons/website/static/tests/tours/website_click_tests.js
+++ b/addons/website/static/tests/tours/website_click_tests.js
@@ -33,6 +33,16 @@ registerWebsitePreviewTour('website_click_tour', {
         trigger: ':iframe a[href="/"]',
         run: "click",
     },
+    {
+        content: "click the User dropdown to show Log out button",
+        trigger: ":iframe .dropdown:has(#o_logout) > a",
+        run: "click",
+    },
+    {
+        content: "click the Log out button and expect not to be logged out during the following steps",
+        trigger: ":iframe .editor_enable #o_logout",
+        run: "click",
+    },
     goBackToBlocks(),
     ...insertSnippet(cover),
     ...clickOnSnippet(cover),


### PR DESCRIPTION
With the initial website builder refactor, the logout button has been made active when in the editor

Steps to reproduce:
- Open the editor of the website builder
- Click on "Log out"
- Bug: it logs out

Website refactor: 9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2
task-4367641
