### PR TITLE
[ADD] core: add new no_filestore flag to export a sql compressed without filestore and the possibility to choose the format on the cli

### DIFF
--- a/addons/web/controllers/database.py
+++ b/addons/web/controllers/database.py
@@ -124,7 +124,8 @@ class Database(http.Controller):
             return self._render_template(error=error)
 
     @http.route('/web/database/backup', type='http', auth="none", methods=['POST'], csrf=False)
-    def backup(self, master_pwd, name, backup_format='zip'):
+    def backup(self, master_pwd, name, backup_format='zip', filestore=True):
+        filestore = str2bool(filestore)
         insecure = odoo.tools.config.verify_admin_password('admin')
         if insecure and master_pwd:
             dispatch_rpc('db', 'change_admin_password', ["admin", master_pwd])
@@ -138,7 +139,7 @@ class Database(http.Controller):
                 ('Content-Type', 'application/octet-stream; charset=binary'),
                 ('Content-Disposition', content_disposition(filename)),
             ]
-            dump_stream = odoo.service.db.dump_db(name, None, backup_format)
+            dump_stream = odoo.service.db.dump_db(name, None, backup_format, filestore)
             response = Response(dump_stream, headers=headers, direct_passthrough=True)
             return response
         except Exception as e:

--- a/addons/web/static/src/public/database_manager.js
+++ b/addons/web/static/src/public/database_manager.js
@@ -27,6 +27,18 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 
+   document.getElementById('backup_format').addEventListener("change", function (ev) {
+            ev.preventDefault();
+            const no_filestore_flag = document.getElementById("filestore_div");
+            if (no_filestore_flag) {
+                if (ev.target.value != "zip") {
+                    no_filestore_flag.classList.add("d-none");
+                } else {
+                    no_filestore_flag.classList.remove("d-none");
+                }
+            }
+    });
+
     // close modal on submit
     const modals = document.querySelectorAll(".modal");
     for (const modalEl of modals) {

--- a/addons/web/static/src/public/database_manager.qweb.html
+++ b/addons/web/static/src/public/database_manager.qweb.html
@@ -284,9 +284,16 @@
                                 <label for="backup_format" class="col-md-4 col-form-label">Backup Format</label>
                                 <div class="col-md-8">
                                     <select id="backup_format" name="backup_format" class="form-select" required="required">
-                                        <option value="zip">zip (includes filestore)</option>
+                                        <option value="zip">zip</option>
                                         <option value="dump">pg_dump custom format (without filestore)</option>
                                     </select>
+                                </div>
+                            </div>
+                             <div class="row mb-3" id="filestore_div">
+                                <label for="backup_format" class="col-md-4 col-form-label">Include filestore</label>
+                                <div class="col-md-8">
+                                     <input id="filestore" type="checkbox" name="filestore" value="1" checked class="form-check-input" />
+                                     <input type="hidden" name="filestore" value="0"/>
                                 </div>
                             </div>
                         </div>

--- a/odoo/cli/db.py
+++ b/odoo/cli/db.py
@@ -123,14 +123,24 @@ class Db(Command):
         dump = subs.add_parser(
             "dump", help="Create a dump with filestore.",
             description="Creates a dump file. The dump is always in zip format "
-                        "(with filestore), to get a no-filestore format use "
-                        "pg_dump directly.")
+                        "(with filestore), to get pg_dump format, use "
+                        "dump_format argument.")
         dump.set_defaults(func=self.dump)
         dump.add_argument('database', help="database to dump")
         dump.add_argument(
             'dump_path', nargs='?', default='-',
             help="if provided, database is dumped to specified path, otherwise "
                  "or if `-`, dumped to stdout",
+        )
+        dump.add_argument(
+            '--format', dest='dump_format', choices=('zip', 'dump'), default='zip',
+            help="if provided, database is dumped used the specified format, "
+                "otherwise defaults to `zip`.\n"
+                "Supported formats are `zip`, `dump` (pg_dump format) ",
+        )
+        dump.add_argument(
+            '--no-filestore', action='store_const', dest='filestore', default=True, const=False,
+            help="if passed, zip database is dumped without filestore (default: false)"
         )
 
         # DUPLICATE -----------------------------
@@ -226,7 +236,7 @@ class Db(Command):
             dump_db(args.database, sys.stdout.buffer)
         else:
             with open(args.dump_path, 'wb') as f:
-                dump_db(args.database, f)
+                dump_db(args.database, f, args.dump_format, args.filestore)
 
     def duplicate(self, args):
         self._check_target(args.target, delete_if_exists=args.force)

--- a/odoo/service/db.py
+++ b/odoo/service/db.py
@@ -276,20 +276,21 @@ def dump_db_manifest(cr):
     return manifest
 
 @check_db_management_enabled
-def dump_db(db_name, stream, backup_format='zip'):
+def dump_db(db_name, stream, backup_format='zip', with_filestore=True):
     """Dump database `db` into file-like object `stream` if stream is None
     return a file object with the dump """
 
-    _logger.info('DUMP DB: %s format %s', db_name, backup_format)
+    _logger.info('DUMP DB: %s format %s %s', db_name, backup_format, 'with filestore' if with_filestore else 'without filestore')
 
     cmd = [find_pg_tool('pg_dump'), '--no-owner', db_name]
     env = exec_pg_environ()
 
     if backup_format == 'zip':
         with tempfile.TemporaryDirectory() as dump_dir:
-            filestore = odoo.tools.config.filestore(db_name)
-            if os.path.exists(filestore):
-                shutil.copytree(filestore, os.path.join(dump_dir, 'filestore'))
+            if with_filestore:
+                filestore = odoo.tools.config.filestore(db_name)
+                if os.path.exists(filestore):
+                    shutil.copytree(filestore, os.path.join(dump_dir, 'filestore'))
             with open(os.path.join(dump_dir, 'manifest.json'), 'w') as fh:
                 db = odoo.sql_db.db_connect(db_name)
                 with db.cursor() as cr:


### PR DESCRIPTION
### Before this PR
If you have a big database and you want to dump only the database in sql and compressed there is not a way on the database manager.
Sometimes you can't use the pg_dump version because it needs that the postgres version should be the same

### After this PR
You can dump a zipped format of database without the filestore






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
