### PR TITLE
[FIX] website: fix mega menu and hamburger menu

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -4252,6 +4252,18 @@ options.registry.MegaMenuLayout = options.registry.SelectTemplate.extend({
             .classList.value.split(' ').filter(cl => cl.startsWith('s_mega_menu'))[0];
         return `website.${templateDefiningClass}`;
     },
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        if (params.optionsPossibleValues.selectClass?.includes("o_mega_menu_container_size")) {
+            const headerTemplate = weUtils.getCSSVariableValue("header-template");
+            if (["hamburger", "sidebar"].includes(headerTemplate.slice(1, -1))) {
+                return false;
+            }
+        }
+        return this._super(...arguments);
+    },
 });
 
 /**

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1665,6 +1665,17 @@ header {
     }
 }
 
+// For the "hamburger" and "sidebar" header, we set the mega menu columns to
+// 100% width when the breakpoint is above lg, because the menu keeps its mobile
+// width when displayed on desktop.
+@if index(("sidebar", "hamburger"), o-website-value("header-template")) {
+    @include media-breakpoint-up(lg) {
+        .o_mega_menu [class*="col-"] {
+            width: 100%;
+        }
+    }
+}
+
 #wrapwrap.o_header_overlay {
     > header:not(.o_header_affixed):not(.o_header_sidebar) {
         @include o-position-absolute(0, 0, auto, 0);


### PR DESCRIPTION
Steps to reproduce:

- Enter website edit mode.
- Click the header.
- Select "Sidebar" in the template options.
- Save the page.
- Click Site > Menu Editor in the backend navbar.
- Add a "Mega menu" to the menu and save the dialog.
- In the sidebar, open the "Mega menu".
- Bug: The layout is broken. The mega menu should be displayed in a single column, but it's displayed in three columns.

In this commit, we fix the issue by forcing the columns width of the mega menu to 100% when the header is set to "Sidebar" or "Hamburger".

This commit also hides the "Size" option of the mega menu when the header template is set to "hamburger" or "sidebar", as it has no effect with either of these headers.

task-4830118