### PR TITLE
[FIX] hr_holidays: Update leave manager after modifying employee manager

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -247,8 +247,6 @@ class HrEmployee(models.Model):
         if 'parent_id' in values or 'department_id' in values:
             today_date = fields.Datetime.now()
             hr_vals = {}
-            if values.get('parent_id') is not None:
-                hr_vals['manager_id'] = values['parent_id']
             if values.get('department_id') is not None:
                 hr_vals['department_id'] = values['department_id']
             holidays = self.env['hr.leave'].sudo().search([
@@ -258,6 +256,8 @@ class HrEmployee(models.Model):
                 ('employee_id', 'in', self.ids),
             ])
             holidays.write(hr_vals)
+            if values.get('parent_id') is not None:
+                hr_vals['manager_id'] = values['parent_id']
             allocations = self.env['hr.leave.allocation'].sudo().search([
                 ('state', '=', 'confirm'),
                 ('employee_id', 'in', self.ids),


### PR DESCRIPTION
Issue:
Changing the manager of an employee who already has validated time off raises an error.

Reason:
The write method on the hr.employee model attempts to update the manager_id on existing leave records. However, the manager_id field was removed from the hr.leave model, leading to a failure.

Solution:
Ensure the manager_id is added to the hr_vals dictionary only after updating the existing leave records, avoiding the attempt to write a removed field.

Task: 4852706


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
