### PR TITLE
[FIX] hr_expense: Record not saved when submitting expense

### DIFF
--- a/addons/hr_expense/static/src/views/expense_form_view.js
+++ b/addons/hr_expense/static/src/views/expense_form_view.js
@@ -22,6 +22,7 @@ export class ExpenseFormController extends FormController {
             clickParams.name === "action_submit" &&
             record.data.duplicate_expense_ids.count
         ) {
+            await record.save();
             return new Promise((resolve) => {
                 this.dialogService.add(ConfirmationDialog, {
                     body: _t("An expense of same category, amount and date already exists."),


### PR DESCRIPTION
When creating an expense and then submitting it, it would not save the expense if the expense had duplicates and show a ConfirmationDialog.

Now we are saving the potential changes made to the record before the user is submitting it since we dont want his changes to be lost when he confirms the expense.

task-4845093

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
