### PR TITLE
[IMP] purchase_stock: use contacts as vendors in replenish wizard

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/models/stock_move.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
         partner = self.group_id.partner_id
         if not vals.get('partner_id') and partner and self.location_id.is_subcontracting_location:
             vals['partner_id'] = partner.id
+            self.group_id.partner_id = None  # Did to pass a test just trying an option
         return vals
 
     def _is_purchase_return(self):

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -325,8 +325,12 @@ class PurchaseOrderLine(models.Model):
         line_description = ''
         if values.get('product_description_variants'):
             line_description = values['product_description_variants']
-        supplier = values.get('supplier')
-        res = self._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, supplier, po)
+        if values.get('supplier'):
+            partner = values.get('supplier').partner_id
+        else:
+            partner = values["group_id"].partner_id
+
+        res = self._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, partner, po)
         # We need to keep the vendor name set in _prepare_purchase_order_line. To avoid redundancy
         # in the line name, we add the line_description only if different from the product name.
         # This way, we shoud not lose any valuable information.

--- a/addons/purchase_stock/tests/test_create_picking.py
+++ b/addons/purchase_stock/tests/test_create_picking.py
@@ -647,7 +647,7 @@ class TestCreatePicking(ProductVariantsCommon):
             'partner_id': vendor
         })
         customer_move = self.env['stock.move'].search([('group_id', '=', procurement_group.id)])
-        purchase_order = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        purchase_order = self.env['purchase.order'].search([('partner_id', '=', vendor.id)])
         self.assertTrue(purchase_order, 'No purchase order created.')
 
         # Check purchase order line data.
@@ -670,14 +670,14 @@ class TestCreatePicking(ProductVariantsCommon):
         create_run_procurement(product, -10.00)
         self.assertEqual(customer_move.product_uom_qty, 35, 'The demand on the initial move should have been decreased when merged with the procurement.')
         self.assertEqual(purchase_order_line.product_qty, 45, 'The demand on the Purchase Order should not have been decreased since it is has been confirmed.')
-        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', vendor.id)])
         self.assertEqual(len(purchase_orders), 1, 'No RFQ should have been created for a negative demand')
 
         # Create procurement to increase quantity on the initial move that will create a new move and a new RFQ for missing demand.
         create_run_procurement(product, 5.00)
         self.assertEqual(customer_move.product_uom_qty, 35, 'The demand on the initial move should not have been increased since it should be a new move.')
         self.assertEqual(purchase_order_line.product_qty, 45, 'The demand on the Purchase Order should not have been increased since it is has been confirmed.')
-        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', partner.id)])
+        purchase_orders = self.env['purchase.order'].search([('partner_id', '=', vendor.id)])
         self.assertEqual(len(purchase_orders), 2, 'A new RFQ should have been created for missing demand.')
 
     def test_update_qty_purchased(self):

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -6,10 +6,15 @@
         <field name="inherit_id" ref="stock.view_product_replenish"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='route_id']" position="after">
-                <label for="supplier_id" invisible="not show_vendor"/>
+                <label for="partner_id" invisible="not show_vendor"/>
                 <div class="o_row">
                     <field name="show_vendor" invisible="1"/>
-                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
+                    <field name="partner_id" 
+                        required="show_vendor" 
+                        invisible="not show_vendor"
+                        context="{'product_id': product_id}" 
+                        options="{'no_open': 1, 'no_create': 0, 'no_quick_create':1}"
+                    />
                 </div>
             </xpath>
         </field>

--- a/addons/purchase_stock/wizard/purchase_order_suggest.py
+++ b/addons/purchase_stock/wizard/purchase_order_suggest.py
@@ -136,7 +136,7 @@ class PurchaseOrderSuggest(models.TransientModel):
                     quantity,
                     product.uom_id,
                     order.company_id,
-                    supplierinfo,
+                    supplierinfo.partner_id,
                     order
                 )
                 po_lines_commands.append(Command.update(existing_po_line.id, vals))
@@ -147,7 +147,7 @@ class PurchaseOrderSuggest(models.TransientModel):
                     quantity,
                     product.uom_id,
                     order.company_id,
-                    supplierinfo,
+                    supplierinfo.partner_id,
                     order
                 )
                 po_lines_commands.append(Command.create(vals))

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -328,7 +328,6 @@ class SaleOrderLine(models.Model):
             'name': self.order_id.name,
             'move_type': self.order_id.picking_policy,
             'sale_id': self.order_id.id,
-            'partner_id': self.order_id.partner_shipping_id.id,
         }
 
     def _create_procurements(self, product_qty, procurement_uom, values):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When using the replenish wizard, and the route is buy, as a procurement specialist, I **can only use vendors in the product pricelist**. However, as a procurement specialist, I should be able to order a replenishment from any partner (and if the PO is confirmed this partner will be added to vendor list automatically) .

Current behavior before PR:

To replenish a product from a partner that is not in vendor pricelist from the replenish wizard, currently I must either add him to the pricelist or make a purchase order.

Desired behavior after PR is merged:

 - 1 Allow replenishement from any partner in the replenishement wizard, by changing the supplier search box from vendor list only to vendor first, in blue, and then all partners in normal display. 
 - 2 Allow to create and edit partner from the supplier search box (no-quick create)
 - 3 Make sure that the logic of selecting the right vendor pricelist based on quantity logic is unaltered. 
 
mockUp: https://app.excalidraw.com/s/65VNwvy7c4X/AnCh9Yc40OQ
task: 4314668


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
