### PR TITLE
[IMP] modules: Manifest class

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -15,7 +15,7 @@ from odoo import api, fields, models, _
 from odoo.exceptions import AccessDenied, AccessError, UserError
 from odoo.fields import Domain
 from odoo.http import request
-from odoo.modules.module import adapt_version, MANIFEST_NAMES
+from odoo.modules.module import MANIFEST_NAMES, Manifest
 from odoo.release import major_version
 from odoo.tools import convert_csv_import, convert_sql_import, convert_xml_import, exception_to_unicode
 from odoo.tools import file_open, file_open_temporary_directory, ormcache
@@ -73,20 +73,11 @@ class IrModuleModule(models.Model):
         known_mods_names = {m.name: m for m in known_mods}
         installed_mods = [m.name for m in known_mods if m.state == 'installed']
 
-        terp = {}
-        manifest_path = next((opj(path, name) for name in MANIFEST_NAMES if os.path.exists(opj(path, name))), None)
-        if manifest_path:
-            with file_open(manifest_path, 'rb', env=self.env) as f:
-                terp.update(ast.literal_eval(f.read().decode()))
+        terp = Manifest._from_path(path, env=self.env)
         if not terp:
             return False
-        if not terp.get('icon'):
-            icon_path = 'static/description/icon.png'
-            module_icon = module if os.path.exists(opj(path, icon_path)) else 'base'
-            terp['icon'] = opj('/', module_icon, icon_path)
         values = self.get_values_from_terp(terp)
-        if 'version' in terp:
-            values['latest_version'] = adapt_version(terp['version'])
+        values['latest_version'] = terp.version
         if self.env.context.get('data_module'):
             values['module_type'] = 'industries'
 
@@ -281,11 +272,9 @@ class IrModuleModule(models.Model):
                 module_data_files = defaultdict(list)
                 dependencies = defaultdict(list)
                 for mod_name, manifest in manifest_files:
-                    manifest_path = z.extract(manifest, module_dir)
-                    try:
-                        with file_open(manifest_path, 'rb', env=self.env) as f:
-                            terp = ast.literal_eval(f.read().decode())
-                    except Exception:
+                    _manifest_path = z.extract(manifest, module_dir)
+                    terp = Manifest._from_path(opj(module_dir, mod_name), env=self.env)
+                    if not terp:
                         continue
                     files_to_import = terp.get('data', []) + terp.get('init_xml', []) + terp.get('update_xml', [])
                     if with_demo:
@@ -323,7 +312,7 @@ class IrModuleModule(models.Model):
                         raise UserError(_(
                             "Error while importing module '%(module)s'.\n\n %(error_message)s \n\n",
                             module=mod_name, error_message=exception_to_unicode(e),
-                        ))
+                        )) from e
         return "", module_names
 
     def module_uninstall(self):

--- a/addons/base_import_module/tests/test_cloc.py
+++ b/addons/base_import_module/tests/test_cloc.py
@@ -40,7 +40,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
         # Check for existing module in case the test run on an existing database
         if not self.env['ir.module.module'].search([('name', '=', 'studio_customization')]):
             self.env['ir.module.module'].create({
-                'author': 'Odoo',
+                'author': 'Odoo S.A.',
                 'imported': True,
                 'latest_version': '13.0.1.0.0',
                 'name': 'studio_customization',
@@ -101,7 +101,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
 
     def test_count_qweb_imported_module(self):
         self.env['ir.module.module'].create({
-            'author': 'Odoo',
+            'author': 'Odoo S.A.',
             'imported': True,
             'latest_version': '15.0.1.0.0',
             'name': 'test_imported_module',
@@ -151,6 +151,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
                 ]
             },
             'license': 'LGPL-3',
+            'author': 'Odoo S.A.',
         })
 
         stream = BytesIO()
@@ -168,7 +169,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
 
     def test_exclude_qweb(self):
         self.env['ir.module.module'].create({
-            'author': 'Odoo',
+            'author': 'Odoo S.A.',
             'imported': True,
             'latest_version': '15.0.1.0.0',
             'name': 'test_imported_module',
@@ -200,6 +201,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
                 ]
             },
             'license': 'LGPL-3',
+            'author': 'Odoo S.A.',
         })
 
         stream = BytesIO()
@@ -243,6 +245,7 @@ class TestClocFields(test_cloc.TestClocCustomization):
                     'data/test.xml',
             ],
             'license': 'LGPL-3',
+            'author': 'Odoo S.A.',
         })
 
         stream = BytesIO()

--- a/addons/contacts/models/res_users.py
+++ b/addons/contacts/models/res_users.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, modules
@@ -15,5 +14,5 @@ class ResUsers(models.Model):
         for activity in activities:
             if activity['model'] != 'res.partner':
                 continue
-            activity['icon'] = modules.module.get_module_icon('contacts')
+            activity['icon'] = modules.module.Manifest.for_addon('contacts').icon
         return activities

--- a/addons/mass_mailing_sms/models/res_users.py
+++ b/addons/mass_mailing_sms/models/res_users.py
@@ -36,17 +36,17 @@ class ResUsers(models.Model):
                     'user_id': self.env.uid,
                 })
                 activity_data = self.env.cr.dictfetchall()
-                
+
                 user_activities = {}
                 for act in activity_data:
                     if not user_activities.get(act['mailing_type']):
                         if act['mailing_type'] == 'sms':
-                            module = 'mass_mailing_sms'
+                            module_name = 'mass_mailing_sms'
                             name = _('SMS Marketing')
                         else:
-                            module = 'mass_mailing'
+                            module_name = 'mass_mailing'
                             name = _('Email Marketing')
-                        icon = module and modules.module.get_module_icon(module)
+                        icon = modules.Manifest.for_addon(module_name).icon
                         res_ids = set()
                         user_activities[act['mailing_type']] = {
                             'id': self.env['ir.model']._get('mailing.mailing').id,

--- a/addons/project_todo/models/res_users.py
+++ b/addons/project_todo/models/res_users.py
@@ -45,12 +45,12 @@ class ResUsers(models.Model):
             is_task = activity['is_task']
             if is_task not in user_activities:
                 if not is_task:
-                    module = 'project_todo'
+                    module_name = 'project_todo'
                     name = _('To-Do')
                 else:
-                    module = 'project'
+                    module_name = 'project'
                     name = _('Task')
-                icon = modules.module.get_module_icon(module)
+                icon = modules.Manifest.for_addon(module_name).icon
                 user_activities[is_task] = {
                     'id': self.env['ir.model']._get('project.task').id,
                     'name': name,

--- a/addons/web/controllers/webclient.py
+++ b/addons/web/controllers/webclient.py
@@ -1,19 +1,10 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import json
 import logging
-import warnings
 
-import werkzeug
-import werkzeug.exceptions
-import werkzeug.utils
-import werkzeug.wrappers
-import werkzeug.wsgi
-
-import odoo
-import odoo.modules.registry
+import odoo.tools
 from odoo import http
-from odoo.modules import get_manifest
+from odoo.modules import Manifest
 from odoo.http import request
 from odoo.tools.misc import file_path
 from .utils import _local_web_translations
@@ -42,7 +33,7 @@ class WebClient(http.Controller):
 
         translations_per_module = {}
         for addon_name in mods:
-            manifest = get_manifest(addon_name)
+            manifest = Manifest.for_addon(addon_name)
             if manifest and manifest['bootstrap']:
                 f_name = file_path(f'{addon_name}/i18n/{lang}.po')
                 if not f_name:

--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -124,9 +124,9 @@ class WebManifest(http.Controller):
 
         if app_icon['type'] == "image/svg+xml":
             # We don't handle SVG images here, let's look for the module icon if possible
-            manifest = modules.module.get_manifest(app_id)
+            manifest = modules.Manifest.for_addon(app_id, display_warning=False)
             add_padding = True
-            if len(manifest) > 0 and manifest['icon']:
+            if manifest and manifest['icon']:
                 icon_src = manifest['icon']
             else:
                 icon_src = f"/{self._icon_path()}"
@@ -167,7 +167,7 @@ class WebManifest(http.Controller):
         return []
 
     def _get_scoped_app_name(self, app_id):
-        manifest = modules.module.get_manifest(app_id)
+        manifest = modules.Manifest.for_addon(app_id, display_warning=False)
         if manifest:
             return manifest['name']
         return app_id

--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -8,7 +8,7 @@ from odoo import api, fields, models
 from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
 from odoo.exceptions import MissingError
 from odoo.http import request
-from odoo.modules.module import get_manifest
+from odoo.modules import Manifest
 from odoo.tools import escape_psql, split_every, SQL
 
 _logger = logging.getLogger(__name__)
@@ -668,7 +668,7 @@ class IrModuleModule(models.Model):
             return set(items)
 
         create_count = 0
-        manifest = get_manifest(self.name)
+        manifest = Manifest.for_addon(self.name)
 
         # ------------------------------------------------------------
         # Configurator
@@ -740,7 +740,7 @@ class IrModuleModule(models.Model):
     def _generate_primary_page_templates(self):
         """ Generates page templates based on manifest entries. """
         View = self.env['ir.ui.view']
-        manifest = get_manifest(self.name)
+        manifest = Manifest.for_addon(self.name)
         templates = manifest['new_page_templates']
 
         # TODO Find a way to create theme and other module's template patches

--- a/addons/website/tests/test_views.py
+++ b/addons/website/tests/test_views.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from hashlib import sha256
-import copy
 import json
 import unittest
 from unittest.mock import patch
@@ -10,7 +9,7 @@ from lxml import etree as ET, html
 from lxml.html import builder as h
 
 from odoo.exceptions import MissingError
-from odoo.modules.module import _DEFAULT_MANIFEST
+from odoo.modules.module import _DEFAULT_MANIFEST, Manifest
 from odoo.tests import common, HttpCase, tagged
 
 
@@ -1519,7 +1518,7 @@ class TestThemeViews(common.TransactionCase):
         main_view.with_context(website_id=website_1.id).arch = '<body>specific</body>'
 
         # 2. Simulate a theme install with a child view of `main_view`
-        patcher = patch('odoo.modules.module._get_manifest_cached', return_value=copy.deepcopy(_DEFAULT_MANIFEST))
+        patcher = patch('odoo.modules.Manifest.for_addon', return_value=Manifest(path='/dummy/test_theme', manifest_content=_DEFAULT_MANIFEST))
         self.startPatcher(patcher)
         test_theme_module = self.env['ir.module.module'].create({'name': 'test_theme'})
         self.env['ir.model.data'].create({

--- a/odoo/addons/base/models/ir_qweb.py
+++ b/odoo/addons/base/models/ir_qweb.py
@@ -389,7 +389,7 @@ from psycopg2.extensions import TransactionRollbackError
 from pathlib import Path
 
 from odoo import api, models, tools
-from odoo.modules import get_module_path
+from odoo.modules import Manifest
 from odoo.modules.registry import _REGISTRY_CACHES
 from odoo.tools import config, safe_eval, OrderedSet
 from odoo.tools.constants import SUPPORTED_DEBUGGER, EXTERNAL_ASSET
@@ -657,7 +657,8 @@ class IrQweb(models.AbstractModel):
         if isinstance(template, etree._Element):
             self = self.with_context(is_t_cache_disabled=True)
         elif isinstance(template, str) and template.endswith('.xml'):
-            if 'templates' not in Path(file_path(template)).relative_to(get_module_path(Path(template).parts[0])).parts:
+            module_path = Manifest.for_addon(Path(template).parts[0]).path
+            if 'templates' not in Path(file_path(template)).relative_to(module_path).parts:
                 raise ValueError("The templates file %s must be under a subfolder 'templates' of a module", template)
             else:
                 with file_open(template, 'rb', filter_ext=('.xml',)) as file:

--- a/odoo/addons/base/tests/test_module.py
+++ b/odoo/addons/base/tests/test_module.py
@@ -63,6 +63,7 @@ class TestModuleManifest(BaseCase):
             'post_load': '',
             'pre_init_hook': '',
             'sequence': 100,
+            'static_path': None,
             'summary': '',
             'test': [],
             'update_xml': [],

--- a/odoo/addons/test_lint/tests/lint_case.py
+++ b/odoo/addons/test_lint/tests/lint_case.py
@@ -2,11 +2,10 @@ import ast
 import fnmatch
 import os
 from collections.abc import Iterable
+from os.path import join as opj
 from typing import Generic, TypeVar
 
-j = os.path.join
-
-from odoo.modules import get_modules, get_module_path
+from odoo.modules import Manifest
 from odoo.tests import BaseCase
 
 
@@ -18,9 +17,13 @@ class LintCase(BaseCase):
         """ Yields the paths of all the module files matching the provided globs
         (AND-ed)
         """
-        for modroot in map(get_module_path, modules or get_modules()):
+        if modules is None:
+            module_roots = [m.path for m in Manifest.all_addon_manifests()]
+        else:
+            module_roots = [m.path for name in modules if (m := Manifest.for_addon(name))]
+        for modroot in module_roots:
             for root, _, fnames in os.walk(modroot):
-                fnames = [j(root, n) for n in fnames]
+                fnames = [opj(root, n) for n in fnames]
                 for glob in globs:
                     fnames = fnmatch.filter(fnames, glob)
                 yield from fnames

--- a/odoo/addons/test_lint/tests/test_dunderinit.py
+++ b/odoo/addons/test_lint/tests/test_dunderinit.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import logging
 from pathlib import Path
 
-from odoo.modules import get_modules, get_module_path
+from odoo.modules import Manifest
 from . import lint_case
 
 _logger = logging.getLogger(__name__)
@@ -12,14 +11,15 @@ _logger = logging.getLogger(__name__)
 # whitelist that allow data modules only
 WHITELIST = ['test_data_module', ]
 
+
 class TestDunderinit(lint_case.LintCase):
 
     def test_dunderinit(self):
         """ Test that __init__.py exists in Odoo modules, otherwise they won't get packaged"""
 
-        modules_list = [mod for mod in get_modules() if mod not in WHITELIST]
+        modules_list = [mod for mod in Manifest.all_addon_manifests() if mod.name not in WHITELIST]
         for mod in modules_list:
-            dunderinit_path = Path(get_module_path(mod)) / '__init__.py'
+            dunderinit_path = Path(mod.path) / '__init__.py'
             self.assertTrue(dunderinit_path.is_file(), "Missing `__init__.py ` in module %s" % mod)
 
         _logger.info('%s modules checked', len(modules_list))

--- a/odoo/addons/test_lint/tests/test_orm_import.py
+++ b/odoo/addons/test_lint/tests/test_orm_import.py
@@ -3,7 +3,7 @@
 import logging
 from pathlib import Path
 
-from odoo.modules import get_modules, get_module_path
+from odoo.modules import Manifest
 from . import lint_case
 import re
 _logger = logging.getLogger(__name__)
@@ -16,8 +16,8 @@ class TestDunderinit(lint_case.LintCase):
     def test_addons_orm_import(self):
         """ Test that odoo.orm is not imported in Odoo modules"""
 
-        for module in get_modules():
-            module_path = Path(get_module_path(module))
+        for manifest in Manifest.all_addon_manifests():
+            module_path = Path(manifest.path)
             for path in module_path.rglob("**/*.py"):
                 for line in path.read_text().splitlines():
                     if import_orm_re.match(line):

--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
 import os
@@ -13,7 +12,7 @@ except ImportError:
 import subprocess
 
 from odoo import tools
-from odoo.modules import get_modules, get_module_path
+from odoo.modules import Manifest
 from odoo.tests import TransactionCase
 from odoo.tools.which import which
 
@@ -37,8 +36,8 @@ class TestPyLint(TransactionCase):
             self._skip_test('please upgrade pylint to >= %s' % required_pylint_version)
 
         paths = {tools.config.root_path}
-        for module in get_modules():
-            module_path = get_module_path(module)
+        for manifest in Manifest.all_addon_manifests():
+            module_path = manifest.path
             if module_path.startswith(join(tools.config.root_path, 'addons')):
                 continue
             paths.add(module_path)

--- a/odoo/addons/test_lint/tests/test_test_holes.py
+++ b/odoo/addons/test_lint/tests/test_test_holes.py
@@ -5,7 +5,7 @@ import unittest.mock
 from collections import Counter
 
 from odoo.addons.test_lint.tests.lint_case import LintCase
-from odoo.modules import get_module_path, get_modules
+from odoo.modules import Manifest
 
 
 class InitChecker(ast.NodeVisitor):
@@ -44,9 +44,9 @@ class TestTestHoles(LintCase):
         checker = InitChecker()
 
         errors = []
-        for modroot in map(get_module_path, get_modules()):
+        for manifest in Manifest.all_addon_manifests():
             checker.names.clear()
-            p = checker.path = pathlib.Path(modroot, 'tests')
+            p = checker.path = pathlib.Path(manifest.path, 'tests')
             if not p.exists():
                 continue
 

--- a/odoo/cli/start.py
+++ b/odoo/cli/start.py
@@ -5,7 +5,7 @@ import sys
 
 from . import Command
 from .server import main
-from odoo.modules.module import get_module_root, MANIFEST_NAMES
+from odoo.modules.module import Manifest, MANIFEST_NAMES
 from odoo.service.db import _create_empty_database, DatabaseExists
 from odoo.tools import config
 
@@ -33,9 +33,8 @@ class Start(Command):
         if args.path == '.' and os.environ.get('VIRTUAL_ENV'):
             args.path = os.environ.get('VIRTUAL_ENV')
         project_path = os.path.abspath(os.path.expanduser(os.path.expandvars(args.path)))
-        module_root = get_module_root(project_path)
         db_name = None
-        if module_root:
+        if is_path_in_module(project_path):
             # started in a module so we choose this module name for database
             db_name = project_path.split(os.path.sep)[-1]
             # go to the parent's directory of the module root
@@ -70,3 +69,13 @@ class Start(Command):
                    if not to_remove(i, cmdargs)]
 
         main(cmdargs)
+
+
+def is_path_in_module(path):
+    old_path = None
+    while path != old_path:
+        if Manifest._from_path(path):
+            return True
+        old_path = path
+        path, _ = os.path.split(path)
+    return False

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -195,7 +195,7 @@ try:
 except ImportError:
     from .tools._vendor.send_file import send_file as _send_file
 
-import odoo
+import odoo.addons
 from .exceptions import UserError, AccessError, AccessDenied
 from .modules import module as module_manager
 from .modules.registry import Registry
@@ -2484,14 +2484,10 @@ class Application:
         system.
         """
         mod2path = {}
-        for addons_path in odoo.addons.__path__:
-            for module in os.listdir(addons_path):
-                manifest = module_manager.get_manifest(module)
-                static_path = opj(addons_path, module, 'static')
-                if (manifest
-                        and (manifest['installable'] or manifest['assets'])
-                        and os.path.isdir(static_path)):
-                    mod2path[module] = static_path
+        for manifest in module_manager.Manifest.all_addon_manifests():
+            static_path = opj(manifest.path, 'static')
+            if (manifest['installable'] or manifest['assets']) and os.path.isdir(static_path):
+                mod2path[manifest.name] = static_path
         return mod2path
 
     def get_static_file(self, url, host=''):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -2060,7 +2060,9 @@ class Request:
         """ Serve a static file from the file system. """
         module, _, path = self.httprequest.path[1:].partition('/static/')
         try:
-            directory = root.statics[module]
+            directory = root.static_path(module)
+            if not directory:
+                raise NotFound(f'Module "{module}" not found.\n')
             filepath = werkzeug.security.safe_join(directory, path)
             debug = (
                 'assets' in self.session.debug and
@@ -2072,8 +2074,6 @@ class Request:
             )
             root.set_csp(res)
             return res
-        except KeyError:
-            raise NotFound(f'Module "{module}" not found.\n')
         except OSError:  # cover both missing file and invalid permissions
             raise NotFound(f'File "{path}" not found in module {module}.\n')
 
@@ -2477,18 +2477,13 @@ class Application:
         from odoo.service.server import load_server_wide_modules  # noqa: PLC0415
         load_server_wide_modules()
 
-    @functools.cached_property
-    def statics(self):
+    def static_path(self, module_name: str) -> str | None:
         """
         Map module names to their absolute ``static`` path on the file
         system.
         """
-        mod2path = {}
-        for manifest in module_manager.Manifest.all_addon_manifests():
-            static_path = opj(manifest.path, 'static')
-            if (manifest['installable'] or manifest['assets']) and os.path.isdir(static_path):
-                mod2path[manifest.name] = static_path
-        return mod2path
+        manifest = module_manager.Manifest.for_addon(module_name, display_warning=False)
+        return manifest.static_path if manifest is not None else None
 
     def get_static_file(self, url, host=''):
         """
@@ -2512,11 +2507,15 @@ class Application:
         if ((netloc and netloc != host) or (path_netloc and path_netloc != host)):
             return None
 
-        if (module not in self.statics or static != 'static' or not resource):
+        if not (static == 'static' and resource):
+            return None
+
+        static_path = self.static_path(module)
+        if not static_path:
             return None
 
         try:
-            return file_path(f'{module}/static/{resource}')
+            return file_path(opj(static_path, resource))
         except FileNotFoundError:
             return None
 

--- a/odoo/modules/__init__.py
+++ b/odoo/modules/__init__.py
@@ -10,10 +10,8 @@ from . import db  # used directly during some migration scripts
 
 from . import module
 from .module import (
-    MissingDependency,
+    Manifest,
     adapt_version,
-    check_manifest_dependencies,
-    check_version,
     get_module_path,
     get_modules,
     get_modules_with_version,

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -217,15 +217,23 @@ class Manifest(Mapping[str, typing.Any]):
     def icon(self) -> str:
         return get_module_icon(self.name)
 
+    @functools.cached_property
+    def static_path(self) -> str | None:
+        static_path = opj(self.path, 'static')
+        manifest = self.manifest_cached
+        if (manifest['installable'] or manifest['assets']) and os.path.isdir(static_path):
+            return static_path
+        return None
+
     def __getitem__(self, key: str):
-        if key in ('description', 'icon', 'addons_path', 'version'):
+        if key in ('description', 'icon', 'addons_path', 'version', 'static_path'):
             return getattr(self, key)
         return copy.deepcopy(self.manifest_cached[key])
 
     def __iter__(self):
         manifest = self.manifest_cached
         yield from manifest
-        for key in ('description', 'icon', 'addons_path', 'version'):
+        for key in ('description', 'icon', 'addons_path', 'version', 'static_path'):
             if key not in manifest:
                 yield key
 

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -376,8 +376,12 @@ def get_resource_from_path(path: str) -> tuple[str, str, str] | None:
 
 
 def get_module_icon(module: str) -> str:
-    fpath = f"{module}/static/description/icon.png"
+    """ Get the path to the module's icon. Invalid module names are accepted. """
+    manifest = Manifest.for_addon(module, display_warning=False)
+    if manifest and 'icon' in manifest.__dict__:
+        return manifest.icon
     try:
+        fpath = f"{module}/static/description/icon.png"
         tools.file_path(fpath)
         return "/" + fpath
     except FileNotFoundError:

--- a/odoo/modules/module_graph.py
+++ b/odoo/modules/module_graph.py
@@ -11,10 +11,10 @@ import typing
 from odoo.tools import reset_cached_properties, OrderedSet
 from odoo.tools.sql import column_exists
 
-from .module import _get_manifest_cached
+from .module import Manifest
 
 if typing.TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Iterator
+    from collections.abc import Collection, Iterable, Iterator, Mapping
     from typing import Literal
     from odoo.sql_db import BaseCursor
 
@@ -143,7 +143,10 @@ class ModuleNode:
         self.name: str = name
         # for performance reasons, use the cached value to avoid deepcopy; it is
         # acceptable in this context since we don't modify it
-        self.manifest: dict = _get_manifest_cached(name)
+        manifest = Manifest.for_addon(name)
+        if manifest is not None:
+            manifest.manifest_cached  # parse the manifest now
+        self.manifest: Mapping = manifest or {}
 
         # ir_module_module data                     # column_name
         self.id: int = 0                            # id

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1767,8 +1767,9 @@ def get_po_paths(module_name: str, lang: str, env: Environment | None = None) ->
 
 
 def get_datafile_translation_path(module_name: str, env: Environment | None = None) -> Iterator[str]:
-    from odoo.modules import get_manifest  # noqa: PLC0415
-    manifest = get_manifest(module_name)
+    from odoo.modules import Manifest  # noqa: PLC0415
+    # if we are importing a module, we have an env, hide warnings
+    manifest = Manifest.for_addon(module_name, downloaded=True, display_warning=env is None) or {}
     for data_type in ('data', 'demo'):
         for path in manifest.get(data_type, ()):
             if path.endswith(('.xml', '.csv')):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Some manifest keys are not necessary, but quite costly costly: description in README file, icon file, etc.
- The first time a static path is accessed, the controller determines **all** static paths using manifests.

For this, we add a new class for manifest files.
- The manifests' cache was already here and still is.
- Add lazy evaluation for costly manifest keys.
- Stop listing all modules at normal startup, and resolve static paths on demand (loading only the required manifest).
- base_import_module uses the Manifest class for parsing.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
