### PR TITLE
[FIX] account: fix error when opening duplicated Profit and Loss reports

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -543,7 +543,7 @@ class AccountReportExpression(models.Model):
 
     report_line_id = fields.Many2one(string="Report Line", comodel_name='account.report.line', required=True, ondelete='cascade')
     report_line_name = fields.Char(string="Report Line Name", related="report_line_id.name")
-    label = fields.Char(string="Label", required=True)
+    label = fields.Char(string="Label", required=True, copy=True)
     engine = fields.Selection(
         string="Computation Engine",
         selection=[
@@ -709,10 +709,6 @@ class AccountReportExpression(models.Model):
                         self.env['account.account.tag'].create(tag_vals)
 
         return result
-
-    def copy_data(self, default=None):
-        vals_list = super().copy_data(default=default)
-        return [dict(vals, label=self.env._("%s (copy)", expression.label)) for expression, vals in zip(self, vals_list)]
 
     @api.ondelete(at_uninstall=False)
     def _unlink_archive_used_tags(self):


### PR DESCRIPTION
**Issue**
Duplicated Profit and Loss reports fail to open and raise an "invalid operation" error when accessed.

**Steps to Reproduce**
1. Install the Accounting module and French localization.
2. Go to Accounting > Configuration > Accounting > Accounting Reports.
3. Duplicate the "Profit and Loss (2024)" report.
4. Navigate to Accounting > Reporting > Profit and Loss.
5. Attempt to open the duplicated report.
6. An error occurs.

**Root Cause**
During duplication, the label field of expressions is altered to include a " (copy)" suffix. Some formula expressions rely on exact label matches (e.g., i_1_2024.balance), so when "balance" becomes "balance (copy)", the lookup fails. This mismatch causes a KeyError when resolving subformulas like line_code.balance, breaking the report evaluation.

**Fix**
Prevent the duplication process from altering the label of expressions. There is no functional need to add " (copy)" to these internal labels, as they are not user-facing and must remain stable for formula resolution to work.

Opw-4826749
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
