### PR TITLE
[FIX] spreadsheet: ensure that fixedPeriod is correct

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -68,6 +68,22 @@ migrationStepRegistry.add("18.4.10", {
     },
 });
 
+migrationStepRegistry.add("18.4.11", {
+    migrate(data) {
+        for (const globalFilter of data.globalFilters || []) {
+            if (globalFilter.type === "date" && globalFilter.rangeType === "fixedPeriod") {
+                if (typeof globalFilter.defaultValue !== "string") {
+                    // If the defaultValue is not a string, it's probably a
+                    // something very old that we do not support anymore
+                    // See migration2to3 (antepenultimate_year for example)
+                    delete globalFilter.defaultValue;
+                }
+            }
+        }
+        return data;
+    },
+});
+
 function migrateOdooData(data) {
     const version = data.odooVersion || 0;
     if (version < 1) {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model.test.js
@@ -345,7 +345,7 @@ test("Domain of date filter with month offset on graph field", async function ()
     /** @type GlobalFilter */
     const filter = {
         ...THIS_YEAR_GLOBAL_FILTER,
-        defaultValue: { yearOffset: 0, period: "july" },
+        defaultValue: "this_month",
     };
     await addGlobalFilter(model, filter, {
         chart: { [chartId]: { chain: "date", type: "date", offset: -2 } },

--- a/addons/spreadsheet/static/tests/migrations/migrations.test.js
+++ b/addons/spreadsheet/static/tests/migrations/migrations.test.js
@@ -123,9 +123,9 @@ test("Global filters: date is correctly migrated", () => {
     };
     const migratedData = load(data);
     const [f1, f2, f3] = migratedData.globalFilters;
-    expect(f1.defaultValue).toEqual({ yearOffset: -1 });
-    expect(f2.defaultValue).toEqual({ yearOffset: -2 });
-    expect(f3.defaultValue).toEqual({ yearOffset: 0 });
+    expect(f1.defaultValue).toBe(undefined);
+    expect(f2.defaultValue).toBe(undefined);
+    expect(f3.defaultValue).toBe(undefined);
 });
 
 test("List name default is model name", () => {
@@ -617,4 +617,20 @@ test("text global filter default value is now an array of strings", () => {
     expect(migratedData.globalFilters[1].defaultValue).toBe(undefined);
     expect(migratedData.globalFilters[1].rangeOfAllowedValues).toBe(undefined);
     expect(migratedData.globalFilters[1].rangesOfAllowedValues).toBe(undefined);
+});
+
+test("Date with antepenultimate_year is not supported anymore", () => {
+    const data = {
+        version: "1",
+        globalFilters: [
+            {
+                id: "1",
+                type: "date",
+                defaultValue: { year: "antepenultimate_year" },
+                rangeType: "fixedPeriod",
+            },
+        ],
+    };
+    const migratedData = load(data);
+    expect(migratedData.globalFilters[0].defaultValue).toBe(undefined);
 });


### PR DESCRIPTION
Some migrations (for example `antepenultimate_year`) introduced a fixedPeriod with a yearOffset different from 0, which was not expected by the global filters model. (It worked fine by chance) This commit ensures that the fixedPeriod is always correct when the migration is applied.

Task: 4848233

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
