### PR TITLE
[IMP] website: display effective write uid and date for website pages

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1594,7 +1594,7 @@ class Website(models.Model):
             record = {'loc': page['url'], 'id': page['id'], 'name': page['name']}
             if page.view_id.priority != 16:
                 record['priority'] = min(round(page.view_id.priority / 32.0, 1), 1)
-            record['lastmod'] = max(page.write_date, page.view_id.write_date).date()
+            record['lastmod'] = max(page.write_date, page.view_write_date).date()
             yield record
 
         # ==== CONTROLLERS ====

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -22,6 +22,12 @@ class WebsitePage(models.Model):
 
     url = fields.Char('Page URL', required=True)
     view_id = fields.Many2one('ir.ui.view', string='View', required=True, index=True, ondelete="cascade")
+
+    view_write_uid = fields.Many2one('res.users', "Last Content Update by",
+        related='view_id.write_uid')
+    view_write_date = fields.Datetime("Last Content Update on",
+        related='view_id.write_date')
+
     website_indexed = fields.Boolean('Is Indexed', default=True)
     date_publish = fields.Datetime('Publishing Date')
     menu_ids = fields.One2many('website.menu', 'page_id', 'Related Menus')

--- a/addons/website/tests/test_sitemap.py
+++ b/addons/website/tests/test_sitemap.py
@@ -28,8 +28,8 @@ class TestWebsiteSitemap(TransactionCase):
                 "UPDATE ir_ui_view SET write_date = %s WHERE id = %s",
                 (view_date, page.view_id.id)
             )
-            Page.invalidate_model(['write_date'])
             View.invalidate_model(['write_date'])
+            Page.invalidate_model(['write_date', 'view_write_date'])
             self.assertEqual(str(page.write_date), page_date)
             self.assertEqual(str(page.view_id.write_date), view_date)
 

--- a/addons/website/views/website_pages_views.xml
+++ b/addons/website/views/website_pages_views.xml
@@ -109,6 +109,8 @@
             <field name="is_published"/>
 
             <field name="create_uid" column_invisible="True"/>
+            <field name="view_write_uid" widget="many2one_avatar" optional="hide"/>
+            <field name="view_write_date" optional="hide"/>
             <field name="write_uid" widget="many2one_avatar" optional="hide"/>
             <field name="write_date" optional="hide"/>
             <field name="track" optional="hide"/>


### PR DESCRIPTION
This is a follow-up of [1] and [2].

The "page" list view (`website.page` model) has the possibility to
display the `write_uid` and `write_date` fields. It was misleading as it
was not about the last modification of the page content, but the last
modification of the page record itself (e.g. when the page URL is
changed). This commit creates two new fields, non-stored related to
the inner view write uid and write date. The list view now allows to
show both the page and the view update data independently.

Note: it was discussed with the framework-py team that this should not
be an optional feature of the `inherits` mechanism, but a case by case
implementation as it is done here.

Note 2: ideally, a computed field with the combination of both write_uid
and write_date would have been better but this lead to:
- Either have the page's write_date synchronized with the view's one
  (because a stored computed field base on the inner write date... would
  update the page's write date once updated).
- SQL queries to support the feature with a non stored field... with
  "hacks" in the ORM system (write_date could be ok but write_uid
  seemed doomed to be complicated or ugly).
=> It was decided the functional gain was not worth investigating this
   deeper.

[1]: https://github.com/odoo/odoo/commit/20a211de39a8db7422e9db83951652681820935c
[2]: https://github.com/odoo/odoo/commit/11c502ee95018a022db47180f56a186accc336ce