### PR TITLE
[FIX] account: avoid crash when currency is empty during demo data loading

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1171,7 +1171,7 @@ class AccountMove(models.Model):
                 continue
 
             currencies = invoice._get_lines_onchange_currency().currency_id
-            currency = currencies if len(currencies) == 1 else invoice.company_id.currency_id
+            currency = currencies if len(currencies) == 1 else invoice.company_id.currency_id or self.env.company.currency_id
             reconciliation_vals = payment_data.get(invoice.id, [])
             payment_state_matters = invoice.is_invoice(True)
 


### PR DESCRIPTION
While loading demo data, there is a possibility of error from this line [1]. According to [2], the currency may come as a null recordset. And if then it causes the error [3].

[1]
https://github.com/odoo/odoo/blob/f33451af032453746ccd662580f2cf26b85031d6/addons/account/models/account_move.py#L1183

[2]
https://github.com/odoo/odoo/blob/f33451af032453746ccd662580f2cf26b85031d6/addons/account/models/account_move.py#L1174

[3] - **Traceback:-**
```ValueError: not enough values to unpack (expected 1, got 0)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/models.py", line 5623, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: res.currency()
  File "/home/odoo/src/odoo/saas-18.3/odoo/http.py", line 2467, in __call__
    response = request._serve_db()
  File "/home/odoo/src/odoo/saas-18.3/odoo/http.py", line 1970, in _serve_db
    return self._transactioning(
  File "/home/odoo/src/odoo/saas-18.3/odoo/http.py", line 2034, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "/home/odoo/src/odoo/saas-18.3/odoo/service/model.py", line 166, in retrying
    env.cr.flush()  # submit the changes to the database
  File "/home/odoo/src/odoo/saas-18.3/odoo/sql_db.py", line 179, in flush
    self.transaction.flush()
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/environments.py", line 545, in flush
    self.default_env.flush_all()
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/environments.py", line 366, in flush_all
    self._recompute_all()
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/environments.py", line 362, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/models.py", line 6746, in _recompute_field
    field.recompute(records)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/fields.py", line 1639, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/fields.py", line 1612, in apply_except_missing
    func(records)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/fields.py", line 1661, in compute_value
    records._compute_field_value(self)
  File "/home/odoo/src/odoo/saas-18.3/addons/mail/models/mail_thread.py", line 467, in _compute_field_value
    return super()._compute_field_value(field)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/models.py", line 4623, in _compute_field_value
    determine(field.compute, self)
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/fields.py", line 73, in determine
    return needle(*args)
  File "/home/odoo/src/odoo/saas-18.3/addons/account/models/account_move.py", line 1182, in _compute_payment_state
    if invoice.state == 'posted' or (invoice.state == 'draft' and not currency.is_zero(invoice.amount_total)):
  File "/home/odoo/src/odoo/saas-18.3/odoo/addons/base/models/res_currency.py", line 261, in is_zero
    self.ensure_one()
  File "/home/odoo/src/odoo/saas-18.3/odoo/orm/models.py", line 5626, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

**Solution:-**
- This commit adds a fallback to `self.env.company.currency_id` to ensure a valid currency is always available.

**Sentry - 6427055389**

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
