### PR TITLE
[FIX] website, *: prevent 404 on records access with website rule

### DIFF
--- a/addons/test_website_modules/tests/__init__.py
+++ b/addons/test_website_modules/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_configurator
 from . import test_controllers
+from . import test_models

--- a/addons/test_website_modules/tests/test_models.py
+++ b/addons/test_website_modules/tests/test_models.py
@@ -1,0 +1,22 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteModels(HttpCase):
+    def test_access_with_website_record_rule(self):
+        website = self.env['website'].get_current_website()
+        blog = self.env['blog.blog'].create({
+            'name': 'test blog',
+            'website_id': website.id,
+        })
+        post = self.env['blog.post'].create({
+            'name': 'test post',
+            'blog_id': blog.id,
+        })
+        post.write({'is_published': True})
+        rule = self.env.ref('website_blog.website_blog_post_public')
+        rule.domain_force = "[('website_id', '=', website.id)]"
+        res = self.url_open(post.website_url, allow_redirects=False)
+        res.raise_for_status()

--- a/addons/website/models/ir_rule.py
+++ b/addons/website/models/ir_rule.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from odoo import api, models
 from odoo.addons.website.models import ir_http
+from odoo.http import request
 
 
 class IrRule(models.Model):
@@ -12,9 +13,14 @@ class IrRule(models.Model):
 
         # We need is_frontend to avoid showing website's company items in backend
         # (that could be different than current company). We can't use
-        # `get_current_website(falback=False)` as it could also return a website
-        # in backend (if domain set & match)..
-        is_frontend = ir_http.get_request_website()
+        # `get_current_website(fallback=False)` as it could also return a
+        # website in backend (if domain set & match).
+        #
+        # Additionally, during early request phases (e.g. access rule evaluation
+        # in `_pre_dispatch`), `request.website` is not yet initialized.
+        # However, `request.is_frontend` is already set by `_match`, so we use
+        # it as a fallback to reliably detect frontend requests.
+        is_frontend = ir_http.get_request_website() or request and getattr(request, 'is_frontend', False)
         Website = self.env['website']
         res['website'] = is_frontend and Website.get_current_website() or Website
         return res


### PR DESCRIPTION
\* = test_website_modules

### Issue:
When accessing a record from the website without logging in, a `404`
error occurs if a public record rule filters records by website related
domain, for example `[('website_id', '=', website.id)]`.

### Steps to reproduce:
- Install the 'website_blog' module and create at least one website.
- Enable debug mode.
- Go to Settings > Technical > Database Structure > Models.
- Open the `blog.post` model.
- Go to the 'Record Rules' tab.
- For the record 'Blog Post: public: published only', change the domain
  from `[('website_published', '=', True)]` to
  `[('website_id', '=', website.id)]`.
- Go to Website > Configuration > Blogs.
- Open a blog (e.g., Travel).
- Select 'My Website' in its 'Website' field.
- Open 'My Website' without logging in.
- Click on the 'Blog' menu and the blog listing will appear correctly.
- Try opening a blog post and a `404` error occurs.

### Reason:
<pre>
┌─────────────────────────────────────────────────────────┐
│                    Request Lifecycle                    │
├─────────────────────────────────────────────────────────┤
│                                                         │
│  User Request (not logged in)                           │
│       ↓                                                 │
│  ┌──────────────────────────────────────┐               │
│  │ 1. _pre_dispatch                     │               │
│  │    ↓                                 │               │
│  │    check_access_rule                 │               │
│  │    ↓                                 │               │
│  │    _eval_context (compute domain)    │               │
│  │    ↓                                 │               │
│  │    get_request_website()             │               │
│  │    ↓                                 │               │
│  │    request.website = None            │  ← Issue      │
│  │    ↓                                 │               │
│  │    Domain evaluation FAILS           │               │
│  │    ↓                                 │               │
│  │    Access DENIED → 404 Error         │               │
│  └──────────────────────────────────────┘               │
│       ↓                                                 │
│  ┌──────────────────────────────────────┐               │
│  │ 2. _frontend_pre_dispatch            │               │
│  │    (NEVER REACHED)                   │               │
│  │    ↓                                 │               │
│  │    request.website initialized ✓     │  ← Too Late   │
│  └──────────────────────────────────────┘               │
│                                                         │
└─────────────────────────────────────────────────────────┘
</pre>
Because `request.website` is initialized later in
`_frontend_pre_dispatch`, access rules evaluated earlier in
`_pre_dispatch` cannot rely on website context. As a result, record
rules depending on `website_id` are evaluated before `request.website`
is available, incorrectly denying access to public records.

### Fix:
Avoid totally relying on `get_request_website` during access rule
evaluation. Use the `request.is_frontend` attribute as a fallback, which
is set earlier, to detect frontend requests and ensure correct access
handling.

task-[4758311](https://www.odoo.com/odoo/project/974/tasks/4758311)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
