### PR TITLE
[REF] web: condition tree: construct tree

### DIFF
--- a/addons/web/static/src/core/domain_selector/domain_selector.js
+++ b/addons/web/static/src/core/domain_selector/domain_selector.js
@@ -6,6 +6,7 @@ import {
     treeFromDomain,
     formatValue,
     condition,
+    constructTree,
 } from "@web/core/tree_editor/condition_tree";
 import { CheckBox } from "@web/core/checkbox/checkbox";
 import { deepEqual } from "@web/core/utils/objects";
@@ -68,9 +69,9 @@ export class DomainSelector extends Component {
             return;
         }
 
-        const tree = treeFromDomain(domain);
-
-        const getFieldDef = await this.makeGetFieldDef(p.resModel, tree, ["active"]);
+        const getFieldDef = await this.makeGetFieldDef(p.resModel, constructTree(domain), [
+            "active",
+        ]);
 
         this.tree = treeFromDomain(domain, {
             getFieldDef,

--- a/addons/web/static/src/core/tree_editor/condition_tree.js
+++ b/addons/web/static/src/core/tree_editor/condition_tree.js
@@ -352,21 +352,21 @@ function getNormalizedCondition(condition) {
 
 /**
  * @param {AST[]} ASTs
- * @param {Options} [options={}]
+ * @param {boolean} [distributeNot=false]
  * @param {boolean} [negate=false]
  * @returns {{ tree: Tree, remaimingASTs: AST[] }}
  */
-function _construcTree(ASTs, options = {}, negate = false) {
+function _constructTree(ASTs, distributeNot = false, negate = false) {
     const [firstAST, ...tailASTs] = ASTs;
 
     if (firstAST.type === 1 && firstAST.value === "!") {
-        return _construcTree(tailASTs, options, !negate);
+        return _constructTree(tailASTs, distributeNot, !negate);
     }
 
     const tree = { type: firstAST.type === 1 ? "connector" : "condition" };
     if (tree.type === "connector") {
         tree.value = firstAST.value;
-        if (options.distributeNot && negate) {
+        if (distributeNot && negate) {
             tree.value = tree.value === "&" ? "|" : "&";
             tree.negate = false;
         } else {
@@ -381,15 +381,7 @@ function _construcTree(ASTs, options = {}, negate = false) {
         tree.value = toValue(valueAST);
         if (["any", "not any"].includes(tree.operator)) {
             try {
-                tree.value = treeFromDomain(formatAST(valueAST), {
-                    ...options,
-                    getFieldDef: (p) => {
-                        if (typeof tree.path === "string" && typeof p === "string") {
-                            return options.getFieldDef?.(`${tree.path}.${p}`) || null;
-                        }
-                        return null;
-                    },
-                });
+                tree.value = constructTree(formatAST(valueAST), distributeNot);
             } catch {
                 tree.value = Array.isArray(tree.value) ? tree.value : [tree.value];
             }
@@ -398,10 +390,10 @@ function _construcTree(ASTs, options = {}, negate = false) {
     let remaimingASTs = tailASTs;
     if (tree.type === "connector") {
         for (let i = 0; i < 2; i++) {
-            const { tree: child, remaimingASTs: otherASTs } = _construcTree(
+            const { tree: child, remaimingASTs: otherASTs } = _constructTree(
                 remaimingASTs,
-                options,
-                options.distributeNot && negate
+                distributeNot,
+                distributeNot && negate
             );
             remaimingASTs = otherASTs;
             addChild(tree, child);
@@ -412,10 +404,10 @@ function _construcTree(ASTs, options = {}, negate = false) {
 
 /**
  * @param {DomainRepr} domain
- * @param {Options} [options={}]
+ * @param {boolean} [distributeNot=false]
  * @returns {Tree}
  */
-function construcTree(domain, options = {}) {
+export function constructTree(domain, distributeNot = false) {
     domain = new Domain(domain);
     const domainAST = domain.ast;
     // @ts-ignore
@@ -423,7 +415,7 @@ function construcTree(domain, options = {}) {
     if (!initialASTs.length) {
         return connector("&");
     }
-    const { tree } = _construcTree(initialASTs, options);
+    const { tree } = _constructTree(initialASTs, distributeNot);
     return tree;
 }
 
@@ -873,6 +865,18 @@ function normalizeConnector(connector) {
     return newTree;
 }
 
+function makeOptions(path, options) {
+    return {
+        ...options,
+        getFieldDef: (p) => {
+            if (typeof path === "string" && typeof p === "string") {
+                return options.getFieldDef?.(`${path}.${p}`) || null;
+            }
+            return null;
+        },
+    };
+}
+
 /**
  * @param {Function} transformation
  * @param {Tree} tree
@@ -880,11 +884,19 @@ function normalizeConnector(connector) {
  * @param {"condition"|"connector"|"complex_condition"} [treeType="condition"]
  * @returns {Tree}
  */
-function operate(transformation, tree, options = {}, treeType = "condition") {
+function operate(
+    transformation,
+    tree,
+    options = {},
+    treeType = "condition",
+    traverseSubTrees = true
+) {
     if (tree.type === "connector") {
         const newTree = {
             ...tree,
-            children: tree.children.map((c) => operate(transformation, c, options, treeType)),
+            children: tree.children.map((c) =>
+                operate(transformation, c, options, treeType, traverseSubTrees)
+            ),
         };
         if (treeType === "connector") {
             return normalizeConnector(transformation(newTree, options) || newTree);
@@ -892,6 +904,15 @@ function operate(transformation, tree, options = {}, treeType = "condition") {
         return normalizeConnector(newTree);
     }
     const clone = cloneTree(tree);
+    if (traverseSubTrees && tree.type === "condition" && isTree(tree.value)) {
+        clone.value = operate(
+            transformation,
+            tree.value,
+            makeOptions(tree.path, options),
+            treeType,
+            traverseSubTrees
+        );
+    }
     if (treeType === tree.type) {
         return transformation(clone, options) || clone;
     }
@@ -946,7 +967,7 @@ class TreePattern extends Pattern {
         for (const name of vars) {
             values[name] = new Hole(name);
         }
-        const tree = construcTree(domain);
+        const tree = constructTree(domain);
         this._template = replaceVariablesByValues(tree, values);
     }
     detect(tree) {
@@ -1644,10 +1665,10 @@ export function domainFromTree(tree) {
 
 /**
  * @param {DomainRepr} domain
- * @param {Object} [options={}] see construcTree API
+ * @param {Object} [options={}] see constructTree API
  * @returns {Tree} a (simple) tree representation of a domain
  */
 export function treeFromDomain(domain, options = {}) {
-    const tree = construcTree(domain, options);
+    const tree = constructTree(domain, options.distributeNot);
     return applyTransformations(FULL_VIRTUAL_OPERATORS_CREATION, tree, options);
 }

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -6,7 +6,11 @@ import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_se
 import { _t } from "@web/core/l10n/translation";
 import { rpcBus } from "@web/core/network/rpc";
 import { evaluateExpr } from "@web/core/py_js/py";
-import { domainFromTree, treeFromDomain } from "@web/core/tree_editor/condition_tree";
+import {
+    constructTree,
+    domainFromTree,
+    treeFromDomain,
+} from "@web/core/tree_editor/condition_tree";
 import {
     useGetTreeDescription,
     useGetTreeTooltip,
@@ -708,7 +712,7 @@ export class SearchModel extends EventBus {
             context = makeContext(contexts);
         }
 
-        const getFieldDef = await this.makeGetFieldDef(this.resModel, treeFromDomain(domain));
+        const getFieldDef = await this.makeGetFieldDef(this.resModel, constructTree(domain));
         const tree = treeFromDomain(domain, { distributeNot: !this.isDebugMode, getFieldDef });
         const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
         const promises = trees.map(async (tree) => {

--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -7,7 +7,11 @@ import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { EvaluationError } from "@web/core/py_js/py_builtin";
 import { registry } from "@web/core/registry";
-import { treeFromDomain, domainContainsExpresssions } from "@web/core/tree_editor/condition_tree";
+import {
+    constructTree,
+    domainContainsExpresssions,
+    treeFromDomain,
+} from "@web/core/tree_editor/condition_tree";
 import { useGetTreeDescription, useMakeGetFieldDef } from "@web/core/tree_editor/utils";
 import { useBus, useOwnedDialogs, useService } from "@web/core/utils/hooks";
 import { useRecordObserver } from "@web/model/relational_model/utils";
@@ -164,7 +168,7 @@ export class DomainField extends Component {
         let promises = [];
         const domain = this.getDomain(props);
         try {
-            const getFieldDef = await this.makeGetFieldDef(resModel, treeFromDomain(domain));
+            const getFieldDef = await this.makeGetFieldDef(resModel, constructTree(domain));
             const tree = treeFromDomain(domain, { distributeNot: !this.env.debug, getFieldDef });
             const trees = !tree.negate && tree.value === "&" ? tree.children : [tree];
             promises = trees.map((tree) => this.getDomainTreeDescription(resModel, tree));


### PR DESCRIPTION
We no longer apply transformations in sub trees when constructing trees. This allows us to avoid to operate on trees without need and opens the possibility to operate on several trees at once.