### PR TITLE
[FIX] http_routing,test_website: no 500 on GET route rewrite

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -667,9 +667,10 @@ class IrHttp(models.AbstractModel):
         router = http.root.get_db_router(request.db).bind('')
         endpoint = False
         try:
-            endpoint = router.match(path, method='POST', query_args=query_args)
-        except werkzeug.exceptions.MethodNotAllowed:
-            endpoint = router.match(path, method='GET', query_args=query_args)
+            try:
+                endpoint = router.match(path, method='POST', query_args=query_args)
+            except werkzeug.exceptions.MethodNotAllowed:
+                endpoint = router.match(path, method='GET', query_args=query_args)
         except werkzeug.routing.RequestRedirect as e:
             new_url = e.new_url.split('?')[0][7:]  # remove scheme
             _, endpoint = self.url_rewrite(new_url, query_args)

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -56,6 +56,28 @@ class TestRedirect(HttpCase):
         self.assertTrue(country_ad.name in r.text, "Ensure the controller returned the expected value (2)")
         self.assertTrue(redirect_url in r.text, "Ensure the url_for has replaced the href URL in the DOM")
 
+    def test_redirect_308_by_method_url_rewrite(self):
+        self.env['website.rewrite'].create({
+            'name': 'Test Website Redirect',
+            'redirect_type': '308',
+            'url_from': url_from,
+            'url_to': f'{url_from}_new',
+        } for url_from in ('/get', '/post', '/get_post'))
+
+        self.env.ref('test_website.test_view').arch = '''
+            <t>
+                <a href="/get"></a><a href="/post"></a><a href="/get_post"></a>
+            </t>
+        '''
+
+        # [Public User] Open the /test_view url and ensure urls are rewritten
+        r = self.url_open('/test_view')
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(
+            r.content.strip(),
+            b'<a href="/get_new"></a><a href="/post_new"></a><a href="/get_post_new"></a>'
+        )
+
     @mute_logger('odoo.http')  # mute 403 warning
     def test_02_redirect_308_RequestUID(self):
         self.env['website.rewrite'].create({


### PR DESCRIPTION
Scenario:
- add an URL rewrite (308) of a route with only GET method (eg.
  test_website route /get rewritten to /get_new)
- add a link in any website page to the original route (eg. /get)
- open that page as public or user without website editing right

Issue: an error 500 is shown instead of the page

Cause: since the introduction of URL rewritting in
be8fc2296b3822baffe0bc68cb4b7efdfe53fa91 the url_for method only worked
for rewrite of route that had a POST method. In a GET method there was
no try/except to handle a rewrite.

Fix: handle GET method rewrite as it's done for POST method.

Note: the added test without the fix fails with a 500 status code
instead of the 200 expected.

opw-4817473