### PR TITLE
[FIX] website_sale: add missing phone number

### DIFF
--- a/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
+++ b/addons/website_sale/tests/test_website_sale_add_to_cart_snippet.py
@@ -77,7 +77,8 @@ class TestAddToCartSnippet(HttpCase):
             'street2': "",
             'city': "Ramillies",
             'zip': 1367,
-            'country_id': self.env.ref('base.be').id
+            'country_id': self.env.ref('base.be').id,
+            'phone': "+32 123456789"
         })
         self.env.ref('base.user_admin').country_id = self.env.ref('base.be')
         self.start_tour("/", 'add_to_cart_snippet_tour', login="admin")


### PR DESCRIPTION
the tour was failing because the phone number was not set in the website configuration, which is required for the add to cart snippet tour to pass because it checks the phone number in the billing address form page which is required to be filled in order to proceed with the tour and confirm order is on the next page which is not reached so the tour was failing due to timeout

build_error-160894
