### PR TITLE
[FIX] hr_work_entry{_contract}: correct the work entry duration

### DIFF
--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -103,7 +103,7 @@ class HrWorkEntry(models.Model):
                 result[work_entry.id] = cached_periods[(date_start, date_stop)]
             else:
                 dt = date_stop - date_start
-                duration = dt.days * 24 + round(dt.total_seconds()) / 3600  # Number of hours
+                duration = round(dt.total_seconds()) / 3600  # Number of hours
                 cached_periods[(date_start, date_stop)] = duration
                 result[work_entry.id] = duration
         return result

--- a/addons/hr_work_entry_contract/tests/test_work_entry.py
+++ b/addons/hr_work_entry_contract/tests/test_work_entry.py
@@ -326,13 +326,34 @@ class TestWorkEntry(TestWorkEntryBase):
         self.assertEqual(work_entry_types, [entry_type_1, entry_type_1, entry_type_1, entry_type_2])
 
     def test_work_entry_duration(self):
-        """ Test the duration of a work entry is rounded to the nearest minute """
-        work_entry = self.env['hr.work.entry'].create({
-            'name': 'Test Work Entry',
-            'employee_id': self.richard_emp.id,
-            'contract_id': self.richard_emp.contract_id.id,
-            'date_start': datetime(2023, 10, 1, 9, 0, 0),
-            'date_stop': datetime(2023, 10, 1, 9, 59, 59, 999999),
-            'work_entry_type_id': self.work_entry_type.id,
-        })
+        """ Test the duration of a work entry is rounded to the nearest minute and correctly calculated """
+        work_entry, one_day_entry, multi_day_entry = self.env['hr.work.entry'].create([
+            {
+                'name': 'Test Work Entry',
+                'employee_id': self.richard_emp.id,
+                'contract_id': self.richard_emp.contract_id.id,
+                'date_start': datetime(2023, 10, 1, 9, 0, 0),
+                'date_stop': datetime(2023, 10, 1, 9, 59, 59, 999999),
+                'work_entry_type_id': self.work_entry_type.id,
+            },
+            {
+                'name': 'Test One Day Entry',
+                'employee_id': self.richard_emp.id,
+                'contract_id': self.richard_emp.contract_id.id,
+                'date_start': datetime(2023, 10, 1, 9, 0, 0),
+                'date_stop': datetime(2023, 10, 2, 9, 30, 0),
+                'work_entry_type_id': self.work_entry_type.id,
+            },
+            {
+                'name': 'Multi-Day Entry',
+                'employee_id': self.richard_emp.id,
+                'contract_id': self.richard_emp.contract_id.id,
+                'date_start': datetime(2023, 10, 1, 0, 0, 0),
+                'date_stop': datetime(2023, 10, 8, 1, 0, 0),
+                'work_entry_type_id': self.work_entry_type.id,
+            }
+        ])
+
         self.assertEqual(work_entry.duration, 1, "The duration should be 1 hour")
+        self.assertEqual(one_day_entry.duration, 24.5, "Duration should be 24 hours and half an hour")
+        self.assertEqual(multi_day_entry.duration, 169, "Duration should be 169 hours (7 days and one hour)")


### PR DESCRIPTION
**Description**

- Correction of the entry to calculate Time as per the set duration. 

**Steps to Reproduce**

1. go to Payroll app -> work entries -> work entries
2. Create new work entry.
3. set the end date at least 24 hours away from the start date.
4. notice that there is a 24 hours extra added/ per everyday you add.

---

**Before**
the calculation of the work entries duration was incorrect if it exceeds one day. ---

**After**
the work entry duration is calculated correctly and still well rounded. ---

**Why the fix**
- When the following commit was merged, it introduced duration rounding , but rouding the entire timedelta converted to seconds instead of the number of seconds within a day, while still adding the total days
-
- commit : https://github.com/odoo/odoo/commit/80ae5f47650077b75dfbe4e813a122c81538cab3
 ---

opw-4827487