### PR TITLE
[FIX] web_editor: unwrap invalid divs and ensure proper paragraph tags

### DIFF
--- a/addons/project/static/tests/tours/project_update_tour_tests.js
+++ b/addons/project/static/tests/tours/project_update_tour_tests.js
@@ -145,13 +145,13 @@ registry.category("web_tour.tours").add('project_update_tour', {
     trigger: ".o_field_widget[name='description'] h3:contains('Milestones')",
     run: function () {},
 }, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(12/12/2099 => 12/12/2100)')",
+        trigger: ".o_field_widget[name='description'] ul li:contains('(12/12/2099 => 12/12/2100)')",
     run: function () {},
 }, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(due 12/12/2022)')",
+        trigger: ".o_field_widget[name='description'] ul li:contains('(due 12/12/2022)')",
     run: function () {},
 }, {
-    trigger: ".o_field_widget[name='description'] div[name='milestone'] ul li:contains('(due 12/12/2100)')",
+        trigger: ".o_field_widget[name='description'] ul li:contains('(due 12/12/2100)')",
     run: function () {},
 }, {
     trigger: '.o_back_button',

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4627,6 +4627,24 @@ export class OdooEditor extends EventTarget {
         for (const el of element.querySelectorAll('.oe-tabs')) {
             el.setAttribute('contenteditable', 'false');
         }
+
+        // some templates injected in editor have `div` as base containers which will break
+        // features, to fix this we unwrap all direct children of editable and put
+        // the inline ones in a `p`.
+        for (const el of element.querySelectorAll(".note-editable > div")) {
+            // we dont unwrap divs with data-* 
+            if (el.parentElement.querySelector("*[data-oe-model], *[data-oe-field], *[data-oe-id], *[data-oe-xpath]")) {
+                continue;
+            }
+            const children = unwrapContents(el);
+            for (const child of children) {
+                if (!isBlock(child) && child.textContent !== "\n") {
+                    const p = this.document.createElement("P");
+                    child.parentElement.replaceChild(p, child);
+                    p.appendChild(child);
+                }
+            }
+        }
     }
 
     cleanForSave(element = this.editable) {


### PR DESCRIPTION
Problem:
Some templates include `div` under `note-editable` elements with nested `p` or `h1` tags. These structures are invalid or inconsistent within the editor's  expected DOM structure and can cause issues when injecting or editing content.

Additionally, after selecting and deleting all content (e.g., with CTRL+A), a residual `div` may remain, which disrupts editor functionality.

Solution:
- Unwrap all `div` elements that contain only block elements.
- Wrap remaining inline content in `p` tags to ensure valid and consistent structure.

Steps to reproduce:
1. Create a new project update.
2. Observe the pre-filled description containing nested `div`s.
3. Select all content (CTRL+A) and delete. → A `div` remains in the editor, causing unexpected behavior.

opw-4805901

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
