### PR TITLE
[IMP] pos*: unify preparation receipt template

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -6,6 +6,7 @@ import { computeComboItems } from "./utils/compute_combo_items";
 import { accountTaxHelpers } from "@account/helpers/account_tax";
 import { localization } from "@web/core/l10n/localization";
 import { formatDate, serializeDateTime } from "@web/core/l10n/dates";
+import { getStrNotes } from "./utils/order_change";
 
 const { DateTime } = luxon;
 
@@ -937,6 +938,25 @@ export class PosOrder extends Base {
 
     get showChange() {
         return !this.currency.isZero(this.orderChange) && this.finalized;
+    }
+
+    getOrderData(reprint = false) {
+        return {
+            reprint: reprint,
+            pos_reference: this.getName(),
+            config_name: this.config_id?.name || this.config.name,
+            time: luxon.DateTime.now().toFormat("HH:mm"),
+            tracking_number: this.tracking_number,
+            preset_name: this.preset_id?.name || "",
+            preset_time: this.presetDateTime,
+            employee_name: this.employee_id?.name || this.user_id?.name,
+            internal_note: getStrNotes(this.internal_note),
+            general_customer_note: this.general_customer_note,
+            changes: {
+                title: "",
+                data: [],
+            },
+        };
     }
 
     getLinesToCompute() {

--- a/addons/point_of_sale/static/src/app/models/utils/order_change.js
+++ b/addons/point_of_sale/static/src/app/models/utils/order_change.js
@@ -1,3 +1,67 @@
+import { logPosMessage } from "@point_of_sale/app/utils/pretty_console_log";
+const CONSOLE_COLOR = "#F5B427";
+
+export const getStrNotes = (note) => {
+    if (!note) {
+        return "";
+    }
+    if (Array.isArray(note)) {
+        return note.map((n) => (typeof n === "string" ? n : n.text)).join(", ");
+    }
+    if (typeof note === "string") {
+        try {
+            const parsed = JSON.parse(note);
+            if (Array.isArray(parsed)) {
+                return parsed.map((n) => (typeof n === "string" ? n : n.text)).join(", ");
+            }
+            return note;
+        } catch (error) {
+            logPosMessage(
+                "OrderChange",
+                "getStrNotes",
+                "Error while parsing note, not valid JSON",
+                CONSOLE_COLOR,
+                [error]
+            );
+            return note;
+        }
+    }
+    return "";
+};
+
+export const filterChangeByCategories = (categories, currentOrderChange, models) => {
+    const matchesCategories = (change) => {
+        const product = models["product.product"].get(change["product_id"]);
+        const categoryIds = product.parentPosCategIds;
+        for (const categoryId of categoryIds) {
+            if (categories.includes(categoryId)) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    const filterChanges = (changes) => {
+        // Combo line uuids to have at least one child line in the given categories
+        const validComboUuids = new Set(
+            changes
+                .filter((change) => change.combo_parent_uuid && matchesCategories(change))
+                .map((change) => change.combo_parent_uuid)
+        );
+        return changes.filter(
+            (change) =>
+                (change.isCombo && validComboUuids.has(change.uuid)) ||
+                (!change.isCombo && matchesCategories(change))
+        );
+    };
+
+    return {
+        new: filterChanges(currentOrderChange["new"]),
+        cancelled: filterChanges(currentOrderChange["cancelled"]),
+        noteUpdate: filterChanges(currentOrderChange["noteUpdate"]),
+    };
+};
+
 export const changesToOrder = (order, orderPreparationCategories, cancelled = false) => {
     const toAdd = [];
     const toRemove = [];
@@ -8,6 +72,7 @@ export const changesToOrder = (order, orderPreparationCategories, cancelled = fa
         : Object.values(order.last_order_preparation_change.lines);
 
     for (const lineChange of linesChanges) {
+        lineChange["note"] = getStrNotes(lineChange.note);
         if (lineChange["quantity"] > 0 && !cancelled) {
             toAdd.push(lineChange);
         } else {
@@ -77,7 +142,7 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
                 product_id: product.id,
                 attribute_value_names: orderline.attribute_value_ids.map((a) => a.name),
                 quantity: quantityDiff,
-                note: note,
+                note: getStrNotes(note),
                 customer_note: customerNote,
                 pos_categ_id: product.pos_categ_ids[0]?.id ?? 0,
                 pos_categ_sequence: product.pos_categ_ids[0]?.sequence ?? 0,
@@ -129,7 +194,7 @@ export const getOrderChanges = (order, orderPreparationCategories) => {
                     display_name: lineResume["display_name"],
                     isCombo: Boolean(lineResume["isCombo"]),
                     combo_parent_uuid: lineResume["combo_parent_uuid"],
-                    note: lineResume["note"],
+                    note: getStrNotes(lineResume["note"]),
                     customer_note: lineResume["customer_note"],
                     attribute_value_names: lineResume["attribute_value_names"],
                     group: lineResume["group"],

--- a/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/point_of_sale/static/src/app/store/order_change_receipt_template.xml
@@ -10,7 +10,7 @@
                 </div>
                 <div class="o-employee-name" style="font-size: 78%;">
                     <span><t t-esc="data.config_name"/> : <t t-esc="data.time"/></span><br/>
-                    <span>By: <t t-esc="data.employee_name"/></span>
+                    <span t-if="data.employee_name">By: <t t-esc="data.employee_name"/></span>
                 </div>
                 <span class="my-4" style="font-size: 150%;">
                     <span>Order <strong><t t-esc="data.pos_reference"/></strong></span>

--- a/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
+++ b/addons/point_of_sale/static/tests/unit/services/pos_service.test.js
@@ -4,6 +4,10 @@ import { definePosModels } from "../data/generate_model_definitions";
 import { ConnectionLostError } from "@web/core/network/rpc";
 import { onRpc } from "@web/../tests/web_test_helpers";
 import { imageUrl } from "@web/core/utils/urls";
+import {
+    getStrNotes,
+    filterChangeByCategories,
+} from "@point_of_sale/app/models/utils/order_change";
 
 definePosModels();
 
@@ -35,11 +39,10 @@ describe("pos_store.js", () => {
     });
 
     test("orderNoteFormat", async () => {
-        const store = await setupPosEnv();
-        const str = store.getStrNotes("string");
+        const str = getStrNotes("string");
         expect(str).toBeOfType("string");
         expect(str).toBe("string");
-        const json2str = store.getStrNotes([{ text: "json", colorIndex: 0 }]);
+        const json2str = getStrNotes([{ text: "json", colorIndex: 0 }]);
         expect(json2str).toBeOfType("string");
         expect(json2str).toBe("json");
     });
@@ -270,7 +273,11 @@ describe("pos_store.js", () => {
             noteUpdate: [],
         };
 
-        const filtered = store.filterChangeByCategories(allowedCategories, currentOrderChange);
+        const filtered = filterChangeByCategories(
+            allowedCategories,
+            currentOrderChange,
+            store.models
+        );
 
         const expectedUuids = ["combo-parent-uuid", "combo-child-a-uuid", "line1"];
         const actualUuids = filtered.new.map((c) => c.uuid);
@@ -301,9 +308,9 @@ describe("pos_store.js", () => {
     test("getOrderData", async () => {
         const store = await setupPosEnv();
         const order = await getFilledOrder(store);
-        const orderData = store.getOrderData(order);
+        const orderData = order.getOrderData();
         expect(orderData).toEqual({
-            reprint: undefined,
+            reprint: false,
             pos_reference: "1001",
             config_name: "Hoot",
             time: "10:30",

--- a/addons/pos_restaurant/static/src/app/models/pos_order.js
+++ b/addons/pos_restaurant/static/src/app/models/pos_order.js
@@ -172,4 +172,11 @@ patch(PosOrder.prototype, {
             ) + 1
         );
     },
+
+    getOrderData(reprint) {
+        return {
+            ...super.getOrderData(reprint),
+            customer_count: this.getCustomerCount(),
+        };
+    },
 });

--- a/addons/pos_restaurant/static/src/app/services/pos_store.js
+++ b/addons/pos_restaurant/static/src/app/services/pos_store.js
@@ -987,13 +987,6 @@ patch(PosStore.prototype, {
             }
         }
     },
-    getOrderData(order, reprint) {
-        return {
-            ...super.getOrderData(order, reprint),
-            customer_count: order.getCustomerCount(),
-        };
-    },
-
     async validateOrderFast(paymentMethod) {
         const currentOrder = this.getOrder();
         if (!currentOrder) {

--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -110,6 +110,7 @@
             "point_of_sale/static/src/app/utils/devices_identifier_sequence.js",
             "point_of_sale/static/src/app/hooks/hooks.js",
             "point_of_sale/static/src/app/utils/debug-formatter.js",
+            "point_of_sale/static/src/app/store/order_change_receipt_template.xml",
         ],
         # Assets tests
         "pos_self_order.assets_tests": [

--- a/addons/pos_self_order/static/src/app/models/pos_order.js
+++ b/addons/pos_self_order/static/src/app/models/pos_order.js
@@ -1,4 +1,5 @@
 import { PosOrder } from "@point_of_sale/app/models/pos_order";
+import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
 patch(PosOrder.prototype, {
@@ -62,5 +63,15 @@ patch(PosOrder.prototype, {
                 delete this.uiState.lineChanges[uuid];
             }
         }
+    },
+    getOrderData(reprint = false) {
+        const orderData = super.getOrderData(reprint);
+        return {
+            ...orderData,
+            name: this.pos_reference || _t("Self Order"),
+            tracker: this.table_stand_number,
+            tracking_number:
+                this.tracking_number != this.getName() ? orderData.tracking_number : "",
+        };
     },
 });

--- a/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
+++ b/addons/pos_self_order/static/src/app/store/order_change_receipt_template.xml
@@ -1,44 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
-    <t t-name="pos_self_order.OrderChangeReceipt">
-        <div class="pos-receipt">
-            <div class="pos-receipt-title" t-if="changes.preset_name">
-                    <t t-esc="changes.preset_name"/> <t t-if="changes.preset_time">(<t t-esc="changes.preset_time"/>)</t>
+    <t t-name="pos_self_order.OrderChangeReceipt" t-inherit="point_of_sale.OrderChangeReceipt" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('receipt-header')]" position="inside">
+            <div t-if="data.tracker" class="pos-receipt-title" style="font-size: 85%;">
+                <span>Tracker number: <t t-esc="data.tracker"/></span>
             </div>
-            <div class="pos-receipt-order-data"><t t-esc="changes.name"/></div>
-            <t t-if="changes.tracker || changes.trackingNumber">
-                <br />
-                <div class="pos-receipt-title">
-                    <t t-esc="changes.trackingNumber"/>
-                    <t t-if="changes.tracker">
-                        / Tracker number: <t t-esc="changes.tracker"/>
-                    </t>
-                </div>
-            </t>
-            <br />
-            <div class="pos-receipt-title">
-                NEW
-                <t t-esc='changes.time.hours'/>:<t t-esc='changes.time.minutes'/>
-            </div>
-            <br />
-            <t t-foreach="changes.new" t-as="change" t-key="change_index">
-                <div class="product-details d-flex" t-att-class="{'ms-5': change.combo_parent_id}">
-                    <span class="product-quantity me-3 mb-1" t-esc="change.qty"/>
-                    <span class="product-name" t-esc="change.full_product_name"/>
-                </div>
-                <t t-if="change.customer_note">
-                    <div>
-                        NOTE
-                        <span class="pos-receipt-right-align">...</span>
-                    </div>
-                    <div><span class="pos-receipt-left-padding">--- <t t-esc="change.customer_note" /></span></div>
-                    <br/>
-                </t>
-            </t>
-            <br />
-            <br />
-    </div>
+            <div t-if="data.name" class="pos-receipt-order-data"><t t-esc="data.name"/></div>
+        </xpath>
     </t>
 
 </templates>

--- a/addons/pos_self_order/static/tests/unit/preparation_receipt_util.js
+++ b/addons/pos_self_order/static/tests/unit/preparation_receipt_util.js
@@ -1,0 +1,76 @@
+import { renderToElement } from "@web/core/utils/render";
+import { changesToOrder } from "@point_of_sale/app/models/utils/order_change";
+
+export function generateKioskPreparationReceipt(store) {
+    const order = store.currentOrder;
+    const orderData = order.getOrderData();
+    const changes = changesToOrder(order, store.config.preparationCategories).new;
+
+    const printingChanges = {
+        ...orderData,
+        changes: {
+            title: "NEW",
+            data: changes,
+        },
+    };
+
+    return renderToElement("point_of_sale.OrderChangeReceipt", {
+        data: printingChanges,
+    });
+}
+
+export function checkKioskPreparationTicketData(
+    store,
+    data,
+    opts = {
+        visibleInDom: [],
+        invisibleInDom: [],
+    }
+) {
+    const receipt = generateKioskPreparationReceipt(store);
+
+    const lines = receipt.querySelectorAll(".orderline");
+    let idx = 0;
+    for (const line of lines) {
+        const name = line.firstChild.children[1].innerHTML;
+        const qty = line.firstChild.children[0].innerHTML;
+        const domAttrs = Object.values(line.children[1]?.children || []);
+        const attrs = domAttrs.map((c) => c.innerHTML).filter(Boolean);
+        const values = data[idx];
+
+        if (values.qty != qty) {
+            return `Ticket data mismatch for ${name}: expected ${values.qty}, got ${qty}`;
+        }
+        if (values.name != name) {
+            return `Ticket data mismatch for ${name}: expected ${values.name}, got ${name}, maybe lines ordering ?`;
+        }
+        if (values.attributes) {
+            for (const attr of values.attributes) {
+                const found = attrs.find((a) => a.includes(attr));
+                if (!found) {
+                    return `Attribute ${attr} not found in printed receipt for ${name}`;
+                }
+            }
+        }
+        if (!values) {
+            return `Received ${name} but no check data found`;
+        }
+        idx++;
+    }
+    if (opts.visibleInDom) {
+        for (const inDom of opts.visibleInDom) {
+            if (!receipt.innerHTML.includes(inDom)) {
+                return `${inDom} not found in printed receipt`;
+            }
+        }
+    }
+
+    if (opts.invisibleInDom) {
+        for (const notInDom of opts.invisibleInDom) {
+            if (receipt.innerHTML.includes(notInDom)) {
+                return `${notInDom} should not be in printed receipt`;
+            }
+        }
+    }
+    return true;
+}

--- a/addons/pos_self_order/static/tests/unit/services/preparation_receipt.test.js
+++ b/addons/pos_self_order/static/tests/unit/services/preparation_receipt.test.js
@@ -1,0 +1,51 @@
+import { test, describe, expect } from "@odoo/hoot";
+import { setupSelfPosEnv, getFilledSelfOrder, addComboProduct } from "../utils";
+import { definePosSelfModels } from "../data/generate_model_definitions";
+import { checkKioskPreparationTicketData } from "../preparation_receipt_util";
+
+definePosSelfModels();
+
+describe("preparation ticket", () => {
+    test("preparation ticket check 1", async () => {
+        const store = await setupSelfPosEnv();
+        await getFilledSelfOrder(store);
+
+        const result = checkKioskPreparationTicketData(
+            store,
+            [
+                { name: "TEST", qty: 3 },
+                { name: "TEST 2", qty: 2 },
+            ],
+            {
+                visibleInDom: ["NEW"],
+                invisibleInDom: ["[]"],
+            }
+        );
+        expect(result).toBe(true);
+    });
+    test("preparation ticket check 2 - preparation categories", async () => {
+        const store = await setupSelfPosEnv();
+
+        const product1 = store.models["product.template"].get(11); // Steel desk
+        const product2 = store.models["product.template"].get(13); // Pizza margarita
+
+        await store.addToCart(product1, 2);
+        await store.addToCart(product2, 2);
+
+        const result = checkKioskPreparationTicketData(store, [{ name: "Steel desk", qty: 2 }], {
+            invisibleInDom: ["Pizza margarita"],
+        });
+        expect(result).toBe(true);
+    });
+    test("preparation ticket check 3 - combo", async () => {
+        const store = await setupSelfPosEnv();
+        await addComboProduct(store);
+
+        const result = checkKioskPreparationTicketData(store, [
+            { name: "Product combo", qty: 2 },
+            { name: "Wood desk", qty: 2 },
+            { name: "Wood chair", qty: 2 },
+        ]);
+        expect(result).toBe(true);
+    });
+});


### PR DESCRIPTION
pos*: point_of_sale, pos_self_order, pos_restaurant

Previously, the POS and self-order modules used separate templates for the preparation receipt, making maintenance more difficult. This pr unifies them by reusing the POS preparation receipt in self-order.

**Changes:**

- Replaced `pos_self_order.OrderChangeReceipt` with `point_of_sale.OrderChangeReceipt` for self-order preparation receipt.

- Move the `getOrderData` method to the `pos.order` model, to avoid reliance on the `pos_store` service.

- Moved `getStrNotes` to `order_change.js` to ensure internal notes are displayed correctly on self-order receipts (fixing the issue where an empty stringified array `"[]"` was shown).

Task: 4827509

Related: https://github.com/odoo/enterprise/pull/91199