### PR TITLE
[FIX] html_builder, website: fix isApplied on composite actions

### DIFF
--- a/addons/html_builder/static/src/core/composite_action_plugin.js
+++ b/addons/html_builder/static/src/core/composite_action_plugin.js
@@ -67,7 +67,7 @@ export class CompositeActionPlugin extends Plugin {
                     results.push(action.isApplied(actionDescr));
                 }
             }
-            return results.every((result) => result);
+            return !!results.length && results.every((result) => result);
         },
         load: async ({ editingElement, params: { mainParam: actions }, value }) => {
             const loadActions = [];

--- a/addons/website/static/tests/builder/composite_action.test.js
+++ b/addons/website/static/tests/builder/composite_action.test.js
@@ -7,6 +7,9 @@ import {
     setupHTMLBuilder,
 } from "@html_builder/../tests/helpers";
 
+// TODO: test composite with each spec: prepare, load, getValue
+// TODO: test reloadComposite
+
 describe.current.tags("desktop");
 test("can call 2 separate actions with composite action", async () => {
     addBuilderAction({
@@ -90,5 +93,67 @@ test("can call the same action twice with composite action", async () => {
     expect.verifySteps(["action1: class1", "action1: class2"]); // clean
 });
 
-// TODO: test composite with each spec: prepare, load, getValue, isApplied
-// TODO: test reloadComposite
+test("composite action's isApplied returns false if no action defined it", async () => {
+    addBuilderAction({
+        action1: {
+            apply: ({ params: { mainParam: cls } }) => {
+                expect.step(`action: ${cls}`);
+            },
+        },
+    });
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
+            <BuilderButton
+                    action="'composite'"
+                    actionParam="[
+                        { action: 'action1', actionParam: { mainParam: 'class1' } },
+                        { action: 'action1', actionParam: { mainParam: 'class2' } },
+                    ]">
+                Click
+            </BuilderButton>`,
+    });
+    await setupHTMLBuilder(`<section class="s_test">Test</section>`);
+    await contains(":iframe .s_test").click();
+    expect("[data-action-id='composite'").not.toHaveClass("active");
+    await contains("[data-action-id='composite']").click();
+    expect("[data-action-id='composite'").not.toHaveClass("active");
+    expect.verifySteps([
+        "action: class1", // preview
+        "action: class2", // preview
+        "action: class1", // apply
+        "action: class2", // apply
+    ]);
+});
+test("composite action's isApplied returns true if at least one action defined it", async () => {
+    addBuilderAction({
+        action1: {
+            apply: () => {},
+        },
+        action2: {
+            isApplied: ({ editingElement, params: { mainParam: cls } }) => {
+                return editingElement.classList.contains(cls);
+            },
+            apply: ({ editingElement, params: { mainParam: cls } }) => {
+                editingElement.classList.add(cls);
+            },
+        },
+    });
+    addBuilderOption({
+        selector: ".s_test",
+        template: xml`
+            <BuilderButton
+                    action="'composite'"
+                    actionParam="[
+                        { action: 'action1', actionParam: { mainParam: 'class1' } },
+                        { action: 'action2', actionParam: { mainParam: 'class2' } },
+                    ]">
+                Click
+            </BuilderButton>`,
+    });
+    await setupHTMLBuilder(`<section class="s_test">Test</section>`);
+    await contains(":iframe .s_test").click();
+    expect("[data-action-id='composite'").not.toHaveClass("active");
+    await contains("[data-action-id='composite']").click();
+    expect("[data-action-id='composite'").toHaveClass("active");
+});


### PR DESCRIPTION
When none of the actions of a composite action had defined `isApplied`, the composite action would always be active. This commit fixes this and adds 2 tests.

This PR follows [the refactor into html_builder].

[the refactor into html_builder]: 9fe45e2b7ddb

Related to task-4367641