### PR TITLE
[IMP] l10n_in_edi: add edi status to list-view and form-view

### DIFF
--- a/addons/l10n_in_edi/views/account_move_views.xml
+++ b/addons/l10n_in_edi/views/account_move_views.xml
@@ -38,6 +38,39 @@
                         groups="base.group_no_one"
                         string="Download EDI JSON"/>
             </xpath>
+            <xpath expr="//div[@name='journal_div']" position="after">
+                <field name="l10n_in_edi_status" invisible="not l10n_in_edi_status or state == 'draft'"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_out_invoice_tree_inherit_l10n_in_edi" model="ir.ui.view">
+        <field name="name">out.invoice.list.inherit.l10n_in_edi</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_out_invoice_tree"/>
+        <field name="arch" type="xml">
+            <field name="status_in_payment" position="before">
+                <field name="l10n_in_edi_status"
+                       optional="hide"
+                       widget="badge"
+                       decoration-success="l10n_in_edi_status == 'sent'"
+                       decoration-info="l10n_in_edi_status == 'to_send'"
+                       decoration-danger="l10n_in_edi_status == 'cancelled'"/>
+            </field>
+        </field>
+    </record>
+    <record id="view_out_credit_note_tree_inherit_l10n_in_edi" model="ir.ui.view">
+        <field name="name">out.credit.note.list.inherit.l10n_in_edi</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_out_credit_note_tree"/>
+        <field name="arch" type="xml">
+            <field name="status_in_payment" position="before">
+                <field name="l10n_in_edi_status"
+                       optional="hide"
+                       widget="badge"
+                       decoration-success="l10n_in_edi_status == 'sent'"
+                       decoration-info="l10n_in_edi_status == 'to_send'"
+                       decoration-danger="l10n_in_edi_status == 'cancelled'"/>
+            </field>
         </field>
     </record>
     <record id="l10n_in_edi_inherit_account_move_search_view" model="ir.ui.view">


### PR DESCRIPTION
**After this commit:**

- Users will be able to view the India e-Invoicing status directly from the invoice list view.

- The India e-Invoicing status field has also been added to the invoice form
  view.

**Task**-4844345



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
