### PR TITLE
[FIX] mrp: avoid division by 0 when computing Qty Packaging for Kit

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -86,7 +86,11 @@ class StockMoveLine(models.Model):
 
     def _compute_product_packaging_qty(self):
         kit_lines = self.filtered(lambda move_line: move_line.move_id.bom_line_id.bom_id.type == 'phantom')
+        kit_lines.product_packaging_qty = 0
         for move_line in kit_lines:
+            if not move_line.move_id.product_packaging_id:
+                continue
+
             move = move_line.move_id
             bom_line = move.bom_line_id
             kit_bom = bom_line.bom_id


### PR DESCRIPTION
Step to reproduce :

- Create a quotation with 2 products using kits
- Use the delivery smart button
- Change one of the line to use a packaging
- Print the picking operation
Problem: ZeroDivisionError: float division by zero

[opw-4824380](https://www.odoo.com/odoo/project.task/4824380)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
