### PR TITLE
[IMP] sale , *: redesigned UI in product configurator dialog

### DIFF
--- a/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
+++ b/addons/sale/static/src/js/badge_extra_price/badge_extra_price.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.BadgeExtraPrice">
-        <span class="badge rounded-pill border ps-1 text-bg-light">
+        <span class="badge rounded-pill border ps-1 text-bg-primary">
             <span t-out="this.props.price > 0 ? '+' : '-'" class="me-1"/>
-            <i t-out="getFormattedPrice()"/>
+            <span t-out="getFormattedPrice()"/>
         </span>
     </t>
 </templates>

--- a/addons/sale/static/src/js/product/product.scss
+++ b/addons/sale/static/src/js/product/product.scss
@@ -6,6 +6,10 @@
     > :not(caption) > *:last-child > * {
         border-bottom: 0;
     }
+
+    &:where(:not(.o_sale_product_configurator_table_optional)) {
+        margin-bottom: $spacer !important;
+    }
 }
 
 .o_sale_product_configurator_img {
@@ -14,6 +18,12 @@
 
     @include media-breakpoint-up(md) {
         width: 120px;
+    }
+
+    img {
+        aspect-ratio: 1;
+        object-fit: cover;
+        object-position: center;
     }
 }
 

--- a/addons/sale/static/src/js/product/product.xml
+++ b/addons/sale/static/src/js/product/product.xml
@@ -3,13 +3,13 @@
     <t t-name="sale.Product">
         <td class="o_sale_product_configurator_img py-3 px-0">
             <img
-                class="w-100"
+                class="w-100 border rounded"
                 t-att-src="imageUrl"
                 alt="Product Image"
             />
         </td>
         <td class="p-3 product_name_description">
-            <div class="mb-4 text-break text-truncate" name="o_sale_product_configurator_name">
+            <div class="mb-3 text-break text-truncate" name="o_sale_product_configurator_name">
                 <span class="h5" t-out="this.props.display_name"/>
                 <div
                     t-if="this.props.description_sale"
@@ -39,15 +39,14 @@
         </td>
         <t t-if="!this.props.optional">
             <td
-                name="price"
-                t-if="env.showPrice"
-                class="o_sale_product_configurator_price py-3 px-0 text-end text-md-center d-block d-md-table-cell"
+                class="o_sale_product_configurator_qty py-3 px-0 text-end d-block d-md-table-cell"
             >
-                <t t-call="sale.product_price" name="sale_product_configurator_price"/>
-            </td>
-            <td
-                class="o_sale_product_configurator_qty py-3 px-0 text-end text-md-center d-block d-md-table-cell"
-            >
+                <div
+                    t-if="env.showPrice"
+                    class="d-flex gap-2 align-items-baseline justify-content-end"
+                >
+                    <t t-call="sale.product_price" name="sale_product_configurator_price"/>
+                </div>
                 <t t-set="isComboProduct" t-value="isMainProduct &amp;&amp; this.props.selectedComboItems.length"/>
                 <t t-if="env.showQuantity &amp;&amp; !isComboProduct">
                     <QuantityButtons
@@ -73,15 +72,15 @@
         </t>
         <t t-else="">
             <td
-                t-if="env.showPrice"
-                class="o_sale_product_configurator_qty py-3 px-0 text-end text-md-center"
-            >
-                <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
-            </td>
-            <td
                 name="price"
-                class="o_sale_product_configurator_price py-3 px-0 text-end text-md-center"
+                class="o_sale_product_configurator_price py-3 px-0 text-end"
             >
+                <div
+                    t-if="env.showPrice"
+                    class="d-flex gap-2 align-items-baseline justify-content-end"
+                >
+                    <t t-call="sale.product_price" name="sale_product_configurator_optional_price"/>
+                </div>
                 <button
                     name="sale_product_configurator_add_button"
                     class="btn btn-secondary"
@@ -89,7 +88,7 @@
                     t-on-click="() => this.env.addProduct(this.props.product_tmpl_id)"
                 >
                     <i class="fa fa-plus" role="img"/>
-                    <span class="ms-2 d-none d-md-inline">Add</span>
+                    <span name="add_button" class="ms-2 d-none d-md-inline">Add</span>
                 </button>
             </td>
         </t>
@@ -98,21 +97,22 @@
     <t t-name="sale.product_price">
         <span
             name="sale_product_configurator_formatted_price"
-            class="h5 text-nowrap"
-            t-out="getFormattedPrice()"/>
+            class="h5 text-nowrap fw-bold text-end h6 mb-2 d-block"
+            t-out="getFormattedPrice()"
+        />
         <div t-if="this.props.price_info" t-out="this.props.price_info" class="text-muted"/>
     </t>
 
     <t t-name="sale.uom_selector">
-        <div class="d-flex flex-column flex-lg-row align-items-center gap-2 mb-2">
-            <label t-out="UoMTitle" class="fw-bold text-break col-lg-3"/>
-            <ul class="list-inline list-unstyled flex-grow-1 mb-0">
+        <div class="d-flex gap-2 flex-column align-items-start justify-content-start mb-2 small">
+            <label t-out="UoMTitle" class="fw-bold me-3"/>
+            <ul class="list-unstyled d-flex flex-column flex-lg-row gap-2 flex-grow-1 mb-0">
                 <li
                     t-foreach="this.props.available_uoms"
                     t-as="uom"
                     t-key="`${this.props.product_tmpl_id}-${uom.id}`"
                     t-att-class="{'active': uom.id == props.uom.id}"
-                    class="o_sale_product_configurator_uom_choice list-inline-item"
+                    class="o_sale_product_configurator_uom_choice"
                 >
                     <label
                         class="btn btn-outline-secondary"

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -3,6 +3,7 @@ import { Dialog } from '@web/core/dialog/dialog';
 import { _t } from "@web/core/l10n/translation";
 import { rpc } from "@web/core/network/rpc";
 import { ProductList } from "../product_list/product_list";
+import { formatCurrency } from '@web/core/currency';
 
 export class ProductConfiguratorDialog extends Component {
     static components = { Dialog, ProductList};
@@ -113,6 +114,23 @@ export class ProductConfiguratorDialog extends Component {
             // Use the currency id retrieved from the server if none was provided in the props.
             this.currency.id ??= currency_id;
         });
+    }
+
+    get totalMessage() {
+        return _t("Total: %s", this.getFormattedTotal());
+    }
+
+    /**
+    * Return the total of the product in the list, in the currency of the `sale.order`.
+    *
+    * @return {String} - The sum of all items in the list, in the currency of the `sale.order`.
+    */
+    getFormattedTotal() {
+        const total = (this.state.products || []).reduce(
+            (sum, product) => sum + product.price * product.quantity,
+            0
+        );
+        return formatCurrency(total, this.currency.id);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -22,6 +22,12 @@
                 >
                     Cancel
                 </button>
+                <h6
+                    class="o_configurator_price_total d-none d-sm-inline-block ms-3 mb-0 mt-0"
+                    name="sale_product_configurator_list_total"
+                >
+                    <t t-out="totalMessage"/>
+                </h6>
             </t>
         </Dialog>
     </t>

--- a/addons/sale/static/src/js/product_list/product_list.js
+++ b/addons/sale/static/src/js/product_list/product_list.js
@@ -1,6 +1,5 @@
 
 import { Component } from "@odoo/owl";
-import { formatCurrency } from "@web/core/currency";
 import { _t } from "@web/core/l10n/translation";
 import { Product } from "../product/product";
 
@@ -17,24 +16,5 @@ export class ProductList extends Component {
 
     setup() {
         this.optionalProductsTitle = _t("Add optional products");
-    }
-
-    get totalMessage() {
-        return _t("Total: %s", this.getFormattedTotal());
-    }
-
-    /**
-     * Return the total of the product in the list, in the currency of the `sale.order`.
-     *
-     * @return {String} - The sum of all items in the list, in the currency of the `sale.order`.
-     */
-    getFormattedTotal() {
-        return formatCurrency(
-            this.props.products.reduce(
-                (totalPrice, product) => totalPrice + product.price * product.quantity,
-                0
-            ),
-            this.env.currency.id,
-        );
     }
 }

--- a/addons/sale/static/src/js/product_list/product_list.scss
+++ b/addons/sale/static/src/js/product_list/product_list.scss
@@ -2,12 +2,6 @@ table.o_sale_product_configurator_table > tbody > tr > td {
     min-width: 50px;
 }
 
-@include media-breakpoint-down(md) {
-    .non_optional_product_row_borders {
-        border-bottom-width: 1px;
-    
-        & > td {
-            border-bottom-width: 0;
-        }
-    }
+.o_sale_optional_products {
+    background: darken($modal-content-bg, 2%);
 }

--- a/addons/sale/static/src/js/product_list/product_list.xml
+++ b/addons/sale/static/src/js/product_list/product_list.xml
@@ -1,45 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.ProductList">
-        <span
-            name="sale_product_configurator_list_title"
-            class="d-inline-block mt-4 mb-3 h4"
-            t-if="this.props.areProductsOptional"
-            t-out="optionalProductsTitle"/>
-        <table
-            class="o_sale_product_configurator_table table table-sm position-relative mb-0"
-            t-att-class="{'o_sale_product_configurator_table_optional': this.props.areProductsOptional}">
-            <thead t-if="!this.props.areProductsOptional">
-                <tr>
-                    <th class="px-0 border-bottom-0" colspan="2">Product</th>
-                    <th
-                        t-if="env.showPrice"
-                        class="px-0 text-center d-none d-md-table-cell border-bottom-0"
-                    >
-                        Price
-                    </th>
-                    <th
-                        t-if="env.showQuantity"
-                        class="px-0 text-center d-none d-md-table-cell border-bottom-0"
-                    >
-                        Quantity
-                    </th>
-                </tr>
-            </thead>
-            <tbody class="border-top-0">
-                <tr t-foreach="this.props.products" t-as="product" t-key="product.product_tmpl_id" t-att-class="{'non_optional_product_row_borders': !this.props.areProductsOptional}">
-                    <Product t-props="product" optional="this.props.areProductsOptional"/>
-                </tr>
-                <tr t-if="!this.props.areProductsOptional &amp;&amp; env.showPrice">
-                    <td colspan="4" class="text-end">
-                        <span
-                            name="sale_product_configurator_list_total"
-                            class="h4"
-                            t-out="totalMessage"
-                        />
-                    </td>
-                </tr>
-            </tbody>
-        </table>
+        <div t-att-class="this.props.areProductsOptional ? 'o_sale_optional_products m-n3 p-3 border-top' : ''">
+            <span
+                name="sale_product_configurator_list_title"
+                class="d-inline-block mb-3 h4"
+                t-if="this.props.areProductsOptional"
+                t-out="optionalProductsTitle"
+            />
+            <table
+                class="o_sale_product_configurator_table table table-sm table-borderless position-relative mb-0"
+                t-att-class="{'o_sale_product_configurator_table_optional': this.props.areProductsOptional}"
+            >
+                <thead t-if="!this.props.areProductsOptional">
+                    <tr>
+                        <th class="px-0 border-bottom-0" colspan="2">Product</th>
+                    </tr>
+                </thead>
+                <tbody class="border-top-0">
+                    <tr t-foreach="this.props.products" t-as="product" t-key="product.product_tmpl_id">
+                        <Product t-props="product" optional="this.props.areProductsOptional"/>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </t>
 </templates>

--- a/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -7,16 +7,16 @@
              value template or the attribute line title unless the single attribute value is custom,
              whereas in this case, only the title of the attribute line and the custom value
              template are rendered. -->
-            <div class="d-flex flex-column flex-lg-row gap-2 mb-2">
+            <div class="d-flex gap-2 flex-column align-items-start justify-content-start mb-2 small">
                 <label
                     t-if="showValuesChoice || isSelectedPTAVCustom()"
                     t-out="this.props.attribute.name"
-                    t-attf-class="fw-bold text-break #{this.props.attribute_values.length === 1
-                        &amp;&amp; hasPTAVCustom() ? '' : 'col-lg-3'}"/>
+                    class="fw-bold me-3"
+                />
                 <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input
-                class="o_input w-lg-75 mb-4 ms-lg-auto"
+                class="o_input form-control w-lg-75 mb-4"
                 type="text"
                 t-att-placeholder="customValuePlaceholder"
                 t-if="hasPTAVCustom &amp;&amp; isSelectedPTAVCustom()"
@@ -27,9 +27,11 @@
     </t>
     <!-- Attributes value templates -->
     <t t-name="sale.ptav_select">
-        <select class="o_input w-lg-50 flex-grow-1"
+        <select
+            class="form-select form-select-sm w-auto"
             t-on-change="updateSelectedPTAV"
-            t-att-name="'ptal-' + this.props.id">
+            t-att-name="'ptal-' + this.props.id"
+        >
             <option
                 t-foreach="this.props.attribute_values"
                 t-as="ptav"
@@ -37,23 +39,24 @@
                 t-att-value="ptav.id"
                 t-att-selected="this.props.selected_attribute_value_ids.includes(ptav.id)"
                 t-out="getPTAVSelectName(ptav)"
-                t-att-class="{ 'css_not_available': ptav.excluded }"/>
+                t-att-class="{ 'css_not_available': ptav.excluded }"
+            />
         </select>
     </t>
     <t t-name="sale.ptav_radio">
-        <ul class="list-unstyled flex-grow-1 m-0">
-            <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id"
-                class="mb-2">
+        <ul class="d-flex flex-column flex-lg-row flex-wrap gap-3 row-gap-0 row-gap-lg-3 align-items-lg-center list-unstyled mb-0">
+            <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id" class="mb-0">
                 <div class="form-check">
                     <label
-                        class="form-check-label d-inline-flex align-items-center flex-wrap"
+                        class="form-check-label d-inline-flex align-items-center"
                         t-att-class="{ 'css_not_available': ptav.excluded }"
                         t-attf-for="ptav-{{ptav.id}}-input">
                         <span class="me-1" t-out="ptav.name"/>
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"
-                            currencyId="this.env.currency.id"/>
+                            currencyId="this.env.currency.id"
+                        />
                     </label>
                     <input
                         type="radio"
@@ -62,7 +65,8 @@
                         t-att-value="ptav.id"
                         t-att-checked="this.props.selected_attribute_value_ids.includes(ptav.id)"
                         t-att-name="'ptal-' + this.props.id"
-                        t-on-change="updateSelectedPTAV"/>
+                        t-on-change="updateSelectedPTAV"
+                    />
                 </div>
             </li>
         </ul>
@@ -75,12 +79,14 @@
                 <label
                     class="btn btn-outline-secondary"
                     t-att-class="{ 'css_not_available': ptav.excluded }"
-                    t-attf-for="ptav-{{ptav.id}}-input">
+                    t-attf-for="ptav-{{ptav.id}}-input"
+                >
                     <span t-out="ptav.name"/>
                     <BadgeExtraPrice
                         t-if="ptav.price_extra"
                         price="ptav.price_extra"
-                        currencyId="this.env.currency.id"/>
+                        currencyId="this.env.currency.id"
+                    />
                 </label>
                 <input
                     class="btn-check"
@@ -89,7 +95,8 @@
                     t-att-value="ptav.id"
                     t-att-name="'ptal-' + this.props.id"
                     t-att-checked="this.props.selected_attribute_value_ids.includes(ptav.id)"
-                    t-on-change="updateSelectedPTAV"/>
+                    t-on-change="updateSelectedPTAV"
+                />
             </li>
         </ul>
     </t>
@@ -114,7 +121,8 @@
                         t-att-value="ptav.id"
                         t-att-name="'ptal-' + this.props.id"
                         t-att-checked="this.props.selected_attribute_value_ids.includes(ptav.id)"
-                        t-on-change="updateSelectedPTAV"/>
+                        t-on-change="updateSelectedPTAV"
+                    />
                 </label>
             </li>
         </ul>
@@ -153,8 +161,7 @@
     </t>
     <t t-name="sale.ptav_multi">
          <ul class="list-unstyled flex-grow-1 m-0">
-            <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id"
-                class="mb-2">
+            <li t-foreach="this.props.attribute_values" t-as="ptav" t-key="ptav.id" class="mb-2">
                 <div class="form-check">
                     <input
                         type="checkbox"
@@ -163,7 +170,8 @@
                         t-att-value="ptav.id"
                         t-att-name="'ptal-' + this.props.id"
                         t-att-checked="this.props.selected_attribute_value_ids.includes(ptav.id)"
-                        t-on-change="updateSelectedPTAV"/>
+                        t-on-change="updateSelectedPTAV"
+                    />
                     <label
                         class="form-check-label"
                         t-attf-for="ptav-{{ptav.id}}-input">
@@ -171,7 +179,8 @@
                         <BadgeExtraPrice
                             t-if="ptav.price_extra"
                             price="ptav.price_extra"
-                            currencyId="this.env.currency.id"/>
+                            currencyId="this.env.currency.id"
+                        />
                     </label>
                 </div>
             </li>

--- a/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -1,28 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <templates xml:space="preserve">
     <t t-name="sale.QuantityButtons">
-        <div name="quantity_buttons_wrapper" class="input-group justify-content-end justify-content-md-center">
+        <div name="quantity_buttons_wrapper" class="input-group justify-content-end ">
             <button
-                t-attf-class="px-2 px-md-3 btn btn-secondary {{ props.btnClasses or 'd-md-inline-block' }}"
                 name="sale_quantity_button_minus"
+                t-attf-class="px-2 px-md-3 btn btn-secondary {{ props.btnClasses or 'd-md-inline-block' }}"
                 aria-label="Remove one"
                 t-att-disabled="props.isMinusButtonDisabled"
-                t-on-click="decreaseQuantity">
-                <i class="fa fa-minus"/>
+                t-on-click="decreaseQuantity"
+            >
+                <i class="oi oi-minus"/>
             </button>
             <input
                 class="form-control quantity text-center"
                 name="sale_quantity"
                 type="number"
                 t-att-value="props.quantity"
-                t-on-change="setQuantity"/>
+                t-on-change="setQuantity"
+            />
             <button
                 t-attf-class="px-2 px-md-3 btn btn-secondary {{ props.btnClasses or 'd-md-inline-block' }}"
                 name="sale_quantity_button_plus"
                 aria-label="Add one"
                 t-att-disabled="props.isPlusButtonDisabled"
-                t-on-click="increaseQuantity">
-                <i class="fa fa-plus"/>
+                t-on-click="increaseQuantity"
+            >
+                <i class="oi oi-plus"/>
             </button>
         </div>
     </t>

--- a/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -52,7 +52,7 @@ function decreaseProductQuantity(productName) {
         trigger: `
             ${productSelector(productName)}
             td.o_sale_product_configurator_qty
-            button:has(i.fa-minus)
+            button:has(i.oi-minus)
         `,
         run: 'click',
     };
@@ -64,7 +64,7 @@ function increaseProductQuantity(productName) {
         trigger: `
             ${productSelector(productName)}
             td.o_sale_product_configurator_qty
-            button:has(i.fa-plus)
+            button:has(i.oi-plus)
         `,
         run: 'click',
     };
@@ -161,8 +161,9 @@ function selectAndSetCustomAttribute(
 function assertPriceTotal(total) {
     return {
         content: `Assert that the total is ${total}`,
-        trigger:
-            `table.o_sale_product_configurator_table tr>td[colspan="4"] span:contains("${total}")`,
+        trigger: `
+            .o_sale_product_configurator_dialog .o_configurator_price_total:contains("${total}"),
+        `,
     };
 }
 
@@ -171,7 +172,7 @@ function assertProductPrice(productName, price) {
         content: `Assert that ${productName} costs ${price}`,
         trigger: `
             ${productSelector(productName)}
-            td.o_sale_product_configurator_price
+            td.o_sale_product_configurator_qty
             span:contains("${price}")
         `,
     };
@@ -182,7 +183,7 @@ function assertOptionalProductPrice(productName, price) {
         content: `Assert that ${productName} costs ${price}`,
         trigger: `
             ${optionalProductSelector(productName)}
-            td.o_sale_product_configurator_qty
+            td.o_sale_product_configurator_price
             span:contains("${price}")
         `,
     };
@@ -193,7 +194,7 @@ function assertProductPriceInfo(productName, priceInfo) {
         content: `Assert that the price info of ${productName} is ${priceInfo}`,
         trigger: `
             ${productSelector(productName)}
-            td.o_sale_product_configurator_price
+            td.o_sale_product_configurator_qty
             div:contains("${priceInfo}")
         `,
     };
@@ -204,7 +205,7 @@ function assertOptionalProductPriceInfo(productName, priceInfo) {
         content: `Assert that the price info of ${productName} is ${priceInfo}`,
         trigger: `
             ${optionalProductSelector(productName)}
-            td.o_sale_product_configurator_qty
+            td.o_sale_product_configurator_price
             div:contains("${priceInfo}")
         `,
     };

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_edition_ui.js
@@ -26,7 +26,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_edition_tour'
         },
         {
             // check updated price
-            trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) span[name="sale_product_configurator_formatted_price"]:contains("800.40")',
         },
         {
             trigger: 'table.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td>div[name="ptal"]:has(div>label:contains("Legs")) label:has(span:contains("Custom")) ~ input',

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_optional_products_ui.js
@@ -14,7 +14,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_optional_prod
             run: "click",
         },
         {
-            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) button:has(i.fa-plus)',
+            trigger: 'tr:has(div[name="o_sale_product_configurator_name"]:contains("Customizable Desk")) button:has(i.oi-plus)',
             run: "click",
         },
         {

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_pricelist_ui.js
@@ -40,16 +40,16 @@ registry.category("web_tour.tours").add('sale_product_configurator_pricelist_tou
         ...tourUtils.addProduct("Customizable Desk (TEST)"),
         {
             content: "check price is correct (USD)",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3) span:contains("750.00")',
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) span[name="sale_product_configurator_formatted_price"]:contains("750.00")',
         },
         {
             content: "add one more",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(4)>div>button:has(i.fa-plus)',
+            trigger: '.o_sale_product_configurator_table tr:has(span:contains("Customizable Desk")) td.o_sale_product_configurator_qty button:has(i.oi-plus)',
             run: "click",
         },
         {
             content: "check price for 2",
-            trigger: 'main.modal-body>table:nth-child(1)>tbody>tr:nth-child(1)>td:nth-child(3) span:contains("600.00")',
+            trigger: '.o_sale_product_configurator_table tr:has(span:contains("Customizable Desk")) td span[name="sale_product_configurator_formatted_price"]:contains("600.00")',
         },
         configuratorTourUtils.addOptionalProduct("Conference Chair (TEST)"),
         configuratorTourUtils.increaseProductQuantity("Conference Chair (TEST)"),

--- a/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_configurator_ui.js
@@ -22,7 +22,7 @@ registry.category("web_tour.tours").add('sale_product_configurator_tour', {
             run: "click",
         },
         {
-            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) td[name="price"] span:contains("800.40")',
+            trigger: '.o_sale_product_configurator_table tr:has(td>div[name="o_sale_product_configurator_name"] span:contains("Customizable Desk")) span[name="sale_product_configurator_formatted_price"]:contains("800.40")',
         },
         {
             trigger: 'label[style="background-color:#000000"] input:not(:visible)',

--- a/addons/website_sale/static/src/js/product/product.xml
+++ b/addons/website_sale/static/src/js/product/product.xml
@@ -9,7 +9,7 @@
         </QuantityButtons>
         <button name="sale_product_configurator_add_button" position="attributes">
             <attribute name="t-if">this.props.can_be_sold</attribute>
-            <attribute name="class" remove="btn-secondary" add="btn-primary" separator=" "/>
+            <attribute name="class" remove="btn-secondary" add="btn-outline-primary" separator=" "/>
         </button>
         <xpath
             expr="//button[@name='sale_product_configurator_add_button']/*[hasclass('fa-plus')]"
@@ -17,18 +17,23 @@
         >
             <attribute name="class" remove="fa-plus" add="fa-shopping-cart" separator=" "/>
         </xpath>
+        <span name="add_button" position="attributes">
+            <attribute name="t-out">'Add to Cart'</attribute>
+        </span>
+
         <button name="sale_product_configurator_add_button" position="after">
             <t t-call="website_sale.not_for_sale"/>
         </button>
-        <t name="sale_product_configurator_price" position="before">
+        <t name="sale_product_configurator_price" position="after">
             <t t-call="website_sale.strikethrough_product_price"/>
         </t>
-        <t name="sale_product_configurator_optional_price" position="before">
+        <t name="sale_product_configurator_optional_price" position="after">
             <t t-call="website_sale.strikethrough_product_price"/>
         </t>
         <xpath
             expr="//div[@name='o_sale_product_configurator_name']//span[hasclass('h5')]"
-            position="attributes">
+            position="attributes"
+        >
             <attribute name="class" remove="h5" add="h6" separator=" "/>
         </xpath>
     </t>

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -29,11 +29,7 @@ patch(ProductConfiguratorDialog.prototype, {
             this.createProductUrl = '/website_sale/product_configurator/create_product';
             this.updateCombinationUrl = '/website_sale/product_configurator/update_combination';
             this.getOptionalProductsUrl = '/website_sale/product_configurator/get_optional_products';
-            // To be translated, the title must be repeated here. Indeed, only
-            // translations of "frontend modules" are fetched in the context of
-            // website. The original definition of the title is in "sale", which
-            // is not a frontend module.
-            this.title = _t("Configure your product");
+            this.title = _t("Configure");
         }
 
         useSubEnv({
@@ -59,4 +55,16 @@ patch(ProductConfiguratorDialog.prototype, {
     showShopButtons() {
         return this.props.isFrontend && !this.props.edit;
     },
+
+    get totalMessage() {
+        if (this.env.isFrontend) {
+            // To be translated, the title must be repeated here. Indeed, only
+            // translations of "frontend modules" are fetched in the context of
+            // website. The original definition of the title is in "sale", which
+            // is not a frontend module.
+            return _t("Total: %s", this.getFormattedTotal());
+        }
+        return super.totalMessage(...arguments);
+    },
+
 });

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.scss
@@ -1,5 +1,24 @@
 .o_sale_product_configurator_dialog {
-    // Ensure a minimal border regardless of the theme options
-    --modal-header-border-width: #{$border-width};
-    --modal-footer-border-width: #{$border-width};
+    --modal-border-radius: #{$btn-border-radius};
+    --product-configurator-img-size-lg: 6rem;
+
+    .modal-header .btn.oi-arrow-left {
+        padding-left: 0;
+    }
+
+    .o_wsale_product_configurator_vr {
+        background: $border-color;
+    }
+
+    .o_sale_product_configurator_img {
+        @include media-breakpoint-down(md) {
+            --product-configurator-img-size-sm: 4rem;
+        }
+
+        width: var(--product-configurator-img-size-sm, var(--product-configurator-img-size-lg));
+    }
+
+    .text-muted {
+        color: inherit !important;
+    }
 }

--- a/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
+++ b/addons/website_sale/static/src/js/product_configurator_dialog/product_configurator_dialog.xml
@@ -8,27 +8,32 @@
             <attribute name="class" remove="btn-secondary" add="btn-light" separator=" "/>
             <attribute name="t-if">!showShopButtons()</attribute>
         </button>
-        <button name="sale_product_configurator_confirm_button" position="after">
-            <button
-                name="website_sale_product_configurator_continue_button"
-                class="btn btn-secondary"
-                t-if="showShopButtons() and !this.props.options.isBuyNow"
-                t-on-click="() => this.onConfirm({goToCart: false})"
-                t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
-            >
-                Continue Shopping
-            </button>
-        </button>
         <button name="sale_product_configurator_cancel_button" position="after">
-            <button
-                name="website_sale_product_configurator_checkout_button"
-                class="btn btn-primary"
+            <div
                 t-if="showShopButtons()"
-                t-on-click="() => this.onConfirm({goToCart: true})"
-                t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
+                class="d-flex flex-column flex-sm-row align-items-center gap-2"
             >
-                Proceed to Checkout
-            </button>
+                <button
+                    t-if="!this.props.options.isBuyNow"
+                    name="website_sale_product_configurator_continue_button"
+                    class="btn btn-primary w-100 w-sm-auto flex-shrink-0 flex-grow-0"
+                    t-on-click="() => this.onConfirm({goToCart: false})"
+                    t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
+                >
+                    <i class="fa fa-shopping-cart"/>
+                    Add to cart
+                </button>
+                <button
+                    name="website_sale_product_configurator_checkout_button"
+                    class="btn btn-outline-primary w-100 w-sm-auto flex-shrink-0 flex-grow-0"
+                    t-on-click="() => this.onConfirm({goToCart: true})"
+                    t-att-disabled="!isPossibleConfiguration() || !canBeSold()"
+                >
+                    Go to Checkout
+                    <i class="fa fa-angle-right ms-2"/>
+                </button>
+
+            </div>
         </button>
     </t>
 </templates>

--- a/addons/website_sale/static/src/js/product_list/product_list.js
+++ b/addons/website_sale/static/src/js/product_list/product_list.js
@@ -7,14 +7,7 @@ patch(ProductList.prototype, {
         super.setup(...arguments);
 
         if (this.env.isFrontend) {
-            this.optionalProductsTitle = _t("Available options");
+            this.optionalProductsTitle = _t("Options");
         }
-    },
-
-    get totalMessage() {
-        if (this.env.isFrontend) {
-            return _t("Total: %s", this.getFormattedTotal());
-        }
-        return super.totalMessage(...arguments);
     },
 });

--- a/addons/website_sale/static/src/js/product_list/product_list.xml
+++ b/addons/website_sale/static/src/js/product_list/product_list.xml
@@ -4,8 +4,6 @@
         <span name="sale_product_configurator_list_title" position="attributes">
             <attribute name="class" remove="h4" add="h5" separator=" "/>
         </span>
-        <span name="sale_product_configurator_list_total" position="attributes">
-            <attribute name="class" remove="h4" add="h5" separator=" "/>
-        </span>
+        <thead position="replace"/>
     </t>
 </templates>

--- a/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
+++ b/addons/website_sale/static/src/js/quantity_buttons/quantity_buttons.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-inherit="sale.QuantityButtons" t-inherit-mode="extension">
         <div name="quantity_buttons_wrapper" position="attributes">
-            <attribute name="class" add="css_quantity border rounded" separator=" "/>
+            <attribute name="class" add="css_quantity d-inline-flex border border rounded" separator=" "/>
         </div>
         <button name="sale_quantity_button_minus" position="attributes">
             <attribute name="t-attf-class" remove="btn-secondary" add="btn-link text-600" separator=" "/>

--- a/addons/website_sale/static/src/js/tours/product_configurator_tour_utils.js
+++ b/addons/website_sale/static/src/js/tours/product_configurator_tour_utils.js
@@ -5,7 +5,6 @@ function assertProductStrikethroughPrice(productName, price) {
         content: `Assert that ${productName} was reduced from ${price}`,
         trigger: `
             ${configuratorTourUtils.productSelector(productName)}
-            td.o_sale_product_configurator_price
             .oe_striked_price:contains("${price}")
         `,
     };
@@ -16,7 +15,6 @@ function assertOptionalProductStrikethroughPrice(productName, price) {
         content: `Assert that ${productName} was reduced from ${price}`,
         trigger: `
             ${configuratorTourUtils.optionalProductSelector(productName)}
-            td.o_sale_product_configurator_qty
             .oe_striked_price:contains("${price}")
         `,
     };

--- a/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
+++ b/addons/website_sale/static/tests/tours/website_sale_combo_configurator.js
@@ -25,7 +25,7 @@ registry
             },
             // Assert that the cart's content is correct.
             {
-                content: "Go to checkout",
+                content: "Proceed to checkout",
                 trigger: 'button:contains(Go to Checkout)',
                 run: 'click',
                 expectUnloadPage: true,

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attribute_value.js
@@ -23,7 +23,7 @@
         run: 'click',
     },
     {
-        trigger: 'button:contains(Proceed to Checkout)',
+        trigger: 'button:contains(Go to Checkout)',
         run: 'click',
         expectUnloadPage: true,
     },

--- a/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_custom_attributes_value.js
@@ -44,7 +44,7 @@ configuratorTourUtils.addOptionalProduct("Conference Chair"),
 configuratorTourUtils.addOptionalProduct("Chair floor protection"),
 configuratorTourUtils.assertPriceTotal("1,228.50"),
 {
-    trigger: 'button:contains(Proceed to Checkout)',
+    trigger: 'button:contains(Go to Checkout)',
     run: 'click',
     expectUnloadPage: true,
 },

--- a/addons/website_sale/static/tests/tours/website_sale_update_cart.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_cart.js
@@ -31,7 +31,7 @@ registry.category('web_tour.tours').add('shop_update_cart', {
         },
         {
             content: "click in modal on 'Proceed to checkout' button",
-            trigger: 'button:contains("Proceed to Checkout")',
+            trigger: 'button:contains("Checkout")',
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale/static/tests/tours/website_sale_variants_modal_window.js
@@ -41,11 +41,11 @@
         },
         {
             trigger:
-                ".modal:contains(configure your product) table.o_sale_product_configurator_table",
+                '.modal:has(table.o_sale_product_configurator_table)',
         },
         {
             content: "Go through the modal window of the product configurator",
-            trigger: ".modal:contains(configure your product) button:contains(Proceed to Checkout)",
+            trigger: 'button:contains("Checkout")',
             run: "click",
             expectUnloadPage: true,
         },

--- a/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
+++ b/addons/website_sale_comparison/static/tests/tours/website_sale_comparison.js
@@ -182,7 +182,7 @@ import * as tourUtils from "@website_sale/js/tours/tour_utils";
         trigger: '.product_summary:contains("Color Pants") button:contains("Add to Cart")',
         run: "click",
     },
-        clickOnElement('Continue Shopping', 'button:contains("Continue Shopping")'),
+        clickOnElement('Add to cart', 'button[name="website_sale_product_configurator_continue_button"]'),
         tourUtils.goToCart(),
     {
         content: "check product correctly added to cart",

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_message_after_close_configurator_modal.js
@@ -21,7 +21,7 @@ registry.category("web_tour.tours").add('website_sale_stock_message_after_close_
     },
     {
         content: "Continue shoppping",
-        trigger: 'button:contains(Continue Shopping)',
+        trigger: 'button[name="website_sale_product_configurator_continue_button"]',
         run: 'click',
     }, {
         content: "Check that the stock quantity is displayed and correct after adding to cart",

--- a/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
+++ b/addons/website_sale_stock/static/tests/tours/website_sale_stock_product_configurator.js
@@ -40,7 +40,7 @@ registry
             configuratorTourUtils.removeOptionalProduct("Optional product"),
             {
                 content: "Proceed to checkout",
-                trigger: 'button:contains(Proceed to Checkout)',
+                trigger: 'button:contains(Go to Checkout)',
                 run: 'click',
                 expectUnloadPage: true,
             },


### PR DESCRIPTION
      * = [website_sale,website_sale_stock,test_sale_product_configurators]
- Redesigned the product configurator Redesigned the product configurator
  dialog to align with modern UI standards and improve the user
  experience across devices.
- Updated cart layout to match modern design spec from reference
- Improved visual hierarchy for product lines and pricing
- Added quantity controls and Save for Later actions with cleaner spacing
- Enhanced warranty option display with Add to Cart/Wishlist buttons
- Updated total section styling and alignment
- Updated tour test cases for updated UI

See Also:

- Enterprise PR: https://github.com/odoo/enterprise/pull/91671

task:4731022
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
