### PR TITLE
[FIX] point_of_sale: Def Pricelist Not auto Applied in Restaurant

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -129,7 +129,8 @@ export class PosOrder extends Base {
     }
 
     setPreset(preset) {
-        this.setPricelist(preset.pricelist_id);
+        const pricelist_id = preset.pricelist_id ? preset.pricelist_id : this.config.pricelist_id;
+        pricelist_id && this.setPricelist(pricelist_id);
         this.fiscal_position_id = preset.fiscal_position_id;
         this.preset_id = preset;
     }

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -683,3 +683,14 @@ registry.category("web_tour.tours").add("test_combo_preparation_receipt_layout",
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("test_pricelist_applied_on_order_line_tour", {
+    steps: () =>
+        [
+            Chrome.startPoS(),
+            Dialog.confirm("Open Register"),
+            FloorScreen.clickNewOrder(),
+            ProductScreen.clickDisplayedProduct("Pricelist Product"),
+            ProductScreen.totalAmountIs("80.00"),
+        ].flat(),
+});


### PR DESCRIPTION
To reproduce:
=============
Activate and add preset
Add a product with the POS box checked
Add a pricelist with a fixed price for that product Set it as the default pricelist for the restaurant in settings Go to the restaurant
Add that product to the order
→ Default pricelist is not applied

Problem :
===========
If a preset is selected, it overrides the value of the pricelist of the order

Solution :
===========
If the preset's pricelist is undefined, we do not override the order's pricelist.

opw-4776674

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
