### PR TITLE
[IMP] point_of_sale: consistency between frontend and backend refund

### DIFF
--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -228,7 +228,7 @@ export class PosOrderline extends Base {
 
         if (this.refunded_orderline_id?.uuid in allLineToRefundUuids) {
             const refundDetails = allLineToRefundUuids[this.refunded_orderline_id.uuid];
-            const maxQtyToRefund = refundDetails.line.qty - refundDetails.line.refunded_qty;
+            const maxQtyToRefund = refundDetails.line.qty - refundDetails.line.refundedQty;
             if (quant > 0) {
                 return {
                     title: _t("Positive quantity not allowed"),
@@ -726,6 +726,14 @@ export class PosOrderline extends Base {
     }
     get canBeRemoved() {
         return this.product_id.uom_id.isZero(this.qty);
+    }
+    get refundedQty() {
+        return (
+            this.refund_orderline_ids?.reduce(
+                (acc, line) => (line.order_id.state !== "cancel" ? acc - line.qty : acc),
+                0
+            ) || 0
+        );
     }
 }
 

--- a/addons/point_of_sale/static/src/app/models/pos_order_line_refund.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line_refund.js
@@ -28,6 +28,6 @@ export class PosOrderLineRefund {
         }
 
         const line = this.line;
-        return line.qty - this.refunded_qty;
+        return line.qty - this.refundedQty;
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -245,7 +245,7 @@ export class TicketScreen extends Component {
                 return this.numberBuffer.reset();
             }
 
-            const refundableQty = toRefundDetail.line.qty - toRefundDetail.line.refunded_qty;
+            const refundableQty = toRefundDetail.line.qty - toRefundDetail.line.refundedQty;
             if (refundableQty <= 0) {
                 return this.numberBuffer.reset();
             }
@@ -583,7 +583,7 @@ export class TicketScreen extends Component {
             return false;
         }
         const theOrderline = orderlines[0];
-        const refundableQty = theOrderline.getQuantity() - theOrderline.refunded_qty;
+        const refundableQty = theOrderline.getQuantity() - theOrderline.refundedQty;
         return this.pos.isProductQtyZero(refundableQty - 1);
     }
     _prepareAutoRefundOnOrder(order) {
@@ -801,7 +801,11 @@ export class TicketScreen extends Component {
             .filter((orderInfo) => {
                 const order = this.pos.models["pos.order"].get(orderInfo[0]);
 
-                if (order && parseDateTime(orderInfo[1]) > order.date_order) {
+                if (
+                    order &&
+                    parseDateTime(orderInfo[1], { tz: "UTC" }).setZone("local").ts >
+                        order.date_order.ts
+                ) {
                     return true;
                 }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -152,9 +152,9 @@
                             <t t-set="line" t-value="scope.line" />
                             <Orderline line="line" t-on-click="() => this.onClickOrderline(line)" class="{'selected': line.id === _selectedOrderlineId}">
                                 <t t-set="toRefundDetail" t-value="line.order_id?.uiState?.lineToRefund?.[line.uuid]" />
-                                <li t-if="!pos.isProductQtyZero(line.refunded_qty)"
+                                <li t-if="!pos.isProductQtyZero(line.refundedQty)"
                                     class="info refund-note mt-1">
-                                    <strong t-esc="env.utils.formatProductQty(line.refunded_qty)" />
+                                    <strong t-esc="env.utils.formatProductQty(line.refundedQty)" />
                                     <span> Refunded</span>
                                 </li>
                                 <li t-if="!pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">

--- a/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/pos/tours/ticket_screen_tour.js
@@ -357,6 +357,31 @@ registry.category("web_tour.tours").add("OrderTimeTour", {
     },
 });
 
+registry
+    .category("web_tour.tours")
+    .add("test_consistent_refund_process_between_frontend_and_backend", {
+        steps: () =>
+            [
+                Chrome.startPoS(),
+                Dialog.confirm("Open Register"),
+                ProductScreen.addOrderline("Desk Pad", "2", "4"),
+                ProductScreen.clickPayButton(),
+                PaymentScreen.clickPaymentMethod("Bank"),
+                PaymentScreen.clickValidate(),
+                ReceiptScreen.isShown(),
+                ReceiptScreen.clickNextOrder(),
+                ...ProductScreen.clickRefund(),
+                TicketScreen.selectOrder("001"),
+                inLeftSide(Order.hasLine({ productName: "Desk Pad", withClass: ".selected" })),
+                ProductScreen.clickNumpad("1"),
+                TicketScreen.toRefundTextContains("To Refund: 1"),
+                TicketScreen.confirmRefund(),
+                PaymentScreen.clickPaymentMethod("Bank"),
+                PaymentScreen.clickValidate(),
+                ReceiptScreen.isShown(),
+            ].flat(),
+    });
+
 registry.category("web_tour.tours").add("test_paid_order_with_archived_product_loads", {
     steps: () =>
         [

--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -70,6 +70,7 @@ class PosMakePayment(models.TransientModel):
             order._process_saved_order(False)
             if order.state in {'paid', 'done'}:
                 order._send_order()
+                order.config_id.notify_synchronisation(order.config_id.current_session_id.id, 0)
             return {'type': 'ir.actions.act_window_close'}
 
         return self.launch_payment()


### PR DESCRIPTION
In this commit:
----------
- Improved the refund flow initiated from the backend to align with the frontend behavior.
- Ensured consistency in refund order creation, state transition, and payment handling between the frontend and the backend.

task-4831414
