### PR TITLE
[FIX] point_of_sale: correct test test_pos_order_refund_ship_delay_to…

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2264,6 +2264,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Product A',
             'categ_id': categ.id,
             'lst_price': 10,
+            'is_storable': True,
             'standard_price': 10
         })
         order = self.PosOrder.create({


### PR DESCRIPTION
…talcost

this commit fixes the test test_pos_order_refund_ship_delay_totalcost from PR https://github.com/odoo/odoo/pull/210868

opw-4614503