### PR TITLE
[FIX] website: fix the website_form_editor_tour tour

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -387,29 +387,55 @@ odoo.define('website.tour.form_editor', function (require) {
             trigger: 'we-list table input:eq(0)',
             run: 'text Germany',
         }, {
+            content: "Check that the label has been changed on the snippet",
+            trigger: "iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                ":has(.s_website_form_select_item:contains('Germany'))",
+            run: function () {},
+        }, {
             content: "Change Option 2 Label",
             trigger: 'we-list table input:eq(1)',
             run: 'text Belgium',
+        }, {
+            content: "Check that the label has been changed on the snippet",
+            trigger: "iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                ":has(.s_website_form_select_item:contains('Belgium'))",
+            run: function () {},
         }, {
             content: "Change first Option 3 label",
             trigger: 'we-list table input:eq(2)',
             run: 'text France',
         }, {
+            content: "Check that the label has been changed on the snippet",
+            trigger: "iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                ":has(.s_website_form_select_item:contains('France'))",
+            run: function () {},
+        }, {
             content: "Click on Add new Checkbox",
             trigger: 'we-list we-button.o_we_list_add_optional',
         }, {
             content: "Change last Option label",
-            trigger: 'we-list table input:eq(3)',
+            trigger: "we-list table input:eq(3)[name='Item']",
             run: 'text Canada',
+        }, {
+            content: "Check that the label has been changed on the snippet",
+            trigger: "iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                ":has(.s_website_form_select_item:contains('Canada'))",
+            run: function () {},
         }, {
             content: "Remove Germany Option",
             trigger: '.o_we_select_remove_option:eq(0)',
+        }, {
+            content: "Check that the Germany option was removed",
+            trigger: "iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                ":has(label:contains('State'))" +
+                ":not(:has(.s_website_form_select_item:contains('Germany')))",
+            run: function () {},
         }, {
             content: "Click on Add new Checkbox",
             trigger: 'we-list we-button.o_we_list_add_optional',
         }, {
             content: "Change last option label with a number",
-            trigger: 'we-list table input:eq(3)',
+            trigger: "we-list table input:eq(3)[name='Item']",
             run: 'text 44 - UK',
         }, {
             content: "Check that the input value is the full option value",

--- a/addons/website/tests/test_website_form_editor.py
+++ b/addons/website/tests/test_website_form_editor.py
@@ -20,7 +20,7 @@ class TestWebsiteFormEditor(HttpCaseWithUserPortal):
         })
 
     def test_tour(self):
-        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=120)
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'website_form_editor_tour', login='admin', timeout=240)
         self.start_tour('/', 'website_form_editor_tour_submit')
         self.start_tour('/', 'website_form_editor_tour_results', login="admin")
 


### PR DESCRIPTION
The goal of this commit is to fix the `website_form_editor_tour` tour that is failing undeterministically. The tour fails because this flow happens;
- The user types something ("A") as input and clicks somewhere else to commit its change.
- The DOM is updated with the new value.
- The user types something else ("B") on the same input.
- The options are rebuild with the DOM value.

-> "A" is displayed in the option input and "B" is lost.

This is a know issue and it has been decided to not fix it in stable as the behavior seems really unlikely to happen with human behavior and the issue is not critical.

Although it is not optimal, the tour is fixed by adding delays before doing further steps.

runbot-64572
