### PR TITLE
[IMP] product,website_sale: add "image" display type to attributes

### DIFF
--- a/addons/product/models/product_attribute.py
+++ b/addons/product/models/product_attribute.py
@@ -41,6 +41,7 @@ class ProductAttribute(models.Model):
             ('select', 'Select'),
             ('color', 'Color'),
             ('multi', 'Multi-checkbox'),
+            ('image', 'Image'),
         ],
         default='radio',
         required=True,

--- a/addons/product/views/product_attribute_views.xml
+++ b/addons/product/views/product_attribute_views.xml
@@ -67,7 +67,7 @@
                                        widget="image"
                                        options="{'size': [70, 70]}"
                                        class="oe_avatar text-start float-none"
-                                       column_invisible="parent.display_type != 'color'"/>
+                                       column_invisible="parent.display_type not in ['color', 'image']"/>
                                 <field name="default_extra_price" width="160px"/>
                                 <button
                                     name="action_add_to_products"

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -17,7 +17,7 @@ export class ProductTemplateAttributeLine extends Component {
                 name: String,
                 display_type: {
                     type: String,
-                    validate: type => ["color", "multi", "pills", "radio", "select"].includes(type),
+                    validate: type => ["color", "multi", "pills", "radio", "select", "image"].includes(type),
                 },
             },
         },
@@ -98,6 +98,8 @@ export class ProductTemplateAttributeLine extends Component {
                 return 'sale.ptav_color';
             case 'multi':
                 return 'sale.ptav_multi';
+            case 'image':
+                return 'sale.ptav_image';
         }
     }
 

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.scss
@@ -59,6 +59,43 @@
     }
 }
 
+.o_sale_product_configurator_ptav_image {
+    border: $border-width * 5 solid $body-bg;
+    outline: $border-width * 2 solid $border-color;
+    transition: $input-transition;
+    height: 62px;
+    aspect-ratio: 1;
+
+    &:hover, &.active {
+        outline-color: map-get($theme-colors, 'primary');
+    }
+
+    &.custom_value {
+        background-image: linear-gradient(to bottom right, #FF0000, #FFF200, #1E9600);
+    }
+
+    &.transparent {
+        background-image: url(/web/static/img/transparent.png);
+    }
+
+    &.css_not_available {
+        opacity: 1;
+        outline-color: map-get($theme-colors, 'danger');
+
+        &:after {
+            content: "";
+            @include o-position-absolute(-5px, -5px, -5px, -5px);
+            background-image: str-replace(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='39' height='39'><line y2='0' x2='39' y1='39' x1='0' style='stroke:#{map-get($theme-colors, 'danger')};stroke-width:2'/><line y2='1' x2='40' y1='40' x1='1' style='stroke:rgb(255,255,255);stroke-width:1'/></svg>"), "#", "%23") ;
+            background-position: center;
+            background-repeat: no-repeat;
+        }
+
+        &:hover, &.active {
+            outline-color: map-get($theme-colors, 'primary');
+        }
+    }
+}
+
 .o_sale_product_configurator_ptav_pills.active label {
     $-btn-secondary-design: map-get($o-btns-bs-override, "secondary");
     

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -119,6 +119,38 @@
             </li>
         </ul>
     </t>
+    <t t-name="sale.ptav_image">
+        <ul class="list-inline flex-grow-1 mb-0">
+            <li
+                t-foreach="this.props.attribute_values"
+                t-as="ptav"
+                t-key="ptav.id"
+                class="list-inline-item me-2"
+            >
+                <label
+                    class="position-relative d-inline-block text-center o_sale_product_configurator_ptav_image rounded-3 cursor-pointer"
+                    t-att-title="ptav.name"
+                    t-attf-style="#{ptav.image ? 'background-image:url(/web/image/product.template.attribute.value/'+ptav.id+'/image); background-size:cover;' : ''}"
+                    t-att-class="{
+                        'active': this.props.selected_attribute_value_ids.includes(ptav.id),
+                        'custom_value': ptav.is_custom,
+                        'transparent': !ptav.is_custom and !ptav.html_color,
+                        'css_not_available': ptav.excluded
+                    }"
+                >
+                    <input
+                        type="radio"
+                        t-attf-id="ptav-{{ptav.id}}-input"
+                        t-att-value="ptav.id"
+                        t-att-name="'ptal-' + this.props.id"
+                        t-att-checked="this.props.selected_attribute_value_ids.includes(ptav.id)"
+                        t-on-change="updateSelectedPTAV"
+                        class="w-100 h-100 opacity-0 cursor-pointer"
+                    />
+                </label>
+            </li>
+        </ul>
+    </t>
     <t t-name="sale.ptav_multi">
          <ul class="list-unstyled flex-grow-1 m-0">
             <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id"

--- a/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
+++ b/addons/test_sale_product_configurators/tests/test_sale_product_configurator.py
@@ -62,7 +62,7 @@ class TestProductConfiguratorUi(TestProductConfiguratorCommon):
             'create_variant': 'no_variant'
         }, {
             'name': 'PA5',
-            'display_type': 'select',
+            'display_type': 'image',
             'create_variant': 'no_variant'
         }, {
             'name': 'PA7',

--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -24,6 +24,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
         'input .o_wsale_attribute_search_bar': '_searchAttributeValues',
         'click .o_wsale_view_more_btn': '_onToggleViewMoreLabel',
         'change .css_attribute_color input': '_onChangeColorAttribute',
+        'change label[name="o_wsale_attribute_image_selector"] input': '_onChangeImageAttribute',
         'click .o_variant_pills': '_onChangePillsAttribute',
     },
 
@@ -131,7 +132,7 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
                     }
                 }
             });
-            this._changeAttribute(['.css_attribute_color', '.o_variant_pills']);
+            this._changeAttribute(['.css_attribute_color', '[name="o_wsale_attribute_image_selector"]', '.o_variant_pills']);
         }
     },
 
@@ -507,6 +508,33 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, {
             $attrValueEl.innerText = $eventTarget.data('value_name');
         }
     },
+
+    /**
+     * Highlight selected image
+     *
+     * @private
+     * @param {MouseEvent} ev
+     */
+    _onChangeImageAttribute(ev) {
+        const parent = ev.target.closest('.js_product');
+        const images = parent.querySelectorAll('label[name="o_wsale_attribute_image_selector"]');
+        images.forEach(el => {
+            el.classList.remove('active');
+        });
+        images.forEach(el => {
+            const input = el.querySelector('input');
+            if (input && input.checked) {
+                el.classList.add('active');
+            }
+        });
+        let attrValueEl = ev.target
+            .closest('[name="variant_attribute"]')?.querySelector('[name="attribute_value"]');
+        if (attrValueEl) {
+            attrValueEl.innerText = ev.target.dataset.value_name;
+        }
+    },
+
+
 
     _onChangePillsAttribute: function (ev) {
         const radio = ev.target.closest('.o_variant_pills').querySelector("input");

--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -49,6 +49,58 @@
     }
 }
 
+.css_attribute_image {
+    --o-wsale-css-attribute-image__height: 4rem;
+    --o-wsale-css-attribute-image__outline-width: #{$border-width * 2};
+
+    height: calc(var(--o-wsale-css-attribute-image__height) - var(--o-wsale-css-attribute-image__outline-width));
+    aspect-ratio: 1;
+    border: $border-width * 5 solid $body-bg;
+    outline: var(--o-wsale-css-attribute-image__outline-width) solid $border-color;
+    transition: $input-transition;
+
+    &:hover, &.active {
+        outline-color: map-get($theme-colors, 'primary');
+    }
+
+
+    &.custom_value {
+        background-image: linear-gradient(to bottom right, #FF0000, #FFF200, #1E9600);
+    }
+
+    &.transparent {
+        background-image: url(/web/static/img/transparent.png);
+    }
+
+    &.size_small {
+        --o-wsale-css-attribute-image__height: 3rem;
+        --o-wsale-css-attribute-image__outline-width: #{$border-width};
+    }
+}
+
+.css_not_available_msg {
+    display: none;
+}
+
+.css_not_available.js_product {
+    .css_quantity {
+        display: none !important;
+    }
+
+    .css_not_available_msg {
+        display: block;
+    }
+
+    .availability_messages {
+        display: none;
+    }
+
+    .oe_price,
+    .oe_default_price {
+        display: none;
+    }
+}
+
 .css_quantity {
     width: initial; // We don't want the quantity form to be full-width
     border-radius: $btn-border-radius;

--- a/addons/website_sale/static/src/website_builder/product_attribute_option.xml
+++ b/addons/website_sale/static/src/website_builder/product_attribute_option.xml
@@ -8,6 +8,7 @@
             <BuilderSelectItem actionValue="'pills'">Pills</BuilderSelectItem>
             <BuilderSelectItem actionValue="'select'">Select</BuilderSelectItem>
             <BuilderSelectItem actionValue="'color'">Color</BuilderSelectItem>
+            <BuilderSelectItem actionValue="'image'">Image</BuilderSelectItem>
         </BuilderSelect>
     </BuilderRow>
 </t>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -409,6 +409,20 @@
                             t-att-title="ptav.name"
                         />
                     </div>
+                    <div
+                        t-elif="ptav.display_type == 'image'"
+                        class="d-flex"
+                    >
+                        <div
+                            t-attf-class="css_attribute_image size_small cursor-pointer d-block rounded bg-body #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}"
+                            t-att-title="ptav.name"
+                        >
+                            <div
+                                class="o_bg_img_center w-100 h-100 rounded-1"
+                                t-att-style="'background-image:url(/web/image/product.attribute.value/%s/image);' % ptav.product_attribute_value_id.id"
+                            />
+                        </div>
+                    </div>
                     <span
                         t-else=""
                         t-attf-class="{{'' if ppr == 2 and layout_mode != 'list' else 'btn-sm'}} btn bg-body w-100 text-body text-truncate"
@@ -950,6 +964,27 @@
         </t>
     </template>
 
+    <template id="website_sale.filter_image_attributes" name="Image attributes in Filter">
+        <t t-foreach="a.value_ids" t-as="v">
+            <label
+                t-attf-class="css_attribute_image size_small position-relative rounded-3 bg-body text-center cursor-pointer #{'active' if v.id in attrib_set else ''} #{'custom_value' if v.is_custom else ''} #{'transparent' if (not v.is_custom and not v.html_color) else ''}"
+            >
+                <input
+                    type="checkbox"
+                    name="attribute_value"
+                    t-att-value="'%s-%s' % (a.id, v.id)"
+                    t-att-checked="'checked' if v.id in attrib_set else None"
+                    t-att-title="v.name"
+                    class="w-100 h-100 opacity-0 cursor-pointer"
+                />
+                <div
+                    class="oe_img_bg o_bg_img_center position-absolute top-0 w-100 h-100 rounded-1"
+                    t-att-style="'background-image:url(/web/image/product.attribute.value/%s/image); background-size:cover;' % v.id if v.image else ''"
+                />
+            </label>
+        </t>
+    </template>
+
     <template id="website_sale.filter_select_attributes" name="Select attributes in Filter">
         <select class="form-select css_attribute_select" name="attribute_value">
             <option value="" selected="true">All <t t-out="a.name"/></option>
@@ -1153,6 +1188,12 @@
                                     t-attf-class="{{'pt-1 pb-3' if isMobile else 'mb-3'}}"
                                 >
                                     <t t-call="website_sale.filter_color_attributes"/>
+                                </div>
+                                <div
+                                    t-elif="a.display_type == 'image'"
+                                    t-attf-class="d-flex flex-wrap gap-2 #{'pt-1 pb-3' if isMobile else 'mb-3'}"
+                                >
+                                    <t t-call="website_sale.filter_image_attributes"/>
                                 </div>
                                 <div
                                     t-elif="a.display_type in ('radio', 'multi')"

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -12,7 +12,8 @@
                 <t t-set="single" t-value="len(ptavs) == 1"/>
 
                 <!-- Attributes selection is hidden if there is only one value available and it's not a custom value -->
-                <li t-att-data-attribute_id="attribute.id"
+                <li name="variant_attribute"
+                    t-att-data-attribute_id="attribute.id"
                     t-att-data-attribute_name="attribute.name"
                     t-att-data-attribute_display_type="attribute.display_type"
                     t-attf-class="variant_attribute #{
@@ -25,14 +26,14 @@
                     <t t-set="single_and_custom" t-value="single and ptavs[0].is_custom"/>
                     <h6 class="attribute_name mb-2">
                         <span t-field="ptal.attribute_id.name"/>
-                        <span t-if="attribute.display_type == 'color'" class="text-muted">
+                        <span t-if="attribute.display_type in ['color', 'image']" class="text-muted">
                             -
                             <t
                                 t-set="active_ptavs"
                                 t-value="[ptav for ptav in ptavs if ptav in combination]"
                             />
                             <t t-foreach="active_ptavs" t-as="ptav">
-                                <span class="attribute_value" t-field="ptav.name"/>
+                                <span class="attribute_value" name="attribute_value" t-field="ptav.name"/>
                             </t>
                         </span>
                     </h6>
@@ -151,6 +152,37 @@
                                         t-att-data-is_custom="ptav.is_custom"
                                         t-att-data-is_single="single"
                                         t-att-data-is_single_and_custom="single_and_custom"/>
+                                </label>
+                            </li>
+                        </ul>
+                    </t>
+
+                    <t t-elif="attribute.display_type == 'image'">
+                        <ul
+                            t-att-data-attribute_id="attribute.id"
+                            t-attf-class="list-inline o_wsale_product_attribute #{'d-none' if single_and_custom else ''}"
+                        >
+                            <li t-foreach="ptavs" t-as="ptav" class="list-inline-item me-2 mb-2">
+                                <label
+                                    name="o_wsale_attribute_image_selector"
+                                    t-attf-style="#{'background-image: url(/web/image/product.template.attribute.value/%s/image); background-size:cover;' % ptav.id if ptav.image else ''}"
+                                    t-attf-class="css_attribute_image oe_img_bg o_bg_img_center position-relative d-inline-block rounded-3 bg-body text-center cursor-pointer #{'active' if ptav in combination else ''} #{'custom_value' if ptav.is_custom else ''} #{'transparent' if (not ptav.is_custom and not ptav.html_color) else ''}"
+                                >
+                                    <input
+                                        type="radio"
+                                        t-attf-class="js_variant_change w-100 h-100 opacity-0 cursor-pointer #{attribute.create_variant}"
+                                        t-att-checked="ptav in combination"
+                                        t-att-name="'ptal-%s' % ptal.id"
+                                        t-att-value="ptav.id"
+                                        t-att-title="ptav.name"
+                                        t-att-data-attribute-value-id="ptav.product_attribute_value_id.id"
+                                        t-att-data-value_id="ptav.id"
+                                        t-att-data-value_name="ptav.name"
+                                        t-att-data-attribute_name="attribute.name"
+                                        t-att-data-is_custom="ptav.is_custom"
+                                        t-att-data-is_single="single"
+                                        t-att-data-is_single_and_custom="single_and_custom"
+                                    />
                                 </label>
                             </li>
                         </ul>


### PR DESCRIPTION
When users add an attribute with display type "color", they can upload images for the different attribute values.
This commit adds a new "image" display type for attributes that is more suitable for displaying the attribute values as images. Using this display type will allow uploading images for attribute values without having to specify a color.
Attributes with this display type will be displayed more clearly in shop and product pages compared to "color" display type attributes with uploaded images.

task-4747409
