### PR TITLE
[FIX] base: remove superfluous whitespace before line breaks in display_name

### DIFF
--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -273,7 +273,7 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
         bill = self.import_attachment(xml_attachment)
 
         self.assertRecordValues(bill.partner_id, [partner_vals])
-        self.assertEqual(bill.partner_id.contact_address, "270 rte d'Arlon\n\n8010 Strassen \nLuxembourg")
+        self.assertEqual(bill.partner_id.contact_address, "270 rte d'Arlon\n8010 Strassen\nLuxembourg")
 
     def test_actual_delivery_date_in_cii_xml(self):
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -1151,7 +1151,8 @@ class ResPartner(models.Model):
         :rtype: string
         '''
         address_format, args = self._prepare_display_address(without_company)
-        return address_format % args
+        address_name = address_format % args
+        return '\n'.join(s.strip() for s in address_name.split('\n') if s.strip())
 
     def _display_address_depends(self):
         # field dependencies of method _display_address()

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -1014,6 +1014,33 @@ class TestPartnerAddressCompany(TransactionCase):
         res_bhide = test_partner_bhide.with_context(show_address=1).display_name
         self.assertEqual(res_bhide, "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
 
+        partner = self.env['res.partner'].create({
+            'name': 'John',
+            'street': '123 Road',
+            'street2': '',
+            'city': 'Nowhere',
+        })
+        name = partner.with_context(show_address=True).display_name
+        self.assertEqual(name, 'John\n123 Road\nNowhere')
+
+        partner = self.env['res.partner'].create({
+            'name': 'John',
+            'street': '',
+            'street2': '123 Road',
+            'city': 'Nowhere',
+        })
+        name = partner.with_context(show_address=True).display_name
+        self.assertEqual(name, 'John\n123 Road\nNowhere')
+
+        partner = self.env['res.partner'].create({
+            'name': 'John',
+            'street': '',
+            'street2': '',
+            'city': 'Nowhere',
+        })
+        name = partner.with_context(show_address=True).display_name
+        self.assertEqual(name, 'John\nNowhere')
+
     def test_accessibility_of_company_partner_from_branch(self):
         """ Check accessibility of company partner from branch. """
         company = self.env['res.company'].create({'name': 'company'})


### PR DESCRIPTION
**Issue**: 
Empty lines appeared in PDF reports (e.g. quotation, sales order, invoice...) when either the `street` or `street2` was empty.

**Steps to reproduce**:
- Open the Sales app
- Create a new quotation
- Set a customer with an incomplete address (either street or street2 left empty)
- Click the "Print" button to generate the PDF

**Cause**:
The commit [29f7475](https://github.com/odoo/odoo/commit/29f7475437586363e473955315d74aef7d80028c) unintentionally removed a line of code that cleaned up whitespace before line breaks. This caused unwanted empty lines in the output:
`name = re.sub(r'\s+\n', '\n', name)`

**Solution**:
-Rather than reintroducing a regex as a workaround to clean up formatting after the fact, the issue is now addressed directly in the `_display_address` method, preventing it at the source.
-The test `test_import_partner_postal_address` has been adapted since the behaviour of `_display_address` changes.

opw-4795300