### PR TITLE
[IMP] account: Add groupby field on the report

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -52,6 +52,16 @@ class AccountReport(models.Model):
     sequence = fields.Integer(string="Sequence")
     active = fields.Boolean(string="Active", default=True)
     line_ids = fields.One2many(string="Lines", comodel_name='account.report.line', inverse_name='report_id')
+    groupby = fields.Char(
+        string="Group By",
+        help="Comma-separated list of fields from account.move.line (Journal Item). \
+            When set, this report will have report lines generating sublines grouped by those keys except when specified on the report line.")
+    user_groupby = fields.Char(
+        string="User Group By",
+        compute='_compute_user_groupby', store=True, readonly=False, precompute=True,
+        help="Comma-separated list of fields from account.move.line (Journal Item). \
+            When set, the report lines will generate sublines grouped by those keys except when specified on the report line.",
+    )
     column_ids = fields.One2many(string="Columns", comodel_name='account.report.column', inverse_name='report_id')
     root_report_id = fields.Many2one(string="Root Report", comodel_name='account.report', index='btree_not_null', help="The report this report is a variant of.")
     variant_report_ids = fields.One2many(string="Variants", comodel_name='account.report', inverse_name='root_report_id')
@@ -229,6 +239,11 @@ class AccountReport(models.Model):
     def _compute_use_sections(self):
         for report in self:
             report.use_sections = bool(report.section_report_ids)
+
+    @api.depends('groupby')
+    def _compute_user_groupby(self):
+        for report in self:
+            report.user_groupby = report.user_groupby or report.groupby
 
     @api.constrains('root_report_id')
     def _validate_root_report_id(self):

--- a/addons/l10n_mx/data/account_report_diot.xml
+++ b/addons/l10n_mx/data/account_report_diot.xml
@@ -4,6 +4,7 @@
         <field name="name">DIOT</field>
         <field name="name@es_419">DIOT</field>
         <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="groupby">partner_id, id</field>
         <field name="filter_show_draft" eval="True"/>
         <field name="filter_period_comparison" eval="False"/>
         <field name="load_more_limit" eval="80"/>
@@ -154,7 +155,6 @@
             <record id="diot_report_line" model="account.report.line">
                 <field name="name">DIOT</field>
                 <field name="name@es_419">DIOT</field>
-                <field name="groupby">partner_id, id</field>
                 <field name="hierarchy_level">0</field>
                 <field name="expression_ids">
                     <record id="tax_report_mx_diot_paid_8_tag" model="account.report.expression">


### PR DESCRIPTION
When using static lines, groupby is defined through 'groupby' field on
account.report.line. When a user wants to customize it(e.g setup
consolidation), it becomes painful as they will need to update each line
one by one.

Since grouping is made on report lines that are often identical for all lines,
Adding a groupby field on the report.

task-4801889



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
