### PR TITLE
[FIX] product: fix logo/img size on product labels

### DIFF
--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -62,6 +62,10 @@
         overflow: hidden;
         height: 2.5em;
         padding: 0;
+        .img {
+            max-height: 100%;
+            max-width: 100%;
+        }
     }
     div.o_label_clear {
         clear: both;


### PR DESCRIPTION
<b>Steps to Reproduce:</b>
1. Navigate to Sales → Products → Products.
2. Click on Print Labels.
3. Select label format 2×7.
4. Add an image to the "Extra Content" field (e.g., by typing `/image`).

<b>Issue:</b>
- When printing labels, the image added via `extra_html` is not fully displayed. It gets cut off due to the fixed height and overflow settings on the
 `.o_label_extra_data` container.

<b>Solution:</b>
- Added responsive styling to o_label_extra_data for img so they resize properly and stay within bounds:

    ```css
    .img {
        max-height: 2.5em;
        max-width: 100%;
    }
    ```
ensures image appear without being cropped.

<b>opw-4741550</b>


Before FIX:
![image](https://github.com/user-attachments/assets/c914571e-6e08-4bb4-b05e-e1c027ed7a5e)
After FIX:
![image](https://github.com/user-attachments/assets/3f8ac94c-a128-418d-88cb-ab4f078c848d)


