### PR TITLE
[FIX] core: fix num2cyrillic monkeypatch

### DIFF
--- a/odoo/_monkeypatches/num2words.py
+++ b/odoo/_monkeypatches/num2words.py
@@ -735,7 +735,7 @@ class NumberToWords_BG(Num2Word_Base):
         0: [None, 'едно', 'две', 'три', 'четири', 'пет', 'шест', 'седем', 'осем', 'девет'],
     }
     _digits[1] = [None, 'един', 'два'] + _digits[0][3:]
-    _digits[-1] = [None, 'една', None] + _digits[0][2:]
+    _digits[-1] = [None, 'една'] + _digits[0][2:]
     _last_and = False
     _zero = 'нула'
     _infinity = 'безкрайност'


### PR DESCRIPTION
### Steps to reproduce:
- Install l10n_bg
- Install the Bulgarian language
- In the Accounting Settings, tick the option "Total amount of invoice in letters"
- Change a contact's language to Bulgarian
- Create an invoice for this partner, select BGN as the currency
- The total should be with a unit in thousands (for example 8500)
- The text transcription of the number substracts 1000: Седем Хиляди И Петстотин = 7500

### Cause:
The class `NumberToWords_BG` is a copy of the library num2cyrillic except for the initialization of the variable `_digits` which specifies three arrays with variants of the numbers (1-9). We do it by copying the index 0, which is the default variant, for the non-different spellings.
 The issue comes from the line `_digits[-1] = [None, 'една', None] + _digits[0][2:]` which have an unneeded `None` which offsets the array by one. So when reading `_digits[-1][8]` we end up with "seven".

### Solution:
Remove the `None`.

opw-4753418