### PR TITLE
[FIX] html_builder, website: fix snippets preview text highlights

### DIFF
--- a/addons/html_builder/static/src/snippets/snippet_service.js
+++ b/addons/html_builder/static/src/snippets/snippet_service.js
@@ -158,7 +158,7 @@ export class SnippetModel extends Reactive {
                 snippetModel: this,
                 selectSnippet: (...args) => {
                     const newSnippetEl = onSelect(...args);
-                    this.cleanSnippetPreview(newSnippetEl);
+                    this.updateSnippetContent(newSnippetEl);
                 },
             },
             { onClose }
@@ -344,7 +344,7 @@ export class SnippetModel extends Reactive {
      *
      * @param {HTMLElement} snippetEl
      */
-    cleanSnippetPreview(snippetEl) {
+    updateSnippetContent(snippetEl) {
         snippetEl.querySelectorAll(".s_dialog_preview").forEach((el) => el.remove());
     }
 

--- a/addons/website/static/src/builder/snippet_model.js
+++ b/addons/website/static/src/builder/snippet_model.js
@@ -1,0 +1,16 @@
+import { SnippetModel } from "@html_builder/snippets/snippet_service";
+import { applyTextHighlight } from "@website/js/highlight_utils";
+import { patch } from "@web/core/utils/patch";
+
+patch(SnippetModel.prototype, {
+    /**
+     * @override
+     */
+    updateSnippetContent(snippetEl) {
+        super.updateSnippetContent(...arguments);
+        // Build the highlighted text content for new added snippets.
+        for (const textEl of snippetEl?.querySelectorAll(".o_text_highlight") || []) {
+            applyTextHighlight(textEl);
+        }
+    },
+});

--- a/addons/website/static/src/js/highlight_utils.js
+++ b/addons/website/static/src/js/highlight_utils.js
@@ -252,18 +252,23 @@ export function makeHighlightSvgs(highlightEl, highlightID) {
     const numberOfCharPerWidth = memoize((width) => Math.round(width / sizePerChar()));
 
     const containerRect = highlightEl.getBoundingClientRect();
+    // Note: We cannot use `getClientRects()` as we want to be able to draw
+    // text highlights in the snippet/page dialogs where iframe is scaled.
+    const inPreviewIframe =
+        highlightEl.ownerDocument.documentElement.classList.contains("o_add_snippets_preview");
+    const scale = inPreviewIframe ? highlightEl.offsetWidth / containerRect.width : 1;
     const firstRect = highlightEl.getClientRects()[0];
     const svgs = [];
     for (const rects of finalRects) {
         const svg = makeHighlightSvg(highlightID || getCurrentTextHighlight(highlightEl), {
-            width: rects.width,
-            height: rects.height,
+            width: rects.width * scale,
+            height: rects.height * scale,
             numberOfCharPerWidth,
         });
         svgs.push(svg);
         const spanOffset = firstRect.x - containerRect.x;
-        svg.style.left = `${rects.x - containerRect.x - spanOffset}px`;
-        svg.style.top = `${rects.y - containerRect.y}px`;
+        svg.style.left = `${(rects.x - containerRect.x - spanOffset) * scale}px`;
+        svg.style.top = `${(rects.y - containerRect.y) * scale}px`;
         svg.style.bottom = `0px`;
         svg.style.right = `0px`;
     }
@@ -327,9 +332,6 @@ export function makeHighlightSvg(highlightID, params) {
  */
 function drawPath(options) {
     const { width, height, numberOfCharPerWidth } = options;
-    // Note: cannot use getBoundingClientRect as we want to be able to draw
-    // text highlights in snippets/add page dialogs where iframe is scaled.
-    options = { ...options, width, height };
     const yStart = options.position === "center" ? height / 2 : height;
 
     switch (options.mode) {


### PR DESCRIPTION
Steps to reproduce:

1. Go to Website and install a theme with snippets that already has text
highlight effects (e.g., `Monglia` > `s_company_team_shapes`).

2. Try to add a `s_company_team_shapes` snippet from the dialog.

3. The highlights are not added correctly on the text of the snippet.

4. Click on the snippet, and it will be added with no highlights.

Starting from [1], snippets with highlights were available by default in
the snippet preview dialog.

A fix from [1] allowed to take into consideration the CSS scale from
the preview iframe that affects SVG computation of the highlight
(by using the `offsetWidth/Height` instead of the
`getBoundingClientRect()` values).

After [2], the "text highlights" main code was adapted to create an SVG
effect on each text line using `getClientRects()` of the selected range.

The goal of this commit is to restore the fix from [1] by applying the
size scale when the targeted element is in the preview iframe.

This commit also adds back the code that applies highlights on new
snippets and allows tracking their changes (from the legacy
`AddSnippetDialog` code).

[1]:https://github.com/odoo/odoo/commit/4a29fa66003ce1f42a7011bc56fc019f34a887f5
[2]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2