### PR TITLE
[FIX] account_edi_ubl_cii: fix error when clicking on Send & Print

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -84,7 +84,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 nl_id = partner.company_registry if partner.peppol_eas not in ('0106', '0190') else partner.peppol_endpoint
                 vals.update({
                     'company_id': nl_id,
-                    'company_id_attrs': {'schemeID': '0190' if len(nl_id) == 9 else '0106'},
+                    'company_id_attrs': {'schemeID': '0190' if nl_id and len(nl_id) == 9 else '0106'},
                 })
             if partner.country_id.code == "LU":
                 if 'l10n_lu_peppol_identifier' in partner._fields and partner.l10n_lu_peppol_identifier:


### PR DESCRIPTION
When the user tries to send & print the invoice,
A traceback will appear.

Steps to reproduce the error:
- Create a new Customer: A > Country: Netherlands > In Invoicing, Format: NLCIUS
  Peppol e-address (EAS): 0106 > Save
- Create a new invoice > Customer: A > Confirm > Send & Print > Select NLCIUS >
  Send & Print

Traceback:
```
TypeError: object of type 'bool' has no len()
```

https://github.com/odoo/odoo/blob/d123df0a0aacd88d89cefb51a795e7865374a46d/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py#L84-L87
Here, If ``nl_id`` is False,
It results in the traceback mentioned above.

opw-4840552
sentry-6653896965

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
