### PR TITLE
[FIX] html_editor: handle images in snippets with default shapes

### DIFF
--- a/addons/html_editor/static/src/utils/image_processing.js
+++ b/addons/html_editor/static/src/utils/image_processing.js
@@ -181,7 +181,20 @@ export async function loadImageInfo(el, attachmentSrc = "") {
     }
 
     const srcUrl = new URL(src, docHref);
-    const relativeSrc = srcUrl.pathname;
+    let relativeSrc = srcUrl.pathname;
+
+    let match = relativeSrc.match(/\/(?:web_editor|html_editor)\/image_shape\/(\w+\.\w+)/);
+    if (el.dataset.shape && match) {
+        match = match[1];
+        if (match.endsWith("_perspective")) {
+            // As an image might already have been modified with a
+            // perspective for some customized snippets in themes. We need
+            // to find the original image to set the 'data-original-src'
+            // attribute.
+            match = match.slice(0, -12);
+        }
+        relativeSrc = `/web/image/${encodeURIComponent(match)}`;
+    }
 
     const { original } = await rpc("/html_editor/get_image_info", { src: relativeSrc });
     // If src was an absolute "external" URL, we consider unlikely that its


### PR DESCRIPTION
This commit fixes an issue where modifying an image's shape would crash if the image originated from a snippet that applied a shape by default. The crash was due to a missing `originalSrc` attribute in the image's dataset.

This bug was introduced by the website refactor [1], which removed the `_initializeImage` method that was in `ImageTools`. This method previously applied a regex to determine the correct URL when `loadImageInfo` was called.

The fix reintroduces the necessary regex logic directly into the `loadImageInfo` function. This logic now also accounts for `html_editor` paths to ensure future compatibility when `image_shape` elements are migrated from `web_editor`.

Steps to reproduce:
- Drop `s_mockup_image` snippet
- Click on the image
- Click to modify its shape from `MacBook #1` to another shape
- The operation should now work without traceback

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddbbfd0445ffe25a859e67a316d02b2

Related to task-4367641