### PR TITLE
[FIX] account: prevent error on uploading empty text file

### DIFF
--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -181,7 +181,7 @@ class IrAttachment(models.Model):
             # XML attachments received by mail have a 'text/plain' mimetype (cfr. context key:
             # 'attachments_mime_plainxml'). Therefore, if content start with '<?xml', or if the filename ends with
             # '.xml', it is considered as XML.
-            is_text_plain_xml = 'text/plain' in attachment.mimetype and (guess_mimetype(attachment.raw).endswith('/xml') or attachment.name.endswith('.xml'))
+            is_text_plain_xml = 'text/plain' in attachment.mimetype and (guess_mimetype(attachment.raw or b'').endswith('/xml') or attachment.name.endswith('.xml'))
             return attachment.mimetype.endswith('/xml') or is_text_plain_xml
 
         return [


### PR DESCRIPTION
Currently, an error occurs when a user uploads an empty text file while attaching a bill in a purchase order.

**Steps to reproduce**:
- Install the `purchase` module.
- In the purchase order(form), click **Upload Bill** button.
- Upload an empty text file. (e.g; [sample here](https://drive.google.com/file/d/1z35T2NY03YVJJPaEL-WjlV8pjvqVCyBW/view?usp=sharing))
- Observe the error.

**Errors:**
- If the **'python-magic'** library is installed: 
 `TypeError - 'bool' object is not subscriptable`
- If not installed: 
  `AttributeError: 'bool' object has no attribute 'startswith'`


The issue occurs when the uploaded attachment is empty, `attachment.raw = False` at [1]. This is then passed to `guess_mimetype`, which expects binary data, resulting in an error.

[1] - https://github.com/odoo/odoo/blob/3e24ff8d3c36b4b924077933ef78a8289a435ee3/addons/account/models/ir_attachment.py#L120

This commit ensures `guess_mimetype` always receives binary input when the file is empty.

Sentry - 6654301906, 6749801114