### PR TITLE
[FIX] sale_stock: update sale module

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -63,7 +63,7 @@ class SaleOrder(models.Model):
         UPDATE sale_order so
         SET warehouse_id = COALESCE(wh.id, %s)
         FROM stock_warehouse wh
-        WHERE so.company_id = wh.company_id
+        WHERE so.company_id = wh.company_id and so.warehouse_id IS NULL AND wh.active
         """
         params = [default_warehouse.id]
 


### PR DESCRIPTION
Since [1], `-u sale` will lead to a `write` on the WH of all existing SO, which is of course unexpected

ORM side:
While dealing with `sale` module, we drop the NOT NULL condition of the WH field
https://github.com/odoo/odoo/blob/1c959dee906eba2f881904b06eeccd584f4653c6/odoo/models.py#L2520-L2542
Later, when processing `sale_stock` since there is a difference between the psql column and the orm field (nullable vs required), we call `_init_column`:
https://github.com/odoo/odoo/blob/1c959dee906eba2f881904b06eeccd584f4653c6/odoo/fields.py#L1055-L1060

[1] d794b8da77c54cc257348d46482ae4b948460cc5