### PR TITLE
[FIX] sale_pdf_quote_builder: handle documents removal from quote template

### DIFF
--- a/addons/sale_pdf_quote_builder/models/sale_order.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order.py
@@ -38,7 +38,7 @@ class SaleOrder(models.Model):
             ).filtered(lambda doc:
                 order.sale_order_template_id in doc.quotation_template_ids
                 or not doc.quotation_template_ids
-            )
+            ) | order.quotation_document_ids
 
     @api.depends('available_product_document_ids', 'order_line', 'order_line.available_product_document_ids')
     def _compute_is_pdf_quote_builder_available(self):

--- a/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
+++ b/addons/sale_pdf_quote_builder/tests/test_pdf_quote_builder.py
@@ -183,7 +183,11 @@ class TestPDFQuoteBuilder(BaseUsersCommon, SaleManagementCommon):
         so_form.sale_order_template_id = so_tmpl_2
         so_form.save()
 
-        self.assertNotEqual(self.sale_order.quotation_document_ids, self.header)
+        self.assertIn(self.header, self.sale_order.available_product_document_ids)
+        so_form.record.quotation_document_ids[0].unlink()
+        so_form.save()
+        self.assertNotIn(self.header, self.sale_order.available_product_document_ids)
+        self.assertEqual(len(self.sale_order.quotation_document_ids), 0)
 
     def test_onchange_product_removes_previously_selected_documents(self):
         """ Check that changing a line that has a selected document unselect said document. """


### PR DESCRIPTION
## Version
18.0+

## Issue
On a quotation setup with a template, when a document is selected in the quote builder and then deleted from the template, it still appears when rendering the quote PDF.

## Steps to reproduce
- Create a new quotation template with a header document
- Create a new quote using the quotation template:
  - Under the 'Quote Builder' tab, select the header document
- On the quotation template, delete the header document
- Come back to the quote
- *(Optional: check the 'Quote Builder' tab - it should be empty)*
- Print the PDF:
  - The header appears on the document

opw-4712958