### PR TITLE
[FIX]: show and hide archive/unarchive in list view as on form view

### DIFF
--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -116,12 +116,6 @@ export class ListController extends Component {
             }
         });
 
-        this.archiveEnabled =
-            "active" in this.props.fields
-                ? !this.props.fields.active.readonly
-                : "x_active" in this.props.fields
-                ? !this.props.fields.x_active.readonly
-                : false;
         useSubEnv({ model: this.model }); // do this in useModelWithSampleData?
         useViewButtons(this.rootRef, {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
@@ -425,6 +419,15 @@ export class ListController extends Component {
             action: [...staticActionItems, ...(actionMenus?.action || [])],
             print: actionMenus?.print,
         };
+    }
+
+    // enable the archive feature in Actions menu only if the active field is in the view
+    get archiveEnabled() {
+        return "active" in this.model.root.activeFields
+            ? !this.props.fields.active.readonly
+            : "x_active" in this.model.root.activeFields
+            ? !this.props.fields.x_active.readonly
+            : false;
     }
 
     async onSelectDomain() {

--- a/doc/cla/individual/jeromeguerriat-msf.md
+++ b/doc/cla/individual/jeromeguerriat-msf.md
@@ -1,0 +1,11 @@
+Belgium, 05/06/2025
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Jerome Guerriat. jguerriat@gmail.com https://github.com/jeromeguerriat-msf


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
On a form view, the archive/unarchive only appears if the field "active" is explicitly added on the form view. The field can be invisible of course, but it must be there.

On listview, the archive/unarchive appears if the field "active" exists on the record. Contrary to the form view, the field does not need to be explicitly added to the view.

Therefore, there is a discrepancy between the way listview and formview works.

Current behavior before PR:
the archive/unarchive feature appear on every list view whose model has the field "active", wether or not the field is displayed on the listview

Desired behavior after PR is merged:
Just as on a form view, the archive/unarchive feature only appears if you explicitly add the field.

Please note, of course, that many listview might need to be updated (basically, every listview for records that can be archived now must have the "active" field. This is already the case for form view


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
