### PR TITLE
[FIX] html_editor: insert separator based on block content

### DIFF
--- a/addons/html_editor/static/src/core/dom_plugin.js
+++ b/addons/html_editor/static/src/core/dom_plugin.js
@@ -611,7 +611,15 @@ export class DomPlugin extends Plugin {
             (block && !isListItemElement(block) ? block : null);
 
         if (element && element !== this.editable) {
-            element.before(sep);
+            if (isEmptyBlock(element)) {
+                element.before(sep);
+            } else {
+                element.after(sep);
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                fillEmpty(baseContainer);
+                sep.after(baseContainer);
+                this.dependencies.selection.setCursorStart(baseContainer);
+            }
         }
         this.dependencies.history.addStep();
     }

--- a/addons/html_editor/static/tests/insert/separator.test.js
+++ b/addons/html_editor/static/tests/insert/separator.test.js
@@ -17,7 +17,7 @@ describe("insert separator", () => {
         });
     });
 
-    test("should insert a separator before current element", async () => {
+    test("should insert a separator before current element if empty", async () => {
         await testEditor({
             contentBefore: "<p>content</p><p>[]<br></p>",
             stepFunction: insertSeparator,
@@ -26,11 +26,28 @@ describe("insert separator", () => {
         });
     });
 
-    test("should insert a separator before current paragraph related element but remain inside the div", async () => {
+    test("should insert a separator after current element if it contains text", async () => {
+        await testEditor({
+            contentBefore: "<p>content</p><p>text[]</p>",
+            stepFunction: insertSeparator,
+            contentAfterEdit: `<p>content</p><p>text</p><hr contenteditable="false"><p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+            contentAfter: "<p>content</p><p>text</p><hr><p>[]<br></p>",
+        });
+    });
+
+    test("should insert a separator before current empty paragraph related element but remain inside the div", async () => {
         await testEditor({
             contentBefore: "<div><p>[]<br></p></div>",
             stepFunction: insertSeparator,
             contentAfter: "<div><hr><p>[]<br></p></div>",
+        });
+    });
+
+    test("should insert a separator after current paragraph related element containing text but remain inside the div", async () => {
+        await testEditor({
+            contentBefore: "<div><p>content[]</p></div>",
+            stepFunction: insertSeparator,
+            contentAfter: "<div><p>content</p><hr><p>[]<br></p></div>",
         });
     });
 
@@ -42,7 +59,7 @@ describe("insert separator", () => {
         });
     });
 
-    test("should insert a separator before a p element inside a table cell", async () => {
+    test("should insert a separator before a empty p element inside a table cell", async () => {
         await testEditor({
             contentBefore: "<table><tbody><tr><td><p>[]<br></p></td></tr></tbody></table>",
             stepFunction: insertSeparator,
@@ -50,11 +67,28 @@ describe("insert separator", () => {
         });
     });
 
-    test("should insert a seperator within a block node", async () => {
+    test("should insert a separator after a p element containing text inside a table cell", async () => {
+        await testEditor({
+            contentBefore: "<table><tbody><tr><td><p>content[]</p></td></tr></tbody></table>",
+            stepFunction: insertSeparator,
+            contentAfter:
+                "<table><tbody><tr><td><p>content</p><hr><p>[]<br></p></td></tr></tbody></table>",
+        });
+    });
+
+    test("should insert a seperator before a empty block node", async () => {
         await testEditor({
             contentBefore: "<div>[]<br></div>",
             stepFunction: insertSeparator,
             contentAfter: "<hr><div>[]<br></div>",
+        });
+    });
+
+    test("should insert a seperator after a block node containing text", async () => {
+        await testEditor({
+            contentBefore: "<div>content[]</div>",
+            stepFunction: insertSeparator,
+            contentAfter: "<div>content</div><hr><p>[]<br></p>",
         });
     });
 


### PR DESCRIPTION
Description of the issue this PR addresses:

Current behavior before PR:

The separator was always inserted before the current block, regardless of its content.

Desired behavior after PR is merged:

The separator is inserted before the block if it's empty, otherwise it is inserted after the block if it contains text.

task-4848276

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
