### PR TITLE
[FIX] website_payment: ensure test_01_donation work without demo data

### DIFF
--- a/addons/website_payment/tests/test_snippets.py
+++ b/addons/website_payment/tests/test_snippets.py
@@ -1,12 +1,9 @@
-import odoo
-import odoo.tests
-import logging
-
-_logger = logging.getLogger(__name__)
+from odoo.tests.common import tagged
+from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 
 
-@odoo.tests.common.tagged('post_install', '-at_install')
-class TestSnippets(odoo.tests.HttpCase):
+@tagged('post_install', '-at_install')
+class TestSnippets(HttpCaseWithUserPortal):
 
     def test_01_donation(self):
         payment_demo = self.env['ir.module.module']._get('payment_demo')
@@ -15,6 +12,18 @@ class TestSnippets(odoo.tests.HttpCase):
 
         demo_provider = self.env['payment.provider'].search([('code', '=', "demo")])
         demo_provider.write({'state': 'test'})
-        self.env.ref('base.user_admin').partner_id.country_id = self.env.ref('base.be')
+
+        belgium = self.env.ref('base.be')
+
+        self.env.ref('base.user_admin').write({
+            'country_id': belgium.id,
+            'email': 'mitchell.admin@example.com',
+        })
+        self.env.company.write({
+            'email': 'no-reply@company.com',
+        })
+
+        self.user_portal.country_id = belgium.id
+
         self.start_tour("/?enable_editor=1", "donation_snippet_edition", login='admin')
         self.start_tour("/", "donation_snippet_use", login="portal")


### PR DESCRIPTION
Commit [1] added the use of the portal user in test_01_donation. Its forward-port at [2] was adapted so that it works without demo data, and more, as it became the new default in that version.

But [1] still made our test fail in some custom non-demo runbot builds. This commit fixes that by backporting the relevant parts of [2].

[1]: https://github.com/odoo/odoo/commit/4229a3f68e17f05b75bd13347589497682575bd0
[2]: https://github.com/odoo/odoo/commit/c4418cdbf82627fa7c0dc43087de790d61c01208

runbot-223118
