### PR TITLE
[IMP] web: remove unnecessary spacer in mobile SearchPanel

### DIFF
--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -173,7 +173,6 @@
                 </t>
             </Dropdown>
             <a href="#" t-if="hasSelection()" title="Clear All" class="btn btn-link text-nowrap text-uppercase" t-on-click="() => this.clearSelection()">CLEAR ALL</a>
-            <div t-else="" class="mx-4"/>
         </div>
     </div>
 </t>


### PR DESCRIPTION
Before this commit, the mobile SearchPanel included an empty div with a `mx-4` class, likely added to somehow balance the layout when the "CLEAR ALL" button was absent.

However, this spacer seems currently unnecessary, and causes layout issues ; such as unwanted horizontal scrolling when dropdowns are long but not wide enough to already justify a scroll.

This commit removes the div.

task-4784155

| Before | After |
|--------|--------|
| <img width="396" alt="image" src="https://github.com/user-attachments/assets/b4a2037b-5a74-411d-affa-8fd9b6cc2958" /> | <img width="396" alt="image" src="https://github.com/user-attachments/assets/a3f78dd2-8d5c-4b1e-a3d8-c23712df4c50" /> |
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
