### PR TITLE
[IMP] l10n_sa_edi: error messages and UI improvements

### DIFF
--- a/addons/l10n_sa_edi/i18n/ar.po
+++ b/addons/l10n_sa_edi/i18n/ar.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.5alpha1\n"
+"Project-Id-Version: Odoo Server 18.4a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-09 12:08+0000\n"
-"PO-Revision-Date: 2025-07-07 13:24+0400\n"
+"POT-Creation-Date: 2025-07-07 13:26+0000\n"
+"PO-Revision-Date: 2025-08-18 15:21+0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ar\n"
@@ -25,30 +25,33 @@ msgid ""
 "Building Number: %(building_number)s, Plot Identification: %(plot_identification)s\n"
 "Neighborhood: %(neighborhood)s"
 msgstr ""
+"\n"
+"رقم المبنى: %(building_number)s, مُعرّف قطعة الأرض: %(plot_identification)s\n"
+"الحي: %(neighborhood)s"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Finish the Onboarding procees for journal %s by requesting the CSIDs and completing the checks."
-msgstr "- قم بإنهاء إجراءات الإعداد لدفتر اليومية %s عن طريق طلب معرّفات CSID واستكمال عمليات التحقق."
+msgid "- %(missing_info)s"
+msgstr "- %(missing_fields)s"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Invoice lines should have at least one Tax applied."
-msgstr "- يجب تطبيق ضريبة واحدة على الأقل في بنود الفاتورة."
+msgid "- Invoice cannot be posted as the Supplier and Buyer are the same."
+msgstr "- لا يمكن ترحيل الفاتورة لأن المورد والمشتري هما نفس الشخص."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- No Private Key was generated for company %s. A Private Key is mandatory in order to generate Certificate Signing Requests (CSR)."
-msgstr "- لم يتم إنشاء مفتاح خاص للشركة %s. يعد المفتاح الخاص إلزاميًا لإنشاء طلبات توقيع الشهادة (CSR)."
+msgid "- Invoice lines need at least one tax. Please input it and try again."
+msgstr "- يجب أن تحتوي بنود الفاتورة على ضريبة واحدة على الأقل. يرجى إدخالها ثم إعادة المحاولة."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid "- Please make sure the 'Customer Reference' contains the sequential number of the original invoice(s) that the Credit/Debit Note is related to."
-msgstr ""
+msgstr "- يرجى التأكد من أن 'رقم العميل المرجعي' يحتوي على الرقم التسلسلي للفاتورة (الفواتير) الأصلية التي يرتبط بها الإشعار الدائن/إشعار الخصم."
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -76,55 +79,57 @@ msgstr ""
 msgid ""
 "- Please make sure the 'ZATCA Reason' for the issuance of the Credit/Debit "
 "Note is specified."
-msgstr "- يرجى التأكد من تحديد 'سبب ZATCA' لإصدار إشعار الدائنة/الخصم."
+msgstr "- يرجى التأكد من تحديد 'سبب زاتكا' لإصدار الإشعار الدائن/إشعار الخصم."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"- Please, make sure the invoice date is set to either the same as or before "
-"Today."
-msgstr "- يُرجى التأكد من ضبط تاريخ الفاتورة على نفس تاريخ اليوم أو قبله."
+msgid "- Please set the Invoice Date to be either less than or equal to today."
+msgstr "- يرجى تعيين تاريخ الفاتورة بحيث يكون قبل أو في نفس اليوم."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Please, set the following fields on the Customer: %(missing_fields)s"
-msgstr "- يُرجى إعداد الحقول التالية لدى العميل: %(missing_fields)s "
+msgid "- Please set the VAT Number on the Company to be 15 digits, with first and last digits being 3."
+msgstr "- يرجى تعيين رقم ضريبة القيمة المضافة للشركة ليكون مكونًا من 15 رقم، بحيث يكون الرقمان الأول والأخير 3."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Please, set the following fields on the Supplier: %(missing_fields)s"
-msgstr "- يُرجى إعداد الحقول التالية لدى المورّد: %(missing_fields)s "
+msgid "- Please set the following fields on the %(company_name)s: %(missing_fields)s"
+msgstr "- يرجى تعيين الحقول التالية في %(company_name)s: %(missing_fields)s"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- The company VAT identification must contain 15 digits, with the first and last digits being '3' as per the BR-KSA-39 and BR-KSA-40 of ZATCA KSA business rule."
-msgstr "- يجب أن يحتوي معرف ضريبة القيمة المضافة للشركة على 15 رقمًا، على أن يكون الرقمان الأول والأخير \"3\" وفقًا لقواعد الأعمال BR-KSA-39 و BR-KSA-40 لهيئة الزكاة والضريبة والجمارك (زاتكا) في المملكة العربية السعودية."
+msgid "- Something went wrong. Please onboard the journal again."
+msgstr "- حدث خطأ ما. يرجى تهيئة دفتر اليومية مرة أخرى."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- You cannot post invoices where the Seller is the Buyer"
-msgstr "لا يمكنك تحرير فواتير حيث البائع هو المشتري"
+msgid "- The Journal (%s) is not onboarded yet. Please onboard it and try again."
+msgstr "- لم تتم تهيئة دفتر اليومية (%s) بعد. يرجى تهيئته ثم إعادة المحاولة."
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "1. There are three modes available:"
+msgstr "1. هناك ثلاثة أوضاع متاحة:"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "2. After selecting the mode, please go to <span class=\"o_form_label\">Journals &gt; Sales Type &gt; ZATCA Tab &gt; Onboard.</span>"
+msgstr "2. بعد تحديد الأوضاع، اذهب إلى <span class=\"o_form_label\">دفاتر اليومية &gt; نوع المبيعات &gt; علامة تبويب زاتكا &gt; تهيئة.</span>"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "3. Once the Journal is onboarded, you can begin using the selected mode."
+msgstr "3. بمجرد أن تتم تهيئة دفتر اليومية، يمكنك البدء في استخدام الوضع المحدد."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__700
 msgid "700 Number"
 msgstr "700 رقم"
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"<b>\n"
-"                                In order to be able to submit Invoices to ZATCA, the following steps need to be completed:\n"
-"                            </b>"
-msgstr ""
-"<b>\n"
-"                                حتى تتمكن من إرسال الفواتير إلى هيئة الزكاة والضريبة والجمارك (زاتكا)، يجب إتمام الخطوات التالية:\n"
-"                            </b>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -134,42 +139,57 @@ msgstr "تحذير <i class=\"fa fa-warning me-2\"/> "
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<span class=\"fw-bold\">Exchange Rate</span>"
-msgstr ""
+msgstr "<span class=\"fw-bold\">سعر صرف العملة</span>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<span class=\"fw-bold\">Subtotal</span>"
-msgstr ""
+msgstr "<span class=\"fw-bold\">الإجمالي الفرعي</span>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<span class=\"fw-bold\">Total</span>"
-msgstr ""
+msgstr "<span class=\"fw-bold\">الإجمالي</span>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<span class=\"fw-bold\">VAT Amount</span>"
-msgstr ""
+msgstr "<span class=\"fw-bold\">مبلغ ضريبة القيمة المضافة</span>"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "<span class=\"o_form_label\">Production</span> - Live environment"
+msgstr "<span class=\"o_form_label\">قاعدة بيانات الإنتاج</span> - البيئة الفعلية"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "<span class=\"o_form_label\">Sandbox</span> - Common pre-configured testing environment"
+msgstr "<span class=\"o_form_label\">Sandbox</span> - بيئة تجريبية شائعة تم إعدادها مسبقًا"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "<span class=\"o_form_label\">Simulation</span> - Unique testing environment"
+msgstr "<span class=\"o_form_label\">المحاكاة</span> - بيئة تجريبية فريدة"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
-msgstr ""
+msgstr "<strong>الإجمالي الفرعي بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>الإجمالي بالريال السعودي</strong>"
-msgstr ""
+msgstr "<strong>الإجمالي بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>سعر الصرف</strong>"
-msgstr ""
+msgstr "<strong>سعر الصرف</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
-msgstr ""
+msgstr "<strong>مبلغ ضريبة القيمة المضافة بالريال السعودي</strong>"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
@@ -179,54 +199,31 @@ msgstr "وضع الواجهة البرمجية للتطلبيق"
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_move_send
 msgid "Account Move Send"
-msgstr ""
+msgstr "إرسال حركة الحساب"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_number
-msgid "Additional Identification Number for Seller/Buyer"
-msgstr "رقم التعريف الإضافي للبائع/المشتري"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Additional Identification Number is required for commercial partners"
-msgstr "رقم التعريف الإضافي مطلوب للشركاء التجاريين"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Additional Identification Scheme is required for the Buyer if tax exemption reason is either VATEX-SA-HEA or VATEX-SA-EDU, and its value must be NAT"
-msgstr "خطة التعريف الإضافي مطلوب للمشتري إذا كان سبب الإعفاء الضريبي إما VATEX-SA-HEA أو VATEX-SA-EDU، ويجب أن تكون قيمته NAT"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Additional Identification Scheme is required for the Seller, and must be one of CRN, MOM, MLS, SAG or OTH"
-msgstr "خطة التعريف الإضافي مطلوب للبائع، ويج أن يكون إما CRN، MOM، MLS، SAG، أو OTH"
+msgid "Additional Identification Number for the Seller/Buyer"
+msgstr "رقم تعريف إضافي للبائع/المشتري"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_scheme
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_scheme
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_scheme
-msgid "Additional Identification scheme for Seller/Buyer"
-msgstr "خطة التعريف الإضافي للبائع/المشتري"
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Are you sure you wish to re-onboard the Journal?"
-msgstr "هل أنت متأكد من أنك ترغب في إعادة تجهيز دفتر اليومية؟"
+msgid "Additional Identification Scheme for the Seller/Buyer"
+msgstr "مخطط تعريف إضافي للبائع/المشتري"
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_ir_attachment
 msgid "Attachment"
-msgstr ""
+msgstr "المرفق"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_form_inherit
 msgid "Blocking Invoice"
-msgstr ""
+msgstr "الفاتورة المعطلة"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_building_number
@@ -237,12 +234,6 @@ msgid "Building Number"
 msgstr "رقم المبنى"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Building Number for the Buyer is required on Standard Invoices"
-msgstr "رقم المبنى للمشتري مطلوب في الفواتير القياسية"
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_json
 msgid "CCSID JSON"
 msgstr "CCSID JSON"
@@ -250,7 +241,7 @@ msgstr "CCSID JSON"
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_certificate_id
 msgid "CCSID certificate"
-msgstr ""
+msgstr "شهادة CCSID"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
@@ -258,35 +249,19 @@ msgid "Cancel"
 msgstr "إلغاء"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Cannot request a Production CSID before completing the Compliance Checks"
-msgstr "لا يمكن طلب CSID الإنتاج قبل إتمام فحوصات الامتثال"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Cannot request a Production CSID before requesting a CCSID first"
-msgstr "لا يمكن طلب CSID الإنتاج قبل طلب CCSID أولاً"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_tax.py:0
-msgid "Cannot set a tax to Retention if the amount is greater than or equal 0"
-msgstr "لا يمكن تعيين الضريبة للاحتفاظ إذا كان المبلغ أكبر من أو يساوي 0"
-
-#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_certificate_certificate
 msgid "Certificate"
-msgstr ""
+msgstr "الشهادة"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 msgid "Chain Head"
-msgstr ""
+msgstr "بداية السلسلة"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "City"
 msgstr "المدينة"
@@ -295,7 +270,7 @@ msgstr "المدينة"
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Clearance and reporting seem to have been mixed up. "
-msgstr ""
+msgstr "يبدو أنه قد حدث لبس بين إجراءات التخليص وإعداد التقارير."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__crn
@@ -308,15 +283,6 @@ msgid "Companies"
 msgstr "الشركات "
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_checks_passed\"/>"
-msgstr ""
-"إكمال عملية التحقق من الامتثال\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_checks_passed\"/>"
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_json
 msgid "Compliance CSID data received from the Compliance CSID API in dumped json format"
 msgstr "بيانات CSID للامتثال التي تم استلامها من الواجهة البرمجية لـ CSID الامتثال بصيغة json"
@@ -327,15 +293,14 @@ msgid "Compliance Checks Done"
 msgstr "فحوصات الامتثال المنجزة"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Compliance checks can only be run for companies operating from KSA"
-msgstr "يمكن إجراء فحوصات الامتثال فقط للشركات التي تعمل في المملكة العربية السعودية"
-
-#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_res_config_settings
 msgid "Config Settings"
 msgstr "تهيئة الإعدادات "
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
+msgid "Confirm"
+msgstr "تأكيد"
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_res_partner
@@ -344,41 +309,9 @@ msgstr "جهة الاتصال"
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Could not complete Compliance Checks for the following file:"
-msgstr "تعذر إجراء فحوصات الامتثال للملف التالي:"
-
-#. module: l10n_sa_edi
-#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid "Could not generate Invoice UBL content: %s"
 msgstr "تعذر إنشاء محتوى فاتورة UBL: %s"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Could not generate PCSID values:\n"
-"%(error)s"
-msgstr ""
-"تعذر إنشاء قيم PCSID:\n"
-"%(error)s"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Could not generate signed XML values:\n"
-"%(error)s"
-msgstr ""
-"تعذر إنشاء قيم XML موقّعة:\n"
-"%(error)s"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Could not obtain Compliance CSID: %s"
-msgstr "تعذر الحصول على CSID للامتثال: %s"
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -424,6 +357,11 @@ msgid "Display Name"
 msgstr "اسم العرض"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Do you really want to re-onboard this Journal with ZATCA?"
+msgstr "هل ترغب حقًا في إعادة تهيئة دفتر اليوميات هذا مع زاتكا؟"
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
 msgid "Document UUID (SA)"
@@ -435,16 +373,26 @@ msgid "EDI format"
 msgstr "صيغة EDI "
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Error: This invoice is blocked due to %s. Please check it."
-msgstr ""
+#: model:ir.actions.act_window,name:l10n_sa_edi.l10n_sa_edi_otp_wizard_act_window
+msgid "Enter the OTP"
+msgstr "أدخل الرقم السري لمرة واحدة"
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Errors:"
-msgstr "الأخطاء:"
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Error: Invoice rejected by ZATCA"
+msgstr "خطأ: تم رفض الفاتورة من قِبَل زاتكاز"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Error: Journal is not onboarded"
+msgstr "خطأ: لم تتم تهيئة دفتر اليومية"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Error: This invoice is blocked due to %s. Please check it."
+msgstr "خطأ: هذه الفاتورة محظورة بسبب %s. يرجى التحقق من ذلك."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_exemption_reason_code
@@ -454,7 +402,7 @@ msgstr "كود سبب الإعفاء"
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_production_csid_validity
 msgid "Expiration date"
-msgstr ""
+msgstr "تاريخ انتهاء الصلاحية"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__gcc
@@ -484,6 +432,12 @@ msgid "ID"
 msgstr "المعرف"
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_partner_form
+msgid "Identification Number"
+msgstr "رقم التعريف"
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_number
@@ -496,12 +450,6 @@ msgstr "رقم التعريف (المملكة العربية السعودية)"
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_scheme
 msgid "Identification Scheme"
 msgstr "خطة التعريف"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice Successfully Submitted to ZATCA"
-msgstr "تم إرسال الفاتورة بنجاح إلى زاتكا"
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -520,6 +468,8 @@ msgid ""
 "Invoice could not be reported:\n"
 "%s"
 msgstr ""
+"تعذر الإبلاغ عن الفاتورة:\n"
+"%s"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_chain_index
@@ -534,21 +484,14 @@ msgid "Invoice submission to ZATCA returned errors"
 msgstr "حدثت أخطاء عند إرسال الفواتير إلى زاتكا"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice was Accepted by ZATCA (with Warnings)"
-msgstr "تم قبول الفاتورة من قِبَل زاتكا (مع تحذيرات)"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice was rejected by ZATCA"
-msgstr "تم رفض الفاتورة من قِبَل زاتكا"
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__iqa
 msgid "Iqama Number"
 msgstr "رقم إقامة "
+
+#. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_edi_is_production
+msgid "Is Production"
+msgstr "الانتاج"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_tax__l10n_sa_is_retention
@@ -584,21 +527,16 @@ msgid "Journal could not be onboarded"
 msgstr "تعذر تجهيز دفتر اليومية"
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Journal could not be onboarded. Please make sure the Company VAT/Identification Number are correct."
-msgstr "تعذر تجهيز دفتر اليومية. يرجى التأكد من أن رقمي ضريبة القيمة المضافة/رقم التعريف صحيحين."
-
-#. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Journal onboarded with ZATCA successfully"
-msgstr ""
+msgstr "تمت تهيئة دفتر اليومية مع زاتكا بنجاح"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Journal re-onboarded with ZATCA successfully"
-msgstr ""
+msgstr "تمت إعادة تهيئة دفتر اليومية مع زاتكا بنجاح"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_api_mode
@@ -652,21 +590,9 @@ msgid "National ID"
 msgstr "الهوية الوطنية"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Neighborhood for the Buyer is required on Standard Invoices"
-msgstr "الحي الخاص بالمشتري مطلوب في الفواتير القياسية"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Neighborhood for the Seller is required on Standard Invoices"
-msgstr "الحي الخاص بالبائع مطلوب في الفواتير القياسية"
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "Neighborhood..."
-msgstr ""
+msgstr "الحي..."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__l10n_sa_otp
@@ -680,41 +606,41 @@ msgstr "يتطلب كلمة المرور لمرة واحدة للحصول على
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Onboard Journal"
-msgstr "تجهيز دفتر اليومية"
+msgid "Onboard"
+msgstr "تهيئة"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Onboard the Journal by completing each step"
-msgstr "قم بتجهيز دفتر اليومية عن طريق إكمال كافة الخطوات"
+msgid "Onboard this Journal"
+msgstr "تهيئة دفتر اليومية هذا"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_csr_errors
 msgid "Onboarding Errors"
-msgstr "أخطاء التجهيز"
+msgstr "أخطاء التهيئة"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
-"Once you change the submission mode to <strong>Production</strong>, you cannot change it anymore.\n"
-"                            Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
-"                            and might lead to <strong>Fines &amp; Penalties</strong>."
+"Once the mode is set to <strong>Production</strong> and an Invoice has been submitted to ZATCA,\n"
+"                            then the API mode cannot be changed. Any invoice submitted in the Production mode will be officially\n"
+"                            recorded with ZATCA and considered in the calculation of the VAT Liability."
 msgstr ""
-"بمجرد أن قيامك بتغيير وضع التسليم إلى <strong>الإنتاج</strong>، لن تتمكن من تغييره بعد ذلك.\n"
-"                            انتبه، فإن كل فاتورة تقوم بتسليمها إلى هيئة الضريبة والزكاة والجمارك (زاتكا) في وضع الإنتاج سيتم وضعها \n"
-"                            بعين الاعتبار وقد تتسبب في <strong>غرامات وعقوبات</strong>. "
+"بمجر أن يتم تعيين الوضع كـ <strong>قاعدة بيانات الإنتاج</strong> ويتم إرسال الفاتورة إلى هيئة الزكاة والضريبة والجمارك (زاتكا)،\n"
+"                            لن يكون بالإمكان تغيير وضع الواجهة البرمجية بعد الآن. سيتم تسجيل أي فاتورة مقدمة في وضع الإنتاج رسميًا\n"
+"                            لدى زاتكا وستؤخذ في الاعتبار عند حساب ضريبة القيمة المضافة المستحقة."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/ir_attachment.py:0
 msgid "Oops! The invoice PDF(s) are linked to a validated EDI document and cannot be deleted according to ZATCA rules: %s"
-msgstr ""
+msgstr "عذرًا! ملف/ملفات الفاتورة بصيغة PDF مرتبطة بمستند EDI مُعتمد ولا يمكن حذفها وفقًا لأنظمة ZATCA: %s"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Oops! The journal is stuck. Please submit the pending invoices to ZATCA and try again."
-msgstr ""
+msgstr "عذراً! هناك مشكلة في دفتر اليومية. يرجى إرسال الفواتير المعلقة إلى زاتكا (ZATCA) ثم إعادة المحاولة."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__oth
@@ -724,7 +650,7 @@ msgstr "معرف آخر"
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_production_csid_certificate_id
 msgid "PCSID Certificate"
-msgstr ""
+msgstr "شهادة PCSID"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_production_csid_json
@@ -743,12 +669,6 @@ msgstr "معرف جواز السفر"
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/migrations/0.2/post-migrate.py:0
-msgid "Please Re-Onboard the Journal for a new serial number"
-msgstr "يرجى إعادة تجهيز دفتر اليومية للحصول على رقم تسلسلي جديد"
-
-#. module: l10n_sa_edi
-#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid "Please make sure that the invoice company matches the journal company on all invoices you wish to confirm"
@@ -757,31 +677,55 @@ msgstr "يرجى التأكد من أن الشركة المرتبطة بالفا
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, generate a CSR before requesting a CCSID"
-msgstr "يرجى إنشاء CSR قبل طلب CCSID"
+msgid "Please change the (%s)'s country to Saudi Arabia and try again."
+msgstr "يرجى تغيير دولة (%s) إلى المملكة العربية السعودية ثم حاول مرة أخرى."
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, make a request to obtain the Compliance CSID and Production CSID before sending documents to ZATCA"
-msgstr "يرجى إنشاء طلب للحصول على CSID للامتثال وCSID للإنتاج قبل إرسال المستندات إلى زاتكا"
+msgid "Please check the details below and onboard the journal again:"
+msgstr "يُرجى التحقق من التفاصيل أدناه لتهيئة دفتر اليومية مجدداً:"
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, make sure all the following fields have been correctly set on the Company:%(fields)s"
-msgstr "يُرجى التأكد من أن الحقول التالية قد تم إعدادها بشكل صحيح في الشركة:%(fields)s "
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Please check the details below and retry after addressing them:"
+msgstr "يُرجى التحقق من التفاصيل أدناه لإعادة المحاولة بعد معالجتها:"
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, set a valid OTP to be used for Onboarding"
-msgstr "يرجى إعداد كلمة سر لمرة واحدة صالحة ليتم استخدامها للتجهيز"
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Please check the details below:"
+msgstr "يُرجى التحقق من التفاصيل أدناه:"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
-msgid "Please, set the OTP you received from ZATCA in the input below then validate."
-msgstr "يرجى إعداد كلمة السر لمرة واحدة التي قمت باستلامها من زاتكا في المدخل أدناه، ثم قم بالتصديق."
+msgid "Please input the OTP generated from the Fatoora Portal."
+msgstr "يُرجى إدخال كلمة المرور لمرة واحدة التي تم إنشاؤها من بوابة \"فاتورة\"."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
+msgid "Please provide an OTP to complete the onboarding process"
+msgstr "يرجى تقديم كلمة المرور لمرة واحدة (OTP) لإكمال عملية التسجيل"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Please set the Identification Scheme as National ID and Identification Number as the respective number on the Customer, as the Tax Exemption Reason is set either as VATEX-SA-HEA or VATEX-SA-EDU"
+msgstr "يرجى تعيين نظام التعريف على ”الهوية الوطنية“ ورقم التعريف كالرقم الموجود في سجل العميل، حيث تم تعيين سبب الإعفاء الضريبي ليكون إما VATEX-SA-HEA أو VATEX-SA-EDU."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Please set the VAT Number as the Identification Scheme is Tax Identification Number"
+msgstr "يرجى تعيين رقم ضريبة القيمة المضافة بحيث يكون نظام التعريف هو رقم التعريف الضريبي"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "Please set the following on %(company_name)s: %(fields)s"
+msgstr "يُرجى تعيين ما يلي في %(company_name)s: %(fields)s"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_plot_identification
@@ -802,53 +746,19 @@ msgid "Production CSID data received from the Production CSID API in dumped json
 msgstr "بيانات CSID للإنتاج التي تم استلامها من الواجهة البرمجية لـCSID الإنتاج بصيغة json"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Production certificate has expired, please renew the PCSID before proceeding"
-msgstr "لقد انتهت مدة صلاحية شهادة الإنتاج. يرجى تجديد PCSID قبل الاستمرار"
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "Re-Onboard"
 msgstr "إعادة التجهيز"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Renew Production CSID"
-msgstr "تجديد CSID الإنتاج"
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
-msgid "Request"
-msgstr "طلب"
+msgid "Renew"
+msgstr "تجديد"
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_l10n_sa_edi_otp_wizard
 msgid "Request ZATCA OTP"
 msgstr "طلب كلمة السر لمرة واحدة لزاتكا"
-
-#. module: l10n_sa_edi
-#: model:ir.actions.act_window,name:l10n_sa_edi.l10n_sa_edi_otp_wizard_act_window
-msgid "Request a CSID"
-msgstr "طلب CSID"
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_csid_json\" groups=\"base.group_system\"/>"
-msgstr ""
-"طلب شهادة امتثال (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_csid_json\" groups=\"base.group_system\"/> "
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_production_csid_json\" groups=\"base.group_system\"/>"
-msgstr ""
-"طلب شهادة إنتاج (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_production_csid_json\" groups=\"base.group_system\"/>"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__sag
@@ -861,10 +771,9 @@ msgid "Sandbox"
 msgstr "Sandbox"
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move_send.py:0
-msgid "Send to Zatca"
-msgstr "إرسال إلى زاتكا"
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "Saudi Arabia Electronic Invoicing"
+msgstr "الفوترة الإلكترونية في المملكة العربية السعودية"
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -888,6 +797,18 @@ msgid "Simulation (Pre-Production)"
 msgstr "المحاكاة (قبل الإنتاج)"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "Something went wrong. Please onboard the journal again."
+msgstr "حدث خطأ ما. يرجى تسجيل الدخول إلى دفاتر اليومية مرة أخرى."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Something went wrong. Please retry, and if that does not work, then onboard the journal again."
+msgstr "حدث خطأ ما. يرجى إعادة المحاولة، وإذا لم ينجح ذلك، فقم بتهيئة دفتر اليومية مرة أخرى."
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_compliance_checks_passed
 msgid "Specifies if the Compliance Checks have been completed successfully"
 msgstr "يحدد ما إذا كان قد تم إكمال فحوصات الامتثال بنجاح أم لا"
@@ -899,25 +820,32 @@ msgid "Specifies which API the system should use"
 msgstr "يحدد نظام الواجهة البرمجية الذي يجب استخدامه"
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
-msgid "State"
-msgstr ""
-
-#. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "State / Country subdivision"
-msgstr "المحافظة / التقسيمات الدولية"
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+msgid "State"
+msgstr "المحافظة"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "Street 2..."
-msgstr ""
+msgstr "الشارع 2..."
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "Street..."
-msgstr ""
+msgstr "الشارع..."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Success: Invoice accepted by ZATCA"
+msgstr "تم بنجاح: تم قبول الفاتورة من قبل زاتكا"
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Success: Journal is onboarded and valid until"
+msgstr "تم بنجاح: تمت تهيئة دفتر اليومية وهو صالح حتى"
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_tax
@@ -943,7 +871,7 @@ msgstr "فاتورة الضريبة"
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_edi_chain_head_id
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_move__l10n_sa_edi_chain_head_id
 msgid "Technical field to know if the chain has been stopped by a previous invoice"
-msgstr ""
+msgstr "حقل تقني لمعرفة ما إذا كانت السلسلة قد توقفت بسبب فاتورة سابقة"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_csr
@@ -952,36 +880,49 @@ msgstr "طلب توقيع الشهادة المرسل إلى الواجهة ال
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "The Production CSID is still valid. You can only renew it once it has expired."
-msgstr "لا يزال CSID الإنتاج صالحاً. يمكنك تجديده مرة واحدة فقط بمجرد انتهاء تاريخ صلاحيته."
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "The Invoice(s) are linked to a validated EDI document and cannot be modified according to ZATCA rules"
+msgstr "الفاتورة (الفواتير) مرتبطة بمستند EDI تم تصديقه ولا يمكن تعديلها وفقًا لقواعد زاتكا."
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "The Production certificate is valid until"
-msgstr "شهادة الإنتاج سارية حتى"
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The Journal is not valid anymore. Please Renew it."
+msgstr "لم يعد دفتر اليومية صالحًا. يرجى تجديده."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The Journal is valid until (%s) and can only be renewed upon expiry."
+msgstr "دفتر اليومية صالح حتى (%s) ولا يمكن تجديده إلا بعد انتهاء صلاحيته."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The OTP is invalid. Please try again."
+msgstr "كلمة المرور لمرة واحدة (OTP) غير صالحة. يرجى المحاولة مرة أخرى."
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_production_csid_validity
 msgid "The date on which the certificate expires"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "The invoice was accepted by ZATCA, but returned warnings. Please, check the response below:"
-msgstr "تم قبول الفاتورة من قِبَل زاتكا، ولكن ظهرت تحذيرات. يرجى إلقاء نظرة على الرد أدناه:"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "The invoice was rejected by ZATCA. Please, check the response below:"
-msgstr "تم رفض الفاتورة من قِبَل زاتكا. يرجى التحقق من الرد أدناه:"
+msgstr "التاريخ الذي تنتهي فيه مدة صلاحية الشهادة"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_private_key_id
 msgid "The private key used to generate the CSR and obtain certificates"
 msgstr "المفتاح الخاص المستخدَم لإنشاء CSR والحصول على الشهادات"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_tax.py:0
+msgid "The tax is unable to be set as Retention as the Amount is greater than or equal to 0."
+msgstr "لا يمكن تعيين الضريبة على أنها ضريبة احتجاز لأن المبلغ أكبر من أو يساوي 0."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move_send.py:0
+msgid "To ZATCA"
+msgstr "إلى زاتكا"
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_account_edi_xml_ubl_21_zatca
@@ -1009,12 +950,6 @@ msgstr "استخدم كلمة المرور لمرة واحدة لطلب CSID"
 #: model:ir.model.fields,help:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__l10n_sa_renewal
 msgid "Used to decide whether we should call the PCSID renewal API or the CCSID API"
 msgstr "يُستخدَم لتحديد ما إذا كان يجب استدعاء الواجهة البرمجية لتجديد PCSID أو الواجهة البرمجية لـCCSID"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "VAT is required when Identification Scheme is set to Tax Identification Number"
-msgstr "ضريبة القيمة المضافة مطلوبة عندما يتم إعداد خطة التعريف كرقم التعريف الضريبي"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__account_tax__l10n_sa_exemption_reason_code__vatex-sa-29
@@ -1094,53 +1029,48 @@ msgstr "VATEX-SA-OOS غير خاضعة لضريبة القيمة المضافة.
 
 #. module: l10n_sa_edi
 #. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Warning: Invoice accepted by ZATCA with warnings"
+msgstr "تحذير: تم قبول الفاتورة من قبل هيئة الزكاة والضريبة والجمارك (ZATCA) مع تحذيرات"
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Warnings:"
 msgstr "التحذيرات:"
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid ""
-"You can select the API used for submissions down below. There are three modes available: Sandbox, Pre-Production and Production.\n"
-"                            Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
-msgstr ""
-"يمكنك تحديد الواجهة البرمجية المُستَخدَمة للتسليمات أدناه. توجد ثلاثة أوضاع متاحة: Sandbox و ما قبل الإنتاج والإنتاج.\n"
-"                            بمجرد قيامك بتحديد الواجهة البرمجية المناسبة، يمكنك بدء عملية التهيئة للعمل عن طريق الذهاب إلى دفاتر اليومية وتحديد الخيارات أسفل علامة تبويب زاتكا. "
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Yes"
+msgstr "نعم"
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/ir_attachment.py:0
 msgid "You can't unlink an attachment being an EDI document refused by the government."
-msgstr ""
+msgstr "لا يمكنك إلغاء ربط المرفق إذا كان مستند EDI تم رفضه من قِبَل الحكومة."
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/res_company.py:0
-msgid "You cannot change the ZATCA Submission Mode once it has been set to Production"
-msgstr "لا يمكنك تغيير وضع تسليم زاتكا بمجرد أن يتم تعيينه إلى الإنتاج "
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
-msgid "You need to provide an OTP to be able to request a CCSID"
-msgstr "عليك تقديم كلمة مرور لمرة واحدة قبل طلب CCSID "
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "You need to request the CCSID first before you can proceed"
-msgstr "عليك طلب CCSID أولاً قبل الاستمرار"
-
-#. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move_send__l10n_sa_edi_enable_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
 msgstr "زاتكا"
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/res_company.py:0
+msgid "ZATCA API Mode cannot be changed after an invoice has been successfully submitted under the Production Mode."
+msgstr "لا يمكن تغيير وضع الواجهة البرمجية لنظام زاتكا بعد إرسال الفاتورة بنجاح في قاعدة بيانات الإنتاج."
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/res_company.py:0
+msgid "ZATCA API Mode changed to %s"
+msgstr "تم تغيير وضع الواجهة البرمجية لنظام زاتكا إلى %s"
+
+#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "ZATCA E-Invoicing Settings"
-msgstr "إعدادات الفوترة الإلكترونية لدى زاتكا"
+msgid "ZATCA API Modes"
+msgstr "أوضاع الواجهة البرمجية لنظام زاتكا"
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_private_key_id
@@ -1162,23 +1092,12 @@ msgstr "مؤشر سلسلة زاتكا"
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_edi_chain_head_id
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_edi_chain_head_id
 msgid "ZATCA chain stopping move"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "ZATCA specific settings for Saudi eInvoicing"
-msgstr "إعدادات خاصة بهيئة الضريبة والزكاة والجمارك للفوترة الإلكترونية في المملكة العربية السعودية "
+msgstr "الحركة المُوقفة لسلسلة ZATCA"
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "ZIP"
 msgstr "ZIP"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "l10n_sa_edi_additional_identification_scheme"
-msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
@@ -1194,12 +1113,6 @@ msgstr "not(//ancestor-or-self::cac:Signature)"
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
 msgid "not(//ancestor-or-self::ext:UBLExtensions)"
 msgstr "not(//ancestor-or-self::ext:UBLExtensions)"
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "street2"
-msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions

--- a/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
+++ b/addons/l10n_sa_edi/i18n/l10n_sa_edi.pot
@@ -6,14 +6,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.5a1+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-09 12:08+0000\n"
-"PO-Revision-Date: 2025-07-09 12:08+0000\n"
+"POT-Creation-Date: 2025-07-30 05:12+0000\n"
+"PO-Revision-Date: 2025-07-30 05:12+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid ""
+"\n"
+"                Please set the Identification Scheme as National ID and Identification Number as the respective\n"
+"                number on the Customer, as the Tax Exemption Reason is set either as VATEX-SA-HEA or VATEX-SA-EDU\n"
+"            "
+msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
@@ -27,23 +37,19 @@ msgstr ""
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"- Finish the Onboarding procees for journal %s by requesting the CSIDs and "
-"completing the checks."
+msgid "- %(missing_info)s"
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Invoice lines should have at least one Tax applied."
+msgid "- Invoice cannot be posted as the Supplier and Buyer are the same."
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"- No Private Key was generated for company %s. A Private Key is mandatory in"
-" order to generate Certificate Signing Requests (CSR)."
+msgid "- Invoice lines need at least one tax. Please input it and try again."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -66,48 +72,60 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid ""
-"- Please, make sure the invoice date is set to either the same as or before "
-"Today."
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Please, set the following fields on the Customer: %(missing_fields)s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- Please, set the following fields on the Supplier: %(missing_fields)s"
+"- Please set the Invoice Date to be either less than or equal to today."
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid ""
-"- The company VAT identification must contain 15 digits, with the first and "
-"last digits being '3' as per the BR-KSA-39 and BR-KSA-40 of ZATCA KSA "
-"business rule."
+"- Please set the VAT Number on the Company to be 15 digits, with first and "
+"last digits being 3."
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "- You cannot post invoices where the Seller is the Buyer"
+msgid ""
+"- Please set the following fields on the %(company_name)s: "
+"%(missing_fields)s"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "- Something went wrong. Please onboard the journal again."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid ""
+"- The Journal (%s) is not onboarded yet. Please onboard it and try again."
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "1. There are three modes available:"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid ""
+"2. After selecting the mode, please go to <span "
+"class=\"o_form_label\">Journals &gt; Sales Type &gt; ZATCA Tab &gt; "
+"Onboard.</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid ""
+"3. Once the Journal is onboarded, you can begin using the selected mode."
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__700
 msgid "700 Number"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"<b>\n"
-"                                In order to be able to submit Invoices to ZATCA, the following steps need to be completed:\n"
-"                            </b>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -133,6 +151,24 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.arabic_english_invoice
 msgid "<span class=\"fw-bold\">VAT Amount</span>"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "<span class=\"o_form_label\">Production</span> - Live environment"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">Sandbox</span> - Common pre-configured testing "
+"environment"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid ""
+"<span class=\"o_form_label\">Simulation</span> - Unique testing environment"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -169,41 +205,14 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_number
-msgid "Additional Identification Number for Seller/Buyer"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Additional Identification Number is required for commercial partners"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Additional Identification Scheme is required for the Buyer if tax exemption "
-"reason is either VATEX-SA-HEA or VATEX-SA-EDU, and its value must be NAT"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Additional Identification Scheme is required for the Seller, and must be one"
-" of CRN, MOM, MLS, SAG or OTH"
+msgid "Additional Identification Number for the Seller/Buyer"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_scheme
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_scheme
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_scheme
-msgid "Additional Identification scheme for Seller/Buyer"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Are you sure you wish to re-onboard the Journal?"
+msgid "Additional Identification Scheme for the Seller/Buyer"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -225,12 +234,6 @@ msgid "Building Number"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Building Number for the Buyer is required on Standard Invoices"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_json
 msgid "CCSID JSON"
 msgstr ""
@@ -246,25 +249,6 @@ msgid "Cancel"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid ""
-"Cannot request a Production CSID before completing the Compliance Checks"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Cannot request a Production CSID before requesting a CCSID first"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_tax.py:0
-msgid "Cannot set a tax to Retention if the amount is greater than or equal 0"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_certificate_certificate
 msgid "Certificate"
 msgstr ""
@@ -276,6 +260,8 @@ msgid "Chain Head"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "City"
 msgstr ""
@@ -297,13 +283,6 @@ msgid "Companies"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Complete the Compliance Checks\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_checks_passed\"/>"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_compliance_csid_json
 msgid ""
 "Compliance CSID data received from the Compliance CSID API in dumped json "
@@ -316,14 +295,13 @@ msgid "Compliance Checks Done"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Compliance checks can only be run for companies operating from KSA"
+#: model:ir.model,name:l10n_sa_edi.model_res_config_settings
+msgid "Config Settings"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model:ir.model,name:l10n_sa_edi.model_res_config_settings
-msgid "Config Settings"
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
+msgid "Confirm"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -333,36 +311,8 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Could not complete Compliance Checks for the following file:"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid "Could not generate Invoice UBL content: %s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Could not generate PCSID values:\n"
-"%(error)s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"Could not generate signed XML values:\n"
-"%(error)s"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Could not obtain Compliance CSID: %s"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -409,6 +359,11 @@ msgid "Display Name"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Do you really want to re-onboard this Journal with ZATCA?"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_bank_statement_line__l10n_sa_uuid
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move__l10n_sa_uuid
 msgid "Document UUID (SA)"
@@ -420,15 +375,25 @@ msgid "EDI format"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Error: This invoice is blocked due to %s. Please check it."
+#: model:ir.actions.act_window,name:l10n_sa_edi.l10n_sa_edi_otp_wizard_act_window
+msgid "Enter the OTP"
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Errors:"
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Error: Invoice rejected by ZATCA"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Error: Journal is not onboarded"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid "Error: This invoice is blocked due to %s. Please check it."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -471,6 +436,12 @@ msgid "ID"
 msgstr ""
 
 #. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_partner_form
+msgid "Identification Number"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_number
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_number
@@ -482,12 +453,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_partner__l10n_sa_edi_additional_identification_scheme
 #: model:ir.model.fields,field_description:l10n_sa_edi.field_res_users__l10n_sa_edi_additional_identification_scheme
 msgid "Identification Scheme"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice Successfully Submitted to ZATCA"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -521,20 +486,13 @@ msgid "Invoice submission to ZATCA returned errors"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice was Accepted by ZATCA (with Warnings)"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "Invoice was rejected by ZATCA"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields.selection,name:l10n_sa_edi.selection__res_partner__l10n_sa_edi_additional_identification_scheme__iqa
 msgid "Iqama Number"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model:ir.model.fields,field_description:l10n_sa_edi.field_res_company__l10n_sa_edi_is_production
+msgid "Is Production"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -568,13 +526,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Journal could not be onboarded"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Journal could not be onboarded. Please make sure the Company "
-"VAT/Identification Number are correct."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -641,18 +592,6 @@ msgid "National ID"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Neighborhood for the Buyer is required on Standard Invoices"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "Neighborhood for the Seller is required on Standard Invoices"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "Neighborhood..."
 msgstr ""
@@ -671,12 +610,12 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Onboard Journal"
+msgid "Onboard"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Onboard the Journal by completing each step"
+msgid "Onboard this Journal"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -687,9 +626,9 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
 msgid ""
-"Once you change the submission mode to <strong>Production</strong>, you cannot change it anymore.\n"
-"                            Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for\n"
-"                            and might lead to <strong>Fines &amp; Penalties</strong>."
+"Once the mode is set to <strong>Production</strong> and an Invoice has been submitted to ZATCA,\n"
+"                            then the API mode cannot be changed. Any invoice submitted in the Production mode will be officially\n"
+"                            recorded with ZATCA and considered in the calculation of the VAT Liability."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -735,12 +674,6 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/migrations/0.2/post-migrate.py:0
-msgid "Please Re-Onboard the Journal for a new serial number"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_move.py:0
 #, python-format
 msgid ""
@@ -751,36 +684,50 @@ msgstr ""
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, generate a CSR before requesting a CCSID"
+msgid "Please change the (%s)'s country to Saudi Arabia and try again."
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid ""
-"Please, make a request to obtain the Compliance CSID and Production CSID "
-"before sending documents to ZATCA"
+msgid "Please check the details below and onboard the journal again:"
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid ""
-"Please, make sure all the following fields have been correctly set on the "
-"Company:%(fields)s"
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Please check the details below and retry after addressing them:"
 msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "Please, set a valid OTP to be used for Onboarding"
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Please check the details below:"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
+msgid "Please input the OTP generated from the Fatoora Portal."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
+msgid "Please provide an OTP to complete the onboarding process"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
 msgid ""
-"Please, set the OTP you received from ZATCA in the input below then "
-"validate."
+"Please set the VAT Number as the Identification Scheme is Tax Identification"
+" Number"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "Please set the following on %(company_name)s: %(fields)s"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -804,49 +751,18 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid ""
-"Production certificate has expired, please renew the PCSID before proceeding"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "Re-Onboard"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "Renew Production CSID"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.l10n_sa_edi_otp_wizard_view_form
-msgid "Request"
+msgid "Renew"
 msgstr ""
 
 #. module: l10n_sa_edi
 #: model:ir.model,name:l10n_sa_edi.model_l10n_sa_edi_otp_wizard
 msgid "Request ZATCA OTP"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model:ir.actions.act_window,name:l10n_sa_edi.l10n_sa_edi_otp_wizard_act_window
-msgid "Request a CSID"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Request a Compliance Certificate (CCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_compliance_csid_json\" groups=\"base.group_system\"/>"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid ""
-"Request a Production Certificate (PCSID)\n"
-"                                    <i class=\"fa fa-check text-success ms-1\" invisible=\"not l10n_sa_production_csid_json\" groups=\"base.group_system\"/>"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -860,9 +776,8 @@ msgid "Sandbox"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move_send.py:0
-msgid "Send to Zatca"
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
+msgid "Saudi Arabia Electronic Invoicing"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -887,6 +802,20 @@ msgid "Simulation (Pre-Production)"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "Something went wrong. Please onboard the journal again."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
+msgid ""
+"Something went wrong. Please retry, and if that does not work, then onboard "
+"the journal again."
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_account_journal__l10n_sa_compliance_checks_passed
 msgid "Specifies if the Compliance Checks have been completed successfully"
 msgstr ""
@@ -898,14 +827,10 @@ msgid "Specifies which API the system should use"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
-msgid "State"
-msgstr ""
-
-#. module: l10n_sa_edi
 #. odoo-python
 #: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "State / Country subdivision"
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
+msgid "State"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -916,6 +841,17 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "Street..."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Success: Invoice accepted by ZATCA"
+msgstr ""
+
+#. module: l10n_sa_edi
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Success: Journal is onboarded and valid until"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -953,15 +889,28 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
+#: code:addons/l10n_sa_edi/models/account_move.py:0
 msgid ""
-"The Production CSID is still valid. You can only renew it once it has "
-"expired."
+"The Invoice(s) are linked to a validated EDI document and cannot be modified"
+" according to ZATCA rules"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
-msgid "The Production certificate is valid until"
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The Journal is not valid anymore. Please Renew it."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The Journal is valid until (%s) and can only be renewed upon expiry."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_journal.py:0
+msgid "The OTP is invalid. Please try again."
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -970,22 +919,22 @@ msgid "The date on which the certificate expires"
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid ""
-"The invoice was accepted by ZATCA, but returned warnings. Please, check the "
-"response below:"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_move.py:0
-msgid "The invoice was rejected by ZATCA. Please, check the response below:"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model:ir.model.fields,help:l10n_sa_edi.field_res_company__l10n_sa_private_key_id
 msgid "The private key used to generate the CSR and obtain certificates"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_tax.py:0
+msgid ""
+"The tax is unable to be set as Retention as the Amount is greater than or "
+"equal to 0."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move_send.py:0
+msgid "To ZATCA"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1014,14 +963,6 @@ msgstr ""
 #: model:ir.model.fields,help:l10n_sa_edi.field_l10n_sa_edi_otp_wizard__l10n_sa_renewal
 msgid ""
 "Used to decide whether we should call the PCSID renewal API or the CCSID API"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid ""
-"VAT is required when Identification Scheme is set to Tax Identification "
-"Number"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1111,15 +1052,19 @@ msgstr ""
 
 #. module: l10n_sa_edi
 #. odoo-python
+#: code:addons/l10n_sa_edi/models/account_move.py:0
+msgid "Warning: Invoice accepted by ZATCA with warnings"
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
 #: code:addons/l10n_sa_edi/models/account_journal.py:0
 msgid "Warnings:"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid ""
-"You can select the API used for submissions down below. There are three modes available: Sandbox, Pre-Production and Production.\n"
-"                            Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab."
+#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
+msgid "Yes"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1131,34 +1076,27 @@ msgid ""
 msgstr ""
 
 #. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/res_company.py:0
-msgid ""
-"You cannot change the ZATCA Submission Mode once it has been set to "
-"Production"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py:0
-msgid "You need to provide an OTP to be able to request a CCSID"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_journal.py:0
-msgid "You need to request the CCSID first before you can proceed"
-msgstr ""
-
-#. module: l10n_sa_edi
-#: model:ir.model.fields,field_description:l10n_sa_edi.field_account_move_send__l10n_sa_edi_enable_zatca
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.view_account_journal_form
 msgid "ZATCA"
 msgstr ""
 
 #. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/res_company.py:0
+msgid ""
+"ZATCA API Mode cannot be changed after an invoice has been successfully "
+"submitted under the Production Mode."
+msgstr ""
+
+#. module: l10n_sa_edi
+#. odoo-python
+#: code:addons/l10n_sa_edi/models/res_company.py:0
+msgid "ZATCA API Mode changed to %s"
+msgstr ""
+
+#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "ZATCA E-Invoicing Settings"
+msgid "ZATCA API Modes"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1184,19 +1122,8 @@ msgid "ZATCA chain stopping move"
 msgstr ""
 
 #. module: l10n_sa_edi
-#: model_terms:ir.ui.view,arch_db:l10n_sa_edi.res_config_settings_view_form
-msgid "ZATCA specific settings for Saudi eInvoicing"
-msgstr ""
-
-#. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.sa_partner_address_form
 msgid "ZIP"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "l10n_sa_edi_additional_identification_scheme"
 msgstr ""
 
 #. module: l10n_sa_edi
@@ -1212,12 +1139,6 @@ msgstr ""
 #. module: l10n_sa_edi
 #: model_terms:ir.ui.view,arch_db:l10n_sa_edi.export_sa_zatca_ubl_extensions
 msgid "not(//ancestor-or-self::ext:UBLExtensions)"
-msgstr ""
-
-#. module: l10n_sa_edi
-#. odoo-python
-#: code:addons/l10n_sa_edi/models/account_edi_format.py:0
-msgid "street2"
 msgstr ""
 
 #. module: l10n_sa_edi

--- a/addons/l10n_sa_edi/models/account_move_send.py
+++ b/addons/l10n_sa_edi/models/account_move_send.py
@@ -12,7 +12,7 @@ class AccountMoveSend(models.AbstractModel):
     def _get_all_extra_edis(self) -> dict:
         # EXTENDS 'account'
         res = super()._get_all_extra_edis()
-        res.update({'sa_edi': {'label': _("Send to Zatca"), 'is_applicable': self._is_sa_edi_applicable}})
+        res.update({'sa_edi': {'label': _("To ZATCA"), 'is_applicable': self._is_sa_edi_applicable}})
         return res
 
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):

--- a/addons/l10n_sa_edi/models/account_tax.py
+++ b/addons/l10n_sa_edi/models/account_tax.py
@@ -39,4 +39,4 @@ class AccountTax(models.Model):
     def _l10n_sa_constrain_is_retention(self):
         for tax in self:
             if tax.amount >= 0 and tax.l10n_sa_is_retention and tax.type_tax_use == 'sale':
-                raise UserError(_("Cannot set a tax to Retention if the amount is greater than or equal 0"))
+                raise UserError(_("The tax is unable to be set as Retention as the Amount is greater than or equal to 0."))

--- a/addons/l10n_sa_edi/models/ir_attachment.py
+++ b/addons/l10n_sa_edi/models/ir_attachment.py
@@ -12,8 +12,8 @@ class IrAttachment(models.Model):
         '''
         descr = 'Rejected ZATCA Document not to be deleted - ثيقة ZATCA المرفوضة لا يجوز حذفها'
         for attach in self.filtered(lambda a: a.description == descr and a.res_model == 'account.move'):
-            move = self.env['account.move'].browse(attach.res_id)
-            if move.country_code == "SA":
+            move = self.env['account.move'].browse(attach.res_id).exists()
+            if move and move.country_code == "SA":
                 raise UserError(_("You can't unlink an attachment being an EDI document refused by the government."))
 
     @api.ondelete(at_uninstall=False)

--- a/addons/l10n_sa_edi/models/res_partner.py
+++ b/addons/l10n_sa_edi/models/res_partner.py
@@ -19,9 +19,9 @@ class ResPartner(models.Model):
         ('IQA', 'Iqama Number'),
         ('PAS', 'Passport ID'),
         ('OTH', 'Other ID')
-    ], default="OTH", string="Identification Scheme", help="Additional Identification scheme for Seller/Buyer")
+    ], default="OTH", string="Identification Scheme", help="Additional Identification Scheme for the Seller/Buyer")
 
-    l10n_sa_edi_additional_identification_number = fields.Char("Identification Number (SA)", help="Additional Identification Number for Seller/Buyer")
+    l10n_sa_edi_additional_identification_number = fields.Char("Identification Number (SA)", help="Additional Identification Number for the Seller/Buyer")
 
     @api.model
     def _commercial_fields(self):

--- a/addons/l10n_sa_edi/views/account_journal_views.xml
+++ b/addons/l10n_sa_edi/views/account_journal_views.xml
@@ -13,66 +13,43 @@
                     <field name="l10n_sa_production_csid_json" invisible="1"/>
                     <field name="l10n_sa_compliance_checks_passed" invisible="1"/>
                     <page name="zatca_einvoicing" string="ZATCA" invisible="country_code != 'SA' or type != 'sale'">
-                        <p>
-                            <b>
-                                In order to be able to submit Invoices to ZATCA, the following steps need to be completed:
-                            </b>
-                            <ol class="mt-2 mb-4">
-                                <li>
-                                    Request a Compliance Certificate (CCSID)
-                                    <i class="fa fa-check text-success ms-1"
-                                       invisible="not l10n_sa_compliance_csid_json" groups="base.group_system"/>
-                                </li>
-                                <li>
-                                    Complete the Compliance Checks
-                                    <i class="fa fa-check text-success ms-1"
-                                       invisible="not l10n_sa_compliance_checks_passed"/>
-                                </li>
-                                <li>
-                                    Request a Production Certificate (PCSID)
-                                    <i class="fa fa-check text-success ms-1"
-                                       invisible="not l10n_sa_production_csid_json" groups="base.group_system"/>
-                                </li>
-                            </ol>
-                        </p>
                         <div class="alert alert-info d-flex justify-content-between align-items-center" role="alert"
                              invisible="l10n_sa_csr_errors or l10n_sa_compliance_csid_json" groups="base.group_system">
                             <p class="mb-0">
-                                Onboard the Journal by completing each step
+                                Onboard this Journal
                             </p>
                             <button name="%(l10n_sa_edi_otp_wizard_act_window)d" type="action" icon="fa-key"
                                     class="btn-info ">
-                                Onboard Journal
+                                Onboard
                             </button>
                         </div>
-                        <div class="alert alert-danger d-flex flex-column align-items-end" role="alert"
+                        <div class="alert alert-danger d-flex justify-content-between align-items-center" role="alert"
                              groups="base.group_system"
                              invisible="not l10n_sa_csr_errors or l10n_sa_compliance_csid_json or l10n_sa_production_csid_json">
-                            <div class="w-100">
-                                <h4 role="alert" class="alert-heading">Journal could not be onboarded. Please make sure the Company VAT/Identification Number are correct.</h4>
+                            <div>
+                                <h4 role="alert" class="alert-heading">Error: Journal is not onboarded</h4>
                                 <field name="l10n_sa_csr_errors" nolabel="1" readonly="1"/>
-                                <hr/>
                             </div>
                             <button name="%(l10n_sa_edi_otp_wizard_act_window)d" type="action" icon="fa-key"
                                     class="btn-danger">
-                                Onboard Journal
+                                Onboard
                             </button>
                         </div>
                         <div class="alert alert-info d-flex justify-content-between align-items-center" role="alert"
                              groups="base.group_system"
                              invisible="not l10n_sa_compliance_checks_passed or not l10n_sa_production_csid_json">
                             <p class="mb-0">
-                                The Production certificate is valid until
+                                Success: Journal is onboarded and valid until
                                 <field name="l10n_sa_production_csid_validity" readonly="1" nolabel="1"
                                        class="fw-bold"/>
                             </p>
                             <div>
                                 <button name="%(l10n_sa_edi_otp_wizard_act_window)d" type="action" icon="fa-refresh"
                                         class="btn-info" context="{'default_l10n_sa_renewal': True}">
-                                    Renew Production CSID
+                                    Renew
                                 </button>
                                 <button name="%(l10n_sa_edi_otp_wizard_act_window)d" type="action" icon="fa-refresh" class="btn-warning ms-2"
-                                    confirm="Are you sure you wish to re-onboard the Journal?">
+                                    confirm="Do you really want to re-onboard this Journal with ZATCA?" confirm-title="Re-onboarding Confirmation" confirm-label="Yes">
                                     Re-Onboard
                                 </button>
                             </div>

--- a/addons/l10n_sa_edi/views/res_company_views.xml
+++ b/addons/l10n_sa_edi/views/res_company_views.xml
@@ -16,7 +16,7 @@
                 </xpath>
                 <xpath expr="//field[@name='vat']" position="before">
                     <field name="l10n_sa_edi_additional_identification_scheme" invisible="country_code != 'SA'"/>
-                    <field name="l10n_sa_edi_additional_identification_number" invisible="country_code != 'SA' or l10n_sa_edi_additional_identification_scheme == 'TIN'"/>
+                    <field name="l10n_sa_edi_additional_identification_number" string="Identification Number" invisible="country_code != 'SA' or l10n_sa_edi_additional_identification_scheme == 'TIN'"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_sa_edi/views/res_config_settings_view.xml
+++ b/addons/l10n_sa_edi/views/res_config_settings_view.xml
@@ -6,27 +6,33 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//app[@name='account']/block" position="before">
+            <xpath expr="//app[@name='account']/block" position="after">
                 <field name="country_code" invisible="1"/>
-                <block title="ZATCA E-Invoicing Settings" name="zatca_einvoicing_setting_container" invisible="country_code != 'SA'">
-                    <setting string="ZATCA E-Invoicing Settings" company_dependent="1" help="ZATCA specific settings for Saudi eInvoicing">
+                <block title="Saudi Arabia Electronic Invoicing" name="zatca_einvoicing_setting_container" invisible="country_code != 'SA'">
+                    <setting class="col-lg-12" string="ZATCA API Modes" company_dependent="1">
                         <div class="text-muted">
-                            You can select the API used for submissions down below. There are three modes available: Sandbox, Pre-Production and Production.
-                            Once you have selected the correct API, you can start the Onboarding process by going to the Journals and checking the options under the ZATCA tab.
+                            <div>1. There are three modes available:</div>
+                            <ul class="mb8">
+                                <li><span class="o_form_label">Sandbox</span> - Common pre-configured testing environment</li>
+                                <li><span class="o_form_label">Simulation</span> - Unique testing environment</li>
+                                <li><span class="o_form_label">Production</span> - Live environment</li>
+                            </ul>
+                            <div>2. After selecting the mode, please go to <span class="o_form_label">Journals &gt; Sales Type &gt; ZATCA Tab &gt; Onboard.</span></div>
+                            <div>3. Once the Journal is onboarded, you can begin using the selected mode.</div>
                         </div>
-                        <div class="content-group">
+                        <div class="content-group col-lg-6">
                             <div class="row mt16">
                                 <label for="l10n_sa_api_mode" string="API Mode" class="col-3 o_light_label"/>
                                 <field name="l10n_sa_api_mode" help="Set whether the system should use the Production API"/>
                             </div>
                         </div>
-                        <div class="alert alert-warning mt8" role="alert">
+                        <div class="alert alert-warning mt8 col-lg-6" role="alert" invisible="l10n_sa_api_mode != 'prod'">
                             <h4 class="alert-heading" role="alert">
                                 <i class="fa fa-warning me-2" /> Warning
                             </h4>
-                            Once you change the submission mode to <strong>Production</strong>, you cannot change it anymore.
-                            Be very careful, as any invoice submitted to ZATCA in Production mode will be accounted for
-                            and might lead to <strong>Fines &amp; Penalties</strong>.
+                            Once the mode is set to <strong>Production</strong> and an Invoice has been submitted to ZATCA,
+                            then the API mode cannot be changed. Any invoice submitted in the Production mode will be officially
+                            recorded with ZATCA and considered in the calculation of the VAT Liability.
                         </div>
                     </setting>
                 </block>

--- a/addons/l10n_sa_edi/views/res_partner_views.xml
+++ b/addons/l10n_sa_edi/views/res_partner_views.xml
@@ -9,7 +9,7 @@
             <field name="arch" type="xml">
                 <xpath expr="//div[hasclass('o_address_format')]"  position="after">
                     <field name="l10n_sa_edi_additional_identification_scheme" invisible="'SA' not in fiscal_country_codes or country_code != 'SA'"/>
-                    <field name="l10n_sa_edi_additional_identification_number" invisible="'SA' not in fiscal_country_codes or country_code != 'SA' or l10n_sa_edi_additional_identification_scheme == 'TIN'"/>
+                    <field name="l10n_sa_edi_additional_identification_number" string="Identification Number" invisible="'SA' not in fiscal_country_codes or country_code != 'SA' or l10n_sa_edi_additional_identification_scheme == 'TIN'"/>
                 </xpath>
             </field>
         </record>

--- a/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py
+++ b/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.py
@@ -22,7 +22,7 @@ class L10n_Sa_EdiOtpWizard(models.TransientModel):
 
     def validate(self):
         if not self.l10n_sa_otp:
-            raise UserError(_("You need to provide an OTP to be able to request a CCSID"))
+            raise UserError(_("Please provide an OTP to complete the onboarding process"))
         if self.l10n_sa_renewal:
             return self.journal_id._l10n_sa_get_production_CSID(self.l10n_sa_otp)
         self.journal_id._l10n_sa_api_onboard_journal(self.l10n_sa_otp)

--- a/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
+++ b/addons/l10n_sa_edi/wizard/l10n_sa_edi_otp_wizard.xml
@@ -6,14 +6,14 @@
         <field name="model">l10n_sa_edi.otp.wizard</field>
         <field name="arch" type="xml">
             <form string="Use an OTP to request for a CSID">
-                Please, set the OTP you received from ZATCA in the input below then validate.
+                Please input the OTP generated from the Fatoora Portal.
                 <group>
                     <field name="journal_id" invisible="1"/>
                     <field name="l10n_sa_renewal" invisible="1"/>
                     <field name="l10n_sa_otp"/>
                 </group>
                 <footer>
-                    <button string="Request" type="object" name="validate" class="btn btn-primary" data-hotkey="q"/>
+                    <button string="Confirm" type="object" name="validate" class="btn btn-primary" data-hotkey="q"/>
                     <button string="Cancel" special="cancel" data-hotkey="x" class="btn btn-secondary"/>
                 </footer>
             </form>
@@ -21,7 +21,7 @@
     </record>
 
     <record id="l10n_sa_edi_otp_wizard_act_window" model="ir.actions.act_window">
-        <field name="name">Request a CSID</field>
+        <field name="name">Enter the OTP</field>
         <field name="res_model">l10n_sa_edi.otp.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>


### PR DESCRIPTION
Before this commit:
1. Error messages contained technical terms like PCSID and CSID, which were
difficult for end users to understand.
2. If a user accidentally switched the api_mode to Production, they could not go
back to Sandbox/Simulation mode again.
3. The Reset to Draft button was not visible in Sandbox/Simulation mode.
4. Users could not delete invoices in Draft/Cancel state in Sandbox/Simulation
mode.

After this commit:
1. Error messages are now easier to read and help users understand what to do
next.
2. Users can now switch back from Production to Sandbox/Simulation as long as no
invoices have been submitted to ZATCA in Production mode.
3. The Reset to Draft button is now visible in Sandbox/Simulation mode.
Also, the Reset to Draft button is invisible during timeout in all api modes.
4. Users can now delete invoices in Draft/Cancel state in Sandbox/Simulation
mode.

task-4571781