### PR TITLE
[FIX] point_of_sale: save loaded pricelist items in indexedDB

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -744,6 +744,7 @@ export class PosData extends Reactive {
         if (data) {
             this.deviceSync?.dispatch && this.deviceSync.dispatch(data);
             const results = this.models.loadData(data, [], true);
+            this.synchronizeServerDataInIndexedDB(data);
             return results;
         }
         return false;

--- a/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/product_screen_tour.js
@@ -8,7 +8,7 @@ import * as ReceiptScreen from "@point_of_sale/../tests/pos/tours/utils/receipt_
 import { registry } from "@web/core/registry";
 import * as Order from "@point_of_sale/../tests/generic_helpers/order_widget_util";
 import { back, inLeftSide, selectButton } from "@point_of_sale/../tests/pos/tours/utils/common";
-import { scan_barcode, negateStep } from "@point_of_sale/../tests/generic_helpers/utils";
+import { scan_barcode, negateStep, refresh } from "@point_of_sale/../tests/generic_helpers/utils";
 import * as ProductConfiguratorPopup from "@point_of_sale/../tests/pos/tours/utils/product_configurator_util";
 import * as Numpad from "@point_of_sale/../tests/generic_helpers/numpad_util";
 import * as OfflineUtil from "@point_of_sale/../tests/generic_helpers/offline_util";
@@ -284,6 +284,10 @@ registry.category("web_tour.tours").add("limitedProductPricelistLoading", {
 
             scan_barcode("0100202"),
             ProductScreen.selectedOrderlineHas("Test Product 2", "1", "120.0", "Red"),
+
+            refresh(),
+            scan_barcode("0100100"),
+            ProductScreen.selectedOrderlineHas("Test Product 1", "2", "160.0"),
 
             scan_barcode("0100300"),
             Chrome.endTour(),


### PR DESCRIPTION
Before this commit, when loading missing products, the corresponding pricelist rules were loaded but not saved in indexedDB. As a result, after a page refresh, the product would remain available but its pricelist information would be missing, leading to incorrect pricing.

opw-4848511

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
