### PR TITLE
[FIX] payment_demo: fix demo express checkout

### DIFF
--- a/addons/payment_demo/static/src/js/express_checkout_form.js
+++ b/addons/payment_demo/static/src/js/express_checkout_form.js
@@ -57,12 +57,12 @@ paymentExpressCheckoutForm.include({
                 'country': shippingInfo.querySelector('#o_payment_demo_shipping_country').value,
             };
             // Call the shipping address update route to fetch the shipping options.
-            const availableCarriers = await rpc(
+            const { delivery_methods } = await rpc(
                 this.paymentContext['shippingAddressUpdateRoute'],
                 {partial_delivery_address: expressDeliveryAddress},
             );
-            if (availableCarriers.length > 0) {
-                const id = parseInt(availableCarriers[0].id);
+            if (delivery_methods.length > 0) {
+                const id = parseInt(delivery_methods[0].id);
                 await rpc('/shop/set_delivery_method', {dm_id: id});
             } else {
                 this.call('dialog', 'add', ConfirmationDialog, {


### PR DESCRIPTION
Versions
--------
- 18.0+

Steps
-----
1. Enable Demo express checkout;
2. pay with Demo Express checkout in eCommerce.

Issue
-----
Validation error: No delivery method is available.

Cause
-----
Commit bf8d08cd22b5 changed the express checkout delivery method RPC API. Instead of an array, `availableCarriers` is now an object with a `delivery_methods` attribute.

Because it checks the length of an object, which is `undefined`, Demo express checkout incorrectly believes no delivery methods are available.

Solution
--------
Check the length of `delivery_methods` instead of `availableCarriers`.