### PR TITLE
[FIX] account: adjust compute method dependency for invoice EDI format

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -671,7 +671,7 @@ class ResPartner(models.Model):
         return self.env['res.partner.bank'].search(domain)
 
     @api.depends_context('company')
-    @api.depends('commercial_partner_id.country_code')
+    @api.depends('country_code')
     def _compute_invoice_edi_format(self):
         for partner in self:
             if not partner.commercial_partner_id or partner.commercial_partner_id.invoice_edi_format_store == 'none':


### PR DESCRIPTION
Before this **PR**:
When creating a new partner for the first time, the compute method for the invoice EDI format is triggered as expected. However, if a country is set while creating the partner, compute method is not triggered again.

This breaks the intended flow where a default edi_format should be automatically set based on the country (using _get_suggested_invoice_edi_format). Since the compute method doesn’t re-trigger upon changing the country during record creation, the inverse method ends up setting invoice_edi_format_store to 'none'. This prevents subsequent calls to _get_suggested_invoice_edi_format from resolving the appropriate format, requiring users to manually set it — defeating the purpose of automatic localization-based assignment.

After this **PR**:
The dependency for the compute method has been changed from commercial_partner_id.country_code to country_code. This ensures the compute method reacts to changes in the country field during record creation. The logic still utilizes commercial_partner_id internally, so the intended behavior and correctness should be preserved, while ensuring the default format is set appropriately.
