### PR TITLE
[FIX] pos_loyalty: prevent points deducted again when refunding

### DIFF
--- a/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/app/screens/payment_screen/payment_screen.js
@@ -125,7 +125,8 @@ patch(PaymentScreen.prototype, {
             if (!couponData[couponId].line_codes.includes(line.reward_identifier_code)) {
                 !couponData[couponId].line_codes.push(line.reward_identifier_code);
             }
-            couponData[couponId].points -= line.points_cost;
+            couponData[couponId].points =
+                line.refunded_qty > 0 ? 0.0 : couponData[couponId].points - line.points_cost;
         }
         // We actually do not care about coupons for 'current' programs that did not claim any reward, they will be lost if not validated
         couponData = Object.fromEntries(

--- a/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/pos_loyalty_tour.js
@@ -1,6 +1,7 @@
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/pos/tours/utils/product_screen_util";
 import * as TicketScreen from "@point_of_sale/../tests/pos/tours/utils/ticket_screen_util";
+import * as PaymentScreen from "@point_of_sale/../tests/pos/tours/utils/payment_screen_util";
 import * as SelectionPopup from "@point_of_sale/../tests/generic_helpers/selection_popup_util";
 import * as Dialog from "@point_of_sale/../tests/generic_helpers/dialog_util";
 import * as Chrome from "@point_of_sale/../tests/pos/tours/utils/chrome_util";
@@ -599,5 +600,29 @@ registry.category("web_tour.tours").add("test_scan_loyalty_card_select_customer"
             Dialog.confirm("Open Register"),
             scan_barcode("0444-e050-4548"),
             ProductScreen.customerIsSelected("Test Partner"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("test_refund_does_not_decrease_points", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            ProductScreen.clickPartnerButton(),
+            ProductScreen.clickCustomer("Refunding Guy"),
+            ProductScreen.clickDisplayedProduct("Refund Product"),
+            ProductScreen.clickControlButton("Reward"),
+            SelectionPopup.has("$ 1 per point on your order", { run: "click" }),
+            PosLoyalty.finalizeOrder("Cash", "200"),
+            ProductScreen.clickRefund(),
+            TicketScreen.selectOrder("001"),
+            ProductScreen.clickNumpad("1"),
+            ProductScreen.clickLine("$ 1 per point on your order"),
+            ProductScreen.clickNumpad("1"),
+            TicketScreen.confirmRefund(),
+            PosLoyalty.orderTotalIs("-200.00"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Cash"),
+            PaymentScreen.clickValidate(),
         ].flat(),
 });

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -2838,3 +2838,46 @@ class TestUi(TestPointOfSaleHttpCommon):
             "test_scan_loyalty_card_select_customer",
             login="pos_user",
         )
+
+    def test_refund_does_not_decrease_points(self):
+        """
+        Tests that when refunding a product bought while spending points, it does not decrease the points a second time
+        """
+        LoyaltyProgram = self.env['loyalty.program']
+        (LoyaltyProgram.search([])).write({'pos_ok': False})
+        self.loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Loyalty Program Test',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'pricelist_ids': [(4, self.main_pos_config.pricelist_id.id)],
+            'pos_ok': True,
+            'pos_config_ids': [Command.link(self.main_pos_config.id)],
+            'rule_ids': [Command.create({
+                'reward_point_mode': 'money',
+                'reward_point_amount': 0.1,
+                'minimum_amount': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'required_points': 100,
+                'discount': 1,
+                'discount_mode': 'per_point',
+            })],
+        })
+        self.product_refund = self.env["product.product"].create({
+            "name": "Refund Product",
+            "is_storable": True,
+            "list_price": 300,
+            "available_in_pos": True,
+            "taxes_id": False,
+        })
+        partner_refunding = self.env['res.partner'].create({'name': 'Refunding Guy'})
+        card = self.env['loyalty.card'].create({
+            'partner_id': partner_refunding.id,
+            'program_id': self.loyalty_program.id,
+            'points': 100,
+        })
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'test_refund_does_not_decrease_points', login="pos_user")
+        self.assertEqual(card.points, 30)


### PR DESCRIPTION
**Problem:**
When refunding an order that has been paid using a reward system, the points are deducted again as if the client made another purchase using those points. This means that in the case of a refund, the client would not only lose those points but have to spend them again.

**Steps to reproduce:**
- Make a purchase in POS using a reward such as $1 for every point
- Refund this purchase
- The points are deducted again

**Why the fix:**
The points do not need to be refunded after a refund, but they don't have to be paid again. The total point for this refund order is now set to zero in case of a refund. This means the transaction will not be visible on the Coupon Card in the Loyalty Program.

opw-4771724