### PR TITLE
[FIX] point_of_sale: prevent infinite calls with multiple pricelists

### DIFF
--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -29,9 +29,9 @@ export class ProductProduct extends Base {
         const productTmplRules =
             this.product_tmpl_id["<-product.pricelist.item.product_tmpl_id"] || [];
         const productRules = this["<-product.pricelist.item.product_id"] || [];
-        const rulesIds = [...new Set([...productTmplRules, ...productRules])].map(
-            (rule) => rule.id
-        );
+        const rulesIds = [...new Set([...productTmplRules, ...productRules])]
+            .filter((rule) => rule.pricelist_id.id === pricelist.id)
+            .map((rule) => rule.id);
         if (
             this.uiState.applicablePricelistRules[pricelist.id] &&
             (!rulesIds.length ||

--- a/addons/point_of_sale/static/src/app/models/product_template.js
+++ b/addons/point_of_sale/static/src/app/models/product_template.js
@@ -170,7 +170,9 @@ export class ProductTemplate extends Base {
 
     getApplicablePricelistRules(pricelist) {
         const productTmplRules = this["<-product.pricelist.item.product_tmpl_id"] || [];
-        const rulesIds = [...new Set([...productTmplRules])].map((rule) => rule.id);
+        const rulesIds = [...new Set([...productTmplRules])]
+            .filter((rule) => rule.pricelist_id.id === pricelist.id)
+            .map((rule) => rule.id);
         if (
             this.uiState.applicablePricelistRules[pricelist.id] &&
             (!rulesIds.length ||


### PR DESCRIPTION
Before this commit, if a PoS had two pricelists and a product had pricelist rules in both, determining the applicable pricelist could result in infinite recursive calls. This commit resolves the issue by filtering rules based on the selected pricelist.

opw-4840723

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
