### PR TITLE
Update es.po

### DIFF
--- a/addons/website/i18n/es.po
+++ b/addons/website/i18n/es.po
@@ -941,7 +941,7 @@ msgid ""
 "<span class=\"s_blockquote_author\"><b>Iris DOE</b> • CEO of "
 "MyCompany</span>"
 msgstr ""
-"<span class=\"s_blockquote_author\"b>Iris DOE</b> • CEO de MyCompany</span>"
+"<span class=\"s_blockquote_author\"><b>Iris DOE</b> • CEO de MyCompany</span>"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_quotes_carousel
@@ -949,7 +949,7 @@ msgid ""
 "<span class=\"s_blockquote_author\"><b>Jane DOE</b> • CEO of "
 "MyCompany</span>"
 msgstr ""
-"<span class=\"s_blockquote_author\"b>Jane DOE</b> • CEO de MyCompany</span>"
+"<span class=\"s_blockquote_author\"><b>Jane DOE</b> • CEO de MyCompany</span>"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_blockquote
@@ -958,7 +958,7 @@ msgid ""
 "<span class=\"s_blockquote_author\"><b>John DOE</b> • CEO of "
 "MyCompany</span>"
 msgstr ""
-"<span class=\"s_blockquote_author\"b>John DOE</b> • CEO de MyCompany</span>"
+"<span class=\"s_blockquote_author\"><b>John DOE</b> • CEO de MyCompany</span>"
 
 #. module: website
 #: model_terms:ir.ui.view,arch_db:website.s_comparisons


### PR DESCRIPTION
Fix malformed <span> tags in Spanish translations of s_quotes_carousel Some Spanish translations in website.s_quotes_carousel were missing the closing > in the <span> tag, resulting in invalid HTML and XPath failures when extending the view. This fix corrects the malformed tags to ensure proper rendering and compatibility with inherited views.

Description of the issue/feature this PR addresses:
Some Spanish translations of the website.s_quotes_carousel view had malformed HTML. Specifically, the <span> tags for the blockquote author were missing the closing >, which caused rendering issues and made XPath expressions fail when trying to inherit the view.

Current behavior before PR:
The malformed tags break the HTML structure in the translated view and prevent proper extension using XPath.

Desired behavior after PR is merged:
Translations include correctly formed <span> tags, restoring valid HTML and allowing view inheritance via XPath as expected.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
