### PR TITLE
[FIX] mrp: fix ZeroDivisionError for kit packaging qty

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -85,7 +85,7 @@ class StockMoveLine(models.Model):
         return aggregated_properties
 
     def _compute_product_packaging_qty(self):
-        kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        kit_lines = self.filtered(lambda ml: ml.move_id.bom_line_id.bom_id.type == 'phantom' and ml.move_id.product_packaging_id)
         for move_line in kit_lines:
             move = move_line.move_id
             bom_line = move.bom_line_id


### PR DESCRIPTION
**Step to reproduce:**
   1. Install mrp & sales module.
   2. Ensure Product Packaging is activated for Inventory.
   3. Create a product with a Kit-type BOM that includes two components.
   4. Assign packaging to the product.
   5. Create and confirm a Sales Order for this product.
   6. Open the Delivery Order generated from the Sales Order.
   7. Remove the packaging from one of the components of the kit in the delivery order.
   8. Try to print the Picking Operations report.

**Issue:**

   When printing the Picking Operations report, a
   `ZeroDivisionError: float division by zero` occurs during the 
    computation of the `product_packaging_qty` field on stock.move.line.

**Cause:**

   The `_compute_product_packaging_qty` method performs a
   division operation that assumes packaging is present on the move:  
   https://github.com/odoo/odoo/blob/c1d88949a3c305b425ab3a862741ebab7b7cd344/addons/mrp/models/stock_move.py#L101
   When the packaging is removed, `move.product_packaging_id` becomes
   falsy, and accessing `.qty` returns 0. This leads to division by zero.

**Solution:**

   To fix this, the computation of product_packaging_qty is avoided for kit 
   component move lines that do not have packaging assigned.
   This ensures that the computation only applies to valid lines with the packaging.

**opw-4805679**