### PR TITLE
 [FIX] mail: hide link preview delete button for users without delete access

### DIFF
--- a/addons/mail/static/src/core/common/link_preview.js
+++ b/addons/mail/static/src/core/common/link_preview.js
@@ -14,7 +14,7 @@ import { useService } from "@web/core/utils/hooks";
  */
 export class LinkPreview extends Component {
     static template = "mail.LinkPreview";
-    static props = ["linkPreview", "delete?", "deleteAll?"];
+    static props = ["linkPreview", "delete?", "deleteAll?", "message?"];
     static components = {};
 
     setup() {

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -78,7 +78,7 @@
     </t>
 
     <t t-name="mail.LinkPreview.aside">
-        <div class="position-absolute top-0 end-0 small">
+        <div t-if="props.message?.allowsEdition" class="position-absolute top-0 end-0 small">
             <button t-attf-class="{{ className }}" class="o-mail-LinkPreview-aside btn" aria-label="Remove" t-on-click="onClick">
                 <i class="fa fa-times"/>
             </button>

--- a/addons/mail/static/src/core/common/message_link_preview_list.xml
+++ b/addons/mail/static/src/core/common/message_link_preview_list.xml
@@ -5,11 +5,11 @@
             <div class="d-flex flex-grow-1 flex-wrap">
                 <t t-if="props.messageLinkPreviews.length > 1">
                     <t t-foreach="props.messageLinkPreviews" t-as="messageLinkPreview" t-key="messageLinkPreview.id">
-                        <LinkPreview linkPreview="messageLinkPreview.link_preview_id" delete.bind="messageLinkPreview.hide" deleteAll.bind="messageLinkPreview.message_id.hideAllLinkPreviews"/>
+                        <LinkPreview linkPreview="messageLinkPreview.link_preview_id" delete.bind="messageLinkPreview.hide" deleteAll.bind="messageLinkPreview.message_id.hideAllLinkPreviews" message="messageLinkPreview.message_id"/>
                     </t>
                 </t>
                 <t t-else="">
-                   <LinkPreview linkPreview="props.messageLinkPreviews[0].link_preview_id" delete.bind="props.messageLinkPreviews[0].hide"/>
+                   <LinkPreview linkPreview="props.messageLinkPreviews[0].link_preview_id" delete.bind="props.messageLinkPreviews[0].hide" message="props.messageLinkPreviews[0].message_id"/>
                 </t>
             </div>
         </div>

--- a/addons/mail/static/tests/mock_server/mock_models/res_partner.js
+++ b/addons/mail/static/tests/mock_server/mock_models/res_partner.js
@@ -286,7 +286,11 @@ export class ResPartner extends webModels.ResPartner {
                 data.userId = mainUser ? mainUser.id : false;
                 data.isInternalUser = mainUser ? !mainUser.share : false;
                 if (fields.includes("isAdmin")) {
-                    data.isAdmin = true; // mock server simplification
+                    // mock server simplificationAdd commentMore actions
+                    const users = ResUsers.search([["login", "=", "admin"]]);
+                    data.isAdmin =
+                        this.env.cookie.get("authenticated_user_sid") ===
+                            (Number.isInteger(users?.[0]) ? users?.[0] : users?.[0]?.id) ?? false; // HOOT weirdness: somehow sometimes [0] of search is record, sometimes it's already record id...
                 }
                 if (fields.includes("notification_type")) {
                     data.notification_preference = mainUser.notification_type;


### PR DESCRIPTION
**Current behavior before PR:**

The delete button for link previews was visible to all users, including those who did not have access to delete the preview. When such users attempted to delete a link preview, the confirmation dialog appeared, but no action was taken

**Desired behavior after PR is merged:**

The delete button is only shown to the message author or admin users, ensuring that only users with delete access can see and interact with the button.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
