### PR TITLE
[FIX] sale{,_project}: only use custom line descriptions for names

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -315,10 +315,17 @@ class SaleOrderLine(models.Model):
     def _compute_display_name(self):
         name_per_id = self._additional_name_per_id()
         for so_line in self.sudo():
-            product = so_line.product_id
-            parts = (so_line.name or "").split('\n', 2)
-            # if there's a description, use the first line (skipping the product name)
-            description = (parts[1:2] and parts[1]) or product.name if product else parts[0]
+            if so_line.order_partner_id.lang:
+                so_line = so_line.with_context(lang=so_line.order_id._get_lang())
+            if (product := so_line.product_id).display_name:
+                default_name = so_line._get_sale_order_line_multiline_description_sale()
+                if so_line.name == default_name:
+                    description = product.display_name
+                else:
+                    parts = (so_line.name or "").split('\n', 2)
+                    description = parts[1] if len(parts) > 1 and parts[1] else product.display_name
+            else:
+                description = (so_line.name or "").split('\n', 1)[0]
             name = f"{so_line.order_id.name} - {description}"
             additional_name = name_per_id.get(so_line.id)
             if additional_name:

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -359,6 +359,10 @@ class TestSaleOrder(SaleCommon):
         no_variant_product = no_variant_product_tmpl.product_variant_id
         ptals = no_variant_product_tmpl.valid_product_template_attribute_line_ids
         ptav1 = next(iter(ptals.product_template_value_ids))
+        product_with_desc = self.env['product.product'].create({
+            'name': "Product with description",
+            'description_sale': "Additional\ninfo.",
+        })
 
         self.sale_order.order_line = [
             Command.create({'is_downpayment': True}),
@@ -367,18 +371,19 @@ class TestSaleOrder(SaleCommon):
                 'product_id': no_variant_product.id,
                 'product_no_variant_attribute_value_ids': ptav1.ids,
             }),
+            Command.create({'product_id': product_with_desc.id}),
         ]
-        sol1, sol2, sol3, sol4, sol5 = self.sale_order.order_line
+        sol1, sol2, sol3, sol4, sol5, sol6 = self.sale_order.order_line
         sol1.name += "\nOK THANK YOU\nGOOD BYE"
 
         self.assertEqual(
             sol1.display_name,
             f"{self.sale_order.name} - OK THANK YOU ({self.partner.name})",
-            "Product line with description should display the first line of description",
+            "Product line with a custom description should display the first line of description",
         )
         self.assertEqual(
             sol2.display_name,
-            f"{self.sale_order.name} - {sol2.product_id.name} ({self.partner.name})",
+            f"{self.sale_order.name} - {sol2.product_id.display_name} ({self.partner.name})",
             "Product line without description should display the product name",
         )
         self.assertEqual(
@@ -396,6 +401,11 @@ class TestSaleOrder(SaleCommon):
             sol5.display_name,
             f"{self.sale_order.name} - {no_variant_product.name} ({self.partner.name})",
             "Lines with attribute-based descriptions should display the product name",
+        )
+        self.assertEqual(
+            sol6.display_name,
+            f"{self.sale_order.name} - {product_with_desc.display_name} ({self.partner.name})",
+            "Product lines with standard sales description should display the product name",
         )
 
     def test_state_changes(self):

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -279,8 +279,15 @@ class SaleOrderLine(models.Model):
             title = self.product_id.name
             description = '<br/>'.join(sale_line_name_parts)
         else:
-            if len(sale_line_name_parts) > 1 and sale_line_name_parts[1]:
-                # if there's multiple lines, skip the product name part
+            default_name = self.with_context(
+                lang=self.order_id._get_lang(),
+            )._get_sale_order_line_multiline_description_sale()
+            if (
+                self.name != default_name
+                and len(sale_line_name_parts) > 1
+                and sale_line_name_parts[1]
+            ):
+                # if there's a custom line description, skip the product name part when possible
                 sale_line_name_parts.pop(0)
             title = sale_line_name_parts[0]
             description = '<br/>'.join(sale_line_name_parts[1:])

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -139,8 +139,14 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             'order_id': sale_order.id,
         })
 
+        self.product_order_service3.description_sale = "Task in New Project"
         so_line_order_new_task_new_project = SaleOrderLine.create({
             'name': f"{self.product_order_service3.display_name}\n[TEST2]\nNew project",
+            'product_id': self.product_order_service3.id,
+            'product_uom_qty': 10,
+            'order_id': sale_order.id,
+        })
+        so_line_order_new_task_new_project2 = SaleOrderLine.create({
             'product_id': self.product_order_service3.id,
             'product_uom_qty': 10,
             'order_id': sale_order.id,
@@ -179,6 +185,11 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         self.assertEqual(
             str(so_line_order_new_task_new_project.task_id.description),
             '<p>New project</p>',
+        )
+        self.assertEqual(
+            so_line_order_new_task_new_project2.task_id.name,
+            self.product_order_service3.display_name,
+            "Task name created from a SOL with default description should use the product name",
         )
         # service_tracking 'project_only'
         self.assertFalse(so_line_order_only_project.task_id, "Task should not be created")


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Have a service product that creates a task on order confirmation;
2. give it a sales description;
3. add it to an order and confirm.

Issue
-----
The task is named using the sales description.

Cause
-----
Commits 47d223759f07 & c3877b2acd74 attempted to restore previous task/display name behavior by using the second line of the SOL description as the task/display name.

This behavior only happened in previous versions when the line description was manually modified.

Solution
--------
Only use the new behavior if the line name isn't the same as the default.

opw-4634149