### PR TITLE
[IMP] iot_box_image: ssh certificate authority instead of standard keypair

### DIFF
--- a/addons/iot_box_image/build_image.sh
+++ b/addons/iot_box_image/build_image.sh
@@ -161,17 +161,10 @@ cp -av "${OVERWRITE_FILES_BEFORE_INIT_DIR}"/* "${MOUNT_POINT}"
 # it needs to be performed in the classic filesystem, as 'systemctl' commands are not available in /root_bypass_ramdisks
 sudo systemctl reload NetworkManager
 
-# generate a keypair for the IoT Box
+# generate a keypair for the IoT Box SSH Certificate Authority
 mkdir -pv ./.ssh
-echo "y" | ssh-keygen -t ed25519 -f ./.ssh/iotbox -N "" -C https://www.odoo.com/app/iot
-# copy the public key to the image
-mkdir -pv "${MOUNT_POINT}/home/pi/.ssh"
-cp -v ./.ssh/iotbox.pub "${MOUNT_POINT}/home/pi/.ssh/authorized_keys"
-
-# ensure the image has the correct permissions
-chmod 700 "${MOUNT_POINT}/home/pi/.ssh"
-chmod 755 "${MOUNT_POINT}/home/pi"
-chmod 600 "${MOUNT_POINT}/home/pi/.ssh/authorized_keys"
+echo "y" | ssh-keygen -t ed25519 -f "./.ssh/iotbox_ca_${VERSION_IOTBOX}" -N "" -C "Odoo SSH CA ${VERSION_IOTBOX}"
+cp -v "./.ssh/iotbox_ca_${VERSION_IOTBOX}.pub" "${MOUNT_POINT}/etc/ssh/ca.pub"
 
 chroot "${MOUNT_POINT}" /bin/bash -c "/etc/init_image.sh"
 
@@ -199,4 +192,4 @@ kpartx -dv "${LOOP_IOT_PATH}"  # /dev/loop1
 losetup -d "${LOOP_IOT_PATH}"  # /dev/loop1
 
 echo ""
-echo "Image build finished, you'll find the private key at './.ssh/iotbox'"
+echo "Image build finished, you'll find the certificate authority keypair at './.ssh/iotbox_ca_${VERSION_IOTBOX}'"

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -156,7 +156,7 @@ apt-get update
 # This will be modified by a unique password on the first start of Odoo
 password="$(openssl rand -base64 12)"
 echo "pi:${password}" | chpasswd
-chown -R pi:pi "/home/pi/.ssh"  # Ensure pi user has access to its .ssh directory
+echo TrustedUserCAKeys /etc/ssh/ca.pub >> /etc/ssh/sshd_config
 
 PKGS_TO_INSTALL="
     chromium-browser \


### PR DESCRIPTION
We recently implemented a keypair generation to connect to the IoT Box using SSH. This required users to have the generated private key to connect to the IoT Box.

We now generate a certificate authority keypair to allow signing users' public keys in order to grant them access for a specific amount of time, without providing them the IoT Box private key.
