### PR TITLE
[IMP] pos_self_order: make self_order_visible non-stored and remove depends

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -14,10 +14,7 @@ class ProductTemplate(models.Model):
         default=True,
     )
 
-    self_order_visible = fields.Boolean(
-        compute='_compute_self_order_visible',
-        store=True
-    )
+    self_order_visible = fields.Boolean(compute='_compute_self_order_visible')
 
     def _load_pos_self_data_read(self, data, config):
         domain = self._load_pos_self_data_domain(data, config)
@@ -67,12 +64,10 @@ class ProductTemplate(models.Model):
             if not record.available_in_pos:
                 record.self_order_available = False
 
-    @api.depends('pos_categ_ids', 'pos_categ_ids.pos_config_ids.self_ordering_mode')
     def _compute_self_order_visible(self):
-        config_with_self = self.env['pos.config'].search([('self_ordering_mode', '!=', 'nothing')])
-        categ_ids = config_with_self.iface_available_categ_ids.ids
+        active_self_order_configs = self.env['pos.config'].sudo().search_count([('self_ordering_mode', '!=', 'nothing')])
         for product in self:
-            product.self_order_visible = any(p_cat_id in categ_ids for p_cat_id in product.pos_categ_ids.ids)
+            product.self_order_visible = bool(active_self_order_configs)
 
     def write(self, vals_list):
         if 'available_in_pos' in vals_list:


### PR DESCRIPTION
### Before this commit:

- **self_order_visible** was a stored computed field (store=True), meaning its value was saved in the database.
- Also if only same category is chose which is added in the config then only field is available in product form.

### After this commit:

- **self_order_visible** is now a non-stored field — its value is computed dynamically and not stored in the database.
- Now if any self orders / kiosk is active then `Available in self order` field available in product form.

Task - 4840350

Related PR:
- Upgrade: [[IMP] pos_self_order/saas~18.4: make self_order_visible field non-stored #7809](https://github.com/odoo/upgrade/pull/7809)