### PR TITLE
[FIX] hr_expense: show correct currency on expense report

### DIFF
--- a/addons/hr_expense/report/hr_expense_report.xml
+++ b/addons/hr_expense/report/hr_expense_report.xml
@@ -72,16 +72,16 @@
                                     <tbody>
                                         <tr>
                                             <td>Untaxed Amount</td>
-                                            <td class="text-end"><span t-field="o.untaxed_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$500.00</span></td>
+                                            <td class="text-end"><span t-field="o.untaxed_amount" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>$500.00</span></td>
                                         </tr>
                                         <tr>
                                             <td>Taxes</td>
-                                            <td class="text-end"><span t-field="o.tax_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$100.00</span></td>
+                                            <td class="text-end"><span t-field="o.tax_amount" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>$100.00</span></td>
                                         </tr>
                                         <tr class="fw-bold">
                                             <td>Total</td>
                                             <td class="text-end">
-                                                <span t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.currency_id}'>$600.00</span>
+                                                <span t-field="o.total_amount" t-options='{"widget": "monetary", "display_currency": o.company_currency_id}'>$600.00</span>
                                             </td>
                                         </tr>
                                     </tbody>


### PR DESCRIPTION
Current behavior before PR: When print an expense report with different company currency, the currency it's displayed incorrectly [bug](https://drive.google.com/file/d/1GWjcIGA_czPpl44QAORN6vj6hLcMOYhF/view?usp=sharing)

[Related ticket](https://www.odoo.com/odoo/project/49/tasks/4807756)

Description of the issue/feature this PR addresses: Update widget currency symbol

Desired behavior after PR is merged: The report will show the correct symbol depending on the currencies used for the expense

fixed versions:

saas-18.2
saas-18.3
master 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
