### PR TITLE
[IMP] mail: pause gifs when thread is not focused

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -1,3 +1,5 @@
+import { Gif } from "@mail/core/common/gif";
+
 import { Component } from "@odoo/owl";
 import { isMobileOS } from "@web/core/browser/feature_detection";
 
@@ -30,7 +32,7 @@ class Actions extends Component {
  * @extends {Component<Props, Env>}
  */
 export class AttachmentList extends Component {
-    static components = { Actions };
+    static components = { Actions, Gif };
     static props = ["attachments", "unlinkAttachment", "messageSearch?"];
     static template = "mail.AttachmentList";
 
@@ -148,10 +150,6 @@ export class AttachmentList extends Component {
      * @param {import("models").Attachment} attachment
      */
     showUploaded(attachment) {
-        return (
-            !attachment.isImage &&
-            !attachment.uploading &&
-            this.env.inComposer
-        );
+        return !attachment.isImage && !attachment.uploading && this.env.inComposer;
     }
 }

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -23,8 +23,15 @@
                      role="menuitem"
                 >
                     <!-- display of image attachments-->
+                    <Gif
+                        t-if="attachment.mimetype === 'image/gif'"
+                        src="getImageUrl(attachment)"
+                        paused="attachment.gifPaused"
+                        alt="attachment.name"
+                        class="'o-mail-AttachmentImage img img-fluid object-fit-cover w-100 rounded-3'"
+                    />
                     <img
-                        t-if="attachment.isImage"
+                        t-elif="attachment.isImage"
                         class="o-mail-AttachmentImage img img-fluid object-fit-cover w-100 rounded-3"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"

--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -19,12 +19,17 @@ export class Attachment extends FileModelMixin(Record) {
         return attachment;
     }
 
+    composer = fields.One("Composer", { inverse: "attachments" });
     thread = fields.One("Thread", { inverse: "attachments" });
     /** @type {string} */
     raw_access_token;
     res_name;
     message = fields.One("mail.message", { inverse: "attachment_ids" });
     create_date = fields.Datetime();
+
+    get gifPaused() {
+        return this.thread ? !this.thread.isFocused : !this.composer?.isFocused;
+    }
 
     get isDeletable() {
         if (this.message && !this.store.self.isInternalUser) {

--- a/addons/mail/static/src/core/common/gif.js
+++ b/addons/mail/static/src/core/common/gif.js
@@ -1,0 +1,60 @@
+import { Component, useState } from "@odoo/owl";
+
+import { Deferred, KeepLast } from "@web/core/utils/concurrency";
+import { memoize } from "@web/core/utils/functions";
+
+/**
+ * @typedef {Object} Props
+ * @property {string} src
+ * @property {string} [alt]
+ * @property {string} [class]
+ * @property {string} [loading]
+ * @property {((event: Event) => void)} [onLoad]
+ * @property {((event: Event) => void)} [onClick]
+ * @property {boolean} [paused]
+ * @property {string} [style]
+ * @extends {Component<Props, Env>}
+ */
+export class Gif extends Component {
+    static template = "mail.Gif";
+    static props = {
+        src: String,
+        alt: { type: String, optional: true },
+        class: { type: String, optional: true },
+        loading: { type: String, optional: true },
+        onLoad: { type: Function, optional: true },
+        onClick: { type: Function, optional: true },
+        paused: { type: Boolean, optional: true },
+        style: { type: String, optional: true },
+    };
+    static components = {};
+
+    generateGifSnapshot = memoize(async (src) => {
+        const deferred = new Deferred();
+        const image = document.createElement("img");
+        if (new URL(src).origin !== location.origin) {
+            image.crossOrigin = "anonymous";
+        }
+        image.src = src;
+        image.onload = () => {
+            const canvas = document.createElement("canvas");
+            canvas.width = image.width;
+            canvas.height = image.height;
+            canvas.getContext("2d").drawImage(image, 0, 0, image.width, image.height);
+            deferred.resolve(canvas.toDataURL("image/gif"));
+        };
+        return deferred;
+    });
+
+    setup() {
+        this.state = useState({ snapshot: null });
+        this.keepLast = new KeepLast();
+    }
+
+    onLoad() {
+        this.props.onLoad?.(...arguments);
+        this.keepLast
+            .add(this.generateGifSnapshot(this.props.src))
+            .then((snapshot) => (this.state.snapshot = snapshot));
+    }
+}

--- a/addons/mail/static/src/core/common/gif.xml
+++ b/addons/mail/static/src/core/common/gif.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="mail.Gif">
+       <img t-att-src="props.paused and state.snapshot ? state.snapshot : props.src" t-att-loading="props.loading" t-att-data-paused="props.paused" t-att-alt="props.alt" t-att-class="props.class" t-att-style="props.style" t-on-click="props.onClick" t-on-load="onLoad"/>
+    </t>
+</templates>

--- a/addons/mail/static/src/core/common/link_preview.js
+++ b/addons/mail/static/src/core/common/link_preview.js
@@ -1,3 +1,4 @@
+import { Gif } from "@mail/core/common/gif";
 import { LinkPreviewConfirmDelete } from "@mail/core/common/link_preview_confirm_delete";
 
 import { Component, useEffect, useRef, useState } from "@odoo/owl";
@@ -8,14 +9,15 @@ import { useService } from "@web/core/utils/hooks";
  * @typedef {Object} Props
  * @property {import("models").LinkPreview} linkPreview
  * @property {import("models").Message} [message]
+ * @property {Boolean} [gifPaused]
  * @property {function} [delete] Function bound to the delete button
  * @property {function} [deleteAll] Function bound to the delete all button
  * @extends {Component<Props, Env>}
  */
 export class LinkPreview extends Component {
     static template = "mail.LinkPreview";
-    static props = ["linkPreview", "delete?", "deleteAll?"];
-    static components = {};
+    static props = ["linkPreview", "delete?", "deleteAll?", "gifPaused?"];
+    static components = { Gif };
 
     setup() {
         super.setup();

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -43,7 +43,8 @@
     <t t-name="mail.LinkPreviewImage">
         <div class="o-mail-LinkPreviewImage position-relative mb-2 rounded" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
             <a t-if="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
-                <img class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
+                <Gif t-if="props.linkPreview.isGif" paused="props.gifPaused" class="'h-auto w-auto rounded'" src="props.linkPreview.imageUrl" onLoad.bind="onImageLoaded"/>
+                <img t-else="" class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
             </a>
             <t t-if="props.delete" t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -29,6 +29,10 @@ export class LinkPreview extends Record {
     /** @type {string} */
     source_url;
 
+    get isGif() {
+        return [this.og_mimetype, this.image_mimetype].includes("image/gif");
+    }
+
     get imageUrl() {
         return this.og_image ? this.og_image : this.source_url;
     }

--- a/addons/mail/static/src/core/common/message_link_preview_list.xml
+++ b/addons/mail/static/src/core/common/message_link_preview_list.xml
@@ -5,11 +5,11 @@
             <div class="d-flex flex-grow-1 flex-wrap">
                 <t t-if="props.messageLinkPreviews.length > 1">
                     <t t-foreach="props.messageLinkPreviews" t-as="messageLinkPreview" t-key="messageLinkPreview.id">
-                        <LinkPreview linkPreview="messageLinkPreview.link_preview_id" delete.bind="messageLinkPreview.hide" deleteAll.bind="messageLinkPreview.message_id.hideAllLinkPreviews"/>
+                        <LinkPreview linkPreview="messageLinkPreview.link_preview_id" delete.bind="messageLinkPreview.hide" deleteAll.bind="messageLinkPreview.message_id.hideAllLinkPreviews" gifPaused="messageLinkPreview.gifPaused"/>
                     </t>
                 </t>
                 <t t-else="">
-                   <LinkPreview linkPreview="props.messageLinkPreviews[0].link_preview_id" delete.bind="props.messageLinkPreviews[0].hide"/>
+                   <LinkPreview linkPreview="props.messageLinkPreviews[0].link_preview_id" delete.bind="props.messageLinkPreviews[0].hide" gifPaused="props.messageLinkPreviews[0].gifPaused"/>
                 </t>
             </div>
         </div>

--- a/addons/mail/static/src/core/common/message_link_preview_model.js
+++ b/addons/mail/static/src/core/common/message_link_preview_model.js
@@ -9,6 +9,10 @@ export class MessageLinkPreview extends Record {
     message_id = fields.One("mail.message", { inverse: "message_link_preview_ids" });
     link_preview_id = fields.One("mail.link.preview", { inverse: "message_link_preview_ids" });
 
+    get gifPaused() {
+        return !this.message_id.thread?.isFocused;
+    }
+
     hide() {
         rpc("/mail/link_preview/hide", { message_link_preview_ids: [this.id] });
     }

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -1,5 +1,7 @@
-import { Component, onWillStart, useState, useEffect } from "@odoo/owl";
+import { Gif } from "@mail/core/common/gif";
 import { useOnBottomScrolled, useSequential } from "@mail/utils/common/hooks";
+
+import { Component, onWillStart, useState, useEffect } from "@odoo/owl";
 import { user } from "@web/core/user";
 import { useService, useAutofocus } from "@web/core/utils/hooks";
 import { useDebounced } from "@web/core/utils/timing";
@@ -53,13 +55,14 @@ export function useGifPicker(...args) {
 export class GifPicker extends Component {
     static template = "discuss.GifPicker";
     static props = PICKER_PROPS;
+    static components = { Gif };
 
     setup() {
         super.setup();
         this.orm = useService("orm");
         this.store = useService("mail.store");
         this.sequential = useSequential();
-        useAutofocus();
+        this.inputRef = useAutofocus();
         useOnBottomScrolled(
             "scroller",
             () => {
@@ -101,6 +104,7 @@ export class GifPicker extends Component {
                 /** Size, in pixel, of the column. */
                 columnSize: 0,
             },
+            focused: false,
         });
         this.loadFavoritesDebounced = useDebounced(this.loadFavorites, 200);
         onWillStart(() => {
@@ -253,6 +257,7 @@ export class GifPicker extends Component {
     async onClickCategory(category) {
         this.clear();
         this.searchTerm = category.searchterm;
+        this.inputRef.el?.focus();
         this.closeCategories();
     }
 

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="discuss.GifPicker">
-        <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }">
+        <div class="o-discuss-GifPicker d-flex flex-column" t-attf-class="{{ props.className }}" t-att-class="{ 'h-100': props.mobile }" t-on-focusin="() => state.focused = true" t-on-focusout="() => state.focused = false">
             <div t-if="!store.hasGifPickerFeature and store.self.isAdmin" class="d-flex flex-column align-items-center justify-content-center m-3 h-100">
                 <span class="o-discuss-GifPicker-bigEmoji">🧑‍🍳🌶️</span>
                 <span class="fs-5 text-muted">Want to spice up your conversations with GIFs? Activate the feature in the settings!</span>
@@ -63,12 +63,12 @@
                         <div class="d-flex gap-1">
                             <div>
                                 <t t-foreach="state.evenGif.gifs" t-as="gif" t-key="gif_index">
-                                    <t t-call="discuss.Gif"/>
+                                    <t t-call="discuss.GifPicker.gif"/>
                                 </t>
                             </div>
                             <div>
                                 <t t-foreach="state.oddGif.gifs" t-as="gif" t-key="gif_index">
-                                    <t t-call="discuss.Gif"/>
+                                    <t t-call="discuss.GifPicker.gif"/>
                                 </t>
                             </div>
                         </div>
@@ -85,7 +85,7 @@
         </div>
     </t>
 
-    <t t-name="discuss.Gif">
+    <t t-name="discuss.GifPicker.gif">
         <div class="o-discuss-Gif position-relative mt-1 fs-5 cursor-pointer rounded overflow-hidden">
             <i
                 t-if="store.self.type === 'partner'"
@@ -93,14 +93,7 @@
                 t-att-class="{ 'o-text-white fa-star-o': !isFavorite(gif_value), 'fa-star o-starred': isFavorite(gif_value) }"
                 t-on-click="() => this.onClickFavorite(gif_value)"
             />
-            <img
-                class="img-fluid"
-                t-att-src="gif_value.media_formats.tinygif.url"
-                t-on-click="() => this.onClickGif(gif_value)"
-                loading="lazy"
-                alt="GIF"
-                t-att-style="style"
-            />
+            <Gif class="'img-fluid'" style="style" alt="'GIF'" onClick="() => this.onClickGif(gif_value)" src="gif_value.media_formats.tinygif.url" loading="'lazy'" paused="!state.focused"/>
         </div>
     </t>
 

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -2024,3 +2024,30 @@ test("display the notification message's posting date and time", async () => {
         text: "Tom Riddle joined the channel1:00 PM",
     });
 });
+
+test("Pause GIF when thread is not focused", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    const attachmentId = pyEnv["ir.attachment"].create({
+        mimetype: "image/gif",
+        name: "foo.gif",
+        type: "binary",
+        res_id: channelId,
+        res_model: "discuss.channel",
+    });
+    pyEnv["mail.message"].create({
+        attachment_ids: [attachmentId],
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
+    });
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Message");
+    await focus(".o-mail-Thread");
+    await contains(".o-mail-AttachmentImage:not([data-paused])");
+    queryFirst(".o-mail-Thread").blur();
+    await contains(".o-mail-AttachmentImage[data-paused]");
+    await focus(".o-mail-Thread");
+    await contains(".o-mail-AttachmentImage:not([data-paused])");
+});


### PR DESCRIPTION
Gifs should not play when the conversation is not focused as it is distracting. This commit adapts gifs to only play when the thread has focus.

task-4593250

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
