### PR TITLE
[FIX] html_editor: prevent text toolbar from appearing on image click

### DIFF
--- a/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
+++ b/addons/html_editor/static/src/main/toolbar/toolbar_plugin.js
@@ -275,7 +275,9 @@ export class ToolbarPlugin extends Plugin {
     getFilterTraverseNodes() {
         return this.dependencies.selection
             .getTraversedNodes()
-            .filter((node) => !isTextNode(node) || (node.textContent !== "\n" && !isZWS(node)));
+            .filter(
+                (node) => !isTextNode(node) || (node.textContent.trim().length && !isZWS(node))
+            );
     }
 
     updateToolbarVisibility(selectionData) {

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -692,6 +692,24 @@ test("toolbar does not evaluate isActive when namespace does not match", async (
     expect.verifySteps(["image format evaluated"]);
 });
 
+test("toolbar should open with image namespace the selection spans an image and whitespace", async () => {
+    const { el } = await setupEditor(`<p>[abc]</p>`);
+    await waitFor(".o-we-toolbar");
+    expect(".o-we-toolbar").toHaveCount(1);
+    expect(queryAll(".o-we-toolbar .btn-group[name='font']").length).toBe(1);
+    expect(queryAll(".o-we-toolbar .btn-group[name='decoration']").length).toBe(1);
+    setContent(
+        el,
+        `<p>[
+            <img>
+        ]</p>`
+    );
+    await animationFrame();
+    await waitFor(".o-we-toolbar");
+    expect(queryAll(".o-we-toolbar .btn-group[name='font']").length).toBe(0);
+    expect(queryAll(".o-we-toolbar .btn-group[name='decoration']").length).toBe(0);
+});
+
 test("plugins can create buttons with text in toolbar", async () => {
     class TestPlugin extends Plugin {
         static id = "TestPlugin";


### PR DESCRIPTION
Current behavior before PR:

- Clicking an image inside `<div class="o-paragraph">` opened the text toolbar. This is because the selection traversed a whitespace text node that was not filtered out.

Desired behavior after PR is merged:

- This fix filters out such nodes to show the correct (image) toolbar.

task-4844821



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
