### PR TITLE
[FIX] sale_pdf_quote_builder: Add default value for custom_form_fields

### DIFF
--- a/addons/sale_pdf_quote_builder/models/ir_actions_report.py
+++ b/addons/sale_pdf_quote_builder/models/ir_actions_report.py
@@ -180,14 +180,14 @@ class IrActionsReport(models.Model):
         :return: value that need to be shown in the final pdf.
         :rtype: str
         """
-        existing_mapping = json.loads(order.customizable_pdf_form_fields)
+        existing_mapping = json.loads(order.customizable_pdf_form_fields or '{}')
         if order_line:
             base_values = existing_mapping.get('line', {}).get(str(order_line.id), {})
         elif document.document_type == 'header':
             base_values = existing_mapping.get('header', {})
         else:
             base_values = existing_mapping.get('footer', {})
-        custom_form_fields = base_values.get(str(document.id), {}).get('custom_form_fields')
+        custom_form_fields = base_values.get(str(document.id), {}).get('custom_form_fields', {})
         return custom_form_fields.get(form_field_name, "")
 
     @api.model


### PR DESCRIPTION
Before this commit, there was not default value for some variables that are being calculated on _get_custom_value_from_order if the field customizable_pdf_form_fields was not updated by the frontend.

## Issue:
When creating a quotation with headers or footers set to *"Add by
default"* (e.g. via Quotation Templates), and printing the PDF without
entering the Quotation Builder tab, the system raises the following
error:

```python
TypeError: the JSON object must be str, bytes or bytearray, not bool
```

This occurs because `customizable_pdf_form_fields` remains `False`
(the default value), and `json.loads(False)` is invalid.

Impacted Versions: saas-18.2 and later

## Steps to Reproduce (on runbot):
1. Go to Sales > Configuration > Headers / Footers
2. Select *Project Description*
3. Activate *Add by default*
4. Create a new quotation
5. Select *Office Furniture* as the Quotation Template
6. Directly print *PDF Quote* without opening the *Quotation Builder* tab

## Current Behavior:
Raises Error
```python
TypeError: the JSON object must be str, bytes or bytearray, not bool
```
## Expected Behavior:
The PDF prints correctly with the default header/footer.

Video: Available on task

OPW-4840953

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
