### PR TITLE
[FIX] crm: prevent error when clicking AI icon without a record

### DIFF
--- a/addons/crm/static/src/views/crm_form/crm_pls_tooltip_button.js
+++ b/addons/crm/static/src/views/crm_form/crm_pls_tooltip_button.js
@@ -39,7 +39,7 @@ export class CrmPlsTooltipButton extends Component {
         } else {
             // Apply pending changes. They may change probability
             await this.props.record.save();
-            if (status(this) === "destroyed") {
+            if (status(this) === "destroyed" || !this.props.record.resId) {
                 return;
             }
 


### PR DESCRIPTION
Currently, an error occurs when clicking the AI icon to calculate the probability of CRM leads.

Steps to Reproduce:

 - Install the `crm` module.
 - Go to `Leads` > `List View` > Click `"New"`.
 - Click on the `AI` (automated probability) icon.

`ValueError: Expected singleton: crm.lead()`

This error occurs when the user clicks on the `AI` icon to calculate the probability of `CRM leads`. Since the record does not exist [1], the system raises an error.

[1] https://github.com/odoo/odoo/blob/d3b4d1e8d35eebbc015f5ead02f249e8ae5267d8/addons/crm/models/crm_lead.py#L2763

This commit ensures that the `AI icon` is `visible` when the record exists.

sentry-6657175088


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
