### PR TITLE
[FIX] survey: fix button in conditional flow

### DIFF
--- a/addons/survey/models/survey_survey.py
+++ b/addons/survey/models/survey_survey.py
@@ -823,8 +823,8 @@ class SurveySurvey(models.Model):
         A question/page will be determined as the last one if any of the following is true:
           - The survey layout is "one_page",
           - There are no more questions/page after `page_or_question` in `user_input`,
-          - All the following questions are conditional AND were not triggered by previous answers,
-            AND cannot be triggered by any answer given on the current page/question.
+          - All the following questions are conditional AND were not triggered by previous answers.
+            Not accounting for the question/page own conditionals.
         """
         if self.questions_layout == "one_page":
             return True
@@ -834,16 +834,11 @@ class SurveySurvey(models.Model):
         if not next_page_or_question_candidates:
             return True
         inactive_questions = user_input._get_inactive_conditional_questions()
-        __, triggered_questions_by_answer, __ = user_input._get_conditional_values()
         if self.questions_layout == 'page_per_question':
             return not (
                 any(next_question not in inactive_questions for next_question in next_page_or_question_candidates)
-                or any(answer in triggered_questions_by_answer for answer in page_or_question.suggested_answer_ids)
             )
         elif self.questions_layout == 'page_per_section':
-            for question in page_or_question.question_ids:
-                if any(answer in triggered_questions_by_answer for answer in question.suggested_answer_ids):
-                    return False
             for section in next_page_or_question_candidates:
                 if any(next_question not in inactive_questions for next_question in section.question_ids):
                     return False

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -171,6 +171,28 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         const $target = $(event.currentTarget);
         const $choiceItemGroup = $target.closest('.o_survey_form_choice');
 
+        // Update survey button to "continue" if the current page/question is the last (without accounting for
+        // its own conditional questions) but a selected answer is triggering a conditional question on a next page.
+        const surveyLastTriggeringAnswers = this.$('.o_survey_form_content_data').data('surveyLastTriggeringAnswers');
+        if (surveyLastTriggeringAnswers) {
+            const currentSelectedAnswers = Array.from(document.querySelectorAll(`
+                .o_survey_form_choice[data-question-type='simple_choice_radio'] input:checked,
+                .o_survey_form_choice[data-question-type='multiple_choice'] input:checked
+            `)).map((input) => parseInt(input.value));
+            const submitButton = document.querySelector("button[type=submit]");
+            if (currentSelectedAnswers.some((answerId) => surveyLastTriggeringAnswers.includes(answerId))) {
+                // change to continue
+                submitButton.value = "next";
+                submitButton.textContent = _t("Continue");
+                submitButton.classList.replace("btn-secondary", "btn-primary");
+            } else {
+                // change to submit
+                submitButton.value = "finish";
+                submitButton.textContent = _t("Submit");
+                submitButton.classList.replace("btn-primary", "btn-secondary");
+            }
+        }
+
         this._applyCommentAreaVisibility($choiceItemGroup);
         const isQuestionComplete = this._checkConditionalQuestionsConfiguration($target, $choiceItemGroup);
         if (isQuestionComplete && this.options.usersCanGoBack) {

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -54,6 +54,7 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
             self.isStartScreen = self.$el.data('isStartScreen');
             self.isFirstQuestion = self.$el.data('isFirstQuestion');
             self.isLastQuestion = self.$el.data('isLastQuestion');
+            self.surveyLastTriggeringAnswers = self.$el.data('surveyLastTriggeringAnswers');
             // scoring props
             self.isScoredQuestion = self.$el.data('isScoredQuestion');
             self.sessionShowLeaderboard = self.$el.data('sessionShowLeaderboard');
@@ -457,6 +458,16 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
         ).then(function (questionResults) {
             if (questionResults) {
                 self.attendeesCount = questionResults.attendees_count;
+
+                // Update the last question next screen tooltip depending on the selected answers.
+                // Because if a selected answer triggers a conditional question, the last question
+                // may no longer be the last.
+                if (self.surveyLastTriggeringAnswers) {
+                    self.isLastQuestion =
+                        !questionResults.answer_count ||
+                        !self.surveyLastTriggeringAnswers.some(answerId => questionResults.selected_answers.includes(answerId));
+                    self._updateNextScreenTooltip();
+                }
 
                 if (self.resultsChart && questionResults.question_statistics_graph) {
                     self.resultsChart.updateChart(JSON.parse(questionResults.question_statistics_graph));

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -197,6 +197,7 @@
             t-att-data-has-answered="bool(has_answered)"
             t-att-data-is-page-description="bool(question and question.is_page and not is_html_empty(question.description))"
             t-att-data-server-time="server_time"
+            t-att-data-survey-last-triggering-answers="survey_last_triggering_answers"
             t-att-data-timer="timer_start"
             t-att-data-time-limit-minutes="time_limit_minutes"/>
         <t t-if="survey.questions_layout == 'one_page'">

--- a/addons/survey/views/survey_templates_user_input_session.xml
+++ b/addons/survey/views/survey_templates_user_input_session.xml
@@ -96,6 +96,7 @@
             t-att-data-answers-validity="answers_validity"
             t-att-data-is-first-question="is_first_question"
             t-att-data-is-last-question="is_last_question"
+            t-att-data-survey-last-triggering-answers="survey_last_triggering_answers"
             t-att-data-current-screen="'question' if is_scored_question else 'userInputs'"
             t-att-data-show-bar-chart="show_bar_chart"
             t-att-data-show-text-answers="show_text_answers"


### PR DESCRIPTION
Purpose
=======
Fix the survey submit button which is marked "Continue" even though submitting the answers is ending the survey.

Specification
=============
If a question can trigger a conditional question but not necessarily, for example selecting A will trigger another question but selecting B won't, the survey button will be labelled "Continue" no matter what. This can lead to strange behavior when the question is the last of the survey as selecting B and clicking "Continue" will end the survey.

=> Fixing that by updating the survey button label and behavior depending on the selected answers, the potential conditional questions and the survey layout.

In "one_page" layout, the button will always be "Submit" no matter what. The fix isn't applied to this layout.

In "page_per_section", the survey button will be updated to "Submit" if the page selected answers don't lead to any conditional question on the following pages and if the current page is, in that case, considered the last.

In "page_per_question", the survey button will be updated to "Submit" if the question selected answers don't lead to any following questions and if the current question is, in that case, considered the last.

Task-4792193


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
