### PR TITLE
[PERF] stock: batch orderpoints compute method

### DIFF
--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -69,26 +69,33 @@ class ProductProduct(models.Model):
             ('product_id', 'in', self.ids)
         ]
         if location_ids:
-            domains.append(expression.AND([rfq_domain, [
+            domains.append([
                 '|',
-                '|',
-                    ('order_id.picking_type_id.default_location_dest_id', 'in', location_ids),
                     '&',
-                        ('move_ids', '=', False),
-                        ('location_final_id', 'child_of', location_ids),
+                    ('orderpoint_id', '=', False),
+                    '|',
+                        '&',
+                            ('location_final_id', '=', False),
+                            ('order_id.picking_type_id.default_location_dest_id', 'in', location_ids),
+                        '&',
+                            ('move_ids', '=', False),
+                            ('location_final_id', 'child_of', location_ids),
                     '&',
                         ('move_dest_ids', '=', False),
                         ('orderpoint_id.location_id', 'in', location_ids)
-            ]]))
+            ])
         if warehouse_ids:
-            domains.append(expression.AND([rfq_domain, [
+            domains.append([
                 '|',
-                    ('order_id.picking_type_id.warehouse_id', 'in', warehouse_ids),
+                    '&',
+                        ('orderpoint_id', '=', False),
+                        ('order_id.picking_type_id.warehouse_id', 'in', warehouse_ids),
                     '&',
                         ('move_dest_ids', '=', False),
                         ('orderpoint_id.warehouse_id', 'in', warehouse_ids)
-            ]]))
-        return expression.OR(domains) if domains else []
+            ])
+        domains = expression.OR(domains) if domains else []
+        return expression.AND([rfq_domain, domains])
 
 
 class SupplierInfo(models.Model):

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -339,28 +339,34 @@ class StockWarehouseOrderpoint(models.Model):
 
     @api.depends('qty_multiple', 'qty_forecast', 'product_min_qty', 'product_max_qty', 'visibility_days')
     def _compute_qty_to_order_computed(self):
-        for orderpoint in self:
-            if not orderpoint.product_id or not orderpoint.location_id:
-                orderpoint.qty_to_order_computed = False
-                continue
-            orderpoint.qty_to_order_computed = orderpoint._get_qty_to_order(qty_in_progress_by_orderpoint=orderpoint._quantity_in_progress())
+        def to_compute(orderpoint):
+            rounding = orderpoint.product_uom.rounding
+            # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
+            # there is a already something to ressuply base on lead times.
+            return float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=rounding) < 0
 
-    def _get_qty_to_order(self, force_visibility_days=False, qty_in_progress_by_orderpoint={}):
+        orderpoints = self.filtered(to_compute)
+        qty_in_progress_by_orderpoint = orderpoints._quantity_in_progress()
+        for orderpoint in orderpoints:
+            orderpoint.qty_to_order_computed = orderpoint._get_qty_to_order(qty_in_progress_by_orderpoint=qty_in_progress_by_orderpoint)
+        (self - orderpoints).qty_to_order_computed = False
+
+    def _get_qty_to_order(self, force_visibility_days=False, qty_in_progress_by_orderpoint=None):
         self.ensure_one()
-        if not self.product_id or not self.location_id:
-            return False
         visibility_days = self.visibility_days
         if force_visibility_days is not False:
             # Accepts falsy values such as 0.
             visibility_days = force_visibility_days
         qty_to_order = 0.0
+        qty_in_progress_by_orderpoint = qty_in_progress_by_orderpoint or {}
+        qty_in_progress = qty_in_progress_by_orderpoint.get(self.id)
+        if qty_in_progress is None:
+            qty_in_progress = self._quantity_in_progress()[self.id]
         rounding = self.product_uom.rounding
         # The check is on purpose. We only want to consider the visibility days if the forecast is negative and
         # there is a already something to ressuply base on lead times.
         if float_compare(self.qty_forecast, self.product_min_qty, precision_rounding=rounding) < 0:
-            # We want to know how much we should order to also satisfy the needs that gonna appear in the next (visibility) days
             product_context = self._get_product_context(visibility_days=visibility_days)
-            qty_in_progress = qty_in_progress_by_orderpoint.get(self.id) or self._quantity_in_progress()[self.id]
             qty_forecast_with_visibility = self.product_id.with_context(product_context).read(['virtual_available'])[0]['virtual_available'] + qty_in_progress
             qty_to_order = max(self.product_min_qty, self.product_max_qty) - qty_forecast_with_visibility
             remainder = (self.qty_multiple > 0.0 and qty_to_order % self.qty_multiple) or 0.0


### PR DESCRIPTION
The method `orderpoint._compute_qty_order_computed` was batched in commit 17a2de9 then reverted in commit a58b995 because of a bug introduced when purchase_stock is installed.

It should still be beneficial performance-wise to batch the calls to `orderpoint._quantity_in_progress` so this commit reintroduces the batching. The part that led to the issue was the override of `_quantity_in_progress` in the purchase_stock module.

In this commit we fix the `_quantity_in_progress` method. Thanks to that, the test introduced in 606dc71 is passing even with the batched version of `_compute_qty_to_order_computed`.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
