### PR TITLE
[IMP] website_payment: new supported payment methods snippet

### DIFF
--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -495,6 +495,7 @@
                 <t id="snippet_donation_button_hook"/>
                 <t id="snippet_add_to_cart_hook"/>
                 <t id="snippet_rental_search_hook"/>
+                <t id="snippet_supported_payment_methods_hook"/>
             </snippets>
         </t>
     </xpath>

--- a/addons/website_payment/__manifest__.py
+++ b/addons/website_payment/__manifest__.py
@@ -20,6 +20,7 @@ This is a bridge module that adds multi-website support for payment providers.
         'views/res_config_settings_views.xml',
         'views/snippets/snippets.xml',
         'views/snippets/s_donation.xml',
+        'views/snippets/s_supported_payment_methods.xml',
     ],
     'auto_install': True,
     'assets': {

--- a/addons/website_payment/static/img/s_supported_payment_methods.svg
+++ b/addons/website_payment/static/img/s_supported_payment_methods.svg
@@ -1,0 +1,77 @@
+<svg width="82" height="60" viewBox="0 0 82 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7000_7279)">
+<g filter="url(#filter0_i_7000_7279)">
+<path d="M63 21V41H19V21H63ZM63 23.2857H19V28.1429H63V23.2857Z" fill="black"/>
+</g>
+<path d="M62 18C62.5523 18 63 18.4477 63 19V41C63 41.5523 62.5523 42 62 42H20C19.4477 42 19 41.5523 19 41V19C19 18.4477 19.4477 18 20 18H62ZM63 23.2857H19V28.1429H63V23.2857Z" fill="url(#paint0_linear_7000_7279)"/>
+<g filter="url(#filter1_i_7000_7279)">
+<path d="M42 32H22V34H42V32Z" fill="black"/>
+</g>
+<path d="M42 32H22V34H42V32Z" fill="white"/>
+<path d="M33 36H22V38H33V36Z" fill="white"/>
+<path d="M59 32H53V38H59V32Z" fill="white"/>
+<g filter="url(#filter2_i_7000_7279)">
+<path d="M63 21V41H19V21H63ZM63 23.2857H19V28.1429H63V23.2857Z" fill="black"/>
+</g>
+<path d="M62 18C62.5523 18 63 18.4477 63 19V41C63 41.5523 62.5523 42 62 42H20C19.4477 42 19 41.5523 19 41V19C19 18.4477 19.4477 18 20 18H62ZM63 23.2857H19V28.1429H63V23.2857Z" fill="url(#paint1_linear_7000_7279)"/>
+<g filter="url(#filter3_i_7000_7279)">
+<path d="M42 32H22V34H42V32Z" fill="black"/>
+</g>
+<path d="M42 32H22V34H42V32Z" fill="white"/>
+<path d="M33 36H22V38H33V36Z" fill="white"/>
+<path d="M59 32H53V38H59V32Z" fill="white"/>
+</g>
+<defs>
+<filter id="filter0_i_7000_7279" x="19" y="21" width="44" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_7000_7279"/>
+</filter>
+<filter id="filter1_i_7000_7279" x="22" y="32" width="20" height="3" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.0995138 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_7000_7279"/>
+</filter>
+<filter id="filter2_i_7000_7279" x="19" y="21" width="44" height="21" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.4 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_7000_7279"/>
+</filter>
+<filter id="filter3_i_7000_7279" x="22" y="32" width="20" height="3" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="1"/>
+<feGaussianBlur stdDeviation="2"/>
+<feComposite in2="hardAlpha" operator="arithmetic" k2="-1" k3="1"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.0995138 0"/>
+<feBlend mode="normal" in2="shape" result="effect1_innerShadow_7000_7279"/>
+</filter>
+<linearGradient id="paint0_linear_7000_7279" x1="19.0002" y1="28.9617" x2="62.2416" y2="35.8183" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00A09D"/>
+<stop offset="1" stop-color="#00C0D9"/>
+</linearGradient>
+<linearGradient id="paint1_linear_7000_7279" x1="19.0002" y1="28.9617" x2="62.2416" y2="35.8183" gradientUnits="userSpaceOnUse">
+<stop stop-color="#00A09D"/>
+<stop offset="1" stop-color="#00C0D9"/>
+</linearGradient>
+<clipPath id="clip0_7000_7279">
+<rect width="82" height="60" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_payment.s_supported_payment_methods.no_payment_methods_alert">
+        <t
+            t-if="payment_methods.length"
+            t-call="website_payment.s_supported_payment_methods.icons"
+        />
+        <t t-else="">
+            <div class="alert alert-warning my-0">
+                <div class="container">
+                    <div class="row gx-1 align-items-center">
+                        <span class="col-auto me-auto">No published payment methods</span>
+                        <!-- Open the link in a new tab to keep any pending edits in the editor. -->
+                        <a
+                            class="o_wpay_view_providers_btn col-auto btn btn-primary"
+                            href="/odoo/action-payment.action_payment_provider"
+                            target="_blank"
+                        >
+                            View providers
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </t>
+
+</templates>

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.xml
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/000.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_payment.s_supported_payment_methods.icons">
+        <div name="container" class="d-flex flex-wrap gap-1">
+            <t t-foreach="payment_methods" t-as="pm" t-key="pm.id">
+                <!-- The `image` field on the payment method has a max height of 64px. -->
+                <img
+                    t-att-src="pm.image_url"
+                    t-att-title="pm.name"
+                    t-att-alt="pm.name"
+                    class="img img-fluid rounded"
+                    t-attf-style="height: #{Math.min(height, 64)}px;"
+                    loading="lazy"
+                />
+            </t>
+        </div>
+    </t>
+
+</templates>

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.edit.js
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.edit.js
@@ -1,0 +1,31 @@
+import { SupportedPaymentMethods } from './supported_payment_methods';
+import { registry } from '@web/core/registry';
+import { browser } from '@web/core/browser/browser';
+
+
+const SupportedPaymentMethodsEdit = I => class extends I {
+    dynamicContent = {
+        // Bypass the ctrl-click required to open a link in edit mode.
+        '.o_wpay_view_providers_btn': { 't-on-click': this.onClickViewProviders.bind(this) },
+    };
+
+    /**
+     * @override To display an alert when no payment methods could be found.
+     */
+    setup() {
+        super.setup();
+        this.templateKey = 'website_payment.s_supported_payment_methods.no_payment_methods_alert';
+    }
+
+    async onClickViewProviders() {
+        // Open the view in a separate tab such that any edits are kept.
+        browser.open('/odoo/action-payment.action_payment_provider', '_blank');
+    }
+};
+
+registry
+    .category('public.interactions.edit')
+    .add('website.supported_payment_methods', {
+        Interaction: SupportedPaymentMethods,
+        mixin: SupportedPaymentMethodsEdit,
+    });

--- a/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.js
+++ b/addons/website_payment/static/src/snippets/s_supported_payment_methods/supported_payment_methods.js
@@ -1,0 +1,60 @@
+import { browser } from '@web/core/browser/browser';
+import { rpc } from '@web/core/network/rpc';
+import { registry } from '@web/core/registry';
+import { Interaction } from '@web/public/interaction';
+
+
+export class SupportedPaymentMethods extends Interaction {
+    static selector = '.s_supported_payment_methods';
+
+    setup() {
+        this.payment_methods = [];
+        this.templateKey = 'website_payment.s_supported_payment_methods.icons';
+    }
+
+    async willStart() {
+        await this.fetchPaymentMethods();
+    }
+
+    /**
+     * Fetch the payment methods and cache them in the session.
+     *
+     * Caching limits the amount of rpc calls when switching pages, or when editing the snippet in
+     * the editor as any edit reloads the interaction.
+     */
+    async fetchPaymentMethods() {
+        let cache = JSON.parse(
+            browser.sessionStorage.getItem('website_payment.supported_payment_methods') || '{}',
+        );
+
+        // Re-fetch if the cached list can potentially be larger
+        if (cache.payment_methods === undefined || cache.limit < this.limit) {
+            cache.payment_methods = await this.waitFor(
+                rpc('/website_payment/snippet/supported_payment_methods', { limit: this.limit }),
+            ).catch(_ => []);
+            cache.limit = this.limit;
+            browser.sessionStorage.setItem(
+                'website_payment.supported_payment_methods', JSON.stringify(cache),
+            );
+        }
+
+        this.payment_methods = cache.payment_methods.slice(0, this.limit);
+    }
+
+    start() {
+        this.el.replaceChildren();
+        this.renderAt(
+            this.templateKey,
+            { payment_methods: this.payment_methods, height: this.height },
+            this.el,
+        );
+    }
+
+    get limit() { return parseInt(this.el.dataset.limit) || 6; }
+
+    get height() { return parseInt(this.el.dataset.height) || 30; }
+}
+
+registry
+    .category('public.interactions')
+    .add('website_sale.supported_payment_methods', SupportedPaymentMethods);

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_payment.SupportedPaymentMethodsOption">
+        <BuilderRow label.translate="Limit">
+            <BuilderNumberInput
+                min="1"
+                step="1"
+                unit="'icons'"
+                applyWithUnit="false"
+                action="'supportedPaymentMethodsLimit'"
+            />
+        </BuilderRow>
+        <BuilderRow label.translate="Height">
+            <!-- The `image` field on payment methods is max 64px tall. -->
+            <BuilderRange
+                min="16"
+                max="64"
+                step="1"
+                unit="'px'"
+                displayRangeValue="true"
+                action="'supportedPaymentMethodsHeight'"
+            />
+        </BuilderRow>
+    </t>
+
+</templates>

--- a/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
+++ b/addons/website_payment/static/src/website_builder/supported_payment_methods_option_plugin.js
@@ -1,0 +1,84 @@
+import { BuilderAction } from '@html_builder/core/builder_action';
+import { SNIPPET_SPECIFIC } from '@html_builder/utils/option_sequence';
+import { Plugin } from '@html_editor/plugin';
+import { withSequence } from '@html_editor/utils/resource';
+import { browser } from '@web/core/browser/browser';
+import { _t } from '@web/core/l10n/translation';
+import { registry } from '@web/core/registry';
+
+
+class SupportedPaymentMethodsOptionPlugin extends Plugin {
+    static id = 'supportedPaymentMethodsOption';
+    static dependencies = ['edit_interaction'];
+    resources = {
+        so_content_addition_selector: ['.s_supported_payment_methods'],
+        builder_options: [
+            withSequence(SNIPPET_SPECIFIC, {
+                template: 'website_payment.SupportedPaymentMethodsOption',
+                selector: '.s_supported_payment_methods',
+            }),
+        ],
+        builder_actions: { SupportedPaymentMethodsLimit, SupportedPaymentMethodsHeight },
+        get_options_container_top_buttons: withSequence(0, this.getOptionButtons.bind(this)),
+        get_overlay_buttons: withSequence(0, { getButtons: this.getOptionButtons.bind(this) }),
+    };
+
+    setup() {
+        // Invalidate the cache if the user made backend changes and reloads the page.
+        this.addDomListener(this.window, "beforeunload", this.invalidateSnippetCache.bind(this));
+    }
+
+    /**
+     * Add a reload button at the top in case the user made some changes to the supported payment
+     * methods.
+     */
+    getOptionButtons(editingElement) {
+        if (editingElement.dataset.snippet !== 's_supported_payment_methods') {
+            return [];
+        }
+        return [{
+            class: 'fa fa-fw fa-rotate-right btn btn-outline-info',
+            title: _t("Reload the payment methods"),
+            handler: () => {
+                this.invalidateSnippetCache();
+                this.dependencies.edit_interaction.restartInteractions(editingElement);
+            }
+        }];
+    }
+
+    invalidateSnippetCache() {
+        // Invalidate the interaction cache to force a new call to the server.
+        browser.sessionStorage.removeItem('website_payment.supported_payment_methods');
+    }
+}
+
+
+class SupportedPaymentMethodsLimit extends BuilderAction {
+    static id = 'supportedPaymentMethodsLimit';
+
+    getValue({ editingElement }) {
+        return editingElement.dataset.limit;
+    }
+
+    apply({ editingElement, value }) {
+        editingElement.dataset.limit = value;
+    }
+}
+
+
+class SupportedPaymentMethodsHeight extends BuilderAction {
+    static id = 'supportedPaymentMethodsHeight';
+
+    getValue({ editingElement }) {
+        return editingElement.dataset.height;
+    }
+
+    apply({ editingElement, value }) {
+        editingElement.dataset.height = value;
+    }
+}
+
+
+registry
+    .category('website-plugins')
+    .add(SupportedPaymentMethodsOptionPlugin.id, SupportedPaymentMethodsOptionPlugin);

--- a/addons/website_payment/views/snippets/s_supported_payment_methods.xml
+++ b/addons/website_payment/views/snippets/s_supported_payment_methods.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="s_supported_payment_methods" name="Supported Payment Methods">
+        <div class="s_supported_payment_methods o_not_editable" data-limit="6" data-height="30px"/>
+    </template>
+
+    <record id="s_supported_payment_methods_OOO_xml" model="ir.asset">
+        <field name="name">Supported Payment Methods 000 XML</field>
+        <field name="bundle">web.assets_frontend</field>
+        <field name="path">/website_payment/static/src/snippets/s_supported_payment_methods/000.xml</field>
+    </record>
+
+    <record id="s_supported_payment_methods_OOO_edit_xml" model="ir.asset">
+        <field name="name">Supported Payment Methods 000 XML (edit)</field>
+        <field name="bundle">website.assets_edit_frontend</field>
+        <field name="path">/website_payment/static/src/snippets/s_supported_payment_methods/000.edit.xml</field>
+    </record>
+
+</odoo>

--- a/addons/website_payment/views/snippets/snippets.xml
+++ b/addons/website_payment/views/snippets/snippets.xml
@@ -12,6 +12,13 @@
     <xpath expr="//t[@id='snippet_donation_button_hook']" position="replace">
         <t t-snippet="website_payment.s_donation_button" string="Donation Button" t-thumbnail="/website/static/src/img/snippets_thumbs/s_donation_button.svg" t-forbid-sanitize="form"/>
     </xpath>
+    <xpath expr="//t[@id='snippet_supported_payment_methods_hook']" position="replace">
+        <t
+            t-snippet="website_payment.s_supported_payment_methods"
+            string="Supported Payment Methods"
+            t-thumbnail="/website_payment/static/img/s_supported_payment_methods.svg"
+        />
+     </xpath>
 </template>
 
 </odoo>


### PR DESCRIPTION
Many eCommerce websites display the available payment methods at checkout. This practice enhances conversion rates and informs customers promptly that their preferred payment method is supported.

This commit introduces a new “Supported Payment Methods” snippet to the Odoo building blocks. This snippet dynamically displays the supported payment methods published on the website to potential customers.

To customize the snippet, two parameters are available:
- Limit: This parameter limits the number of brands displayed in the snippet.
- Height: This parameter controls the height of each image.

When no payment method is published, a subtle warning message is displayed (only in editor mode) with a link to quickly configure the payment providers.

task-2889752

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
