### PR TITLE
[FIX] website: no preview on the visibility option

### DIFF
--- a/addons/website/static/src/builder/plugins/options/visibility_option.xml
+++ b/addons/website/static/src/builder/plugins/options/visibility_option.xml
@@ -37,7 +37,7 @@
     <t t-set="geoip_country_code" t-value="this.props.websiteSession.geoip_country_code"/>
     <BuilderRow label.translate="Visibility" expand="true">
         <t t-call="website.DeviceVisibility"></t>
-        <BuilderSelect dataAttributeAction="'visibility'" action="'forceVisible'">
+        <BuilderSelect dataAttributeAction="'visibility'" action="'forceVisible'" preview="false">
             <BuilderSelectItem dataAttributeActionValue="null">No condition</BuilderSelectItem>
             <BuilderSelectItem dataAttributeActionValue="'conditional'" classAction="'o_snippet_invisible'" id="'visibility_conditional'">Conditionally</BuilderSelectItem>
         </BuilderSelect>


### PR DESCRIPTION
Steps to reproduce the problem:
- Add a block in edit mode
- Click on it
- Open the visibility condition dropdown
- Hover "conditional", close the dropdown 
Bug: the element is considered as invisible in the bottom right section.
This commit follows the [html_builder refactoring].

[html_builder refactoring]: odoo/odoo@9fe45e2b7ddb 
Related to task-4367641