### PR TITLE
[FIX] website: reverse accordion arrows when showed on left

### DIFF
--- a/addons/website/static/src/builder/plugins/options/accordion_option.xml
+++ b/addons/website/static/src/builder/plugins/options/accordion_option.xml
@@ -54,7 +54,7 @@
         </BuilderRow>
         <BuilderRow label.translate="Position" level="1" applyTo="'.accordion-header'">
             <BuilderButtonGroup>
-                <BuilderButton title.translate="Left" classAction="'justify-content-end flex-row-reverse'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
+                <BuilderButton title.translate="Left" classAction="'justify-content-end flex-row-reverse o_icons_position_reversed'" iconImg="'/website/static/src/img/snippets_options/pos_left.svg'"/>
                 <BuilderButton title.translate="Right" classAction="'justify-content-between'" iconImg="'/website/static/src/img/snippets_options/pos_right.svg'"/>
             </BuilderButtonGroup>
         </BuilderRow>


### PR DESCRIPTION
**Problem**
1. Place an accordion element on the page
2. Set Icons on `side/bottom`
3. Set Position on `left`
4. Problem: when the item is collapsed, the arrow points left (it should point right, and this was the case in the old editor). This happens because the class `o_icons_position_reversed` was forgotten during the conversion.

**Solution**
The class `o_icons_position_reversed` is now properly applied when the position is `left`.
