### PR TITLE
[IMP] website: improve popup dismissal and tool-tips clarity

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review.scss
+++ b/addons/web/static/src/scss/bootstrap_review.scss
@@ -53,6 +53,7 @@
 // (e.g. the website #wrapwrap) whose stacking context is different of the body
 // one (where the backdrop is opened). This would make the backdrop appears on
 // top of the modal.
+// See MODAL_BACKDROP_WEBSITE.
 .modal-backdrop {
     display: none;
 }

--- a/addons/website/static/src/builder/plugins/options/popup_option.xml
+++ b/addons/website/static/src/builder/plugins/options/popup_option.xml
@@ -32,14 +32,13 @@
     </BuilderRow>
     <BuilderRow label.translate="Display">
         <BuilderSelect dataAttributeAction="'display'" preview="false">
-            <BuilderSelectItem dataAttributeActionValue="'afterDelay'" id="'show_delay'">Delay</BuilderSelectItem>
-            <BuilderSelectItem dataAttributeActionValue="'mouseExit'">On Exit</BuilderSelectItem>
-            <BuilderSelectItem dataAttributeActionValue="'onClick'" id="'onclick_opt'" action="'copyAnchor'">On Click (via link)</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'afterDelay'" id="'show_delay'" title.translate="Automatically opens the pop-up if the user stays on a page longer than the specified time.">Delay</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'mouseExit'" title.translate="Pop-up appears when a user is about to leave the website.">On Exit</BuilderSelectItem>
+            <BuilderSelectItem dataAttributeActionValue="'onClick'" id="'onclick_opt'" action="'copyAnchor'" title.translate="Use the generated link to open the pop-up.">On Click (via link)</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
     <BuilderRow level="1" label.translate="Delay">
         <BuilderNumberInput t-if="isActiveItem('show_delay')"
-                tooltip.translate="Automatically opens the pop-up if the user stays on a page longer than the specified time."
                 action="'setPopupDelay'" unit="'s'" saveUnit="''"/>
     </BuilderRow>
     <BuilderRow label.translate="Hide For" t-if="!isActiveItem('onclick_opt')">

--- a/addons/website/static/src/interactions/popup/popup.js
+++ b/addons/website/static/src/interactions/popup/popup.js
@@ -22,6 +22,13 @@ export class Popup extends Interaction {
         "_window": {
             "t-on-hashchange": this.onHashChange,
         },
+        ".modal:not(.s_popup_no_backdrop)": {
+            // Here, bootstrap's data-bs-backdrop attribute is not used and
+            // we use a custom click handler instead to dismiss the popup on
+            // click outside as we do not use bootstrap native backdrop.
+            // See MODAL_BACKDROP_WEBSITE.
+            "t-on-click": this.onBackdropModalClick,
+        },
     };
 
     setup() {
@@ -214,6 +221,17 @@ export class Popup extends Interaction {
             // TODO : it should not have been a hash at all for ecommerce, but a
             // query string parameter
             this.showPopupOnClick(new URL(ev.newURL).hash);
+        }
+    }
+
+    /**
+     * Handles clicks outside the popup to dismiss it.
+     *
+     * @param {MouseEvent} ev
+     */
+    onBackdropModalClick(ev) {
+        if (ev.target === ev.currentTarget) {
+            this.hidePopup();
         }
     }
 }

--- a/addons/website/static/src/snippets/s_popup/001.scss
+++ b/addons/website/static/src/snippets/s_popup/001.scss
@@ -54,7 +54,8 @@
 
     // No backdrop
     .s_popup_no_backdrop {
-        // Allow scrolling on elements behind
+        // Allow using elements behind the modal (especially useful for small
+        // popups like the cookie bar one).
         pointer-events: none;
 
         // Allow Chrome to scroll the modal content even if there is no scroll on the document behind.

--- a/addons/website/static/tests/interactions/popup/popup.test.js
+++ b/addons/website/static/tests/interactions/popup/popup.test.js
@@ -144,6 +144,17 @@ describe("close popup", () => {
         await click(".btn-primary.o_website_form_send");
         expect(modal).toBeVisible();
     });
+
+    test("close popup by clicking outside the modal", async () => {
+        const { core } = await startInteractions(getPopupTemplate());
+        expect(core.interactions).toHaveLength(1);
+        await tick();
+        await animationFrame();
+        await advanceTime(100);
+        expect(modal).toBeVisible();
+        await click(".modal");
+        expect(modal).not.toBeVisible();
+    });
 });
 
 describe("show popup", () => {


### PR DESCRIPTION
This PR enhances user experience by allowing pop-ups to be dismissed by clicking outside and adds informative tooltips for visibility settings to reduce confusion

### What’s improved:

* **Easier to close:**
  Users can now dismiss pop-ups by clicking outside them, eliminating the need to hunt for the close (X) button.

* **Tooltip enhancements for visibility settings:**
  Added helpful tooltips for options like "On Exit" and "On Click (via link)" to explain exactly how they work and avoid confusion. The existing "Delay" tooltip was also updated for consistency.

task-4675456