### PR TITLE
[FIX] website: catch UnicodeError

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -230,8 +230,11 @@ class Website(models.Model):
         for website in self:
             website_domain = website.domain or ''
             hostname = urlparse(website_domain).hostname or ''
-            punycode_hostname = hostname.encode('idna').decode('ascii')
-            website.domain_punycode = website_domain.replace(hostname, punycode_hostname)
+            try:
+                punycode_hostname = hostname.encode('idna').decode('ascii')
+                website.domain_punycode = website_domain.replace(hostname, punycode_hostname)
+            except UnicodeError:
+                website.domain_punycode = website_domain
 
     @api.depends('social_default_image')
     def _compute_has_social_default_image(self):


### PR DESCRIPTION
It's possible that the `hostname` obtained from `website_domain` is invalid, for instance:

```
website_domain='https://.com'
hostname='.com'
```

Attempt to encode it with `idna` will raise an error:
`UnicodeError: encoding with 'idna' codec failed (UnicodeError: label empty or too long)`

There's a few upgrades to 18.3 failing due to this:
[Traceback Group](https://upgrade.odoo.com/odoo/action-178/2029)
Tested with [upg-2847175](https://upgrade.odoo.com/odoo/action-150/2847175)