### PR TITLE
[FIX] sale_(project, timesheet): move get_first_service_line method to sale_project

### DIFF
--- a/addons/sale_project/models/sale_order.py
+++ b/addons/sale_project/models/sale_order.py
@@ -324,3 +324,9 @@ class SaleOrder(models.Model):
             # do nothing since the SO has been automatically confirmed during its creation
             return True
         return super().action_confirm()
+
+    def get_first_service_line(self):
+        line = next((sol for sol in self.order_line if sol.is_service), False)
+        if not line:
+            raise UserError(self.env._('The Sales Order must contain at least one service product.'))
+        return line

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -163,9 +163,3 @@ class SaleOrder(models.Model):
         moves._link_timesheets_to_invoice(self.env.context.get("timesheet_start_date"), self.env.context.get("timesheet_end_date"))
         self._reset_has_displayed_warning_upsell_order_lines()
         return moves
-
-    def get_first_service_line(self):
-        line = next((sol for sol in self.order_line if sol.is_service), False)
-        if not line:
-            raise UserError(_('The Sales Order must contain at least one service product.'))
-        return line


### PR DESCRIPTION

Issue:
----------
 A traceback occurs when creating a new sale order from a task if the sale_timesheet module is not installed.

Cause:
-------
The method `get_first_service_line` is defined in the sale_timesheet module, which causes an error when 
the module is not installed.

Fix:
----------
The `get_first_service_line` method moved to the sale_project module to prevent the traceback.

Steps to reproduce:
----------
  - Install the sale_project module (do not install sale_timesheet).
  - Create a product of type Service and link it to a project and task.
  - Create a sale order using the above product.
  - Confirm the sale order and click on the "Task" stat button.
  - Click the "+" button to create a new sale order from the task.
  - Add a sale order line and save.
