### PR TITLE
[FIX] website: handle wheel events happening on padding handles

### DIFF
--- a/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
+++ b/addons/html_builder/static/src/core/builder_overlay/builder_overlay_plugin.js
@@ -29,6 +29,13 @@ export class BuilderOverlayPlugin extends Plugin {
         this.overlayContainer = this.dependencies.localOverlay.makeLocalOverlay(
             "builder-overlay-container"
         );
+        // If the user scrolls the mouse wheel while hovering overlayContainer,
+        // no scroll will happen to the page. We need to manually process
+        // wheel events happening on overlayContainer.
+        this.overlayContainer.addEventListener(
+            "wheel",
+            (ev) => (this.document.documentElement.scrollTop += ev.deltaY)
+        );
         /** @type {[BuilderOverlay]} */
         this.overlays = [];
         // Refresh the overlays position everytime their target size changes.


### PR DESCRIPTION
> [CHGO] Padding handles seem to prevent the user to scroll when your mouse hovers them


**Problem**
Before this commit, if the user scrolls the mouse wheel while hovering a padding handle, the page does not scroll. This happens because the handles are positioned in an overlay element outside the iframe.

**Solution**
This commit introduces a listener for  wheel events happening on overlay elements. When a wheel event is recorded, the page is scrolled accordingly.

