### PR TITLE
[FIX] point_of_sale: prevent the new session sequencing with prefix to start with the config name

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1727,9 +1727,12 @@ class PosSession(models.Model):
             return
         self.state = 'opened'
         self.start_at = fields.Datetime.now()
-        self.name = self.config_id.name + self.env['ir.sequence'].with_context(
+
+        sequence = self.env['ir.sequence'].with_context(
             company_id=self.config_id.company_id.id
-        ).next_by_code('pos.session') + (self.name if self.name != '/' else '')
+        ).search([('code', '=', 'pos.session'), ('company_id', 'in', [self.config_id.company_id.id, False])], order='company_id', limit=1)
+
+        self.name = (self.config_id.name if sequence.prefix == '/' else '') + sequence.next_by_code('pos.session') + (self.name if self.name != '/' else '')
 
         cash_payment_method_ids = self.config_id.payment_method_ids.filtered(lambda pm: pm.is_cash_count)
         if cash_payment_method_ids:

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -889,6 +889,24 @@ class TestPoSBasicConfig(TestPoSCommon):
         open_and_check(pos01_data)
         open_and_check(pos02_data)
 
+    def test_pos_session_name_sequencing(self):
+        """ This test check if the session name is correctly set according to the sequence """
+
+        sequence = self.env['ir.sequence'].search([('code', '=', 'pos.session')])
+        sequence.prefix = '/'
+        sequence.write({'number_next_actual': 1000})
+        name = self.config.name
+
+        self.open_new_session(0)
+        self.assertEqual(self.pos_session.name, name + '/01000')
+
+        self.pos_session.close_session_from_ui()
+
+        sequence.prefix = 'TEST/'
+
+        self.open_new_session(0)
+        self.assertEqual(self.pos_session.name, 'TEST/01001')
+
     def test_load_data_should_not_fail(self):
         """load_data shouldn't fail
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The sequencing for new PoS Session isn't right when set to another value than the default.

Current behavior before PR:
The PoS name was added before the intended sequence.
For example, if you set the pos.session sequence to TEST/ with the Furniture Shop, it return Furniture ShopTEST/00001.

Desired behavior after PR is merged:
The PoS Session name should be using only the sequence if the sequence isn't the default one.
When the pos.session sequence is set to TEST/ and you open the Furniture Shop, it should return TEST/00001.

Steps to reproduce:
- change the default sequence prefix for pos.session
- open a pos session and Open Register
- go to Point of Sale > Orders > Sessions
- check the Session ID

opw-4822673

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
