### PR TITLE
[FIX] purchase: tool tip correction in purchase dashboard

### DIFF
--- a/addons/purchase/static/src/views/purchase_dashboard.xml
+++ b/addons/purchase/static/src/views/purchase_dashboard.xml
@@ -42,7 +42,7 @@
                                 </a>
                             </div>
                             <div class="g-col-1"/>
-                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Not Acknowledged RFQs" filter_name="not_acknowledged">
+                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Not Acknowledged POs" filter_name="not_acknowledged">
                                 <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div class="fs-2">
@@ -53,7 +53,7 @@
                                     </div>Not Acknowledged
                                 </a>
                             </div>
-                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late Receipt RFQs" filter_name="late_receipt">
+                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="All Late Receipt POs" filter_name="late_receipt">
                                 <a href="#" class="o_purchase_dashboard_card_top btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['global']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
                                     <div class="fs-2">
@@ -104,7 +104,7 @@
                                 </a>
                             </div>
                             <div class="g-col-1"/>
-                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Not Acknowledged RFQs" filter_name="not_acknowledged,my_purchases">
+                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Not Acknowledged POs" filter_name="not_acknowledged,my_purchases">
                                 <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['not_acknowledged']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-info-subtle text-info-emphasis' }}">
                                     <div>
@@ -115,7 +115,7 @@
                                     </div>
                                 </a>
                             </div>
-                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late Receipt RFQs" filter_name="late_receipt,my_purchases">
+                            <div class="g-col-12 p-0" t-on-click="setSearchContext" title="My Late Receipt POs" filter_name="late_receipt,my_purchases">
                                 <a href="#" class="o_purchase_dashboard_card_bottom btn purchase-dashboard-card p-1 p-lg-2 text-truncate text-wrap"
                                     t-attf-class="{{ purchaseData['my']['late_receipt']['all'] == 0 ? 'bg-secondary-subtle text-secondary-emphasis' : 'bg-danger-subtle text-danger-emphasis' }}">
                                     <div>


### PR DESCRIPTION
**Steps to reproduce:**
-  Purchase Order > Dashboard > hover on
 not acknowledged, late receipt and their counts

**Issue:**
 - Tool tips of 'not acknowledged' and 'late receipt' mentions
 RFQ's instead of PO's. These two kpi are related with PO and 
 filter only Purchase Orders not RFQ's

**Solution:**
 - Update the title of divs to 'POs'

opw-4848307