### PR TITLE
[IMP] html_editor: merge and unmerge selected cells

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -16,6 +16,7 @@ import {
 } from "@html_editor/utils/base_container";
 import { DIRECTIONS } from "../utils/position";
 import { isHtmlContentSupported } from "./selection_plugin";
+import { getRowIndex } from "@html_editor/utils/table";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -62,6 +63,8 @@ export const CLIPBOARD_WHITELISTS = {
         "TBODY",
         "TR",
         "TD",
+        "COLGROUP",
+        "COL",
         // Miscellaneous
         "IMG",
         "BR",
@@ -94,8 +97,8 @@ export const CLIPBOARD_WHITELISTS = {
         /^btn/,
         /^fa/,
     ],
-    attributes: ["class", "href", "src", "target"],
-    styledTags: ["SPAN", "B", "STRONG", "I", "S", "U", "FONT", "TD"],
+    attributes: ["class", "href", "src", "target", "colspan", "rowspan"],
+    styledTags: ["SPAN", "B", "STRONG", "I", "S", "U", "FONT", "TD", "COL", "TR", "TH"],
 };
 
 const ONLY_LINK_REGEX = /^(https?:\/\/)?([\w-]+\.)+[\w-]+(\/[\w-./?%&=]*)?$/i;
@@ -501,7 +504,7 @@ export class ClipboardPlugin extends Plugin {
                 }
             }
         } else if (node.nodeType !== Node.TEXT_NODE) {
-            if (["TD", "TH"].includes(node.nodeName)) {
+            if (["TD", "TH", "COL"].includes(node.nodeName)) {
                 // Insert base container into empty TD.
                 if (isEmptyBlock(node)) {
                     const baseContainer = this.dependencies.baseContainer.createBaseContainer();
@@ -511,6 +514,10 @@ export class ClipboardPlugin extends Plugin {
 
                 if (node.hasAttribute("bgcolor") && !node.style["background-color"]) {
                     node.style["background-color"] = node.getAttribute("bgcolor");
+                }
+
+                if (node.hasAttribute("width")) {
+                    node.style["width"] = node.getAttribute("width") + "px";
                 }
             } else if (node.nodeName === "FONT") {
                 // FONT tags have some style information in custom attributes,
@@ -557,7 +564,25 @@ export class ClipboardPlugin extends Plugin {
                     CLIPBOARD_WHITELISTS.styledTags.includes(node.nodeName) &&
                     attribute.name === "style"
                 ) {
+                    const width = node.style.width;
+                    const height = node.style.height;
                     node.removeAttribute(attribute.name);
+                    if (["TD", "TH"].includes(node.nodeName) && getRowIndex(node) === 0 && width) {
+                        const table = closestElement(node, "table");
+                        let colgroup = table.querySelector("colgroup");
+                        if (!colgroup) {
+                            colgroup = this.document.createElement("colgroup");
+                            table.prepend(colgroup);
+                        }
+                        const col = this.document.createElement("col");
+                        colgroup.append(col);
+                        col.style.width = width;
+                    } else if (node.nodeName === "COL" && width) {
+                        node.style.width = width;
+                    }
+                    if (node.nodeName === "TR" && height) {
+                        node.style.height = height;
+                    }
                     if (["SPAN", "FONT"].includes(node.tagName)) {
                         for (const unwrappedNode of unwrapContents(node)) {
                             this.cleanForPaste(unwrappedNode);

--- a/addons/html_editor/static/src/main/table/table_drag_drop.js
+++ b/addons/html_editor/static/src/main/table/table_drag_drop.js
@@ -16,6 +16,7 @@ export class TableDragDrop extends Component {
         close: Function,
         moveRow: Function,
         moveColumn: Function,
+        tableGrid: Object,
     };
 
     setup() {
@@ -37,7 +38,7 @@ export class TableDragDrop extends Component {
         this.itemRects =
             this.props.type === "row"
                 ? [...this.tableElement.rows].map((r) => r.getBoundingClientRect())
-                : [...this.props.target.parentElement.cells].map((c) => c.getBoundingClientRect());
+                : [...this.props.tableGrid[0]].map((c) => c.getBoundingClientRect());
 
         useExternalListener(this.props.document, "pointermove", this.onPointerMove);
         useExternalListener(this.props.document, "pointerup", this.onPointerUp);
@@ -100,7 +101,38 @@ export class TableDragDrop extends Component {
 
         // Determine whether to insert before or after the target
         // Insert before if overlay middle is left, else after
-        return { targetIndex, insertBefore: overlayMiddle < targetMiddle };
+        return {
+            targetIndex,
+            insertBefore: overlayMiddle < targetMiddle,
+        };
+    }
+
+    getDropPosition() {
+        const { targetIndex, insertBefore } = this.getInsertPosition();
+        const { tableGrid, type } = this.props;
+        if (type === "row") {
+            const targetCell = tableGrid[targetIndex][0];
+            const referenceIndex = insertBefore
+                ? targetIndex
+                : tableGrid.map((row) => row[0]).lastIndexOf(targetCell);
+            const canDropRow = tableGrid[referenceIndex].every((cell, colIndex) => {
+                const column = tableGrid.map((row) => row[colIndex]);
+                const rowIndex = insertBefore ? column.indexOf(cell) : column.lastIndexOf(cell);
+                return rowIndex === referenceIndex;
+            });
+            return canDropRow ? { targetIndex: referenceIndex, insertBefore } : null;
+        } else {
+            const targetCell = tableGrid[0][targetIndex];
+            const referenceIndex = insertBefore
+                ? targetIndex
+                : tableGrid[0].lastIndexOf(targetCell);
+            const canDropColumn = tableGrid.every((row) => {
+                const cell = row[referenceIndex];
+                const rowIndex = insertBefore ? row.indexOf(cell) : row.lastIndexOf(cell);
+                return rowIndex === referenceIndex;
+            });
+            return canDropColumn ? { targetIndex: referenceIndex, insertBefore } : null;
+        }
     }
 
     onPointerMove(ev) {
@@ -126,17 +158,21 @@ export class TableDragDrop extends Component {
                 Math.max(min, this.overlayRect.left + ev.clientX - this.pointerPos.x)
             );
         }
-        this.clearBorderHighlights();
-        const { targetIndex, insertBefore } = this.getInsertPosition();
-        // Highlight the target row or column
-        if (this.props.type === "row") {
-            const targetRow = this.tableElement.rows[targetIndex];
-            targetRow.classList.add(insertBefore ? "tr-highlight-top" : "tr-highlight-bottom");
-        } else {
-            [...this.tableElement.rows].forEach((row) => {
-                const targetCell = row.cells[targetIndex];
-                targetCell.classList.add(insertBefore ? "td-highlight-left" : "td-highlight-right");
-            });
+        const dropPosition = this.getDropPosition();
+        if (dropPosition) {
+            this.clearBorderHighlights();
+            const { targetIndex, insertBefore } = dropPosition;
+            // Highlight the target row or column border
+            if (this.props.type === "row") {
+                const targetRow = this.tableElement.rows[targetIndex];
+                targetRow.classList.add(insertBefore ? "tr-highlight-top" : "tr-highlight-bottom");
+            } else {
+                // Apply highlight
+                this.props.tableGrid.forEach((row) => {
+                    const cell = row[targetIndex];
+                    cell.classList.add(insertBefore ? "td-highlight-left" : "td-highlight-right");
+                });
+            }
         }
         // Apply updated overlay position to the overlay element
         const overlayStyle = this.overlayRef.el.style;
@@ -149,24 +185,25 @@ export class TableDragDrop extends Component {
 
     onPointerUp() {
         this.clearBorderHighlights();
-
-        let { targetIndex, insertBefore } = this.getInsertPosition();
-        const draggedIndex =
-            this.props.type === "row"
-                ? getRowIndex(this.props.target.parentElement)
-                : getColumnIndex(this.props.target);
-        if (draggedIndex > targetIndex && !insertBefore) {
-            // Moving upward or leftward
-            targetIndex += 1;
-        } else if (draggedIndex < targetIndex && insertBefore) {
-            // Moving downward or rightward
-            targetIndex -= 1;
-        }
-
-        if (this.props.type === "row") {
-            this.props.moveRow(targetIndex, this.props.target.parentElement);
-        } else {
-            this.props.moveColumn(targetIndex, this.props.target);
+        const dropPosition = this.getDropPosition();
+        if (dropPosition) {
+            let { targetIndex, insertBefore } = dropPosition;
+            const draggedIndex =
+                this.props.type === "row"
+                    ? getRowIndex(this.props.target.parentElement)
+                    : getColumnIndex(this.props.target);
+            if (draggedIndex > targetIndex && !insertBefore) {
+                // Moving upward or leftward
+                targetIndex += 1;
+            } else if (draggedIndex < targetIndex && insertBefore) {
+                // Moving downward or rightward
+                targetIndex -= 1;
+            }
+            if (this.props.type === "row") {
+                this.props.moveRow(targetIndex, this.props.target.parentElement);
+            } else {
+                this.props.moveColumn(targetIndex, this.props.target);
+            }
         }
         // Close overlay after drop
         this.props.close();

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,7 +1,7 @@
 import { useExternalListener, useRef } from "@web/owl2/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component, onMounted, onWillUnmount } from "@odoo/owl";
-import { getColumnIndex, getRowIndex } from "@html_editor/utils/table";
+import { getColumnIndex, getRowIndex, getSelectedCellsMergeInfo } from "@html_editor/utils/table";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -24,8 +24,11 @@ export class TableMenu extends Component {
         resetColumnWidth: Function,
         resetTableSize: Function,
         clearColumnContent: Function,
+        mergeSelectedCells: Function,
+        unmergeSelectedCell: Function,
         clearRowContent: Function,
         toggleAlternatingRows: Function,
+        buildTableGrid: Function,
         overlay: Object,
         tableDragDropOverlay: Object,
         dropdownState: Object,
@@ -47,6 +50,8 @@ export class TableMenu extends Component {
             this.isLast = !tr.nextElementSibling;
             this.isTableHeader = [...tr.children][0].nodeName === "TH";
         }
+        this.editableDocument = this.props.editable.ownerDocument;
+        this.tableGrid = this.props.buildTableGrid(closestElement(this.props.target, "table"));
         this.items = this.props.type === "column" ? this.colItems() : this.rowItems();
         this.menuRef = useRef("menuRef");
         const onPointerDown = (ev) => this.onPointerDown(ev);
@@ -132,6 +137,11 @@ export class TableMenu extends Component {
 
     colItems() {
         const ltr = this.props.direction === "ltr";
+        const { canMerge, canUnmerge, cells, spanType } = getSelectedCellsMergeInfo(
+            this.editableDocument,
+            this.tableGrid,
+            this.props.target
+        );
         return [
             !this.isFirst && {
                 name: "move_left",
@@ -181,12 +191,31 @@ export class TableMenu extends Component {
                 text: _t("Clear content"),
                 action: this.props.clearColumnContent.bind(this),
             },
+            cells.length > 1 && {
+                name: "merge_cell",
+                icon: "fa fa-compress",
+                text: _t("Merge Cells"),
+                disable: !canMerge,
+                tooltip: _t("Only rows or cells selection can be merged"),
+                action: () => this.props.mergeSelectedCells(cells, spanType),
+            },
+            canUnmerge && {
+                name: "unmerge_cell",
+                icon: "fa fa-compress",
+                text: _t("Unmerge Cells"),
+                action: this.props.unmergeSelectedCell.bind(this),
+            },
         ].filter(Boolean);
     }
 
     rowItems() {
         const table = closestElement(this.props.target, "table");
         const hasAlternatingRowClass = table.classList.contains("o_alternating_rows");
+        const { canMerge, canUnmerge, cells, spanType } = getSelectedCellsMergeInfo(
+            this.editableDocument,
+            this.tableGrid,
+            this.props.target
+        );
         return [
             this.isFirst &&
                 !this.isTableHeader && {
@@ -259,6 +288,20 @@ export class TableMenu extends Component {
                 icon: "fa-times-circle",
                 text: _t("Clear content"),
                 action: (target) => this.props.clearRowContent(target.parentElement),
+            },
+            cells.length > 1 && {
+                name: "merge_cell",
+                icon: "fa fa-compress",
+                text: _t("Merge Cells"),
+                disable: !canMerge,
+                tooltip: _t("Only rows or cells selection can be merged"),
+                action: () => this.props.mergeSelectedCells(cells, spanType),
+            },
+            canUnmerge && {
+                name: "unmerge_cell",
+                icon: "fa fa-compress",
+                text: _t("Unmerge Cells"),
+                action: this.props.unmergeSelectedCell.bind(this),
             },
         ].filter(Boolean);
     }

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -1,7 +1,7 @@
 import { useExternalListener, useRef } from "@web/owl2/utils";
 import { closestElement } from "@html_editor/utils/dom_traversal";
 import { Component, onMounted, onWillUnmount } from "@odoo/owl";
-import { getColumnIndex, getRowIndex, getSelectedCellsMergeInfo } from "@html_editor/utils/table";
+import { getRowIndex, getSelectedCellsMergeInfo } from "@html_editor/utils/table";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
@@ -135,6 +135,26 @@ export class TableMenu extends Component {
         delete this.longPressTimer;
     }
 
+    isCurrentOrAdjacentCellRowSpanned(position) {
+        const td = this.props.target;
+        const tr = closestElement(td, "tr");
+        const rowIndex = getRowIndex(tr);
+        const adjacentRowIndex = position === "move_down" ? rowIndex + 1 : rowIndex - 1;
+        return (
+            this.tableGrid[rowIndex]?.some((cell) => cell?.rowSpan > 1) ||
+            this.tableGrid[adjacentRowIndex]?.some((cell) => cell?.rowSpan > 1)
+        );
+    }
+
+    isCurrentOrAdjacentCellColSpanned(position) {
+        const targetCell = this.props.target;
+        const columnIndex = this.tableGrid[0].indexOf(targetCell);
+        const adjacentIndex = position === "move_right" ? columnIndex + 1 : columnIndex - 1;
+        return this.tableGrid.some(
+            (row) => row[columnIndex]?.colSpan > 1 || row[adjacentIndex]?.colSpan > 1
+        );
+    }
+
     colItems() {
         const ltr = this.props.direction === "ltr";
         const { canMerge, canUnmerge, cells, spanType } = getSelectedCellsMergeInfo(
@@ -147,13 +167,19 @@ export class TableMenu extends Component {
                 name: "move_left",
                 icon: "fa-chevron-left disabled",
                 text: ltr ? _t("Move left") : _t("Move right"),
-                action: (target) => this.props.moveColumn(getColumnIndex(target) - 1, target),
+                action: (target) =>
+                    this.props.moveColumn(this.tableGrid[0].indexOf(target) - 1, target),
+                disable: this.isCurrentOrAdjacentCellColSpanned("move_left"),
+                tooltip: _t("Merged columns cannot be moved left or right."),
             },
             !this.isLast && {
                 name: "move_right",
                 icon: "fa-chevron-right",
                 text: ltr ? _t("Move right") : _t("Move left"),
-                action: (target) => this.props.moveColumn(getColumnIndex(target) + 1, target),
+                action: (target) =>
+                    this.props.moveColumn(this.tableGrid[0].indexOf(target) + 1, target),
+                disable: this.isCurrentOrAdjacentCellColSpanned("move_right"),
+                tooltip: _t("Merged columns cannot be moved left or right."),
             },
             {
                 name: "insert_left",
@@ -236,14 +262,18 @@ export class TableMenu extends Component {
                 icon: "fa-chevron-up",
                 text: _t("Move up"),
                 action: (target) =>
-                    this.props.moveRow(getRowIndex(target.parentElement) - 1, target.parentElement),
+                    this.props.moveRow(getRowIndex(target) - 1, target.parentElement),
+                disable: this.isCurrentOrAdjacentCellRowSpanned("move_up"),
+                tooltip: _t("Merged rows cannot be moved up or down."),
             },
             !this.isLast && {
                 name: "move_down",
                 icon: "fa-chevron-down",
                 text: _t("Move down"),
                 action: (target) =>
-                    this.props.moveRow(getRowIndex(target.parentElement) + 1, target.parentElement),
+                    this.props.moveRow(getRowIndex(target) + 1, target.parentElement),
+                disable: this.isCurrentOrAdjacentCellRowSpanned("move_down"),
+                tooltip: _t("Merged rows cannot be moved up or down."),
             },
             !this.isTableHeader && {
                 name: "insert_above",

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -5,7 +5,7 @@ import { getRowIndex, getSelectedCellsMergeInfo } from "@html_editor/utils/table
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { _t } from "@web/core/l10n/translation";
-import { isEmpty } from "@html_editor/utils/dom_info";
+import { isEmpty, isTableCell } from "@html_editor/utils/dom_info";
 import { getBaseContainerSelector } from "@html_editor/utils/base_container";
 
 export class TableMenu extends Component {
@@ -74,26 +74,33 @@ export class TableMenu extends Component {
             return false;
         }
         const rows = [...table.rows];
-        const firstRowCells = [...rows[0].cells];
         const rowHasHeight = rows.some((row) => row.style.height);
-        const cellHasWidth = firstRowCells.some((cell) => cell.style.width);
-        return rowHasHeight || cellHasWidth;
+        const colgroup = table.querySelector("colgroup");
+        return rowHasHeight || colgroup;
     }
 
-    get hasCustomSize() {
-        return this.props.type === "row"
-            ? !!this.props.target.parentElement.style?.height
-            : !!this.props.target.style?.width;
+    get hasCustomRowHeight() {
+        return !!closestElement(this.props.target, "tr")?.style.height;
+    }
+
+    get hasCustomColumnWidth() {
+        const table = closestElement(this.props.target, "table");
+        const index = this.tableGrid[0].indexOf(closestElement(this.props.target, isTableCell));
+        const colgroup = table.querySelector("colgroup");
+        if (colgroup) {
+            return colgroup.children[index]?.style.width;
+        }
+        return false;
     }
 
     get hasContent() {
         const baseContainerSelector = getBaseContainerSelector();
         const cell = this.props.target;
-        const table = closestElement(cell, "table");
+        const colIndex = this.tableGrid[0].indexOf(cell);
         const targetCells =
             this.props.type === "row"
                 ? [...cell.parentElement.children]
-                : [...table.rows].map((row) => row.cells[getColumnIndex(cell)]);
+                : this.tableGrid.map((row) => row[colIndex]);
         return targetCells.some((td) => {
             const { children } = td;
             return !(
@@ -213,17 +220,18 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: this.props.removeColumn.bind(this),
             },
-            this.hasCustomSize && {
+            this.hasCustomColumnWidth && {
                 name: "reset_column_size",
                 icon: "fa-table",
                 text: _t("Reset column size"),
-                action: (target) => this.props.resetColumnWidth(target.closest("td, th")),
+                action: (target) =>
+                    this.props.resetColumnWidth(closestElement(target, isTableCell)),
             },
             this.hasCustomTableSize && {
                 name: "reset_table_size",
                 icon: "fa-table",
                 text: _t("Reset table size"),
-                action: (target) => this.props.resetTableSize(target.closest("table")),
+                action: (target) => this.props.resetTableSize(closestElement(target, "table")),
             },
             this.hasContent && {
                 name: "clear_content",
@@ -315,17 +323,17 @@ export class TableMenu extends Component {
                 text: _t("Delete"),
                 action: (target) => this.props.removeRow(target.parentElement),
             },
-            this.hasCustomSize && {
+            this.hasCustomRowHeight && {
                 name: "reset_row_size",
                 icon: "fa-table",
                 text: _t("Reset row size"),
-                action: (target) => this.props.resetRowHeight(target.closest("tr")),
+                action: (target) => this.props.resetRowHeight(closestElement(target, "tr")),
             },
             this.hasCustomTableSize && {
                 name: "reset_table_size",
                 icon: "fa-table",
                 text: _t("Reset table size"),
-                action: (target) => this.props.resetTableSize(target.closest("table")),
+                action: (target) => this.props.resetTableSize(closestElement(target, "table")),
             },
             this.hasContent && {
                 name: "clear_content",

--- a/addons/html_editor/static/src/main/table/table_menu.js
+++ b/addons/html_editor/static/src/main/table/table_menu.js
@@ -110,20 +110,34 @@ export class TableMenu extends Component {
     }
 
     onPointerDown(ev) {
+        const target = this.props.target;
+        let hasMergedSpan = false;
+        if (this.props.type === "column") {
+            const colIndex = this.tableGrid[0].indexOf(target);
+            hasMergedSpan = this.tableGrid.some((row) => row[colIndex].colSpan > 1);
+        } else {
+            const colIndex = getRowIndex(target);
+            hasMergedSpan = this.tableGrid[colIndex].some((cell) => cell.rowSpan > 1);
+        }
+        // Do not allow drag-and-drop on merged cells
+        if (hasMergedSpan) {
+            return;
+        }
         this.longPressTimer = setTimeout(() => {
             this.props.overlay.close();
             // Open the TableDragDrop overlay.
             this.props.tableDragDropOverlay.open({
-                target: this.props.target,
+                target: target,
                 props: {
                     type: this.props.type,
                     pointerPos: { x: ev.clientX, y: ev.clientY },
-                    target: this.props.target,
+                    target: target,
                     document: this.props.document,
                     editable: this.props.editable,
                     close: () => this.props.tableDragDropOverlay.close(),
                     moveRow: this.props.moveRow,
                     moveColumn: this.props.moveColumn,
+                    tableGrid: this.tableGrid,
                 },
             });
         }, 200); // long press threshold

--- a/addons/html_editor/static/src/main/table/table_menu.xml
+++ b/addons/html_editor/static/src/main/table/table_menu.xml
@@ -12,8 +12,8 @@
             <t t-set-slot="content">
                 <div t-on-pointerdown.stop="() => {}">
                     <t t-foreach="this.items" t-as="item" t-key="item_index">
-                        <DropdownItem onSelected="() => this.onSelected(item)">
-                            <div class="user-select-none d-flex align-items-center" t-att-name="item.name">
+                        <DropdownItem onSelected="() => !item.disable and this.onSelected(item)">
+                            <div class="user-select-none d-flex align-items-center" t-att-name="item.name" t-att-title="item.disable ? item.tooltip : ''" t-att-class="item.disable ? 'disabled text-muted' : ''">
                                 <span t-if="item.icon"
                                     class="fa text-center"
                                     style="width:16px;"

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -139,7 +139,7 @@ export class TablePlugin extends Plugin {
         clean_for_save_processors: (root) => {
             this.deselectTable(root);
         },
-        normalize_processors: this.distributeTableColorsToAllCells.bind(this),
+        normalize_processors: this.normalizeTable.bind(this),
         clipboard_content_processors: this.processContentForClipboard.bind(this),
         targeted_nodes_processors: this.adjustTargetedNodes.bind(this),
         on_undone_handlers: () => {
@@ -349,19 +349,43 @@ export class TablePlugin extends Plugin {
      *
      * @param {Element} root
      */
-    distributeTableColorsToAllCells(root) {
-        [...root.querySelectorAll("table")]
-            .filter((table) => table.style["color"] || table.style["backgroundColor"])
-            .forEach((table) => {
-                const tds = table.querySelectorAll("td");
-                for (const td of tds) {
-                    td.style["color"] = td.style["color"] || table.style["color"];
-                    td.style["backgroundColor"] =
-                        td.style["backgroundColor"] || table.style["backgroundColor"];
+    normalizeTable(root) {
+        const tables = root.querySelectorAll("table");
+        for (const table of tables) {
+            const firstRow = table.rows[0];
+            let colgroup;
+            for (const cell of firstRow?.children || []) {
+                const width = cell.style.width;
+                if (!width) {
+                    continue;
                 }
-                table.style["color"] = "";
-                table.style["backgroundColor"] = "";
-            });
+                if (!colgroup) {
+                    colgroup = this.document.createElement("colgroup");
+                }
+                // Apply width to col
+                const col = this.document.createElement("col");
+                col.style.width = width;
+                colgroup.appendChild(col);
+                // Remove the inline width from the cell
+                cell.style.removeProperty("width");
+            }
+            if (colgroup) {
+                table.prepend(colgroup);
+            }
+
+            // --- Normalize table colors ---
+            const tableColor = table.style.color;
+            const tableBgColor = table.style.backgroundColor;
+
+            if (tableColor || tableBgColor) {
+                for (const td of table.querySelectorAll("td")) {
+                    td.style.color = td.style.color || tableColor;
+                    td.style.backgroundColor = td.style.backgroundColor || tableBgColor;
+                }
+                table.style.color = "";
+                table.style.backgroundColor = "";
+            }
+        }
     }
 
     createTable({ rows = 2, cols = 2 } = {}) {
@@ -406,20 +430,21 @@ export class TablePlugin extends Plugin {
             const referenceCellWidth = reference.style.width
                 ? parseFloat(reference.style.width)
                 : reference.clientWidth;
+
             // Temporarily set widths so proportions are respected.
-            const firstRowCells = [...table.rows[0].cells];
             let totalWidth = 0;
-            if (tableWidth) {
-                for (const cell of firstRowCells) {
-                    const width = parseFloat(cell.style.width);
-                    cell.style.width = width + "px";
+            const colgroup = table.querySelector("colgroup");
+            if (tableWidth && colgroup) {
+                for (const col of colgroup.children) {
+                    const width = parseFloat(col.style.width);
+                    col.style.width = width + "px";
                     // Spread the widths to preserve proportions.
                     // -1 for the width of the border of the new column.
                     const newWidth = Math.max(
                         Math.round((width * tableWidth) / (tableWidth + referenceCellWidth - 1)),
                         13
                     );
-                    cell.style.width = newWidth + "px";
+                    col.style.width = newWidth + "px";
                     totalWidth += newWidth;
                 }
             }
@@ -460,16 +485,23 @@ export class TablePlugin extends Plugin {
                     }
                 }
             }
-            if (tableWidth) {
-                if (totalWidth !== tableWidth - 1) {
-                    // -1 for the width of the border of the new column.
-                    firstRowCells[firstRowCells.length - 1].style.width =
-                        parseFloat(firstRowCells[firstRowCells.length - 1].style.width) +
-                        (tableWidth - totalWidth - 1) +
-                        "px";
+            if (colgroup) {
+                const newcol = document.createElement("col");
+                const children = colgroup.children;
+                const currentCol = children[gridCellIndex];
+                newcol.style.width = currentCol.style.width;
+                totalWidth += parseFloat(newcol.style.width);
+                if (tableWidth) {
+                    if (totalWidth !== tableWidth - 1) {
+                        // -1 for the width of the border of the new column.
+                        const lastCol = colgroup.children[colgroup.children.length - 1];
+                        lastCol.style.width =
+                            parseFloat(lastCol.style.width) + (tableWidth - totalWidth - 1) + "px";
+                    }
+                    // Fix the table and row's width so it doesn't change.
+                    table.style.width = tableWidth + "px";
                 }
-                // Fix the table and row's width so it doesn't change.
-                table.style.width = tableWidth + "px";
+                currentCol[position](newcol);
             }
         }
         this.tableGridMap.delete(table);
@@ -491,6 +523,7 @@ export class TablePlugin extends Plugin {
                 newRow.style.height = referenceRowHeight + "px";
             }
             const gridCells = tableGrid[rowIndex];
+            const referenceRowWidths = [...gridCells].map((cell) => cell.style.width);
 
             for (let columnIndex = 0; columnIndex < gridCells.length; columnIndex++) {
                 const cell = gridCells[columnIndex];
@@ -513,10 +546,11 @@ export class TablePlugin extends Plugin {
             reference[position](newRow);
             // Preserve the width of the columns (applied only on the first row).
             if (getRowIndex(newRow) === 0) {
-                for (let columnIndex = 0; columnIndex < reference.cells.length; columnIndex++) {
-                    newRow.cells[columnIndex].style.width =
-                        reference.cells[columnIndex].style.width;
-                    reference.cells[columnIndex].style.width = "";
+                let columnIndex = 0;
+                for (const column of newRow.children) {
+                    column.style.width = referenceRowWidths[columnIndex];
+                    gridCells[columnIndex].style.width = "";
+                    columnIndex++;
                 }
             }
         }
@@ -555,6 +589,7 @@ export class TablePlugin extends Plugin {
      */
     removeColumn(cell) {
         const table = closestElement(cell, "table");
+        const colgroup = table.querySelector("colgroup");
         const tableGrid = this.buildTableGrid(table);
         const rowIndex = getRowIndex(cell);
         const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
@@ -579,6 +614,10 @@ export class TablePlugin extends Plugin {
                 td.remove();
             }
         });
+        if (colgroup) {
+            const children = colgroup.children;
+            children[gridCellIndex].remove();
+        }
         // not sure we should move the cursor?
         siblingCell
             ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingCell))
@@ -658,6 +697,13 @@ export class TablePlugin extends Plugin {
                 index += moveStep;
             }
         });
+        const colgroup = table.querySelector("colgroup");
+        if (colgroup) {
+            const cols = colgroup.children;
+            insertBefore
+                ? cols[targetIndex].before(cols[columnIndex])
+                : cols[targetIndex].after(cols[columnIndex]);
+        }
         this.dependencies.selection.setSelection(selectionToRestore);
         this.tableGridMap.delete(table);
     }
@@ -691,11 +737,6 @@ export class TablePlugin extends Plugin {
         const newFirstRow = table.rows[0];
         // If the moved row becomes the first row
         if (newFirstRow !== oldFirstRow) {
-            // Copy the widths of its td elements from the previous
-            // first row, as td widths are only applied to the first row.
-            [...newFirstRow.cells].forEach((cell, i) => {
-                cell.style.width = oldFirstRow.cells[i].style.width || "";
-            });
             // Maintain header row at top position.
             if (isHeader) {
                 this.turnIntoHeader(newFirstRow);
@@ -736,17 +777,26 @@ export class TablePlugin extends Plugin {
      * @param {HTMLTableElement} table
      */
     normalizeColumnWidth(table) {
-        const rows = [...table.rows];
-        const firstRowCells = [...rows[0].cells];
-        const tableWidth = parseFloat(table.style.width);
-        if (tableWidth) {
-            const expectedCellWidth = tableWidth / firstRowCells.length;
-            firstRowCells.forEach((cell, i) => {
-                const cellWidth = parseFloat(cell.style.width);
-                if (cellWidth && Math.abs(cellWidth - expectedCellWidth) <= 1) {
-                    rows.forEach((row) => (row.cells[i].style.width = ""));
+        const colgroup = table.querySelector("colgroup");
+        if (colgroup) {
+            const columns = Array.from(colgroup.children);
+            const tableWidth = parseFloat(table.style.width);
+            if (tableWidth) {
+                const expectedColWidth = tableWidth / columns.length;
+                const columnsToReset = columns.filter((col) => {
+                    const colWidth = parseFloat(col.style.width) || col.clientWidth;
+                    return colWidth && Math.abs(colWidth - expectedColWidth) <= 1;
+                });
+                // If all columns are default, remove the <colgroup> entirely
+                if (columnsToReset.length === columns.length) {
+                    colgroup.remove();
+                } else {
+                    // Otherwise, reset only the columns that need it
+                    columnsToReset.forEach((col) => {
+                        col.style.width = "";
+                    });
                 }
-            });
+            }
         }
     }
 
@@ -754,75 +804,73 @@ export class TablePlugin extends Plugin {
      * @param {HTMLTableCellElement} cell
      */
     resetColumnWidth(cell) {
-        const currentCellWidth = parseFloat(cell.style.width);
-        if (!currentCellWidth) {
+        const table = closestElement(cell, "table");
+        const colgroup = table.querySelector("colgroup");
+        if (!colgroup) {
             return;
         }
+        const tableWidth = parseFloat(table.style.width) || table.clientWidth;
+        const colElements = Array.from(colgroup.children);
+        const totalCols = colElements.length;
+        const expectedColWidth = tableWidth / totalCols;
 
-        const table = closestElement(cell, "table");
-        const tableWidth = parseFloat(table.style.width);
-        const currentRow = cell.parentElement;
-        const currentRowCells = [...currentRow.cells];
-        const rowCellCount = currentRowCells.length;
-        const expectedCellWidth = tableWidth / rowCellCount;
-        const widthDifference = currentCellWidth - expectedCellWidth;
-        const currentColumnIndex = getColumnIndex(cell);
+        const tableGrid = this.buildTableGrid(table);
+        const cellColIndex = tableGrid[0].indexOf(cell);
+        const cellColSpan = cell.colSpan;
 
-        let totalWidthLeftOfCell = 0,
-            totalWidthRightOfCell = 0;
-        currentRowCells.forEach((rowCell, i) => {
-            const cellWidth = parseFloat(rowCell.style.width) || rowCell.clientWidth;
-            if (i < currentColumnIndex) {
-                totalWidthLeftOfCell += cellWidth;
-            } else if (i > currentColumnIndex) {
-                totalWidthRightOfCell += cellWidth;
+        const getColWidth = (col) => parseFloat(col.style.width) || col.clientWidth;
+
+        const targetCols = colElements.slice(cellColIndex, cellColIndex + cellColSpan);
+        const leftCols = colElements.slice(0, cellColIndex);
+        const rightCols = colElements.slice(cellColIndex + cellColSpan);
+
+        const currentTargetWidth = targetCols.reduce((sum, col) => sum + getColWidth(col), 0);
+        let remainingLeftWidth = leftCols.reduce((sum, col) => sum + getColWidth(col), 0);
+        let remainingRightWidth = rightCols.reduce((sum, col) => sum + getColWidth(col), 0);
+        let expectedLeftColWidth = leftCols.length * expectedColWidth;
+        let expectedRightColWidth = rightCols.length * expectedColWidth;
+        const widthDifference = currentTargetWidth - expectedColWidth * cellColSpan;
+
+        let colsToAdjust = [];
+        for (const col of [...leftCols].reverse()) {
+            if (Math.abs(expectedLeftColWidth - remainingLeftWidth) <= 1) {
+                break;
             }
-        });
-
-        let expectedWidthLeftOfCell = currentColumnIndex * expectedCellWidth;
-        let expectedWidthRightOfCell = (rowCellCount - 1 - currentColumnIndex) * expectedCellWidth;
-        let cellsToAdjust = [];
-        for (
-            let i = currentColumnIndex - 1;
-            i >= 0 && Math.abs(expectedWidthLeftOfCell - totalWidthLeftOfCell) > 1;
-            i--
-        ) {
-            cellsToAdjust.push(currentRowCells[i]);
-            totalWidthLeftOfCell -=
-                parseFloat(currentRowCells[i].style.width) || currentRowCells[i].clientWidth;
-            expectedWidthLeftOfCell -= expectedCellWidth;
+            colsToAdjust.push(col);
+            expectedLeftColWidth -= expectedColWidth;
+            remainingLeftWidth -= getColWidth(col);
         }
-        for (
-            let j = currentColumnIndex + 1;
-            j < rowCellCount && Math.abs(expectedWidthRightOfCell - totalWidthRightOfCell) > 1;
-            j++
-        ) {
-            cellsToAdjust.push(currentRowCells[j]);
-            totalWidthRightOfCell -=
-                parseFloat(currentRowCells[j].style.width) || currentRowCells[j].clientWidth;
-            expectedWidthRightOfCell -= expectedCellWidth;
+        for (const col of rightCols) {
+            if (Math.abs(expectedRightColWidth - remainingRightWidth) <= 1) {
+                break;
+            }
+            colsToAdjust.push(col);
+            expectedRightColWidth -= expectedColWidth;
+            remainingRightWidth -= getColWidth(col);
         }
 
-        cellsToAdjust = cellsToAdjust.filter((adjCell) => {
-            const cellWidth = parseFloat(adjCell.style.width) || adjCell.clientWidth;
+        colsToAdjust = colsToAdjust.filter((adjCol) => {
+            const cellWidth = getColWidth(adjCol);
             return widthDifference > 0
-                ? cellWidth < expectedCellWidth
-                : cellWidth > expectedCellWidth;
+                ? cellWidth < expectedColWidth
+                : cellWidth > expectedColWidth;
         });
 
-        const totalWidthForAdjustment = cellsToAdjust.reduce((width, adjCell) => {
-            const cellWidth = parseFloat(adjCell.style.width) || adjCell.clientWidth;
-            return width + Math.abs(expectedCellWidth - cellWidth);
+        const totalWidthForAdjustment = colsToAdjust.reduce((width, adjCol) => {
+            const cellWidth = getColWidth(adjCol);
+            return width + Math.abs(expectedColWidth - cellWidth);
         }, 0);
 
-        cell.style.width = `${expectedCellWidth}px`;
-        cellsToAdjust.forEach((adjCell) => {
-            const adjCellWidth = parseFloat(adjCell.style.width) || adjCell.clientWidth;
+        targetCols.forEach((col) => {
+            col.style.width = `${expectedColWidth}px`;
+        });
+        colsToAdjust.forEach((adjCol) => {
+            const adjColWidth = parseFloat(adjCol.style.width) || adjCol.clientWidth;
             const adjustmentWidth =
-                (Math.abs(expectedCellWidth - adjCellWidth) / totalWidthForAdjustment) *
+                (Math.abs(expectedColWidth - adjColWidth) / totalWidthForAdjustment) *
                 Math.abs(widthDifference);
-            adjCell.style.width = `${
-                adjCellWidth + (widthDifference > 0 ? adjustmentWidth : -adjustmentWidth)
+            adjCol.style.width = `${
+                adjColWidth + (widthDifference > 0 ? adjustmentWidth : -adjustmentWidth)
             }px`;
         });
         this.normalizeColumnWidth(table);
@@ -833,15 +881,10 @@ export class TablePlugin extends Plugin {
      */
     resetTableSize(table) {
         table.removeAttribute("style");
-        const cells = [...table.querySelectorAll("tr, td, th")];
-        cells.forEach((cell) => {
-            const cStyle = cell.style;
-            if (cell.tagName === "TR") {
-                cStyle.height = "";
-            } else {
-                cStyle.width = "";
-            }
+        table.querySelectorAll("tr").forEach((row) => {
+            row.style.height = "";
         });
+        table.querySelector("colgroup")?.remove();
     }
     /**
      * @param {HTMLTableCellElement} cell
@@ -905,7 +948,6 @@ export class TablePlugin extends Plugin {
             spanAttr,
             tds.reduce((total, td) => total + td[spanAttr], 0)
         );
-
         for (let i = 1; i < tds.length; i++) {
             const currentTd = tds[i];
             if (currentTd.textContent.trim() !== "") {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1070,25 +1070,20 @@ export class TablePlugin extends Plugin {
      * @param {KeyboardEvent} ev
      */
     updateTableKeyboardSelection(ev) {
-        const selection = this.dependencies.selection.getSelectionData().deepEditableSelection;
-        const startTable = closestElement(selection.anchorNode, "table");
-        const endTable = closestElement(selection.focusNode, "table");
+        const { anchorNode, anchorOffset, focusNode, focusOffset, direction } =
+            this.dependencies.selection.getSelectionData().deepEditableSelection;
+        const startTable = closestElement(anchorNode, "table");
+        const endTable = closestElement(focusNode, "table");
         if (!(startTable || endTable)) {
             return;
         }
-        const [startTd, endTd] = [
-            closestElement(selection.anchorNode, isTableCell),
-            closestElement(selection.focusNode, isTableCell),
-        ];
         if (startTable !== endTable) {
             // Deselect the table if it was fully selected.
             if (endTable) {
                 const deselectingBackward =
-                    ["ArrowLeft", "ArrowUp"].includes(ev.key) &&
-                    selection.direction === DIRECTIONS.RIGHT;
+                    ["ArrowLeft", "ArrowUp"].includes(ev.key) && direction === DIRECTIONS.RIGHT;
                 const deselectingForward =
-                    ["ArrowRight", "ArrowDown"].includes(ev.key) &&
-                    selection.direction === DIRECTIONS.LEFT;
+                    ["ArrowRight", "ArrowDown"].includes(ev.key) && direction === DIRECTIONS.LEFT;
                 let targetNode;
                 if (deselectingBackward) {
                     targetNode = endTable.previousElementSibling;
@@ -1098,8 +1093,8 @@ export class TablePlugin extends Plugin {
                 if (targetNode) {
                     ev.preventDefault();
                     this.dependencies.selection.setSelection({
-                        anchorNode: selection.anchorNode,
-                        anchorOffset: selection.anchorOffset,
+                        anchorNode,
+                        anchorOffset,
                         focusNode: targetNode,
                         focusOffset: deselectingBackward ? nodeSize(targetNode) : 0,
                     });
@@ -1107,9 +1102,13 @@ export class TablePlugin extends Plugin {
             }
             return;
         }
+
+        const [startTd, endTd] = [
+            closestElement(anchorNode, "td, th"),
+            closestElement(focusNode, "td, th"),
+        ];
         // Handle selection for the single cell.
         if (startTd === endTd && !startTd.classList.contains("o_selected_td")) {
-            const { focusNode } = selection;
             // Do not prevent default when there is a text in cell.
             if (
                 !(ev.ctrlKey && ["ArrowUp", "ArrowDown"].includes(ev.key)) &&
@@ -1138,46 +1137,84 @@ export class TablePlugin extends Plugin {
             }
             return;
         }
-        // Select cells symmetrically.
-        const endCellPosition = { x: getRowIndex(endTd), y: getColumnIndex(endTd) };
-        const tds = [...startTable.rows].map((row) => [...row.cells]);
-        let targetTd, targetNode;
+
+        const tableGrid = this.buildTableGrid(startTable);
+        const endRowIndex = getRowIndex(endTd);
+        const endColIndex = tableGrid[endRowIndex].indexOf(endTd);
+        if (endColIndex < 0) {
+            return;
+        }
+        // Handle selection for multiple cells.
+        let targetNode = endTd;
+        let targetOffset = nodeSize(targetNode);
+        const isAtStart = focusOffset === 0;
+        const lastRow = tableGrid.length - 1;
+        const lastCol = tableGrid[0]?.length - 1;
+        const hasRowSpan = endTd.hasAttribute("rowspan");
+        const hasColSpan = endTd.hasAttribute("colspan");
         switch (ev.key) {
             case "ArrowUp": {
-                if (endCellPosition.x > 0) {
-                    targetTd = tds[endCellPosition.x - 1][endCellPosition.y];
+                if (endRowIndex > 0 && (isAtStart || !hasRowSpan)) {
+                    targetNode = tableGrid[endRowIndex - 1][endColIndex];
+                    if (targetNode?.rowSpan > 1) {
+                        targetNode = tableGrid[endRowIndex - targetNode.rowSpan]?.[endColIndex];
+                    }
+                    targetOffset = nodeSize(targetNode);
+                } else if (!isAtStart && hasRowSpan) {
+                    targetOffset = 0;
                 } else {
                     targetNode = previousLeaf(startTable, this.editable);
                 }
                 break;
             }
             case "ArrowDown": {
-                if (endCellPosition.x < tds.length - 1) {
-                    targetTd = tds[endCellPosition.x + 1][endCellPosition.y];
+                if (endRowIndex < lastRow && (!isAtStart || !hasRowSpan)) {
+                    targetNode = tableGrid[endRowIndex + 1][endColIndex];
+                    if (targetNode?.rowSpan > 1 && !isAtStart) {
+                        targetNode =
+                            tableGrid[endRowIndex + targetNode.rowSpan]?.[endColIndex] ||
+                            targetNode;
+                    }
+                    targetOffset = 0;
+                } else if (isAtStart && hasRowSpan) {
+                    targetOffset = nodeSize(targetNode);
                 } else {
                     targetNode = nextLeaf(startTable, this.editable);
                 }
                 break;
             }
             case "ArrowRight": {
-                if (endCellPosition.y < tds[0].length - 1) {
-                    targetTd = tds[endCellPosition.x][endCellPosition.y + 1];
+                if (endColIndex < lastCol && (!isAtStart || !hasColSpan)) {
+                    targetNode = tableGrid[endRowIndex][endColIndex + 1];
+                    if (targetNode?.colSpan > 1 && !isAtStart) {
+                        targetNode =
+                            tableGrid[endRowIndex][endColIndex + targetNode.colSpan] || targetNode;
+                    }
+                    targetOffset = 0;
+                } else if (isAtStart && hasColSpan) {
+                    targetOffset = nodeSize(targetNode);
                 }
                 break;
             }
             case "ArrowLeft": {
-                if (endCellPosition.y > 0) {
-                    targetTd = tds[endCellPosition.x][endCellPosition.y - 1];
+                if (endColIndex > 0 && (isAtStart || !hasColSpan)) {
+                    targetNode = tableGrid[endRowIndex][endColIndex - 1];
+                    if (targetNode?.colSpan > 1) {
+                        targetNode = tableGrid[endRowIndex][endColIndex - targetNode.colSpan];
+                    }
+                    targetOffset = nodeSize(targetNode);
+                } else if (!isAtStart || hasColSpan) {
+                    targetOffset = 0;
                 }
                 break;
             }
         }
-        if (targetTd || targetNode) {
+        if (targetNode) {
             this.dependencies.selection.setSelection({
-                anchorNode: selection.anchorNode,
-                anchorOffset: selection.anchorOffset,
-                focusNode: targetTd || targetNode,
-                focusOffset: 0,
+                anchorNode,
+                anchorOffset,
+                focusNode: targetNode,
+                focusOffset: targetOffset,
             });
         }
         ev.preventDefault();
@@ -1479,10 +1516,20 @@ export class TablePlugin extends Plugin {
             [selection.endContainer, ...ancestors(selection.endContainer, this.editable)].find(
                 (node) => isTableCell(node) && closestElement(node, "table") === table
             ) || columns[columns.length - 1];
-        const [startRow, endRow] = [closestElement(startCol, "tr"), closestElement(endCol, "tr")];
-        const [startRowIndex, endRowIndex] = [getRowIndex(startRow), getRowIndex(endRow)];
-        const startColIndex = tableGrid[startRowIndex].indexOf(startCol);
-        const endColIndex = tableGrid[endRowIndex].indexOf(endCol);
+        const startRowIndex =
+            getRowIndex(startCol) + (selection.startOffset > 0 ? startCol.rowSpan - 1 : 0);
+
+        const endRowIndex =
+            getRowIndex(endCol) + (selection.endOffset > 0 ? endCol.rowSpan - 1 : 0);
+
+        const startColIndex =
+            selection.startOffset > 0
+                ? tableGrid[startRowIndex].lastIndexOf(startCol)
+                : tableGrid[startRowIndex].indexOf(startCol);
+        const endColIndex =
+            selection.endOffset > 0
+                ? tableGrid[endRowIndex].lastIndexOf(endCol)
+                : tableGrid[endRowIndex].indexOf(endCol);
         const [minRowIndex, maxRowIndex] = [
             Math.min(startRowIndex, endRowIndex),
             Math.max(startRowIndex, endRowIndex),

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -64,6 +64,9 @@ function isUnremovableTableComponent(node, root) {
  * @property { TablePlugin['clearColumnContent'] } clearColumnContent
  * @property { TablePlugin['clearRowContent'] } clearRowContent
  * @property { TablePlugin['toggleAlternatingRows'] } toggleAlternatingRows
+ * @property { TablePlugin['mergeSelectedCells'] } mergeSelectedCells
+ * @property { TablePlugin['unmergeSelectedCell'] } unmergeSelectedCell
+ * @property { TablePlugin['buildTableGrid'] } buildTableGrid
  */
 
 /**
@@ -101,6 +104,9 @@ export class TablePlugin extends Plugin {
         "clearColumnContent",
         "clearRowContent",
         "toggleAlternatingRows",
+        "mergeSelectedCells",
+        "unmergeSelectedCell",
+        "buildTableGrid",
     ];
     /** @type {import("plugins").EditorResources} */
     resources = {
@@ -136,6 +142,12 @@ export class TablePlugin extends Plugin {
         normalize_processors: this.distributeTableColorsToAllCells.bind(this),
         clipboard_content_processors: this.processContentForClipboard.bind(this),
         targeted_nodes_processors: this.adjustTargetedNodes.bind(this),
+        on_undone_handlers: () => {
+            delete this.tableGridMap;
+        },
+        on_redone_handlers: () => {
+            delete this.tableGridMap;
+        },
 
         /** Overrides */
         tab_overrides: withSequence(20, this.handleTab.bind(this)),
@@ -480,16 +492,12 @@ export class TablePlugin extends Plugin {
         const preserveSelection = this.dependencies.selection.preserveSelection();
         [...reference.children].forEach((td) => {
             if (td.nodeName == "TD") {
-                const th = this.document.createElement("th");
-                if (td.style?.cssText.length) {
-                    th.style.cssText = td.style?.cssText;
-                }
+                const th = this.dependencies.dom.setTagName(td, "th");
                 th.classList.add("o_table_header");
-                th.append(...td.childNodes);
-                td.replaceWith(th);
             }
         });
         preserveSelection.restore();
+        this.tableGridMap?.delete(closestElement(reference, "table"));
     }
     /**
      * @param {HTMLTableRowElement} reference
@@ -498,15 +506,12 @@ export class TablePlugin extends Plugin {
         const preserveSelection = this.dependencies.selection.preserveSelection();
         [...reference.children].forEach((th) => {
             if (th.nodeName == "TH") {
-                const td = this.document.createElement("td");
-                if (th.style?.cssText.length) {
-                    td.style.cssText = th.style?.cssText;
-                }
-                td.append(...th.childNodes);
-                th.replaceWith(td);
+                th.classList.remove("o_table_header");
+                this.dependencies.dom.setTagName(th, "td");
             }
         });
         preserveSelection.restore();
+        this.tableGridMap?.delete(closestElement(reference, "table"));
     }
     /**
      * @param {HTMLTableCellElement} cell
@@ -784,6 +789,91 @@ export class TablePlugin extends Plugin {
         table.before(baseContainer);
         table.remove();
         this.dependencies.selection.setCursorStart(baseContainer);
+    }
+
+    /**
+     * Merges the given list of <td> elements by applying rowspan or colspan,
+     * moving their content into the first cell, and removing the rest.
+     *
+     * @param {HTMLTableCellElement[]} tds - The cells to merge.
+     * @param {"rowSpan" | "colSpan"} spanAttr - The attribute to apply for merging.
+     */
+    mergeSelectedCells(tds, spanAttr) {
+        if (!spanAttr || tds.length === 0) {
+            return;
+        }
+        const firstTd = tds[0];
+        firstTd.setAttribute(
+            spanAttr,
+            tds.reduce((total, td) => total + td[spanAttr], 0)
+        );
+
+        for (let i = 1; i < tds.length; i++) {
+            const currentTd = tds[i];
+            if (currentTd.textContent.trim() !== "") {
+                firstTd.append(...currentTd.childNodes);
+            }
+            currentTd.remove();
+        }
+        this.dependencies.selection.setSelection({
+            anchorNode: firstTd.firstChild,
+            anchorOffset: 0,
+            focusNode: firstTd.lastChild,
+            focusOffset: nodeSize(firstTd.lastChild),
+        });
+        this.tableGridMap.delete(closestElement(firstTd, "table"));
+    }
+
+    /**
+     * Splits a merged table cell (using either `rowspan` or `colspan`) back
+     * into individual cells by inserting new empty `<td>` elements
+     */
+    unmergeSelectedCell() {
+        const selectedCells = Array.from(this.editable.querySelectorAll(".o_selected_td"));
+        const { anchorNode, isCollapsed } = this.dependencies.selection.getEditableSelection();
+        if (isCollapsed && anchorNode && closestElement(anchorNode, isTableCell)) {
+            selectedCells.push(closestElement(anchorNode, isTableCell));
+        }
+        if (!selectedCells.length) {
+            return;
+        }
+        for (const cell of selectedCells) {
+            if (cell.hasAttribute("rowspan")) {
+                let tr = closestElement(cell, "tr");
+                const colIndex = getColumnIndex(cell);
+                for (let i = 1; i < cell.rowSpan; i++) {
+                    const nextTr = tr.nextElementSibling;
+                    if (nextTr) {
+                        const newTd = this.document.createElement("td");
+                        const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                        fillEmpty(baseContainer);
+                        newTd.append(baseContainer);
+                        const targetTd = nextTr.childNodes[colIndex];
+                        if (targetTd) {
+                            nextTr.insertBefore(newTd, targetTd);
+                        } else {
+                            nextTr.appendChild(newTd);
+                        }
+                        tr = nextTr;
+                    }
+                }
+                cell.removeAttribute("rowspan");
+            } else if (cell.hasAttribute("colspan")) {
+                for (let i = 1; i < cell.colSpan; i++) {
+                    const newCell = this.document.createElement(cell.nodeName);
+                    if (cell.classList.contains("o_table_header")) {
+                        newCell.classList.add("o_table_header");
+                    }
+                    const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                    fillEmpty(baseContainer);
+                    newCell.append(baseContainer);
+                    cell.after(newCell);
+                }
+                cell.removeAttribute("colspan");
+            }
+        }
+        this.tableGridMap.delete(closestElement(selectedCells[0], "table"));
+        this.updateSelectionTable(this.dependencies.selection.getSelectionData());
     }
 
     // @todo @phoenix: handle deleteBackward on table cells
@@ -1556,5 +1646,54 @@ export class TablePlugin extends Plugin {
         }
         this.deselectTable(clonedContents);
         return clonedContents;
+    }
+
+    /**
+     * Builds and returns a 2D grid representing the structure of the given table.
+     * Each cell in the grid corresponds to a <td> or <th> element, taking into
+     * account their rowspan and colspan.
+     *
+     * @param {HTMLTableElement} table - The table element to process.
+     * @returns {HTMLTableCellElement[][] | undefined} A 2D array representing
+     *          the table grid, or undefined if no table is provided.
+     */
+    buildTableGrid(table) {
+        if (!table) {
+            return;
+        }
+        this.tableGridMap ??= new WeakMap();
+        const tableGrid = this.tableGridMap.get(table);
+        if (tableGrid) {
+            return tableGrid;
+        }
+        const grid = [];
+        const rows = [...table.rows];
+        for (let rowIndex = 0; rowIndex < rows.length; rowIndex++) {
+            const row = rows[rowIndex];
+            grid[rowIndex] = grid[rowIndex] || [];
+            let colIndex = 0;
+
+            for (const cell of [...row.cells]) {
+                while (grid[rowIndex][colIndex]) {
+                    colIndex++;
+                }
+
+                const rowspan = cell.rowSpan || 1;
+                const colspan = cell.colSpan || 1;
+
+                for (let r = 0; r < rowspan; r++) {
+                    const targetRow = rowIndex + r;
+                    grid[targetRow] = grid[targetRow] || [];
+                    for (let c = 0; c < colspan; c++) {
+                        const targetCol = colIndex + c;
+                        grid[targetRow][targetCol] = cell;
+                    }
+                }
+
+                colIndex += colspan;
+            }
+        }
+        this.tableGridMap.set(table, grid);
+        return grid;
     }
 }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -633,24 +633,33 @@ export class TablePlugin extends Plugin {
      * @param {HTMLTableCellElement} cell
      */
     moveColumn(targetIndex, cell) {
-        const columnIndex = getColumnIndex(cell);
+        const table = closestElement(cell, "table");
+        const tableGrid = this.buildTableGrid(table);
+        const columnIndex = tableGrid[0].indexOf(cell);
         const nColumns = cell.parentElement.children.length;
         if (targetIndex < 0 || targetIndex >= nColumns || targetIndex === columnIndex) {
             return;
         }
 
+        const tdsToMove = new Set([...tableGrid].map((tr) => tr[columnIndex]));
         const selectionToRestore = this.dependencies.selection.getEditableSelection();
-        [...cell.parentElement.parentElement.children].map((tr) => {
-            const tdToMove = tr.children[columnIndex];
-            const targetTd = tr.children[targetIndex];
-            if (targetIndex < columnIndex) {
-                targetTd.before(tdToMove);
-            } else {
-                targetTd.after(tdToMove);
+        const insertBefore = targetIndex < columnIndex;
+        tdsToMove.forEach((td) => {
+            const rowIndex = getRowIndex(td);
+            const row = tableGrid[rowIndex];
+            const moveStep = insertBefore ? 1 : -1;
+            let index = targetIndex;
+            while (index !== columnIndex) {
+                const cell = row[index];
+                if (cell && getRowIndex(cell) === rowIndex) {
+                    insertBefore ? cell.before(td) : cell.after(td);
+                    break;
+                }
+                index += moveStep;
             }
         });
-
         this.dependencies.selection.setSelection(selectionToRestore);
+        this.tableGridMap.delete(table);
     }
 
     /**
@@ -694,6 +703,7 @@ export class TablePlugin extends Plugin {
             }
         }
         this.dependencies.selection.setSelection(selectionToRestore);
+        this.tableGridMap?.delete(closestElement(row, "table"));
     }
 
     /**

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -393,13 +393,19 @@ export class TablePlugin extends Plugin {
      */
     addColumn(position, reference, columnsToAdd = 1) {
         const table = closestElement(reference, "table");
+        const rows = table.rows;
         const tableWidth = table.style.width && parseFloat(table.style.width);
+        const tableGrid = this.buildTableGrid(table);
+        const referenceRowIndex = getRowIndex(reference);
+        const sholdInsertAfter = position === "after";
         for (let columnOffset = 0; columnOffset < columnsToAdd; columnOffset++) {
-            const columnIndex = getColumnIndex(reference);
+            const rowGrid = tableGrid[referenceRowIndex];
+            const gridCellIndex = sholdInsertAfter
+                ? rowGrid.findLastIndex((cell) => cell === reference)
+                : rowGrid.indexOf(reference);
             const referenceCellWidth = reference.style.width
                 ? parseFloat(reference.style.width)
                 : reference.clientWidth;
-
             // Temporarily set widths so proportions are respected.
             const firstRowCells = [...table.rows[0].cells];
             let totalWidth = 0;
@@ -417,29 +423,43 @@ export class TablePlugin extends Plugin {
                     totalWidth += newWidth;
                 }
             }
-
-            for (let rowIndex = 0; rowIndex < table.rows.length; rowIndex++) {
-                const row = table.rows[rowIndex];
-                const cell = row.cells[columnIndex];
+            for (let rowIndex = 0; rowIndex < tableGrid.length; rowIndex++) {
+                const cell = tableGrid[rowIndex][gridCellIndex];
+                if (
+                    cell ===
+                    (sholdInsertAfter
+                        ? tableGrid[rowIndex][gridCellIndex + 1]
+                        : tableGrid[rowIndex][gridCellIndex - 1])
+                ) {
+                    cell.colSpan += 1;
+                    continue;
+                }
                 const newCell = this.document.createElement(cell.tagName);
                 const baseContainer = this.dependencies.baseContainer.createBaseContainer();
                 fillEmpty(baseContainer);
                 newCell.append(baseContainer);
-                cell[position](newCell);
-
-                if (rowIndex === 0) {
+                if (rows[rowIndex].contains(cell)) {
+                    cell[position](newCell);
                     // If the first row is a header, ensure the new column's
                     // first cell is also marked as a header (<th>).
-                    if (cell.classList.contains("o_table_header")) {
+                    if (rowIndex === 0 && cell.classList.contains("o_table_header")) {
                         newCell.classList.add("o_table_header");
                     }
-                    if (tableWidth) {
-                        newCell.style.width = cell.style.width;
-                        totalWidth += parseFloat(cell.style.width);
+                } else {
+                    const row = tableGrid[rowIndex];
+                    const nextAdjacentCell = sholdInsertAfter
+                        ? row.findLast((c, index) => index < gridCellIndex && c.rowSpan === 1)
+                        : row.find((c, index) => index > gridCellIndex && c.rowSpan === 1);
+                    if (nextAdjacentCell) {
+                        nextAdjacentCell[position](newCell);
+                    } else {
+                        // If no adjacent cell, append or prepend depending on position
+                        sholdInsertAfter
+                            ? rows[rowIndex].prepend(newCell)
+                            : rows[rowIndex].append(newCell);
                     }
                 }
             }
-
             if (tableWidth) {
                 if (totalWidth !== tableWidth - 1) {
                     // -1 for the width of the border of the new column.
@@ -452,6 +472,7 @@ export class TablePlugin extends Plugin {
                 table.style.width = tableWidth + "px";
             }
         }
+        this.tableGridMap.delete(table);
     }
     /**
      * @param {'before'|'after'} position
@@ -459,22 +480,37 @@ export class TablePlugin extends Plugin {
      * @param {number} [rowsToAdd=1]
      */
     addRow(position, reference, rowsToAdd = 1) {
+        const table = closestElement(reference, "table");
+        const tableGrid = this.buildTableGrid(table);
+        const rowIndex = getRowIndex(reference);
+
         const referenceRowHeight = reference.style.height && parseFloat(reference.style.height);
         for (let rowOffset = 0; rowOffset < rowsToAdd; rowOffset++) {
             const newRow = this.document.createElement("tr");
             if (referenceRowHeight) {
                 newRow.style.height = referenceRowHeight + "px";
             }
+            const gridCells = tableGrid[rowIndex];
 
-            for (let columnIndex = 0; columnIndex < reference.cells.length; columnIndex++) {
-                const td = this.document.createElement("td");
-                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
-                fillEmpty(baseContainer);
-                td.append(baseContainer);
-                newRow.append(td);
+            for (let columnIndex = 0; columnIndex < gridCells.length; columnIndex++) {
+                const cell = gridCells[columnIndex];
+                if (
+                    columnIndex > 0 &&
+                    cell ===
+                        (position === "after"
+                            ? tableGrid[rowIndex + 1]?.[columnIndex]
+                            : tableGrid[rowIndex - 1]?.[columnIndex])
+                ) {
+                    cell.rowSpan += 1;
+                } else {
+                    const td = this.document.createElement("td");
+                    const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                    fillEmpty(baseContainer);
+                    td.append(baseContainer);
+                    newRow.append(td);
+                }
             }
             reference[position](newRow);
-
             // Preserve the width of the columns (applied only on the first row).
             if (getRowIndex(newRow) === 0) {
                 for (let columnIndex = 0; columnIndex < reference.cells.length; columnIndex++) {
@@ -484,6 +520,7 @@ export class TablePlugin extends Plugin {
                 }
             }
         }
+        this.tableGridMap.delete(table);
     }
     /**
      * @param {HTMLTableRowElement} reference

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -636,7 +636,7 @@ export class TablePlugin extends Plugin {
         const table = closestElement(cell, "table");
         const tableGrid = this.buildTableGrid(table);
         const columnIndex = tableGrid[0].indexOf(cell);
-        const nColumns = cell.parentElement.children.length;
+        const nColumns = tableGrid[0].length;
         if (targetIndex < 0 || targetIndex >= nColumns || targetIndex === columnIndex) {
             return;
         }

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1469,7 +1469,8 @@ export class TablePlugin extends Plugin {
             return;
         }
         table.classList.toggle("o_selected_table", true);
-        const columns = getTableCells(table);
+        const tableGrid = this.buildTableGrid(table);
+        const columns = tableGrid.flat();
         const startCol =
             [selection.startContainer, ...ancestors(selection.startContainer, this.editable)].find(
                 (node) => isTableCell(node) && closestElement(node, "table") === table
@@ -1479,8 +1480,9 @@ export class TablePlugin extends Plugin {
                 (node) => isTableCell(node) && closestElement(node, "table") === table
             ) || columns[columns.length - 1];
         const [startRow, endRow] = [closestElement(startCol, "tr"), closestElement(endCol, "tr")];
-        const [startColIndex, endColIndex] = [getColumnIndex(startCol), getColumnIndex(endCol)];
         const [startRowIndex, endRowIndex] = [getRowIndex(startRow), getRowIndex(endRow)];
+        const startColIndex = tableGrid[startRowIndex].indexOf(startCol);
+        const endColIndex = tableGrid[endRowIndex].indexOf(endCol);
         const [minRowIndex, maxRowIndex] = [
             Math.min(startRowIndex, endRowIndex),
             Math.max(startRowIndex, endRowIndex),
@@ -1489,17 +1491,16 @@ export class TablePlugin extends Plugin {
             Math.min(startColIndex, endColIndex),
             Math.max(startColIndex, endColIndex),
         ];
-        // Create an array of arrays of tds (each of which is a row).
-        const grid = [...table.querySelectorAll("tr")]
-            .filter((tr) => closestElement(tr, "table") === table)
-            .map((tr) => [...tr.children].filter(isTableCell));
-        for (const tds of grid.filter((_, index) => index >= minRowIndex && index <= maxRowIndex)) {
-            for (const td of tds.filter(
-                (_, index) => index >= minColIndex && index <= maxColIndex
-            )) {
-                td.classList.toggle("o_selected_td", true);
-                this.processThrough("deselect_custom_selected_nodes_processors", td);
-            }
+
+        const tdsToSelect = new Set(
+            tableGrid
+                .slice(minRowIndex, maxRowIndex + 1)
+                .flatMap((row) => row.slice(minColIndex, maxColIndex + 1))
+        );
+
+        for (const td of tdsToSelect) {
+            td.classList.toggle("o_selected_td", true);
+            this.processThrough("deselect_custom_selected_nodes_processors", td);
         }
     }
 

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -1436,6 +1436,12 @@ export class TablePlugin extends Plugin {
             return;
         }
         const currentTable = closestElement(currentCell, "table");
+        const tableGrid = this.buildTableGrid(currentTable);
+        const currentRowIndex = getRowIndex(currentCell);
+        const currentColIndex = tableGrid[currentRowIndex].indexOf(currentCell);
+        if (currentColIndex < 0) {
+            return;
+        }
         const areCellsSelected = currentCell.classList.contains("o_selected_td");
         const isArrowUp = ev.key === "ArrowUp";
         // Should navigate within multi-line text node itself ?
@@ -1456,11 +1462,6 @@ export class TablePlugin extends Plugin {
                 return;
             }
         }
-        const cellPosition = {
-            row: getRowIndex(currentCell),
-            col: getColumnIndex(currentCell),
-        };
-        const tableRows = [...currentTable.rows].map((row) => [...row.cells]);
         const shouldNavigateCell = (currentNode) => {
             const siblingDirection = isArrowUp ? "previousElementSibling" : "nextElementSibling";
             const direction = isArrowUp ? DIRECTIONS.LEFT : DIRECTIONS.RIGHT;
@@ -1478,8 +1479,8 @@ export class TablePlugin extends Plugin {
             }
             return true;
         };
-        const rowOffset = isArrowUp ? -1 : 1;
-        let targetNode = tableRows[cellPosition.row + rowOffset]?.[cellPosition.col];
+        const rowOffset = currentRowIndex + (isArrowUp ? -1 : currentCell.rowSpan);
+        let targetNode = tableGrid[rowOffset]?.[currentColIndex];
         const siblingElement = isArrowUp
             ? currentTable.previousElementSibling
             : currentTable.nextElementSibling;

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -518,27 +518,78 @@ export class TablePlugin extends Plugin {
      */
     removeColumn(cell) {
         const table = closestElement(cell, "table");
+        const tableGrid = this.buildTableGrid(table);
+        const rowIndex = getRowIndex(cell);
         const cells = [...closestElement(cell, "tr").querySelectorAll("th, td")];
-        const index = cells.findIndex((td) => td === cell);
-        const siblingCell = cells[index - 1] || cells[index + 1];
-        table
-            .querySelectorAll(`tr :is(td, th):nth-of-type(${index + 1})`)
-            .forEach((td) => td.remove());
+        const gridCellIndex = tableGrid[rowIndex].indexOf(cell);
+        const cellIndex = cells.indexOf(cell);
+        const siblingCell = cells[cellIndex - 1] || cells[cellIndex + 1];
+        const spanningCells = tableGrid
+            .map((row) => row[gridCellIndex])
+            .filter((cell) => cell?.colSpan > 1);
+        const minColSpanToRemove =
+            spanningCells.length === tableGrid.length
+                ? Math.min(...spanningCells.map((cell) => cell.colSpan))
+                : 1;
+        tableGrid.forEach((row) => {
+            const td = row[gridCellIndex];
+            if (td && td.colSpan > minColSpanToRemove) {
+                td.colSpan -= minColSpanToRemove;
+                const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+                baseContainer.appendChild(this.document.createElement("br"));
+                td.replaceChildren(baseContainer);
+            } else if (td) {
+                td.remove();
+            }
+        });
         // not sure we should move the cursor?
         siblingCell
             ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingCell))
             : this.deleteTable(table);
+        delete this.tableGridMap.delete(table);
     }
     /**
      * @param {HTMLTableRowElement} row
      */
     removeRow(row) {
         const table = closestElement(row, "table");
-        const siblingRow = row.previousElementSibling || row.nextElementSibling;
-        row.remove();
+        const tableGrid = this.buildTableGrid(table);
+        const rows = Array.from(table.rows);
+        const rowIndex = rows.indexOf(row);
+        const spanningCells = tableGrid[rowIndex].filter((node) => node.rowSpan > 1);
+        const minRowSpanToRemove =
+            spanningCells.length === tableGrid[rowIndex].length
+                ? Math.min(...spanningCells.map((cell) => cell.rowSpan))
+                : 1;
+        const siblingRow =
+            rows[rowIndex + minRowSpanToRemove] || rows[rowIndex - minRowSpanToRemove];
+        spanningCells.forEach((cell) => {
+            cell.rowSpan -= minRowSpanToRemove;
+            const cellRow = cell.parentElement;
+            if (cellRow === row && cell.rowSpan > 0) {
+                const cellIndex = tableGrid[rows.indexOf(cellRow)].indexOf(cell);
+                // In the sibling row, find the first cell after the current
+                // cell index in the grid that actually exists in the DOM.
+                const siblingRowCell = tableGrid[rows.indexOf(siblingRow)]
+                    .slice(cellIndex + 1)
+                    .find((candidate) => candidate && siblingRow.contains(candidate));
+                siblingRow.insertBefore(cell, siblingRowCell);
+            }
+
+            if (cell.rowSpan <= 1) {
+                cell.removeAttribute("rowspan");
+            }
+            const baseContainer = this.dependencies.baseContainer.createBaseContainer();
+            baseContainer.appendChild(this.document.createElement("br"));
+            cell.replaceChildren(baseContainer);
+        });
+        for (let i = 0; i < minRowSpanToRemove; i++) {
+            rows[rowIndex + i].remove();
+        }
         siblingRow
             ? this.dependencies.selection.setCursorEnd(lastLeaf(siblingRow.cells[0]))
             : this.deleteTable(table);
+        delete this.tableGridMap.delete(table);
     }
     /**
      * @param {number} targetIndex - index to which the column should be moved
@@ -892,33 +943,44 @@ export class TablePlugin extends Plugin {
      * NodeList of selected table cells.
      */
     deleteTableCells(selectedTds) {
-        const rows = [...closestElement(selectedTds[0], "tr").parentElement.children].filter(
+        const firstCell = selectedTds[0];
+        const lastCell = selectedTds[selectedTds.length - 1];
+        const rows = [...closestElement(firstCell, "tr").parentElement.children].filter(
             (child) => child.nodeName === "TR"
         );
-        const firstRowCells = [...rows[0].children].filter(
-            (child) => child.nodeName === "TD" || child.nodeName === "TH"
+        const table = closestElement(firstCell, "table");
+        const tableGrid = this.tableGridMap.get(table);
+        const firstCellRowIndex = getRowIndex(firstCell);
+        const firstCellColumnIndex = tableGrid[firstCellRowIndex].indexOf(firstCell);
+        const lastCellRowIndex = getRowIndex(lastCell);
+        const lastCellColumnIndex = tableGrid[lastCellRowIndex].findLastIndex(
+            (td) => td === lastCell
         );
-        const firstCellRowIndex = getRowIndex(selectedTds[0]);
-        const firstCellColumnIndex = getColumnIndex(selectedTds[0]);
-        const lastCellRowIndex = getRowIndex(selectedTds[selectedTds.length - 1]);
-        const lastCellColumnIndex = getColumnIndex(selectedTds[selectedTds.length - 1]);
-
-        const areFullColumnsSelected =
-            firstCellRowIndex === 0 && lastCellRowIndex === rows.length - 1;
-        const areFullRowsSelected =
-            firstCellColumnIndex === 0 && lastCellColumnIndex === firstRowCells.length - 1;
-
-        if (areFullColumnsSelected) {
-            for (let index = firstCellColumnIndex; index <= lastCellColumnIndex; index++) {
-                this.removeColumn(firstRowCells[index]);
+        const selectedSet = new Set(selectedTds);
+        // Removes all rows that are fully selected.
+        const removeFullySelectedRows = () => {
+            let removed = false;
+            for (let i = lastCellRowIndex; i >= firstCellRowIndex; i--) {
+                if (tableGrid[i].every((td) => selectedSet.has(td))) {
+                    this.removeRow(rows[i]);
+                    removed = true;
+                }
             }
-            return;
-        }
-
-        if (areFullRowsSelected) {
-            for (let index = firstCellRowIndex; index <= lastCellRowIndex; index++) {
-                this.removeRow(rows[index]);
+            return removed;
+        };
+        // Removes all columns that are fully selected.
+        const removeFullySelectedColumns = () => {
+            let removed = false;
+            for (let i = lastCellColumnIndex; i >= firstCellColumnIndex; i--) {
+                if (tableGrid.every((row) => selectedSet.has(row[i]))) {
+                    this.removeColumn(tableGrid[0][i]);
+                    removed = true;
+                }
             }
+            return removed;
+        };
+        // remove rows and columns, return early if anything removed
+        if (removeFullySelectedRows() || removeFullySelectedColumns()) {
             return;
         }
 
@@ -927,7 +989,7 @@ export class TablePlugin extends Plugin {
             baseContainer.appendChild(this.document.createElement("br"));
             td.replaceChildren(baseContainer);
         }
-        this.dependencies.selection.setCursorStart(selectedTds[0].firstChild);
+        this.dependencies.selection.setCursorStart(firstCell.firstChild);
     }
 
     /**

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -32,6 +32,7 @@ export class TableUIPlugin extends Plugin {
                 commandId: "openTablePicker",
             },
         ],
+        selectionchange_handlers: this.updateActiveCell.bind(this),
     };
 
     setup() {
@@ -97,6 +98,15 @@ export class TableUIPlugin extends Plugin {
         } else {
             this.openPicker();
         }
+    }
+
+    updateActiveCell(selectionData) {
+        const selection = selectionData.editableSelection;
+        const selectedTd = closestElement(selection.startContainer, ".o_selected_td");
+        if (selection.isCollapsed || !selectedTd) {
+            return;
+        }
+        this.activeTd = false;
     }
 
     onMouseMove(ev) {
@@ -168,6 +178,9 @@ export class TableUIPlugin extends Plugin {
             clearColumnContent: withAddStep(this.dependencies.table.clearColumnContent),
             clearRowContent: withAddStep(this.dependencies.table.clearRowContent),
             toggleAlternatingRows: withAddStep(this.dependencies.table.toggleAlternatingRows),
+            mergeSelectedCells: withAddStep(this.dependencies.table.mergeSelectedCells),
+            unmergeSelectedCell: withAddStep(this.dependencies.table.unmergeSelectedCell),
+            buildTableGrid: this.dependencies.table.buildTableGrid,
         };
         if (td.cellIndex === 0) {
             this.rowMenu.open({

--- a/addons/html_editor/static/src/main/table/table_ui_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_ui_plugin.js
@@ -6,6 +6,7 @@ import { TableMenu } from "./table_menu";
 import { TablePicker } from "./table_picker";
 import { isHtmlContentSupported } from "@html_editor/core/selection_plugin";
 import { TableDragDrop } from "./table_drag_drop";
+import { getRowIndex } from "@html_editor/utils/table";
 
 /**
  * This plugin only contains the table ui feature (table picker, menus, ...).
@@ -182,7 +183,9 @@ export class TableUIPlugin extends Plugin {
             unmergeSelectedCell: withAddStep(this.dependencies.table.unmergeSelectedCell),
             buildTableGrid: this.dependencies.table.buildTableGrid,
         };
-        if (td.cellIndex === 0) {
+        const grid = this.dependencies.table.buildTableGrid(closestElement(td, "table"));
+        const rowIndex = getRowIndex(td.parentElement);
+        if (grid[rowIndex][0] === td) {
             this.rowMenu.open({
                 target: td,
                 props: {

--- a/addons/html_editor/static/src/utils/table.js
+++ b/addons/html_editor/static/src/utils/table.js
@@ -1,3 +1,4 @@
+import { isTableCell } from "./dom_info";
 import { closestElement } from "./dom_traversal";
 
 /**
@@ -34,4 +35,82 @@ export function getTableCells(table) {
     return [...table.querySelectorAll("td, th")].filter(
         (cell) => closestElement(cell, "table") === table
     );
+}
+
+/**
+ * Analyzes the currently selected table cells and determines:
+ *  - whether they can be merged,
+ *  - whether they can be unmerged,
+ *  - and along which span type (`rowSpan` or `colSpan`) a merge is possible.
+ *
+ * @param {Document} editableDocument
+ * @param {HTMLTableCellElement[][]} tableGrid
+ * @param {HTMLTableCellElement} targetCell
+ * The table cell currently hovered by the mouse.
+ * @returns {Object} An object with the following properties:
+ *   - {boolean} canMerge - True if selected cells can be merged.
+ *   - {boolean} canUnmerge
+ *     True if the anchor or selected table cell has rowSpan or colSpan > 1.
+ *   - {Array<HTMLTableCellElement>} selectedCells - The selected cells.
+ *   - {"colSpan" | "rowSpan" | ""} spanType - The span type along which
+ *     the cells can be merged, or an empty string if merging is not possible.
+ */
+export function getSelectedCellsMergeInfo(editableDocument, tableGrid, targetCell) {
+    const selectedTds = Array.from(editableDocument.querySelectorAll(".o_selected_td"));
+    if (selectedTds.length <= 1) {
+        const { anchorNode } = editableDocument.getSelection();
+        const td = selectedTds[0] ?? (anchorNode && closestElement(anchorNode, isTableCell));
+        return {
+            canMerge: false,
+            canUnmerge: td?.rowSpan > 1 || td?.colSpan > 1,
+            cells: [],
+            spanType: "",
+        };
+    }
+
+    const firstCell = selectedTds[0];
+    const lastCell = selectedTds[selectedTds.length - 1];
+
+    const table = closestElement(firstCell, "table");
+    const isSameTable =
+        table &&
+        table === closestElement(lastCell, "table") &&
+        table === closestElement(targetCell, "table");
+
+    if (!isSameTable) {
+        return { canMerge: false, canUnmerge: false, cells: [], spanType: "" };
+    }
+
+    const getGridColumnIndex = (cell, row) => tableGrid[row].indexOf(cell);
+
+    const rowIndexes = selectedTds.map(getRowIndex);
+    const colIndexes = selectedTds.map((td, i) => getGridColumnIndex(td, rowIndexes[i]));
+
+    const referenceRowIndex = rowIndexes[0];
+    const referenceColIndex = colIndexes[0];
+
+    const allInSameRow = rowIndexes.every((r) => r === referenceRowIndex);
+    const allInSameCol = colIndexes.every((c) => c === referenceColIndex);
+    const containsMergedCell = selectedTds.some((td) => td.rowSpan > 1 || td.colSpan > 1);
+    // All in same row + no rowspan
+    if (allInSameRow && selectedTds.every((td) => !td.hasAttribute("rowspan"))) {
+        return {
+            canMerge: true,
+            canUnmerge: containsMergedCell,
+            cells: selectedTds,
+            spanType: "colSpan",
+        };
+    }
+
+    // All in same col + no colspan
+    if (allInSameCol && selectedTds.every((td) => !td.hasAttribute("colspan"))) {
+        return {
+            canMerge: true,
+            canUnmerge: containsMergedCell,
+            cells: selectedTds,
+            spanType: "rowSpan",
+        };
+    }
+
+    return { canMerge: false, canUnmerge: containsMergedCell, cells: selectedTds, spanType: "" };
 }

--- a/addons/html_editor/static/tests/paste.test.js
+++ b/addons/html_editor/static/tests/paste.test.js
@@ -22,7 +22,20 @@ function isInline(node) {
 }
 
 function toIgnore(node) {
-    return ["TABLE", "THEAD", "TH", "TBODY", "TR", "TD", "IMG", "BR", "LI", ".FA"].includes(node);
+    return [
+        "TABLE",
+        "THEAD",
+        "TH",
+        "TBODY",
+        "TR",
+        "TD",
+        "IMG",
+        "BR",
+        "LI",
+        ".FA",
+        "COL",
+        "COLGROUP",
+    ].includes(node);
 }
 
 describe("Html Paste cleaning - whitelist", () => {
@@ -4162,27 +4175,27 @@ describe("Paste HTML tables", () => {
                 );
             },
             contentAfter: `<table class="table table-bordered o_table">
-${"            "}
-${"            "}
-            <tbody><tr>
+            <colgroup><col style="width: 187px;">
+            <col style="width: 211px;">
+            <col style="width: 187px;"><col style="width: 211px;"></colgroup><tbody><tr style="height: 15pt;">
                 <td>Italic
                         then also BOLD</td>
                 <td><s>Italic strike</s></td>
             </tr>
-            <tr>
+            <tr style="height: 15pt;">
                 <td>Just bold Just Italic</td>
                 <td>Bold underline</td>
             </tr>
-            <tr>
+            <tr style="height: 15pt;">
                 <td>Color text</td>
                 <td><s>Color strike and underline</s></td>
             </tr>
-            <tr>
+            <tr style="height: 15pt;">
                 <td>Color background</td>
                 <td>Color text on color background</td>
             </tr>
-            <tr>
-                <td>14pt MONO TEXT
+            <tr style="height: 20.25pt;">
+                <td colspan="2">14pt MONO TEXT
                 []</td>
             </tr>
         </tbody></table>`,
@@ -4261,19 +4274,19 @@ ${"            "}
                 );
             },
             contentAfter: `<table class="table table-bordered o_table">
-${"        "}
-${"            "}
-${"            "}
-${"        "}
+        <colgroup>
+            <col style="width: 170px;">
+            <col style="width: 187px;">
+        </colgroup>
         <tbody>
-            <tr>
+            <tr style="height: 21px;">
                 <td>
                     Italic then also
                     BOLD
                 </td>
                 <td>Italic strike</td>
             </tr>
-            <tr>
+            <tr style="height: 21px;">
                 <td>
                     Just
                         Bold Just
@@ -4281,19 +4294,19 @@ ${"        "}
                 </td>
                 <td>Bold underline</td>
             </tr>
-            <tr>
+            <tr style="height: 21px;">
                 <td>Color text</td>
                 <td>Color
                     strike and underline</td>
             </tr>
-            <tr>
+            <tr style="height: 21px;">
                 <td>Color background
                 </td>
                 <td>Color
                     text on color background</td>
             </tr>
-            <tr>
-                <td>14pt MONO TEXT[]</td>
+            <tr style="height: 21px;">
+                <td rowspan="1" colspan="2">14pt MONO TEXT[]</td>
             </tr>
         </tbody>
     </table>`,
@@ -4396,8 +4409,8 @@ ${"        "}
                 );
             },
             contentAfter: `<table class="table table-bordered o_table">
-${"        "}
-${"        "}
+        <colgroup></colgroup>
+        <colgroup></colgroup>
         <tbody><tr>
             <td><i>Italic then also BOLD</i></td>
             <td><i><s>Italic strike</s></i></td>
@@ -4421,7 +4434,7 @@ ${"        "}
             </td>
         </tr>
         <tr>
-            <td>
+            <td colspan="2">
                 14pt MONO TEXT[]
             </td>
         </tr>

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -105,9 +105,9 @@ describe("row", () => {
                     <table>
                         <tbody>
                             <tr style="height: 20px;">
-                                <th class="o_table_header" style="width: 20px;">ab[]</th>
-                                <th class="o_table_header" style="width: 25px;">cd</th>
-                                <th class="o_table_header" style="width: 30px;">ef</th>
+                                <th style="width: 20px;" class="o_table_header">ab[]</th>
+                                <th style="width: 25px;" class="o_table_header">cd</th>
+                                <th style="width: 30px;" class="o_table_header">ef</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>ab</td>

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -382,9 +382,9 @@ describe("row", () => {
                     <table>
                         <tbody>
                             <tr style="height: 30px;">
-                                <th class="o_table_header" style="width: 20px;">gh</th>
-                                <th class="o_table_header" style="width: 25px;">ij</th>
-                                <th class="o_table_header" style="width: 30px;">kl</th>
+                                <th style="width: 20px;" class="o_table_header">gh</th>
+                                <th style="width: 25px;" class="o_table_header">ij</th>
+                                <th style="width: 30px;" class="o_table_header">kl</th>
                             </tr>
                             <tr style="height: 20px;">
                                 <td style="width: 20px;">ab[]</td>
@@ -420,9 +420,9 @@ describe("row", () => {
                     <table>
                         <tbody>
                             <tr style="height: 30px;">
-                                <th class="o_table_header" style="width: 20px;">gh</th>
-                                <th class="o_table_header" style="width: 25px;">ij</th>
-                                <th class="o_table_header" style="width: 30px;">kl[]</th>
+                                <th style="width: 20px;" class="o_table_header">gh</th>
+                                <th style="width: 25px;" class="o_table_header">ij</th>
+                                <th style="width: 30px;" class="o_table_header">kl[]</th>
                             </tr>
                             <tr style="height: 20px;">
                                 <td style="width: 20px;">ab</td>
@@ -961,12 +961,12 @@ describe("column", () => {
                         <tbody>
                             <tr style="height: 20px;">
                                 <th class="o_table_header" style="width: 20px;">ab</th>
-                                <th class="o_table_header" style="width: 25px;">cd</th>
+                                <th class="o_table_header" style="width: 25px;">cd[]</th>
                                 <th class="o_table_header" style="width: 30px;">ef</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>gh</td>
-                                <td>ij[]</td>
+                                <td>ij</td>
                                 <td>kl</td>
                             </tr>
                         </tbody>
@@ -979,12 +979,12 @@ describe("column", () => {
                             <tr style="height: 20px;">
                                 <th class="o_table_header" style="width: 20px;">ab</th>
                                 <th class="o_table_header" style="width: 30px;">ef</th>
-                                <th class="o_table_header" style="width: 25px;">cd</th>
+                                <th class="o_table_header" style="width: 25px;">cd[]</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>gh</td>
                                 <td>kl</td>
-                                <td>ij[]</td>
+                                <td>ij</td>
                             </tr>
                         </tbody>
                     </table>

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -519,6 +519,117 @@ describe("row", () => {
                 contentAfter: "<p>[]<br></p>",
             });
         });
+        test("should remove column intersecting rowspan without breaking table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>a</td><td rowspan="3"><p><br></p></td><td>c</td>
+                            </tr>
+                            <tr>
+                                <td>d</td><td>e</td>
+                            </tr>
+                            <tr>
+                                <td>f</td><td>g</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    // Select the second row
+                    const row = editor.editable.querySelectorAll("tr")[1];
+                    removeRow(row)(editor);
+                },
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>a</td><td rowspan="2"><p><br></p></td><td>c</td>
+                            </tr>
+                            <tr>
+                                <td>f[]</td><td>g</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should remove column intersecting muliple rowspan without breaking table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>1</td>
+                                <td>2</td>
+                                <td>3</td>
+                                <td>4</td>
+                            </tr>
+                            <tr>
+                                <td rowspan="3">[]5</td>
+                                <td rowspan="3">6</td>
+                                <td>7</td>
+                                <td>8</td>
+                            </tr>
+                            <tr>
+                                <td rowspan="2">9</td>
+                                <td>10</td>
+                            </tr>
+                            <tr>
+                                <td>11</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    // Select the second row
+                    const row = editor.editable.querySelectorAll("tr")[1];
+                    removeRow(row)(editor);
+                },
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>1</td>
+                                <td>2</td>
+                                <td>3</td>
+                                <td>4</td>
+                            </tr>
+                            <tr>
+                                <td rowspan="2"><p>[]<br></p></td>
+                                <td rowspan="2"><p><br></p></td>
+                                <td rowspan="2">9</td>
+                                <td>10</td>
+                            </tr>
+                            <tr>
+                                <td>11</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should remove the entire table when removing a row from a table where all cells have rowspan", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td rowspan="3">a</td><td rowspan="3">b</td><td rowspan="3">c</td>
+                            </tr>
+                            <tr></tr>
+                            <tr></tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    const row = editor.editable.querySelectorAll("tr")[0];
+                    removeRow(row)(editor);
+                },
+                contentAfter: "<p>[]<br></p>",
+            });
+        });
     });
 });
 
@@ -1000,6 +1111,114 @@ describe("column", () => {
                 ),
                 stepFunction: removeColumn(),
                 contentAfter: "<p>[]<br></p>",
+            });
+        });
+        test("should remove column intersecting colspan without breaking table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>a</td><td>b</td><td>c</td>
+                            </tr>
+                            <tr>
+                                <td colspan="3">d</td>
+                            </tr>
+                            <tr>
+                                <td>e</td><td>f</td><td>g</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    // Select the second cell
+                    const cell = editor.editable.querySelectorAll("td")[1];
+                    removeColumn(cell)(editor);
+                },
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>a[]</td><td>c</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2"><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td>e</td><td>g</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+            });
+        });
+        test("should remove the entire table when removing a column from a table where all rows have only colspan cells", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td colspan="3">a</td>
+                            </tr>
+                            <tr>
+                                <td colspan="3">b</td>
+                            </tr>
+                            <tr>
+                                <td colspan="3">c</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    const cell = editor.editable.querySelectorAll("td")[0];
+                    removeColumn(cell)(editor);
+                },
+                contentAfter: "<p>[]<br></p>",
+            });
+        });
+        test("should remove row intersecting colspan and rowspan without breaking table", async () => {
+            await testEditor({
+                contentBefore: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td>1</td>
+                                <td>2</td>
+                                <td rowspan="3">3</td>
+                                <td>4</td>
+                            </tr>
+                            <tr>
+                                <td colspan="2">5</td>
+                                <td>6</td>
+                            </tr>
+                            <tr>
+                                <td>7</td>
+                                <td>8</td>
+                                <td>9</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
+                stepFunction: (editor) => {
+                    const row = editor.editable.querySelectorAll("tr")[0];
+                    removeRow(row)(editor);
+                },
+                contentAfter: unformat(`
+                    <table>
+                        <tbody>
+                            <tr>
+                                <td colspan="2">5[]</td>
+                                <td rowspan="2"><p><br></p></td>
+                                <td>6</td>
+                            </tr>
+                            <tr>
+                                <td>7</td>
+                                <td>8</td>
+                                <td>9</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                `),
             });
         });
     });

--- a/addons/html_editor/static/tests/table/children.test.js
+++ b/addons/html_editor/static/tests/table/children.test.js
@@ -103,11 +103,16 @@ describe("row", () => {
                 stepFunction: turnIntoHeader(),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 20px;">
+                            <col style="width: 25px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 20px;">
-                                <th style="width: 20px;" class="o_table_header">ab[]</th>
-                                <th style="width: 25px;" class="o_table_header">cd</th>
-                                <th style="width: 30px;" class="o_table_header">ef</th>
+                                <th class="o_table_header">ab[]</th>
+                                <th class="o_table_header">cd</th>
+                                <th class="o_table_header">ef</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>ab</td>
@@ -141,11 +146,16 @@ describe("row", () => {
                 stepFunction: turnIntoRow(),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 20px;">
+                            <col style="width: 25px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 20px;">
-                                <td style="width: 20px;">ab[]</td>
-                                <td style="width: 25px;">cd</td>
-                                <td style="width: 30px;">ef</td>
+                                <td>ab[]</td>
+                                <td>cd</td>
+                                <td>ef</td>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>ab</td>
@@ -170,10 +180,16 @@ describe("row", () => {
                     "</tr></tbody></table>",
                 stepFunction: addRow("before"),
                 contentAfter:
-                    '<table><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 20px;"><p><br></p></td>' +
-                    '<td style="width: 25px;"><p><br></p></td>' +
-                    '<td style="width: 30px;"><p><br></p></td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
                     "</tr>" +
                     '<tr style="height: 20px;">' +
                     "<td>ab</td>" +
@@ -198,10 +214,16 @@ describe("row", () => {
                     "</tr></tbody></table>",
                 stepFunction: addRow("before"),
                 contentAfter:
-                    '<table><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 20px;">ab</td>' +
-                    '<td style="width: 25px;">cd</td>' +
-                    '<td style="width: 30px;">ef</td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td><p><br></p></td>" +
@@ -233,11 +255,16 @@ describe("row", () => {
                     "</tbody></table>",
                 stepFunction: addRow("before", 2),
                 contentAfter:
-                    "<table><tbody>" +
-                    '<tr style="height: 20px;">' +
-                    '<td style="width: 20px;"><p><br></p></td>' +
-                    '<td style="width: 25px;"><p><br></p></td>' +
-                    '<td style="width: 30px;"><p><br></p></td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
                     "</tr>" +
                     '<tr style="height: 20px;">' +
                     "<td><p><br></p></td>" +
@@ -274,11 +301,16 @@ describe("row", () => {
                     "</tbody></table>",
                 stepFunction: addRow("after", 2),
                 contentAfter:
-                    "<table><tbody>" +
-                    '<tr style="height: 20px;">' +
-                    '<td style="width: 20px;">ab</td>' +
-                    '<td style="width: 25px;">cd</td>' +
-                    '<td style="width: 30px;">ef</td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td>gh</td>" +
@@ -311,10 +343,16 @@ describe("row", () => {
                     "</tr></tbody></table>",
                 stepFunction: addRow("after"),
                 contentAfter:
-                    '<table><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 20px;">ab</td>' +
-                    '<td style="width: 25px;">cd</td>' +
-                    '<td style="width: 30px;">ef[]</td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef[]</td>" +
                     "</tr>" +
                     '<tr style="height: 20px;">' +
                     "<td><p><br></p></td>" +
@@ -339,10 +377,16 @@ describe("row", () => {
                     "</tr></tbody></table>",
                 stepFunction: addRow("after"),
                 contentAfter:
-                    '<table><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 20px;">ab</td>' +
-                    '<td style="width: 25px;">cd</td>' +
-                    '<td style="width: 30px;">ef[]</td>' +
+                    "<table>" +
+                    "<colgroup>" +
+                    '<col style="width: 20px;">' +
+                    '<col style="width: 25px;">' +
+                    '<col style="width: 30px;">' +
+                    "</colgroup>" +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef[]</td>" +
                     "</tr>" +
                     '<tr style="height: 20px;">' +
                     "<td><p><br></p></td>" +
@@ -380,16 +424,21 @@ describe("row", () => {
                 stepFunction: moveRow(1),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 20px;">
+                            <col style="width: 25px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 30px;">
-                                <th style="width: 20px;" class="o_table_header">gh</th>
-                                <th style="width: 25px;" class="o_table_header">ij</th>
-                                <th style="width: 30px;" class="o_table_header">kl</th>
+                                <th class="o_table_header">gh</th>
+                                <th class="o_table_header">ij</th>
+                                <th class="o_table_header">kl</th>
                             </tr>
                             <tr style="height: 20px;">
-                                <td style="width: 20px;">ab[]</td>
-                                <td style="width: 25px;">cd</td>
-                                <td style="width: 30px;">ef</td>
+                                <td>ab[]</td>
+                                <td>cd</td>
+                                <td>ef</td>
                             </tr>
                         </tbody>
                     </table>
@@ -418,16 +467,21 @@ describe("row", () => {
                 stepFunction: moveRow(0),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 20px;">
+                            <col style="width: 25px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 30px;">
-                                <th style="width: 20px;" class="o_table_header">gh</th>
-                                <th style="width: 25px;" class="o_table_header">ij</th>
-                                <th style="width: 30px;" class="o_table_header">kl[]</th>
+                                <th class="o_table_header">gh</th>
+                                <th class="o_table_header">ij</th>
+                                <th class="o_table_header">kl[]</th>
                             </tr>
                             <tr style="height: 20px;">
-                                <td style="width: 20px;">ab</td>
-                                <td style="width: 25px;">cd</td>
-                                <td style="width: 30px;">ef</td>
+                                <td>ab</td>
+                                <td>cd</td>
+                                <td>ef</td>
                             </tr>
                         </tbody>
                     </table>
@@ -638,7 +692,8 @@ describe("column", () => {
         test("should add a column left of the leftmost column", async () => {
             await testEditor({
                 contentBefore:
-                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
+                    '<table style="width: 150px;">' +
+                    '<tbody><tr style="height: 20px;">' +
                     '<td style="width: 40px;">ab[]</td>' +
                     '<td style="width: 50px;">cd</td>' +
                     '<td style="width: 60px;">ef</td>' +
@@ -650,11 +705,15 @@ describe("column", () => {
                     "</tr></tbody></table>",
                 stepFunction: addColumn("before"),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 32px;"><p><br></p></td>' +
-                    '<td style="width: 32px;">ab[]</td>' +
-                    '<td style="width: 40px;">cd</td>' +
-                    '<td style="width: 45px;">ef</td>' +
+                    '<table style="width: 150px;">' +
+                    '<colgroup><col style="width: 32px;">' +
+                    '<col style="width: 32px;"><col style="width: 40px;">' +
+                    '<col style="width: 45px;"></colgroup>' +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<td><p><br></p></td>" +
+                    "<td>ab[]</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td><p><br></p></td>" +
@@ -680,11 +739,14 @@ describe("column", () => {
                     "</tr></tbody></table>",
                 stepFunction: addColumn("before"),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
-                    '<th style="width: 32px;"><p><br></p></th>' +
-                    '<th style="width: 32px;">ab[]</th>' +
-                    '<th style="width: 40px;">cd</th>' +
-                    '<th style="width: 45px;">ef</th>' +
+                    '<table style="width: 150px;">' +
+                    '<colgroup><col style="width: 32px;"><col style="width: 32px;">' +
+                    '<col style="width: 40px;"><col style="width: 45px;"></colgroup>' +
+                    '<tbody><tr style="height: 20px;">' +
+                    "<th><p><br></p></th>" +
+                    "<th>ab[]</th>" +
+                    "<th>cd</th>" +
+                    "<th>ef</th>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td><p><br></p></td>" +
@@ -703,47 +765,40 @@ describe("column", () => {
                     '<td style="width: 65px;">cd</td>' +
                     '<td style="width: 85px;">ef</td>' +
                     "</tr>" +
-                    '<tr style="height: 30px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd[]</td>" +
-                    "<td>ef</td>" +
-                    "</tr>" +
-                    '<tr style="height: 40px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd</td>" +
-                    "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    '<tr style="height: 30px;"><td>ab</td><td>cd[]</td><td>ef</td></tr>' +
+                    '<tr style="height: 40px;"><td>ab</td><td>cd</td><td>ef</td></tr>' +
+                    "</tbody></table>",
                 stepFunction: addColumn("before"),
                 contentAfter:
-                    '<table style="width: 200px;"><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 38px;">ab</td>' +
-                    '<td style="width: 49px;"><p><br></p></td>' +
-                    '<td style="width: 49px;">cd</td>' +
-                    '<td style="width: 63px;">ef</td>' +
-                    "</tr>" +
-                    '<tr style="height: 30px;">' +
-                    "<td>ab</td>" +
-                    "<td><p><br></p></td>" +
-                    "<td>cd[]</td>" +
-                    "<td>ef</td>" +
-                    "</tr>" +
-                    '<tr style="height: 40px;">' +
-                    "<td>ab</td>" +
-                    "<td><p><br></p></td>" +
-                    "<td>cd</td>" +
-                    "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    '<table style="width: 200px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 38px;">' +
+                    '<col style="width: 49px;">' +
+                    '<col style="width: 49px;">' +
+                    '<col style="width: 63px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
+                    '<tr style="height: 20px;"><td>ab</td><td><p><br></p></td><td>cd</td><td>ef</td></tr>' +
+                    '<tr style="height: 30px;"><td>ab</td><td><p><br></p></td><td>cd[]</td><td>ef</td></tr>' +
+                    '<tr style="height: 40px;"><td>ab</td><td><p><br></p></td><td>cd</td><td>ef</td></tr>' +
+                    "</tbody></table>",
             });
         });
 
         test("should add two columns before the leftmost column and preserve table width", async () => {
             await testEditor({
                 contentBefore:
-                    '<table style="width: 150px;"><tbody>' +
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 40px;">' +
+                    '<col style="width: 50px;">' +
+                    '<col style="width: 60px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
                     '<tr style="height: 20px;">' +
-                    '<td style="width: 40px;">ab[]</td>' +
-                    '<td style="width: 50px;">cd</td>' +
-                    '<td style="width: 60px;">ef</td>' +
+                    "<td>ab[]</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td>ab</td>" +
@@ -753,13 +808,21 @@ describe("column", () => {
                     "</tbody></table>",
                 stepFunction: addColumn("before", 2),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody>' +
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 27px;">' +
+                    '<col style="width: 27px;">' +
+                    '<col style="width: 27px;">' +
+                    '<col style="width: 33px;">' +
+                    '<col style="width: 35px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
                     '<tr style="height: 20px;">' +
-                    '<td style="width: 27px;"><p><br></p></td>' +
-                    '<td style="width: 27px;"><p><br></p></td>' +
-                    '<td style="width: 27px;">ab[]</td>' +
-                    '<td style="width: 33px;">cd</td>' +
-                    '<td style="width: 35px;">ef</td>' +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
+                    "<td>ab[]</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td><p><br></p></td>" +
@@ -775,11 +838,17 @@ describe("column", () => {
         test("should add two columns after the rightmost column and preserve table width", async () => {
             await testEditor({
                 contentBefore:
-                    '<table style="width: 150px;"><tbody>' +
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 40px;">' +
+                    '<col style="width: 50px;">' +
+                    '<col style="width: 60px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
                     '<tr style="height: 20px;">' +
-                    '<td style="width: 40px;">ab</td>' +
-                    '<td style="width: 50px;">cd</td>' +
-                    '<td style="width: 60px;">ef[]</td>' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef[]</td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td>ab</td>" +
@@ -789,13 +858,21 @@ describe("column", () => {
                     "</tbody></table>",
                 stepFunction: addColumn("after", 2),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody>' +
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 23px;">' +
+                    '<col style="width: 28px;">' +
+                    '<col style="width: 32px;">' +
+                    '<col style="width: 32px;">' +
+                    '<col style="width: 34px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
                     '<tr style="height: 20px;">' +
-                    '<td style="width: 23px;">ab</td>' +
-                    '<td style="width: 28px;">cd</td>' +
-                    '<td style="width: 32px;">ef[]</td>' +
-                    '<td style="width: 32px;"><p><br></p></td>' +
-                    '<td style="width: 34px;"><p><br></p></td>' +
+                    "<td>ab</td>" +
+                    "<td>cd</td>" +
+                    "<td>ef[]</td>" +
+                    "<td><p><br></p></td>" +
+                    "<td><p><br></p></td>" +
                     "</tr>" +
                     '<tr style="height: 30px;">' +
                     "<td>ab</td>" +
@@ -825,21 +902,20 @@ describe("column", () => {
                     "</tr></tbody></table>",
                 stepFunction: addColumn("after"),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 29px;">ab</td>' +
-                    '<td style="width: 36px;">cd</td>' +
-                    '<td style="width: 41px;">ef[]</td>' +
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 29px;">' +
+                    '<col style="width: 36px;">' +
+                    '<col style="width: 41px;">' +
                     // size was slightly adjusted to
                     // preserve table width in view on
                     // fractional division results
-                    '<td style="width: 43px;"><p><br></p></td>' +
-                    "</tr>" +
-                    '<tr style="height: 30px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd</td>" +
-                    "<td>ef</td>" +
-                    "<td><p><br></p></td>" +
-                    "</tr></tbody></table>",
+                    '<col style="width: 43px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
+                    '<tr style="height: 20px;"><td>ab</td><td>cd</td><td>ef[]</td><td><p><br></p></td></tr>' +
+                    '<tr style="height: 30px;"><td>ab</td><td>cd</td><td>ef</td><td><p><br></p></td></tr>' +
+                    "</tbody></table>",
             });
         });
 
@@ -858,18 +934,17 @@ describe("column", () => {
                     "</tr></tbody></table>",
                 stepFunction: addColumn("after"),
                 contentAfter:
-                    '<table style="width: 150px;"><tbody><tr style="height: 20px;">' +
-                    '<th style="width: 30px;">ab</th>' +
-                    '<th style="width: 38px;">cd[]</th>' +
-                    '<th style="width: 38px;"><p><br></p></th>' +
-                    '<th style="width: 43px;">ef</th>' +
-                    "</tr>" +
-                    '<tr style="height: 30px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd</td>" +
-                    "<td><p><br></p></td>" +
-                    "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    '<table style="width: 150px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 30px;">' +
+                    '<col style="width: 38px;">' +
+                    '<col style="width: 38px;">' +
+                    '<col style="width: 43px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
+                    '<tr style="height: 20px;"><th>ab</th><th>cd[]</th><th><p><br></p></th><th>ef</th></tr>' +
+                    '<tr style="height: 30px;"><td>ab</td><td>cd</td><td><p><br></p></td><td>ef</td></tr>' +
+                    "</tbody></table>",
             });
         });
 
@@ -893,24 +968,18 @@ describe("column", () => {
                     "</tr></tbody></table>",
                 stepFunction: addColumn("after"),
                 contentAfter:
-                    '<table style="width: 200px;"><tbody><tr style="height: 20px;">' +
-                    '<td style="width: 38px;">ab</td>' +
-                    '<td style="width: 49px;">cd</td>' +
-                    '<td style="width: 49px;"><p><br></p></td>' +
-                    '<td style="width: 63px;">ef</td>' +
-                    "</tr>" +
-                    '<tr style="height: 30px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd[]</td>" +
-                    "<td><p><br></p></td>" +
-                    "<td>ef</td>" +
-                    "</tr>" +
-                    '<tr style="height: 40px;">' +
-                    "<td>ab</td>" +
-                    "<td>cd</td>" +
-                    "<td><p><br></p></td>" +
-                    "<td>ef</td>" +
-                    "</tr></tbody></table>",
+                    '<table style="width: 200px;">' +
+                    "<colgroup>" +
+                    '<col style="width: 38px;">' +
+                    '<col style="width: 49px;">' +
+                    '<col style="width: 49px;">' +
+                    '<col style="width: 63px;">' +
+                    "</colgroup>" +
+                    "<tbody>" +
+                    '<tr style="height: 20px;"><td>ab</td><td>cd</td><td><p><br></p></td><td>ef</td></tr>' +
+                    '<tr style="height: 30px;"><td>ab</td><td>cd[]</td><td><p><br></p></td><td>ef</td></tr>' +
+                    '<tr style="height: 40px;"><td>ab</td><td>cd</td><td><p><br></p></td><td>ef</td></tr>' +
+                    "</tbody></table>",
             });
         });
     });
@@ -937,11 +1006,16 @@ describe("column", () => {
                 stepFunction: moveColumn(0),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 25px;">
+                            <col style="width: 20px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 20px;">
-                                <th class="o_table_header" style="width: 25px;">cd[]</th>
-                                <th class="o_table_header" style="width: 20px;">ab</th>
-                                <th class="o_table_header" style="width: 30px;">ef</th>
+                                <th class="o_table_header">cd[]</th>
+                                <th class="o_table_header">ab</th>
+                                <th class="o_table_header">ef</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>ij</td>
@@ -961,8 +1035,8 @@ describe("column", () => {
                         <tbody>
                             <tr style="height: 20px;">
                                 <th class="o_table_header" style="width: 20px;">ab</th>
-                                <th class="o_table_header" style="width: 25px;">cd[]</th>
-                                <th class="o_table_header" style="width: 30px;">ef</th>
+                                <th class="o_table_header" style="width: 30px;">cd[]</th>
+                                <th class="o_table_header" style="width: 25px;">ef</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>gh</td>
@@ -975,11 +1049,16 @@ describe("column", () => {
                 stepFunction: moveColumn(2),
                 contentAfter: unformat(`
                     <table>
+                        <colgroup>
+                            <col style="width: 20px;">
+                            <col style="width: 25px;">
+                            <col style="width: 30px;">
+                        </colgroup>
                         <tbody>
                             <tr style="height: 20px;">
-                                <th class="o_table_header" style="width: 20px;">ab</th>
-                                <th class="o_table_header" style="width: 30px;">ef</th>
-                                <th class="o_table_header" style="width: 25px;">cd[]</th>
+                                <th class="o_table_header">ab</th>
+                                <th class="o_table_header">ef</th>
+                                <th class="o_table_header">cd[]</th>
                             </tr>
                             <tr style="height: 30px;">
                                 <td>gh</td>
@@ -1235,23 +1314,25 @@ describe("tab", () => {
                 </tr>
             </tbody></table>`);
         const { el, editor } = await setupEditor(contentBefore);
-
         await press("Tab");
 
         const expectedContent = unformat(
             `<p data-selection-placeholder=""><br></p>
-            <table><tbody>
-                <tr style="height: 20px;">
-                    <td style="width: 20px;">ab</td>
-                    <td>cd</td>
-                    <td>ef</td>
-                </tr>
-                <tr style="height: 20px;">
-                    <td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
-                    <td><p><br></p></td>
-                    <td><p><br></p></td>
-                </tr>
-            </tbody></table>
+            <table>
+                <colgroup><col style="width: 20px;"></colgroup>
+                <tbody>
+                    <tr style="height: 20px;">
+                        <td style="">ab</td>
+                        <td>cd</td>
+                        <td>ef</td>
+                    </tr>
+                    <tr style="height: 20px;">
+                        <td><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                        <td><p><br></p></td>
+                        <td><p><br></p></td>
+                    </tr>
+                </tbody>
+            </table>
             <p data-selection-placeholder=""><br></p>`
         );
 
@@ -1260,9 +1341,19 @@ describe("tab", () => {
         // Check that it was registed as a history step.
         undo(editor);
         expect(getContent(el)).toBe(
-            '<p data-selection-placeholder=""><br></p>' +
-                contentBefore +
-                '<p data-selection-placeholder=""><br></p>'
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table>
+                    <colgroup><col style="width: 20px;"></colgroup>
+                    <tbody>
+                        <tr style="height: 20px;">
+                            <td style="">ab</td>
+                            <td>cd</td>
+                            <td>ef[]</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder=""><br></p>`)
         );
     });
 
@@ -1272,7 +1363,7 @@ describe("tab", () => {
                 '<table><tbody><tr style="height: 20px;"><td style="width: 20px;">ab</td><td>[cd]</td><td>ef</td></tr></tbody></table>',
             stepFunction: () => press("Tab"),
             contentAfter:
-                '<table><tbody><tr style="height: 20px;"><td style="width: 20px;">ab</td><td>cd</td><td>ef[]</td></tr></tbody></table>',
+                '<table><colgroup><col style="width: 20px;"></colgroup><tbody><tr style="height: 20px;"><td>ab</td><td>cd</td><td>ef[]</td></tr></tbody></table>',
         });
     });
 });

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1783,6 +1783,312 @@ describe("symmetrical selection", () => {
         );
     });
 
+    test("Shift + arrow key navigation selects cells symmetrically across colspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td>[]<br></td><td><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td colspan="2"><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+            `)
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td colspan="2"><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td colspan="2"><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td">]<br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2" class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td colspan="2"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">]<br></td><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowUp"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">]<br></td><td colspan="2"><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+    });
+
+    test("Shift + arrow key selection with rowspan (start from first row first td)", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td>[]<br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td rowspan="2"><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+            `)
+        );
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td rowspan="2"><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                    <tr><td><br></td><td rowspan="2"><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2" class="o_selected_td">]<br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2" class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
+                    <tr><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2" class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2" class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2" class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+        expectContentToBe(
+            el,
+            `<p data-selection-placeholder=""><br></p>
+            <table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td rowspan="2"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+        );
+    });
+
     test("select single cell containing text when pressing shift + arrow key", async () => {
         const { el, editor } = await setupEditor(
             unformat(
@@ -2667,7 +2973,7 @@ describe("keyboard navigation with multiline", () => {
                     <p data-selection-placeholder=""><br></p>
                     <table class="o_selected_table"><tbody>
                     <tr><td>A1</td><td>B1</td><td>C1</td><td>D1</td><td>E1</td></tr>
-                    <tr><td>A2</td><td>B2</td><td class="o_selected_td">]C2</td><td>D2</td><td>E2</td></tr>
+                    <tr><td>A2</td><td>B2</td><td class="o_selected_td">C2]</td><td>D2</td><td>E2</td></tr>
                     <tr><td>A3</td><td>B3</td><td class="o_selected_td">
                         <div class="o-paragraph">P1[L1<br>P1L2</div><div class="o-paragraph">P2L1<br>P2L2</div>
                     </td><td>D3</td><td>E3</td></tr>

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -844,28 +844,36 @@ describe("select columns on cross over", () => {
     describe("reset size", () => {
         test("should remove any height or width of the table and bring it back to it original form", async () => {
             await testEditor({
-                contentBefore: `<table class="table table-bordered o_table" style="height: 980.5px; width: 736px;"><tbody>
-                                    <tr style="height: 306.5px;">
-                                        <td style="width: 356px;"><p>[]<br></p></td>
-                                        <td style="width: 108.5px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 38.25px;"><p><br></p></td>
-                                    </tr>
-                                    <tr style="height: 252px;">
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                    </tr>
-                                    <tr style="height: 57px;">
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                        <td style="width: 232.25px;"><p><br></p></td>
-                                    </tr>
-                                </tbody></table>`,
+                contentBefore:
+                    unformat(`<table class="table table-bordered o_table" style="height: 980.5px; width: 736px;">
+                                    <colgroup>
+                                        <col style="width: 356px;">
+                                        <col style="width: 108.5px;">
+                                        <col style="width: 232.25px;">
+                                        <col style="width: 38.25px;">
+                                    </colgroup>
+                                    <tbody>
+                                        <tr style="height: 306.5px;">
+                                            <td><p>[]<br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                        </tr>
+                                        <tr style="height: 252px;">
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                        </tr>
+                                        <tr style="height: 57px;">
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                            <td><p><br></p></td>
+                                        </tr>
+                                </tbody></table>`),
                 stepFunction: resetSize,
-                contentAfter: `<table class="table table-bordered o_table"><tbody>
+                contentAfter: unformat(`<table class="table table-bordered o_table"><tbody>
                                     <tr>
                                         <td><p>[]<br></p></td>
                                         <td><p><br></p></td>
@@ -884,44 +892,52 @@ describe("select columns on cross over", () => {
                                         <td><p><br></p></td>
                                         <td><p><br></p></td>
                                     </tr>
-                                </tbody></table>`,
+                                </tbody></table>`),
             });
         });
 
         test("should remove any height or width of the table without loosing the style of the element inside it.", async () => {
             await testEditor({
-                contentBefore: `<table class="table table-bordered o_table" style="width: 472.182px; height: 465.403px;"><tbody>
-                                    <tr style="height: 104.872px;">
-                                        <td style="width: 191.273px;"><h1>[]TESTTEXT</h1></td>
-                                        <td style="width: 154.009px;"><p><br></p></td>
-                                        <td style="width: 126.003px;">
-                                            <ul>
-                                                <li>test</li>
-                                                <li>test</li>
-                                                <li>test</li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr style="height: 254.75px;">
-                                        <td style="width: 229.673px;"><p><br></p></td>
-                                        <td style="width: 229.687px;">
-                                            <blockquote>TESTTEXT</blockquote>
-                                        </td>
-                                        <td style="width: 229.73px;"><p><br></p></td>
-                                    </tr>
-                                    <tr style="height: 104.872px;">
-                                        <td style="width: 229.673px;"><pre>codeTEST</pre></td>
-                                        <td style="width: 229.687px;"><p><br></p></td>
-                                        <td style="width: 229.73px;">
-                                            <ol>
-                                                <li>text</li>
-                                                <li>text</li>
-                                                <li>text</li>
-                                            </ol>
+                contentBefore:
+                    unformat(`<table class="table table-bordered o_table" style="width: 472.182px; height: 465.403px;">
+                                        <colgroup>
+                                        <col style="width: 191.273px;">
+                                        <col style="width: 154.009px;">
+                                        <col style="width: 126.003px;">
+                                    </colgroup>
+                                    <tbody>
+                                        <tr style="height: 104.872px;">
+                                            <td><h1>[]TESTTEXT</h1></td>
+                                            <td><p><br></p></td>
+                                            <td>
+                                                <ul>
+                                                    <li>test</li>
+                                                    <li>test</li>
+                                                    <li>test</li>
+                                                </ul>
                                             </td>
-                                    </tr></tbody></table>`,
+                                        </tr>
+                                        <tr style="height: 254.75px;">
+                                            <td><p><br></p></td>
+                                            <td>
+                                                <blockquote>TESTTEXT</blockquote>
+                                            </td>
+                                            <td><p><br></p></td>
+                                        </tr>
+                                        <tr style="height: 104.872px;">
+                                            <td><pre>codeTEST</pre></td>
+                                            <td><p><br></p></td>
+                                            <td>
+                                                <ol>
+                                                    <li>text</li>
+                                                    <li>text</li>
+                                                    <li>text</li>
+                                                </ol>
+                                                </td>
+                                        </tr>
+                                    </tbody></table>`),
                 stepFunction: resetSize,
-                contentAfter: `<table class="table table-bordered o_table"><tbody>
+                contentAfter: unformat(`<table class="table table-bordered o_table"><tbody>
                                     <tr>
                                         <td><h1>[]TESTTEXT</h1></td>
                                         <td><p><br></p></td>
@@ -950,31 +966,39 @@ describe("select columns on cross over", () => {
                                                 <li>text</li>
                                             </ol>
                                             </td>
-                                    </tr></tbody></table>`,
+                                    </tr></tbody></table>`),
             });
         });
 
         test("should remove any height or width of the table without removig the style of the table.", async () => {
             await testEditor({
-                contentBefore: `<table class="table table-bordered o_table" style="height: 594.5px; width: 807px;"><tbody>
-                                    <tr style="height: 229.5px;">
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 500px;"><p>[]<br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 119.328px;"><p><br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 186.672px;"><p><br></p></td>
-                                    </tr>
-                                    <tr style="height: 260px;">
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.656px;"><p><br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.672px;"><p><br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.672px;"><p><br></p></td>
-                                    </tr>
-                                    <tr style="height: 104px;">
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.656px;"><p><br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.672px;"><p><br></p></td>
-                                        <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255); width: 309.672px;"><p><br></p></td>
-                                    </tr>
-                                </tbody></table>`,
+                contentBefore:
+                    unformat(`<table class="table table-bordered o_table" style="height: 594.5px; width: 807px;">
+                    <colgroup>
+                        <col style="width: 500px;">
+                        <col style="width: 119.328px;">
+                        <col style="width: 186.672px;">
+                    </colgroup>
+                    <tbody>
+                        <tr style="height: 229.5px;">
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p>[]<br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                        </tr>
+                        <tr style="height: 260px;">
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                        </tr>
+                        <tr style="height: 104px;">
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                            <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`),
                 stepFunction: resetSize,
-                contentAfter: `<table class="table table-bordered o_table"><tbody>
+                contentAfter: unformat(`<table class="table table-bordered o_table"><tbody>
                                     <tr>
                                         <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p>[]<br></p></td>
                                         <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
@@ -990,7 +1014,7 @@ describe("select columns on cross over", () => {
                                         <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
                                         <td style="background-color: rgb(206, 231, 247); color: rgb(0, 0, 255);"><p><br></p></td>
                                     </tr>
-                                </tbody></table>`,
+                                </tbody></table>`),
             });
         });
     });

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1453,6 +1453,97 @@ describe("move cursor with arrow keys", () => {
                 `),
             });
         });
+        test("should move the cursor down across cells with colspan using ArrowUp", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr><td><br></td><td><br></td><td><br></td></tr>
+                            <tr><td><br></td><td colspan="2"><br></td></tr>
+                            <tr><td><br></td><td><br></td><td>[]<br></td></tr>
+                        </tbody>
+                    </table>
+                `)
+            );
+            press(["ArrowUp"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td colspan="2">[]<br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+
+            press(["ArrowUp"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td>[]<br></td><td><br></td></tr>
+                        <tr><td><br></td><td colspan="2"><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+        });
+        test("should move the cursor down across cells with rowspan using ArrowUp", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr><td><br></td><td><br></td></tr>
+                            <tr><td><br></td><td rowspan="2"><br></td></tr>
+                            <tr><td><br></td></tr>
+                            <tr><td><br></td><td>[]<br></td></tr>
+                        </tbody>
+                    </table>
+                `)
+            );
+            press(["ArrowUp"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td rowspan="2">[]<br></td></tr>
+                        <tr><td><br></td></tr>
+                        <tr><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+
+            press(["ArrowUp"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td>[]<br></td></tr>
+                        <tr><td><br></td><td rowspan="2"><br></td></tr>
+                        <tr><td><br></td></tr>
+                        <tr><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+        });
     });
 
     describe("arrowdown", () => {
@@ -1685,6 +1776,97 @@ describe("move cursor with arrow keys", () => {
                     </table>
                 `),
             });
+        });
+        test("should move the cursor down across cells with colspan using ArrowDown", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr><td><br></td><td><br></td><td>[]<br></td></tr>
+                            <tr><td><br></td><td colspan="2"><br></td></tr>
+                            <tr><td><br></td><td><br></td><td><br></td></tr>
+                        </tbody>
+                    </table>
+                `)
+            );
+            press(["ArrowDown"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td colspan="2">[]<br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+
+            press(["ArrowDown"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td colspan="2"><br></td></tr>
+                        <tr><td><br></td><td>[]<br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+        });
+        test("should move the cursor down across cells with rowspan using ArrowDown", async () => {
+            const { el } = await setupEditor(
+                unformat(`
+                    <table class="table table-bordered o_table">
+                        <tbody>
+                            <tr><td><br></td><td>[]<br></td></tr>
+                            <tr><td><br></td><td rowspan="2"><br></td></tr>
+                            <tr><td><br></td></tr>
+                            <tr><td><br></td><td><br></td></tr>
+                        </tbody>
+                    </table>
+                `)
+            );
+            press(["ArrowDown"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td rowspan="2">[]<br></td></tr>
+                        <tr><td><br></td></tr>
+                        <tr><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
+
+            press(["ArrowDown"]);
+            await animationFrame();
+
+            expectContentToBe(
+                el,
+                `<p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td rowspan="2"><br></td></tr>
+                        <tr><td><br></td></tr>
+                        <tr><td><br></td><td>[]<br></td></tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`
+            );
         });
     });
 });

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1453,7 +1453,7 @@ describe("move cursor with arrow keys", () => {
                 `),
             });
         });
-        test("should move the cursor down across cells with colspan using ArrowUp", async () => {
+        test("should move the cursor up across cells with colspan using ArrowUp", async () => {
             const { el } = await setupEditor(
                 unformat(`
                     <table class="table table-bordered o_table">

--- a/addons/html_editor/static/tests/table/table_drag_drop.test.js
+++ b/addons/html_editor/static/tests/table/table_drag_drop.test.js
@@ -187,6 +187,211 @@ test("should move third column before first column on drag and drop", async () =
     );
 });
 
+test("should not allow dropping a column inside a merged column", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td class="g">6</td>
+                        <td colspan="3" class="h">7</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over the first cell to display the column menu
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+    const colMenu = document.querySelector("[data-type='column'].o-we-table-menu");
+    const colMenuRect = colMenu.getBoundingClientRect();
+    // Start a long press on the column menu to enable drag-and-drop
+    await manuallyDispatchProgrammaticEvent(colMenu, "pointerdown", {
+        clientX: colMenuRect.x + colMenuRect.width / 2,
+        clientY: colMenuRect.y,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+    // Drag to the boundary before the merged column (valid drop)
+    let targetCell = el.querySelector("td.a");
+    let targetCellRect = targetCell.getBoundingClientRect();
+
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+
+    // The left boundary of the merged column should highlight
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a td-highlight-right">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td class="g td-highlight-right">6</td>
+                        <td colspan="3" class="h">7</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Drag over the middle of a merged column (invalid drop position)
+    targetCell = el.querySelector("td.c");
+    targetCellRect = targetCell.getBoundingClientRect();
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+
+    // No highlight should appear on the merged column themselves.
+    // Instead, the next valid boundary is highlighted
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a td-highlight-right">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td class="g td-highlight-right">6</td>
+                        <td colspan="3" class="h">7</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+
+    // Drag near the right edge of the merged column (valid drop boundary)
+    targetCell = el.querySelector("td.d");
+    targetCellRect = targetCell.getBoundingClientRect();
+
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointermove", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    // The right border of the merged column should highlight to indicate a
+    // valid drop position
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d td-highlight-right">4</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td class="g">6</td>
+                        <td colspan="3" class="h td-highlight-right">7</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    // Release pointer: column should be moved after the merged column
+    await manuallyDispatchProgrammaticEvent(targetCell, "pointerup", {
+        clientX: targetCellRect.x + targetCellRect.width * 0.75,
+        clientY: targetCellRect.y,
+    });
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                        <td class="a">[]1</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td colspan="3" class="h">7</td>
+                        <td class="g">6</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("should not allow dragging a merged column", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4</td>
+                        <td class="f">5</td>
+                    </tr>
+                    <tr>
+                        <td class="g">6</td>
+                        <td colspan="3" class="h">7</td>
+                        <td class="i">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over first cell to trigger column menu
+    await hover(el.querySelector("td.b"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+    const colMenu = document.querySelector("[data-type='column'].o-we-table-menu");
+    const colMenuRect = colMenu.getBoundingClientRect();
+    // Start a long press on the merged column menu
+    await manuallyDispatchProgrammaticEvent(colMenu, "pointerdown", {
+        clientX: colMenuRect.x + colMenuRect.width / 2,
+        clientY: colMenuRect.y,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    // Drag overlay should not appear for merged columns
+    await expectElementCount(".o-we-table-drag-drop", 0);
+});
+
 test("undo/redo should work correctly after dragging and dropping a column", async () => {
     const { el, editor } = await setupEditor(
         unformat(`
@@ -359,16 +564,16 @@ test("should move first header row to last position on drag and drop", async () 
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>
-                        <th class="o_table_header">3</th>
-                        <th class="o_table_header">4</th>
+                        <th class="c o_table_header">3</th>
+                        <th class="d o_table_header">4</th>
                     </tr>
                     <tr class="">
                         <td class="e">5</td>
                         <td class="f">6</td>
                     </tr>
                     <tr>
-                        <td>[]1</td>
-                        <td>2</td>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
                     </tr>
                 </tbody>
             </table>
@@ -471,6 +676,247 @@ test("should move last row above the first header row on drag and drop", async (
             <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
         `)
     );
+});
+
+test("should not allow dropping a row inside a merged row", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="d">3</td>
+                        <td rowspan="3" class="c">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                    <tr>
+                        <td class="f">6</td>
+                    </tr>
+                    <tr>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                    </tr>
+                </tbody>
+            </table>
+        `)
+    );
+
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over the first row to trigger the row menu
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    const rowMenu = document.querySelector("[data-type='row'].o-we-table-menu");
+    const rowMenuRect = rowMenu.getBoundingClientRect();
+    // Long press to start drag
+    await manuallyDispatchProgrammaticEvent(rowMenu, "pointerdown", {
+        clientX: rowMenuRect.x,
+        clientY: rowMenuRect.y + rowMenuRect.height / 2,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    await expectElementCount(".o-we-table-drag-drop", 1);
+
+    // Drag over top boundary of merged row
+    let targeCell = el.querySelector("td.a");
+    let targetRow = targeCell.parentElement;
+    let targetRowRect = targetRow.getBoundingClientRect();
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+
+    // Top border of merged row should highlight
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr class="tr-highlight-bottom">
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="d">3</td>
+                        <td rowspan="3" class="c">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                    <tr>
+                        <td class="f">6</td>
+                    </tr>
+                    <tr>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+
+    // Drag over the middle of a merged row (invalid drop position)
+    targeCell = el.querySelector("td.e");
+    targetRow = targeCell.parentElement;
+    targetRowRect = targetRow.getBoundingClientRect();
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+
+    // No highlight should appear on the merged rows themselves.
+    // Instead, the next valid boundary is highlighted
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr class="tr-highlight-bottom">
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="d">3</td>
+                        <td rowspan="3" class="c">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                    <tr>
+                        <td class="f">6</td>
+                    </tr>
+                    <tr>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+
+    // Drag just past merged row bottom
+    targeCell = el.querySelector("td.f");
+    targetRow = targeCell.parentElement;
+    targetRowRect = targetRow.getBoundingClientRect();
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointermove", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+
+    // Bottom border of merged row should highlight
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr class="">
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="d">3</td>
+                        <td rowspan="3" class="c">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                    <tr class="tr-highlight-bottom">
+                        <td class="f">6</td>
+                    </tr>
+                    <tr>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+
+    // Release pointer: row should move after merged row
+    await manuallyDispatchProgrammaticEvent(targetRow, "pointerup", {
+        clientX: targetRowRect.x,
+        clientY: targetRowRect.y + targetRowRect.height * 0.75,
+    });
+
+    await expectElementCount(".o-we-table-drag-drop", 0);
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="d">3</td>
+                        <td rowspan="3" class="c">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                    <tr class="">
+                        <td class="f">6</td>
+                    </tr>
+                    <tr class="">
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+});
+
+test("should not allow dragging a merged row", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <p><br></p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr>
+                        <td class="a">[]1</td>
+                        <td class="b">2</td>
+                    </tr>
+                    <tr>
+                        <td rowspan="2" class="c">3</td>
+                        <td class="d">4</td>
+                    </tr>
+                    <tr>
+                        <td class="e">5</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+        `)
+    );
+
+    await expectElementCount(".o-we-table-menu", 0);
+    // Hover over a cell in the merged row
+    await hover(el.querySelector("td.c"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    const rowMenu = document.querySelector("[data-type='row'].o-we-table-menu");
+    const rowMenuRect = rowMenu.getBoundingClientRect();
+    // Start a long press on the merged row menu
+    await manuallyDispatchProgrammaticEvent(rowMenu, "pointerdown", {
+        clientX: rowMenuRect.x,
+        clientY: rowMenuRect.y + rowMenuRect.height / 2,
+    });
+    // Table drag-drop overlay activates after a 200ms long press.
+    // Wait 300ms to ensure reliability in tests.
+    await delay(300);
+    // Drag overlay should not appear for merged rows
+    await expectElementCount(".o-we-table-drag-drop", 0);
 });
 
 test("undo/redo should work correctly after dragging and dropping a row", async () => {

--- a/addons/html_editor/static/tests/table/table_drag_drop.test.js
+++ b/addons/html_editor/static/tests/table/table_drag_drop.test.js
@@ -660,12 +660,12 @@ test("should move last row above the first header row on drag and drop", async (
             <table class="table table-bordered o_table">
                 <tbody>
                     <tr>
-                        <th class="o_table_header">[]5</th>
-                        <th class="o_table_header">6</th>
+                        <th class="e o_table_header">[]5</th>
+                        <th class="f o_table_header">6</th>
                     </tr>
                     <tr class="">
-                        <td>1</td>
-                        <td>2</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
                     </tr>
                     <tr>
                         <td class="c">3</td>

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -58,6 +58,26 @@ test("should display the table ui menu only if hover on first row/col", async ()
     await waitForNone(".o-we-table-menu");
 });
 
+test("should not display the table UI menu when hovering over non-first row/col cells", async () => {
+    const { el } = await setupEditor(`
+        <table>
+            <tbody>
+                <tr><td rowspan="3">1</td><td>2</td><td>3</td></tr>
+                <tr><td class="a">4[]</td><td>5</td></tr>
+                <tr><td class="b">6</td><td>7</td></tr>
+            </tbody>
+        </table>`);
+    await expectElementCount(".o-we-table-menu", 0);
+
+    await hover(el.querySelector("td.a"));
+    await animationFrame();
+    await expectElementCount(".o-we-table-menu", 0);
+
+    await hover(el.querySelector("td.b"));
+    await animationFrame();
+    await expectElementCount(".o-we-table-menu", 0);
+});
+
 test("should not display the table ui menu if the table element isContentEditable=false", async () => {
     const { el } = await setupEditor(`
         <table contenteditable="false"><tbody><tr>

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1361,6 +1361,71 @@ test("move column right operation", async () => {
     );
 });
 
+test("disables move column left/right when current or adjacent columns are affected by colspan", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td><br></td>
+                    <td class="a"><br></td>
+                    <td class="b"><br></td>
+                    <td><br></td>
+                    <td class="c"><br></td>
+                    <td><br></td>
+                </tr>
+                <tr>
+                    <td><br></td>
+                    <td><br></td>
+                    <td colspan="2"><br></td>
+                    <td><br></td>
+                    <td><br></td>
+                </tr>
+            </tbody>
+        </table>`)
+    );
+
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // Hover on td.a to show column UI
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    // Open menu and check disabled states
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_right']").toHaveClass("disabled");
+    expect("div[name='move_left']").not.toHaveClass("disabled");
+
+    // Close menu
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+
+    // Open menu again and hover on td.b
+    await hover(el.querySelector("td.b"));
+    await animationFrame();
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_right']").toHaveClass("disabled");
+    expect("div[name='move_left']").toHaveClass("disabled");
+
+    // Close menu
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+
+    // Open menu again and hover on td.c
+    await hover(el.querySelector("td.c"));
+    await animationFrame();
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    await click("[data-type='column'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_right']").not.toHaveClass("disabled");
+    expect("div[name='move_left']").toHaveClass("disabled");
+});
+
 test("move row above operation", async () => {
     const { el, editor } = await setupEditor(
         unformat(`
@@ -1529,6 +1594,58 @@ test("move row below operation", async () => {
     );
 });
 
+test("disables row move up or down when affected by rowspan in current or adjacent rows", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td><br></td><td><br></td></tr>
+                <tr><td class="a"><br></td><td><br></td></tr>
+                <tr><td class="b"><br></td><td rowspan="2"><br></td></tr>
+                <tr><td><br></td></tr>
+                <tr><td class="c"><br></td><td><br></td></tr>
+                <tr><td><br></td><td><br></td></tr>
+            </tbody>
+        </table>`)
+    );
+    // Initially no menu visible
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // Check on row "a"
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_down']").toHaveClass("disabled");
+    expect("div[name='move_up']").not.toHaveClass("disabled");
+
+    // Close menu
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+
+    // Check on row "b" (covered by rowspan)
+    await hover(el.querySelector("td.b"));
+    await animationFrame();
+    await waitFor("[data-type='row'].o-we-table-menu");
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_down']").toHaveClass("disabled");
+    expect("div[name='move_up']").toHaveClass("disabled");
+
+    // Close menu
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+
+    // Check on row "c"
+    await hover(el.querySelector("td.c"));
+    await animationFrame();
+    await waitFor("[data-type='row'].o-we-table-menu");
+    await click("[data-type='row'].o-we-table-menu");
+    await animationFrame();
+    expect("div[name='move_down']").not.toHaveClass("disabled");
+    expect("div[name='move_up']").toHaveClass("disabled");
+});
+
 test("move header row below operation", async () => {
     const { el } = await setupEditor(
         unformat(`
@@ -1592,7 +1709,7 @@ test("should revert a converted header row back to normal after undo", async () 
             <p data-selection-placeholder=""><br></p>
             <table>
                 <tbody>
-                    <tr><th class="o_table_header">1[]</th><th class="o_table_header">2</th></tr>
+                    <tr><th class="a o_table_header">1[]</th><th class="o_table_header">2</th></tr>
                     <tr><td>3</td><td>4</td></tr>
                 </tbody>
             </table>

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -790,6 +790,134 @@ test("insert column right operation", async () => {
     );
 });
 
+test("insert column at the start of a merge column", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td>2</td><td>3</td></tr>
+                <tr><td colspan="3">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor("div[name='insert_left']");
+
+    // insert column left
+    await click("div[name='insert_left']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table>
+            <tbody>
+                <tr>
+                    <td><p><br></p></td>
+                    <td class="a">1[]</td>
+                    <td>2</td>
+                    <td>3</td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td colspan="3">4</td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
+    );
+});
+
+test("insert column in the middle of a a merged column", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr><td class="a">1[]</td><td>2</td><td>3</td></tr>
+                <tr><td colspan="3">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor("div[name='insert_right']");
+
+    // insert column right
+    await click("div[name='insert_right']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td class="a">1[]</td>
+                    <td><p><br></p></td>
+                    <td>2</td>
+                    <td>3</td>
+                </tr>
+                <tr>
+                    <td colspan="4">4</td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+    );
+});
+
+test("insert column at the end of a merged column below", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr><td>1</td><td>2</td><td class="a">3[]</td></tr>
+                <tr><td colspan="3">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show col ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='column'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor("div[name='insert_right']");
+
+    // insert column right
+    await click("div[name='insert_right']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table class="table table-bordered o_table">
+            <tbody>
+                <tr>
+                    <td>1</td>
+                    <td>2</td>
+                    <td class="a">3[]</td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td colspan="3">4</td>
+                    <td><p><br></p></td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+    );
+});
+
 test("insert column right operation when table header exists", async () => {
     const { el } = await setupEditor(
         unformat(`
@@ -988,6 +1116,149 @@ test("insert row below operation", async () => {
             <tbody>
                 <tr><td class="a">1[]</td><td class="b">2</td></tr>
                 <tr><td class="c">3</td><td class="d">4</td></tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
+    );
+});
+
+test("insert row above the rowspan cell", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a" rowspan="3">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td></tr>
+                <tr><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show row ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor("div[name='insert_above']");
+
+    // insert row above
+    await click("div[name='insert_above']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table>
+            <tbody>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td class="a" rowspan="3">1[]</td>
+                    <td class="b">2</td>
+                </tr>
+                <tr>
+                    <td class="c">3</td>
+                </tr>
+                <tr>
+                    <td class="d">4</td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
+    );
+});
+
+test("insert row in the middle of a rowspan cell", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b" rowspan="3">2</td></tr>
+                <tr><td class="c">3</td></tr>
+                <tr><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show row ui
+    await hover(el.querySelector("td.a"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor("div[name='insert_below']");
+
+    // insert row below
+    await click("div[name='insert_below']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="a">1[]</td>
+                    <td class="b" rowspan="4">2</td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                </tr>
+                <tr>
+                    <td class="c">3</td>
+                </tr>
+                <tr>
+                    <td class="d">4</td>
+                </tr>
+            </tbody>
+        </table>
+        <p data-selection-placeholder=""><br></p>`)
+    );
+});
+
+test("insert row at the end of a rowspan cell", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+        <table>
+            <tbody>
+                <tr><td class="a">1[]</td><td class="b" rowspan="3">2</td></tr>
+                <tr><td class="c">3</td></tr>
+                <tr><td class="d">4</td></tr>
+            </tbody>
+        </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    // hover on td to show row ui
+    await hover(el.querySelector("td.d"));
+    await waitFor("[data-type='row'].o-we-table-menu");
+
+    // click on it to open dropdown
+    await click("[data-type='row'].o-we-table-menu");
+    await waitFor("div[name='insert_below']");
+
+    // insert row below
+    await click("div[name='insert_below']");
+    expect(getContent(el)).toBe(
+        unformat(`
+        <p data-selection-placeholder=""><br></p>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="a">1[]</td>
+                    <td class="b" rowspan="3">2</td>
+                </tr>
+                <tr>
+                    <td class="c">3</td>
+                </tr>
+                <tr>
+                    <td class="d">4</td>
+                </tr>
+                <tr>
+                    <td><p><br></p></td>
+                    <td><p><br></p></td>
+                </tr>
             </tbody>
         </table>
         <p data-selection-placeholder=""><br></p>`)

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1,4 +1,4 @@
-import { expect, test } from "@odoo/hoot";
+import { describe, expect, test } from "@odoo/hoot";
 import {
     click,
     hover,
@@ -1145,7 +1145,7 @@ test("move second row to top when first row is header row", async () => {
         <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
-                <tr><th class="o_table_header">3</th><th class="o_table_header">4</th></tr>
+                <tr><th class="a o_table_header">3</th><th class="o_table_header">4</th></tr>
                 <tr><td>1[]</td><td>2</td></tr>
             </tbody>
         </table>
@@ -1266,7 +1266,7 @@ test("move header row below operation", async () => {
         <table>
             <tbody>
                 <tr><th class="o_table_header">3</th><th class="o_table_header">4</th></tr>
-                <tr><td>1[]</td><td>2</td></tr>
+                <tr><td class="a">1[]</td><td>2</td></tr>
             </tbody>
         </table>
         <p data-selection-placeholder=""><br></p>`)
@@ -1726,4 +1726,668 @@ test("removes alternating row colors when 'Clear Alternate Colors' option is cli
     expect(
         cells.every((cell) => getComputedStyle(cell).backgroundColor === firstRowCellColor)
     ).toBe(true);
+});
+
+describe("Disable table merge options", () => {
+    test("disables both merge options when selection spans multiple rows and columns", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>[<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="b"><p><br></p></td>
+                            <td><p><br>]</p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td"><p>[<br></p></td>
+                            <td class="o_selected_td"><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="b o_selected_td"><p><br></p></td>
+                            <td class="o_selected_td"><p><br>]</p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        expect("div[name='merge_cell']").toHaveClass("disabled");
+
+        // click on menu to close dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await animationFrame();
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.b"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='row'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        expect("div[name='merge_cell']").toHaveClass("disabled");
+    });
+});
+
+describe("Merge column cells", () => {
+    test("merges selected cells in a single row into one with colspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a">[<p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p>]</td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a o_selected_td">[<p><br></p></td>
+                            <td class="o_selected_td"><p><br></p></td>
+                            <td class="o_selected_td"><p><br></p>]</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='row'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        await click("div[name='merge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a o_selected_td" colspan="3"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+
+    test("merges selected filled cells by combining their content into one cell with colspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a">[<p>a</p></td>
+                            <td><p>b</p></td>
+                            <td><p>c</p>]</td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a o_selected_td">[<p>a</p></td>
+                            <td class="o_selected_td"><p>b</p></td>
+                            <td class="o_selected_td"><p>c</p>]</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='row'].o-we-table-menu");
+        await waitFor("div[name='merge_cell'");
+
+        await click("div[name='merge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a o_selected_td" colspan="3"><p>[a</p><p>b</p><p>c]</p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+});
+
+describe("Merge row cells", () => {
+    test("merges selected cells vertically in a column by applying rowspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>[<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br>]</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td"><p>[<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="o_selected_td"><p><br>]</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        await click("div[name='merge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td" rowspan="2"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+
+    test("merges filled cells vertically by combining their content into one cell with rowspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>[a</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p>b]</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td"><p>[a</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="o_selected_td"><p>b]</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await waitFor("div[name='merge_cell'");
+
+        await click("div[name='merge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td" rowspan="2"><p>[a</p><p>b]</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+
+    test("does not display merge cell option when hovering over a table that has no selected cells", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <p><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>[<br></p></td>
+                            <td><p><br>]</p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="b"><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td"><p>[<br></p></td>
+                            <td class="o_selected_td"><p><br>]</p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="b"><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+        await hover(el.querySelector("td.b"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+        await click("[data-type='column'].o-we-table-menu");
+        await animationFrame();
+        expect("div[name='merge_cell']").toHaveCount(0);
+        await click("[data-type='column'].o-we-table-menu");
+        await animationFrame();
+    });
+});
+
+describe("unmerge cells option", () => {
+    test("unmerge merged row cells via column menu", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a" rowspan="2"><p>[]<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a" rowspan="2"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await animationFrame();
+        expect("div[name='unmerge_cell']").toHaveCount(1);
+
+        await click("div[name='unmerge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+    test("unmerge merged column cells via row menu", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a" colspan="3"><p>[]<br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a" colspan="3"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await waitFor("[data-type='row'].o-we-table-menu");
+        await click("[data-type='row'].o-we-table-menu");
+        await animationFrame();
+        expect("div[name='unmerge_cell']").toHaveCount(1);
+
+        await click("div[name='unmerge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a"><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+    test("unmerge merged filled row cells via column menu", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a" rowspan="2"><p>a[]</p><p>b</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a" rowspan="2"><p>a[]</p><p>b</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await animationFrame();
+        expect("div[name='unmerge_cell']").toHaveCount(1);
+
+        await click("div[name='unmerge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>a[]</p><p>b</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
+    test("unmerge merged filled column cells via row menu", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a" colspan="3"><p>a[]</p><p>b</p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a" colspan="3"><p>a[]</p><p>b</p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await waitFor("[data-type='row'].o-we-table-menu");
+        await click("[data-type='row'].o-we-table-menu");
+        await animationFrame();
+        expect("div[name='unmerge_cell']").toHaveCount(1);
+
+        await click("div[name='unmerge_cell']");
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a"><p>a[]</p><p>b</p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+    });
 });

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1792,6 +1792,101 @@ describe("Disable table merge options", () => {
 
         expect("div[name='merge_cell']").toHaveClass("disabled");
     });
+
+    test("disables merge row option when selection includes cells with rowspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td rowspan="2"><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a">[<p><br></p></td>
+                            <td><p><br></p>]</td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td><p><br></p></td>
+                            <td rowspan="2" class="o_selected_td"><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td class="a o_selected_td">[<p><br></p></td>
+                            <td class="o_selected_td"><p><br></p>]</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='row'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='row'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        expect("div[name='merge_cell']").toHaveClass("disabled");
+    });
+    test("disables merge column option when selection includes cells with colspan", async () => {
+        const { el } = await setupEditor(
+            unformat(`
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr>
+                            <td class="a"><p>[<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td colspan="3"><p>]<br></p></td>
+                        </tr>
+                    </tbody>
+                </table>`)
+        );
+        expect(getContent(el)).toBe(
+            unformat(`
+                <p data-selection-placeholder=""><br></p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr>
+                            <td class="a o_selected_td"><p>[<br></p></td>
+                            <td><p><br></p></td>
+                            <td><p><br></p></td>
+                        </tr>
+                        <tr>
+                            <td colspan="3" class="o_selected_td"><p>]<br></p></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+        );
+
+        await expectElementCount(".o-we-table-menu", 0);
+
+        // hover on td to show col ui
+        await hover(el.querySelector("td.a"));
+        await waitFor("[data-type='column'].o-we-table-menu");
+
+        // click on it to open dropdown
+        await click("[data-type='column'].o-we-table-menu");
+        await waitFor("div[name='merge_cell']");
+
+        expect("div[name='merge_cell']").toHaveClass("disabled");
+    });
 });
 
 describe("Merge column cells", () => {

--- a/addons/html_editor/static/tests/table/ui.test.js
+++ b/addons/html_editor/static/tests/table/ui.test.js
@@ -1509,43 +1509,6 @@ test("move second row to top when first row is header row", async () => {
     );
 });
 
-test("preserve table rows width on move row above operation", async () => {
-    const { el } = await setupEditor(
-        unformat(`
-        <table>
-            <tbody>
-                <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
-                <tr><td style="width: 150px;" class="c">3</td><td style="width: 150px;" class="d">4</td></tr>
-                <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
-            </tbody>
-        </table>`)
-    );
-    await expectElementCount(".o-we-table-menu", 0);
-
-    // hover on td to show row ui
-    await hover(el.querySelector("td.c"));
-    await waitFor("[data-type='row'].o-we-table-menu");
-
-    // click on it to open dropdown
-    await click("[data-type='row'].o-we-table-menu");
-    await waitFor("div[name='move_up']");
-
-    // move row up
-    await click("div[name='move_up']");
-    expect(getContent(el)).toBe(
-        unformat(`
-        <p data-selection-placeholder=""><br></p>
-        <table>
-            <tbody>
-                <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
-                <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
-                <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
-            </tbody>
-        </table>
-        <p data-selection-placeholder=""><br></p>`)
-    );
-});
-
 test("move row below operation", async () => {
     const { el, editor } = await setupEditor(
         unformat(`
@@ -1736,10 +1699,14 @@ test("preserve table rows width on move row below operation", async () => {
     const { el } = await setupEditor(
         unformat(`
         <table>
+            <colgroup>
+                <col style="width: 100px;">
+                <col style="width: 200px;">
+            </colgroup>
             <tbody>
-                <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
-                <tr><td style="width: 150px;" class="c">3</td><td style="width: 150px;" class="d">4</td></tr>
-                <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+                <tr><td class="e">5</td><td class="f">6</td></tr>
             </tbody>
         </table>`)
     );
@@ -1759,10 +1726,14 @@ test("preserve table rows width on move row below operation", async () => {
         unformat(`
         <p data-selection-placeholder=""><br></p>
         <table>
+            <colgroup>
+                <col style="width: 100px;">
+                <col style="width: 200px;">
+            </colgroup>
             <tbody>
-                <tr><td style="width: 100px;" class="c">3</td><td style="width: 200px;" class="d">4</td></tr>
-                <tr><td style="width: 100px;" class="a">1[]</td><td style="width: 200px;" class="b">2</td></tr>
-                <tr><td style="width: 150px;" class="e">5</td><td style="width: 150px;" class="f">6</td></tr>
+                <tr><td class="c">3</td><td class="d">4</td></tr>
+                <tr><td class="a">1[]</td><td class="b">2</td></tr>
+                <tr><td class="e">5</td><td class="f">6</td></tr>
             </tbody>
         </table>
         <p data-selection-placeholder=""><br></p>`)
@@ -1773,9 +1744,12 @@ test("reset table size to remove custom width", async () => {
     const { el, editor } = await setupEditor(
         unformat(`
         <table style="width: 150px;">
+            <colgroup>
+            <col style="width: 100px;"><col style="width: 50px;">
+            </colgroup>
             <tbody>
-            <tr><td style="width: 100px;" class="a">1[]</td></tr>
-            <tr><td style="width: 50px;" class="b">2</td></tr>
+            <tr><td class="a">1[]</td></tr>
+            <tr><td class="b">2</td></tr>
             </tbody>
         </table>`)
     );
@@ -1793,8 +1767,8 @@ test("reset table size to remove custom width", async () => {
         <p data-selection-placeholder=""><br></p>
         <table>
             <tbody>
-                <tr><td style="" class="a">1[]</td></tr>
-                <tr><td style="" class="b">2</td></tr>
+                <tr><td class="a">1[]</td></tr>
+                <tr><td class="b">2</td></tr>
             </tbody>
         </table>
         <p data-selection-placeholder=""><br></p>`)
@@ -1805,9 +1779,12 @@ test("reset table size to remove custom width", async () => {
         unformat(
             `<p data-selection-placeholder=""><br></p>
             <table style="width: 150px;">
+            <colgroup>
+            <col style="width: 100px;"><col style="width: 50px;">
+            </colgroup>
             <tbody>
-            <tr><td style="width: 100px;" class="a">1[]</td></tr>
-            <tr><td style="width: 50px;" class="b">2</td></tr>
+            <tr><td class="a">1[]</td></tr>
+            <tr><td class="b">2</td></tr>
             </tbody>
         </table>
         <p data-selection-placeholder=""><br></p>`
@@ -1923,20 +1900,27 @@ test("should redistribute excess width from current column to smaller columns", 
     const { el } = await setupEditor(
         unformat(`
             <table class="table table-bordered o_table" style="width: 500px">
+                <colgroup>
+                    <col style="width: 100px;">
+                    <col style="width: 120px;">
+                    <col style="width: 60px;">
+                    <col style="width: 120px;">
+                    <col style="width: 100px;">
+                </colgroup>
                 <tbody>
                     <tr>
-                        <td style="width: 100px;" class="a">1</td>
-                        <td style="width: 120px;" class="b">2</td>
-                        <td style="width: 60px;" class="c">3[]</td>
-                        <td style="width: 120px;" class="d">4</td>
-                        <td style="width: 100px;" class="e">5</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">3[]</td>
+                        <td class="d">4</td>
+                        <td class="e">5</td>
                     </tr>
                     <tr>
-                        <td style="width: 100px;" class="f">6</td>
-                        <td style="width: 120px;" class="g">7</td>
-                        <td style="width: 60px;" class="h">8</td>
-                        <td style="width: 120px;" class="i">9</td>
-                        <td style="width: 100px;" class="j">10</td>
+                        <td class="f">6</td>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                        <td class="i">9</td>
+                        <td class="j">10</td>
                     </tr>
                 </tbody>
             </table>`)
@@ -1956,18 +1940,18 @@ test("should redistribute excess width from current column to smaller columns", 
             <table class="table table-bordered o_table" style="width: 500px">
                 <tbody>
                     <tr>
-                        <td style="" class="a">1</td>
-                        <td style="" class="b">2</td>
-                        <td style="" class="c">3[]</td>
-                        <td style="" class="d">4</td>
-                        <td style="" class="e">5</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">3[]</td>
+                        <td class="d">4</td>
+                        <td class="e">5</td>
                     </tr>
                     <tr>
-                        <td style="" class="f">6</td>
-                        <td style="" class="g">7</td>
-                        <td style="" class="h">8</td>
-                        <td style="" class="i">9</td>
-                        <td style="" class="j">10</td>
+                        <td class="f">6</td>
+                        <td class="g">7</td>
+                        <td class="h">8</td>
+                        <td class="i">9</td>
+                        <td class="j">10</td>
                     </tr>
                 </tbody>
             </table>
@@ -1976,28 +1960,122 @@ test("should redistribute excess width from current column to smaller columns", 
     );
 });
 
+test("should redistribute excess width from the current colspan column when resetting column sizes", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 1182px">
+                <colgroup>
+                    <col style="width: 236.188px;">
+                    <col style="width: 236.188px;">
+                    <col style="width: 312.125px;">
+                    <col style="width: 160.25px;">
+                    <col style="width: 236.25px;">
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td class="a" colspan="2">2</td>
+                        <td>3</td>
+                        <td>4</td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>6</td>
+                        <td colspan="2">7</td>
+                        <td>8</td>
+                    </tr>
+                    <tr>
+                        <td>9</td>
+                        <td>10</td>
+                        <td>11</td>
+                        <td>12</td>
+                        <td>13</td>
+                    </tr>
+                    <tr>
+                        <td>14</td>
+                        <td colspan="2">15</td>
+                        <td>16</td>
+                        <td>17</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu", { timeout: 1000 });
+    await click(queryOne(".dropdown-menu [name='reset_column_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p data-selection-placeholder="" class="o-horizontal-caret"><br></p>
+            <table class="table table-bordered o_table" style="width: 1182px">
+                <tbody>
+                    <tr>
+                        <td>1</td>
+                        <td class="a" colspan="2">2</td>
+                        <td>3</td>
+                        <td>4</td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>6</td>
+                        <td colspan="2">7</td>
+                        <td>8</td>
+                    </tr>
+                    <tr>
+                        <td>9</td>
+                        <td>10</td>
+                        <td>11</td>
+                        <td>12</td>
+                        <td>13</td>
+                    </tr>
+                    <tr>
+                        <td>14</td>
+                        <td colspan="2">15</td>
+                        <td>16</td>
+                        <td>17</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+    );
+});
+
 test("should redistribute excess width from larger columns to current column", async () => {
     const { el } = await setupEditor(
         unformat(`
             <table class="table table-bordered o_table" style="width: 700px">
+                <colgroup>
+                    <col style="width: 120px;">
+                    <col style="width: 80px;">
+                    <col style="width: 60px;">
+                    <col style="width: 180px;">
+                    <col style="width: 60px;">
+                    <col style="width: 80px;">
+                    <col style="width: 120px;">
+                </colgroup>
                 <tbody>
                     <tr>
-                        <td style="width: 120px;" class="a">1</td>
-                        <td style="width: 80px;" class="b">2</td>
-                        <td style="width: 60px;" class="c">3</td>
-                        <td style="width: 180px;" class="d">4[]</td>
-                        <td style="width: 60px;" class="e">5</td>
-                        <td style="width: 80px;" class="f">6</td>
-                        <td style="width: 120px;" class="g">7</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4[]</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                        <td class="g">7</td>
                     </tr>
                     <tr>
-                        <td style="width: 120px;" class="h">8</td>
-                        <td style="width: 80px;" class="i">9</td>
-                        <td style="width: 60px;" class="j">10</td>
-                        <td style="width: 180px;" class="k">11</td>
-                        <td style="width: 60px;" class="l">12</td>
-                        <td style="width: 80px;" class="m">13</td>
-                        <td style="width: 120px;" class="n">14</td>
+                        <td class="h">8</td>
+                        <td class="i">9</td>
+                        <td class="j">10</td>
+                        <td class="k">11</td>
+                        <td class="l">12</td>
+                        <td class="m">13</td>
+                        <td class="n">14</td>
                     </tr>
                 </tbody>
             </table>`)
@@ -2015,24 +2093,33 @@ test("should redistribute excess width from larger columns to current column", a
         unformat(
             `<p data-selection-placeholder=""><br></p>
             <table class="table table-bordered o_table" style="width: 700px">
+                <colgroup>
+                    <col style="width: 120px;">
+                    <col style="width: 80px;">
+                    <col style="">
+                    <col style="">
+                    <col style="">
+                    <col style="width: 80px;">
+                    <col style="width: 120px;">
+                </colgroup>
                 <tbody>
                     <tr>
-                        <td style="width: 120px;" class="a">1</td>
-                        <td style="width: 80px;" class="b">2</td>
-                        <td style="" class="c">3</td>
-                        <td style="" class="d">4[]</td>
-                        <td style="" class="e">5</td>
-                        <td style="width: 80px;" class="f">6</td>
-                        <td style="width: 120px;" class="g">7</td>
+                        <td class="a">1</td>
+                        <td class="b">2</td>
+                        <td class="c">3</td>
+                        <td class="d">4[]</td>
+                        <td class="e">5</td>
+                        <td class="f">6</td>
+                        <td class="g">7</td>
                     </tr>
                     <tr>
-                        <td style="width: 120px;" class="h">8</td>
-                        <td style="width: 80px;" class="i">9</td>
-                        <td style="" class="j">10</td>
-                        <td style="" class="k">11</td>
-                        <td style="" class="l">12</td>
-                        <td style="width: 80px;" class="m">13</td>
-                        <td style="width: 120px;" class="n">14</td>
+                        <td class="h">8</td>
+                        <td class="i">9</td>
+                        <td class="j">10</td>
+                        <td class="k">11</td>
+                        <td class="l">12</td>
+                        <td class="m">13</td>
+                        <td class="n">14</td>
                     </tr>
                 </tbody>
             </table>
@@ -2134,6 +2221,65 @@ test("removes alternating row colors when 'Clear Alternate Colors' option is cli
     expect(
         cells.every((cell) => getComputedStyle(cell).backgroundColor === firstRowCellColor)
     ).toBe(true);
+});
+
+test("should redistribute excess width from the current column to a colspan column when resetting column sizes", async () => {
+    const { el } = await setupEditor(
+        unformat(`
+            <table class="table table-bordered o_table" style="width: 500px">
+                <colgroup>
+                    <col style="width: 100px;">
+                    <col style="width: 50px;">
+                    <col style="width: 200px">
+                    <col style="width: 50px">
+                    <col style="width: 100px">
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <td colspan="2">1</td>
+                        <td class="a">2</td>
+                        <td >3</td>
+                        <td >4</td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>6</td>
+                        <td>7</td>
+                        <td colspan="2">8</td>
+                    </tr>
+                </tbody>
+            </table>`)
+    );
+    await expectElementCount(".o-we-table-menu", 0);
+
+    await hover(el.querySelector("td.a"));
+    await waitFor(".o-we-table-menu");
+    expect("[data-type='column'].o-we-table-menu").toHaveCount(1);
+
+    await click("[data-type='column'].o-we-table-menu");
+    await waitFor(".dropdown-menu", { timeout: 1000 });
+    await click(queryOne(".dropdown-menu [name='reset_column_size']"));
+    expect(getContent(el)).toBe(
+        unformat(`
+            <p data-selection-placeholder="" class="o-horizontal-caret"><br></p>
+            <table class="table table-bordered o_table" style="width: 500px">
+                <tbody>
+                    <tr>
+                        <td colspan="2">1</td>
+                        <td class="a">2</td>
+                        <td>3</td>
+                        <td>4</td>
+                    </tr>
+                    <tr>
+                        <td>5</td>
+                        <td>6</td>
+                        <td>7</td>
+                        <td colspan="2">8</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p data-selection-placeholder="" style="margin: -9px 0px 8px;"><br></p>`)
+    );
 });
 
 describe("Disable table merge options", () => {


### PR DESCRIPTION
Purpose:

- Add a new option in the table menu to merge selected cells.

- Disable the merge option if:
  - The selection spans both rows and columns.
  - The selection includes already merged cells or rows.


- Add a new Unmerge Cell option in the table menu.
- Unmerge Cell option appears only when the selected cell is merged.
- It splits the merged cell back into individual cells.

task:4778359
