### PR TITLE
[FIX] html_builder, website: disable image dragging in the website builder

### DIFF
--- a/addons/html_builder/static/src/builder.js
+++ b/addons/html_builder/static/src/builder.js
@@ -164,7 +164,19 @@ export class Builder extends Component {
             // instantiating the sub components that potentially need the
             // editor.
             const iframeEl = await this.props.iframeLoaded;
-            this.editor.attachTo(iframeEl.contentDocument.body.querySelector("#wrapwrap"));
+            this.editableEl = iframeEl.contentDocument.body.querySelector("#wrapwrap");
+
+            // Prevent image dragging in the website builder. Not via css because
+            // if one of the image ancestor has a dragstart listener, the dragstart handler
+            // can be called with the image as target.
+            this.onDragStart = (ev) => {
+                if (ev.target.nodeName === "IMG") {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                }
+            };
+            this.editor.attachTo(this.editableEl);
+            this.editableEl.addEventListener("dragstart", this.onDragStart);
         });
 
         useSubEnv({
@@ -176,6 +188,7 @@ export class Builder extends Component {
         // });
         onWillDestroy(() => {
             this.editor.destroy();
+            this.editableEl.removeEventListener("dragstart", this.onDragStart);
             this.snippetModel.unregisterBeforeReload();
             // actionService.setActionMode("current");
         });

--- a/addons/website/static/tests/builder/images.test.js
+++ b/addons/website/static/tests/builder/images.test.js
@@ -1,6 +1,13 @@
 import { setSelection } from "@html_editor/../tests/_helpers/selection";
 import { describe, expect, test } from "@odoo/hoot";
-import { animationFrame, dblclick, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
+import {
+    manuallyDispatchProgrammaticEvent,
+    animationFrame,
+    dblclick,
+    queryAll,
+    queryFirst,
+    waitFor,
+} from "@odoo/hoot-dom";
 import { contains } from "@web/../tests/web_test_helpers";
 import { defineWebsiteModels, setupWebsiteBuilder, dummyBase64Img } from "./website_helpers";
 import { testImg } from "./image_test_helpers";
@@ -37,6 +44,21 @@ test("double click on text", async () => {
     await dblclick(":iframe .text_class");
     await animationFrame();
     expect(".modal-content").toHaveCount(0);
+});
+
+test("image should not be draggable", async () => {
+    const { getEditor } = await setupWebsiteBuilder(
+        `<div><p>a</p><img class=a_nice_img src='${dummyBase64Img}'></div>`
+    );
+    const editor = getEditor();
+    const img = editor.editable.querySelector("img");
+
+    const dragdata = new DataTransfer();
+    const ev = await manuallyDispatchProgrammaticEvent(img, "dragstart", {
+        dataTransfer: dragdata,
+    });
+
+    expect(ev.defaultPrevented).toBe(true);
 });
 
 describe("Image format/optimize", () => {


### PR DESCRIPTION
Before this commit: In the website builder, images could be dragged to other locations within the editing area, messing the template structure and formatting.

After this commit: The `dragstart` event is prevented for images, ensuring that only the drag-and-drop mechanism provided by the website module is used.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
