### PR TITLE
[FIX] l10n_sg_ubl_pint: fix pint singapore invoice format

### DIFF
--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -66,11 +66,11 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
             )
             # [BR-53-GST-SG]-If the GST accounting currency code (BT-6-GST) is present, then the Invoice total GST amount (BT-111-GST),
             # Invoice total including GST amount and Invoice Total excluding GST amount in accounting currency shall be provided.
-            additional_document_reference_list.append([{
+            additional_document_reference_list += [{
                 'id': invoice.company_id.currency_id.name,
                 'document_description': amount,
                 'document_type_code': code,
-            } for code, amount in amounts_in_accounting_currency])
+            } for code, amount in amounts_in_accounting_currency]
         return additional_document_reference_list
 
     def _export_invoice_vals(self, invoice):


### PR DESCRIPTION
**Steps to reproduce:**
- Install the modules `l10n_sg` and `l10n_sg_ubl_pint`.
- Create an invoice.
- On the form view of the partner you chose. Under the `Accounting` tab, set `eInvoice format` as PINT singapore.
- On the invoice, for `currency_id`, use a currency other than SGD.
- Download the invoice in the 'PINT Singapore' format.

**Issue:**
The invoice is not downloaded and it throws a traceback.

**Cause:**
The method '_get_additional_document_reference_list' returns a list of dictionnaries within another list, while the XML is expecting a list of dictionnaries.

**Solution:**
Remove the append method.

opw-4799363

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
