### PR TITLE
[FIX] hr: Remove greyed-out days for flexible working hours

### DIFF
--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
 from psycopg2.errors import UniqueViolation
 
 from odoo.tests import Form, users, HttpCase, tagged
@@ -458,6 +459,34 @@ class TestHrEmployee(TestHrCommon):
         employee.resource_calendar_id = False
         self.assertTrue(employee.is_flexible)
         self.assertTrue(employee.is_fully_flexible)
+
+    def test_flexible_working_hours(self):
+        """
+        Test to verifie that get_unusual_days() return false for flexible work schedule
+        """
+
+        # Creating a flexible working schedule
+        calendar_flex = self.env['resource.calendar'].create([
+            {
+                'tz': "Europe/Brussels",
+                'name': 'flexible hours',
+                'flexible_hours': "True",
+            },
+        ])
+        employeeA = self.env['hr.employee'].create({
+            'name': 'Employee',
+        })
+
+        # Testing employeA on regular working schedule
+        days = employeeA._get_unusual_days(datetime(2025, 1, 1), datetime(2025, 12, 31))
+        self.assertTrue(days)
+        self.assertTrue(days['2025-01-04'])
+
+        # Assigning flexible work hours to employeeA
+        employeeA.resource_calendar_id = calendar_flex.id
+        days = employeeA._get_unusual_days(datetime(2025, 1, 1), datetime(2025, 12, 31))
+        self.assertTrue(days)
+        self.assertFalse(days['2025-01-04'])
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -628,6 +628,9 @@ class ResourceCalendar(models.Model):
         domain = []
         if company_id:
             domain = [('company_id', 'in', (company_id.id, False))]
+        if self.flexible_hours:
+            works = {d[0].date() for d in self._leave_intervals_batch(start_dt, end_dt, domain=domain)[False]}
+            return {fields.Date.to_string(day.date()): (day.date() in works) for day in rrule(DAILY, start_dt, until=end_dt)}
         works = {d[0].date() for d in self._work_intervals_batch(start_dt, end_dt, domain=domain)[False]}
         return {fields.Date.to_string(day.date()): (day.date() not in works) for day in rrule(DAILY, start_dt, until=end_dt)}
 


### PR DESCRIPTION
The calendar view in the Time Off app was displaying greyed-out days. These days corresponded to those from the underlying work schedule on which the flexible working hours were based.

Steps to reproduce:
-------------------
* In the Work Information tab of an Employee, set the Working Hours to flexible.
* Save and click on the Time Off smart button

> Observation:
Some days were greyed-out

Why the fix:
------------
`get_unusual_days()` usually return a dict of each days with True or False. That dict is then interpreted to display white or greyed-out days. Simply be returning False, every days are going to be white.

opw-4816609

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
