### PR TITLE
[IMP] {website_}event{_sale}, mail: group tickets in one mail

### DIFF
--- a/addons/event/controllers/main.py
+++ b/addons/event/controllers/main.py
@@ -58,6 +58,9 @@ class EventController(Controller):
         if len(event_registrations_sudo) == 1:
             report_name += f" - {event_registrations_sudo[0].name}"
 
+        if event_registrations_sudo.child_ids:
+            event_registrations_sudo = event_registrations_sudo.child_ids
+
         # sudo is necessary for accesses in templates.
         if responsive_html:
             html = request.env['ir.actions.report'].sudo()._render_qweb_html(

--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -290,7 +290,7 @@
                         </a>
                     </div>
                 </td><td valign="middle" align="right">
-                    <t t-if="object.barcode"> 
+                    <t t-if="object.barcode and not object.child_ids">
                         <div style="margin-bottom: 5px;">
                             <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"/>
                         </div>
@@ -557,7 +557,7 @@
                         </a>
                     </div>
                 </td><td valign="middle" align="right">
-                    <t t-if="object.barcode">
+                    <t t-if="object.barcode and not object.child_ids">
                         <div style="margin-bottom: 5px;">
                             <img t-attf-src="/report/barcode/QR/{{object.barcode}}?&amp;width=100&amp;height=100&amp;quiet=0" width="100" height="100" alt="QR Code"/>
                         </div>

--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -26,3 +26,14 @@ class MailTemplate(models.Model):
         self.env['event.mail'].sudo().search([domain]).unlink()
         self.env['event.type.mail'].sudo().search([domain]).unlink()
         return res
+
+    def _render_report_qweb_pdf(self, report, res_id):
+        """
+        Overriding the function here to send multiple tickets in a single pdf
+        """
+        if self.model == 'event.registration':
+            registrations = self.env['event.registration'].browse(res_id)
+            child_ids = registrations.child_ids.ids
+            if child_ids:
+                return self.env['ir.actions.report']._render_qweb_pdf(report, child_ids)
+        return super()._render_report_qweb_pdf(report, res_id)

--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -150,6 +150,14 @@ class EventRegistration(models.Model):
         res = super()._compute_field_value(field)
         confirmed = unconfirmed.filtered(lambda reg: reg.state == 'open')
         if confirmed:
+            parent_registration = confirmed.child_ids.filtered(lambda registration: registration.child_ids)
+            email_question = self.env['event.question'].sudo().search([
+                ('event_id', '=', confirmed.event_id.id),
+                ('question_type', '=', 'email'),
+            ])
+            if email_question.once_per_order or email_question.is_mandatory_answer:
+                parent_registration._update_mail_schedulers()
+                return res
             confirmed._update_mail_schedulers()
         return res
 

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -311,7 +311,7 @@ class MailTemplate(models.Model):
                 for report in self.report_template_ids:
                     # generate content
                     if report.report_type in ['qweb-html', 'qweb-pdf']:
-                        report_content, report_format = self.env['ir.actions.report']._render_qweb_pdf(report, [res_id])
+                        report_content, report_format = self._render_report_qweb_pdf(report, res_id)
                     else:
                         render_res = self.env['ir.actions.report']._render(report, [res_id])
                         if not render_res:
@@ -348,6 +348,12 @@ class MailTemplate(models.Model):
                     render_results[res_id].setdefault('attachments', []).extend(additional_attachments['attachments'])
 
         return render_results
+
+    def _render_report_qweb_pdf(self, report, res_id):
+        """
+        Helper function will be overriden in event module to combine multiple report pdfs into a single pdf
+        """
+        return self.env['ir.actions.report']._render_qweb_pdf(report, [res_id])
 
     def _generate_template_recipients(self, res_ids, render_fields,
                                       allow_suggested=False,

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -413,6 +413,8 @@ class WebsiteEventController(http.Controller):
 
             # update registration based on visitor
             registration_values['visitor_id'] = visitor_sudo.id
+            # name should remain empty if not explicitly added
+            registration_values['name'] = registration_values.get('name') or ''
 
             registrations_to_create.append(registration_values)
 


### PR DESCRIPTION
**Purpose:**
When email is requested once per order, the entered email gets spammed by
event tickets of all the attendees.

**Specifications:**
If 
   - Email has been requested "once per order", or 
   - Email was not requested but logged user is registering to an event, or
   - Email was not requested but user had to give one for invoice information
  => "Event: Registration Confirmation" and "Event: Reminder", should be sent
      only once to that email:

       - With all tickets in it. 
       - Combine all tickets in 1 PDF file. 
       - Remove the in-email QR code 

If 
   - Email was asked for each attendee but wasn't mandatory
  => First attendee on the list who provided his email will:
        - receive the email with all tickets in it
        - tickets combined in 1 PDF file
        - Remove the in-email QR code 
        - Any attendee who filled his email in should receive a personal email.

Attendees and tickets should be assigned a name only if the "name" field has
been filled in for that attendee.

Task-4526222
