### PR TITLE
[FIX] hr_holidays: add Time Off refuse button for manager

### DIFF
--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -162,15 +162,15 @@
                                 </div>
                                 <div class="me-2 align-items-center" t-if="['confirm', 'validate1'].includes(record.state.raw_value)">
                                     <button t-if="record.state.raw_value === 'confirm'" name="action_approve" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_user">
+                                        groups="hr_holidays.group_hr_holidays_responsible">
                                         <i class="fa fa-thumbs-up"/> Approve
                                     </button>
                                     <button t-if="record.state.raw_value === 'validate1'" name="action_validate" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_manager">
+                                        groups="hr_holidays.group_hr_holidays_responsible">
                                         <i class="fa fa-check"/> Validate
                                     </button>
                                     <button t-if="['confirm', 'validate1'].includes(record.state.raw_value)" name="action_refuse" type="object" class="btn btn-link btn-sm ps-0"
-                                        groups="hr_holidays.group_hr_holidays_user">
+                                        groups="hr_holidays.group_hr_holidays_responsible">
                                         <i class="fa fa-times"/> Refuse
                                     </button>
                                 </div>
@@ -531,11 +531,11 @@
                 <button string="Validate" name="action_validate" type="object"
                     icon="fa-check"
                     invisible="state != 'validate1'"
-                    groups="hr_holidays.group_hr_holidays_user"/>
+                    groups="hr_holidays.group_hr_holidays_responsible"/>
                 <button string="Refuse" name="action_refuse" type="object"
                     icon="fa-times"
                     invisible="state not in ('confirm', 'validate1')"
-                    groups="hr_holidays.group_hr_holidays_user"/>
+                    groups="hr_holidays.group_hr_holidays_responsible"/>
                 <field name="activity_exception_decoration" widget="activity_exception"/>
             </tree>
         </field>


### PR DESCRIPTION
Backport of e21ff0ed57574694e75ef2b4f4e2e41f8bb0412a

Manager of an employee could only approve a Time Off request

Steps to reproduce:
-------------------
* Revoke Marc Demo's Time Off Access Rights in Settings
* Assign Marc Demo as manager to an employee
* Create a New Time Off request for that employee
* Log in as Marc Demo
* Head to Time Off > Management > Time Off

> Observation:
The request can only be approved.
Time Off Access Rights' tooltip specifiy that `A user without any rights on Time Off will be able to see the application, create his own holidays and manage the requests of the users he's manager of.`

opw-4725537
