### PR TITLE
[FIX] web: calendar: avoid inconsistent state

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -75,6 +75,7 @@ export class CalendarCommonRenderer extends Component {
 
         const fullCalendarRenderDebounced = useDebounced(() => this.fc.api.updateSize(), 100, {
             immediate: true,
+            trailing: true,
         });
         const fullCalendarResizeObserver = new ResizeObserver(fullCalendarRenderDebounced);
         useEffect(


### PR DESCRIPTION
When we toggle the CalendarSidePanel many times too quickly, we can have the CalendarSidePanel hidden and a blank space on the side of the FullCalendar as before the previous fix[1].

This commit, recalculate the size(in particular the width in our case) of FullCalendar at the start and the end of all batched resizes.

[1]: odoo/odoo@46bfc53b66ecf410ee7703ada79dfaa714331660

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
