### PR TITLE
[FIX] hr_expense: next activity sent to the wrong manager

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -989,7 +989,10 @@ class HrExpense(models.Model):
             if expense.state == 'submitted':
                 expense.activity_schedule(
                     'hr_expense.mail_act_expense_approval',
-                    user_id=expense.sudo()._get_default_responsible_for_approval().id or self.env.user.id)
+                    user_id=expense.manager_id.id or
+                    expense.sudo()._get_default_responsible_for_approval().id or
+                    self.env.user.id
+                )
                 expenses_submitted_to_review |= expense
             elif expense.state == 'approved':
                 expenses_activity_done |= expense

--- a/addons/hr_expense/tests/common.py
+++ b/addons/hr_expense/tests/common.py
@@ -38,6 +38,16 @@ class TestExpenseCommon(AccountTestInvoicingCommon):
             company_ids=[Command.set(cls.env.companies.ids)],
         )
 
+        cls.expense_user_manager_2 = mail_new_test_user(
+            cls.env,
+            name='Expense manager',
+            login='expense_manager_2',
+            email='expense_manager_2@example.com',
+            notification_type='email',
+            groups='base.group_user,hr_expense.group_hr_expense_manager',
+            company_ids=[Command.set(cls.env.companies.ids)],
+        )
+
         cls.expense_employee = cls.env['hr.employee'].create({
             'name': 'expense_employee',
             'user_id': cls.expense_user_employee.id,

--- a/addons/hr_expense/tests/test_expenses_states.py
+++ b/addons/hr_expense/tests/test_expenses_states.py
@@ -192,3 +192,10 @@ class TestExpensesStates(TestExpenseCommon):
         self.expenses_all.manager_id = False
         self.expenses_all.action_submit()
         self.assertSequenceEqual(['approved', 'approved'], self.expenses_all.mapped('state'))
+
+    def test_expense_next_activity(self):
+        """ Test the auto-validation flow skips 'submitted' state when there is no manager"""
+        self.expenses_employee.manager_id = self.expense_user_manager_2
+        self.expenses_all.action_submit()
+        mail_activity = self.env['mail.activity'].search([('res_model', '=', 'hr.expense'), ('res_id', '=', self.expenses_employee.id)])
+        self.assertEqual(mail_activity.user_id.id, self.expense_user_manager_2.id)


### PR DESCRIPTION
When an expense is submited and you've selected a different manager than the default one, this is not the right person that gets the activity linked to the expense.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
