### PR TITLE
[FIX] im_livechat: do not send im status of agent to visitor

### DIFF
--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -151,7 +151,7 @@ class DiscussChannelMember(models.Model):
             )
         ]
 
-    def _get_store_partner_fields(self, fields):
+    def _get_store_partner_fields(self, target: Store.Target, fields):
         self.ensure_one()
         if self.channel_id.channel_type == 'livechat':
             new_fields = [
@@ -159,13 +159,14 @@ class DiscussChannelMember(models.Model):
                 Store.One("country_id", ["code", "name"]),
                 "is_public",
                 *self.env["res.partner"]._get_store_avatar_fields(),
-                *self.env["res.partner"]._get_store_im_status_fields(),
                 *self.env["res.partner"]._get_store_livechat_username_fields(),
             ]
             if self.livechat_member_type == "visitor":
                 new_fields += ["offline_since", "email"]
+            if target.is_internal(self.env):
+                new_fields += self.env["res.partner"]._get_store_im_status_fields()
             return new_fields
-        return super()._get_store_partner_fields(fields)
+        return super()._get_store_partner_fields(target, fields)
 
     def _get_store_guest_fields(self, fields):
         self.ensure_one()

--- a/addons/im_livechat/tests/test_chatbot_internals.py
+++ b/addons/im_livechat/tests/test_chatbot_internals.py
@@ -312,8 +312,6 @@ class ChatbotCase(MailCommon, chatbot_common.ChatbotCase):
                                     "avatar_128_access_token": self.partner_employee._get_avatar_128_access_token(),
                                     "country_id": self.env.ref("base.be").id,
                                     "id": self.partner_employee.id,
-                                    "im_status": "offline",
-                                    "im_status_access_token": self.partner_employee._get_im_status_access_token(),
                                     "is_public": False,
                                     "mention_token": self.partner_employee._get_mention_token(),
                                     "name": "Ernest Employee",

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -81,8 +81,6 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
                     "avatar_128_access_token": operator.partner_id._get_avatar_128_access_token(),
                     "country_id": False,
                     "id": operator.partner_id.id,
-                    "im_status": "offline",
-                    "im_status_access_token": operator.partner_id._get_im_status_access_token(),
                     "is_public": False,
                     "mention_token": operator.partner_id._get_mention_token(),
                     "user_livechat_username": "Michel Operator",

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -109,7 +109,8 @@ class DiscussChannelRtcSession(models.Model):
         """
         valid_values = {'is_screen_sharing_on', 'is_camera_on', 'is_muted', 'is_deaf'}
         self.write({key: values[key] for key in valid_values if key in values})
-        store = Store().add(self, extra_fields=self._get_store_extra_fields())
+        store = Store(bus_channel=self.channel_id)
+        store.add(self, extra_fields=self._get_store_extra_fields())
         self.channel_id._bus_send(
             "discuss.channel.rtc.session/update_and_broadcast",
             {"data": store.get_result(), "channelId": self.channel_id.id},
@@ -169,7 +170,7 @@ class DiscussChannelRtcSession(models.Model):
             "channel_member_id",
             [
                 Store.One("channel_id", [], as_thread=True),
-                *self.env["discuss.channel.member"]._to_store_persona("avatar_card"),
+                *self.env["discuss.channel.member"]._to_store_persona(target, "avatar_card"),
             ],
         )
 

--- a/addons/mail/models/discuss/res_partner.py
+++ b/addons/mail/models/discuss/res_partner.py
@@ -131,15 +131,13 @@ class ResPartner(models.Model):
         partners = self._search_mention_suggestions(domain, limit, extra_domain)
         members_domain = [("channel_id", "=", channel.id), ("partner_id", "in", partners.ids)]
         members = self.env["discuss.channel.member"].search(members_domain)
+        store = Store()
         member_fields = [
             Store.One("channel_id", [], as_thread=True),
-            *self.env["discuss.channel.member"]._to_store_persona([]),
+            *self.env["discuss.channel.member"]._to_store_persona(store.target, []),
         ]
-        store = (
-            Store()
-            .add(members, member_fields)
-            .add(partners, extra_fields=partners._get_store_mention_fields())
-        )
+        store.add(members, member_fields)
+        store.add(partners, extra_fields=partners._get_store_mention_fields())
         store.add(channel, "group_public_id")
         if allowed_group:
             for p in partners:


### PR DESCRIPTION
This commit removes the im_status from the fields fetched for non-visitors.

task-4823845