### PR TITLE
[FIX] sale, website_sale: run function should not return anything

### DIFF
--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -1,4 +1,4 @@
-import { queryAttribute, queryValue, waitUntil } from '@odoo/hoot-dom';
+import { queryAttribute } from '@odoo/hoot-dom';
 
 function productSelector(productName) {
     return `
@@ -71,16 +71,13 @@ function setProductQuantity(productName, quantity) {
 }
 
 function assertProductQuantity(productName, quantity) {
-    const quantitySelector = `
-        ${productSelector(productName)}
-        td.o_sale_product_configurator_qty
-        input[name="sale_quantity"]
-    `;
     return {
         content: `Assert that the quantity of ${productName} is ${quantity}`,
-        trigger: quantitySelector,
-        run: async () =>
-            await waitUntil(() => queryValue(quantitySelector) === quantity, { timeout: 1000 }),
+        trigger: `
+            ${productSelector(productName)}
+            td.o_sale_product_configurator_qty
+            input[name="sale_quantity"]:value(${quantity})
+        `,
     };
 }
 

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -1,5 +1,4 @@
 import { registry } from '@web/core/registry';
-import { queryValue, waitUntil } from '@odoo/hoot-dom';
 import comboConfiguratorTourUtils from '@sale/js/tours/combo_configurator_tour_utils';
 import productConfiguratorTourUtils from '@sale/js/tours/product_configurator_tour_utils';
 import * as wsTourUtils from '@website_sale/js/tours/tour_utils';
@@ -35,10 +34,7 @@ registry
             },
             {
                 content: "Verify the combo product's quantity",
-                trigger: 'div[name="website_sale_cart_line_quantity"] input.quantity',
-                run: async () => await waitUntil(
-                    () => queryValue('div[name="website_sale_cart_line_quantity"] input.quantity') === '3', { timeout: 1000 }
-                ),
+                trigger: 'div[name="website_sale_cart_line_quantity"] input.quantity:value(3)',
             },
             {
                 content: "Verify the combo product's price",


### PR DESCRIPTION
In this commit, we ensure that run function return nothing.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
