### PR TITLE
[FIX] web: domain field: detect expressions in sub trees

### DIFF
--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -202,6 +202,9 @@ export function complexCondition(value) {
 function treeContainsExpressions(tree) {
     if (tree.type === "condition") {
         const { path, operator, value } = tree;
+        if (isTree(value) && treeContainsExpressions(value)) {
+            return true;
+        }
         return [path, operator, value].some(
             (v) =>
                 v instanceof Expression ||

--- a/addons/web/static/tests/core/domain_field.test.js
+++ b/addons/web/static/tests/core/domain_field.test.js
@@ -87,6 +87,25 @@ test("The domain editor should not crash the view when given a dynamic filter (a
     expect.verifySteps(["The domain should not involve non-literals"]);
 });
 
+test("The domain editor should not crash the view when given a dynamic filter (allow_expressions=False) in a sub domain", async function () {
+    Partner._fields.company_id = fields.Many2one({ relation: "partner" });
+    Partner._records[0].foo = "[('company_id', 'any', [('id', '=', uid)])]";
+
+    replaceNotificationService();
+
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        resId: 1,
+        arch: `
+                <form>
+                    <field name="foo" widget="domain" options="{'model': 'partner'}" />
+                    <field name="int" invisible="1" />
+                </form>`,
+    });
+    expect.verifySteps(["The domain should not involve non-literals"]);
+});
+
 test("The domain editor should not crash the view when given a dynamic filter (allow_expressions=True)", async function () {
     Partner._records[0].foo = `[("int", "=", uid)]`;
 


### PR DESCRIPTION
If allowExpressions = false, the domain field is supposed to detect when expressions are used in the domain and notify the user that the domain is invalid. The current version of domainContainsExpressions do not allow detection of expressions in sub domains used in conjunction with the any operator. We fix that.
