### PR TITLE
[FIX] mail: assign on Many field index with One as inverse

### DIFF
--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -332,7 +332,7 @@ export class RecordList extends Array {
                                 );
                                 const inverse = getInverse(recordList);
                                 if (inverse) {
-                                    oldRecord[inverse].delete(recordList);
+                                    oldRecord[inverse].delete(recordList._.owner);
                                 }
                                 recordListProxy.data[index] = newRecord?.localId;
                                 if (newRecord) {
@@ -344,7 +344,7 @@ export class RecordList extends Array {
                                         newRecord
                                     );
                                     if (inverse) {
-                                        newRecord[inverse].add(recordList);
+                                        newRecord[inverse].add(recordList._.owner);
                                     }
                                 }
                             }

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -1054,10 +1054,7 @@ test("insert with id relation keeps existing field values", async () => {
     expect(member2.is_internal).toBe(true);
 });
 
-test("Re-assign on Many relation index with a One inverse should delete record from record list", async () => {
-    // Assign on record list index deletes the old record from record list.
-    // A typo can easily happen in internal code of JS and instead of calling
-    // recordList.delete() it calls oldRecord.delete()!
+test("Can assign new record on Many field with One inverse", async () => {
     (class Thread extends Record {
         static id = "name";
         name;
@@ -1065,15 +1062,21 @@ test("Re-assign on Many relation index with a One inverse should delete record f
     }).register(localRegistry);
     (class File extends Record {
         static id = "name";
+        name;
         thread = Record.one("Thread", { inverse: "files" });
     }).register(localRegistry);
     const store = await start();
-    store.Thread.insert("general");
-    store.File.insert(["file1.txt", "file2.txt"]);
-    store.Thread.get("general").files = ["file1.txt"];
-    store.Thread.get("general").files[0] = "file2.txt";
-    // Note: using .get() to check no record is deleted by mistake
-    expect(store.Thread.get("general").files.length).toBe(1);
-    expectRecord(store.Thread.get("general").files[0]).toEqual(store.File.get("file2.txt"));
-    expect(store.File.get("file1.txt").exists()).toBe(true);
+    const thread = store.Thread.insert("general");
+    const file1 = store.File.insert("file1.txt");
+    const file2 = store.File.insert("file2.txt");
+    thread.files.push(file1);
+    expect(thread.files.length).toBe(1);
+    expectRecord(thread.files[0]).toEqual(file1);
+    expectRecord(file1.thread).toEqual(thread);
+    expect(file2.thread).toBe(undefined);
+    thread.files[0] = file2;
+    expect(thread.files.length).toBe(1);
+    expectRecord(thread.files[0]).toEqual(file2);
+    expectRecord(file2.thread).toEqual(thread);
+    expect(file1.thread).toBe(undefined);
 });


### PR DESCRIPTION
Before this commit, when a Many field has a One inverse, assigning on the many field in a specific index lead to a crash.

The crash was fixed by https://github.com/odoo/odoo/pull/212963 But the resulting relations were still incorrect: the old record still was linked in the relation, and the new record was not properly linked in the inverse field.

This was happening due to similar typo in the inner code of JS models: deletion and addition of respectively old and new records were done with respectively
`recordList.delete(recordList)` and `recordList.add(recordList)`. The error comes from passing `recordList` instead of `recordList._.owner`, i.e. the old/new records.

The typo comes from `RecordUses` that also have methods `add` and `delete` and have `recordList` as 1st param. FYI, `RecordUses` is used for very-low level internal links of record being used by other records. Semantically this is like a relational field but the shape differs for improved computational complexity.