### PR TITLE
[FIX] pos_self_order: Set floating order name on kiosk order

### DIFF
--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -30,6 +30,9 @@ class PosSelfOrderController(http.Controller):
         if 'name' in order:
             del order['name']
 
+        if device_type == 'kiosk':
+            order['floating_order_name'] = f"Table tracker {order['table_stand_number']}" if order.get('table_stand_number') else tracking_number
+
         order['pos_reference'] = pos_reference
         order['tracking_number'] = tracking_number
         order['sequence_number'] = sequence_number


### PR DESCRIPTION
For Kiosk order, set `floating_order_name` with `table_stand_number` or `tracking_number`.

task-id: 4711661



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
