### PR TITLE
[FIX] website: fix 403 error on blog post access in multi-website

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -176,6 +176,15 @@ class Http(models.AbstractModel):
 
     @classmethod
     def _pre_dispatch(cls, rule, arguments):
+        if request.is_frontend:
+            # Ensure model-bound route arguments have the correct
+            # website context to apply website-specific record rules
+            # during access checks.
+            website = request.env['website'].get_current_website()
+            for key, val in list(arguments.items()):
+                if isinstance(val, models.BaseModel):
+                    arguments[key] = val.with_context(website_id=website.id)
+
         super()._pre_dispatch(rule, arguments)
 
         for record in arguments.values():


### PR DESCRIPTION
**Issue:**
After the changes in commit 83464bf, accessing a blog post in a multi-website setup works for the first visited website, but trying to access a blog post on the second website results in a '403 Forbidden error'.

**Steps to reproduce:**
- Set up two blogs, each assigned to a different website.
- Visit the first website and open a blog post (works as expected).
- Visit the second website and open a blog post (results in a 403 error).

**Reason:**
The issue is caused by ORM cache on computed access domains. Since `website_id` is part of `_compute_domain_keys`, different websites should trigger separate domain computations. However, the `website_id` is missing from the `recordset` context (`args`) during `check_access_rule` in `_pre_dispatch`. As a result, the domain computed for the first website is reused for the second, leading to incorrect access denial.

**Fix:**
We inject the appropriate `website_id` into the context of the `recordset` (`args`) before `check_access_rule` is called in `_pre_dispatch`, ensuring correct domain computation per website.

Related to commit 83464bf

task-4758311

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
