### PR TITLE
[FIX] website: escape bad characters compile in website name

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -675,9 +675,10 @@ class Website(models.Model):
                     'database_id': database_id,
                 })
                 name_replace_parser = re.compile(r"XXXX", re.MULTILINE)
+                website_name = re.escape(website.name)
                 for key in generated_content:
                     if response.get(key):
-                        generated_content[key] = (name_replace_parser.sub(website.name, response[key], 0))
+                        generated_content[key] = (name_replace_parser.sub(website_name, response[key], 0))
             except AccessError:
                 # If IAP is broken continue normally (without generating text)
                 pass


### PR DESCRIPTION
Currently, using special characters like backslashes `(\)` in the website name would cause a regex substitution error during website configuration.

**Steps to Reproduce:**
- Install the `website` module.
- Go to Settings and change the website name (e.g; "`test\`").
- Navigate to the URL: "http://localhost:8069/website/configurator"
- Select a theme and a color palette for the website, then apply the changes.

Error: `error - bad escape (end of pattern) at position 19`

**Cause:**
At [1], a backslash in the `website.name` string leads to a malformed replacement string in `re.sub()`, causing a regex syntax error due to an invalid escape sequence.

[1]: https://github.com/odoo/odoo/blob/b8edcd131b3288d037bee9ee03726153932d82f1/addons/website/models/website.py#L678

**Fix:**
This PR escapes the `website.name` using `re.escape()` before using it in regex substitution, prevents runtime errors during website configuration.

sentry-6651288996,6557563272