### PR TITLE
[FIX] html_editor: support macOS deletion shortcuts using Option key

### DIFF
--- a/addons/html_editor/static/src/core/delete_plugin.js
+++ b/addons/html_editor/static/src/core/delete_plugin.js
@@ -43,7 +43,7 @@ import {
 import { CTYPES } from "../utils/content_types";
 import { withSequence } from "@html_editor/utils/resource";
 import { compareListTypes } from "@html_editor/main/list/utils";
-import { hasTouch, isBrowserChrome } from "@web/core/browser/feature_detection";
+import { hasTouch, isBrowserChrome, isMacOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} RangeLike
@@ -63,7 +63,7 @@ import { hasTouch, isBrowserChrome } from "@web/core/browser/feature_detection";
  */
 
 export class DeletePlugin extends Plugin {
-    static dependencies = ["baseContainer", "selection", "history", "input"];
+    static dependencies = ["baseContainer", "selection", "history", "input", "userCommand"];
     static id = "delete";
     static shared = ["deleteRange", "deleteSelection", "delete"];
     resources = {
@@ -110,6 +110,36 @@ export class DeletePlugin extends Plugin {
     setup() {
         this.findPreviousPosition = this.makeFindPositionFn("backward");
         this.findNextPosition = this.makeFindPositionFn("forward");
+        if (isMacOS()) {
+            // Bypass the hotkey service for Alt+Backspace and Cmd+Backspace
+            // on macOS which would otherwise conflict with other shortcuts.
+            this.addDomListener(this.editable, "keydown", (event) => {
+                const runCommand = (commandId) => {
+                    this.dependencies.userCommand.getCommand(commandId).run();
+                    event.stopImmediatePropagation();
+                    event.preventDefault();
+                };
+                // Delete word backward: Option + Backspace
+                if (event.altKey && event.key === "Backspace") {
+                    return runCommand("deleteBackwardWord");
+                }
+
+                // Delete word forward: Option + Delete
+                if (event.altKey && event.key === "Delete") {
+                    return runCommand("deleteForwardWord");
+                }
+
+                // Delete line backward: Command + Backspace
+                if (event.metaKey && event.key === "Backspace") {
+                    return runCommand("deleteBackwardLine");
+                }
+
+                // Delete line forward: Command + Delete
+                if (event.metaKey && event.key === "Delete") {
+                    return runCommand("deleteForwardLine");
+                }
+            });
+        }
     }
 
     // --------------------------------------------------------------------------

--- a/addons/html_editor/static/tests/delete/backward_line.test.js
+++ b/addons/html_editor/static/tests/delete/backward_line.test.js
@@ -2,6 +2,7 @@ import { test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
+import { mockUserAgent } from "@odoo/hoot-mock";
 
 const ctrlShiftBackspace = () => press(["Ctrl", "Shift", "Backspace"]);
 
@@ -94,5 +95,14 @@ test("should not merge an unbreakable element on CTRL+SHIFT+BACKSPACE (2)", asyn
         contentAfter: unformat(`
             <p>abc</p>
             <div class="oe_unbreakable">[]def</div>`),
+    });
+});
+
+test("Should delete last line on MacOS", async () => {
+    mockUserAgent("mac");
+    await testEditor({
+        contentBefore: `<p>hello world, How Are you ?[]</p>`,
+        stepFunction: () => press(["Meta", "Backspace"]),
+        contentAfter: `<p>[]<br></p>`,
     });
 });

--- a/addons/html_editor/static/tests/delete/backward_word.test.js
+++ b/addons/html_editor/static/tests/delete/backward_word.test.js
@@ -2,6 +2,7 @@ import { test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
+import { mockUserAgent } from "@odoo/hoot-mock";
 
 // CTRL+BACKSPACE
 test("should not remove the last p with ctrl+backspace", async () => {
@@ -106,5 +107,14 @@ test("should not merge an unbreakable element on CTRL+BACKSPACE (2)", async () =
         contentAfter: unformat(`
             <p>abc</p>
             <div class="oe_unbreakable">[]def</div>`),
+    });
+});
+
+test("Should delete last word on MacOS", async () => {
+    mockUserAgent("mac");
+    await testEditor({
+        contentBefore: `<p>hello world[]</p>`,
+        stepFunction: () => press(["Alt", "Backspace"]),
+        contentAfter: `<p>hello&nbsp;[]</p>`,
     });
 });

--- a/addons/html_editor/static/tests/delete/forward_line.test.js
+++ b/addons/html_editor/static/tests/delete/forward_line.test.js
@@ -2,6 +2,7 @@ import { test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
+import { mockUserAgent } from "@odoo/hoot-mock";
 
 const ctrlShiftDelete = () => press(["Ctrl", "Shift", "Delete"]);
 
@@ -93,5 +94,14 @@ test("should not merge an unbreakable element on CTRL+SHIFT+DELETE (2)", async (
         contentAfter: unformat(`
             <p>abc[]</p>
             <div class="oe_unbreakable">def</div>`),
+    });
+});
+
+test("Should delete last line on MacOS", async () => {
+    mockUserAgent("mac");
+    await testEditor({
+        contentBefore: `<p>[]hello world, How Are you ?</p>`,
+        stepFunction: () => press(["Meta", "Delete"]),
+        contentAfter: `<p>[]<br></p>`,
     });
 });

--- a/addons/html_editor/static/tests/delete/forward_word.test.js
+++ b/addons/html_editor/static/tests/delete/forward_word.test.js
@@ -2,6 +2,7 @@ import { test } from "@odoo/hoot";
 import { press } from "@odoo/hoot-dom";
 import { testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
+import { mockUserAgent } from "@odoo/hoot-mock";
 
 test("should not remove an unremovable element on CTRL+DELETE", async () => {
     await testEditor({
@@ -36,5 +37,14 @@ test("should not merge an unbreakable element on CTRL+DELETE (2)", async () => {
         contentAfter: unformat(`
             <p>abc[]</p>
             <div class="oe_unbreakable">def</div>`),
+    });
+});
+
+test("Should delete last word on MacOS", async () => {
+    mockUserAgent("mac");
+    await testEditor({
+        contentBefore: `<p>hello[] world</p>`,
+        stepFunction: () => press(["Alt", "Delete"]),
+        contentAfter: `<p>hello[]</p>`,
     });
 });


### PR DESCRIPTION
Problem:
On macOS, pressing Option (Alt) + Backspace does not delete the previous word as expected. Instead, only a single character is removed.

Cause:
The `hotkey_service` does not support registering shortcuts that use the `Alt` key, which macOS relies on for word-level deletion. This prevents native macOS editing behavior from being handled properly.

Solution:
Add a dedicated `keydown` listener for macOS that manually handles deletion shortcuts involving `Alt` (Option) and `Command`. This restores expected word and line deletion behavior for macOS users.

Steps to reproduce:
- On macOS, enter a two-word line in the editor.
- Press Option (Alt) + Backspace.
- Only the last character is deleted, instead of the last word.

opw-4781484

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
