### PR TITLE
[FIX] point_of_sale, pos_restaurant: sync before printing

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -13,7 +13,6 @@ class PosPayment(models.Model):
 
     _name = "pos.payment"
     _description = "Point of Sale Payments"
-    _order = "id desc"
     _inherit = ['pos.load.mixin']
 
     name = fields.Char(string='Label', readonly=True)

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2189,9 +2189,9 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
         pos_order = self.PosOrder.search([('id', '=', pos_order_id)])
         payments = pos_order.payment_ids
         self.assertRecordValues(payments.sorted(), [
-            {'amount': -50, 'payment_method_id': cash_payment_method.id, 'is_change': True},
-            {'amount': 100, 'payment_method_id': cash_payment_method.id, 'is_change': False},
             {'amount': 400, 'payment_method_id': self.bank_payment_method.id, 'is_change': False},
+            {'amount': 100, 'payment_method_id': cash_payment_method.id, 'is_change': False},
+            {'amount': -50, 'payment_method_id': cash_payment_method.id, 'is_change': True},
         ])
         account_moves = self.env['account.move'].search([('pos_payment_ids', 'in', pos_order.payment_ids.ids)])
         self.assertEqual(sum(account_moves.mapped('amount_total')), pos_order.amount_total)

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -257,9 +257,9 @@ patch(PosStore.prototype, {
             this.removeOrder(order);
         } else if (order && this.previousScreen !== "ReceiptScreen") {
             if (!this.orderToTransferUuid) {
-                this.syncAllOrders({ orders: [order] });
+                this.syncAllOrders();
             } else {
-                await this.syncAllOrders({ orders: [order] });
+                await this.syncAllOrders();
             }
         }
         this.set_order(null);

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -57,6 +57,11 @@ class PosOrder(models.Model):
             for line in order.lines.filtered(lambda l: l.product_id == order.config_id.down_payment_product_id and l.qty != 0 and (l.sale_order_origin_id or l.refunded_orderline_id.sale_order_origin_id)):
                 sale_lines = line.sale_order_origin_id.order_line or line.refunded_orderline_id.sale_order_origin_id.order_line
                 sale_order_origin = line.sale_order_origin_id or line.refunded_orderline_id.sale_order_origin_id
+
+                if line.sale_order_line_id:
+                    # This line is already linked to a sale order line, we skip it
+                    continue
+
                 if not any(line.display_type and line.is_downpayment for line in sale_lines):
                     self.env['sale.order.line'].create(
                         self.env['sale.advance.payment.inv']._prepare_down_payment_section_values(sale_order_origin)


### PR DESCRIPTION
Before this commit, when an user clicked on the "Order" button in the Point of Sale, the system would not synchronize the current order with the server before printing the order. This could lead to issues where the printed order did not reflect the most recent changes made by the user.

Sometime, when two devices were used, users were able to print the same changes two times, leading to confusion and potential errors in the order processing.

Task ID: 4845554

