### PR TITLE
[FIX] l10n_latam_base: make "Identification Number" translatable on c…

### DIFF
--- a/addons/l10n_latam_base/i18n/es_419.po
+++ b/addons/l10n_latam_base/i18n/es_419.po
@@ -77,6 +77,8 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_latam_base
+#. odoo-python
+#: code:addons/l10n_latam_base/controllers/portal.py:0
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_partner__vat
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_users__vat
 #: model_terms:ir.ui.view,arch_db:l10n_latam_base.view_partner_latam_form

--- a/addons/l10n_latam_base/i18n/l10n_latam_base.pot
+++ b/addons/l10n_latam_base/i18n/l10n_latam_base.pot
@@ -72,6 +72,8 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_latam_base
+#. odoo-python
+#: code:addons/l10n_latam_base/controllers/portal.py:0
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_partner__vat
 #: model:ir.model.fields,field_description:l10n_latam_base.field_res_users__vat
 #: model_terms:ir.ui.view,arch_db:l10n_latam_base.view_partner_latam_form


### PR DESCRIPTION
**Description**

The label **"Identification Number"**, displayed in the website checkout form, was not being translated despite being properly marked with `_()` in `portal.py`.

---

**Why the fix**
- When the translatable term was introduced the `.pot` file wasn't updated. By exporting the `.pot` file from the db we are able to update it to make it translatable
---

**Steps to Reproduce**

1. Install the `l10n_latam` module.
2. Create an Argentinian company.
3. Create a new website , add spanish to its languages and assign it to the          Argentinian company.
4. Switch the current user’s **default company** to the Argentinian one.
6. Go to Inventory → Create and publish a new product.
7. On the website:
   - Add the product to the cart.
   - Proceed to checkout.
8. Observe that the **"Identification Number"** field in the address form remains untranslated.

---

**Before**

- The "Identification Number" label appeared only in English and could not be translated.

---

**After**

- It shows up in the translation interface and can be translated into Spanish.

---

Ticket ID: opw-4814341
