### PR TITLE
[FIX] mail: make "Email Signature" label visible in user form

### DIFF
--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -9,12 +9,12 @@
             <field name="inherit_id" ref="base.view_users_form_simple_modif"/>
             <field name="arch" type="xml">
                 <data>
-                    <field name="signature" position="before">
+                    <xpath expr="//group[@name='signature']|//field[@name='signature']" position="before">
                         <group string="Discuss" name="discuss">
                             <field name="notification_type" widget="radio" readonly="0"/>
                             <field name="role_ids" widget="many2many_tags" readonly="not can_edit_role"/>
                         </group>
-                    </field>
+                    </xpath>
                     <field name="signature" position="attributes">
                         <attribute name="widget">html_mail</attribute>
                     </field>
@@ -29,12 +29,12 @@
             <field name="inherit_id" ref="base.view_users_form"/>
             <field name="arch" type="xml">
                 <data>
-                    <field name="signature" position="before">
+                    <xpath expr="//group[@name='messaging']|//field[@name='signature']" position="before">
                         <group string="Discuss" name="discuss">
                             <field name="notification_type" widget="radio" invisible="share"/>
                             <field name="role_ids" widget="many2many_tags" readonly="not can_edit_role"/>
                         </group>
-                    </field>
+                    </xpath>
                     <field name="signature" position="attributes">
                         <attribute name="widget">html_mail</attribute>
                     </field>


### PR DESCRIPTION
---

**Description of the issue/feature this PR addresses:**
The "Email Signature" field in the user profile form had no visible label, which created a poor UX—especially for new users who could not understand the purpose of the field.

This was caused by a misplacement of the "Discuss" group in a previous commit: https://github.com/odoo/odoo/commit/eab0e7c17633658ce9ca194606bc6f78f6b7b285

---

**Steps to Reproduce**

1. Check under *My profile* (from the top-right user menu).
2. Also Go to *Settings* → *Users* → open any user profile --same issue.
3. Scroll to the **Email Signature** section.

**Current behavior before PR:**
-  Notice the field is rendered with no label.

---

**Why the fix**
A previous commit (eab0e7c17633658ce9ca194606bc6f78f6b7b285) inserted a group before the `<field name="signature">`, but in the base views, the field is nested inside a group (`<group name="signature">`) for (`view_users_form_simple_modif`), (`<group name="messaging">`) for (`view_users_form`). This mismatch caused the XPath expression to silently fail.

---

**Desired behavior after PR is merged:**
Target the correct wrapping group instead of the field to ensure the "Discuss" section is properly inserted and the label displays as expected.
while also keeping the field as a wrapping option to not risk stable

---

Ticket_id: opw-4816611

