### PR TITLE
[FIX] project: fixed state field misalignment in task header

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -142,7 +142,7 @@
                         </button>
                     </div>
                     <widget name="web_ribbon" title="Archived" bg_color="text-bg-danger" invisible="active"/>
-                    <div class="oe_title pe-0">
+                    <div class="oe_title mw-100 pe-0">
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
                             <div class="d-flex justify-content-end o_state_container" invisible="not active">


### PR DESCRIPTION
### Steps to Reproduce:

1. Login as Admin user
2. Open project module
3. Share the project
4. Login as Portal user 
5. Go to sales order inside the project
6. Open task there you be able to see the state misalignment
___

### Issue:

 The task header section (.oe_title) was restricted by a max-width: 75% styling. When the priority field was
 removed, the remaining fields in the header, particularly the state field, appeared misaligned due to this
 layout constraint.
___

### Root Cause:

 The .oe_title class imposes a max-width that limits the available horizontal space for inline fields in 
 the header. This fixed constraint does not adapt when fields like priority are removed, resulting in 
 layout misalignment.

___

### Fix:

 To resolve this, the class mw-100 was added to the `<div class="oe_title"> `element. This overrides 
the  default max-width behavior, allowing the container to use full width when needed.

___

### Technical Details:
This approach keeps layout logic within the view. It also preserves layout flexibility for different screen 
sizes and future field additions or removals.

 task-4813557
