### PR TITLE
[IMP] Uniformize Time Off Popups

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.py
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.py
@@ -15,6 +15,7 @@ class HrLeaveReportCalendar(models.Model):
     name = fields.Char(string='Name', readonly=True, compute="_compute_name")
     start_datetime = fields.Datetime(string='From', readonly=True)
     stop_datetime = fields.Datetime(string='To', readonly=True)
+    duration_display = fields.Char(related='leave_id.duration_display', readonly=True)
     tz = fields.Selection(_tz_get, string="Timezone", readonly=True)
     duration = fields.Float(string='Duration', readonly=True)
     employee_id = fields.Many2one('hr.employee', readonly=True)

--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -28,17 +28,28 @@
         <field name="model">hr.leave.report.calendar</field>
         <field name="arch" type="xml">
             <form string="Time Off">
-                <sheet >
+                <sheet class="pt-2" style="min-height: 10rem">
                     <widget name="web_ribbon" title="Cancelled" bg_color="text-bg-danger" invisible="state != 'cancel'"/>
                     <widget name="web_ribbon" title="Refused" bg_color="bg-danger" invisible="state != 'refuse'"/>
                     <widget name="web_ribbon" title="Approved" bg_color="bg-success" invisible="state != 'validate'"/>
                     <group class="py-0 pe-0 overflow-hidden">
-                        <field name="name"/>
-                        <field name="start_datetime"/>
-                        <field name="stop_datetime"/>
-                        <field name="employee_id" />
-                        <field name="description"/>
+                        <field name="employee_id" widget="many2one_avatar_employee"/>
+                        <field name="holiday_status_id"/>
+                        <label for="start_datetime" string="Dates" />
+                        <div id="full_date" class="o_row">
+                            <field
+                                string='dates'
+                                name="start_datetime"
+                                widget="daterange"
+                                readonly='1'
+                                options="{'end_date_field': 'stop_datetime', 'show_time': false}"/>
+                            <field name="start_datetime" invisible="1"/>
+                            <div style="margin-left: 4.82rem;">
+                            ( <field name="duration_display" readonly="1" class="w-auto"/> )
+                            </div>
+                        </div>
                     </group>
+                    <field name="description"/>
                     <footer class="d-flex justify-content-end gap-1">
                         <button name="action_approve" string="Approve" type="object" close="1" invisible="state not in ['confirm', 'refuse'] or not is_manager"/>
                         <button name="action_refuse" string="Refuse" type="object" close="1" invisible="state == 'refuse' or not is_manager"/>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -385,6 +385,9 @@
         <field name="mode">primary</field>
         <field name="priority">100</field>
         <field name="arch" type="xml">
+            <field name="holiday_status_id" position="before">
+                <field name="employee_id" widget="many2one_avatar_employee" readonly="1"/>
+            </field>
             <xpath expr="//header" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
@@ -428,9 +431,11 @@
         <field name="mode">primary</field>
         <field name="priority">17</field>
         <field name="arch" type="xml">
+            <xpath expr="//field[@widget='many2one_avatar_employee']" position="attributes"> 
+                <attribute name="readonly">0</attribute>
+            </xpath>
             <field name="holiday_status_id" position="before">
                 <field name="user_id" invisible="1"/> <!-- Used in HolidaysFormViewDialog -->
-                <field name="employee_id" widget="many2one_avatar_employee"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
  Standardizing the timeoff popup views across multiple views.

Desired behavior after PR is merged: 
  Standardized popup for timeoffs form views:
  -  Employee name display should be removed and replaced with employee widget.

Task: https://www.odoo.com/odoo/all-tasks/4711632