### PR TITLE
[FIX] base, contacts: partner view cache updated on vat_label change

### DIFF
--- a/odoo/addons/base/models/res_country.py
+++ b/odoo/addons/base/models/res_country.py
@@ -119,9 +119,11 @@ class Country(models.Model):
         if ('code' in vals or 'phone_code' in vals):
             # Intentionally simplified by not clearing the cache in create and unlink.
             self.env.registry.clear_cache()
-        if 'address_view_id' in vals:
+        if 'address_view_id' in vals or 'vat_label' in vals:
             # Changing the address view of the company must invalidate the view cached for res.partner
             # because of _view_get_address
+            # Same goes for vat_label
+            # because of _get_view override from FormatVATLabelMixin
             self.env.registry.clear_cache('templates')
         return res
 


### PR DESCRIPTION
**PROBLEM**
When changing the vat label associated to the country of the user's company, it should change the label of the `vat` field. The cached partners views are not invalidated as they should and the old views with the old label  are presented to the user instead of the new ones. This can be confusing to the user, because while their change had an effect on the database, it doesn't reflect on the views showed to them.

**STEP TO REPRODUCE**
1. On a fresh database, install the contact app.
2. From the contact app, Configuration->Countries, select United States which should be the country of the demo company.
3. Change the Vat Label field value.
4. Go on any contact form view, and notice the label of the `vat` field wasn't updated.
5. You can refresh the pages, and sometimes the new value will be there, sometimes not.

**CAUSE**
https://github.com/odoo/odoo/blob/ac106704f3c2d3e3fa94415134b9d5522b325378/odoo/addons/base/models/res_partner.py#L41C1-L55C1
In the mixin `FormatVATLabelMixin` we modify the form view, changing the label of the vat field accordingly. However, the `_get_view_cache_key` override that would add the field used to make the change (`self.env.company.country_id.vat_label`) to the cache key is missing. Which means the cache isn't invalidated when it should.

**FIX**
Invalidating cache when writing on `vat_label`

opw-4825749