### PR TITLE
[FIX] account: move fields access group to view

### DIFF
--- a/addons/account/models/account_analytic_account.py
+++ b/addons/account/models/account_analytic_account.py
@@ -15,9 +15,6 @@ class AccountAnalyticAccount(models.Model):
         compute='_compute_vendor_bill_count',
     )
 
-    debit = fields.Monetary(groups='account.group_account_readonly')
-    credit = fields.Monetary(groups='account.group_account_readonly')
-
     @api.depends('line_ids')
     def _compute_invoice_count(self):
         sale_types = self.env['account.move'].get_sale_types(include_receipts=True)

--- a/addons/account/views/account_analytic_account_views.xml
+++ b/addons/account/views/account_analytic_account_views.xml
@@ -28,9 +28,11 @@
             <field name="arch" type="xml">
                 <field name="debit" position="attributes">
                     <attribute name="column_invisible">False</attribute>
+                    <attribute name="groups">account.group_account_readonly</attribute>
                 </field>
                 <field name="credit" position="attributes">
                     <attribute name="column_invisible">False</attribute>
+                    <attribute name="groups">account.group_account_readonly</attribute>
                 </field>
             </field>
         </record>


### PR DESCRIPTION
The field `account.analytic.account.balance` is a computed field that is [computed](https://github.com/odoo/odoo/blob/69e29c5c37b133e8c75388718820c307c5f1148b/addons/analytic/models/analytic_account.py#L77-L88) with 2 other fields in the same model `credit` and `debit`. The 2 other fields have group `account.group_account_readonly` and will be hidden from views in read calls, but the balance field will still be computed.
Due to a [change](https://github.com/odoo/odoo/commit/f885f50d0a3381be1935cfb1dd3241fe8fe1a91f) in checking field access, the access to `balance` now requires access to the other fields, making the [menu](https://github.com/odoo/odoo/blob/f33451af032453746ccd662580f2cf26b85031d6/addons/account/views/account_menuitem.xml#L63) `account.account_analytic_def_account` fail when the user is an account manager and does not have the accountant module installed (the group_account_manager in community does not imply group_account_readonly)

The access error on the failing menu was seen in upgrades when the module accountant was uninstalled.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
