### PR TITLE
[FIX] mail: assign on index of Many() with inverse as One()

### DIFF
--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -316,9 +316,11 @@ export class RecordList extends Array {
                             recordList,
                             val,
                             function recordListSet_Insert(newRecord) {
-                                const oldRecord = toRaw(recordList._store.recordByLocalId).get(
-                                    recordList.data[index]
-                                );
+                                const oldRecord = toRaw(
+                                    toRaw(recordList._store.recordByLocalId).get(
+                                        recordList.data[index]
+                                    )
+                                )._raw;
                                 if (oldRecord && oldRecord.notEq(newRecord)) {
                                     oldRecord._.uses.delete(recordList);
                                 }

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1053,3 +1053,27 @@ test("insert with id relation keeps existing field values", async () => {
     expect(member2.channel.eq(channel1)).toBe(true);
     expect(member2.is_internal).toBe(true);
 });
+
+test("Re-assign on Many relation index with a One inverse should delete record from record list", async () => {
+    // Assign on record list index deletes the old record from record list.
+    // A typo can easily happen in internal code of JS and instead of calling
+    // recordList.delete() it calls oldRecord.delete()!
+    (class Thread extends Record {
+        static id = "name";
+        name;
+        files = Record.many("File", { inverse: "thread" });
+    }).register(localRegistry);
+    (class File extends Record {
+        static id = "name";
+        thread = Record.one("Thread", { inverse: "files" });
+    }).register(localRegistry);
+    const store = await start();
+    store.Thread.insert("general");
+    store.File.insert(["file1.txt", "file2.txt"]);
+    store.Thread.get("general").files = ["file1.txt"];
+    store.Thread.get("general").files[0] = "file2.txt";
+    // Note: using .get() to check no record is deleted by mistake
+    expect(store.Thread.get("general").files.length).toBe(1);
+    expectRecord(store.Thread.get("general").files[0]).toEqual(store.File.get("file2.txt"));
+    expect(store.File.get("file1.txt").exists()).toBe(true);
+});


### PR DESCRIPTION
Before this commit, when defining a `fields.Many()` in JS models with an inverse as `fields.One()`, assign a new record on index of the `Many()` field leads to erroneously record deletion.

This happens because when record list changes, it should sync the inverse relation by deleting the old record from the record list. In the internal code of JS models, all relational fields are stored as recordList, and the removal of a record from a relational field is made with recordList.delete().

In business code, Many fields values are returned as recordList, but One fields are returned as record or undefined. The recordList is not exposed. When the inner-code has to retrieve the record list of the relational field, it should make sure to use raw accessors rather than proxy accessors.

Due to a typo in internal code of JS models, it retrieved the record rather than the record list of the One relational field, and thus called `record.delete()` instead of `recordList.delete()`, which lead the bug at hand.

This commit fixes the issue by ensuring proper access to relational field to retrieve the record list even with One relational fields. The `toRaw()._raw` is to "remove" the proxy layer so we retrieve the raw object of relation which is always the record list for all relational fields.