### PR TITLE
[FIX] point_of_sale: correctly update existing records when loading

### DIFF
--- a/addons/point_of_sale/static/src/app/services/data_service.js
+++ b/addons/point_of_sale/static/src/app/services/data_service.js
@@ -743,7 +743,7 @@ export class PosData extends Reactive {
         const data = await this.execute({ type: "call", model, method, args, kwargs, queue });
         if (data) {
             this.deviceSync?.dispatch && this.deviceSync.dispatch(data);
-            const results = this.models.loadData(data, [], true);
+            const results = this.models.loadData(data, [], true, true);
             this.synchronizeServerDataInIndexedDB(data);
             return results;
         }

--- a/addons/point_of_sale/static/src/app/services/pos_store.js
+++ b/addons/point_of_sale/static/src/app/services/pos_store.js
@@ -1262,6 +1262,7 @@ export class PosStore extends WithLazyGetterTrap {
             const newData = this.models.loadData(missingRecords, [], false, true);
 
             for (const line of newData["pos.order.line"]) {
+                line.pack_lot_ids = line.pack_lot_ids.filter((lot) => typeof lot.id === "number");
                 const refundedOrderLine = line.refunded_orderline_id;
 
                 if (refundedOrderLine && ["paid", "done"].includes(line.order_id.state)) {


### PR DESCRIPTION
Before this commit, when loading data that already existed, the records were not updated and were instead recreated. This commit ensures that existing records are properly updated.

opw-4850601

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
