### PR TITLE
[IMP] website: remove highlight preview

### DIFF
--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.js
@@ -1,7 +1,6 @@
-import { Component, onMounted, useRef, useState } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
 import { ColorPicker } from "@web/core/color_picker/color_picker";
 import { HighlightPicker } from "./highlight_picker";
-import { applyTextHighlight } from "@website/js/highlight_utils";
 import { normalizeColor } from "@html_builder/utils/utils_css";
 
 export const highlightIdToName = {
@@ -47,13 +46,9 @@ export class HighlightConfigurator extends Component {
     setup() {
         this.state = useState(this.props.getHighlightState());
         this.highlightIdToName = highlightIdToName;
-        this.preview = useRef("preview");
-        onMounted(() => {
+        onWillStart(() => {
             if (!this.state.highlightId) {
                 this.openHighlightPicker(false);
-            }
-            if (this.state.highlightId && this.preview.el) {
-                applyTextHighlight(this.preview.el, this.state.highlightId);
             }
         });
     }

--- a/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_configurator.xml
@@ -21,10 +21,6 @@
             <input type="number" id="thicknessInput" class="text-end w-25" t-att-value="this.state.thickness" t-on-input="onThicknessChange" />
             <span class="ms-1">px</span>
         </div>
-
-        <div class="fs-2 mt-3 p-5 text-center fw-bolder border" style="padding: 20px 5px;">
-            <span t-attf-style="--text-highlight-color: {{this.state.color}}; --text-highlight-width: {{this.state.thickness}};" t-ref="preview" t-attf-class="o_text_highlight o_text_highlight_{{this.state.highlightId}}">Text</span>
-        </div>
     </div>
 </t>
 </templates>

--- a/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
+++ b/addons/website/static/src/builder/plugins/highlight/highlight_plugin.js
@@ -219,7 +219,7 @@ class HighlightToolbarButton extends Component {
     openHighlightConfigurator() {
         this.configuratorPopover.open(this.root.el, {
             stackState: this.componentStack,
-            style: "height: 275px; width: 262px",
+            style: "max-height: 275px; width: 262px",
             class: "d-flex flex-column",
         });
     }

--- a/addons/website/static/src/builder/plugins/highlight/stacking_component.js
+++ b/addons/website/static/src/builder/plugins/highlight/stacking_component.js
@@ -1,4 +1,5 @@
-import { xml, Component, reactive, useState } from "@odoo/owl";
+import { xml, Component, reactive, useState, useEffect } from "@odoo/owl";
+import { POSITION_BUS } from "@web/core/position/position_hook";
 
 export function useStackingComponentState() {
     const stack = reactive([]);
@@ -31,5 +32,12 @@ export class StackingComponent extends Component {
     };
     setup() {
         this.stack = useState(this.props.stackState.stack);
+        useEffect(
+            () => {
+                // Recompute the positioning of the popover if any.
+                this.env[POSITION_BUS]?.trigger("update");
+            },
+            () => [this.stack.length]
+        );
     }
 }


### PR DESCRIPTION
Context: In the website editor, select a text, in the toolbar click on the highlight button. This will open the highlight configurator.

This commit removes the highlight preview from the highlight configurator because it is unnecessary.

Tech note:  By doing this, the height of the popovers in the highlight configurator are not the same anymore. So we're now recomputing the position of the popover when the user go from one screen to another.
![image](https://github.com/user-attachments/assets/35fe3c30-1193-46aa-b543-825f44289326)
