### PR TITLE
[FIX] website_event: fix the filters on the events list page

### DIFF
--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -501,33 +501,42 @@ class Event(models.Model):
 
     @api.model
     def _search_build_dates(self):
-        today = fields.Datetime.today()
-
-        def sdn(date):
-            return fields.Datetime.to_string(date.replace(hour=23, minute=59, second=59))
+        # To fetch events of the user's current day. The start and the end of the user's day must
+        # be localized and then converted in UTC, as it is the timezone used to record dates and
+        # times in db.
+        tz = timezone(self.env.user.tz or self.env.context.get('tz') or 'UTC')
+        localized_today_begin = tz.localize(fields.Datetime.today())
+        utc_today_begin = localized_today_begin.astimezone(utc)
+        utc_today_end = localized_today_begin.replace(hour=23, minute=59, second=59).astimezone(utc)
 
         def sd(date):
             return fields.Datetime.to_string(date)
 
         def get_month_filter_domain(filter_name, months_delta):
-            first_day_of_the_month = today.replace(day=1)
+            localized_month_begin = localized_today_begin.replace(day=1)
+            utc_month_begin = (localized_month_begin + relativedelta(months=months_delta)).astimezone(utc)
+            # As utc_month_begin may be the 30th day of the month, adding months may lead to miscalculation the
+            # last day of the interval since 31st day may be missing. Since localized_month_begin is always the
+            # first day of the month, it must be used to calculate the end of the interval and then the UTC
+            # conversion can be done.
+            utc_months_delta_end = (localized_month_begin + relativedelta(months=months_delta + 1)).astimezone(utc)
             filter_string = _('This month') if months_delta == 0 \
-                else format_date(self.env, value=today + relativedelta(months=months_delta),
+                else format_date(self.env, value=localized_today_begin + relativedelta(months=months_delta),
                     date_format='LLLL', lang_code=get_lang(self.env).code).capitalize()
             return [filter_name, filter_string, [
-                ("date_end", ">=", sd(first_day_of_the_month + relativedelta(months=months_delta))),
-                ("date_begin", "<", sd(first_day_of_the_month + relativedelta(months=months_delta+1)))],
+                ("date_end", ">=", sd(utc_month_begin)),
+                ("date_begin", "<", sd(utc_months_delta_end))],
                 0]
 
         return [
-            ['upcoming', _('Upcoming Events'), [("date_end", ">", sd(today))], 0],
+            ['upcoming', _('Upcoming Events'), [("date_end", ">=", sd(utc_today_begin))], 0],
             ['today', _('Today'), [
-                ("date_end", ">", sd(today)),
-                ("date_begin", "<", sdn(today))],
+                ("date_end", ">", sd(utc_today_begin)),
+                ("date_begin", "<", sd(utc_today_end))],
                 0],
             get_month_filter_domain('month', 0),
             ['old', _('Past Events'), [
-                ("date_end", "<", sd(today))],
+                ("date_end", "<", sd(utc_today_begin))],
                 0],
             ['all', _('All Events'), [], 0]
         ]


### PR DESCRIPTION
The filters use today in UTC to fetch events in db. The commit fixes this by located today first and then converts it in UTC.

related odoo/odoo@bfd55de7c846a0d523e4de4b17020341d8fcfd23

task-4796181
