### PR TITLE
[FIX] point_of_sale: fix refund shiplater

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1586,8 +1586,8 @@ class PosOrderLine(models.Model):
             product = line.product_id
             if line._is_product_storable_fifo_avco() and stock_moves:
                 product_cost = product._compute_average_price(0, line.qty, line._get_stock_moves_to_consider(stock_moves, product))
-                if (product.cost_currency_id.is_zero(product_cost) and self.order_id.shipping_date and self.refunded_orderline_id):
-                    product_cost = self.refunded_orderline_id.total_cost / self.refunded_orderline_id.qty
+                if (product.cost_currency_id.is_zero(product_cost) and line.order_id.shipping_date and line.refunded_orderline_id):
+                    product_cost = line.refunded_orderline_id.total_cost / line.refunded_orderline_id.qty
             else:
                 product_cost = product.standard_price
             line.total_cost = line.qty * product.cost_currency_id._convert(

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -2264,7 +2264,15 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'name': 'Product A',
             'categ_id': categ.id,
             'lst_price': 10,
-            'standard_price': 10
+            'standard_price': 10,
+            'is_storable': True,
+        })
+        productB = self.env['product.product'].create({
+            'name': 'Product B',
+            'categ_id': categ.id,
+            'lst_price': 10,
+            'standard_price': 10,
+            'is_storable': True,
         })
         order = self.PosOrder.create({
             'company_id': self.env.company.id,
@@ -2273,6 +2281,16 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'lines': [[0, 0, {
                 'name': "OL/0001",
                 'product_id': product.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': 2,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': 20,
+                'price_subtotal_incl': 20,
+                'total_cost': 20,
+            }], [0, 0, {
+                'name': "OL/0001",
+                'product_id': productB.id,
                 'price_unit': 10,
                 'discount': 0,
                 'qty': 2,
@@ -2308,6 +2326,16 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 'price_subtotal': -20,
                 'price_subtotal_incl': -20,
                 'refunded_orderline_id': order.lines[0].id,
+                'price_type': 'automatic'
+            }], [0, 0, {
+                'product_id': productB.id,
+                'price_unit': 10,
+                'discount': 0,
+                'qty': -2,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': -20,
+                'price_subtotal_incl': -20,
+                'refunded_orderline_id': order.lines[1].id,
                 'price_type': 'automatic'
             }]],
             'shipping_date': fields.Date.today(),


### PR DESCRIPTION
When refunding a PoS order with mulitple lines containing a product with a category that use FIFO/AVCO valuation method, there was a traceback

Steps to reproduce:
-------------------
* Create a category CAT that use FIFO/AVCO valuation method
* Create a product P1 with category CAT
* Create a product P2 with category CAT
* Create a PoS order with P1 and P2
* Validate the order using the shiplater and invoice option
* Refund the order using the shiplater and invoice option
> Observation: You get a traceback

opw-4848667