### PR TITLE
[IMP] im_livechat: add an option to block chat assignment when in call

### DIFF
--- a/addons/im_livechat/tests/test_get_operator.py
+++ b/addons/im_livechat/tests/test_get_operator.py
@@ -286,15 +286,14 @@ class TestGetOperator(MailCommon, TestGetOperatorCommon):
         self.assertEqual(livechat_channel.available_operator_ids, operator_2)
 
     @users("employee")
-    def test_max_sessions_mode_limited_operator_in_call_no_new_sessions(self):
+    def test_block_assignment_during_call(self):
         """Test operator is not available when they are in call, even below the livechat channel
         limit."""
         operator = self._create_operator()
         livechat_channel_data = {
             "name": "Livechat Channel",
             "user_ids": operator,
-            "max_sessions_mode": "limited",
-            "max_sessions": 2,
+            "block_assignment_during_call": True,
         }
         livechat_channel = self.env["im_livechat.channel"].sudo().create(livechat_channel_data)
         self._create_chat(livechat_channel, operator, in_call=True)

--- a/addons/im_livechat/views/im_livechat_channel_views.xml
+++ b/addons/im_livechat/views/im_livechat_channel_views.xml
@@ -140,10 +140,11 @@
                                         </div>
                                     </group>
                                 </group>
-                                <group>
+                                <group string="Session Limits">
                                     <group>
                                         <field name="max_sessions_mode" widget="radio" options="{'horizontal': true}"/>
                                         <field name="max_sessions" invisible="max_sessions_mode != 'limited'"/>
+                                        <field name="block_assignment_during_call"/>
                                     </group>
                                 </group>
                             </page>


### PR DESCRIPTION
Before this commit, an agent would not receive any chats during a call only if `max_session_mode` was set to `limited`. Grouping the maximum number of sessions with the restriction on chat assignment during calls was not convenient. This commit separates the two options.

task-4818793

upgrade: https://github.com/odoo/upgrade/pull/7814.