### PR TITLE
[FIX] mail: Access error when updating activity

### DIFF
--- a/addons/mail/models/res_partner.py
+++ b/addons/mail/models/res_partner.py
@@ -257,10 +257,10 @@ class ResPartner(models.Model):
                 main_user = main_user_by_partner and main_user_by_partner.get(partner)
                 if not main_user:
                     users = partner.with_context(active_test=False).user_ids
-                    internal_users = users - users.filtered("share")
+                    internal_users = users - users.sudo().filtered("share")
                     main_user = internal_users[:1] or users[:1]
                 data["userId"] = main_user.id
-                data["isInternalUser"] = not main_user.share if main_user else False
+                data["isInternalUser"] = not main_user.sudo().share if main_user else False
                 if "isAdmin" in fields:
                     data["isAdmin"] = main_user._is_admin()
                 if "notification_type" in fields:


### PR DESCRIPTION
To reproduce:
=============
- Install project, voip
- Create a second company
- Switch Company
- Open "Project / Tasks / All Tasks"
- For the first task with activity and assigned to admin, edit the activity and change the date

Problem :
=========
problem in this line :
https://github.com/odoo/odoo/blob/saas-18.2/addons/mail/models/res_partner.py#L259 it's returning users from other companies due to cache pollution. In the ORM, the first time you access an X2many (partner.user_ids), we read it with the access rights of the current user (env.user), depending on the sudo flag (env.su), and put the result in the cache. This cached value remains valid until the end of the transaction. When you access partner.user_ids a second time with a different user and/or sudo=False, the cached value is used, which may return records that you cannot access with the current user. This is an ORM inconsistency that rd-framework-py want to fix, but it is not a small change. This issue has existed since v13.0

Solution :
===========
browse partner.user_ids in sudo mode

PR test link : 
===========
https://github.com/odoo/enterprise/pull/88999

opw-4778418

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
