### PR TITLE
[FIX] hw_posbox_homepage: fix expired pairing code

### DIFF
--- a/addons/hw_drivers/connection_manager.py
+++ b/addons/hw_drivers/connection_manager.py
@@ -104,6 +104,8 @@ class ConnectionManager(Thread):
             req.raise_for_status()
             if req.json().get('error') == 'expired':
                 self.pairing_code_expired = True
+                self.pairing_code = False
+                self.pairing_uuid = False
             return req.json().get('result', {})
         except Exception:
             _logger.exception('Could not reach iot-proxy.odoo.com')

--- a/addons/hw_posbox_homepage/static/src/app/Homepage.js
+++ b/addons/hw_posbox_homepage/static/src/app/Homepage.js
@@ -164,7 +164,7 @@ export class Homepage extends Component {
 					<ServerDialog />
 				</t>
 			</SingleData>
-            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up" name="'Pairing Code'" value="state.data.pairing_code + ' - Enter this code in the IoT app in your Odoo database'" icon="'fa-code'"/>
+            <SingleData t-if="state.data.pairing_code and !this.store.base.is_access_point_up and !state.data.pairing_code_expired" name="'Pairing Code'" value="state.data.pairing_code + ' - Enter this code in the IoT app in your Odoo database'" icon="'fa-code'"/>
             <SingleData t-if="state.data.pairing_code_expired" name="'Pairing Code'" value="'Code has expired - restart the IoT Box to generate a new one'" icon="'fa-code'"/>
             <SingleData  t-if="store.advanced and !store.base.is_access_point_up" name="'Six terminal'" value="state.data.six_terminal" icon="'fa-money'">
                 <t t-set-slot="button">

--- a/addons/hw_posbox_homepage/static/src/app/status.js
+++ b/addons/hw_posbox_homepage/static/src/app/status.js
@@ -97,7 +97,7 @@ class StatusPage extends Component {
             <div t-if="(state.data.pairing_code || state.data.pairing_code_expired) and !state.data.is_access_point_up" class="status-display-box">
                 <h4 class="text-center mb-3">Pairing Code</h4>
                 <hr/>
-                <t t-if="state.data.pairing_code">
+                <t t-if="state.data.pairing_code and !state.data.pairing_code_expired">
                     <h4 t-out="state.data.pairing_code" class="text-center mb-3"/>
                     <p class="text-center mb-3">
                         Enter this code in the IoT app in your Odoo database to pair the IoT Box.


### PR DESCRIPTION
This PR fixes the condition used to show "Pairing code expired" on the iot box homepage and the status screen

task-4852692
