### PR TITLE
[FIX] point_of_sale: correct test_pos_order_refund_ship_delay_total_cost

### DIFF
--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2264,6 +2264,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Product A',
             'categ_id': categ.id,
             'lst_price': 10,
+            'is_storable': True,
             'standard_price': 10
         })
         order = self.PosOrder.create({


### PR DESCRIPTION
this commit fixes the test test_pos_order_refund_ship_delay_totalcost from PR #210868

opw-4614503
