### PR TITLE
[FIX] html_editor: use waitFor to handle popovers in hoot tests

### DIFF
--- a/addons/html_editor/static/tests/_helpers/ui_expectations.js
+++ b/addons/html_editor/static/tests/_helpers/ui_expectations.js
@@ -1,0 +1,18 @@
+import { expect } from "@odoo/hoot";
+import { waitFor, waitForNone } from "@odoo/hoot-dom";
+
+/**
+ * Waits for the presence or absence of elements matching the selector,
+ * then asserts that the number of elements matches the expected count.
+ *
+ * @param {string} selector - CSS selector to query elements.
+ * @param {number} count - Expected number of elements.
+ */
+export async function expectElementCount(selector, count) {
+    if (count === 0) {
+        await waitForNone(selector);
+    } else {
+        await waitFor(selector);
+    }
+    expect(selector).toHaveCount(count);
+}

--- a/addons/html_editor/static/tests/banner.test.js
+++ b/addons/html_editor/static/tests/banner.test.js
@@ -7,6 +7,7 @@ import { insertText } from "./_helpers/user_actions";
 import { loader } from "@web/core/emoji_picker/emoji_picker";
 import { execCommand } from "./_helpers/userCommands";
 import { unformat } from "./_helpers/format";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test("should insert a banner with focus inside followed by a paragraph", async () => {
     const { el, editor } = await setupEditor("<p>Test[]</p>");
@@ -28,13 +29,12 @@ test("should insert a banner with focus inside followed by a paragraph", async (
 
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await insertText(editor, "banner");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0, {
-        message: "shouldn't be possible to add a banner inside a banner",
-    });
+    await expectElementCount(".o-we-powerbox", 0);
+
 });
 
 test("should insert a banner with DIV as basecontainer and focus inside it", async () => {

--- a/addons/html_editor/static/tests/color_selector.test.js
+++ b/addons/html_editor/static/tests/color_selector.test.js
@@ -15,6 +15,7 @@ import { setupEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
 import { contains } from "@web/../tests/web_test_helpers";
 import { execCommand } from "./_helpers/userCommands";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test("can set foreground color", async () => {
     const { el } = await setupEditor("<p>[test]</p>");
@@ -28,8 +29,7 @@ test("can set foreground color", async () => {
 
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(`<p><font style="color: rgb(107, 173, 222);">[test]</font></p>`);
 });
@@ -46,8 +46,7 @@ test("can set background color", async () => {
 
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect(getContent(el)).toBe(
         `<p><font style="background-color: rgba(107, 173, 222, 0.6);">[test]</font></p>`
@@ -64,8 +63,7 @@ test("should add opacity to custom background colors but not to theme colors", a
     expect(".o_font_color_selector").toHaveCount(1);
 
     await contains(".o_color_button[data-color='#FF0000']").click(); // Select a custom color.
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0);
     // Verify custom color applies RGBA with 0.6 opacity.
     expect(getContent(el)).toBe(
@@ -629,7 +627,7 @@ describe("color preview", () => {
                 </tbody>
             </table>
         `);
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        await expectElementCount(".o-we-toolbar", 1);
     });
 
     test("should preview color in table on hover in custom tab", async () => {
@@ -697,6 +695,6 @@ describe("color preview", () => {
                 </tbody>
             </table>
         `);
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        await expectElementCount(".o-we-toolbar", 1);
     });
 });

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -3,11 +3,11 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { setSelection, setContent, getContent } from "../_helpers/selection";
 import { deleteBackward, insertText, undo } from "../_helpers/user_actions";
-import { waitFor, waitForNone } from "@odoo/hoot-dom";
 import { parseHTML } from "@html_editor/utils/html";
 import { Plugin } from "@html_editor/plugin";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { execCommand } from "../_helpers/userCommands";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should ignore protected elements children mutations (true)", async () => {
     await testEditor({
@@ -232,22 +232,19 @@ test("select a protected element shouldn't open the toolbar", async () => {
     const { el } = await setupEditor(
         `<div><p>[a]</p></div><div data-oe-protected="true"><p>b</p><div data-oe-protected="false">c</div></div>`
     );
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     setContent(
         el,
         `<div><p>a</p></div><div data-oe-protected="true"><p>[b]</p><div data-oe-protected="false">c</div></div>`
     );
-    await waitForNone(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 
     setContent(
         el,
         `<div><p>a</p></div><div data-oe-protected="true"><p>b</p><div data-oe-protected="false">[c]</div></div>`
     );
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test("should protect disconnected nodes", async () => {

--- a/addons/html_editor/static/tests/embedded_components.test.js
+++ b/addons/html_editor/static/tests/embedded_components.test.js
@@ -41,6 +41,7 @@ import { patchWithCleanup } from "@web/../tests/web_test_helpers";
 import { Deferred } from "@web/core/utils/concurrency";
 import { Plugin } from "@html_editor/plugin";
 import { dispatchClean, dispatchCleanForSave } from "./_helpers/dispatch";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 function getConfig(components) {
     return {
@@ -894,7 +895,7 @@ describe("In-editor manipulations", () => {
             }
         );
         await animationFrame();
-        expect(".o-we-toolbar").toHaveCount(1);
+        await expectElementCount(".o-we-toolbar", 1);
         expect(getContent(el)).toBe(
             `<div><p>[a]</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">Counter:0</span></span></div>`
         );
@@ -906,7 +907,7 @@ describe("In-editor manipulations", () => {
         expect(getContent(el)).toBe(
             `<div><p>a</p><span data-embedded="counter" data-oe-protected="true" contenteditable="false"><span class="counter">C[ou]nter:0</span></span></div>`
         );
-        expect(".o-we-toolbar").toHaveCount(0);
+        await expectElementCount(".o-we-toolbar", 0);
     });
 
     test("should remove embedded elements children during clean for save (on a clone)", async () => {

--- a/addons/html_editor/static/tests/emoji.test.js
+++ b/addons/html_editor/static/tests/emoji.test.js
@@ -5,19 +5,19 @@ import { loadBundle } from "@web/core/assets";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText, undo } from "./_helpers/user_actions";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test.tags("desktop");
 test("add an emoji with powerbox", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
     await loadBundle("web.assets_emoji");
 
-    expect(".o-EmojiPicker").toHaveCount(0);
+    await expectElementCount(".o-EmojiPicker", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
 
     await insertText(editor, "/emoji");
     await press("enter");
-    await waitFor(".o-EmojiPicker", { timeout: 1000 });
-    expect(".o-EmojiPicker").toHaveCount(1);
+    await expectElementCount(".o-EmojiPicker", 1);
 
     await click(".o-EmojiPicker .o-Emoji");
     expect(getContent(el)).toBe("<p>ab😀[]</p>");
@@ -27,14 +27,13 @@ test("click on emoji command to open emoji picker", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
     await loadBundle("web.assets_emoji");
 
-    expect(".o-EmojiPicker").toHaveCount(0);
+    await expectElementCount(".o-EmojiPicker", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
 
     await insertText(editor, "/emoji");
     await animationFrame();
     await click(".active .o-we-command-name");
-    await waitFor(".o-EmojiPicker", { timeout: 1000 });
-    expect(".o-EmojiPicker").toHaveCount(1);
+    await expectElementCount(".o-EmojiPicker", 1);
 });
 
 test.tags("desktop");
@@ -66,6 +65,6 @@ test("close emoji picker with escape", async () => {
 
     await press("escape");
     await animationFrame();
-    expect(".o-EmojiPicker").toHaveCount(0);
+    await expectElementCount(".o-EmojiPicker", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
 });

--- a/addons/html_editor/static/tests/format/bold.test.js
+++ b/addons/html_editor/static/tests/format/bold.test.js
@@ -7,6 +7,7 @@ import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { BOLD_TAGS, notStrong, span, strong, em } from "../_helpers/tags";
 import { bold, italic, simulateArrowKeyPress, tripleClick } from "../_helpers/user_actions";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 const styleH1Bold = `h1 { font-weight: bold; }`;
 
@@ -285,13 +286,13 @@ test("create bold with shortcut + selected with arrow", async () => {
     await simulateArrowKeyPress(editor, ["Shift", "ArrowRight"]);
     await tick(); // await selectionchange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
     expect(getContent(el)).toBe(`<p>ab${strong("[\u200B", "first")}c]d</p>`);
 
     await simulateArrowKeyPress(editor, ["Shift", "ArrowLeft"]);
     await tick(); // await selectionchange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     expect(getContent(el)).toBe(`<p>ab${strong("[\u200B]", "first")}cd</p>`);
 });
 

--- a/addons/html_editor/static/tests/format/remove_format.test.js
+++ b/addons/html_editor/static/tests/format/remove_format.test.js
@@ -4,6 +4,7 @@ import { getContent } from "../_helpers/selection";
 import { click, queryAll, waitFor } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
 import { execCommand } from "../_helpers/userCommands";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should do nothing if no format is set", async () => {
     await testEditor({
@@ -666,14 +667,13 @@ test("should remove font size and color styles", async () => {
 
 describe("Toolbar", () => {
     async function removeFormatClick() {
-        await waitFor(".o-we-toolbar");
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveCount(1); // remove format
         expect(".btn[name='remove_format']").not.toHaveClass("disabled"); // remove format button should not be disabled
 
         await click(".btn[name='remove_format']");
         await animationFrame();
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveClass("disabled"); // remove format button should be disabled
     }
 
@@ -721,14 +721,13 @@ describe("Toolbar", () => {
         const { el } = await setupEditor(
             `<p>this <span class="random-class">is[ a ]UX</span> test.</p>`
         );
-        await waitFor(".o-we-toolbar");
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveCount(1); // remove format
         expect(".btn[name='remove_format']").toHaveClass("disabled"); // remove format button should be disabled when no format
 
         await click(".btn[name='remove_format']");
         await animationFrame();
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveClass("disabled"); // remove format button should still be disabled
         expect(getContent(el)).toBe(
             `<p>this <span class="random-class">is[ a ]UX</span> test.</p>`
@@ -737,14 +736,13 @@ describe("Toolbar", () => {
 
     test("Remove format button should be available if selection contains formatted nodes among unformatted nodes", async () => {
         const { el } = await setupEditor(`<p>this <b>is[ a UX</b> te]st.</p>`);
-        await waitFor(".o-we-toolbar");
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveCount(1); // remove format
         expect(".btn[name='remove_format']").not.toHaveClass("disabled"); // remove format button should not be disabled
 
         await click(".btn[name='remove_format']");
         await animationFrame();
-        expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+        await expectElementCount(".o-we-toolbar", 1);
         expect(".btn[name='remove_format']").toHaveClass("disabled"); // remove format button should now be disabled
         expect(getContent(el)).toBe(`<p>this <b>is</b>[ a UX te]st.</p>`);
     });

--- a/addons/html_editor/static/tests/format/text_direction.test.js
+++ b/addons/html_editor/static/tests/format/text_direction.test.js
@@ -4,6 +4,7 @@ import { insertText, switchDirection } from "../_helpers/user_actions";
 import { animationFrame } from "@odoo/hoot-mock";
 import { press, queryAllTexts } from "@odoo/hoot-dom";
 import { getContent } from "../_helpers/selection";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should switch direction on a collapsed range", async () => {
     await testEditor({
@@ -116,13 +117,13 @@ test("should switch the direction from the powerbox", async () => {
     await insertText(editor, "/Switchdirection");
     await animationFrame();
     expect(queryAllTexts(".o-we-command-name")).toEqual(["Switch direction"]);
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     expect(getContent(el)).toBe(`<p dir="rtl">a[]</p>`);
     await insertText(editor, "/Switchdirection");
     await animationFrame();
     expect(queryAllTexts(".o-we-command-name")).toEqual(["Switch direction"]);
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     expect(getContent(el)).toBe(`<p>a[]</p>`);
 });

--- a/addons/html_editor/static/tests/history.test.js
+++ b/addons/html_editor/static/tests/history.test.js
@@ -6,6 +6,7 @@ import { click, pointerDown, pointerUp, press, queryOne, microTick } from "@odoo
 import { animationFrame, mockUserAgent, tick } from "@odoo/hoot-mock";
 import { setupEditor, testEditor } from "./_helpers/editor";
 import { getContent, setSelection } from "./_helpers/selection";
+import { expectElementCount } from "./_helpers/ui_expectations";
 import { addStep, deleteBackward, insertText, redo, undo } from "./_helpers/user_actions";
 import { execCommand } from "./_helpers/userCommands";
 
@@ -35,7 +36,7 @@ describe("reset", () => {
         await insertText(editor, "/tab");
         await press("enter");
         await animationFrame();
-        expect(".o-we-tablepicker").toHaveCount(1);
+        await expectElementCount(".o-we-tablepicker", 1);
         expect(getContent(el)).toBe(
             `<p placeholder='Type "/" for commands' class="o-we-hint">[]</p>`
         );
@@ -44,7 +45,7 @@ describe("reset", () => {
 
         await click(".odoo-editor-editable p");
         await animationFrame();
-        expect(".o-we-tablepicker").toHaveCount(0);
+        await expectElementCount(".o-we-tablepicker", 0);
         expect(historyPlugin.currentStep.mutations.length).toBe(0);
     });
 });

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -16,7 +16,6 @@ import {
     queryAllTexts,
     queryOne,
     waitFor,
-    waitForNone,
 } from "@odoo/hoot-dom";
 import { Deferred, animationFrame, mockSendBeacon, tick } from "@odoo/hoot-mock";
 import { onWillDestroy, xml } from "@odoo/owl";
@@ -41,6 +40,7 @@ import { Counter, EmbeddedWrapperMixin } from "./_helpers/embedded_component";
 import { moveSelectionOutsideEditor, setSelection } from "./_helpers/selection";
 import { insertText, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/user_actions";
 import { unformat } from "./_helpers/format";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 class Partner extends models.Model {
     txt = fields.Html({ trim: true });
@@ -961,8 +961,7 @@ test("link preview in Link Popover", async () => {
     });
     // Move selection outside to discard
     setSelectionInHtmlField(".test_target");
-    await waitForNone(".o-we-linkpopover", { root: document, timeout: 500 });
-    expect(".o-we-linkpopover").toHaveCount(0);
+    await expectElementCount(".o-we-linkpopover", 0);
     expect(".test_target a").toHaveText("This website");
 
     // Select link label to open the floating toolbar.

--- a/addons/html_editor/static/tests/html_field.test.js
+++ b/addons/html_editor/static/tests/html_field.test.js
@@ -846,7 +846,7 @@ test("A new MediaDialog after switching record in a Form view should have the co
     setSelectionInHtmlField();
     await insertText(htmlEditor, "/Media");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     expect(".active .o-we-command-name").toHaveText("Media");
 
     await press("Enter");
@@ -885,7 +885,7 @@ test("Embed video by pasting video URL", async () => {
     pasteText(htmlEditor, "https://www.youtube.com/watch?v=qxb74CMR748");
     await animationFrame();
     expect(anchorNode.outerHTML).toBe("<p>https://www.youtube.com/watch?v=qxb74CMR748</p>");
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     expect(queryAllTexts(".o-we-command-name")).toEqual(["Embed Youtube Video", "Paste as URL"]);
 
     // Press Enter to select first option in the powerbox ("Embed Youtube Video").

--- a/addons/html_editor/static/tests/icon.test.js
+++ b/addons/html_editor/static/tests/icon.test.js
@@ -4,6 +4,7 @@ import { setupEditor } from "./_helpers/editor";
 import { animationFrame } from "@odoo/hoot-mock";
 import { getContent, setContent, setSelection } from "./_helpers/selection";
 import { undo } from "./_helpers/user_actions";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test("icon toolbar is displayed", async () => {
     const { el } = await setupEditor(`<p><span class="fa fa-glass"></span></p>`);
@@ -173,7 +174,7 @@ test("Can set icon color", async () => {
     expect(".o_font_color_selector").toHaveCount(1);
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
     expect("span.fa-glass").toHaveStyle({ color: "rgb(107, 173, 222)" });
 });

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -5,6 +5,7 @@ import { contains } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent, setContent } from "./_helpers/selection";
 import { undo } from "./_helpers/user_actions";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -356,11 +357,10 @@ test("Image transformation scalers position", async () => {
         }
     };
     click("img.test-image");
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
     click(".o-we-toolbar div[name='image_transform'] button");
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".transfo-container").toHaveCount(1);
     checkScalersPositions(queryOne("img"));
     // resize by 25% update the position of the scalers

--- a/addons/html_editor/static/tests/image.test.js
+++ b/addons/html_editor/static/tests/image.test.js
@@ -506,7 +506,7 @@ test("can remove the link of an image", async () => {
     await click("button[name='unlink']");
     await animationFrame();
     expect(img.parentElement.tagName).toBe("DIV");
-    expect(".o-we-linkpopover").toHaveCount(0);
+    await expectElementCount(".o-we-linkpopover", 0);
 });
 
 test("can undo link removing of an image", async () => {

--- a/addons/html_editor/static/tests/link/isolated.test.js
+++ b/addons/html_editor/static/tests/link/isolated.test.js
@@ -5,9 +5,10 @@ import { descendants } from "@html_editor/utils/dom_traversal";
 import { tick } from "@odoo/hoot-mock";
 import { getContent, setSelection } from "../_helpers/selection";
 import { cleanLinkArtifacts } from "../_helpers/format";
-import { animationFrame, pointerDown, pointerUp, queryOne, waitFor } from "@odoo/hoot-dom";
+import { animationFrame, pointerDown, pointerUp, queryOne } from "@odoo/hoot-dom";
 import { dispatchNormalize } from "../_helpers/dispatch";
 import { nodeSize } from "@html_editor/utils/position";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 test("should pad a link with ZWNBSPs and add visual indication", async () => {
     await testEditor({
@@ -63,8 +64,7 @@ test("should keep isolated link after a delete and typing", async () => {
 
 test("should delete the content from the link when popover is active", async () => {
     const { editor, el } = await setupEditor('<p><a href="#/">abc[]abc</a></p>');
-    await waitFor(".o-we-linkpopover");
-    expect(".o-we-linkpopover").toHaveCount(1);
+    await expectElementCount(".o-we-linkpopover", 1);
     deleteBackward(editor);
     deleteBackward(editor);
     deleteBackward(editor);

--- a/addons/html_editor/static/tests/link/popover.test.js
+++ b/addons/html_editor/static/tests/link/popover.test.js
@@ -19,6 +19,7 @@ import { cleanLinkArtifacts } from "../_helpers/format";
 import { getContent, setContent, setSelection } from "../_helpers/selection";
 import { insertLineBreak, insertText, splitBlock, undo } from "../_helpers/user_actions";
 import { execCommand } from "../_helpers/userCommands";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 const base64Img =
     "data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUA\n        AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO\n            9TXL0Y4OHwAAAABJRU5ErkJggg==";
@@ -26,27 +27,23 @@ const base64Img =
 describe("should open a popover", () => {
     test("should open a popover when the selection is inside a link and close outside of a link", async () => {
         const { el } = await setupEditor("<p>this is a <a>link</a></p>");
-        expect(".o-we-linkpopover").toHaveCount(0);
+        await expectElementCount(".o-we-linkpopover", 0);
         // selection inside a link
         setContent(el, "<p>this is a <a>li[]nk</a></p>");
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         // selection outside a link
         setContent(el, "<p>this []is a <a>link</a></p>");
-        await waitForNone(".o-we-linkpopover", { timeout: 1500 });
-        expect(".o-we-linkpopover").toHaveCount(0);
+        await expectElementCount(".o-we-linkpopover", 0);
     });
     test("link popover should have input field for href when the link doesn't have href", async () => {
         await setupEditor("<p>this is a <a>li[]nk</a></p>");
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         expect(".o_we_label_link").toHaveValue("link");
         expect(".o_we_href_input_link").toHaveValue("");
     });
     test("link popover should have buttons for link operation when the link has href", async () => {
         await setupEditor('<p>this is a <a href="test.com">li[]nk</a></p>');
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         expect(".o_we_copy_link").toHaveCount(1);
         expect(".o_we_edit_link").toHaveCount(1);
         expect(".o_we_remove_link").toHaveCount(1);
@@ -78,7 +75,7 @@ describe("should open a popover", () => {
             anchorOffset: 1,
         });
         await animationFrame();
-        expect(".o-we-linkpopover").toHaveCount(0);
+        await expectElementCount(".o-we-linkpopover", 0);
     });
 });
 
@@ -124,7 +121,7 @@ describe("popover should switch UI depending on editing state", () => {
         await click(".o_we_href_input_link");
         await click(".o_we_apply_link");
         await waitFor(".o_we_edit_link");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         expect(".o_we_copy_link").toHaveCount(1);
         expect(".o_we_edit_link").toHaveCount(1);
         expect(".o_we_remove_link").toHaveCount(1);
@@ -178,7 +175,7 @@ describe("popover should edit,copy,remove the link", () => {
         const notifications = queryAllTexts(".o_notification_body");
         expect(notifications).toInclude("Link copied to clipboard.");
         await animationFrame();
-        expect(".o-we-linkpopover").toHaveCount(0);
+        await expectElementCount(".o-we-linkpopover", 0);
         await expect(navigator.clipboard.readText()).resolves.toBe("http://test.com/");
     });
     test("when edit a link's label and URL to '', the link should be removed", async () => {
@@ -247,8 +244,7 @@ describe("Link creation", () => {
 
             await click(".o-we-command-name:first");
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>ab<a>[]</a></p>");
-            await waitFor(".o-we-linkpopover");
-            expect(".o-we-linkpopover").toHaveCount(1);
+            await expectElementCount(".o-we-linkpopover", 1);
             expect(".o-we-linkpopover input.o_we_label_link").toBeFocused({
                 message: "should focus label input by default, when we don't have a label",
             });
@@ -271,8 +267,7 @@ describe("Link creation", () => {
             await insertText(editor, "/link");
             await animationFrame();
             await click(".o-we-command-name:first");
-            await waitFor(".o-we-linkpopover");
-            expect(".o-we-linkpopover").toHaveCount(1);
+            await expectElementCount(".o-we-linkpopover", 1);
             expect(cleanLinkArtifacts(getContent(el))).toBe("<p>ab<a></a></p>");
 
             const pNode = queryOne("p");
@@ -451,8 +446,7 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
 
             await click(".o-we-toolbar .fa-link");
-            await waitFor(".o-we-linkpopover", { timeout: 1500 });
-            expect(".o-we-linkpopover").toHaveCount(1);
+            await expectElementCount(".o-we-linkpopover", 1);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 '<p>a<a href="http://test.com/">bcd[]</a>ef</p>'
             );
@@ -462,8 +456,7 @@ describe("Link creation", () => {
             await waitFor(".o-we-toolbar");
 
             await click(".o-we-toolbar .fa-link");
-            await waitFor(".o-we-linkpopover", { timeout: 1500 });
-            expect(".o-we-linkpopover").toHaveCount(1);
+            await expectElementCount(".o-we-linkpopover", 1);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 '<p>a<a href="http://test.com/">bcde[]</a>f</p>'
             );
@@ -843,8 +836,7 @@ describe("link in templates", () => {
     test("Should not remove a link with t-attf-href", async () => {
         const { el } = await setupEditor('<p>test<a t-attf-href="/test/1">li[]nk</a></p>');
 
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         const pNode = queryOne("p");
         setSelection({
             anchorNode: pNode,
@@ -860,8 +852,7 @@ describe("link in templates", () => {
     test("Should not remove a link with t-att-href", async () => {
         const { el } = await setupEditor('<p>test<a t-att-href="/test/1">li[]nk</a></p>');
 
-        await waitFor(".o-we-linkpopover");
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
         const pNode = queryOne("p");
         setSelection({
             anchorNode: pNode,
@@ -908,7 +899,7 @@ describe("links with inline image", () => {
         expect(cleanLinkArtifacts(getContent(el))).toBe(
             `<p>ab<a href="#">cd[</a><img src="${base64Img}"><a href="#">]ef</a>g</p>`
         );
-        expect(".o-we-linkpopover").toHaveCount(0);
+        await expectElementCount(".o-we-linkpopover", 0);
     });
     test("can remove link from a selection of an inline image + text", async () => {
         const { el } = await setupEditor(

--- a/addons/html_editor/static/tests/media.test.js
+++ b/addons/html_editor/static/tests/media.test.js
@@ -5,6 +5,7 @@ import { makeMockEnv, onRpc } from "@web/../tests/web_test_helpers";
 import { setupEditor } from "./_helpers/editor";
 import { getContent } from "./_helpers/selection";
 import { insertText } from "./_helpers/user_actions";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test("Can replace an image", async () => {
     onRpc("/web/dataset/call_kw/ir.attachment/search_read", () => {
@@ -81,7 +82,7 @@ test("Can insert an image, and selection should be collapsed after it", async ()
     const { editor, el } = await setupEditor("<p>a[]bc</p>", { env });
     await insertText(editor, "/image");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     await animationFrame();
     await click("img.o_we_attachment_highlight");

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -8,6 +8,7 @@ import { cleanLinkArtifacts, unformat } from "./_helpers/format";
 import { getContent, setSelection } from "./_helpers/selection";
 import { pasteHtml, pasteOdooEditorHtml, pasteText, undo } from "./_helpers/user_actions";
 import { createBaseContainer } from "@html_editor/utils/base_container";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 function isInline(node) {
     return ["I", "B", "U", "S", "EM", "STRONG", "IMG", "BR", "A", "FONT"].includes(node);
@@ -2528,7 +2529,7 @@ describe("link", () => {
             );
             pasteText(editor, "http://odoo.com");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>xy<a href="http://odoo.com">http://odoo.com</a>[]z</p>`
             );
@@ -2541,7 +2542,7 @@ describe("link", () => {
             );
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe(`<p>xy${imgUrl}[]z</p>`);
 
             await press("Enter");
@@ -2554,7 +2555,7 @@ describe("link", () => {
             );
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe(`<p>xy${imgUrl}[]z</p>`);
 
             await press("ArrowDown");
@@ -2616,7 +2617,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, `abc ${url} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${url}">${url}</a> def[]</p>`
             );
@@ -2626,7 +2627,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, `abc ${imgUrl} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]</p>`
             );
@@ -2636,7 +2637,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, `abc ${videoUrl} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]</p>`
             );
@@ -2646,7 +2647,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, `${url} ${videoUrl} ${imgUrl}`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]</p>`
             );
@@ -2656,7 +2657,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, `${url} abc ${videoUrl} def ${imgUrl}`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p><a href="${url}">${url}</a> abc <a href="${videoUrl}">${videoUrl}</a> def <a href="${imgUrl}">${imgUrl}</a>[]</p>`
             );
@@ -2767,7 +2768,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[xyz]</p>");
             pasteText(editor, `abc ${url} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${url}">${url}</a> def[]</p>`
             );
@@ -2777,7 +2778,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[xyz]</p>");
             pasteText(editor, `abc ${imgUrl} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]</p>`
             );
@@ -2787,7 +2788,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[xyz]</p>");
             pasteText(editor, `abc ${videoUrl} def`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]</p>`
             );
@@ -2797,7 +2798,7 @@ describe("link", () => {
             const { el, editor } = await setupEditor("<p>[xyz]</p>");
             pasteText(editor, `${url} ${videoUrl} ${imgUrl}`);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]</p>`
             );
@@ -2856,7 +2857,7 @@ describe("link", () => {
             );
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe(
                 `<p>abhttps://download.odoocdn.com/icons/website/static/description/icon.png[]cd</p>`
             );
@@ -2870,7 +2871,7 @@ describe("link", () => {
             );
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe(
                 `<p>abhttps://download.odoocdn.com/icons/website/static/description/icon.png[]cd</p>`
             );
@@ -2916,7 +2917,7 @@ describe("images", () => {
             const { el, editor } = await setupEditor("<p>ab[]cd</p>");
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             await press("Enter");
             expect(getContent(el)).toBe(`<p>ab<img src="${imgUrl}">[]cd</p>`);
         });
@@ -2925,7 +2926,7 @@ describe("images", () => {
             const { el, editor } = await setupEditor('<p>a<span class="a">b[]c</span>d</p>');
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             await press("Enter");
             expect(getContent(el)).toBe(
                 `<p>a<span class="a">b<img src="${imgUrl}">[]c</span>d</p>`
@@ -2939,7 +2940,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>a<a href="http://existing.com">b<img src="${imgUrl}">[]c</a>d</p>`
             );
@@ -2950,7 +2951,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -2966,7 +2967,7 @@ describe("images", () => {
             pasteText(editor, "*should not disappear*");
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -2982,7 +2983,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             await press("Enter");
             expect(cleanLinkArtifacts(getContent(el))).toBe(`<p>ab<img src="${imgUrl}">[]cd</p>`);
         });
@@ -2994,7 +2995,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             await press("Enter");
             expect(getContent(el)).toBe(
                 `<p>a<span class="a">b<img src="${imgUrl}">[]c</span>d</p>`
@@ -3008,7 +3009,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(cleanLinkArtifacts(getContent(el))).toBe(
                 `<p>a<a href="http://existing.com">b<img src="${imgUrl}">[]c</a>d</p>`
             );
@@ -3019,7 +3020,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3045,7 +3046,7 @@ describe("images", () => {
             // paste url
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3058,7 +3059,7 @@ describe("images", () => {
             const { el, editor } = await setupEditor("<p>[abc]</p>");
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick first command (Embed image)
             await press("Enter");
             // Undo
@@ -3071,7 +3072,7 @@ describe("images", () => {
 
             pasteText(editor, imgUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3095,7 +3096,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>ab[]cd</p>");
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Force powerbox validation on the default first choice
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
@@ -3109,7 +3110,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor('<p>a<span class="a">b[]c</span>d</p>');
             pasteText(editor, "https://youtu.be/dQw4w9WgXcQ");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Force powerbox validation on the default first choice
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
@@ -3137,7 +3138,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>[]</p>");
             pasteText(editor, url);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3151,7 +3152,7 @@ describe("youtube video", () => {
             pasteText(editor, "*should not disappear*");
             pasteText(editor, url);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3173,7 +3174,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>ab[xxx]cd</p>");
             pasteText(editor, "https://youtu.be/dQw4w9WgXcQ");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Force powerbox validation on the default first choice
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
@@ -3189,7 +3190,7 @@ describe("youtube video", () => {
             );
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Force powerbox validation on the default first choice
             await press("Enter");
             // Wait for the getYoutubeVideoElement promise to resolve.
@@ -3216,7 +3217,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>ab[xxx]cd</p>");
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3243,7 +3244,7 @@ describe("youtube video", () => {
             // paste url
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");
@@ -3256,7 +3257,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>[abc]</p>");
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Force powerbox validation on the default first choice
             await press("Enter");
             // Undo
@@ -3268,7 +3269,7 @@ describe("youtube video", () => {
             const { el, editor } = await setupEditor("<p>[abc]</p>");
             pasteText(editor, videoUrl);
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Pick the second command (Paste as URL)
             await press("ArrowDown");
             await press("Enter");

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -8,6 +8,7 @@ import { onRpc } from "@web/../tests/web_test_helpers";
 import { Plugin } from "@html_editor/plugin";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 describe.tags("desktop");
 describe("visibility", () => {
@@ -133,7 +134,7 @@ describe("buttons", () => {
         await setupEditor("<p>[]<br></p>");
         click(".o_we_power_buttons .power_button.fa-link");
         await animationFrame();
-        expect(".o-we-linkpopover").toHaveCount(1);
+        await expectElementCount(".o-we-linkpopover", 1);
     });
 
     test("should open powerbox using power buttons", async () => {

--- a/addons/html_editor/static/tests/power_buttons.test.js
+++ b/addons/html_editor/static/tests/power_buttons.test.js
@@ -141,7 +141,7 @@ describe("buttons", () => {
         await setupEditor("<p>[]<br></p>");
         click(".o_we_power_buttons .power_button.fa-ellipsis-v");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
     });
 });
 

--- a/addons/html_editor/static/tests/powerbox.test.js
+++ b/addons/html_editor/static/tests/powerbox.test.js
@@ -26,6 +26,7 @@ import { PowerboxPlugin } from "@html_editor/main/powerbox/powerbox_plugin";
 import { SearchPowerboxPlugin } from "@html_editor/main/powerbox/search_powerbox_plugin";
 import { withSequence } from "@html_editor/utils/resource";
 import { execCommand } from "./_helpers/userCommands";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 function commandNames() {
     return queryAllTexts(".o-we-command-name");
@@ -33,33 +34,33 @@ function commandNames() {
 
 test("should open the Powerbox on type `/`", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 });
 
 test.tags("iframe", "desktop");
 test("in iframe, desktop: should open the Powerbox on type `/`", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
     expect("iframe").toHaveCount(1);
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 });
 
 test.tags("iframe", "mobile");
 test("in iframe, mobile: should open the Powerbox on type `/`", async () => {
     const { el, editor } = await setupEditor("<p>ab[]</p>", { props: { iframe: true } });
     expect("iframe").toHaveCount(2);
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(getContent(el)).toBe("<p>ab[]</p>");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 });
 
 test("should correctly hint in iframes", async () => {
@@ -71,14 +72,14 @@ test("should correctly hint in iframes", async () => {
 
 test("should open the Powerbox on type `/`, but in an empty paragraph", async () => {
     const { el, editor } = await setupEditor("<p>[]<br></p>");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(getContent(el)).toBe(
         `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
     );
     await press("/");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 });
 
 describe("search", () => {
@@ -151,18 +152,18 @@ describe("search", () => {
         const { editor, el } = await setupEditor(`<p>[]</p>`, {
             config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
         });
-        expect(".o-we-powerbox").toHaveCount(0);
+        await expectElementCount(".o-we-powerbox", 0);
         await insertText(editor, "/test12");
         await animationFrame();
         expect(getContent(el)).toBe("<p>/test12[]</p>");
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames(el)).toEqual(["Test12"]);
         expect(".active .o-we-command-name").toHaveText("Test12");
 
         await press("backspace");
         await animationFrame();
         expect(getContent(el)).toBe("<p>/test1[]</p>");
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames(el)).toEqual(["Test1", "Test12"]);
         expect(".active .o-we-command-name").toHaveText("Test1");
     });
@@ -171,16 +172,16 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames(el).length).toBe(28);
 
         await insertText(editor, "headx");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(0);
+        await expectElementCount(".o-we-powerbox", 0);
 
         await press("Backspace");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
     });
 
@@ -203,17 +204,17 @@ describe("search", () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/head");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
         expect(".active .o-we-command-name").toHaveText("Heading 1");
 
         await insertText(editor, "/headx");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(0);
+        await expectElementCount(".o-we-powerbox", 0);
 
         await press("backspace");
         await animationFrame();
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(".active .o-we-command-name").toHaveText("Heading 1");
         expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
     });
@@ -231,7 +232,7 @@ describe("search", () => {
         });
         await animationFrame();
         mergePeersSteps(peerInfos);
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames()).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
 
         applyConcurrentActions(peerInfos, {
@@ -241,7 +242,7 @@ describe("search", () => {
         });
         await animationFrame();
         mergePeersSteps(peerInfos);
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames()).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
 
         applyConcurrentActions(peerInfos, {
@@ -251,7 +252,7 @@ describe("search", () => {
         });
         await animationFrame();
         mergePeersSteps(peerInfos);
-        expect(".o-we-powerbox").toHaveCount(1);
+        await expectElementCount(".o-we-powerbox", 1);
         expect(commandNames()).toEqual(["Heading 1"]);
 
         renderTextualSelection(peerInfos);
@@ -261,10 +262,10 @@ describe("search", () => {
     test("powerbox doesn't need to be displayed to apply a command (fast search)", async () => {
         const { el, editor } = await setupEditor("<p>ab[]</p>");
         await insertText(editor, "/head");
-        expect(".o-we-powerbox").toHaveCount(0);
+        await expectElementCount(".o-we-powerbox", 0);
 
         await press("enter");
-        expect(".o-we-powerbox").toHaveCount(0);
+        await expectElementCount(".o-we-powerbox", 0);
         expect(getContent(el)).toBe("<h1>ab[]</h1>");
     });
 
@@ -295,10 +296,10 @@ describe("search", () => {
             const { editor, el } = await setupEditor(`<p>[]</p>`, {
                 config: { Plugins: [...MAIN_PLUGINS, TestPlugin] },
             });
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             insertText(editor, "/apple");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // Both commands should be found with the keyword "apple", being the first
             // one with a higher score
             expect(commandNames(el)).toEqual(["Test1", "Test2"]);
@@ -353,10 +354,10 @@ describe("search", () => {
                     Plugins: [...CORE_PLUGINS, PowerboxPlugin, SearchPowerboxPlugin, TestPlugin],
                 },
             });
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             insertText(editor, "/icon");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
 
             const matchedCommands = commandNames(el);
             // All three commands are found, as they all match "icon" in some way.
@@ -374,43 +375,43 @@ describe("search", () => {
             const { el, editor } = await setupEditor("<p>a[]</p>");
             await insertText(editor, "/");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             await insertText(editor, "zxzxzxz");
             await animationFrame();
             expect(getContent(el)).toBe("<p>a/zxzxzxz[]</p>");
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
         });
         test("should close powerbox typing a space", async () => {
             const { el, editor } = await setupEditor("<p>a[]</p>");
             await insertText(editor, "/");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             // We need to add another character (b) otherwise the space will be
             // considered invisible in the getContent(el). This is a limitation
             // of the test suite that does not transform the space into a nbsp.
             await insertText(editor, " b");
             await animationFrame();
             expect(getContent(el)).toBe("<p>a/ b[]</p>");
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
         });
 
         test("delete '/' should close the powerbox", async () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
             await insertText(editor, "/");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe("<p>/[]</p>");
 
             await press("backspace");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(getContent(el)).toBe(
                 `<p placeholder='Type "/" for commands' class="o-we-hint">[]<br></p>`
             );
 
             await insertText(editor, "a");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(getContent(el)).toBe("<p>a[]<br></p>");
         });
 
@@ -418,17 +419,17 @@ describe("search", () => {
             const { editor, el } = await setupEditor("<p>[]</p>");
             await insertText(editor, "/");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(1);
+            await expectElementCount(".o-we-powerbox", 1);
             expect(getContent(el)).toBe("<p>/[]</p>");
 
             await press("escape");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(getContent(el)).toBe(`<p>/[]</p>`);
 
             await insertText(editor, "h");
             await animationFrame();
-            expect(".o-we-powerbox").toHaveCount(0);
+            await expectElementCount(".o-we-powerbox", 0);
             expect(getContent(el)).toBe(`<p>/h[]</p>`);
         });
     });
@@ -439,13 +440,13 @@ test("should execute command and remove term and hot character on Enter", async 
     await insertText(editor, "/head");
     await animationFrame();
     expect(commandNames(el)).toEqual(["Heading 1", "Heading 2", "Heading 3"]);
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     expect(getContent(el)).toBe("<h1>ab[]</h1>");
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     // need 1 animation frame to close
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test("should execute command and remove term and hot character on Tab", async () => {
@@ -461,11 +462,11 @@ test.todo("should close the powerbox if keyup event is called on other block", a
     const { editor } = await setupEditor("<p>ab</p><p>c[]d</p>");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     // await dispatch(editor.editable, "keyup");
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test.tags("desktop");
@@ -512,14 +513,14 @@ test("should toggle list on empty paragraph", async () => {
     expect(getContent(el)).toBe("<p>/checklist[]</p>");
     await animationFrame();
     expect(commandNames(el)).toEqual(["Checklist"]);
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     await press("Enter");
     expect(getContent(el)).toBe(
         `<ul class="o_checklist"><li placeholder="List" class="o-we-hint">[]<br></li></ul>`
     );
     // need 1 animation frame to close
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 class NoOpPlugin extends Plugin {
@@ -551,7 +552,7 @@ test("should restore state before /command insertion when command is executed (1
     await insertText(editor, "/no-op");
     expect(getContent(el)).toBe("<p>abc/no-op[]</p>");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     expect(commandNames(el)).toEqual(["No-op"]);
     await press("Enter");
     expect(getContent(el)).toBe("<p>abc[]</p>");
@@ -575,7 +576,7 @@ test("should restore state before /command insertion when command is executed (2
     await insertText(editor, "no-op");
     expect(getContent(el)).toBe("<p>/no-op[]</p>");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     expect(commandNames(el)).toEqual(["No-op"]);
     await press("Enter");
     expect(getContent(el, { sortAttrs: true })).toBe(
@@ -598,7 +599,7 @@ test("should discard /command insertion from history when command is executed", 
     await insertText(editor, "abc/heading1");
     expect(getContent(el)).toBe("<p>abc/heading1[]</p>");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
     expect(commandNames(el)).toEqual(["Heading 1"]);
     await press("Enter");
     expect(getContent(el)).toBe("<h1>abc[]</h1>");
@@ -635,11 +636,11 @@ test("should adapt the search of the powerbox when undo/redo", async () => {
 
 test("should open the Powerbox on type `/` in DIV", async () => {
     const { editor } = await setupEditor(`<div>ab<br><br>[]</div>`);
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     await insertText(editor, "/");
     await animationFrame();
 
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 });
 
 test("press 'arrowdown' to navigate", async () => {
@@ -686,22 +687,22 @@ test("press 'arrowleft' should close PowerBox", async () => {
     const { editor } = await setupEditor("<p>ab[]c</p>");
     await insertText(editor, "/head");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await press("arrowleft");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test("press 'arrowright' should close PowerBox", async () => {
     const { editor } = await setupEditor("<p>ab[]c</p>");
     await insertText(editor, "/head");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await press("arrowright");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 });
 
 test.tags("desktop");

--- a/addons/html_editor/static/tests/rating_star.test.js
+++ b/addons/html_editor/static/tests/rating_star.test.js
@@ -4,6 +4,7 @@ import { setupEditor, testEditor } from "./_helpers/editor";
 import { deleteBackward, insertText } from "./_helpers/user_actions";
 import { getContent } from "./_helpers/selection";
 import { animationFrame } from "@odoo/hoot-mock";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 /**
  * Rating Star Element Tests
@@ -13,7 +14,7 @@ test("add 3 star elements", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "/3star");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await press("Enter");
     expect(getContent(el)).toBe(
@@ -25,7 +26,7 @@ test("add 5 star elements", async () => {
     const { el, editor } = await setupEditor("<p>[]</p>");
     await insertText(editor, "/5star");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(1);
+    await expectElementCount(".o-we-powerbox", 1);
 
     await press("Enter");
     expect(getContent(el)).toBe(

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -20,7 +20,7 @@ test("can add a table using the powerbox and keyboard", async () => {
     // open powerbox
     await insertText(editor, "/");
     await waitFor(".o-we-powerbox");
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 
     // filter to get table command in first position
     await insertText(editor, "table");
@@ -35,7 +35,7 @@ test("can add a table using the powerbox and keyboard", async () => {
     await press("Enter");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
     expectContentToBe(
         el,
         `<p>a</p>
@@ -71,12 +71,11 @@ test("can close table picker with escape", async () => {
     expectContentToBe(el, "<p>a/table[]</p>");
     await animationFrame();
     await press("Enter");
-    await waitFor(".o-we-tablepicker");
-    expect(".o-we-tablepicker").toHaveCount(1);
+    await expectElementCount(".o-we-tablepicker", 1);
     expectContentToBe(el, "<p>a[]</p>");
     await press("escape");
     await animationFrame();
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 });
 
 test.tags("iframe", "desktop");
@@ -91,7 +90,7 @@ test("in iframe, can add a table using the powerbox and keyboard", async () => {
     // open powerbox
     await insertText(editor, "/");
     await waitFor(".o-we-powerbox");
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 
     // filter to get table command in first position
     await insertText(editor, "table");
@@ -106,7 +105,7 @@ test("in iframe, can add a table using the powerbox and keyboard", async () => {
     await press("Enter");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
     expect(":iframe .o_table").toHaveCount(1);
 });
 
@@ -156,7 +155,7 @@ test("add table inside empty list", async () => {
     // open powerbox
     insertText(editor, "/");
     await waitFor(".o-we-powerbox");
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 
     // filter to get table command in first position
     insertText(editor, "table");
@@ -171,7 +170,7 @@ test("add table inside empty list", async () => {
     await press("Enter");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
     expectContentToBe(
         el,
         `<ul>
@@ -209,7 +208,7 @@ test("add table inside non-empty list", async () => {
     // open powerbox
     insertText(editor, "/");
     await waitFor(".o-we-powerbox");
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 
     // filter to get table command in first position
     insertText(editor, "table");
@@ -224,7 +223,7 @@ test("add table inside non-empty list", async () => {
     await press("Enter");
     await animationFrame();
     await expectElementCount(".o-we-powerbox", 0);
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
     expectContentToBe(
         el,
         `<ul>
@@ -264,12 +263,11 @@ test("should close the table picker when any key except arrow keys pressed", asy
     expectContentToBe(el, "<p>a/table[]</p>");
     await animationFrame();
     await press("Enter");
-    await waitFor(".o-we-tablepicker");
-    expect(".o-we-tablepicker").toHaveCount(1);
+    await expectElementCount(".o-we-tablepicker", 1);
     expectContentToBe(el, "<p>a[]</p>");
     await insertText(editor, "b");
     await animationFrame();
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
     expectContentToBe(el, "<p>ab[]</p>");
     await insertText(editor, "/");
     await waitFor(".o-we-powerbox");
@@ -277,10 +275,9 @@ test("should close the table picker when any key except arrow keys pressed", asy
     expectContentToBe(el, "<p>ab/table[]</p>");
     await animationFrame();
     await press("Enter");
-    await waitFor(".o-we-tablepicker");
-    expect(".o-we-tablepicker").toHaveCount(1);
+    await expectElementCount(".o-we-tablepicker", 1);
     expectContentToBe(el, "<p>ab[]</p>");
     await insertText(editor, "/");
     await animationFrame();
-    expect(".o-we-tablepicker").toHaveCount(0);
+    await expectElementCount(".o-we-tablepicker", 0);
 });

--- a/addons/html_editor/static/tests/table/adding_table.test.js
+++ b/addons/html_editor/static/tests/table/adding_table.test.js
@@ -5,6 +5,7 @@ import { getContent } from "../_helpers/selection";
 import { insertText } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
 import { press, waitFor, queryOne } from "@odoo/hoot-dom";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 function expectContentToBe(el, html) {
     expect(getContent(el)).toBe(unformat(html));
@@ -13,7 +14,7 @@ function expectContentToBe(el, html) {
 test.tags("desktop");
 test("can add a table using the powerbox and keyboard", async () => {
     const { el, editor } = await setupEditor("<p>a[]</p>");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expectContentToBe(el, `<p>a[]</p>`);
 
     // open powerbox
@@ -28,12 +29,12 @@ test("can add a table using the powerbox and keyboard", async () => {
     // press enter to open tablepicker
     await press("Enter");
     await waitFor(".o-we-tablepicker");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 
     // press enter to validate current dimension (3x3)
     await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(".o-we-tablepicker").toHaveCount(0);
     expectContentToBe(
         el,
@@ -83,7 +84,7 @@ test("in iframe, can add a table using the powerbox and keyboard", async () => {
     const { el, editor } = await setupEditor("<p>a[]</p>", {
         props: { iframe: true },
     });
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(getContent(el)).toBe(`<p>a[]</p>`);
     expect(":iframe .o_table").toHaveCount(0);
 
@@ -99,12 +100,12 @@ test("in iframe, can add a table using the powerbox and keyboard", async () => {
     // press enter to open tablepicker
     await press("Enter");
     await waitFor(".o-we-tablepicker");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 
     // press enter to validate current dimension (3x3)
     await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(".o-we-tablepicker").toHaveCount(0);
     expect(":iframe .o_table").toHaveCount(1);
 });
@@ -164,12 +165,12 @@ test("add table inside empty list", async () => {
     // press enter to open tablepicker
     await press("Enter");
     await waitFor(".o-we-tablepicker");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 
     // press enter to validate current dimension (3x3)
     await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(".o-we-tablepicker").toHaveCount(0);
     expectContentToBe(
         el,
@@ -217,12 +218,12 @@ test("add table inside non-empty list", async () => {
     // press enter to open tablepicker
     await press("Enter");
     await waitFor(".o-we-tablepicker");
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
 
     // press enter to validate current dimension (3x3)
     await press("Enter");
     await animationFrame();
-    expect(".o-we-powerbox").toHaveCount(0);
+    await expectElementCount(".o-we-powerbox", 0);
     expect(".o-we-tablepicker").toHaveCount(0);
     expectContentToBe(
         el,

--- a/addons/html_editor/static/tests/table/misc.test.js
+++ b/addons/html_editor/static/tests/table/misc.test.js
@@ -4,6 +4,7 @@ import { click, queryAll, queryFirst, waitFor } from "@odoo/hoot-dom";
 import { animationFrame, tick } from "@odoo/hoot-mock";
 import { setSelection } from "../_helpers/selection";
 import { execCommand } from "../_helpers/userCommands";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 function insertTable(editor, cols, rows) {
     execCommand(editor, "insertTable", { cols, rows });
@@ -36,7 +37,7 @@ test("can color cells", async () => {
 
     await click(".o_color_button[data-color='#6BADDE']");
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1); // toolbar still open
+    await expectElementCount(".o-we-toolbar", 1);
     expect(".o_font_color_selector").toHaveCount(0); // selector closed
 
     // Collapse selection to deselect cells

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -5,6 +5,7 @@ import { setupEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { undo } from "../_helpers/user_actions";
+import { expectElementCount } from "../_helpers/ui_expectations";
 
 function availableCommands(menu) {
     return queryAllAttributes("span div.user-select-none", "name", { root: menu });
@@ -15,12 +16,11 @@ test("should only display the table ui menu if the table isContentEditable=true"
         <table><tbody><tr>
             <td>11[]</td>
         </tr></tbody></table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td"));
-    await waitFor(".o-we-table-menu");
     // 1 menu for columns, and 1 for rows
-    expect(".o-we-table-menu").toHaveCount(2);
+    await expectElementCount(".o-we-table-menu", 2);
 });
 
 test("should display the table ui menu only if hover on first row/col", async () => {
@@ -31,7 +31,7 @@ test("should display the table ui menu only if hover on first row/col", async ()
             <tr><td class="c">3</td><td class="d">4</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td.a"));
     await waitFor(".o-we-table-menu");
@@ -55,11 +55,11 @@ test("should not display the table ui menu if the table element isContentEditabl
         <table contenteditable="false"><tbody><tr>
             <td>11[]</td>
         </tr></tbody></table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td"));
     await animationFrame();
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 });
 
 test("should not display the table ui menu if we leave the editor content", async () => {
@@ -67,15 +67,15 @@ test("should not display the table ui menu if we leave the editor content", asyn
         <table><tbody><tr>
             <td>11[]</td>
         </tr></tbody></table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td"));
     await animationFrame();
-    expect(".o-we-table-menu").toHaveCount(2);
+    await expectElementCount(".o-we-table-menu", 2);
 
     await hover(el.parentElement);
     await animationFrame();
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 });
 
 test("should display the table ui menu when hovering on TH", async () => {
@@ -83,11 +83,11 @@ test("should display the table ui menu when hovering on TH", async () => {
         <table><tbody><tr>
             <th>11[]</th>
         </tr></tbody></table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("th"));
     await animationFrame();
-    expect(".o-we-table-menu").toHaveCount(2);
+    await expectElementCount(".o-we-table-menu", 2);
 });
 
 test.tags("desktop");
@@ -134,7 +134,7 @@ test("list of table commands in first column", async () => {
             <tr><td class="a">1[]</td><td class="b">2</td><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on first column
     await hover(el.querySelector("td.a"));
@@ -163,7 +163,7 @@ test("list of table commands in second column", async () => {
             <tr><td class="a">1[]</td><td class="b">2</td><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on second column
     await hover(el.querySelector("td.b"));
@@ -187,7 +187,7 @@ test("list of table commands in last column", async () => {
             <tr><td class="a">1[]</td><td class="b">2</td><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on last column
     await hover(el.querySelector("td.c"));
@@ -213,7 +213,7 @@ test("list of table commands in first row", async () => {
             <tr><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on first row
     await hover(el.querySelector("td.a"));
@@ -244,7 +244,7 @@ test("list of table commands in second row", async () => {
             <tr><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on second row
     await hover(el.querySelector("td.b"));
@@ -270,7 +270,7 @@ test("list of table commands in last row", async () => {
             <tr><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on last row
     await hover(el.querySelector("td.c"));
@@ -296,7 +296,7 @@ test("open/close table menu", async () => {
             <tr><td class="c">3</td></tr>
             </tbody>
         </table>`);
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // check list of commands on first row
     await hover(el.querySelector("td.a"));
@@ -329,7 +329,7 @@ test("basic delete column operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show col ui
     await hover(el.querySelector("td.b"));
@@ -374,7 +374,7 @@ test("basic delete row operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show col ui
     await hover(el.querySelector("td.c"));
@@ -418,7 +418,7 @@ test("insert column left operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show col ui
     await hover(el.querySelector("td.b"));
@@ -470,7 +470,7 @@ test("insert column right operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show col ui
     await hover(el.querySelector("td.a"));
@@ -522,7 +522,7 @@ test("insert row above operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.c"));
@@ -576,7 +576,7 @@ test("insert row above operation should not retain height and width styles", asy
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.a"));
@@ -619,7 +619,7 @@ test("insert row below operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.a"));
@@ -673,7 +673,7 @@ test("move column left operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.b"));
@@ -717,7 +717,7 @@ test("move column right operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.a"));
@@ -761,7 +761,7 @@ test("move row above operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.c"));
@@ -806,7 +806,7 @@ test("preserve table rows width on move row above operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.c"));
@@ -840,7 +840,7 @@ test("move row below operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.a"));
@@ -885,7 +885,7 @@ test("preserve table rows width on move row below operation", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     // hover on td to show row ui
     await hover(el.querySelector("td.a"));
@@ -919,7 +919,7 @@ test("reset table size to remove custom width", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td.a"));
     await waitFor(".o-we-table-menu");
@@ -960,7 +960,7 @@ test("reset table size to remove custom height", async () => {
             </tbody>
         </table>`)
     );
-    expect(".o-we-table-menu").toHaveCount(0);
+    await expectElementCount(".o-we-table-menu", 0);
 
     await hover(el.querySelector("td.a"));
     await waitFor(".o-we-table-menu");

--- a/addons/html_editor/static/tests/toolbar.test.js
+++ b/addons/html_editor/static/tests/toolbar.test.js
@@ -42,21 +42,20 @@ import {
 import { strong } from "./_helpers/tags";
 import { delay } from "@web/core/utils/concurrency";
 import { nodeSize } from "@html_editor/utils/position";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 test.tags("desktop");
 test("toolbar is only visible when selection is not collapsed in desktop", async () => {
     const { el } = await setupEditor("<p>test</p>");
 
     // set a non-collapsed selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     // set a collapsed selection to close toolbar
     setContent(el, "<p>test[]</p>");
-    await waitForNone(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test.tags("mobile");
@@ -64,14 +63,13 @@ test("toolbar is also visible when selection is collapsed in mobile", async () =
     const { el } = await setupEditor("<p>test</p>");
 
     // set a non-collapsed selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     setContent(el, "<p>test[]</p>");
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test("toolbar closes when selection leaves editor", async () => {
@@ -81,8 +79,7 @@ test("toolbar closes when selection leaves editor", async () => {
 
     await click(document.body);
     moveSelectionOutsideEditor();
-    await waitForNone(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test("toolbar works: can format bold", async () => {
@@ -90,7 +87,7 @@ test("toolbar works: can format bold", async () => {
     expect(getContent(el)).toBe("<p>test</p>");
 
     // set selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
 
@@ -106,7 +103,7 @@ test("toolbar in an iframe works: can format bold", async () => {
     expect(getContent(el)).toBe("<p>test</p>");
 
     // set selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
 
@@ -242,7 +239,7 @@ test("toolbar works: can select font", async () => {
     expect(getContent(el)).toBe("<p>test</p>");
 
     // set selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
     expect(".o-we-toolbar [name='font']").toHaveText("Paragraph");
@@ -309,7 +306,7 @@ test("toolbar works: can select font size", async () => {
     };
 
     // set selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
     await waitFor(".o-we-toolbar");
     const iframeEl = queryOne(".o-we-toolbar [name='font-size'] iframe");
@@ -338,7 +335,7 @@ test("toolbar works: display correct font size on select all", async () => {
     expect(getContent(el)).toBe("<p>test</p>");
 
     // set selection to open toolbar
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
     const style = getHtmlStyle(document);
     const getFontSizeFromVar = (cssVar) => {
@@ -382,7 +379,7 @@ test("toolbar works: displays correct font size on input", async () => {
     await advanceTime(200);
     expect(".o_font_size_selector_menu").toHaveCount(1);
     expect(getContent(el)).toBe(`<p><span style="font-size: 8px;">[test]</span></p>`);
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test("toolbar works: font size dropdown closes on Enter and Tab key press", async () => {
@@ -458,7 +455,7 @@ test("toolbar should not open on keypress tab inside table", async () => {
     await press("Tab");
     expect(getContent(el)).toBe(contentAfter);
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test("toolbar open on single selected cell in table", async () => {
@@ -498,7 +495,7 @@ test("toolbar open on single selected cell in table", async () => {
     await animationFrame();
     await tick();
     expect(targetTd).toHaveClass("o_selected_td");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test("should select table single cell when entire content is selected via mouse movement", async () => {
@@ -567,7 +564,7 @@ test("should select table single cell when entire content is selected via mouse 
     await tick();
 
     expect(firstTd).toHaveClass("o_selected_td");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 });
 
 test.tags("desktop");
@@ -597,8 +594,7 @@ test("toolbar should close on keypress tab inside table", async () => {
     await waitFor(".o-we-toolbar");
     await press("Tab");
     expect(getContent(el)).toBe(contentAfter);
-    await waitForNone(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test("toolbar buttons shouldn't be active without text node in the selection", async () => {
@@ -610,17 +606,15 @@ test("toolbar buttons shouldn't be active without text node in the selection", a
 test("toolbar behave properly if selection has no range", async () => {
     const { el } = await setupEditor("<p>test</p>");
 
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
     setContent(el, "<p>[test]</p>");
-    await waitFor(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     const selection = document.getSelection();
     selection.removeAllRanges();
 
     setContent(el, "<p>abc</p>");
-    await waitForNone(".o-we-toolbar");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test("toolbar correctly show namespace button group and stop showing when namespace change", async () => {
@@ -794,51 +788,51 @@ test("toolbar buttons should have title attribute with translated text", async (
 test.tags("desktop");
 test("close the toolbar if the selection contains any nodes (traverseNode = [])", async () => {
     const { el } = await setupEditor("<p>a</p><p>b</p>");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 
     setContent(el, "<p>[a</p><p>]b</p>");
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     // This selection is possible when you double-click at the end of a line.
     setContent(el, "<p>a[</p><p>]b</p>");
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test.tags("desktop");
 test("close the toolbar if the selection contains any nodes (traverseNode = [], ignore whitespace)", async () => {
     const { el } = await setupEditor("<p>a</p>\n<p>b</p>");
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 
     setContent(el, "<p>[a</p>\n<p>]b</p>");
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     // This selection is possible when you double-click at the end of a line.
     setContent(el, "<p>a[</p>\n<p>]b</p>");
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test.tags("desktop");
 test("close the toolbar if the selection contains any nodes (traverseNode = [], ignore zws)", async () => {
     const { el } = await setupEditor(`<p>ab${strong("\u200B", "first")}cd</p>`);
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 
     setContent(el, `<p>a[b${strong("\u200B", "first")}c]d</p>`);
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(1);
+    await expectElementCount(".o-we-toolbar", 1);
 
     setContent(el, `<p>ab${strong("[\u200B]", "first")}cd</p>`);
     await tick(); // selectionChange
     await animationFrame();
-    expect(".o-we-toolbar").toHaveCount(0);
+    await expectElementCount(".o-we-toolbar", 0);
 });
 
 test.tags("desktop");
@@ -875,7 +869,7 @@ describe("toolbar open and close on user interaction", () => {
     describe("mouse", () => {
         test("toolbar should not open while mousedown (only after mouseup)", async () => {
             const { el } = await setupEditor("<p>test</p>");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerDown(el);
             // <p>[]test</p>
@@ -887,16 +881,15 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
 
             await animationFrame();
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerUp(el);
-            await waitFor(".o-we-toolbar");
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should open on mouseup after selecting text (even if mouseup happens outside the editable)", async () => {
             const { el } = await setupEditor("<p>test</p>");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerDown(el);
             // <p>[]test</p>
@@ -908,11 +901,10 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
 
             await animationFrame();
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerUp(el.ownerDocument);
-            await waitFor(".o-we-toolbar");
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should close on mousedown", async () => {
@@ -923,14 +915,13 @@ describe("toolbar open and close on user interaction", () => {
             // <p>test</p><p>[]text</p>
             setSelection({ anchorNode: el.children[1], anchorOffset: 0 });
             await tick(); // selectionChange
-            await waitForNone(".o-we-toolbar");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerUp(el);
             await tick();
             expect(getContent(el)).toBe("<p>test</p><p>[]text</p>");
             await animationFrame();
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
         });
 
         test("toolbar should close on mousedown (2)", async () => {
@@ -944,14 +935,13 @@ describe("toolbar open and close on user interaction", () => {
             // Mousedown on the selected text: it does not change the selection until mouseup
             await pointerDown(el);
             await tick();
-            await waitForNone(".o-we-toolbar");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await pointerUp(el);
             setContent(el, "<p>[]test</p>");
             await tick();
             await animationFrame();
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
         });
 
         test("toolbar should open on double click", async () => {
@@ -962,7 +952,7 @@ describe("toolbar open and close on user interaction", () => {
             expect(getContent(el)).toBe("<p>[test]</p>");
             // toolbar open after double click is debounced
             await advanceTime(500);
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should open on triple click", async () => {
@@ -973,7 +963,7 @@ describe("toolbar open and close on user interaction", () => {
             expect(getContent(el)).toBe("<p>[test text]</p>");
             // toolbar open after triple click is debounced
             await advanceTime(500);
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should not open between double and triple click", async () => {
@@ -986,13 +976,13 @@ describe("toolbar open and close on user interaction", () => {
             expect(getContent(el)).toBe("<p>[test] text</p>");
             await advanceTime(100);
             // Toolbar is not open yet, waiting for a possible third click
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Third click
             await thirdClick(p);
             expect(getContent(el)).toBe("<p>[test text]</p>");
             await advanceTime(500);
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should not open after triple click while mouse is down", async () => {
@@ -1007,32 +997,32 @@ describe("toolbar open and close on user interaction", () => {
             expect(getContent(el)).toBe("<p>[test text]</p>");
             await advanceTime(500);
             // Toolbar is not open yet, waiting for mouseup
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Mouse up
             manuallyDispatchProgrammaticEvent(p, "mouseup", { detail: 3 });
             manuallyDispatchProgrammaticEvent(p, "click", { detail: 3 });
             await advanceTime(500);
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
     });
 
     describe("keyboard", () => {
         test("toolbar should not open on keydown Arrow (only after keyup)", async () => {
             const { el } = await setupEditor("<p>[]test</p>");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await keyDown(["Shift", "ArrowRight"]);
             setContent(el, "<p>[t]est</p>");
             await tick(); // selectionChange
 
             await animationFrame();
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             await keyUp(["Shift", "ArrowRight"]);
 
             await advanceTime(500); // Toolbar open on keyup is debounced
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should close on keydown Arrow", async () => {
@@ -1044,13 +1034,13 @@ describe("toolbar open and close on user interaction", () => {
             setContent(el, "<p>[test]</p>");
             await tick(); // selectionChange
             await waitForNone(".o-we-toolbar");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Toolbar should open after keyup
             await keyUp(["Shift", "ArrowRight"]);
 
             await advanceTime(500); // toolbar open on keyup is debounced
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should not close on keydown shift or control", async () => {
@@ -1060,25 +1050,25 @@ describe("toolbar open and close on user interaction", () => {
             // Toolbar should not close on keydown shift
             await keyDown(["Shift"]);
             await tick();
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
 
             await keyUp(["Shift"]);
             await tick();
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
 
             // Toolbar should not close on keydown ctrl
             await keyDown(["Control"]);
             await tick();
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
 
             await keyUp(["Control"]);
             await tick();
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
 
         test("toolbar should not open between keystrokes separated by a short interval", async () => {
             const { el } = await setupEditor("<p>[]test</p>");
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Keystroke # 1
             await keyDown(["Shift", "ArrowRight"]);
@@ -1086,7 +1076,7 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
             await keyUp(["Shift", "ArrowRight"]);
             await advanceTime(100);
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Keystroke # 2
             await keyDown(["Shift", "ArrowRight"]);
@@ -1094,11 +1084,11 @@ describe("toolbar open and close on user interaction", () => {
             await tick(); // selectionChange
             await keyUp(["Shift", "ArrowRight"]);
             await advanceTime(100);
-            expect(".o-we-toolbar").toHaveCount(0);
+            await expectElementCount(".o-we-toolbar", 0);
 
             // Toolbar opens some time after the last keyup
             await advanceTime(500);
-            expect(".o-we-toolbar").toHaveCount(1);
+            await expectElementCount(".o-we-toolbar", 1);
         });
     });
 });

--- a/addons/html_editor/static/tests/wysiwyg.test.js
+++ b/addons/html_editor/static/tests/wysiwyg.test.js
@@ -10,20 +10,21 @@ import {
     setContent,
     setSelection,
 } from "./_helpers/selection";
+import { expectElementCount } from "./_helpers/ui_expectations";
 
 describe("Wysiwyg Component", () => {
     test("Wysiwyg component can be instantiated", async () => {
         const { el } = await setupWysiwyg();
         expect(".o-wysiwyg").toHaveCount(1);
         expect(".odoo-editor-editable").toHaveCount(1);
-        expect(".o-we-toolbar").toHaveCount(0);
+        await expectElementCount(".o-we-toolbar", 0);
 
         // set the selection to a range, and check that the toolbar
         // is opened
         expect(getContent(el)).toBe("");
         setContent(el, "hello [hoot]");
         await animationFrame();
-        expect(".o-we-toolbar").toHaveCount(1);
+        await expectElementCount(".o-we-toolbar", 1);
     });
 
     test("Wysiwyg component can be instantiated with initial content", async () => {
@@ -34,19 +35,19 @@ describe("Wysiwyg Component", () => {
     });
 
     test("Wysiwyg component can be instantiated with a permanent toolbar", async () => {
-        expect(".o-we-toolbar").toHaveCount(0);
+        await expectElementCount(".o-we-toolbar", 0);
         await setupWysiwyg({ toolbar: true });
         expect(".o-wysiwyg").toHaveCount(1);
         expect(".odoo-editor-editable").toHaveCount(1);
-        expect(".o-we-toolbar").toHaveCount(1);
+        await expectElementCount(".o-we-toolbar", 1);
     });
 
     test("Wysiwyg component can't display a permanent toolbar if toolbar plugin is missing", async () => {
-        expect(".o-we-toolbar").toHaveCount(0);
+        await expectElementCount(".o-we-toolbar", 0);
         await setupWysiwyg({ toolbar: true, config: { Plugins: CORE_PLUGINS } });
         expect(".o-wysiwyg").toHaveCount(1);
         expect(".odoo-editor-editable").toHaveCount(1);
-        expect(".o-we-toolbar").toHaveCount(0);
+        await expectElementCount(".o-we-toolbar", 0);
     });
 
     test("wysiwyg with toolbar: buttons react to selection change", async () => {


### PR DESCRIPTION
### Purpose of this PR:

- Add `expectElementCount` test helper to wait for elements to appear or disappear before asserting their count. This fixes flaky tests caused by timing issues and animations, especially on slower environments like runbot, in toolbar, link popover, powerbox, tablepicker, tablemenu, and emoji picker tests.

task-4849995

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
