### PR TITLE
[FIX] l10n_it_edi: fix xml export for italy localization

### DIFF
--- a/addons/l10n_it_edi/data/invoice_it_template.xml
+++ b/addons/l10n_it_edi/data/invoice_it_template.xml
@@ -148,9 +148,6 @@
             <DatiOrdineAcquisto t-if="origin_document_type == 'purchase_order'">
                 <t t-call="l10n_it_edi.account_invoice_FatturaPA_origin_document"/>
             </DatiOrdineAcquisto>
-            <DatiOrdineAcquisto t-elif="record.ref and not record.reversed_entry_id">
-                <IdDocumento t-out="format_alphanumeric(record.ref, 20)"/>
-            </DatiOrdineAcquisto>
             <DatiContratto t-if="origin_document_type == 'contract'">
                 <t t-call="l10n_it_edi.account_invoice_FatturaPA_origin_document"/>
             </DatiContratto>
@@ -160,13 +157,19 @@
             <t t-if="reconciled_moves">
                 <DatiFattureCollegate t-foreach="reconciled_moves" t-as="reconciled_move">
                     <IdDocumento t-out="format_alphanumeric(reconciled_move.name, -20)"/>
-                    <Data t-out="format_date(reconciled_move.date if reconciled_move.l10n_it_edi_is_self_invoice else reconciled_move.invoice_date)"/>
+                    <DataDocumento t-out="format_date(reconciled_move.date if reconciled_move.l10n_it_edi_is_self_invoice else reconciled_move.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <t t-elif="record.reversed_entry_id">
                 <DatiFattureCollegate>
                     <IdDocumento t-out="format_alphanumeric(record.reversed_entry_id.name, -20)"/>
-                    <Data t-out="format_date(record.reversed_entry_id.date if record.reversed_entry_id.l10n_it_edi_is_self_invoice else record.reversed_entry_id.invoice_date)"/>
+                    <DataDocumento t-out="format_date(record.reversed_entry_id.date if record.reversed_entry_id.l10n_it_edi_is_self_invoice else record.reversed_entry_id.invoice_date)"/>
+                </DatiFattureCollegate>
+            </t>
+            <t t-elif="record.ref">
+                <DatiFattureCollegate>
+                    <IdDocumento t-out="format_alphanumeric(record.ref, 20)"/>
+                    <DataDocumento t-out="format_date(record.invoice_date)"/>
                 </DatiFattureCollegate>
             </t>
             <DatiFattureCollegate t-foreach="downpayment_moves" t-as="downpayment_move">
@@ -197,7 +200,7 @@
                 </DatiRiepilogo>
             </t>
         </DatiBeniServizi>
-        <DatiPagamento t-if="partner_bank and record.move_type != 'out_refund'">
+        <DatiPagamento t-if="partner_bank and record.move_type != 'out_refund' and not is_self_invoice">
             <t t-set="payments" t-value="record.line_ids.filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))"/>
             <CondizioniPagamento t-translation="off"><t t-if="len(payments) == 1">TP02</t><t t-else="">TP01</t></CondizioniPagamento>
             <t t-foreach="payments" t-as="payment">

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge.xml
@@ -63,6 +63,10 @@
                 <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>832.42</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
+            <DatiFattureCollegate>
+                <IdDocumento>BILL/2022/04/0001</IdDocumento>
+                <DataDocumento>2022-03-24</DataDocumento>
+            </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>
@@ -82,13 +86,5 @@
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
-        <DatiPagamento>
-            <CondizioniPagamento>TP02</CondizioniPagamento>
-            <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>800.40</ImportoPagamento>
-            </DettaglioPagamento>
-        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_2.xml
@@ -63,6 +63,10 @@
                 <Numero>BILL/2022/04/0001</Numero>
                 <ImportoTotaleDocumento>1808.91</ImportoTotaleDocumento>
             </DatiGeneraliDocumento>
+            <DatiFattureCollegate>
+                <IdDocumento>BILL/2022/04/0001</IdDocumento>
+                <DataDocumento>2022-03-24</DataDocumento>
+            </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>
             <DettaglioLinee>
@@ -94,13 +98,5 @@
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
-        <DatiPagamento>
-            <CondizioniPagamento>TP02</CondizioniPagamento>
-            <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>1600.80</ImportoPagamento>
-            </DettaglioPagamento>
-        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_san_marino.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/bill_reverse_charge_san_marino.xml
@@ -94,13 +94,5 @@
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
-        <DatiPagamento>
-            <CondizioniPagamento>TP02</CondizioniPagamento>
-            <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>1600.80</ImportoPagamento>
-            </DettaglioPagamento>
-        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_negative_price.xml
@@ -66,7 +66,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>___ignore___</IdDocumento>
-                <Data>___ignore___</Data>
+                <DataDocumento>___ignore___</DataDocumento>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_refund_no_reconcile.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_refund_no_reconcile.xml
@@ -62,7 +62,7 @@
       </DatiGeneraliDocumento>
       <DatiFattureCollegate>
         <IdDocumento>BILL/2022/03/0001</IdDocumento>
-        <Data>2022-03-24</Data>
+        <DataDocumento>2022-03-24</DataDocumento>
       </DatiFattureCollegate>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/credit_note_reverse_charge.xml
@@ -65,11 +65,11 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <Data>2022-04-01</Data>
+                <DataDocumento>2022-04-01</DataDocumento>
             </DatiFattureCollegate>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0002</IdDocumento>
-                <Data>2022-04-01</Data>
+                <DataDocumento>2022-04-01</DataDocumento>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>
@@ -102,13 +102,5 @@
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
-        <DatiPagamento>
-            <CondizioniPagamento>TP02</CondizioniPagamento>
-            <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2022-03-24</DataScadenzaPagamento>
-                <ImportoPagamento>1200.80</ImportoPagamento>
-            </DettaglioPagamento>
-        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>

--- a/addons/l10n_it_edi/tests/export_xmls/invoice_exclude_postdated_moves.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/invoice_exclude_postdated_moves.xml
@@ -63,7 +63,7 @@
       </DatiGeneraliDocumento>
       <DatiFattureCollegate>
         <IdDocumento>INV/2022/00001</IdDocumento>
-        <Data>2022-03-24</Data>
+        <DataDocumento>2022-03-24</DataDocumento>
       </DatiFattureCollegate>
     </DatiGenerali>
     <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/export_xmls/split_payment_cn.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/split_payment_cn.xml
@@ -63,7 +63,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>INV/2022/00001</IdDocumento>
-                <Data>2022-03-24</Data>
+                <DataDocumento>2022-03-24</DataDocumento>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>

--- a/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
+++ b/addons/l10n_it_edi/tests/test_edi_reverse_charge.py
@@ -169,6 +169,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'date': '2022-04-01',
             'partner_id': self.french_partner.id,
             'partner_bank_id': self.test_bank.id,
+            'ref': 'BILL/2022/04/0001',
             'invoice_line_ids': [
                 Command.create({
                     'name': name,
@@ -189,6 +190,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'invoice_date_due': '2022-03-24',
             'date': '2022-04-01',
             'move_type': 'in_refund',
+            'ref': 'BILL/2022/04/0001',
             'partner_id': self.french_partner.id,
             'invoice_line_ids': [
                 Command.create({
@@ -216,6 +218,7 @@ class TestItEdiReverseCharge(TestItEdi):
             'invoice_date': '2022-03-24',
             'invoice_date_due': '2022-03-24',
             'date': '2022-04-01',
+            'ref': 'BILL/2022/04/0001',
             'partner_id': self.french_partner.id,
             'partner_bank_id': self.test_bank.id,
             'invoice_line_ids': [

--- a/addons/l10n_it_edi_ndd/tests/export_xmls/credit_note_export_document_type.xml
+++ b/addons/l10n_it_edi_ndd/tests/export_xmls/credit_note_export_document_type.xml
@@ -65,7 +65,7 @@
             </DatiGeneraliDocumento>
             <DatiFattureCollegate>
                 <IdDocumento>BILL/2022/04/0001</IdDocumento>
-                <Data>2022-04-01</Data>
+                <DataDocumento>2022-04-01</DataDocumento>
             </DatiFattureCollegate>
         </DatiGenerali>
         <DatiBeniServizi>
@@ -84,13 +84,5 @@
                 <EsigibilitaIVA>I</EsigibilitaIVA>
             </DatiRiepilogo>
         </DatiBeniServizi>
-        <DatiPagamento>
-            <CondizioniPagamento>TP02</CondizioniPagamento>
-            <DettaglioPagamento>
-                <ModalitaPagamento>MP05</ModalitaPagamento>
-                <DataScadenzaPagamento>2022-04-01</DataScadenzaPagamento>
-                <ImportoPagamento>800.40</ImportoPagamento>
-            </DettaglioPagamento>
-        </DatiPagamento>
     </FatturaElettronicaBody>
 </p:FatturaElettronica>


### PR DESCRIPTION
1- `<DatiPagamento>` shouldn't be included in autofatture.
2- The supplier's original invoice number and date must be placed in the `<DatiFattureCollegate>`, using `<IdDocumento>` and `<DataDocumento>` fields respectively. Currently `<IdDocumento>` is added to the `<DatiOrdineAcquisto>`. A fix is made to add `<IdDocumento>` and `<DataDocumento>` to `<DatiFattureCollegate>`.


references:
https://www.agenziaentrate.gov.it/portale/documents/d/guest/guida_compilazione-fe-esterometro-v1-10_aprile_2025

opw-4810326