### PR TITLE
[FIX] account_payment: change compute methods to onchange for journal_id

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -403,7 +403,7 @@ class AccountPayment(models.Model):
                     ('type', 'in', ['bank', 'cash', 'credit']),
                 ], limit=1)
 
-    @api.depends('journal_id')
+    @api.onchange('journal_id')
     def _compute_company_id(self):
         for payment in self:
             if payment.journal_id.company_id not in payment.company_id.parent_ids:


### PR DESCRIPTION
This commit changes the decorator from @api.depends to @api.onchange for the methods _compute_company_id and _compute_partner_id in account_payment.py.

Using onchange instead of compute for these methods improves the behavior of the fields when a user selects a different journal. The compute decorator was causing issues because it was recomputing values even when users had already manually set them, while onchange will only trigger when the user actively changes the journal.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


adhoc tasks: 52647, 54945


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
