### PR TITLE
[FIX] marketing_card: don't translate robots.txt

### DIFF
--- a/addons/marketing_card/i18n/marketing_card.pot
+++ b/addons/marketing_card/i18n/marketing_card.pot
@@ -897,13 +897,6 @@ msgid "Update Cards"
 msgstr ""
 
 #. module: marketing_card
-#: model_terms:ir.ui.view,arch_db:marketing_card.robots
-msgid ""
-"User-agent: *\n"
-"                Allow: /cards/"
-msgstr ""
-
-#. module: marketing_card
 #: model:ir.model.fields.selection,name:marketing_card.selection__card_card__share_status__visited
 #: model_terms:ir.ui.view,arch_db:marketing_card.card_card_view_search
 msgid "Visited"

--- a/addons/marketing_card/views/website_templates.xml
+++ b/addons/marketing_card/views/website_templates.xml
@@ -2,8 +2,10 @@
     <data>
         <template id="robots" inherit_id="website.robots">
             <xpath expr="//t[@t-out='request.website.sudo().robots_txt']" position="before">
-                User-agent: *
-                Allow: /cards/
+<t t-translation="off">
+User-agent: *
+Allow: /cards/
+</t>
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Set up a site in Dutch;
2. go to `/nl/robots.txt`

Issue
-----
File shows "Toestaan: /kaarten/", which is not a valid string for a robots.txt file.

This section is also oddly indented.

Cause
-----
Inserting the additional text in a template override does not inherit the parent view's `t-translation="off"` setting.

Solution
--------
Add `t-translation="off"` to the template override, and ensure there's no indentation when generating the file.

opw-4815818