### PR TITLE
[FIX] mail: propagate subject of scheduled message

### DIFF
--- a/addons/mail/models/mail_scheduled_message.py
+++ b/addons/mail/models/mail_scheduled_message.py
@@ -186,6 +186,7 @@ class ScheduledMessage(models.Model):
                 self.env[scheduled_message.model].browse(scheduled_message.res_id).with_user(message_creator).message_post(
                     attachment_ids=list(scheduled_message.attachment_ids.ids),
                     author_id=scheduled_message.author_id.id,
+                    subject=scheduled_message.subject,
                     body=scheduled_message.body,
                     partner_ids=list(scheduled_message.partner_ids.ids),
                     subtype_xmlid='mail.mt_note' if scheduled_message.is_note else 'mail.mt_comment',

--- a/addons/test_mail/tests/test_mail_scheduled_message.py
+++ b/addons/test_mail/tests/test_mail_scheduled_message.py
@@ -144,6 +144,7 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
                 scheduled_date='2022-12-24 14:00:00',
                 partner_ids=self.test_record.customer_id,
                 body="success",
+                subject="Test subject",
             ).id
             # cron should be triggered at scheduled date
             self.assertEqual(capt.records['call_at'], FieldDatetime.to_datetime('2022-12-24 14:00:00'))
@@ -196,7 +197,7 @@ class TestScheduledMessageBusiness(TestScheduledMessage, CronMixinCase):
                         'author_id': self.partner_employee,
                         'model': self.test_record._name,
                         'res_id': self.test_record.id,
-                        'subject': self.test_record._message_compute_subject(),
+                        'subject': "Test subject",
                     },
                     'notif': [
                         {'partner': self.test_record.customer_id, 'type': 'email'}


### PR DESCRIPTION
Steps to reproduce
===================​
1. Open a record with chatter, and open the full composer.
2. Add a custom subject and add a body.
3. Schedule message to send in the future.
4. Click on send now from chatter.
=> Subject is not propagated to the mail

After this commit
=================
This commit propagate subject to mail.

Task-4845440

