### PR TITLE
[FIX] website: theme selector in website creator translated

### DIFF
--- a/addons/website/static/src/client_actions/configurator/configurator.js
+++ b/addons/website/static/src/client_actions/configurator/configurator.js
@@ -538,7 +538,8 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
         const proms = [];
         this.uiService.block({delay: 700});
         themes.forEach((theme, idx) => {
-            const svgEl = new DOMParser().parseFromString(theme.svg, "image/svg+xml").documentElement;
+            const parsedSvg = new DOMParser().parseFromString(theme.svg, "image/svg+xml");
+            const svgEl = this.translateSVG(parsedSvg).documentElement;
             for (const imgEl of svgEl.querySelectorAll("image")) {
                 proms.push(new Promise((resolve, reject) => {
                     imgEl.addEventListener("load", () => {
@@ -556,6 +557,157 @@ export class ThemeSelectionScreen extends ApplyConfiguratorScreen {
         Promise.allSettled(proms).then(() => {
             this.uiService.unblock();
         });
+    }
+
+    translateSVG(doc) {
+        doc.querySelectorAll("text").forEach((elem) => {
+            const sanitizedTextContent = elem.textContent
+                .trim()
+                .split("\n")
+                .map((word) => word.trim());
+            var translatedTextContent = sanitizedTextContent.join(" ");
+            switch (translatedTextContent) {
+                case "Welcome":
+                    translatedTextContent = _t("Welcome");
+                    break;
+                case "Welcome Message":
+                    translatedTextContent = _t("Welcome Message");
+                    break;
+                case "A Welcome Message":
+                    translatedTextContent = _t("A Welcome Message");
+                    break;
+                case "A Welcoming Message":
+                    translatedTextContent = _t("A Welcoming Message");
+                    break;
+                case "Title":
+                    translatedTextContent = _t("Title");
+                    break;
+                case "Welcome Title":
+                    translatedTextContent = _t("Welcome Title");
+                    break;
+                case "Second Title":
+                    translatedTextContent = _t("Second Title");
+                    break;
+                case "Discover":
+                    translatedTextContent = _t("Discover");
+                    break;
+                case "Section Title":
+                    translatedTextContent = _t("Section Title");
+                    break;
+                case "Section longer title":
+                    translatedTextContent = _t("Section longer title");
+                    break;
+                case "A longer section title":
+                    translatedTextContent = _t("A longer section title");
+                    break;
+                case "Large section title":
+                    translatedTextContent = _t("Large section title");
+                    break;
+                case "Entry Title":
+                    translatedTextContent = _t("Entry Title");
+                    break;
+                case "Team Member":
+                    translatedTextContent = _t("Team Member");
+                    break;
+                case "A Section Title":
+                    translatedTextContent = _t("A Section Title");
+                    break;
+                case "A Very Long Title":
+                    translatedTextContent = _t("A Very Long Title");
+                    break;
+                case "A Big Title":
+                    translatedTextContent = _t("A Big Title");
+                    break;
+                case "A Very Long Subtitle":
+                    translatedTextContent = _t("A Very Long Subtitle");
+                    break;
+                case "Block Title":
+                    translatedTextContent = _t("Block Title");
+                    break;
+                case "BLOCK":
+                    translatedTextContent = _t("BLOCK");
+                    break;
+                case "TITLE":
+                    translatedTextContent = _t("TITLE");
+                    break;
+                case "Feature #01":
+                    translatedTextContent = _t("Feature") + " #01";
+                    break;
+                case "Feature #02":
+                    translatedTextContent = _t("Feature") + " #02";
+                    break;
+                case "Feature #03":
+                    translatedTextContent = _t("Feature") + " #03";
+                    break;
+                case "Section Entry":
+                    translatedTextContent = _t("Section Entry");
+                    break;
+                case "Contact":
+                    translatedTextContent = _t("Contact");
+                    break;
+                case "Contact Us":
+                    translatedTextContent = _t("Contact Us");
+                    break;
+                case "Contact Me":
+                    translatedTextContent = _t("Contact Me");
+                    break;
+                case "Card Title":
+                    translatedTextContent = _t("Card Title");
+                    break;
+                case "Call-To-Action Title":
+                    translatedTextContent = _t("Call-To-Action Title");
+                    break;
+                case "Subtitle #01":
+                    translatedTextContent = _t("Subtitle") + " #01";
+                    break;
+                case "Subtitle #02":
+                    translatedTextContent = _t("Subtitle") + " #02";
+                    break;
+                case "“A quote about your services”":
+                    translatedTextContent = "“" + _t("A quote about your services") + "”";
+                    break;
+                case "LOGO":
+                    translatedTextContent = _t("LOGO");
+                    break;
+            }
+
+            /*
+             * This code handles translating multiline phrases into languages
+             * whose corresponding phrases have more words, while keeping the
+             * same amount of lines
+             *
+             * Example: translating     Welcome     into    Messaggio di
+             *                          Message             Benvenuto
+             *
+             * starting phrase = 2 lines, 2 words
+             * translated phrase = 2 lines, 3 words
+             */
+            if (sanitizedTextContent.length > 1) {
+                const distributedTranslatedTextContent = [];
+                const splitTranslatedTextContent = translatedTextContent.split(/\s/);
+                const wordsPerLine = Math.ceil(
+                    splitTranslatedTextContent.length / sanitizedTextContent.length
+                );
+
+                for (let i = 0; i < splitTranslatedTextContent.length; i += wordsPerLine) {
+                    distributedTranslatedTextContent.push(
+                        splitTranslatedTextContent.slice(i, i + wordsPerLine).join(" ")
+                    );
+                }
+
+                distributedTranslatedTextContent.forEach((word, index) => {
+                    elem.querySelectorAll("tspan")[index].textContent = word;
+                });
+            } else {
+                const tspanEl = elem.querySelector("tspan");
+                if (tspanEl) {
+                    tspanEl.textContent = translatedTextContent;
+                } else {
+                    elem.textContent = translatedTextContent;
+                }
+            }
+        });
+        return doc;
     }
 
     async chooseTheme(themeName) {


### PR DESCRIPTION
Before this change, when a user is creating a website, the three theme previews that appear at the last step are always in english, even if the user installed another language.

Steps to reproduce:

- Go into the user preferences and install any other language
- Switch to that language
- Install the website app and follow the creation steps => When you reach the theme preview step, the themes will be in english even if another language was selected

After the change, the theme previews get translated and appear in the language chosen by the user.

design-themes PR: https://github.com/odoo/design-themes/pull/1098

task-3415840
