### PR TITLE
[IMP] sale, website_sale, website_sale_stock: template mail designs update

### DIFF
--- a/addons/sale/data/mail_template_data.xml
+++ b/addons/sale/data/mail_template_data.xml
@@ -4,7 +4,7 @@
         <record id="email_template_edi_sale" model="mail.template">
             <field name="name">Sales: Send Quotation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
-            <field name="subject">{{ object.company_id.name }} {{ object.state in ('draft', 'sent') and 'Quotation' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
+            <field name="subject">{{ object.company_id.name }} {{ object.state in ('draft', 'sent') and 'Quotation' or 'Order' }} {{ object.name or 'n/a' }}</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to" eval="False"/>
             <field name="use_default_to" eval="True"/>
@@ -86,257 +86,266 @@
         <record id="mail_template_sale_confirmation" model="mail.template">
             <field name="name">Sales: Order Confirmation</field>
             <field name="model_id" ref="sale.model_sale_order"/>
-            <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} (Ref {{ object.name or 'n/a' }})</field>
+            <field name="subject">{{ object.company_id.name }} {{ (object.get_portal_last_transaction().state == 'pending') and 'Pending Order' or 'Order' }} {{ object.name or 'n/a' }}</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted) }}</field>
             <field name="partner_to" eval="False"/>
             <field name="use_default_to" eval="True"/>
             <field name="description">Sent to customers on order confirmation</field>
             <field name="body_html" type="html">
-<div style="margin: 0px; padding: 0px;">
-    <p style="margin: 0px; padding: 0px; font-size: 12px;">
-        Hello,
-        <br/><br/>
-        <t t-set="tx_sudo" t-value="object.get_portal_last_transaction()"/>
-        Your order <span style="font-weight:bold;" t-out="object.name or ''">S00049</span> amounting in <span style="font-weight:bold;" t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</span>
-        <t t-if="object.state == 'sale' or (tx_sudo and tx_sudo.state in ('done', 'authorized'))">
-            has been confirmed.<br/>
-            Thank you for your trust!
-        </t>
-        <t t-elif="tx_sudo and tx_sudo.state == 'pending'">
-            is pending. It will be confirmed when the payment is received.
-            <t t-if="object.reference">
-                Your payment reference is <span style="font-weight:bold;" t-out="object.reference or ''"></span>.
-            </t>
-        </t>
-        <br/>
-        <t t-set="documents" t-value="object._get_product_documents()"/>
-        <t t-if="documents">
-            <br/>
-            <t t-if="len(documents)>1">
-                Here are some additional documents that may interest you:
-            </t>
-            <t t-else="">
-                Here is an additional document that may interest you:
-            </t>
-            <ul style="margin-bottom: 0;">
-                <t t-foreach="documents" t-as="document">
-                    <li style="font-size: 13px;">
-                        <a t-out="document.ir_attachment_id.name"
-                            t-att-href="object.get_portal_url('/document/' + str(document.id))"
-                            t-att-target="target"/>
-                    </li>
-                </t>
-            </ul>
-        </t>
-        <br/>
-        Do not hesitate to contact us if you have any questions.
-        <t t-if="not is_html_empty(object.user_id.signature)">
-            <div>--<br/><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
-        </t>
-    </p>
-<t t-if="hasattr(object, 'website_id') and object.website_id">
-    <div style="margin: 0px; padding: 0px;">
-        <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse; white-space: nowrap;">
-            <tr style="border-bottom: 2px solid #dee2e6;">
-                <td style="width: 150px;"><span style="font-weight:bold;">Products</span></td>
-                <td></td>
-                <td width="15%" align="center"><span style="font-weight:bold;">Quantity</span></td>
-                <td width="20%" align="right">
-                    <span style="font-weight:bold;">
-                        <t t-if="object.website_id.show_line_subtotals_tax_selection == 'tax_excluded'">
-                            Tax Excl.
+                <div style="margin: 0px; padding: 0px;">
+                    <t t-set="color" t-value="object.company_id.email_secondary_color or '#875A7B'"/>
+                    <t
+                            t-if="'website_id' in object and object.website_id"
+                            t-set="logo_src"
+                            t-value="object.website_id.image_url(object.website_id, 'logo')"
+                        />
+                    <t t-else="" t-set="logo_src" t-valuef="/logo.png?company=#{object.company_id.id}"/>
+                    <img t-att-src="logo_src" style="display: block; height: 50px; margin: 0 0 16px;" alt="Logo"/>
+                    <p style="margin: 0 0 12px; padding: 0px; line-height: 18px; font-size: 14px;">
+                        Hello <t t-out="object.partner_id.display_name or ''">Johnny Tester</t>,
+                        <br/><br/>
+                        <t t-set="tx_sudo" t-value="object.get_portal_last_transaction()"/>
+                        Your order <span style="font-weight:bold;" t-out="object.name or ''">S00049</span>
+                        <t t-if="object.state == 'sale' or (tx_sudo and tx_sudo.state in ('done', 'authorized'))">
+                            has been confirmed.<br/>
+                            Thank you for your trust.
                         </t>
-                        <t t-else="">
-                            Tax Incl.
-                        </t>
-                    </span>
-                </td>
-            </tr>
-        </table>
-        <t t-set="current_subtotal" t-value="0"/>
-        <t t-foreach="object.order_line" t-as="line">
-            <t
-                t-set="line_subtotal"
-                t-value="
-                    line.price_subtotal
-                    if object.website_id.show_line_subtotals_tax_selection == 'tax_excluded'
-                    else line.price_total
-                "
-            />
-            <t t-set="current_subtotal" t-value="current_subtotal + line_subtotal"/>
-            <t
-                t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (
-                    line.display_type in ['line_section', 'line_subsection', 'line_note']
-                    or line.product_type == 'combo'
-                )"
-            >
-                <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse;">
-                    <t t-set="loop_cycle_number" t-value="loop_cycle_number or 0" />
-                    <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
-                        <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
-                        <td colspan="4">
-                            <t t-if="line.display_type in ('line_section', 'line_subsection') or line.product_type == 'combo'">
-                                <span t-att-style="'font-weight:bold;' if line.display_type == 'line_subsection' else 'font-weight:bolder;'" t-out="line.name or ''">Taking care of Trees Course</span>
-                                <t t-set="current_section" t-value="line"/>
-                                <t t-set="current_subtotal" t-value="0"/>
+                        <t t-elif="tx_sudo and tx_sudo.state == 'pending'">
+                            is pending. It will be confirmed when the payment is received.
+                            <t t-if="object.reference">
+                                Your payment reference is <span style="font-weight:bold;" t-out="object.reference or ''"></span>.
                             </t>
-                            <t t-elif="line.display_type == 'line_note'">
-                                <i t-out="line.name or ''">Taking care of Trees Course</i>
+                        </t>
+                        <br/>
+                        <t t-set="documents" t-value="object._get_product_documents()"/>
+                        <t t-if="documents">
+                            <br/>
+                            <t t-if="len(documents)>1">
+                                Here are some additional documents that may interest you:
                             </t>
-                        </td>
-                    </tr>
-                </table>
-            </t>
-            <t t-elif="(not hasattr(line, 'is_delivery') or not line.is_delivery)">
-                <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse;">
-                    <t t-set="loop_cycle_number" t-value="loop_cycle_number or 0" />
-                    <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
-                        <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1" />
-                        <td style="width: 150px;">
-                            <img
-                                t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128"
-                                t-attf-style="width: 64px; height: {{object.website_id and object.website_id._get_product_image_ratio_height() or '64px'}}; object-fit: cover; object-position: center;"
-                                alt="Product image"
-                            />
-                        </td>
-                        <td align="left" t-out="line.product_id.name or ''">	Taking care of Trees Course</td>
-                        <td width="15%" align="center" t-out="line.product_uom_qty or ''">1</td>
-                        <td width="20%" align="right"><span style="font-weight:bold; white-space: nowrap;">
-                        <t t-if="object.website_id.show_line_subtotals_tax_selection == 'tax_excluded'">
-                            <t t-out="format_amount(line.price_reduce_taxexcl, object.currency_id) or ''">$ 10.00</t>
+                            <t t-else="">
+                                Here is an additional document that may interest you:
+                            </t>
+                            <ul style="margin-bottom: 0;">
+                                <t t-foreach="documents" t-as="document">
+                                    <li style="font-size: 14px;">
+                                        <a t-out="document.ir_attachment_id.name"
+                                            t-att-href="object.get_portal_url('/document/' + str(document.id))"
+                                            t-att-target="target"/>
+                                    </li>
+                                </t>
+                            </ul>
                         </t>
-                        <t t-else="">
-                            <t t-out="format_amount(line.price_reduce_taxinc, object.currency_id) or ''">$ 10.00</t>
+                        <t t-if="not is_html_empty(object.user_id.signature)">
+                            <div style="font-size: 14px; margin: 0 0 16px;"><t t-out="object.user_id.signature or ''">Mitchell Admin</t></div>
                         </t>
-                        </span></td>
-                    </tr>
-                </table>
-            </t>
-            <t
-                t-if="current_section and (
-                    line_last
-                    or object.order_line[line_index+1].display_type in ('line_section', 'line_subsection')
-                    or object.order_line[line_index+1].product_type == 'combo'
-                    or (
-                        line.combo_item_id
-                        and not object.order_line[line_index+1].combo_item_id
-                    )
-                ) and not line.is_downpayment"
-            >
-                <t t-set="current_section" t-value="None"/>
-                <table width="100%" style="color: #454748; font-size: 12px; border-collapse: collapse;">
-                    <t t-set="loop_cycle_number" t-value="loop_cycle_number or 0"/>
-                    <tr t-att-style="'background-color: #f2f2f2' if loop_cycle_number % 2 == 0 else 'background-color: #ffffff'">
-                        <t t-set="loop_cycle_number" t-value="loop_cycle_number + 1"/>
-                        <td style="width: 100%" align="right">
-                            <span style="font-weight: bold;">Subtotal:</span>
-                            <span t-out="format_amount(current_subtotal, object.currency_id) or ''">$ 10.00</span>
-                        </td>
-                    </tr>
-                </table>
-            </t>
-        </t>
-    </div>
-    <div style="margin: 0px; padding: 0px;" t-if="hasattr(object, 'carrier_id') and object.carrier_id">
-        <table width="100%" style="color: #454748; font-size: 12px; border-spacing: 0px 4px; white-space: nowrap;" align="right">
-            <tr>
-                <td style="width: 60%"/>
-                <td style="width: 30%; border-top: 1px solid #dee2e6;" align="right"><span style="font-weight:bold;">Delivery:</span></td>
-                <td style="width: 10%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_delivery, object.currency_id) or ''">$ 0.00</td>
-            </tr>
-            <tr>
-                <td style="width: 60%"/>
-                <td style="width: 30%;" align="right"><span style="font-weight:bold;">Untaxed Amount:</span></td>
-                <td style="width: 10%;" align="right" t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">$ 10.00</td>
-            </tr>
-        </table>
-    </div>
-    <div style="margin: 0px; padding: 0px;" t-else="">
-        <table width="100%" style="color: #454748; font-size: 12px; border-spacing: 0px 4px; white-space: nowrap;" align="right">
-            <tr>
-                <td style="width: 60%"/>
-                <td style="width: 30%; border-top: 1px solid #dee2e6;" align="right"><span style="font-weight:bold;">Untaxed Amount:</span></td>
-                <td style="width: 10%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">$ 10.00</td>
-            </tr>
-        </table>
-    </div>
-    <div style="margin: 0px; padding: 0px;">
-        <table width="100%" style="color: #454748; font-size: 12px; border-spacing: 0px 4px; white-space: nowrap;" align="right">
-            <tr>
-                <td style="width: 60%"/>
-                <td style="width: 30%;" align="right"><span style="font-weight:bold;">Taxes:</span></td>
-                <td style="width: 10%;" align="right" t-out="format_amount(object.amount_tax, object.currency_id) or ''">$ 0.00</td>
-            </tr>
-            <tr>
-                <td style="width: 60%"/>
-                <td style="width: 30%; border-top: 1px solid #dee2e6;" align="right"><span style="font-weight:bold;">Total:</span></td>
-                <td style="width: 10%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</td>
-            </tr>
-        </table>
-    </div>
-    <div t-if="object.partner_invoice_id" style="margin: 0px; padding: 0px;">
-        <table width="100%" style="color: #454748; font-size: 12px;">
-            <tr>
-                <td style="padding-top: 10px;">
-                    <span style="font-weight:bold;">Bill to:</span>
-                    <t t-out="object.partner_invoice_id.street or ''">1201 S Figueroa St</t>
-                    <t t-out="object.partner_invoice_id.city or ''">Los Angeles</t>
-                    <t t-out="object.partner_invoice_id.state_id.name or ''">California</t>
-                    <t t-out="object.partner_invoice_id.zip or ''">90015</t>
-                    <t t-out="object.partner_invoice_id.country_id.name or ''">United States</t>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <span style="font-weight:bold;">Payment Method:</span>
-                    <t t-if="tx_sudo.token_id">
-                        <t t-out="tx_sudo.token_id.display_name or ''"></t>
+                    </p>
+                    <t t-if="hasattr(object, 'website_id') and object.website_id">
+                        <div style="margin: 0px; padding: 0px;">
+                            <!-- The following loop is also used in the addons > sale > data > mail_template_data.xml file because we want the same layout. -->
+                            <t t-foreach="object.order_line" t-as="line">
+                                <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and not line.combo_item_id">
+                                    <table width="100%" style="max-width: 590px; font-size: 14px; border-collapse: collapse;" role="presentation">
+                                        <tr>
+                                            <td width="24%" style="max-width: 120px; padding: 0 10px 10px 0; vertical-align: top;">
+                                                <img t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128" t-attf-style="width: 64px; height: {{object.website_id and object.website_id._get_product_image_ratio_height() or '64px'}}; object-fit: cover; object-position: center;" alt="Product image"></img>
+                                            </td>
+                                            <td align="left" style="vertical-align: top; padding-bottom: 22px;">
+                                                <h3 t-attf-style="mso-line-height-rule:exactly; margin:0; font-size: 14px; {{'margin-bottom: 6px;' if line.product_type == 'combo' else ''}}">
+                                                    <strong t-out="line.product_id.name or ''" t-attf-style="color: #{color};">Taking care of Trees Course</strong>
+                                                    <span t-if="line.product_id.product_template_attribute_value_ids" style="opacity: 0.5;">
+                                                        <t t-out="', '.join(line.product_id.product_template_attribute_value_ids.mapped('name'))" />
+                                                    </span>
+                                                </h3>
+                                                <t t-set="combo_line_idx" t-value="0"/>
+                                                <t t-set="totalComboLines" t-value="0"/>
+                                                <t t-set="line_idx" t-value="line_index"/>
+                                                <t t-foreach="object.order_line" t-as="combo_liness">
+                                                    <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (combo_liness.linked_line_id.id == line.id) and line_idx == line_index">
+                                                        <t t-if="combo_liness.linked_line_id.id == line.id and combo_liness.id != line.id">
+                                                            <t t-set="totalComboLines" t-value="totalComboLines + 1"/>
+                                                        </t>
+                                                    </t>
+                                                </t>
+                                                <t t-foreach="object.order_line" t-as="combo_line">
+                                                    <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (combo_line.linked_line_id.id == line.id) and combo_line.combo_item_id and line_idx == line_index">
+                                                            <t t-set="borderRadiusStyle" t-value="''"/>
+                                                            <t t-set="borderTopStyle" t-value="''"/>
+                                                            <t t-set="borderBottomStyle" t-value="''"/>
+
+                                                            <t t-if="combo_line.linked_line_id.id == line.id and combo_line.id != line.id">
+                                                                <t t-set="combo_line_idx" t-value="combo_line_idx + 1"/>
+                                                            </t>
+                                                            <t t-elif="combo_line.id == line.id and line_idx != line_index">
+                                                                <t t-set="combo_line_idx" t-value="0"/>
+                                                            </t>
+                                                            <t t-if="combo_line_idx == 1">
+                                                                <t t-if="totalComboLines != 1">
+                                                                    <t t-set="borderRadiusStyle" t-value="'border-radius: 6px 6px 0 0;'"/>
+                                                                    <t t-set="borderBottomStyle" t-value="'border-bottom: none;'"/>
+                                                                </t>
+                                                                <t t-else="">
+                                                                    <t t-set="borderRadiusStyle" t-value="'border-radius: 6px;'"/>
+                                                                </t>
+                                                            </t>
+                                                            <t t-elif="totalComboLines == combo_line_idx">
+                                                                <t t-set="borderRadiusStyle" t-value="'border-radius: 0 0 6px 6px;'"/>
+                                                                <t t-if="totalComboLines != 2">
+                                                                    <t t-set="borderTopStyle" t-value="'border-top: none;'"/>
+                                                                </t>
+                                                            </t>
+                                                            <div t-attf-style="width: 100%; border: 1px solid #dee2e6; padding: 5px 8px; {{ borderRadiusStyle }} {{ borderBottomStyle }} {{ borderTopStyle }}">
+                                                                        <t t-out="combo_line.product_id.name or ''">Taking care of Trees Course</t>
+                                                                        <span t-if="combo_line.product_id.product_template_attribute_value_ids" style="opacity: 0.5;">
+                                                                            <t t-out="', '.join(combo_line.product_id.product_template_attribute_value_ids.mapped('name'))" />
+                                                                        </span>
+                                                                        -
+                                                                        <span>
+                                                                            <t t-out="int(combo_line.product_uom_qty) or ''">10000</t>
+                                                                            <t t-out="combo_line.product_uom_id.name or ''" t-if="combo_line.order_id.create_uid._has_group('uom.group_uom')"></t>
+                                                                        </span>
+                                                                        <p t-if="hasattr(combo_line, 'is_rental') and combo_line.is_rental and combo_line.id == line.id" style="opacity: 0.7;">
+                                                                            <t t-out="combo_line._get_rental_pricing_description() or ''"/><br/>
+                                                                        </p>
+                                                                        <t t-if="(hasattr(combo_line, 'is_rental') and combo_line.is_rental) or (hasattr(combo_line, 'event_id') and combo_line.event_id) or (hasattr(combo_line, 'calendar_event_id') and combo_line.calendar_event_id)">
+                                                                            <t
+                                                                                t-set="description_lines"
+                                                                                t-value="combo_line.get_description_following_lines()"
+                                                                            />
+                                                                            <div t-if="description_lines" style="opacity: 0.7;">
+                                                                                <t t-foreach="description_lines" t-as="description_line">
+                                                                                    <p
+                                                                                        t-if="description_line"
+                                                                                        t-out="description_line"
+                                                                                        style="margin: 4px 0 0;"
+                                                                                    />
+                                                                                </t>
+                                                                            </div>
+                                                                        </t>
+                                                            </div>
+                                                        </t>
+                                                    <t t-elif="not(combo_line.linked_line_id) and combo_line.id == line.id">
+                                                        <p t-if="hasattr(line, 'is_rental') and line.is_rental" style="margin: 4px 0 0; opacity: 0.7;">
+                                                            <t t-out="line._get_rental_pricing_description() or ''"/><br/>
+                                                        </p>
+                                                        <t t-if="(hasattr(combo_line, 'is_rental') and combo_line.is_rental) or (hasattr(combo_line, 'event_id') and combo_line.event_id) or (hasattr(combo_line, 'calendar_event_id') and combo_line.calendar_event_id)">
+                                                            <t
+                                                                t-set="product_description_lines"
+                                                                t-value="line.get_description_following_lines()"
+                                                            />
+                                                            <div t-if="product_description_lines" style="opacity: 0.7;">
+                                                                <t t-foreach="product_description_lines" t-as="product_description_line">
+                                                                    <p
+                                                                        t-if="product_description_line"
+                                                                        t-out="product_description_line"
+                                                                        style="margin: 4px 0 0;"
+                                                                    />
+                                                                </t>
+                                                            </div>
+                                                        </t>
+                                                    </t>
+                                                </t>
+                                                <span style="display: inline-block;  margin-top: 4px; padding: 4px 8px; border-radius: 20px; background-color: #e9ecef; color: #454748; font-size: 12px;">
+                                                    <t t-out="int(line.product_uom_qty) or ''">10000</t>
+                                                    <t t-out="line.product_uom_id.name or ''" t-if="line.order_id.create_uid._has_group('uom.group_uom')"></t>
+                                                </span>
+                                            </td>
+                                            <td width="19%" align="right" style="max-width: 100px; vertical-align: top;">
+                                                <t t-if="line.product_type == 'combo'">
+                                                    <span t-out="format_amount(line._get_cart_display_price(), object.currency_id) or ''">$ 10.00</span>
+                                                </t>
+                                                <t t-else="">
+                                                    <span style="white-space: nowrap;">
+                                                        <t t-if="object.website_id.show_line_subtotals_tax_selection == 'tax_excluded'">
+                                                            <t t-out="format_amount(line.price_subtotal, object.currency_id) or ''">$ 10.00</t>
+                                                        </t>
+                                                        <t t-else="">
+                                                            <t t-out="format_amount(line.price_total, object.currency_id) or ''">$ 10.00</t>
+                                                        </t>
+                                                    </span>
+                                                </t>
+                                                <t t-if="hasattr(line, 'recurring_invoice') and line.recurring_invoice">
+                                                    <br/>
+                                                    <t t-out="line.subscription_plan_id.billing_period_display_sentence or ''"/>
+                                                </t>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </t>
+                            </t>
+                        </div>
+                        <div style="margin: 10px 0 16px; padding: 0px;">
+                            <table width="100%" t-if="hasattr(object, 'carrier_id') and object.carrier_id" style="max-width: 590px; font-size: 14px; border-spacing: 0px 4px; white-space: nowrap;" role="presentation">
+                                <tr>
+                                    <td style="padding-top: 8px; width: 50%; border-top: 1px solid #dee2e6;" align="left">Delivery</td>
+                                    <td style="padding-top: 8px; width: 50%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_delivery, object.currency_id) or ''">$ 0.00</td>
+                                </tr>
+                                <tr>
+                                    <td style="width: 50%;" align="left">Untaxed Amount</td>
+                                    <td style="width: 50%;" align="right" t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">$ 10.00</td>
+                                </tr>
+                            </table>
+                            <table width="100%" t-else="" style="max-width: 590px; opacity: 0.8; font-size: 14px; border-spacing: 0px 4px; white-space: nowrap;" role="presentation">
+                                <tr>
+                                    <td style="width: 50%; border-top: 1px solid #dee2e6;" align="left">Untaxed Amount</td>
+                                    <td style="width: 50%; border-top: 1px solid #dee2e6;" align="right" t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">$ 10.00</td>
+                                </tr>
+                            </table>
+                            <table width="100%" style="max-width: 590px; font-size: 14px; border-spacing: 0px; white-space: nowrap;" role="presentation">
+                                <tr>
+                                    <td style="width: 20%; padding-bottom: 8px;" align="left">Taxes:</td>
+                                    <td style="width: 80%; padding-bottom: 8px;" align="right" t-out="format_amount(object.amount_tax, object.currency_id) or ''">$ 0.00</td>
+                                </tr>
+                                <tr>
+                                    <td style="width: 20%; padding-top: 4px; border-top: 1px solid #343a40; opacity: 0.9;" align="left"><strong>Total</strong></td>
+                                    <td style="width: 80%; padding-top: 4px; border-top: 1px solid #343a40; font-weight: bold; " align="right">
+                                        <span style="display: inline-block; margin-right: 4px; padding: 4px 8px; border: 1px solid #dee2e6; border-radius: 4px;">
+                                            <span style="opacity: 0.9;">Paid with</span>
+                                            <span t-attf-style="color: #{color}; font-weight: bold;">
+                                                <t t-out="tx_sudo.provider_id.sudo().name or ''"></t>
+                                            </span>
+                                        </span>
+                                        <span style="opacity: 0.9;"><t t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</t></span>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <table t-if="object.partner_shipping_id and not object.only_services" width="295" style="vertical-align: top; font-size: 14px; margin-bottom: 12px;" align="left" role="presentation">
+                            <tr>
+                                <td style="padding-bottom: 4px; font-weight: bold;">
+                                    <span style="opacity: 0.9;">Delivery with</span>
+                                    <span t-attf-style="color: {{color}}; opacity: 1;"><t t-out="object.carrier_id.name or ''"></t></span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="opacity: 0.9;">
+                                    <t t-out="object.partner_shipping_id.street or ''">1201 S Figueroa St</t><br/>
+                                    <t t-out="object.partner_shipping_id.city or ''">Los Angeles</t>
+                                    <t t-out="object.partner_shipping_id.state_id.name or ''">California</t>
+                                    <t t-out="object.partner_shipping_id.zip or ''">90015</t><br/>
+                                    <t t-out="object.partner_shipping_id.country_id.name or ''">United States</t>
+                                </td>
+                            </tr>
+                        </table>
+                        <table t-if="object.partner_invoice_id" width="295" style="vertical-align: top; opacity: 0.8; font-size: 14px;" align="left" role="presentation">
+                            <tr>
+                                <td style="padding-bottom: 4px;">
+                                    <span style="font-weight:bold;">Billing</span>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <t t-out="object.partner_invoice_id.street or ''">1201 S Figueroa St</t><br/>
+                                    <t t-out="object.partner_invoice_id.city or ''">Los Angeles</t>
+                                    <t t-out="object.partner_invoice_id.state_id.name or ''">California</t>
+                                    <t t-out="object.partner_invoice_id.zip or ''">90015</t><br/>
+                                    <t t-out="object.partner_invoice_id.country_id.name or ''">United States</t>
+                                </td>
+                            </tr>
+                        </table>
                     </t>
-                    <t t-else="">
-                        <t t-out="tx_sudo.provider_id.sudo().name or ''"></t>
-                    </t>
-                    (<t t-out="format_amount(tx_sudo.amount, object.currency_id) or ''">$ 10.00</t>)
-                </td>
-            </tr>
-        </table>
-    </div>
-    <div t-if="object.partner_shipping_id and not object.only_services" style="margin: 0px; padding: 0px;">
-        <table width="100%" style="color: #454748; font-size: 12px;">
-            <tr>
-                <td>
-                    <br/>
-                    <span style="font-weight:bold;">Ship to:</span>
-                    <t t-out="object.partner_shipping_id.street or ''">1201 S Figueroa St</t>
-                    <t t-out="object.partner_shipping_id.city or ''">Los Angeles</t>
-                    <t t-out="object.partner_shipping_id.state_id.name or ''">California</t>
-                    <t t-out="object.partner_shipping_id.zip or ''">90015</t>
-                    <t t-out="object.partner_shipping_id.country_id.name or ''">United States</t>
-                </td>
-            </tr>
-        </table>
-        <table t-if="hasattr(object, 'carrier_id') and object.carrier_id" width="100%" style="color: #454748; font-size: 12px;">
-            <tr>
-                <td>
-                    <span style="font-weight:bold;">Delivery Method:</span>
-                    <t t-out="object.carrier_id.name or ''"></t>
-                    <t t-if="object.amount_delivery == 0.0">
-                        (Free)
-                    </t>
-                    <t t-else="">
-                        (<t t-out="format_amount(object.amount_delivery, object.currency_id) or ''">$ 10.00</t>)
-                    </t>
-                </td>
-            </tr>
-            <tr t-if="object.carrier_id.carrier_description">
-                <td>
-                    <strong>Delivery Description:</strong>
-                    <t t-out="object.carrier_id.carrier_description"/>
-                </td>
-            </tr>
-        </table>
-    </div>
-</t>
-</div></field>
+                </div>
+            </field>
             <field name="report_template_ids" eval="[(4, ref('sale.action_report_saleorder'))]"/>
             <field name="auto_delete" eval="True"/>
         </record>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1259,7 +1259,7 @@ class SaleOrder(models.Model):
             # Send the email synchronously.
             self.with_context(force_send=True).message_post_with_source(
                 mail_template,
-                email_layout_xmlid='mail.mail_notification_layout_with_responsible_signature',
+                email_layout_xmlid='mail.mail_notification_light',
                 subtype_xmlid='mail.mt_comment',
             )
 

--- a/addons/website_sale/data/mail_template_data.xml
+++ b/addons/website_sale/data/mail_template_data.xml
@@ -4,49 +4,203 @@
         <record id="mail_template_sale_cart_recovery" model="mail.template">
             <field name="name">Ecommerce: Cart Recovery</field>
             <field name="model_id" ref="sale.model_sale_order"/>
-            <field name="subject">You left items in your cart!</field>
+            <field name="subject">Your cart is waiting</field>
             <field name="email_from">{{ (object.user_id.email_formatted or object.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="partner_to" eval="False"/>
             <field name="use_default_to" eval="True"/>
             <field name="description">If the setting is set, sent to authenticated visitors who abandoned their cart</field>
+            <field name="email_layout_xmlid">mail.mail_notification_light</field>
             <field name="body_html" type="html">
-<table border="0" cellpadding="0" cellspacing="0" width="590" style="padding: 0px; background-color: white; color: #454748; border-collapse:separate;">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 590px; padding: 0px; background-color: white; color: #454748; border-collapse: collapse;" role="presentation">
 <tbody>
     <!-- CONTENT -->
     <tr>
         <td align="center" style="min-width: 590px;">
-            <table border="0" cellpadding="0" cellspacing="0" width="590" style="min-width: 590px; background-color: white; padding: 0px 0px 0px 0px; border-collapse:separate;">
-                <tr><td valign="top" style="font-size: 13px;">
-                    <h1 style="color:#A9A9A9;">THERE'S SOMETHING IN YOUR CART.</h1>
-                    Would you like to complete your purchase?<br/><br/>
-                    <t t-if="object.order_line">
-                        <t t-foreach="object.website_order_line" t-as="line">
-                            <hr/>
-                            <table width="100%">
-                                <tr>
-                                    <td style="padding: 10px; width:150px;">
-                                        <img t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128" style="width: 100px; height: 100px; object-fit: contain;" alt="Product image"></img>
-                                    </td>
-                                    <td>
-                                        <strong t-out="line.product_id.display_name or ''">[FURN_7800] Desk Combination</strong><br/><t t-out="line.name or ''">[FURN_7800] Desk Combination Desk combination, black-brown: chair + desk + drawer.</t>
-                                    </td>
-                                    <td width="100px" align="right">
-                                        <t t-out="int(line.product_uom_qty) or ''">10000</t> <t t-out="line.product_uom_id.name or ''">Units</t>
-                                    </td>
-                                </tr>
-                            </table>
-                        </t>
-                        <hr/>
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="max-width: 590px; background-color: white; padding: 0px 0px 0px 0px; border-collapse:collapse;" role="presentation">
+                <tr><td valign="top" style="font-size: 14px;">
+                    <t t-set="color" t-value="object.company_id.email_secondary_color or '#875A7B'"/>
+                    <t
+                        t-if="'website_id' in object and object.website_id"
+                        t-set="logo_src"
+                        t-value="object.website_id.image_url(object.website_id, 'logo')"
+                    />
+                    <t t-else="" t-set="logo_src" t-valuef="/logo.png?company=#{object.company_id.id}"/>
+                    <img t-att-src="logo_src" style="display: block; height: 50px; margin: 0 0 16px;" alt="Logo"/>
+                    <p style="margin: 0 0 12px; line-height: 18px;">
+                        Hello <t t-out="object.partner_id.display_name or ''">Johnny Tester</t>,
+                        <br/><br/>
+                        You did not complete your online order.<br/>
+                        Do you have any question about our products?<br/>
+                        Just reply to this email to discuss!<br/>
+                    </p>
+                    <t t-if="not is_html_empty(user.signature)">
+                        <div style="font-size: 14px; margin: 0 0 16px;"><t t-out="user.signature or ''">Mitchell Admin</t></div>
                     </t>
-                    <div style="text-align: center; padding: 16px 0px 16px 0px; font-size: 14px;">
-                        <a t-attf-href="{{ object.get_base_url() }}/shop/cart?id={{ object.id }}&amp;access_token={{ object.access_token }}"
-                            target="_blank"
-                            t-attf-style="background-color: {{object.user_id.company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{object.user_id.company_id.email_primary_color or '#FFFFFF'}}; border-radius: 5px; font-size:13px;">
-                            Resume order
-                        </a>
-                    </div>
+                    <t t-if="'hide_recovery_button' not in ctx">
+                        <div t-attf-style="margin-bottom: 22px; font-size: 14px;">
+                            <a t-attf-href="{{ object.get_base_url() }}/shop/cart?id={{ object.id }}&amp;access_token={{ object.access_token }}"
+                                target="_blank"
+                                t-attf-style="background-color: {{object.company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{object.company_id.email_primary_color or '#fff'}}; border-radius: 5px; font-size:14px;">
+                                Resume order
+                            </a>
+                        </div>
+                    </t>
+                    <t t-if="object.order_line">
+                        <!-- The following loop is also used in the addons > sale > data > mail_template_data.xml file because we want the same layout. -->
+                        <t t-foreach="object.order_line" t-as="line">
+                            <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and not line.combo_item_id">
+                                <table width="100%" style="max-width: 590px; color: #454748; font-size: 14px; border-collapse: collapse;" role="presentation">
+                                    <tr>
+                                        <td width="24%" style="max-width: 120px; padding: 0 10px 10px 0; vertical-align: top;">
+                                            <img t-attf-src="/web/image/product.product/{{ line.product_id.id }}/image_128" style="width: 100px; height: 100px; object-fit: contain;" alt="Product image"></img>
+                                        </td>
+                                        <td align="left" style="vertical-align: top; padding-bottom: 22px;">
+                                            <h3 t-attf-style="mso-line-height-rule:exactly; margin:0; font-size: 14px; color: {{color}}; {{'margin-bottom: 6px;' if line.product_type == 'combo' else ''}}">
+                                                <strong t-out="line.product_id.name or ''">Taking care of Trees Course</strong>
+                                                <span t-if="line.product_id.product_template_attribute_value_ids" style="color: #6c757d;">
+                                                    <t t-out="', '.join(line.product_id.product_template_attribute_value_ids.mapped('name'))" />
+                                                </span>
+                                            </h3>
+                                            <t t-set="combo_line_idx" t-value="0"/>
+                                            <t t-set="totalComboLines" t-value="0"/>
+                                            <t t-set="line_idx" t-value="line_index"/>
+                                            <t t-foreach="object.order_line" t-as="combo_liness">
+                                                <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (combo_liness.linked_line_id.id == line.id) and line_idx == line_index">
+                                                    <t t-if="combo_liness.linked_line_id.id == line.id and combo_liness.id != line.id">
+                                                        <t t-set="totalComboLines" t-value="totalComboLines + 1"/>
+                                                    </t>
+                                                </t>
+                                            </t>
+                                            <t t-foreach="object.order_line" t-as="combo_line">
+                                                <t t-if="(not hasattr(line, 'is_delivery') or not line.is_delivery) and (combo_line.linked_line_id.id == line.id) and combo_line.combo_item_id and line_idx == line_index">
+                                                        <t t-set="borderRadiusStyle" t-value="''"/>
+                                                        <t t-set="borderTopStyle" t-value="''"/>
+                                                        <t t-set="borderBottomStyle" t-value="''"/>
+
+                                                        <t t-if="combo_line.linked_line_id.id == line.id and combo_line.id != line.id">
+                                                            <t t-set="combo_line_idx" t-value="combo_line_idx + 1"/>
+                                                        </t>
+                                                        <t t-elif="combo_line.id == line.id and line_idx != line_index">
+                                                            <t t-set="combo_line_idx" t-value="0"/>
+                                                        </t>
+                                                        <t t-if="combo_line_idx == 1">
+                                                            <t t-if="totalComboLines != 1">
+                                                                <t t-set="borderRadiusStyle" t-value="'border-radius: 6px 6px 0 0;'"/>
+                                                                <t t-set="borderBottomStyle" t-value="'border-bottom: none;'"/>
+                                                            </t>
+                                                            <t t-else="">
+                                                                <t t-set="borderRadiusStyle" t-value="'border-radius: 6px;'"/>
+                                                            </t>
+                                                        </t>
+                                                        <t t-elif="totalComboLines == combo_line_idx">
+                                                            <t t-set="borderRadiusStyle" t-value="'border-radius: 0 0 6px 6px;'"/>
+                                                            <t t-if="totalComboLines != 2">
+                                                                <t t-set="borderTopStyle" t-value="'border-top: none;'"/>
+                                                            </t>
+                                                        </t>
+                                                        <div t-attf-style="width: 100%; border: 1px solid #dee2e6; padding: 5px 8px; {{ borderRadiusStyle }} {{ borderBottomStyle }} {{ borderTopStyle }}">
+                                                                    <t t-out="combo_line.product_id.name or ''">Taking care of Trees Course</t>
+                                                                    <span t-if="combo_line.product_id.product_template_attribute_value_ids" style="color: #6c757d;">
+                                                                        <t t-out="', '.join(combo_line.product_id.product_template_attribute_value_ids.mapped('name'))" />
+                                                                    </span>
+                                                                    -
+                                                                    <span>
+                                                                        <t t-out="int(combo_line.product_uom_qty) or ''">10000</t>
+                                                                        <t t-out="combo_line.product_uom_id.name or ''" t-if="combo_line.order_id.create_uid._has_group('uom.group_uom')"></t>
+                                                                    </span>
+                                                                    <p t-if="hasattr(combo_line, 'is_rental') and combo_line.is_rental and combo_line.id == line.id" style="color: #6c757d;">
+                                                                        <t t-out="combo_line._get_rental_pricing_description() or ''"/><br/>
+                                                                    </p>
+                                                                    <t t-if="(hasattr(combo_line, 'is_rental') and combo_line.is_rental) or (hasattr(combo_line, 'event_id') and combo_line.event_id) or (hasattr(combo_line, 'calendar_event_id') and combo_line.calendar_event_id)">
+                                                                        <t
+                                                                            t-set="description_lines"
+                                                                            t-value="combo_line.get_description_following_lines()"
+                                                                        />
+                                                                        <div t-if="description_lines" style="color: #6c757d;">
+                                                                            <t t-foreach="description_lines" t-as="description_line">
+                                                                                <p
+                                                                                    t-if="description_line"
+                                                                                    t-out="description_line"
+                                                                                    style="margin: 4px 0 0;"
+                                                                                />
+                                                                            </t>
+                                                                        </div>
+                                                                    </t>
+                                                        </div>
+                                                    </t>
+                                                <t t-elif="not(combo_line.linked_line_id) and combo_line.id == line.id">
+                                                    <p t-if="hasattr(line, 'is_rental') and line.is_rental" style="margin: 4px 0 0; color: #6c757d;">
+                                                        <t t-out="line._get_rental_pricing_description() or ''"/><br/>
+                                                    </p>
+                                                    <t t-if="(hasattr(combo_line, 'is_rental') and combo_line.is_rental) or (hasattr(combo_line, 'event_id') and combo_line.event_id) or (hasattr(combo_line, 'calendar_event_id') and combo_line.calendar_event_id)">
+                                                        <t
+                                                            t-set="product_description_lines"
+                                                            t-value="line.get_description_following_lines()"
+                                                        />
+                                                        <div t-if="product_description_lines" style="color: #6c757d;">
+                                                            <t t-foreach="product_description_lines" t-as="product_description_line">
+                                                                <p
+                                                                    t-if="product_description_line"
+                                                                    t-out="product_description_line"
+                                                                    style="margin: 4px 0 0;"
+                                                                />
+                                                            </t>
+                                                        </div>
+                                                    </t>
+                                                </t>
+                                            </t>
+                                            <span style="display: inline-block;  margin-top: 4px; padding: 4px 8px; border-radius: 20px; background-color: #e9ecef; color: #454748; font-size: 12px;">
+                                                <t t-out="int(line.product_uom_qty) or ''">10000</t>
+                                                <t t-out="line.product_uom_id.name or ''" t-if="line.order_id.create_uid._has_group('uom.group_uom')"></t>
+                                            </span>
+                                        </td>
+                                        <td width="19%" align="right" style="max-width: 100px; vertical-align: top;">
+                                            <t t-if="line.product_type == 'combo'">
+                                                <span t-out="format_amount(line._get_cart_display_price(), object.currency_id) or ''">$ 10.00</span>
+                                            </t>
+                                            <t t-else="">
+                                                <span style="white-space: nowrap;">
+                                                    <t t-if="object.website_id.show_line_subtotals_tax_selection == 'tax_excluded'">
+                                                        <t t-out="format_amount(line.price_subtotal, object.currency_id) or ''">$ 10.00</t>
+                                                    </t>
+                                                    <t t-else="">
+                                                        <t t-out="format_amount(line.price_total, object.currency_id) or ''">$ 10.00</t>
+                                                    </t>
+                                                </span>
+                                            </t>
+                                            <t t-if="hasattr(line, 'recurring_invoice') and line.recurring_invoice">
+                                                <br/>
+                                                <t t-out="line.subscription_plan_id.billing_period_display_sentence or ''"/>
+                                            </t>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </t>
+                        </t>
+                        <table width="100%" role="presentation" style="font-size: 14px; border-collapse:collapse;">
+                            <tr>
+                                <td style="padding-top: 8px;  border-top: 1px solid #dee2e6; color: #495057;">Delivery</td>
+                                <td style="padding-top: 8px;  border-top: 1px solid #dee2e6; text-align: right; color: #495057;" width="100px" align="right">
+                                    <t t-out="format_amount(object.amount_delivery, object.currency_id) or ''">-</t>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td style="padding-top: 4px; color: #495057;">Subtotal</td>
+                                <td style="padding-top: 4px; text-align: right; color: #495057;" width="100px" align="right"><t t-out="format_amount(object.amount_untaxed, object.currency_id) or ''">-</t></td>
+                            </tr>
+                            <tr>
+                                <td style="padding: 4px 0 8px 0; color: #495057;">Taxes</td>
+                                <td style="padding: 4px 0 8px 0; text-align: right; color: #495057;" width="100px" align="right"><t t-out="format_amount(object.amount_tax, object.currency_id) or ''">-</t></td>
+                            </tr>
+                            <tr>
+                                <td style="padding-top: 8px; border-top: 1px solid #343a40;"><strong>Total</strong></td>
+                                <td style="padding-top: 8px; border-top: 1px solid #343a40; text-align: right" width="100px" align="right">
+                                    <strong t-out="format_amount(object.amount_total, object.currency_id) or ''">-</strong>
+                                </td>
+                            </tr>
+                        </table>
+                    </t>
                     <t t-set="company" t-value="object.company_id or object.user_id.company_id or user.company_id"/>
-                    <div style="text-align: center;"><strong>Thank you for shopping with <t t-out="company.name or ''">My Company (San Francisco)</t>!</strong></div>
                 </td></tr>
             </table>
         </td>

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -213,6 +213,8 @@ class SaleOrder(models.Model):
                 'default_model': 'sale.order',
                 'default_template_id': template_id,
                 'website_sale_send_recovery_email': True,
+                # Already shown in the header (see `_notify_get_recipients_groups`)
+                'hide_recovery_button': True,
             },
         }
 

--- a/addons/website_sale_stock/data/template_email.xml
+++ b/addons/website_sale_stock/data/template_email.xml
@@ -1,30 +1,45 @@
 <?xml version="1.0" ?>
 <odoo>
     <template id="availability_email_body">
+        <t t-set="partner" t-value="object"/>
+        <t t-set="website" t-value="env['website'].get_current_website()"/>
         <div id="body">
-            <p>Dear Customer,</p>
-            <p>The following product is now available.</p>
-            <div style="display: flex; justify-content: center; width: 100%;">
-                <a t-attf-href="#{product.website_url}">
-                    <img t-attf-src="/web/image/product.product/#{product.id}/image_1920"/>
-                </a>
-            </div>
-            <div style="display: flex; flex-direction: row; align-items: center; justify-content: center; width: 100%;">
-                <p t-out="product.name"/>
-                <p t-if="product.product_template_attribute_value_ids"
-                   style="margin-left: 0.5em;">
-                    (<t
-                    t-out="', '.join(product.product_template_attribute_value_ids.mapped('name'))"
-                    />)
-                </p>
-            </div>
-            <p t-out="product.description_sale"/>
-            <div style="display: flex; justify-content: center; width: 100%;">
-                <a t-attf-href="#{product.website_url}" t-attf-style="background-color: {{product.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{product.website_id.get_current_website().company_id.email_primary_color or '#FFFFFF'}}; border-radius: 5px; font-size:13px;">
+            <img t-att-src="website.image_url(website, 'logo')" style="display: block; height: 50px; margin: 0 0 16px;" alt="Logo"/>
+            <p>Hello <t t-out="partner.name"/>,</p>
+            <p>The product you were waiting for is now back in stock!</p>
+            <t t-if="not is_html_empty(user.signature)">
+                <div style="font-size: 14px; margin: 0 0 16px;"><t t-out="user.signature or ''">Mitchell Admin</t></div>
+            </t>
+            <div t-attf-style="margin-bottom: 22px; font-size: 14px;">
+                <a t-attf-href="#{product.website_url}" t-attf-style="background-color: {{product.website_id.get_current_website().company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: {{product.website_id.get_current_website().company_id.email_primary_color or '#fff'}}; border-radius: 5px; font-size:14px;">
                     Order Now
                 </a>
             </div>
-            <p>Regards,</p>
+            <div style="margin-bottom: 12px;">
+                <table width="100%" style="max-width: 590px; border-collapse: collapse; font-size: 14px;" role="presentation">
+                    <tr>
+                        <td width="24%" style="max-width: 120px; padding: 0 10px 10px 0; vertical-align: top;">
+                            <img t-att-src="website.image_url(product, 'image_1920')" style="width: 100px; height: 100px; object-fit: contain;" alt="Product image"/>
+                        </td>
+                        <td style="padding-bottom: 8px; vertical-align: top;">
+                            <h2 t-attf-style="mso-line-height-rule: exactly; margin: 0; font-size: 14px; color: {{
+                                website.company_id.email_secondary_color or '#875A7B'
+                            }};">
+                                <strong t-out="product.name or ''">Desk Combination</strong>
+                            </h2>
+                            <p t-if="product.product_template_attribute_value_ids" style="margin-left: 4px 0;">
+                                (<t
+                                t-out="', '.join(product.product_template_attribute_value_ids.mapped('name'))"
+                                />)
+                            </p>
+                            <t t-out="product.description_ecommerce"/>
+                        </td>
+                        <td width="19%" align="right" style="max-width: 100%; vertical-align: top;">
+                            <t t-out="product.list_price" t-options="{'widget': 'monetary', 'display_currency': product.currency_id}"/>
+                        </td>
+                    </tr>
+                </table>
+            </div>
         </div>
     </template>
 </odoo>

--- a/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
+++ b/addons/website_sale_stock/tests/test_website_sale_stock_stock_notification.py
@@ -1,58 +1,53 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from contextlib import contextmanager
+
 from odoo.tests import tagged
 from odoo.tests.common import HttpCase
 
+from odoo.addons.website_sale_stock.tests.common import WebsiteSaleStockCommon
+
 
 @tagged('post_install', '-at_install')
-class TestStockNotificationProduct(HttpCase):
+class TestStockNotificationProduct(WebsiteSaleStockCommon, HttpCase):
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        warehouse = cls.env['stock.warehouse'].create({
-            'name': 'Wishlist Warehouse',
-            'code': 'W_WH'
-        })
-        current_website = cls.env['website'].get_current_website()
-        current_website.warehouse_id = warehouse
-
-        cls.warehouse = warehouse
-        cls.current_website = current_website
-
-        cls.product = cls.env['product.product'].create({
-            'name': 'Macbook Pro',
-            'website_published': True,
-            'is_storable': True,
-            'allow_out_of_stock_order': False,
-
-        })
-        cls.pricelist = cls.env['product.pricelist'].create({
-            'name': 'Public Pricelist',
-        })
-        cls.currency = cls.env.ref("base.USD")
+        cls.macbook = cls._create_product(name="Macbook Pro")
 
     def test_back_in_stock_notification_product(self):
-        self.start_tour(self.product.website_url, 'website_sale_stock.subscribe_to_stock_notification')
+        self.start_tour(self.macbook.website_url, 'website_sale_stock.subscribe_to_stock_notification')
 
         partner = self.env['mail.thread']._partner_find_from_emails_single(['test@test.test'], no_create=True)
-        ProductProduct = self.env['product.product']
-        product = ProductProduct.browse(self.product.id)
-        self.assertTrue(product._has_stock_notification(partner))
+        self.assertTrue(self.macbook._has_stock_notification(partner))
 
-        # No email should be sent
-        ProductProduct._send_availability_email()
+        with self.setup_cron_env() as env:
+            env['product.product']._send_availability_email()
+
         emails = self.env['mail.mail'].search([('email_to', '=', partner.email_formatted)])
         self.assertEqual(len(emails), 0)
 
-        # Replenish Product
-        quants = self.env['stock.quant'].with_context(inventory_mode=True).create({
-            'product_id': self.product.id,
-            'inventory_quantity': 10.0,
-            'location_id': self.warehouse.lot_stock_id.id,
-        })
-        quants.action_apply_inventory()
+        self._add_product_qty_to_wh(self.macbook.id, 10.0, self.warehouse.lot_stock_id.id)
 
-        ProductProduct._send_availability_email()
+        with self.setup_cron_env() as env:
+            env['product.product']._send_availability_email()
+
         emails = self.env['mail.mail'].search([('email_to', '=', partner.email_formatted)])
-        self.assertEqual(emails[0].subject, "The product 'Macbook Pro' is now available")
-        self.assertFalse(product._has_stock_notification(partner))
+        self.assertEqual(emails[0].subject, "Macbook Pro is back in stock")
+        self.assertFalse(self.macbook._has_stock_notification(partner))
+
+    @contextmanager
+    def setup_cron_env(self):
+        """Setup the `TestCursor` required to execute a cron job and ensures proper handling of the
+        environment before and after the operation.
+
+        Note: In `HttpCase`, `TransactionCase.enter_registry_test_mode` is enabled by default.
+        """
+        env = self.env
+        env.flush_all()
+        try:
+            with self.registry.cursor() as cr:  # Creates a temporary `TestCursor`
+                yield env(cr=cr)
+        finally:
+            env.invalidate_all()


### PR DESCRIPTION
This PR introduces significant improvements to the email templates used for abandoned carts and order confirmations and for the product availability email.


### Abandoned Cart

- Recovery button now appears only when necessary.
- Layout updated for consistency with other templates.

### Product Availability

- Layout updated for consistency with other mails.
- Sender switched to the website salesperson.

### Order Confirmation

- Website logo is displayed instead of the company logo when the sale occurs through the website.
- Fixed a color display bug.
- Rental and subscription products now include additional information.
- For combo products, the total is shown in the title instead of at the end of the product details.
- For multi-quantity order lines, the total price is shown instead of the unit price.

### General Improvements

- Email template behavior aligned with the shop_cart_recovery tour by adding the recovery button by default, with the option to hide it via context.
- Overall design aligned across abandoned cart, product availability, and order confirmation templates.

task-4826618

PR-upgrade: https://github.com/odoo/upgrade/pull/7839


| Before | After |
|--------|--------|
| <img width="542" alt="Screenshot 2025-06-05 at 15 43 06" src="https://github.com/user-attachments/assets/9cb93f8c-c3e0-4761-8751-fc03ab814083" />  | <img width="641" height="918" alt="Screenshot 2025-08-29 at 13 37 39" src="https://github.com/user-attachments/assets/0f637550-9625-4943-a20d-69f141034066" /> |
|--------|--------|
| <img width="483" alt="Screenshot 2025-06-05 at 15 42 45" src="https://github.com/user-attachments/assets/8a31335c-102c-4dee-8205-8b62be70bdf6" />  | <img width="632" alt="recovery-cart" src="https://github.com/user-attachments/assets/f1a4bc59-4c73-4712-8133-17f4f4092e69" /> |
|--------|--------|
| <img width="650" height="611" alt="Screenshot 2025-10-07 at 09 22 37" src="https://github.com/user-attachments/assets/a0fcf181-3d26-4e65-9107-cbd8c1b7a5eb" /> | <img width="633" height="573" alt="Screenshot 2025-10-07 at 10 54 55" src="https://github.com/user-attachments/assets/325676ba-ab13-425e-9668-fa2afe8fa66f" /> |



---


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
