### PR TITLE
[IMP] mail: regroup correspondent fields

### DIFF
--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -104,15 +104,6 @@ export class Thread extends Record {
         inverse: "thread",
         onDelete: (r) => r.delete(),
     });
-    correspondentCountry = fields.One("res.country", {
-        /** @this {import("models").Thread} */
-        compute() {
-            return this.correspondent?.persona?.country_id ?? this.country_id;
-        },
-    });
-    get showCorrespondentCountry() {
-        return false;
-    }
     counter = 0;
     counter_bus_id = 0;
     /** @type {string} */

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -68,6 +68,12 @@ const threadPatch = {
                 return this.computeCorrespondent();
             },
         });
+        this.correspondentCountry = fields.One("res.country", {
+            /** @this {import("models").Thread} */
+            compute() {
+                return this.correspondent?.persona?.country_id ?? this.country_id;
+            },
+        });
         /** @type {"video_full_screen"|undefined} */
         this.default_display_mode = undefined;
         /** @type {Deferred<Thread|undefined>} */
@@ -226,6 +232,9 @@ const threadPatch = {
             return this.correspondent.persona.avatarUrl;
         }
         return super.avatarUrl;
+    },
+    get showCorrespondentCountry() {
+        return false;
     },
     /** @returns {import("models").ChannelMember} */
     computeCorrespondent() {


### PR DESCRIPTION
Before this PR, correspondent fields were defined within a patch but used in the base model.
This PR moves the fields from the base model to the patch.
