### PR TITLE
[FIX] pos_online_payment: prevent refunding online payment method

### DIFF
--- a/addons/pos_online_payment/models/pos_payment.py
+++ b/addons/pos_online_payment/models/pos_payment.py
@@ -20,8 +20,7 @@ class PosPayment(models.Model):
             pm_id = vals['payment_method_id']
             if pm_id not in online_account_payments_by_pm:
                 online_account_payments_by_pm[pm_id] = set()
-            if vals.get('online_account_payment_id'):
-                online_account_payments_by_pm[pm_id].add(vals['online_account_payment_id'])
+            online_account_payments_by_pm[pm_id].add(vals.get('online_account_payment_id'))
 
         opms_read_id = self.env['pos.payment.method'].search_read(['&', ('id', 'in', list(online_account_payments_by_pm.keys())), ('is_online_payment', '=', True)], ["id"])
         opms_id = {opm_read_id['id'] for opm_read_id in opms_read_id}

--- a/addons/pos_online_payment/tests/test_frontend.py
+++ b/addons/pos_online_payment/tests/test_frontend.py
@@ -12,6 +12,7 @@ from odoo.addons.pos_online_payment.tests.online_payment_common import OnlinePay
 from odoo.addons.account.models.account_payment_method import AccountPaymentMethod
 from odoo.osv.expression import AND
 from odoo.addons.point_of_sale.tests.common import archive_products
+from odoo.exceptions import UserError
 
 import odoo.tests
 
@@ -285,6 +286,49 @@ class TestUi(TestPointOfSaleHttpCommon, OnlinePaymentCommon):
     def test_customer_display_online_payment(self):
         self.start_tour(f"/pos_customer_display/{self.main_pos_config.id}/{self.main_pos_config.access_token}",
                         'CustomerDisplayTourOnlinePayment', login="pos_user")
+
+    def test_refuse_online_payment_without_accounting_payment(self):
+        """
+        Test that a an order can not be paid through an online payment method from the backend
+        when no accounting payment are set for this payment method. Ensure that it will raise
+        an error as soon as it is tried as it is not supported yet. Also ensures that we can still
+        close the session afterwards, as it is a side effect of not throwing the error.
+        """
+        self.main_pos_config.open_ui()
+        session = self.main_pos_config.current_session_id
+        try:
+            self.env["pos.order"].sync_from_ui([{
+                "amount_paid": 1180,
+                "amount_tax": 180,
+                "amount_return": 0,
+                "amount_total": 1180,
+                "lines": [
+                    Command.create({
+                        "price_unit": 1000.0,
+                        "product_id": self.letter_tray.id,
+                        "price_subtotal": 1000.0,
+                        "price_subtotal_incl": 1180.0,
+                        "qty": 1,
+                    }),
+                ],
+                "name": "Order 12345-123-1234",
+                "session_id": session.id,
+                "payment_ids": [
+                    Command.create({
+                        "amount": 1180,
+                        "name": fields.Datetime.now(),
+                        "payment_method_id": self.online_payment_method.id,
+                    }),
+                ],
+                "uuid": "12345-123-1234",
+            }])
+            self.fail("An error should be raised if no accounting payment has been set")
+        except UserError as e:
+            self.assertIn("Cannot create a POS online payment without an accounting payment", str(e))
+            # Make sure that we can close the session
+            session.order_ids.filtered(lambda o: o.state == 'draft').unlink()
+            session.action_pos_session_close()
+            self.assertEqual(session.state, 'closed')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
**Problem:**
When refunding an order that has been done in the frontend from the backend, then
when trying to pay for it again using an online payment method, it will
currently work. The problem is that doing this will prevent the user from
closing their session afterwards. The issue is that refunding through
online payment method is not supported but is going though either way.

**Steps to reproduce:**
- Have an online payment method.
- Go to your POS session and make a purchase, pay for it in cash.
- Go back to the backend, to orders and chose your order.
- Return the products and click payment to pay for it again.
- Chose your online payment method and make the payment.
- Try to close your POS session, an error prevents you from doing so.

**Why the fix:**
The problem is that an error should be thrown when trying to pay the
refund with an online payment method. But this error is never reached.
It was reached before this commit https://github.com/odoo-dev/odoo/commit/2dce0f22e92299b17162343e3629dcdab8a697b5
This commit is fixing an error that has since been avoided by this
commit https://github.com/odoo-dev/odoo/commit/0c8f0d730465028657ff8da28e7ab14e2df08f69
The use case does not even go through the fixed *create* function
anymore, so there should be no problem reverting the fix.
Before said commit, we set the *online_account_payment_id* whether
it exists or not. This then allows us to check if one of them is None
later on. If it is, it means we can't create the online payment, as we
can't create one without an accounting payment. After said commit,
we didn't add it if the accounting payment didn't exist, so the error was
never thrown as the code couldn't be reached.

opw-4815049