### PR TITLE
[FIX] mail: prevent traceback on editing attachment of scheduled mail

### DIFF
--- a/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
+++ b/addons/mail/static/src/core/web/mail_composer_attachment_selector.js
@@ -23,7 +23,12 @@ export class MailComposerAttachmentSelector extends Component {
 
     /** @param {Object} data */
     async onFileUploaded({ data, name, type }) {
-        const resIds = JSON.parse(this.props.record.data.res_ids);
+        let resIds;
+        if (this.props.record.resModel === "mail.scheduled.message") {
+            resIds = [this.props.record.data.res_id.resId];
+        } else {
+            resIds = JSON.parse(this.props.record.data.res_ids);
+        }
         const thread = await this.mailStore.Thread.insert({
             model: this.props.record.data.model,
             id: resIds[0],


### PR DESCRIPTION
Steps to reproduce
- open a record from Contacts app
- from chatter, click `send mail` , open full mail composer
- add a attachment
- schedule a message, by clicking '▼' on send message
- Again from chatter, click on edit the same message
- try to add another attachment

Observation:
A traceback is received

Issue:
Currently, `onFileUploaded` function attempts to get `res_ids` from `data`, 
https://github.com/odoo/odoo/blob/69828835c926485ec80ed92e14dd11fbc6c1caaa/addons/mail/static/src/core/web/mail_composer_attachment_selector.js#L25-L30

but in case message is scheduled, which is stored in `mail.scheduled.message` ,when editing it we do not have `res_ids` 
https://github.com/odoo/odoo/blob/69828835c926485ec80ed92e14dd11fbc6c1caaa/addons/mail/wizard/mail_compose_message.py#L120

instead we have `res_id` field, 
https://github.com/odoo/odoo/blob/69828835c926485ec80ed92e14dd11fbc6c1caaa/addons/mail/models/mail_scheduled_message.py#L46
hence a traceback is received when trying to json parse a `undefined` value.

Fix:
Adapt the `onFileUploaded` function to consider both, `res_ids` and `res_id`

opw-4839926


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
