### PR TITLE
[FIX] l10n_es_edi_tbai: show negative importe total in credit note XML

### DIFF
--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -628,6 +628,9 @@ class L10nEsEdiTbaiDocument(models.Model):
         for values in values_per_grouping_key.values():
             total_amount += values['base_amount']
 
+        if is_refund:
+            total_amount = -total_amount
+
         return {
             'invoice_info': invoice_info,
             'total_amount': total_amount,


### PR DESCRIPTION
**Issue**
Credit notes submitted to TicketBAI incorrectly include a positive ImporteTotalFactura in the generated XML, instead of a negative value.

**Steps to Reproduce**
1. Install Accounting and TicketBAI modules.
2. Create, confirm, and send an invoice.
3. Reverse the invoice to create a credit note.
4. Confirm and send the credit note.
5. Download the generated XML and observe the total amount.

**Root Cause**
The _get_importe_desglose_foreign_partner method did not account for whether the move is a credit note or an invoice. As a result, the total amount (ImporteTotalFactura) is always positive

**Fix**
Use the existing is_refund parameter to correctly apply the sign to the total amount based on the document type.

Opw-4814241
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
