### PR TITLE
[FIX] account: Create Tax Reports for fiscal position when creating taxes

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -302,6 +302,7 @@ class AccountFiscalPosition(models.Model):
             localization_module.sudo().button_immediate_install()
         created_records = self.env["account.chart.template"]._instantiate_foreign_taxes(self.country_id, self.company_id)
         created_records.get('account.tax', self.env['account.tax']).fiscal_position_ids += self
+        self.env['account.return.type']._generate_or_refresh_all_returns(self.company_id.root_id)
 
 
 class AccountFiscalPositionAccount(models.Model):


### PR DESCRIPTION
When we create a fiscal position, we are checking if the user has the taxes for that country create and display a button to have the user download them.

Previously, we were trying to create the tax reports for that fiscal position when creating it, however since the l10n_report is loaded with the taxes, the creation of the tax return wouldn't be triggered.

Now, we are creating the tax returns after the user has downloaded the taxes needed for that fiscal position.

task-4840412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
