### PR TITLE
[REV] point_of_sale: cash in/out rights

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1575,7 +1575,7 @@ class PosSession(models.Model):
         if not sessions:
             raise UserError(_("There is no cash payment method for this PoS Session"))
 
-        self.env['account.bank.statement.line'].sudo().create([
+        self.env['account.bank.statement.line'].create([
             {
                 'pos_session_id': session.id,
                 'journal_id': session.cash_journal_id.id,
@@ -1897,6 +1897,7 @@ class PosSession(models.Model):
         config = self.env['pos.config'].search_read(**params['search_params'])[0]
         config['use_proxy'] = config['is_posbox'] and (config['iface_electronic_scale'] or config['iface_print_via_proxy']
                                                        or config['iface_scan_via_proxy'] or config['iface_customer_facing_display_via_proxy'])
+        config['has_cash_move_permission'] = self.user_has_groups('account.group_account_invoice')
         return config
 
     def _loader_params_pos_bill(self):

--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -50,7 +50,9 @@ export class Navbar extends Component {
         return this.pos.config.iface_customer_facing_display && !isMobileOS();
     }
     get showCashMoveButton() {
-        return Boolean(this.pos?.config?.cash_control);
+        return Boolean(
+            this.pos?.config?.cash_control && this.pos?.config?.has_cash_move_permission
+        );
     }
     onCashMoveButtonClick() {
         this.hardwareProxy.openCashbox(_t("Cash in / out"));

--- a/addons/point_of_sale/static/tests/tours/ChromeWithoutCashMovePermission.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ChromeWithoutCashMovePermission.tour.js
@@ -1,0 +1,16 @@
+/** @odoo-module **/
+
+import * as Chrome from "@point_of_sale/../tests/tours/helpers/ChromeTourMethods";
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("chrome_without_cash_move_permission", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            Chrome.clickMenuButton(),
+            Chrome.isCashMoveButtonHidden(),
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/helpers/ChromeTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ChromeTourMethods.js
@@ -45,6 +45,15 @@ export function closeSession() {
         },
     ];
 }
+export function isCashMoveButtonHidden() {
+    return [
+        {
+            extraTrigger: ".pos-topheader",
+            trigger: ".pos-topheader:not(:contains(Cash In/Out))",
+            run: () => {},
+        },
+    ];
+}
 export function isCashMoveButtonShown() {
     return [
         {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -955,6 +955,18 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'ShowTaxExcludedTour', login="pos_user")
 
+    def test_chrome_without_cash_move_permission(self):
+        self.env.user.write({'groups_id': [
+            Command.set(
+                [
+                    self.env.ref('base.group_user').id,
+                    self.env.ref('point_of_sale.group_pos_user').id,
+                ]
+            )
+        ]})
+        self.main_pos_config.open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'chrome_without_cash_move_permission', login="accountman")
+
     def test_09_pos_barcodes_scan_product_pacaging(self):
         product = self.env['product.product'].create({
             'name': 'Packaging Product',


### PR DESCRIPTION
This commit reverts the changes made in https://github.com/odoo/odoo/pull/190342/commits/d47b256a10713618a853d9eeacb2c1665330ed4f as they are not wanted. The user that wants to have access to cash in/out should have the invoicing rights at least.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
