### PR TITLE
[IMP] hr_holidays: remove expand button time off overview

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -12,7 +12,7 @@
                 quick_create="0"
                 color="employee_id"
                 event_open_popup="True"
-                js_class="time_off_calendar"
+                js_class="time_off_report_calendar"
                 show_unusual_days="True">
                 <field name="name"/>
                 <field name="employee_id" filters="1" invisible="1"/>

--- a/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_controller.js
@@ -84,7 +84,7 @@ export class TimeOffCalendarController extends CalendarController {
         this._deleteRecord(record.id, record.rawRecord.can_cancel);
     }
 
-    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
+    _editRecord(record, context, props = {}) {
         const onDialogClosed = () => {
             this.model.load();
             this.env.timeOffBus.trigger("update_dashboard");
@@ -94,6 +94,7 @@ export class TimeOffCalendarController extends CalendarController {
             this.displayDialog(
                 TimeOffFormViewDialog,
                 {
+                    ...props,
                     resModel: this.model.resModel,
                     resId: record.id || false,
                     context,
@@ -107,5 +108,15 @@ export class TimeOffCalendarController extends CalendarController {
                 { onClose: () => resolve() }
             );
         });
+    }
+
+    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
+        return this._editRecord(record, context)
+    }
+}
+
+export class TimeOffReportCalendarController extends TimeOffCalendarController {
+    async editRecord(record, context = {}, shouldFetchFormViewId = true) {
+        return this._editRecord(record, context, {canExpand: false})
     }
 }

--- a/addons/hr_holidays/static/src/views/calendar/calendar_view.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_view.js
@@ -1,6 +1,6 @@
 import { calendarView } from '@web/views/calendar/calendar_view';
 
-import { TimeOffCalendarController } from './calendar_controller';
+import { TimeOffCalendarController, TimeOffReportCalendarController } from './calendar_controller';
 import { TimeOffCalendarModel } from './calendar_model';
 import { TimeOffCalendarRenderer, TimeOffDashboardCalendarRenderer } from './calendar_renderer';
 
@@ -19,3 +19,7 @@ registry.category('views').add('time_off_calendar_dashboard', {
     ...TimeOffCalendarView,
     Renderer: TimeOffDashboardCalendarRenderer,
 });
+registry.category('views').add('time_off_report_calendar', {
+    ...TimeOffCalendarView,
+    Controller: TimeOffReportCalendarController,
+})


### PR DESCRIPTION
This commit removes the expand button on the form dialog of the time off overview. The expand button is not necessary as axpanding the dialog shows exactly the same information.

task-4784553

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
