### PR TITLE
[FIX] uom: prevent error on installing module

### DIFF
--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -16,8 +16,11 @@ class UomUom(models.Model):
     _order = "relative_uom_id, name, id"
 
     def _unprotected_uom_xml_ids(self):
+        """ Return a list of UoM XML IDs that are not protected by default.
+        Note: Some of these may be protected via overrides in other modules.
+        """
         return [
-            "product_uom_hour",  # NOTE: this uom is protected when hr_timesheet is installed.
+            "product_uom_hour",
             "product_uom_dozen",
             "product_uom_pack_6",
         ]


### PR DESCRIPTION
Steps to reproduce:
---
- Install `sale_management` module
- Enable `Units of Measure & Packagings`
- Delete `Hours` in Units & Packagings
- Install `sale_planning` module

Traceback:
---
```
ValueError: External ID not found in the system: uom.product_uom_hour

ParseError: while parsing /home/odoo/src/enterprise/saas-18.2/sale_planning/views/planning_role_views.xml:26, somewhere inside <record id="planning_role_view_tree_inherit_sale_planning" model="ir.ui.view">
        <field name="name">planning.role.list.inherit.sale.planning</field>
        <field name="model">planning.role</field>
        <field name="inherit_id" ref="planning.planning_role_view_tree"/>
        <field name="arch" type="xml">
            <field name="resource_ids" position="after">
                <field name="product_ids" widget="many2many_tags" placeholder="e.g. Cleaning Services" domain="[('planning_role_id', '=', False), ('type', '=', 'service'), ('sale_ok', '=', True)]" context="{                         'default_type': 'service',                         'default_planning_enabled': True,                         'default_planning_role_id': id,                         'default_uom_id': %(uom.product_uom_hour)d,                     }"/>
            </field>
        </field>
    </record>
```

The error occurred at [1] because the user deleted `Hours` from `Units & Packagings` before attempting to install the other module.

This commit resolves the issue by calling the `ensure_uom_hours` method before updating the "Hours" unit of measure in the data file. This method ensures the UoM is recreated if it no longer exists in the database.

Also restrict deletion of uom Hour in `sale_planning`.

[1]- https://github.com/odoo/enterprise/blob/adfa1ff2ee56b8d43666cd7c2565d6e9430aae48/sale_planning/views/planning_role_views.xml#L38

sentry-6595283261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
