### PR TITLE
[FIX] hr: fix employee presence status aligment

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -140,10 +140,10 @@
                             </aside>
                             <main class="ms-2">
                                 <div>
-                                    <field class="fw-bolder" name="name" placeholder="Employee's Name"/>
-                                    <div t-if="record.show_hr_icon_display.raw_value" class="float-end w-25">
+                                    <div t-if="record.show_hr_icon_display.raw_value" class="float-end">
                                         <field name="hr_icon_display" class=" align-items-center" widget="hr_presence_status" />
                                     </div>
+                                    <field class="fw-bolder" name="name" placeholder="Employee's Name"/>
                                 </div>
                                 <field t-if="record.job_title.raw_value" name="job_title"/>
                                 <div t-if="record.work_email.raw_value" class="text-truncate">

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -355,10 +355,10 @@
                             </aside>
                             <main class="ms-2">
                                 <div>
-                                    <field class="fw-bold fs-5" name="name" placeholder="Employee's Name"/>
                                     <div t-if="record.show_hr_icon_display.raw_value" class="float-end">
                                         <field name="hr_icon_display" widget="hr_presence_status" />
                                     </div>
+                                    <field class="fw-bold fs-5" name="name" placeholder="Employee's Name"/>
                                 </div>
                                 <field t-if="record.job_title.raw_value" name="job_title"/>
                                 <div t-if="record.work_email.raw_value" class="text-truncate">


### PR DESCRIPTION
With this commit, on kanban view, if employee's name is on multiple lines the employee presence status is still on the right top and not on the right bottom

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
