### PR TITLE
[FIX] mrp: preserve BoM line sequence when exploding phantom BoMs

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -427,7 +427,7 @@ class MrpBom(models.Model):
             bom = product_boms.get(current_line.product_id)
             if bom:
                 converted_line_quantity = current_line.product_uom_id._compute_quantity(line_quantity / bom.product_qty, bom.product_uom_id)
-                bom_lines += [(line, current_line.product_id, converted_line_quantity, current_line) for line in bom.bom_line_ids]
+                bom_lines = [(line, current_line.product_id, converted_line_quantity, current_line) for line in bom.bom_line_ids] + bom_lines
                 for bom_line in bom.bom_line_ids:
                     if bom_line.product_id not in product_boms:
                         product_ids.add(bom_line.product_id.id)


### PR DESCRIPTION
When exploding a BoM that includes phantom (kit) components, the resulting list of components moves was not respecting the sequence order defined in the BoM.

Steps to reproduce:
- Create a product P1 with a BoM that includes:
  - Component 1 (sequence = 1)
  - Component 2 - KIT (sequence = 2), which itself contains:
      - Component 2-1 (sequence = 1)
      - Component 2-2 (sequence = 2)
  - Component 3 (sequence = 3)
- Create a Manufacturing Order for P1.

Observed behavior:
- The generated stock moves are ordered as:
    1. Component 1
    2. Component 3
    3. Component 2-1
    4. Component 2-2

Expected behavior:
- The stock moves should respect the BoM line sequence:
    1. Component 1
    2. Component 2-1
    3. Component 2-2
    4. Component 3

Root cause:
- When exploding phantom BoMs, child lines were appended at the end of the processing queue, causing out-of-order moves:

https://github.com/odoo/odoo/blob/d64b108db54c02098c9e95f58fa3278007c92642/addons/mrp/models/mrp_bom.py#L416-L418

https://github.com/odoo/odoo/blob/d64b108db54c02098c9e95f58fa3278007c92642/addons/mrp/models/mrp_bom.py#L430

Solution:
- Insert the child BoM lines at the beginning of the processing queue (`bom_lines`), sorted by their sequence field, to ensure correct processing order.

opw-4809095