### PR TITLE
[FIX] mail: no crash on reply in portal chatter

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -20,7 +20,7 @@
                     'o-discussApp': env.inDiscussApp,
                 }" t-attf-class="{{ props.className }}">
             <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="showComposerAvatar">
-                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="thread.effectiveSelf.avatarUrl" alt="Avatar of user"/>
+                <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="(thread?.effectiveSelf or message.effectiveSelf).avatarUrl" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread?.eq(props.composer.thread)">
                 <span class="cursor-pointer" t-on-click="() => env.messageHighlight?.highlightMessage(props.messageToReplyTo.message, props.composer.thread)">

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -203,6 +203,8 @@ addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet.js
 !addons/test_discuss_full/**/*
 !addons/website_livechat
 !addons/website_livechat/**/*
+!addons/website_slides
+!addons/website_slides/**/*
 !approvals
 !approvals/**/*
 !test_discuss_full_enterprise

--- a/addons/website_slides/static/tests/tours/slides_course_reviews.js
+++ b/addons/website_slides/static/tests/tours/slides_course_reviews.js
@@ -40,7 +40,7 @@ registry.category("web_tour.tours").add("course_reviews", {
             run() {
                 const a = document.querySelector("a[id=review-tab]");
                 if (a.textContent !== "Reviews (1)") {
-                    throw Error("Text should be 'Reviews (1)'.")
+                    throw Error("Text should be 'Reviews (1)'.");
                 }
                 a.click();
             },
@@ -61,7 +61,7 @@ registry.category("web_tour.tours").add("course_reviews", {
             trigger: ".modal.modal_shown.show button.o_portal_chatter_composer_btn",
             run() {
                 if (this.anchor.textContent !== "Update review") {
-                    throw Error("Button text should be 'Update review'.")
+                    throw Error("Button text should be 'Update review'.");
                 }
                 this.anchor.click();
             },
@@ -90,11 +90,24 @@ registry.category("web_tour.tours").add("course_reviews", {
             run: "click",
         },
         {
-            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
+            trigger:
+                "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReactions-add:not(:visible)",
         },
         {
             trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-MessageReaction",
             run: "click",
+        },
+        { trigger: '#chatterRoot:shadow .o-mail-Message button:contains("Comment")', run: "click" },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer textarea",
+            run: "edit Thanks for enjoying my 'mid' course, you mid student",
+        },
+        {
+            trigger: "#chatterRoot:shadow .o-mail-Message .o-mail-Composer textarea",
+            run: "press Enter",
+        },
+        {
+            trigger: `#chatterRoot:shadow .o_wrating_publisher_comment:contains("Thanks for enjoying my 'mid' course, you mid student")`,
         },
     ],
 });


### PR DESCRIPTION
Before this commit, clicking on "Comment" button in portal chatter to reply to a message leads to the following crash:

```
TypeError: Cannot read properties of null (reading 'effectiveSelf')
```

This happens because it opens the composer to reply to the message. Replying to a message should normally use the composer of thread and rely on `props.messageToReplyTo` from the `useMessageToReplyTo` hook, but portal chatter instead makes a composer linked to the message.

The problem is that a message linked to a composer is actually meant to say the composer is for editing the message, and when editing the message the composer shows no avatar as this is shown by the `Message` component.

Portal chatter reply to comment should display avatar of self user, but the problem is that the component `Composer` isn't directly linked to `thread`, therefore the LOC `thread.effectiveSelf` crashes in template.

This commit fixes the issue by using the `message` linked to composer when no immediate thread is found in order to display the `effectiveSelf` avatar. A composer is necessarily linked to either a thread or composer, thus this ensures the `effectiveSelf` is defined.