### PR TITLE
[FIX] website: the loading spinner in editing

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
+++ b/addons/website/static/src/client_actions/website_preview/edit_website_systray_item.js
@@ -22,6 +22,7 @@ export class EditWebsiteSystrayItem extends Component {
     }
 
     onClickEditPage() {
+        this.websiteContext.edition = true;
         this.props.onEditPage();
     }
 


### PR DESCRIPTION
This commit ensures that the loading spinner is the first thing that happens when we click on "Edit", with no code running before that. This commit follows the [html_builder refactoring].

[html_builder refactoring]: odoo/odoo@9fe45e2b7ddb 
Related to task-4367641