### PR TITLE
[FIX] l10n_*: Classify Suspense Account as Current Asset

### DIFF
--- a/addons/l10n_be/data/template/account.account-be.csv
+++ b/addons/l10n_be/data/template/account.account-be.csv
@@ -168,7 +168,7 @@
 "a491","Accrued Income","491","asset_current","","False","","Produits acquis","Verkregen opbrengsten","Erworbene Erträge"
 "a492","Accrued Charges","492","liability_current","","False","","Charges à imputer","Toe te rekenen kosten","Anzurechnende Aufwendungen"
 "a493","Deferred Income","493","liability_current","","False","","Produits à reporter","Over te dragen opbrengsten","Vorzutragende Erträge"
-"a499","Suspense Accounts","499","liability_current","","False","","Comptes d'attente","Wachtrekeningen","Wartekonten"
+"a499","Suspense Accounts","499","asset_current","","False","","Comptes d'attente","Wachtrekeningen","Wartekonten"
 "a511","Shares - Uncalled Amounts (-)","511","asset_current","","False","","Actions et parts - Montants non appelés (-)","Aandelen - Niet-opgevraagde bedragen (-)","Aktien und Anteile - Nicht eingeforderte Beträge (-)"
 "a520","Fixed-Income Securities - Acquisition Value","520","asset_current","","False","","Titres à revenu fixe - Valeur d'acquisition","Vastrentende effecten - Aanschaffingswaarde","Festverzinsliche Wertpapiere - Anschaffungswert"
 "a529","Fixed-Income Securities - Amounts Written Down - Recorded (-)","529","asset_current","","False","","Titres à revenu fixe - Réductions de valeur actées (-)","Vastrentende effecten - Geboekte waardeverminderingen (-)","Festverzinsliche Wertpapiere - Gebuchte Wertminderungen (-)"

--- a/addons/l10n_cz/data/template/account.account-cz.csv
+++ b/addons/l10n_cz/data/template/account.account-cz.csv
@@ -84,7 +84,7 @@
 "chart_cz_257000","Other securities","257000","asset_current","False","","Ostatní cenné papíry"
 "chart_cz_258000","Shares - controlled or controlling person","258000","asset_current","False","","Podíly - ovládaná nebo ovládající osoba"
 "chart_cz_259000","Acquisition of short-term financial assets","259000","asset_current","False","","Pořízování krátkodobého finančního majetku"
-"chart_cz_261000","Cash in transit","261000","asset_cash","False","","Peníze na cestě"
+"chart_cz_261000","Cash in transit","261000","asset_current","False","","Peníze na cestě"
 "chart_cz_291000","Allowance for short-term financial assets","291000","asset_current","False","","Opravná položka ke krátkodobému finančnímu majetku"
 "chart_cz_311000","Customers","311000","asset_receivable","True","","Odběratelé"
 "chart_cz_311001","Customers (POS)","311001","asset_receivable","True","","Odběratelé (POS)"

--- a/addons/l10n_eg/data/template/account.account-eg.csv
+++ b/addons/l10n_eg/data/template/account.account-eg.csv
@@ -50,7 +50,7 @@
 "egy_account_106009","Acc. Depreciation of Motor Vehicles","106009","asset_current","False","","مجمع اهتلاك السيارات"
 "egy_account_106010","Registration of Trademarks","106010","asset_current","False","","تسجيل العلامات التجارية"
 "egy_account_106011","Computer Card Renewal","106011","asset_current","False","","بطاقة تجديد كمبيوتر"
-"egy_account_201001","Bank Suspense Account","201001","liability_current","False","","حساب البنك المعلق"
+"egy_account_201001","Bank Suspense Account","201001","asset_current","False","","حساب البنك المعلق"
 "egy_account_201002","Payables","201002","liability_payable","True","","الذمم الدائنة"
 "egy_account_201003","Credit Notes to Customers","201003","liability_current","False","","اشعار دائن للعملاء"
 "egy_account_201004","Accrued - Salaries","201004","liability_current","False","","الرواتب المستحقة"

--- a/addons/l10n_lu/models/template_lu.py
+++ b/addons/l10n_lu/models/template_lu.py
@@ -30,7 +30,7 @@ class AccountChartTemplate(models.AbstractModel):
                 'account_default_pos_receivable_account_id': 'lu_2011_account_40111',
                 'income_currency_exchange_account_id': 'lu_2020_account_7561',
                 'expense_currency_exchange_account_id': 'lu_2020_account_6561',
-                'account_journal_suspense_account_id': 'lu_2011_account_485',
+                'account_journal_suspense_account_id': 'lu_2011_account_484',
                 'account_journal_early_pay_discount_loss_account_id': 'lu_2020_account_65562',
                 'account_journal_early_pay_discount_gain_account_id': 'lu_2020_account_75562',
                 'account_sale_tax_id': 'lu_2015_tax_VP-PA-17',

--- a/addons/l10n_pk/data/template/account.account-pk.csv
+++ b/addons/l10n_pk/data/template/account.account-pk.csv
@@ -43,7 +43,7 @@
 "l10n_pk_2223002","Other Provision","2223002","liability_current","","False",""
 "l10n_pk_2224000","Unpaid Dividend","2224000","liability_current","","False",""
 "l10n_pk_2225000","Unclaimed Dividend","2225000","liability_current","","False",""
-"l10n_pk_2226000","Suspense Account","2226000","liability_current","","False",""
+"l10n_pk_2226000","Suspense Account","2226000","asset_current","","False",""
 "l10n_pk_3111001","Sales Income","3111001","income","","False",""
 "l10n_pk_3112001","Bank Profit","3112001","income","","False",""
 "l10n_pk_3112002","Employee Fine","3112002","income","","False",""


### PR DESCRIPTION
Since V14, suspense accounts are classified as current assets. They were previously classified as current liabilities while the liquidity accounts were current assets. It would artificially inflates the current assets and current liabilities as long as the bank statements lines weren't reconciled.

We noticed that the belgian default suspense account is still classified as current liability. On the bank Journal, there is a domain so only current assets type can be set as default suspense account. There is no issue at the package installation but if the suspense account is removed from the journal, it can't be added back afterwards.

task-4829826

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
