### PR TITLE
[IMP] hr_timesheet: Adding delete wizard when multiple employees are selected

### DIFF
--- a/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
+++ b/addons/hr_timesheet/wizard/hr_employee_delete_wizard.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
 
 
 class HrEmployeeDeleteWizard(models.TransientModel):
@@ -30,8 +29,6 @@ class HrEmployeeDeleteWizard(models.TransientModel):
 
     def action_archive(self):
         self.ensure_one()
-        if len(self.employee_ids) != 1:
-            return self.employee_ids.action_archive()
         return {
             'name': _('Employee Termination'),
             'type': 'ir.actions.act_window',
@@ -40,9 +37,9 @@ class HrEmployeeDeleteWizard(models.TransientModel):
             'view_mode': 'form',
             'target': 'new',
             'context': {
-                'active_id': self.employee_ids.id,
+                'active_ids': self.employee_ids.ids,
                 'employee_termination': True,
-            }
+            },
         }
 
     def action_confirm_delete(self):


### PR DESCRIPTION
In this PR, we enabled the delete wizard when multiple employees are selected and they have timesheets.

Description of the issue/feature this PR addresses:
In a [previous PR](https://github.com/odoo/odoo/pull/98233), when the delete wizard was introduced, it was intended to archive directly the selected employees when they are more than 1.

Current behavior before PR:
- When selecting multiple employees with timesheets and attempting to delete them, the system bypassed the Employee Termination wizard (`hr.departure.wizard`) and archived the records directly.
![wizard termination bug](https://github.com/user-attachments/assets/42aa63b7-7831-436d-874c-7c89dd229e35)

Desired behavior after PR is merged:
- The wizard now correctly sets `active_ids` for both single employee and multiple ones, ensuring the `hr.departure.wizard` is displayed in all cases.
- Users will now always see the employee termination wizard, maintaining consistent UX and preventing silent archival of multiple employees.
![wizard termination fix](https://github.com/user-attachments/assets/1a9b39da-800f-4d4b-bb6a-9b59fb504b84)

task: 4851899
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
