### PR TITLE
[FIX] web_editor: prevent nested MSO wrappers

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -1406,7 +1406,14 @@ function _createColumnGrid() {
  * @returns {Comment}
  */
 function _createMso(content='') {
-    return document.createComment(`[if mso]>${content}<![endif]`)
+    // We remove comments having opposite condition from the one we will insert
+    // We remove comment tags having the same condition
+    const showRegex = /<!--\[if\s+mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    const hideRegex = /<!--\[if\s+!mso\]>([\s\S]*?)<!\[endif\]-->/g;
+    let contentToInsert = content;
+    contentToInsert = contentToInsert.replace(showRegex, (matchedContent, group) => group);
+    contentToInsert = contentToInsert.replace(hideRegex, "");
+    return document.createComment(`[if mso]>${contentToInsert}<![endif]`);
 }
 /**
  * Return a table element, with its default styles and attributes, as well as
@@ -1776,4 +1783,5 @@ export default {
     normalizeColors: normalizeColors,
     normalizeRem: normalizeRem,
     toInline: toInline,
+    createMso: _createMso,
 };

--- a/addons/web_editor/static/tests/convert_inline_tests.js
+++ b/addons/web_editor/static/tests/convert_inline_tests.js
@@ -1126,6 +1126,20 @@ QUnit.module('convert_inline', {}, function () {
         styleSheet.deleteRule(0);
         $styleSheet.remove();
     });
+
+    QUnit.test('Create mso properly', async function (assert) {
+        assert.strictEqual(convertInline.createMso('<div>abcde</div>').nodeValue,
+            '[if mso]><div>abcde</div><![endif]',
+            "Should wrap the content in mso condition");
+
+        assert.strictEqual(convertInline.createMso('<div>ef<!--[if mso]><div>abcd</div><![endif]-->gh</div>').nodeValue,
+            '[if mso]><div>ef<div>abcd</div>gh</div><![endif]',
+            "Should wrap the content inside one mso condition");
+
+        assert.strictEqual(convertInline.createMso('<div>ef<!--[if !mso]><div>abcd</div><![endif]-->gh</div>').nodeValue,
+            '[if mso]><div>efgh</div><![endif]',
+            "Should remove nested mso hide condition");
+    });
 });
 
 });


### PR DESCRIPTION
Problem:
Adding a document when creating a new email template using `/media` results in duplicated content on save.

Cause:
During HTML processing on save, `flattenBackgroundImages` wraps elements with inline background images (`style*=background-image`) in MSO-specific comments: `<!--[if mso]><![endif]-->`.

However, if multiple such elements are nested, they are each wrapped, resulting in invalid nested comments and broken layout.

Solution:
Since the two conditions are opposites, we remove completely the content of the nested comment if it has oppisite condition otherwise we just remove the comment tags since they will be replaced with the upper comment

Fixed in 17.0 in https://github.com/odoo/odoo/commit/fcedeb63f5b5da6758e75d02f0c1d4f3b965adc1

Steps to reproduce:
1. Create a new email template.
2. Add a document using `/media`.
3. Save. → The content is duplicated or layout is broken.

opw-4675310

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
