### PR TITLE
[FIX] hr: Remove double delete button in employee kanban view

### DIFF
--- a/addons/hr_timesheet/views/hr_employee_views.xml
+++ b/addons/hr_timesheet/views/hr_employee_views.xml
@@ -38,6 +38,17 @@
         </field>
     </record>
 
+    <record id="hr_employee_kanban_inherit_timesheet" model="ir.ui.view">
+        <field name="name">hr.employee.kanban.timesheet</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr.hr_kanban_view_employees"/>
+        <field name="arch" type="xml">
+            <xpath expr="/kanban" position="attributes">
+                <attribute name="delete">0</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="unlink_employee_action" model="ir.actions.server">
         <field name="name">Delete</field>
         <field name="model_id" ref="hr.model_hr_employee"/>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In this PR, we removed the duplicated delete button from the hr employee kanban view when the timesheet app is installed.

Root Cause: We missed to inherit the hr employee kanban view within the hr timehseet.

Current behavior before PR:
![image](https://github.com/user-attachments/assets/ed756556-7d6d-4a42-9a47-2a146f1e7913)


Desired behavior after PR is merged:
![image](https://github.com/user-attachments/assets/f333d4c4-43cf-453f-b2f3-bc10b880e8bd)

Related task: 4843996

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
