### PR TITLE
[ADD] l10n_din5008_expense: add bridge module for din5008 expense reports

### DIFF
--- a/addons/l10n_din5008_expense/__manifest__.py
+++ b/addons/l10n_din5008_expense/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'DIN 5008 - Expenses',
+    'category': 'Accounting/Localizations',
+    'version': '1.0',
+    'depends': [
+        'l10n_din5008',
+        'hr_expense',
+    ],
+    'auto_install': True,
+    'data': [
+        'report/hr_expense_report.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_din5008_expense/i18n/de.po
+++ b/addons/l10n_din5008_expense/i18n/de.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 12:03+0000\n"
+"PO-Revision-Date: 2025-06-03 12:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_expense.report_expense_sheet
+msgid "Expenses Report"
+msgstr "Spesenabrechnung"

--- a/addons/l10n_din5008_expense/i18n/fr.po
+++ b/addons/l10n_din5008_expense/i18n/fr.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 12:03+0000\n"
+"PO-Revision-Date: 2025-06-03 12:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_expense.report_expense_sheet
+msgid "Expenses Report"
+msgstr "Rapport de dépenses"

--- a/addons/l10n_din5008_expense/i18n/it.po
+++ b/addons/l10n_din5008_expense/i18n/it.po
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 12:03+0000\n"
+"PO-Revision-Date: 2025-06-03 12:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_expense.report_expense_sheet
+msgid "Expenses Report"
+msgstr "Nota spese"

--- a/addons/l10n_din5008_expense/i18n/l10n_din5008_expense.pot
+++ b/addons/l10n_din5008_expense/i18n/l10n_din5008_expense.pot
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_din5008_expense
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-03 12:02+0000\n"
+"PO-Revision-Date: 2025-06-03 12:02+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_din5008_expense
+#: model_terms:ir.ui.view,arch_db:l10n_din5008_expense.report_expense_sheet
+msgid "Expenses Report"
+msgstr ""

--- a/addons/l10n_din5008_expense/report/hr_expense_report.xml
+++ b/addons/l10n_din5008_expense/report/hr_expense_report.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_expense_sheet" inherit_id="hr_expense.report_expense_sheet">
+        <xpath expr="//div[hasclass('page', 'o_content_pdf')]" position="before">
+            <t t-set="din5008_document_title">
+                <span t-if="o and o._name == 'hr.expense.sheet'">
+                        <t>Expenses Report</t>
+                </span>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Issue:
Expense title is duplicated when printing an expense report for localizations using the DIN5008 standard.

Steps to reproduce:
- Install German localization
- Create a new expense report
- Print the expense report PDF
-> Title is duplicated

Cause:
DIN5008 reports tries to load a value `din5008_document_title` in their header
and fallbacks to report's name

With this commit, we add a bridge module to extend the expense sheet
report and set the `din5008_document_title` to `Expenses Report`.

opw-4314414
