### PR TITLE
[FIX] website: reapply adjust builder for edge

### DIFF
--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.js
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.js
@@ -28,6 +28,7 @@ import { ResourceEditor } from "@website/components/resource_editor/resource_edi
 import { isHTTPSorNakedDomainRedirection } from "./utils";
 import { WebsiteSystrayItem } from "./website_systray_item";
 import { renderToElement } from "@web/core/utils/render";
+import { isBrowserMicrosoftEdge } from "@web/core/browser/feature_detection";
 
 const websiteSystrayRegistry = registry.category("website_systray");
 
@@ -528,6 +529,10 @@ export class WebsiteBuilder extends Component {
     addListeners(target) {
         target.removeEventListener("keydown", this.onKeydownRefresh);
         target.addEventListener("keydown", this.onKeydownRefresh);
+    }
+
+    get isMicrosoftEdge() {
+        return isBrowserMicrosoftEdge();
     }
 }
 

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.scss
@@ -10,6 +10,24 @@
         .o_website_fullscreen & {
             width: 0;
         }
+
+        // Fix for Edge with 150% zoom: when entering edit mode, the page
+        // switches to mobile view because Edge adds extra border around the
+        // window, causing the width to fall below the mobile breakpoint. To
+        // prevent this, we reduce the sidebar width by 5px to keep the page in
+        // desktop view.
+        // TODO: In the next sidebar redesign, adjust the sidebar width properly
+        // to avoid this workaround.
+        &.o_is_microsoft_edge {
+            @media (min-resolution: 1.5dppx) and (max-resolution: 1.51dppx) {
+                $o-we-sidebar-width-for-edge: $o-we-sidebar-width - 5px;
+                width: $o-we-sidebar-width-for-edge;
+
+                .o-snippets-menu {
+                    width: $o-we-sidebar-width-for-edge;
+                }
+            }
+        }
     }
 
     .o_builder_open & {

--- a/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
+++ b/addons/website/static/src/client_actions/website_preview/website_builder_action.xml
@@ -15,7 +15,8 @@
             <ResourceEditor close="() => this.websiteContext.showResourceEditor = false"/>
         </ResizablePanel>
         <LocalOverlayContainer localOverlay="overlayRef" identifier="env.localOverlayContainerKey"/>
-        <div t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar}" class="o-website-builder_sidebar border-start border-dark">
+        <div t-att-class="{'o_builder_sidebar_open': state.isEditing and state.showSidebar, 'o_is_microsoft_edge': isMicrosoftEdge}"
+            class="o-website-builder_sidebar border-start border-dark">
             <LazyComponent  t-if="state.isEditing" Component="'website.Builder'" props="() => this.menuProps" bundle="'html_builder.assets'" t-key="state.key"/>
         </div>
     </div>


### PR DESCRIPTION
This commit follows the refactor into html_builder [1] which overwrote the fix for edge from commit [2].

Reduce the sidebar width in edit mode by 5 pixels to ensure the page stays in desktop view. This change is applied only if the browser is Edge and 150% zoom is used. In all other cases, no changes are made.

This commit reverts the overwrite and reapplies the changes.

[1]: https://github.com/odoo/odoo/commit/9fe45e2b7ddb
[2]: https://github.com/odoo/odoo/commit/9352520907508dffb39263676b5c6df2cfb201a1

Related to task-4367641
