### PR TITLE
[ADD] html_editor: add syntax highlighting to code blocks

### DIFF
--- a/addons/html_editor/__manifest__.py
+++ b/addons/html_editor/__manifest__.py
@@ -110,6 +110,10 @@ This addon provides an extensible, maintainable editor.
         'web._assets_frontend_helpers': [
             ('prepend', 'html_editor/static/src/scss/bootstrap_overridden.scss'),
         ],
+        'html_editor.assets_prism': [
+            'html_editor/static/lib/prismjs/prism.css',
+            'html_editor/static/lib/prismjs/prism.js',
+        ],
     },
     'license': 'LGPL-3'
 }

--- a/addons/html_editor/static/lib/prismjs/prism.css
+++ b/addons/html_editor/static/lib/prismjs/prism.css
@@ -1,0 +1,143 @@
+/* PrismJS 1.30.0
+https://prismjs.com/download#themes=prism&languages=markup+css+clike+javascript+diff+java+javadoclike+jsdoc+json+markdown+python+sass+scss+sql+typescript */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+	color: black;
+	background: none;
+	text-shadow: 0 1px white;
+	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+	font-size: 1em;
+	text-align: left;
+	white-space: pre;
+	word-spacing: normal;
+	word-break: normal;
+	word-wrap: normal;
+	line-height: 1.5;
+
+	-moz-tab-size: 4;
+	-o-tab-size: 4;
+	tab-size: 4;
+
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+	hyphens: none;
+}
+
+pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+code[class*="language-"]::selection, code[class*="language-"] ::selection {
+	text-shadow: none;
+	background: #b3d4fc;
+}
+
+@media print {
+	code[class*="language-"],
+	pre[class*="language-"] {
+		text-shadow: none;
+	}
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+	padding: 1em;
+	margin: .5em 0;
+	overflow: auto;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+	background: #f5f2f0;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+	padding: .1em;
+	border-radius: .3em;
+	white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+	color: slategray;
+}
+
+.token.punctuation {
+	color: #999;
+}
+
+.token.namespace {
+	opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.boolean,
+.token.number,
+.token.constant,
+.token.symbol,
+.token.deleted {
+	color: #905;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+	color: #690;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+	color: #9a6e3a;
+	/* This background color was intended by the author of this theme. */
+	background: hsla(0, 0%, 100%, .5);
+}
+
+.token.atrule,
+.token.attr-value,
+.token.keyword {
+	color: #07a;
+}
+
+.token.function,
+.token.class-name {
+	color: #DD4A68;
+}
+
+.token.regex,
+.token.important,
+.token.variable {
+	color: #e90;
+}
+
+.token.important,
+.token.bold {
+	font-weight: bold;
+}
+.token.italic {
+	font-style: italic;
+}
+
+.token.entity {
+	cursor: help;
+}
+

--- a/addons/html_editor/static/lib/prismjs/prism.js
+++ b/addons/html_editor/static/lib/prismjs/prism.js
@@ -1,0 +1,2844 @@
+/* PrismJS 1.30.0
+https://prismjs.com/download#themes=prism&languages=markup+css+clike+javascript+diff+java+javadoclike+jsdoc+json+markdown+python+sass+scss+sql+typescript */
+/// <reference lib="WebWorker"/>
+
+var _self = (typeof window !== 'undefined')
+	? window   // if in browser
+	: (
+		(typeof WorkerGlobalScope !== 'undefined' && self instanceof WorkerGlobalScope)
+			? self // if in worker
+			: {}   // if in node js
+	);
+
+/**
+ * Prism: Lightweight, robust, elegant syntax highlighting
+ *
+ * @license MIT <https://opensource.org/licenses/MIT>
+ * @author Lea Verou <https://lea.verou.me>
+ * @namespace
+ * @public
+ */
+var Prism = (function (_self) {
+
+	// Private helper vars
+	var lang = /(?:^|\s)lang(?:uage)?-([\w-]+)(?=\s|$)/i;
+	var uniqueId = 0;
+
+	// The grammar object for plaintext
+	var plainTextGrammar = {};
+
+
+	var _ = {
+		/**
+		 * By default, Prism will attempt to highlight all code elements (by calling {@link Prism.highlightAll}) on the
+		 * current page after the page finished loading. This might be a problem if e.g. you wanted to asynchronously load
+		 * additional languages or plugins yourself.
+		 *
+		 * By setting this value to `true`, Prism will not automatically highlight all code elements on the page.
+		 *
+		 * You obviously have to change this value before the automatic highlighting started. To do this, you can add an
+		 * empty Prism object into the global scope before loading the Prism script like this:
+		 *
+		 * ```js
+		 * window.Prism = window.Prism || {};
+		 * Prism.manual = true;
+		 * // add a new <script> to load Prism's script
+		 * ```
+		 *
+		 * @default false
+		 * @type {boolean}
+		 * @memberof Prism
+		 * @public
+		 */
+		manual: _self.Prism && _self.Prism.manual,
+		/**
+		 * By default, if Prism is in a web worker, it assumes that it is in a worker it created itself, so it uses
+		 * `addEventListener` to communicate with its parent instance. However, if you're using Prism manually in your
+		 * own worker, you don't want it to do this.
+		 *
+		 * By setting this value to `true`, Prism will not add its own listeners to the worker.
+		 *
+		 * You obviously have to change this value before Prism executes. To do this, you can add an
+		 * empty Prism object into the global scope before loading the Prism script like this:
+		 *
+		 * ```js
+		 * window.Prism = window.Prism || {};
+		 * Prism.disableWorkerMessageHandler = true;
+		 * // Load Prism's script
+		 * ```
+		 *
+		 * @default false
+		 * @type {boolean}
+		 * @memberof Prism
+		 * @public
+		 */
+		disableWorkerMessageHandler: _self.Prism && _self.Prism.disableWorkerMessageHandler,
+
+		/**
+		 * A namespace for utility methods.
+		 *
+		 * All function in this namespace that are not explicitly marked as _public_ are for __internal use only__ and may
+		 * change or disappear at any time.
+		 *
+		 * @namespace
+		 * @memberof Prism
+		 */
+		util: {
+			encode: function encode(tokens) {
+				if (tokens instanceof Token) {
+					return new Token(tokens.type, encode(tokens.content), tokens.alias);
+				} else if (Array.isArray(tokens)) {
+					return tokens.map(encode);
+				} else {
+					return tokens.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\u00a0/g, ' ');
+				}
+			},
+
+			/**
+			 * Returns the name of the type of the given value.
+			 *
+			 * @param {any} o
+			 * @returns {string}
+			 * @example
+			 * type(null)      === 'Null'
+			 * type(undefined) === 'Undefined'
+			 * type(123)       === 'Number'
+			 * type('foo')     === 'String'
+			 * type(true)      === 'Boolean'
+			 * type([1, 2])    === 'Array'
+			 * type({})        === 'Object'
+			 * type(String)    === 'Function'
+			 * type(/abc+/)    === 'RegExp'
+			 */
+			type: function (o) {
+				return Object.prototype.toString.call(o).slice(8, -1);
+			},
+
+			/**
+			 * Returns a unique number for the given object. Later calls will still return the same number.
+			 *
+			 * @param {Object} obj
+			 * @returns {number}
+			 */
+			objId: function (obj) {
+				if (!obj['__id']) {
+					Object.defineProperty(obj, '__id', { value: ++uniqueId });
+				}
+				return obj['__id'];
+			},
+
+			/**
+			 * Creates a deep clone of the given object.
+			 *
+			 * The main intended use of this function is to clone language definitions.
+			 *
+			 * @param {T} o
+			 * @param {Record<number, any>} [visited]
+			 * @returns {T}
+			 * @template T
+			 */
+			clone: function deepClone(o, visited) {
+				visited = visited || {};
+
+				var clone; var id;
+				switch (_.util.type(o)) {
+					case 'Object':
+						id = _.util.objId(o);
+						if (visited[id]) {
+							return visited[id];
+						}
+						clone = /** @type {Record<string, any>} */ ({});
+						visited[id] = clone;
+
+						for (var key in o) {
+							if (o.hasOwnProperty(key)) {
+								clone[key] = deepClone(o[key], visited);
+							}
+						}
+
+						return /** @type {any} */ (clone);
+
+					case 'Array':
+						id = _.util.objId(o);
+						if (visited[id]) {
+							return visited[id];
+						}
+						clone = [];
+						visited[id] = clone;
+
+						(/** @type {Array} */(/** @type {any} */(o))).forEach(function (v, i) {
+							clone[i] = deepClone(v, visited);
+						});
+
+						return /** @type {any} */ (clone);
+
+					default:
+						return o;
+				}
+			},
+
+			/**
+			 * Returns the Prism language of the given element set by a `language-xxxx` or `lang-xxxx` class.
+			 *
+			 * If no language is set for the element or the element is `null` or `undefined`, `none` will be returned.
+			 *
+			 * @param {Element} element
+			 * @returns {string}
+			 */
+			getLanguage: function (element) {
+				while (element) {
+					var m = lang.exec(element.className);
+					if (m) {
+						return m[1].toLowerCase();
+					}
+					element = element.parentElement;
+				}
+				return 'none';
+			},
+
+			/**
+			 * Sets the Prism `language-xxxx` class of the given element.
+			 *
+			 * @param {Element} element
+			 * @param {string} language
+			 * @returns {void}
+			 */
+			setLanguage: function (element, language) {
+				// remove all `language-xxxx` classes
+				// (this might leave behind a leading space)
+				element.className = element.className.replace(RegExp(lang, 'gi'), '');
+
+				// add the new `language-xxxx` class
+				// (using `classList` will automatically clean up spaces for us)
+				element.classList.add('language-' + language);
+			},
+
+			/**
+			 * Returns the script element that is currently executing.
+			 *
+			 * This does __not__ work for line script element.
+			 *
+			 * @returns {HTMLScriptElement | null}
+			 */
+			currentScript: function () {
+				if (typeof document === 'undefined') {
+					return null;
+				}
+				if (document.currentScript && document.currentScript.tagName === 'SCRIPT' && 1 < 2 /* hack to trip TS' flow analysis */) {
+					return /** @type {any} */ (document.currentScript);
+				}
+
+				// IE11 workaround
+				// we'll get the src of the current script by parsing IE11's error stack trace
+				// this will not work for inline scripts
+
+				try {
+					throw new Error();
+				} catch (err) {
+					// Get file src url from stack. Specifically works with the format of stack traces in IE.
+					// A stack will look like this:
+					//
+					// Error
+					//    at _.util.currentScript (http://localhost/components/prism-core.js:119:5)
+					//    at Global code (http://localhost/components/prism-core.js:606:1)
+
+					var src = (/at [^(\r\n]*\((.*):[^:]+:[^:]+\)$/i.exec(err.stack) || [])[1];
+					if (src) {
+						var scripts = document.getElementsByTagName('script');
+						for (var i in scripts) {
+							if (scripts[i].src == src) {
+								return scripts[i];
+							}
+						}
+					}
+					return null;
+				}
+			},
+
+			/**
+			 * Returns whether a given class is active for `element`.
+			 *
+			 * The class can be activated if `element` or one of its ancestors has the given class and it can be deactivated
+			 * if `element` or one of its ancestors has the negated version of the given class. The _negated version_ of the
+			 * given class is just the given class with a `no-` prefix.
+			 *
+			 * Whether the class is active is determined by the closest ancestor of `element` (where `element` itself is
+			 * closest ancestor) that has the given class or the negated version of it. If neither `element` nor any of its
+			 * ancestors have the given class or the negated version of it, then the default activation will be returned.
+			 *
+			 * In the paradoxical situation where the closest ancestor contains __both__ the given class and the negated
+			 * version of it, the class is considered active.
+			 *
+			 * @param {Element} element
+			 * @param {string} className
+			 * @param {boolean} [defaultActivation=false]
+			 * @returns {boolean}
+			 */
+			isActive: function (element, className, defaultActivation) {
+				var no = 'no-' + className;
+
+				while (element) {
+					var classList = element.classList;
+					if (classList.contains(className)) {
+						return true;
+					}
+					if (classList.contains(no)) {
+						return false;
+					}
+					element = element.parentElement;
+				}
+				return !!defaultActivation;
+			}
+		},
+
+		/**
+		 * This namespace contains all currently loaded languages and the some helper functions to create and modify languages.
+		 *
+		 * @namespace
+		 * @memberof Prism
+		 * @public
+		 */
+		languages: {
+			/**
+			 * The grammar for plain, unformatted text.
+			 */
+			plain: plainTextGrammar,
+			plaintext: plainTextGrammar,
+			text: plainTextGrammar,
+			txt: plainTextGrammar,
+
+			/**
+			 * Creates a deep copy of the language with the given id and appends the given tokens.
+			 *
+			 * If a token in `redef` also appears in the copied language, then the existing token in the copied language
+			 * will be overwritten at its original position.
+			 *
+			 * ## Best practices
+			 *
+			 * Since the position of overwriting tokens (token in `redef` that overwrite tokens in the copied language)
+			 * doesn't matter, they can technically be in any order. However, this can be confusing to others that trying to
+			 * understand the language definition because, normally, the order of tokens matters in Prism grammars.
+			 *
+			 * Therefore, it is encouraged to order overwriting tokens according to the positions of the overwritten tokens.
+			 * Furthermore, all non-overwriting tokens should be placed after the overwriting ones.
+			 *
+			 * @param {string} id The id of the language to extend. This has to be a key in `Prism.languages`.
+			 * @param {Grammar} redef The new tokens to append.
+			 * @returns {Grammar} The new language created.
+			 * @public
+			 * @example
+			 * Prism.languages['css-with-colors'] = Prism.languages.extend('css', {
+			 *     // Prism.languages.css already has a 'comment' token, so this token will overwrite CSS' 'comment' token
+			 *     // at its original position
+			 *     'comment': { ... },
+			 *     // CSS doesn't have a 'color' token, so this token will be appended
+			 *     'color': /\b(?:red|green|blue)\b/
+			 * });
+			 */
+			extend: function (id, redef) {
+				var lang = _.util.clone(_.languages[id]);
+
+				for (var key in redef) {
+					lang[key] = redef[key];
+				}
+
+				return lang;
+			},
+
+			/**
+			 * Inserts tokens _before_ another token in a language definition or any other grammar.
+			 *
+			 * ## Usage
+			 *
+			 * This helper method makes it easy to modify existing languages. For example, the CSS language definition
+			 * not only defines CSS highlighting for CSS documents, but also needs to define highlighting for CSS embedded
+			 * in HTML through `<style>` elements. To do this, it needs to modify `Prism.languages.markup` and add the
+			 * appropriate tokens. However, `Prism.languages.markup` is a regular JavaScript object literal, so if you do
+			 * this:
+			 *
+			 * ```js
+			 * Prism.languages.markup.style = {
+			 *     // token
+			 * };
+			 * ```
+			 *
+			 * then the `style` token will be added (and processed) at the end. `insertBefore` allows you to insert tokens
+			 * before existing tokens. For the CSS example above, you would use it like this:
+			 *
+			 * ```js
+			 * Prism.languages.insertBefore('markup', 'cdata', {
+			 *     'style': {
+			 *         // token
+			 *     }
+			 * });
+			 * ```
+			 *
+			 * ## Special cases
+			 *
+			 * If the grammars of `inside` and `insert` have tokens with the same name, the tokens in `inside`'s grammar
+			 * will be ignored.
+			 *
+			 * This behavior can be used to insert tokens after `before`:
+			 *
+			 * ```js
+			 * Prism.languages.insertBefore('markup', 'comment', {
+			 *     'comment': Prism.languages.markup.comment,
+			 *     // tokens after 'comment'
+			 * });
+			 * ```
+			 *
+			 * ## Limitations
+			 *
+			 * The main problem `insertBefore` has to solve is iteration order. Since ES2015, the iteration order for object
+			 * properties is guaranteed to be the insertion order (except for integer keys) but some browsers behave
+			 * differently when keys are deleted and re-inserted. So `insertBefore` can't be implemented by temporarily
+			 * deleting properties which is necessary to insert at arbitrary positions.
+			 *
+			 * To solve this problem, `insertBefore` doesn't actually insert the given tokens into the target object.
+			 * Instead, it will create a new object and replace all references to the target object with the new one. This
+			 * can be done without temporarily deleting properties, so the iteration order is well-defined.
+			 *
+			 * However, only references that can be reached from `Prism.languages` or `insert` will be replaced. I.e. if
+			 * you hold the target object in a variable, then the value of the variable will not change.
+			 *
+			 * ```js
+			 * var oldMarkup = Prism.languages.markup;
+			 * var newMarkup = Prism.languages.insertBefore('markup', 'comment', { ... });
+			 *
+			 * assert(oldMarkup !== Prism.languages.markup);
+			 * assert(newMarkup === Prism.languages.markup);
+			 * ```
+			 *
+			 * @param {string} inside The property of `root` (e.g. a language id in `Prism.languages`) that contains the
+			 * object to be modified.
+			 * @param {string} before The key to insert before.
+			 * @param {Grammar} insert An object containing the key-value pairs to be inserted.
+			 * @param {Object<string, any>} [root] The object containing `inside`, i.e. the object that contains the
+			 * object to be modified.
+			 *
+			 * Defaults to `Prism.languages`.
+			 * @returns {Grammar} The new grammar object.
+			 * @public
+			 */
+			insertBefore: function (inside, before, insert, root) {
+				root = root || /** @type {any} */ (_.languages);
+				var grammar = root[inside];
+				/** @type {Grammar} */
+				var ret = {};
+
+				for (var token in grammar) {
+					if (grammar.hasOwnProperty(token)) {
+
+						if (token == before) {
+							for (var newToken in insert) {
+								if (insert.hasOwnProperty(newToken)) {
+									ret[newToken] = insert[newToken];
+								}
+							}
+						}
+
+						// Do not insert token which also occur in insert. See #1525
+						if (!insert.hasOwnProperty(token)) {
+							ret[token] = grammar[token];
+						}
+					}
+				}
+
+				var old = root[inside];
+				root[inside] = ret;
+
+				// Update references in other language definitions
+				_.languages.DFS(_.languages, function (key, value) {
+					if (value === old && key != inside) {
+						this[key] = ret;
+					}
+				});
+
+				return ret;
+			},
+
+			// Traverse a language definition with Depth First Search
+			DFS: function DFS(o, callback, type, visited) {
+				visited = visited || {};
+
+				var objId = _.util.objId;
+
+				for (var i in o) {
+					if (o.hasOwnProperty(i)) {
+						callback.call(o, i, o[i], type || i);
+
+						var property = o[i];
+						var propertyType = _.util.type(property);
+
+						if (propertyType === 'Object' && !visited[objId(property)]) {
+							visited[objId(property)] = true;
+							DFS(property, callback, null, visited);
+						} else if (propertyType === 'Array' && !visited[objId(property)]) {
+							visited[objId(property)] = true;
+							DFS(property, callback, i, visited);
+						}
+					}
+				}
+			}
+		},
+
+		plugins: {},
+
+		/**
+		 * This is the most high-level function in Prism’s API.
+		 * It fetches all the elements that have a `.language-xxxx` class and then calls {@link Prism.highlightElement} on
+		 * each one of them.
+		 *
+		 * This is equivalent to `Prism.highlightAllUnder(document, async, callback)`.
+		 *
+		 * @param {boolean} [async=false] Same as in {@link Prism.highlightAllUnder}.
+		 * @param {HighlightCallback} [callback] Same as in {@link Prism.highlightAllUnder}.
+		 * @memberof Prism
+		 * @public
+		 */
+		highlightAll: function (async, callback) {
+			_.highlightAllUnder(document, async, callback);
+		},
+
+		/**
+		 * Fetches all the descendants of `container` that have a `.language-xxxx` class and then calls
+		 * {@link Prism.highlightElement} on each one of them.
+		 *
+		 * The following hooks will be run:
+		 * 1. `before-highlightall`
+		 * 2. `before-all-elements-highlight`
+		 * 3. All hooks of {@link Prism.highlightElement} for each element.
+		 *
+		 * @param {ParentNode} container The root element, whose descendants that have a `.language-xxxx` class will be highlighted.
+		 * @param {boolean} [async=false] Whether each element is to be highlighted asynchronously using Web Workers.
+		 * @param {HighlightCallback} [callback] An optional callback to be invoked on each element after its highlighting is done.
+		 * @memberof Prism
+		 * @public
+		 */
+		highlightAllUnder: function (container, async, callback) {
+			var env = {
+				callback: callback,
+				container: container,
+				selector: 'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'
+			};
+
+			_.hooks.run('before-highlightall', env);
+
+			env.elements = Array.prototype.slice.apply(env.container.querySelectorAll(env.selector));
+
+			_.hooks.run('before-all-elements-highlight', env);
+
+			for (var i = 0, element; (element = env.elements[i++]);) {
+				_.highlightElement(element, async === true, env.callback);
+			}
+		},
+
+		/**
+		 * Highlights the code inside a single element.
+		 *
+		 * The following hooks will be run:
+		 * 1. `before-sanity-check`
+		 * 2. `before-highlight`
+		 * 3. All hooks of {@link Prism.highlight}. These hooks will be run by an asynchronous worker if `async` is `true`.
+		 * 4. `before-insert`
+		 * 5. `after-highlight`
+		 * 6. `complete`
+		 *
+		 * Some the above hooks will be skipped if the element doesn't contain any text or there is no grammar loaded for
+		 * the element's language.
+		 *
+		 * @param {Element} element The element containing the code.
+		 * It must have a class of `language-xxxx` to be processed, where `xxxx` is a valid language identifier.
+		 * @param {boolean} [async=false] Whether the element is to be highlighted asynchronously using Web Workers
+		 * to improve performance and avoid blocking the UI when highlighting very large chunks of code. This option is
+		 * [disabled by default](https://prismjs.com/faq.html#why-is-asynchronous-highlighting-disabled-by-default).
+		 *
+		 * Note: All language definitions required to highlight the code must be included in the main `prism.js` file for
+		 * asynchronous highlighting to work. You can build your own bundle on the
+		 * [Download page](https://prismjs.com/download.html).
+		 * @param {HighlightCallback} [callback] An optional callback to be invoked after the highlighting is done.
+		 * Mostly useful when `async` is `true`, since in that case, the highlighting is done asynchronously.
+		 * @memberof Prism
+		 * @public
+		 */
+		highlightElement: function (element, async, callback) {
+			// Find language
+			var language = _.util.getLanguage(element);
+			var grammar = _.languages[language];
+
+			// Set language on the element, if not present
+			_.util.setLanguage(element, language);
+
+			// Set language on the parent, for styling
+			var parent = element.parentElement;
+			if (parent && parent.nodeName.toLowerCase() === 'pre') {
+				_.util.setLanguage(parent, language);
+			}
+
+			var code = element.textContent;
+
+			var env = {
+				element: element,
+				language: language,
+				grammar: grammar,
+				code: code
+			};
+
+			function insertHighlightedCode(highlightedCode) {
+				env.highlightedCode = highlightedCode;
+
+				_.hooks.run('before-insert', env);
+
+				env.element.innerHTML = env.highlightedCode;
+
+				_.hooks.run('after-highlight', env);
+				_.hooks.run('complete', env);
+				callback && callback.call(env.element);
+			}
+
+			_.hooks.run('before-sanity-check', env);
+
+			// plugins may change/add the parent/element
+			parent = env.element.parentElement;
+			if (parent && parent.nodeName.toLowerCase() === 'pre' && !parent.hasAttribute('tabindex')) {
+				parent.setAttribute('tabindex', '0');
+			}
+
+			if (!env.code) {
+				_.hooks.run('complete', env);
+				callback && callback.call(env.element);
+				return;
+			}
+
+			_.hooks.run('before-highlight', env);
+
+			if (!env.grammar) {
+				insertHighlightedCode(_.util.encode(env.code));
+				return;
+			}
+
+			if (async && _self.Worker) {
+				var worker = new Worker(_.filename);
+
+				worker.onmessage = function (evt) {
+					insertHighlightedCode(evt.data);
+				};
+
+				worker.postMessage(JSON.stringify({
+					language: env.language,
+					code: env.code,
+					immediateClose: true
+				}));
+			} else {
+				insertHighlightedCode(_.highlight(env.code, env.grammar, env.language));
+			}
+		},
+
+		/**
+		 * Low-level function, only use if you know what you’re doing. It accepts a string of text as input
+		 * and the language definitions to use, and returns a string with the HTML produced.
+		 *
+		 * The following hooks will be run:
+		 * 1. `before-tokenize`
+		 * 2. `after-tokenize`
+		 * 3. `wrap`: On each {@link Token}.
+		 *
+		 * @param {string} text A string with the code to be highlighted.
+		 * @param {Grammar} grammar An object containing the tokens to use.
+		 *
+		 * Usually a language definition like `Prism.languages.markup`.
+		 * @param {string} language The name of the language definition passed to `grammar`.
+		 * @returns {string} The highlighted HTML.
+		 * @memberof Prism
+		 * @public
+		 * @example
+		 * Prism.highlight('var foo = true;', Prism.languages.javascript, 'javascript');
+		 */
+		highlight: function (text, grammar, language) {
+			var env = {
+				code: text,
+				grammar: grammar,
+				language: language
+			};
+			_.hooks.run('before-tokenize', env);
+			if (!env.grammar) {
+				throw new Error('The language "' + env.language + '" has no grammar.');
+			}
+			env.tokens = _.tokenize(env.code, env.grammar);
+			_.hooks.run('after-tokenize', env);
+			return Token.stringify(_.util.encode(env.tokens), env.language);
+		},
+
+		/**
+		 * This is the heart of Prism, and the most low-level function you can use. It accepts a string of text as input
+		 * and the language definitions to use, and returns an array with the tokenized code.
+		 *
+		 * When the language definition includes nested tokens, the function is called recursively on each of these tokens.
+		 *
+		 * This method could be useful in other contexts as well, as a very crude parser.
+		 *
+		 * @param {string} text A string with the code to be highlighted.
+		 * @param {Grammar} grammar An object containing the tokens to use.
+		 *
+		 * Usually a language definition like `Prism.languages.markup`.
+		 * @returns {TokenStream} An array of strings and tokens, a token stream.
+		 * @memberof Prism
+		 * @public
+		 * @example
+		 * let code = `var foo = 0;`;
+		 * let tokens = Prism.tokenize(code, Prism.languages.javascript);
+		 * tokens.forEach(token => {
+		 *     if (token instanceof Prism.Token && token.type === 'number') {
+		 *         console.log(`Found numeric literal: ${token.content}`);
+		 *     }
+		 * });
+		 */
+		tokenize: function (text, grammar) {
+			var rest = grammar.rest;
+			if (rest) {
+				for (var token in rest) {
+					grammar[token] = rest[token];
+				}
+
+				delete grammar.rest;
+			}
+
+			var tokenList = new LinkedList();
+			addAfter(tokenList, tokenList.head, text);
+
+			matchGrammar(text, tokenList, grammar, tokenList.head, 0);
+
+			return toArray(tokenList);
+		},
+
+		/**
+		 * @namespace
+		 * @memberof Prism
+		 * @public
+		 */
+		hooks: {
+			all: {},
+
+			/**
+			 * Adds the given callback to the list of callbacks for the given hook.
+			 *
+			 * The callback will be invoked when the hook it is registered for is run.
+			 * Hooks are usually directly run by a highlight function but you can also run hooks yourself.
+			 *
+			 * One callback function can be registered to multiple hooks and the same hook multiple times.
+			 *
+			 * @param {string} name The name of the hook.
+			 * @param {HookCallback} callback The callback function which is given environment variables.
+			 * @public
+			 */
+			add: function (name, callback) {
+				var hooks = _.hooks.all;
+
+				hooks[name] = hooks[name] || [];
+
+				hooks[name].push(callback);
+			},
+
+			/**
+			 * Runs a hook invoking all registered callbacks with the given environment variables.
+			 *
+			 * Callbacks will be invoked synchronously and in the order in which they were registered.
+			 *
+			 * @param {string} name The name of the hook.
+			 * @param {Object<string, any>} env The environment variables of the hook passed to all callbacks registered.
+			 * @public
+			 */
+			run: function (name, env) {
+				var callbacks = _.hooks.all[name];
+
+				if (!callbacks || !callbacks.length) {
+					return;
+				}
+
+				for (var i = 0, callback; (callback = callbacks[i++]);) {
+					callback(env);
+				}
+			}
+		},
+
+		Token: Token
+	};
+	_self.Prism = _;
+
+
+	// Typescript note:
+	// The following can be used to import the Token type in JSDoc:
+	//
+	//   @typedef {InstanceType<import("./prism-core")["Token"]>} Token
+
+	/**
+	 * Creates a new token.
+	 *
+	 * @param {string} type See {@link Token#type type}
+	 * @param {string | TokenStream} content See {@link Token#content content}
+	 * @param {string|string[]} [alias] The alias(es) of the token.
+	 * @param {string} [matchedStr=""] A copy of the full string this token was created from.
+	 * @class
+	 * @global
+	 * @public
+	 */
+	function Token(type, content, alias, matchedStr) {
+		/**
+		 * The type of the token.
+		 *
+		 * This is usually the key of a pattern in a {@link Grammar}.
+		 *
+		 * @type {string}
+		 * @see GrammarToken
+		 * @public
+		 */
+		this.type = type;
+		/**
+		 * The strings or tokens contained by this token.
+		 *
+		 * This will be a token stream if the pattern matched also defined an `inside` grammar.
+		 *
+		 * @type {string | TokenStream}
+		 * @public
+		 */
+		this.content = content;
+		/**
+		 * The alias(es) of the token.
+		 *
+		 * @type {string|string[]}
+		 * @see GrammarToken
+		 * @public
+		 */
+		this.alias = alias;
+		// Copy of the full string this token was created from
+		this.length = (matchedStr || '').length | 0;
+	}
+
+	/**
+	 * A token stream is an array of strings and {@link Token Token} objects.
+	 *
+	 * Token streams have to fulfill a few properties that are assumed by most functions (mostly internal ones) that process
+	 * them.
+	 *
+	 * 1. No adjacent strings.
+	 * 2. No empty strings.
+	 *
+	 *    The only exception here is the token stream that only contains the empty string and nothing else.
+	 *
+	 * @typedef {Array<string | Token>} TokenStream
+	 * @global
+	 * @public
+	 */
+
+	/**
+	 * Converts the given token or token stream to an HTML representation.
+	 *
+	 * The following hooks will be run:
+	 * 1. `wrap`: On each {@link Token}.
+	 *
+	 * @param {string | Token | TokenStream} o The token or token stream to be converted.
+	 * @param {string} language The name of current language.
+	 * @returns {string} The HTML representation of the token or token stream.
+	 * @memberof Token
+	 * @static
+	 */
+	Token.stringify = function stringify(o, language) {
+		if (typeof o == 'string') {
+			return o;
+		}
+		if (Array.isArray(o)) {
+			var s = '';
+			o.forEach(function (e) {
+				s += stringify(e, language);
+			});
+			return s;
+		}
+
+		var env = {
+			type: o.type,
+			content: stringify(o.content, language),
+			tag: 'span',
+			classes: ['token', o.type],
+			attributes: {},
+			language: language
+		};
+
+		var aliases = o.alias;
+		if (aliases) {
+			if (Array.isArray(aliases)) {
+				Array.prototype.push.apply(env.classes, aliases);
+			} else {
+				env.classes.push(aliases);
+			}
+		}
+
+		_.hooks.run('wrap', env);
+
+		var attributes = '';
+		for (var name in env.attributes) {
+			attributes += ' ' + name + '="' + (env.attributes[name] || '').replace(/"/g, '&quot;') + '"';
+		}
+
+		return '<' + env.tag + ' class="' + env.classes.join(' ') + '"' + attributes + '>' + env.content + '</' + env.tag + '>';
+	};
+
+	/**
+	 * @param {RegExp} pattern
+	 * @param {number} pos
+	 * @param {string} text
+	 * @param {boolean} lookbehind
+	 * @returns {RegExpExecArray | null}
+	 */
+	function matchPattern(pattern, pos, text, lookbehind) {
+		pattern.lastIndex = pos;
+		var match = pattern.exec(text);
+		if (match && lookbehind && match[1]) {
+			// change the match to remove the text matched by the Prism lookbehind group
+			var lookbehindLength = match[1].length;
+			match.index += lookbehindLength;
+			match[0] = match[0].slice(lookbehindLength);
+		}
+		return match;
+	}
+
+	/**
+	 * @param {string} text
+	 * @param {LinkedList<string | Token>} tokenList
+	 * @param {any} grammar
+	 * @param {LinkedListNode<string | Token>} startNode
+	 * @param {number} startPos
+	 * @param {RematchOptions} [rematch]
+	 * @returns {void}
+	 * @private
+	 *
+	 * @typedef RematchOptions
+	 * @property {string} cause
+	 * @property {number} reach
+	 */
+	function matchGrammar(text, tokenList, grammar, startNode, startPos, rematch) {
+		for (var token in grammar) {
+			if (!grammar.hasOwnProperty(token) || !grammar[token]) {
+				continue;
+			}
+
+			var patterns = grammar[token];
+			patterns = Array.isArray(patterns) ? patterns : [patterns];
+
+			for (var j = 0; j < patterns.length; ++j) {
+				if (rematch && rematch.cause == token + ',' + j) {
+					return;
+				}
+
+				var patternObj = patterns[j];
+				var inside = patternObj.inside;
+				var lookbehind = !!patternObj.lookbehind;
+				var greedy = !!patternObj.greedy;
+				var alias = patternObj.alias;
+
+				if (greedy && !patternObj.pattern.global) {
+					// Without the global flag, lastIndex won't work
+					var flags = patternObj.pattern.toString().match(/[imsuy]*$/)[0];
+					patternObj.pattern = RegExp(patternObj.pattern.source, flags + 'g');
+				}
+
+				/** @type {RegExp} */
+				var pattern = patternObj.pattern || patternObj;
+
+				for ( // iterate the token list and keep track of the current token/string position
+					var currentNode = startNode.next, pos = startPos;
+					currentNode !== tokenList.tail;
+					pos += currentNode.value.length, currentNode = currentNode.next
+				) {
+
+					if (rematch && pos >= rematch.reach) {
+						break;
+					}
+
+					var str = currentNode.value;
+
+					if (tokenList.length > text.length) {
+						// Something went terribly wrong, ABORT, ABORT!
+						return;
+					}
+
+					if (str instanceof Token) {
+						continue;
+					}
+
+					var removeCount = 1; // this is the to parameter of removeBetween
+					var match;
+
+					if (greedy) {
+						match = matchPattern(pattern, pos, text, lookbehind);
+						if (!match || match.index >= text.length) {
+							break;
+						}
+
+						var from = match.index;
+						var to = match.index + match[0].length;
+						var p = pos;
+
+						// find the node that contains the match
+						p += currentNode.value.length;
+						while (from >= p) {
+							currentNode = currentNode.next;
+							p += currentNode.value.length;
+						}
+						// adjust pos (and p)
+						p -= currentNode.value.length;
+						pos = p;
+
+						// the current node is a Token, then the match starts inside another Token, which is invalid
+						if (currentNode.value instanceof Token) {
+							continue;
+						}
+
+						// find the last node which is affected by this match
+						for (
+							var k = currentNode;
+							k !== tokenList.tail && (p < to || typeof k.value === 'string');
+							k = k.next
+						) {
+							removeCount++;
+							p += k.value.length;
+						}
+						removeCount--;
+
+						// replace with the new match
+						str = text.slice(pos, p);
+						match.index -= pos;
+					} else {
+						match = matchPattern(pattern, 0, str, lookbehind);
+						if (!match) {
+							continue;
+						}
+					}
+
+					// eslint-disable-next-line no-redeclare
+					var from = match.index;
+					var matchStr = match[0];
+					var before = str.slice(0, from);
+					var after = str.slice(from + matchStr.length);
+
+					var reach = pos + str.length;
+					if (rematch && reach > rematch.reach) {
+						rematch.reach = reach;
+					}
+
+					var removeFrom = currentNode.prev;
+
+					if (before) {
+						removeFrom = addAfter(tokenList, removeFrom, before);
+						pos += before.length;
+					}
+
+					removeRange(tokenList, removeFrom, removeCount);
+
+					var wrapped = new Token(token, inside ? _.tokenize(matchStr, inside) : matchStr, alias, matchStr);
+					currentNode = addAfter(tokenList, removeFrom, wrapped);
+
+					if (after) {
+						addAfter(tokenList, currentNode, after);
+					}
+
+					if (removeCount > 1) {
+						// at least one Token object was removed, so we have to do some rematching
+						// this can only happen if the current pattern is greedy
+
+						/** @type {RematchOptions} */
+						var nestedRematch = {
+							cause: token + ',' + j,
+							reach: reach
+						};
+						matchGrammar(text, tokenList, grammar, currentNode.prev, pos, nestedRematch);
+
+						// the reach might have been extended because of the rematching
+						if (rematch && nestedRematch.reach > rematch.reach) {
+							rematch.reach = nestedRematch.reach;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * @typedef LinkedListNode
+	 * @property {T} value
+	 * @property {LinkedListNode<T> | null} prev The previous node.
+	 * @property {LinkedListNode<T> | null} next The next node.
+	 * @template T
+	 * @private
+	 */
+
+	/**
+	 * @template T
+	 * @private
+	 */
+	function LinkedList() {
+		/** @type {LinkedListNode<T>} */
+		var head = { value: null, prev: null, next: null };
+		/** @type {LinkedListNode<T>} */
+		var tail = { value: null, prev: head, next: null };
+		head.next = tail;
+
+		/** @type {LinkedListNode<T>} */
+		this.head = head;
+		/** @type {LinkedListNode<T>} */
+		this.tail = tail;
+		this.length = 0;
+	}
+
+	/**
+	 * Adds a new node with the given value to the list.
+	 *
+	 * @param {LinkedList<T>} list
+	 * @param {LinkedListNode<T>} node
+	 * @param {T} value
+	 * @returns {LinkedListNode<T>} The added node.
+	 * @template T
+	 */
+	function addAfter(list, node, value) {
+		// assumes that node != list.tail && values.length >= 0
+		var next = node.next;
+
+		var newNode = { value: value, prev: node, next: next };
+		node.next = newNode;
+		next.prev = newNode;
+		list.length++;
+
+		return newNode;
+	}
+	/**
+	 * Removes `count` nodes after the given node. The given node will not be removed.
+	 *
+	 * @param {LinkedList<T>} list
+	 * @param {LinkedListNode<T>} node
+	 * @param {number} count
+	 * @template T
+	 */
+	function removeRange(list, node, count) {
+		var next = node.next;
+		for (var i = 0; i < count && next !== list.tail; i++) {
+			next = next.next;
+		}
+		node.next = next;
+		next.prev = node;
+		list.length -= i;
+	}
+	/**
+	 * @param {LinkedList<T>} list
+	 * @returns {T[]}
+	 * @template T
+	 */
+	function toArray(list) {
+		var array = [];
+		var node = list.head.next;
+		while (node !== list.tail) {
+			array.push(node.value);
+			node = node.next;
+		}
+		return array;
+	}
+
+
+	if (!_self.document) {
+		if (!_self.addEventListener) {
+			// in Node.js
+			return _;
+		}
+
+		if (!_.disableWorkerMessageHandler) {
+			// In worker
+			_self.addEventListener('message', function (evt) {
+				var message = JSON.parse(evt.data);
+				var lang = message.language;
+				var code = message.code;
+				var immediateClose = message.immediateClose;
+
+				_self.postMessage(_.highlight(code, _.languages[lang], lang));
+				if (immediateClose) {
+					_self.close();
+				}
+			}, false);
+		}
+
+		return _;
+	}
+
+	// Get current script and highlight
+	var script = _.util.currentScript();
+
+	if (script) {
+		_.filename = script.src;
+
+		if (script.hasAttribute('data-manual')) {
+			_.manual = true;
+		}
+	}
+
+	function highlightAutomaticallyCallback() {
+		if (!_.manual) {
+			_.highlightAll();
+		}
+	}
+
+	if (!_.manual) {
+		// If the document state is "loading", then we'll use DOMContentLoaded.
+		// If the document state is "interactive" and the prism.js script is deferred, then we'll also use the
+		// DOMContentLoaded event because there might be some plugins or languages which have also been deferred and they
+		// might take longer one animation frame to execute which can create a race condition where only some plugins have
+		// been loaded when Prism.highlightAll() is executed, depending on how fast resources are loaded.
+		// See https://github.com/PrismJS/prism/issues/2102
+		var readyState = document.readyState;
+		if (readyState === 'loading' || readyState === 'interactive' && script && script.defer) {
+			document.addEventListener('DOMContentLoaded', highlightAutomaticallyCallback);
+		} else {
+			if (window.requestAnimationFrame) {
+				window.requestAnimationFrame(highlightAutomaticallyCallback);
+			} else {
+				window.setTimeout(highlightAutomaticallyCallback, 16);
+			}
+		}
+	}
+
+	return _;
+
+}(_self));
+
+if (typeof module !== 'undefined' && module.exports) {
+	module.exports = Prism;
+}
+
+// hack for components to work correctly in node.js
+if (typeof global !== 'undefined') {
+	global.Prism = Prism;
+}
+
+// some additional documentation/types
+
+/**
+ * The expansion of a simple `RegExp` literal to support additional properties.
+ *
+ * @typedef GrammarToken
+ * @property {RegExp} pattern The regular expression of the token.
+ * @property {boolean} [lookbehind=false] If `true`, then the first capturing group of `pattern` will (effectively)
+ * behave as a lookbehind group meaning that the captured text will not be part of the matched text of the new token.
+ * @property {boolean} [greedy=false] Whether the token is greedy.
+ * @property {string|string[]} [alias] An optional alias or list of aliases.
+ * @property {Grammar} [inside] The nested grammar of this token.
+ *
+ * The `inside` grammar will be used to tokenize the text value of each token of this kind.
+ *
+ * This can be used to make nested and even recursive language definitions.
+ *
+ * Note: This can cause infinite recursion. Be careful when you embed different languages or even the same language into
+ * each another.
+ * @global
+ * @public
+ */
+
+/**
+ * @typedef Grammar
+ * @type {Object<string, RegExp | GrammarToken | Array<RegExp | GrammarToken>>}
+ * @property {Grammar} [rest] An optional grammar object that will be appended to this grammar.
+ * @global
+ * @public
+ */
+
+/**
+ * A function which will invoked after an element was successfully highlighted.
+ *
+ * @callback HighlightCallback
+ * @param {Element} element The element successfully highlighted.
+ * @returns {void}
+ * @global
+ * @public
+ */
+
+/**
+ * @callback HookCallback
+ * @param {Object<string, any>} env The environment variables of the hook.
+ * @returns {void}
+ * @global
+ * @public
+ */
+;
+Prism.languages.markup = {
+	'comment': {
+		pattern: /<!--(?:(?!<!--)[\s\S])*?-->/,
+		greedy: true
+	},
+	'prolog': {
+		pattern: /<\?[\s\S]+?\?>/,
+		greedy: true
+	},
+	'doctype': {
+		// https://www.w3.org/TR/xml/#NT-doctypedecl
+		pattern: /<!DOCTYPE(?:[^>"'[\]]|"[^"]*"|'[^']*')+(?:\[(?:[^<"'\]]|"[^"]*"|'[^']*'|<(?!!--)|<!--(?:[^-]|-(?!->))*-->)*\]\s*)?>/i,
+		greedy: true,
+		inside: {
+			'internal-subset': {
+				pattern: /(^[^\[]*\[)[\s\S]+(?=\]>$)/,
+				lookbehind: true,
+				greedy: true,
+				inside: null // see below
+			},
+			'string': {
+				pattern: /"[^"]*"|'[^']*'/,
+				greedy: true
+			},
+			'punctuation': /^<!|>$|[[\]]/,
+			'doctype-tag': /^DOCTYPE/i,
+			'name': /[^\s<>'"]+/
+		}
+	},
+	'cdata': {
+		pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+		greedy: true
+	},
+	'tag': {
+		pattern: /<\/?(?!\d)[^\s>\/=$<%]+(?:\s(?:\s*[^\s>\/=]+(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))|(?=[\s/>])))+)?\s*\/?>/,
+		greedy: true,
+		inside: {
+			'tag': {
+				pattern: /^<\/?[^\s>\/]+/,
+				inside: {
+					'punctuation': /^<\/?/,
+					'namespace': /^[^\s>\/:]+:/
+				}
+			},
+			'special-attr': [],
+			'attr-value': {
+				pattern: /=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+)/,
+				inside: {
+					'punctuation': [
+						{
+							pattern: /^=/,
+							alias: 'attr-equals'
+						},
+						{
+							pattern: /^(\s*)["']|["']$/,
+							lookbehind: true
+						}
+					]
+				}
+			},
+			'punctuation': /\/?>/,
+			'attr-name': {
+				pattern: /[^\s>\/]+/,
+				inside: {
+					'namespace': /^[^\s>\/:]+:/
+				}
+			}
+
+		}
+	},
+	'entity': [
+		{
+			pattern: /&[\da-z]{1,8};/i,
+			alias: 'named-entity'
+		},
+		/&#x?[\da-f]{1,8};/i
+	]
+};
+
+Prism.languages.markup['tag'].inside['attr-value'].inside['entity'] =
+	Prism.languages.markup['entity'];
+Prism.languages.markup['doctype'].inside['internal-subset'].inside = Prism.languages.markup;
+
+// Plugin to make entity title show the real entity, idea by Roman Komarov
+Prism.hooks.add('wrap', function (env) {
+
+	if (env.type === 'entity') {
+		env.attributes['title'] = env.content.replace(/&amp;/, '&');
+	}
+});
+
+Object.defineProperty(Prism.languages.markup.tag, 'addInlined', {
+	/**
+	 * Adds an inlined language to markup.
+	 *
+	 * An example of an inlined language is CSS with `<style>` tags.
+	 *
+	 * @param {string} tagName The name of the tag that contains the inlined language. This name will be treated as
+	 * case insensitive.
+	 * @param {string} lang The language key.
+	 * @example
+	 * addInlined('style', 'css');
+	 */
+	value: function addInlined(tagName, lang) {
+		var includedCdataInside = {};
+		includedCdataInside['language-' + lang] = {
+			pattern: /(^<!\[CDATA\[)[\s\S]+?(?=\]\]>$)/i,
+			lookbehind: true,
+			inside: Prism.languages[lang]
+		};
+		includedCdataInside['cdata'] = /^<!\[CDATA\[|\]\]>$/i;
+
+		var inside = {
+			'included-cdata': {
+				pattern: /<!\[CDATA\[[\s\S]*?\]\]>/i,
+				inside: includedCdataInside
+			}
+		};
+		inside['language-' + lang] = {
+			pattern: /[\s\S]+/,
+			inside: Prism.languages[lang]
+		};
+
+		var def = {};
+		def[tagName] = {
+			pattern: RegExp(/(<__[^>]*>)(?:<!\[CDATA\[(?:[^\]]|\](?!\]>))*\]\]>|(?!<!\[CDATA\[)[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () { return tagName; }), 'i'),
+			lookbehind: true,
+			greedy: true,
+			inside: inside
+		};
+
+		Prism.languages.insertBefore('markup', 'cdata', def);
+	}
+});
+Object.defineProperty(Prism.languages.markup.tag, 'addAttribute', {
+	/**
+	 * Adds an pattern to highlight languages embedded in HTML attributes.
+	 *
+	 * An example of an inlined language is CSS with `style` attributes.
+	 *
+	 * @param {string} attrName The name of the tag that contains the inlined language. This name will be treated as
+	 * case insensitive.
+	 * @param {string} lang The language key.
+	 * @example
+	 * addAttribute('style', 'css');
+	 */
+	value: function (attrName, lang) {
+		Prism.languages.markup.tag.inside['special-attr'].push({
+			pattern: RegExp(
+				/(^|["'\s])/.source + '(?:' + attrName + ')' + /\s*=\s*(?:"[^"]*"|'[^']*'|[^\s'">=]+(?=[\s>]))/.source,
+				'i'
+			),
+			lookbehind: true,
+			inside: {
+				'attr-name': /^[^\s=]+/,
+				'attr-value': {
+					pattern: /=[\s\S]+/,
+					inside: {
+						'value': {
+							pattern: /(^=\s*(["']|(?!["'])))\S[\s\S]*(?=\2$)/,
+							lookbehind: true,
+							alias: [lang, 'language-' + lang],
+							inside: Prism.languages[lang]
+						},
+						'punctuation': [
+							{
+								pattern: /^=/,
+								alias: 'attr-equals'
+							},
+							/"|'/
+						]
+					}
+				}
+			}
+		});
+	}
+});
+
+Prism.languages.html = Prism.languages.markup;
+Prism.languages.mathml = Prism.languages.markup;
+Prism.languages.svg = Prism.languages.markup;
+
+Prism.languages.xml = Prism.languages.extend('markup', {});
+Prism.languages.ssml = Prism.languages.xml;
+Prism.languages.atom = Prism.languages.xml;
+Prism.languages.rss = Prism.languages.xml;
+
+(function (Prism) {
+
+	var string = /(?:"(?:\\(?:\r\n|[\s\S])|[^"\\\r\n])*"|'(?:\\(?:\r\n|[\s\S])|[^'\\\r\n])*')/;
+
+	Prism.languages.css = {
+		'comment': /\/\*[\s\S]*?\*\//,
+		'atrule': {
+			pattern: RegExp('@[\\w-](?:' + /[^;{\s"']|\s+(?!\s)/.source + '|' + string.source + ')*?' + /(?:;|(?=\s*\{))/.source),
+			inside: {
+				'rule': /^@[\w-]+/,
+				'selector-function-argument': {
+					pattern: /(\bselector\s*\(\s*(?![\s)]))(?:[^()\s]|\s+(?![\s)])|\((?:[^()]|\([^()]*\))*\))+(?=\s*\))/,
+					lookbehind: true,
+					alias: 'selector'
+				},
+				'keyword': {
+					pattern: /(^|[^\w-])(?:and|not|only|or)(?![\w-])/,
+					lookbehind: true
+				}
+				// See rest below
+			}
+		},
+		'url': {
+			// https://drafts.csswg.org/css-values-3/#urls
+			pattern: RegExp('\\burl\\((?:' + string.source + '|' + /(?:[^\\\r\n()"']|\\[\s\S])*/.source + ')\\)', 'i'),
+			greedy: true,
+			inside: {
+				'function': /^url/i,
+				'punctuation': /^\(|\)$/,
+				'string': {
+					pattern: RegExp('^' + string.source + '$'),
+					alias: 'url'
+				}
+			}
+		},
+		'selector': {
+			pattern: RegExp('(^|[{}\\s])[^{}\\s](?:[^{};"\'\\s]|\\s+(?![\\s{])|' + string.source + ')*(?=\\s*\\{)'),
+			lookbehind: true
+		},
+		'string': {
+			pattern: string,
+			greedy: true
+		},
+		'property': {
+			pattern: /(^|[^-\w\xA0-\uFFFF])(?!\s)[-_a-z\xA0-\uFFFF](?:(?!\s)[-\w\xA0-\uFFFF])*(?=\s*:)/i,
+			lookbehind: true
+		},
+		'important': /!important\b/i,
+		'function': {
+			pattern: /(^|[^-a-z0-9])[-a-z0-9]+(?=\()/i,
+			lookbehind: true
+		},
+		'punctuation': /[(){};:,]/
+	};
+
+	Prism.languages.css['atrule'].inside.rest = Prism.languages.css;
+
+	var markup = Prism.languages.markup;
+	if (markup) {
+		markup.tag.addInlined('style', 'css');
+		markup.tag.addAttribute('style', 'css');
+	}
+
+}(Prism));
+
+Prism.languages.clike = {
+	'comment': [
+		{
+			pattern: /(^|[^\\])\/\*[\s\S]*?(?:\*\/|$)/,
+			lookbehind: true,
+			greedy: true
+		},
+		{
+			pattern: /(^|[^\\:])\/\/.*/,
+			lookbehind: true,
+			greedy: true
+		}
+	],
+	'string': {
+		pattern: /(["'])(?:\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+		greedy: true
+	},
+	'class-name': {
+		pattern: /(\b(?:class|extends|implements|instanceof|interface|new|trait)\s+|\bcatch\s+\()[\w.\\]+/i,
+		lookbehind: true,
+		inside: {
+			'punctuation': /[.\\]/
+		}
+	},
+	'keyword': /\b(?:break|catch|continue|do|else|finally|for|function|if|in|instanceof|new|null|return|throw|try|while)\b/,
+	'boolean': /\b(?:false|true)\b/,
+	'function': /\b\w+(?=\()/,
+	'number': /\b0x[\da-f]+\b|(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e[+-]?\d+)?/i,
+	'operator': /[<>]=?|[!=]=?=?|--?|\+\+?|&&?|\|\|?|[?*/~^%]/,
+	'punctuation': /[{}[\];(),.:]/
+};
+
+Prism.languages.javascript = Prism.languages.extend('clike', {
+	'class-name': [
+		Prism.languages.clike['class-name'],
+		{
+			pattern: /(^|[^$\w\xA0-\uFFFF])(?!\s)[_$A-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\.(?:constructor|prototype))/,
+			lookbehind: true
+		}
+	],
+	'keyword': [
+		{
+			pattern: /((?:^|\})\s*)catch\b/,
+			lookbehind: true
+		},
+		{
+			pattern: /(^|[^.]|\.\.\.\s*)\b(?:as|assert(?=\s*\{)|async(?=\s*(?:function\b|\(|[$\w\xA0-\uFFFF]|$))|await|break|case|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally(?=\s*(?:\{|$))|for|from(?=\s*(?:['"]|$))|function|(?:get|set)(?=\s*(?:[#\[$\w\xA0-\uFFFF]|$))|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)\b/,
+			lookbehind: true
+		},
+	],
+	// Allow for all non-ASCII characters (See http://stackoverflow.com/a/2008444)
+	'function': /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*(?:\.\s*(?:apply|bind|call)\s*)?\()/,
+	'number': {
+		pattern: RegExp(
+			/(^|[^\w$])/.source +
+			'(?:' +
+			(
+				// constant
+				/NaN|Infinity/.source +
+				'|' +
+				// binary integer
+				/0[bB][01]+(?:_[01]+)*n?/.source +
+				'|' +
+				// octal integer
+				/0[oO][0-7]+(?:_[0-7]+)*n?/.source +
+				'|' +
+				// hexadecimal integer
+				/0[xX][\dA-Fa-f]+(?:_[\dA-Fa-f]+)*n?/.source +
+				'|' +
+				// decimal bigint
+				/\d+(?:_\d+)*n/.source +
+				'|' +
+				// decimal number (integer or float) but no bigint
+				/(?:\d+(?:_\d+)*(?:\.(?:\d+(?:_\d+)*)?)?|\.\d+(?:_\d+)*)(?:[Ee][+-]?\d+(?:_\d+)*)?/.source
+			) +
+			')' +
+			/(?![\w$])/.source
+		),
+		lookbehind: true
+	},
+	'operator': /--|\+\+|\*\*=?|=>|&&=?|\|\|=?|[!=]==|<<=?|>>>?=?|[-+*/%&|^!=<>]=?|\.{3}|\?\?=?|\?\.?|[~:]/
+});
+
+Prism.languages.javascript['class-name'][0].pattern = /(\b(?:class|extends|implements|instanceof|interface|new)\s+)[\w.\\]+/;
+
+Prism.languages.insertBefore('javascript', 'keyword', {
+	'regex': {
+		pattern: RegExp(
+			// lookbehind
+			// eslint-disable-next-line regexp/no-dupe-characters-character-class
+			/((?:^|[^$\w\xA0-\uFFFF."'\])\s]|\b(?:return|yield))\s*)/.source +
+			// Regex pattern:
+			// There are 2 regex patterns here. The RegExp set notation proposal added support for nested character
+			// classes if the `v` flag is present. Unfortunately, nested CCs are both context-free and incompatible
+			// with the only syntax, so we have to define 2 different regex patterns.
+			/\//.source +
+			'(?:' +
+			/(?:\[(?:[^\]\\\r\n]|\\.)*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}/.source +
+			'|' +
+			// `v` flag syntax. This supports 3 levels of nested character classes.
+			/(?:\[(?:[^[\]\\\r\n]|\\.|\[(?:[^[\]\\\r\n]|\\.|\[(?:[^[\]\\\r\n]|\\.)*\])*\])*\]|\\.|[^/\\\[\r\n])+\/[dgimyus]{0,7}v[dgimyus]{0,7}/.source +
+			')' +
+			// lookahead
+			/(?=(?:\s|\/\*(?:[^*]|\*(?!\/))*\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/.source
+		),
+		lookbehind: true,
+		greedy: true,
+		inside: {
+			'regex-source': {
+				pattern: /^(\/)[\s\S]+(?=\/[a-z]*$)/,
+				lookbehind: true,
+				alias: 'language-regex',
+				inside: Prism.languages.regex
+			},
+			'regex-delimiter': /^\/|\/$/,
+			'regex-flags': /^[a-z]+$/,
+		}
+	},
+	// This must be declared before keyword because we use "function" inside the look-forward
+	'function-variable': {
+		pattern: /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*[=:]\s*(?:async\s*)?(?:\bfunction\b|(?:\((?:[^()]|\([^()]*\))*\)|(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*)\s*=>))/,
+		alias: 'function'
+	},
+	'parameter': [
+		{
+			pattern: /(function(?:\s+(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*)?\s*\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\))/,
+			lookbehind: true,
+			inside: Prism.languages.javascript
+		},
+		{
+			pattern: /(^|[^$\w\xA0-\uFFFF])(?!\s)[_$a-z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*=>)/i,
+			lookbehind: true,
+			inside: Prism.languages.javascript
+		},
+		{
+			pattern: /(\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\)\s*=>)/,
+			lookbehind: true,
+			inside: Prism.languages.javascript
+		},
+		{
+			pattern: /((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*\s*)\(\s*|\]\s*\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\)\s*\{)/,
+			lookbehind: true,
+			inside: Prism.languages.javascript
+		}
+	],
+	'constant': /\b[A-Z](?:[A-Z_]|\dx?)*\b/
+});
+
+Prism.languages.insertBefore('javascript', 'string', {
+	'hashbang': {
+		pattern: /^#!.*/,
+		greedy: true,
+		alias: 'comment'
+	},
+	'template-string': {
+		pattern: /`(?:\\[\s\S]|\$\{(?:[^{}]|\{(?:[^{}]|\{[^}]*\})*\})+\}|(?!\$\{)[^\\`])*`/,
+		greedy: true,
+		inside: {
+			'template-punctuation': {
+				pattern: /^`|`$/,
+				alias: 'string'
+			},
+			'interpolation': {
+				pattern: /((?:^|[^\\])(?:\\{2})*)\$\{(?:[^{}]|\{(?:[^{}]|\{[^}]*\})*\})+\}/,
+				lookbehind: true,
+				inside: {
+					'interpolation-punctuation': {
+						pattern: /^\$\{|\}$/,
+						alias: 'punctuation'
+					},
+					rest: Prism.languages.javascript
+				}
+			},
+			'string': /[\s\S]+/
+		}
+	},
+	'string-property': {
+		pattern: /((?:^|[,{])[ \t]*)(["'])(?:\\(?:\r\n|[\s\S])|(?!\2)[^\\\r\n])*\2(?=\s*:)/m,
+		lookbehind: true,
+		greedy: true,
+		alias: 'property'
+	}
+});
+
+Prism.languages.insertBefore('javascript', 'operator', {
+	'literal-property': {
+		pattern: /((?:^|[,{])[ \t]*)(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?=\s*:)/m,
+		lookbehind: true,
+		alias: 'property'
+	},
+});
+
+if (Prism.languages.markup) {
+	Prism.languages.markup.tag.addInlined('script', 'javascript');
+
+	// add attribute support for all DOM events.
+	// https://developer.mozilla.org/en-US/docs/Web/Events#Standard_events
+	Prism.languages.markup.tag.addAttribute(
+		/on(?:abort|blur|change|click|composition(?:end|start|update)|dblclick|error|focus(?:in|out)?|key(?:down|up)|load|mouse(?:down|enter|leave|move|out|over|up)|reset|resize|scroll|select|slotchange|submit|unload|wheel)/.source,
+		'javascript'
+	);
+}
+
+Prism.languages.js = Prism.languages.javascript;
+
+(function (Prism) {
+
+	Prism.languages.diff = {
+		'coord': [
+			// Match all kinds of coord lines (prefixed by "+++", "---" or "***").
+			/^(?:\*{3}|-{3}|\+{3}).*$/m,
+			// Match "@@ ... @@" coord lines in unified diff.
+			/^@@.*@@$/m,
+			// Match coord lines in normal diff (starts with a number).
+			/^\d.*$/m
+		]
+
+		// deleted, inserted, unchanged, diff
+	};
+
+	/**
+	 * A map from the name of a block to its line prefix.
+	 *
+	 * @type {Object<string, string>}
+	 */
+	var PREFIXES = {
+		'deleted-sign': '-',
+		'deleted-arrow': '<',
+		'inserted-sign': '+',
+		'inserted-arrow': '>',
+		'unchanged': ' ',
+		'diff': '!',
+	};
+
+	// add a token for each prefix
+	Object.keys(PREFIXES).forEach(function (name) {
+		var prefix = PREFIXES[name];
+
+		var alias = [];
+		if (!/^\w+$/.test(name)) { // "deleted-sign" -> "deleted"
+			alias.push(/\w+/.exec(name)[0]);
+		}
+		if (name === 'diff') {
+			alias.push('bold');
+		}
+
+		Prism.languages.diff[name] = {
+			pattern: RegExp('^(?:[' + prefix + '].*(?:\r\n?|\n|(?![\\s\\S])))+', 'm'),
+			alias: alias,
+			inside: {
+				'line': {
+					pattern: /(.)(?=[\s\S]).*(?:\r\n?|\n)?/,
+					lookbehind: true
+				},
+				'prefix': {
+					pattern: /[\s\S]/,
+					alias: /\w+/.exec(name)[0]
+				}
+			}
+		};
+
+	});
+
+	// make prefixes available to Diff plugin
+	Object.defineProperty(Prism.languages.diff, 'PREFIXES', {
+		value: PREFIXES
+	});
+
+}(Prism));
+
+(function (Prism) {
+
+	var keywords = /\b(?:abstract|assert|boolean|break|byte|case|catch|char|class|const|continue|default|do|double|else|enum|exports|extends|final|finally|float|for|goto|if|implements|import|instanceof|int|interface|long|module|native|new|non-sealed|null|open|opens|package|permits|private|protected|provides|public|record(?!\s*[(){}[\]<>=%~.:,;?+\-*/&|^])|requires|return|sealed|short|static|strictfp|super|switch|synchronized|this|throw|throws|to|transient|transitive|try|uses|var|void|volatile|while|with|yield)\b/;
+
+	// full package (optional) + parent classes (optional)
+	var classNamePrefix = /(?:[a-z]\w*\s*\.\s*)*(?:[A-Z]\w*\s*\.\s*)*/.source;
+
+	// based on the java naming conventions
+	var className = {
+		pattern: RegExp(/(^|[^\w.])/.source + classNamePrefix + /[A-Z](?:[\d_A-Z]*[a-z]\w*)?\b/.source),
+		lookbehind: true,
+		inside: {
+			'namespace': {
+				pattern: /^[a-z]\w*(?:\s*\.\s*[a-z]\w*)*(?:\s*\.)?/,
+				inside: {
+					'punctuation': /\./
+				}
+			},
+			'punctuation': /\./
+		}
+	};
+
+	Prism.languages.java = Prism.languages.extend('clike', {
+		'string': {
+			pattern: /(^|[^\\])"(?:\\.|[^"\\\r\n])*"/,
+			lookbehind: true,
+			greedy: true
+		},
+		'class-name': [
+			className,
+			{
+				// variables, parameters, and constructor references
+				// this to support class names (or generic parameters) which do not contain a lower case letter (also works for methods)
+				pattern: RegExp(/(^|[^\w.])/.source + classNamePrefix + /[A-Z]\w*(?=\s+\w+\s*[;,=()]|\s*(?:\[[\s,]*\]\s*)?::\s*new\b)/.source),
+				lookbehind: true,
+				inside: className.inside
+			},
+			{
+				// class names based on keyword
+				// this to support class names (or generic parameters) which do not contain a lower case letter (also works for methods)
+				pattern: RegExp(/(\b(?:class|enum|extends|implements|instanceof|interface|new|record|throws)\s+)/.source + classNamePrefix + /[A-Z]\w*\b/.source),
+				lookbehind: true,
+				inside: className.inside
+			}
+		],
+		'keyword': keywords,
+		'function': [
+			Prism.languages.clike.function,
+			{
+				pattern: /(::\s*)[a-z_]\w*/,
+				lookbehind: true
+			}
+		],
+		'number': /\b0b[01][01_]*L?\b|\b0x(?:\.[\da-f_p+-]+|[\da-f_]+(?:\.[\da-f_p+-]+)?)\b|(?:\b\d[\d_]*(?:\.[\d_]*)?|\B\.\d[\d_]*)(?:e[+-]?\d[\d_]*)?[dfl]?/i,
+		'operator': {
+			pattern: /(^|[^.])(?:<<=?|>>>?=?|->|--|\+\+|&&|\|\||::|[?:~]|[-+*/%&|^!=<>]=?)/m,
+			lookbehind: true
+		},
+		'constant': /\b[A-Z][A-Z_\d]+\b/
+	});
+
+	Prism.languages.insertBefore('java', 'string', {
+		'triple-quoted-string': {
+			// http://openjdk.java.net/jeps/355#Description
+			pattern: /"""[ \t]*[\r\n](?:(?:"|"")?(?:\\.|[^"\\]))*"""/,
+			greedy: true,
+			alias: 'string'
+		},
+		'char': {
+			pattern: /'(?:\\.|[^'\\\r\n]){1,6}'/,
+			greedy: true
+		}
+	});
+
+	Prism.languages.insertBefore('java', 'class-name', {
+		'annotation': {
+			pattern: /(^|[^.])@\w+(?:\s*\.\s*\w+)*/,
+			lookbehind: true,
+			alias: 'punctuation'
+		},
+		'generics': {
+			pattern: /<(?:[\w\s,.?]|&(?!&)|<(?:[\w\s,.?]|&(?!&)|<(?:[\w\s,.?]|&(?!&)|<(?:[\w\s,.?]|&(?!&))*>)*>)*>)*>/,
+			inside: {
+				'class-name': className,
+				'keyword': keywords,
+				'punctuation': /[<>(),.:]/,
+				'operator': /[?&|]/
+			}
+		},
+		'import': [
+			{
+				pattern: RegExp(/(\bimport\s+)/.source + classNamePrefix + /(?:[A-Z]\w*|\*)(?=\s*;)/.source),
+				lookbehind: true,
+				inside: {
+					'namespace': className.inside.namespace,
+					'punctuation': /\./,
+					'operator': /\*/,
+					'class-name': /\w+/
+				}
+			},
+			{
+				pattern: RegExp(/(\bimport\s+static\s+)/.source + classNamePrefix + /(?:\w+|\*)(?=\s*;)/.source),
+				lookbehind: true,
+				alias: 'static',
+				inside: {
+					'namespace': className.inside.namespace,
+					'static': /\b\w+$/,
+					'punctuation': /\./,
+					'operator': /\*/,
+					'class-name': /\w+/
+				}
+			}
+		],
+		'namespace': {
+			pattern: RegExp(
+				/(\b(?:exports|import(?:\s+static)?|module|open|opens|package|provides|requires|to|transitive|uses|with)\s+)(?!<keyword>)[a-z]\w*(?:\.[a-z]\w*)*\.?/
+					.source.replace(/<keyword>/g, function () { return keywords.source; })),
+			lookbehind: true,
+			inside: {
+				'punctuation': /\./,
+			}
+		}
+	});
+}(Prism));
+
+(function (Prism) {
+
+	var javaDocLike = Prism.languages.javadoclike = {
+		'parameter': {
+			pattern: /(^[\t ]*(?:\/{3}|\*|\/\*\*)\s*@(?:arg|arguments|param)\s+)\w+/m,
+			lookbehind: true
+		},
+		'keyword': {
+			// keywords are the first word in a line preceded be an `@` or surrounded by curly braces.
+			// @word, {@word}
+			pattern: /(^[\t ]*(?:\/{3}|\*|\/\*\*)\s*|\{)@[a-z][a-zA-Z-]+\b/m,
+			lookbehind: true
+		},
+		'punctuation': /[{}]/
+	};
+
+
+	/**
+	 * Adds doc comment support to the given language and calls a given callback on each doc comment pattern.
+	 *
+	 * @param {string} lang the language add doc comment support to.
+	 * @param {(pattern: {inside: {rest: undefined}}) => void} callback the function called with each doc comment pattern as argument.
+	 */
+	function docCommentSupport(lang, callback) {
+		var tokenName = 'doc-comment';
+
+		var grammar = Prism.languages[lang];
+		if (!grammar) {
+			return;
+		}
+		var token = grammar[tokenName];
+
+		if (!token) {
+			// add doc comment: /** */
+			var definition = {};
+			definition[tokenName] = {
+				pattern: /(^|[^\\])\/\*\*[^/][\s\S]*?(?:\*\/|$)/,
+				lookbehind: true,
+				alias: 'comment'
+			};
+
+			grammar = Prism.languages.insertBefore(lang, 'comment', definition);
+			token = grammar[tokenName];
+		}
+
+		if (token instanceof RegExp) { // convert regex to object
+			token = grammar[tokenName] = { pattern: token };
+		}
+
+		if (Array.isArray(token)) {
+			for (var i = 0, l = token.length; i < l; i++) {
+				if (token[i] instanceof RegExp) {
+					token[i] = { pattern: token[i] };
+				}
+				callback(token[i]);
+			}
+		} else {
+			callback(token);
+		}
+	}
+
+	/**
+	 * Adds doc-comment support to the given languages for the given documentation language.
+	 *
+	 * @param {string[]|string} languages
+	 * @param {Object} docLanguage
+	 */
+	function addSupport(languages, docLanguage) {
+		if (typeof languages === 'string') {
+			languages = [languages];
+		}
+
+		languages.forEach(function (lang) {
+			docCommentSupport(lang, function (pattern) {
+				if (!pattern.inside) {
+					pattern.inside = {};
+				}
+				pattern.inside.rest = docLanguage;
+			});
+		});
+	}
+
+	Object.defineProperty(javaDocLike, 'addSupport', { value: addSupport });
+
+	javaDocLike.addSupport(['java', 'javascript', 'php'], javaDocLike);
+
+}(Prism));
+
+(function (Prism) {
+
+	Prism.languages.typescript = Prism.languages.extend('javascript', {
+		'class-name': {
+			pattern: /(\b(?:class|extends|implements|instanceof|interface|new|type)\s+)(?!keyof\b)(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*(?:\s*<(?:[^<>]|<(?:[^<>]|<[^<>]*>)*>)*>)?/,
+			lookbehind: true,
+			greedy: true,
+			inside: null // see below
+		},
+		'builtin': /\b(?:Array|Function|Promise|any|boolean|console|never|number|string|symbol|unknown)\b/,
+	});
+
+	// The keywords TypeScript adds to JavaScript
+	Prism.languages.typescript.keyword.push(
+		/\b(?:abstract|declare|is|keyof|readonly|require)\b/,
+		// keywords that have to be followed by an identifier
+		/\b(?:asserts|infer|interface|module|namespace|type)\b(?=\s*(?:[{_$a-zA-Z\xA0-\uFFFF]|$))/,
+		// This is for `import type *, {}`
+		/\btype\b(?=\s*(?:[\{*]|$))/
+	);
+
+	// doesn't work with TS because TS is too complex
+	delete Prism.languages.typescript['parameter'];
+	delete Prism.languages.typescript['literal-property'];
+
+	// a version of typescript specifically for highlighting types
+	var typeInside = Prism.languages.extend('typescript', {});
+	delete typeInside['class-name'];
+
+	Prism.languages.typescript['class-name'].inside = typeInside;
+
+	Prism.languages.insertBefore('typescript', 'function', {
+		'decorator': {
+			pattern: /@[$\w\xA0-\uFFFF]+/,
+			inside: {
+				'at': {
+					pattern: /^@/,
+					alias: 'operator'
+				},
+				'function': /^[\s\S]+/
+			}
+		},
+		'generic-function': {
+			// e.g. foo<T extends "bar" | "baz">( ...
+			pattern: /#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*\s*<(?:[^<>]|<(?:[^<>]|<[^<>]*>)*>)*>(?=\s*\()/,
+			greedy: true,
+			inside: {
+				'function': /^#?(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*/,
+				'generic': {
+					pattern: /<[\s\S]+/, // everything after the first <
+					alias: 'class-name',
+					inside: typeInside
+				}
+			}
+		}
+	});
+
+	Prism.languages.ts = Prism.languages.typescript;
+
+}(Prism));
+
+(function (Prism) {
+
+	var javascript = Prism.languages.javascript;
+
+	var type = /\{(?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})+\}/.source;
+	var parameterPrefix = '(@(?:arg|argument|param|property)\\s+(?:' + type + '\\s+)?)';
+
+	Prism.languages.jsdoc = Prism.languages.extend('javadoclike', {
+		'parameter': {
+			// @param {string} foo - foo bar
+			pattern: RegExp(parameterPrefix + /(?:(?!\s)[$\w\xA0-\uFFFF.])+(?=\s|$)/.source),
+			lookbehind: true,
+			inside: {
+				'punctuation': /\./
+			}
+		}
+	});
+
+	Prism.languages.insertBefore('jsdoc', 'keyword', {
+		'optional-parameter': {
+			// @param {string} [baz.foo="bar"] foo bar
+			pattern: RegExp(parameterPrefix + /\[(?:(?!\s)[$\w\xA0-\uFFFF.])+(?:=[^[\]]+)?\](?=\s|$)/.source),
+			lookbehind: true,
+			inside: {
+				'parameter': {
+					pattern: /(^\[)[$\w\xA0-\uFFFF\.]+/,
+					lookbehind: true,
+					inside: {
+						'punctuation': /\./
+					}
+				},
+				'code': {
+					pattern: /(=)[\s\S]*(?=\]$)/,
+					lookbehind: true,
+					inside: javascript,
+					alias: 'language-javascript'
+				},
+				'punctuation': /[=[\]]/
+			}
+		},
+		'class-name': [
+			{
+				pattern: RegExp(/(@(?:augments|class|extends|interface|memberof!?|template|this|typedef)\s+(?:<TYPE>\s+)?)[A-Z]\w*(?:\.[A-Z]\w*)*/.source.replace(/<TYPE>/g, function () { return type; })),
+				lookbehind: true,
+				inside: {
+					'punctuation': /\./
+				}
+			},
+			{
+				pattern: RegExp('(@[a-z]+\\s+)' + type),
+				lookbehind: true,
+				inside: {
+					'string': javascript.string,
+					'number': javascript.number,
+					'boolean': javascript.boolean,
+					'keyword': Prism.languages.typescript.keyword,
+					'operator': /=>|\.\.\.|[&|?:*]/,
+					'punctuation': /[.,;=<>{}()[\]]/
+				}
+			}
+		],
+		'example': {
+			pattern: /(@example\s+(?!\s))(?:[^@\s]|\s+(?!\s))+?(?=\s*(?:\*\s*)?(?:@\w|\*\/))/,
+			lookbehind: true,
+			inside: {
+				'code': {
+					pattern: /^([\t ]*(?:\*\s*)?)\S.*$/m,
+					lookbehind: true,
+					inside: javascript,
+					alias: 'language-javascript'
+				}
+			}
+		}
+	});
+
+	Prism.languages.javadoclike.addSupport('javascript', Prism.languages.jsdoc);
+
+}(Prism));
+
+// https://www.json.org/json-en.html
+Prism.languages.json = {
+	'property': {
+		pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
+		lookbehind: true,
+		greedy: true
+	},
+	'string': {
+		pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
+		lookbehind: true,
+		greedy: true
+	},
+	'comment': {
+		pattern: /\/\/.*|\/\*[\s\S]*?(?:\*\/|$)/,
+		greedy: true
+	},
+	'number': /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
+	'punctuation': /[{}[\],]/,
+	'operator': /:/,
+	'boolean': /\b(?:false|true)\b/,
+	'null': {
+		pattern: /\bnull\b/,
+		alias: 'keyword'
+	}
+};
+
+Prism.languages.webmanifest = Prism.languages.json;
+
+(function (Prism) {
+
+	// Allow only one line break
+	var inner = /(?:\\.|[^\\\n\r]|(?:\n|\r\n?)(?![\r\n]))/.source;
+
+	/**
+	 * This function is intended for the creation of the bold or italic pattern.
+	 *
+	 * This also adds a lookbehind group to the given pattern to ensure that the pattern is not backslash-escaped.
+	 *
+	 * _Note:_ Keep in mind that this adds a capturing group.
+	 *
+	 * @param {string} pattern
+	 * @returns {RegExp}
+	 */
+	function createInline(pattern) {
+		pattern = pattern.replace(/<inner>/g, function () { return inner; });
+		return RegExp(/((?:^|[^\\])(?:\\{2})*)/.source + '(?:' + pattern + ')');
+	}
+
+
+	var tableCell = /(?:\\.|``(?:[^`\r\n]|`(?!`))+``|`[^`\r\n]+`|[^\\|\r\n`])+/.source;
+	var tableRow = /\|?__(?:\|__)+\|?(?:(?:\n|\r\n?)|(?![\s\S]))/.source.replace(/__/g, function () { return tableCell; });
+	var tableLine = /\|?[ \t]*:?-{3,}:?[ \t]*(?:\|[ \t]*:?-{3,}:?[ \t]*)+\|?(?:\n|\r\n?)/.source;
+
+
+	Prism.languages.markdown = Prism.languages.extend('markup', {});
+	Prism.languages.insertBefore('markdown', 'prolog', {
+		'front-matter-block': {
+			pattern: /(^(?:\s*[\r\n])?)---(?!.)[\s\S]*?[\r\n]---(?!.)/,
+			lookbehind: true,
+			greedy: true,
+			inside: {
+				'punctuation': /^---|---$/,
+				'front-matter': {
+					pattern: /\S+(?:\s+\S+)*/,
+					alias: ['yaml', 'language-yaml'],
+					inside: Prism.languages.yaml
+				}
+			}
+		},
+		'blockquote': {
+			// > ...
+			pattern: /^>(?:[\t ]*>)*/m,
+			alias: 'punctuation'
+		},
+		'table': {
+			pattern: RegExp('^' + tableRow + tableLine + '(?:' + tableRow + ')*', 'm'),
+			inside: {
+				'table-data-rows': {
+					pattern: RegExp('^(' + tableRow + tableLine + ')(?:' + tableRow + ')*$'),
+					lookbehind: true,
+					inside: {
+						'table-data': {
+							pattern: RegExp(tableCell),
+							inside: Prism.languages.markdown
+						},
+						'punctuation': /\|/
+					}
+				},
+				'table-line': {
+					pattern: RegExp('^(' + tableRow + ')' + tableLine + '$'),
+					lookbehind: true,
+					inside: {
+						'punctuation': /\||:?-{3,}:?/
+					}
+				},
+				'table-header-row': {
+					pattern: RegExp('^' + tableRow + '$'),
+					inside: {
+						'table-header': {
+							pattern: RegExp(tableCell),
+							alias: 'important',
+							inside: Prism.languages.markdown
+						},
+						'punctuation': /\|/
+					}
+				}
+			}
+		},
+		'code': [
+			{
+				// Prefixed by 4 spaces or 1 tab and preceded by an empty line
+				pattern: /((?:^|\n)[ \t]*\n|(?:^|\r\n?)[ \t]*\r\n?)(?: {4}|\t).+(?:(?:\n|\r\n?)(?: {4}|\t).+)*/,
+				lookbehind: true,
+				alias: 'keyword'
+			},
+			{
+				// ```optional language
+				// code block
+				// ```
+				pattern: /^```[\s\S]*?^```$/m,
+				greedy: true,
+				inside: {
+					'code-block': {
+						pattern: /^(```.*(?:\n|\r\n?))[\s\S]+?(?=(?:\n|\r\n?)^```$)/m,
+						lookbehind: true
+					},
+					'code-language': {
+						pattern: /^(```).+/,
+						lookbehind: true
+					},
+					'punctuation': /```/
+				}
+			}
+		],
+		'title': [
+			{
+				// title 1
+				// =======
+
+				// title 2
+				// -------
+				pattern: /\S.*(?:\n|\r\n?)(?:==+|--+)(?=[ \t]*$)/m,
+				alias: 'important',
+				inside: {
+					punctuation: /==+$|--+$/
+				}
+			},
+			{
+				// # title 1
+				// ###### title 6
+				pattern: /(^\s*)#.+/m,
+				lookbehind: true,
+				alias: 'important',
+				inside: {
+					punctuation: /^#+|#+$/
+				}
+			}
+		],
+		'hr': {
+			// ***
+			// ---
+			// * * *
+			// -----------
+			pattern: /(^\s*)([*-])(?:[\t ]*\2){2,}(?=\s*$)/m,
+			lookbehind: true,
+			alias: 'punctuation'
+		},
+		'list': {
+			// * item
+			// + item
+			// - item
+			// 1. item
+			pattern: /(^\s*)(?:[*+-]|\d+\.)(?=[\t ].)/m,
+			lookbehind: true,
+			alias: 'punctuation'
+		},
+		'url-reference': {
+			// [id]: http://example.com "Optional title"
+			// [id]: http://example.com 'Optional title'
+			// [id]: http://example.com (Optional title)
+			// [id]: <http://example.com> "Optional title"
+			pattern: /!?\[[^\]]+\]:[\t ]+(?:\S+|<(?:\\.|[^>\\])+>)(?:[\t ]+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\)))?/,
+			inside: {
+				'variable': {
+					pattern: /^(!?\[)[^\]]+/,
+					lookbehind: true
+				},
+				'string': /(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))$/,
+				'punctuation': /^[\[\]!:]|[<>]/
+			},
+			alias: 'url'
+		},
+		'bold': {
+			// **strong**
+			// __strong__
+
+			// allow one nested instance of italic text using the same delimiter
+			pattern: createInline(/\b__(?:(?!_)<inner>|_(?:(?!_)<inner>)+_)+__\b|\*\*(?:(?!\*)<inner>|\*(?:(?!\*)<inner>)+\*)+\*\*/.source),
+			lookbehind: true,
+			greedy: true,
+			inside: {
+				'content': {
+					pattern: /(^..)[\s\S]+(?=..$)/,
+					lookbehind: true,
+					inside: {} // see below
+				},
+				'punctuation': /\*\*|__/
+			}
+		},
+		'italic': {
+			// *em*
+			// _em_
+
+			// allow one nested instance of bold text using the same delimiter
+			pattern: createInline(/\b_(?:(?!_)<inner>|__(?:(?!_)<inner>)+__)+_\b|\*(?:(?!\*)<inner>|\*\*(?:(?!\*)<inner>)+\*\*)+\*/.source),
+			lookbehind: true,
+			greedy: true,
+			inside: {
+				'content': {
+					pattern: /(^.)[\s\S]+(?=.$)/,
+					lookbehind: true,
+					inside: {} // see below
+				},
+				'punctuation': /[*_]/
+			}
+		},
+		'strike': {
+			// ~~strike through~~
+			// ~strike~
+			// eslint-disable-next-line regexp/strict
+			pattern: createInline(/(~~?)(?:(?!~)<inner>)+\2/.source),
+			lookbehind: true,
+			greedy: true,
+			inside: {
+				'content': {
+					pattern: /(^~~?)[\s\S]+(?=\1$)/,
+					lookbehind: true,
+					inside: {} // see below
+				},
+				'punctuation': /~~?/
+			}
+		},
+		'code-snippet': {
+			// `code`
+			// ``code``
+			pattern: /(^|[^\\`])(?:``[^`\r\n]+(?:`[^`\r\n]+)*``(?!`)|`[^`\r\n]+`(?!`))/,
+			lookbehind: true,
+			greedy: true,
+			alias: ['code', 'keyword']
+		},
+		'url': {
+			// [example](http://example.com "Optional title")
+			// [example][id]
+			// [example] [id]
+			pattern: createInline(/!?\[(?:(?!\])<inner>)+\](?:\([^\s)]+(?:[\t ]+"(?:\\.|[^"\\])*")?\)|[ \t]?\[(?:(?!\])<inner>)+\])/.source),
+			lookbehind: true,
+			greedy: true,
+			inside: {
+				'operator': /^!/,
+				'content': {
+					pattern: /(^\[)[^\]]+(?=\])/,
+					lookbehind: true,
+					inside: {} // see below
+				},
+				'variable': {
+					pattern: /(^\][ \t]?\[)[^\]]+(?=\]$)/,
+					lookbehind: true
+				},
+				'url': {
+					pattern: /(^\]\()[^\s)]+/,
+					lookbehind: true
+				},
+				'string': {
+					pattern: /(^[ \t]+)"(?:\\.|[^"\\])*"(?=\)$)/,
+					lookbehind: true
+				}
+			}
+		}
+	});
+
+	['url', 'bold', 'italic', 'strike'].forEach(function (token) {
+		['url', 'bold', 'italic', 'strike', 'code-snippet'].forEach(function (inside) {
+			if (token !== inside) {
+				Prism.languages.markdown[token].inside.content.inside[inside] = Prism.languages.markdown[inside];
+			}
+		});
+	});
+
+	Prism.hooks.add('after-tokenize', function (env) {
+		if (env.language !== 'markdown' && env.language !== 'md') {
+			return;
+		}
+
+		function walkTokens(tokens) {
+			if (!tokens || typeof tokens === 'string') {
+				return;
+			}
+
+			for (var i = 0, l = tokens.length; i < l; i++) {
+				var token = tokens[i];
+
+				if (token.type !== 'code') {
+					walkTokens(token.content);
+					continue;
+				}
+
+				/*
+				 * Add the correct `language-xxxx` class to this code block. Keep in mind that the `code-language` token
+				 * is optional. But the grammar is defined so that there is only one case we have to handle:
+				 *
+				 * token.content = [
+				 *     <span class="punctuation">```</span>,
+				 *     <span class="code-language">xxxx</span>,
+				 *     '\n', // exactly one new lines (\r or \n or \r\n)
+				 *     <span class="code-block">...</span>,
+				 *     '\n', // exactly one new lines again
+				 *     <span class="punctuation">```</span>
+				 * ];
+				 */
+
+				var codeLang = token.content[1];
+				var codeBlock = token.content[3];
+
+				if (codeLang && codeBlock &&
+					codeLang.type === 'code-language' && codeBlock.type === 'code-block' &&
+					typeof codeLang.content === 'string') {
+
+					// this might be a language that Prism does not support
+
+					// do some replacements to support C++, C#, and F#
+					var lang = codeLang.content.replace(/\b#/g, 'sharp').replace(/\b\+\+/g, 'pp');
+					// only use the first word
+					lang = (/[a-z][\w-]*/i.exec(lang) || [''])[0].toLowerCase();
+					var alias = 'language-' + lang;
+
+					// add alias
+					if (!codeBlock.alias) {
+						codeBlock.alias = [alias];
+					} else if (typeof codeBlock.alias === 'string') {
+						codeBlock.alias = [codeBlock.alias, alias];
+					} else {
+						codeBlock.alias.push(alias);
+					}
+				}
+			}
+		}
+
+		walkTokens(env.tokens);
+	});
+
+	Prism.hooks.add('wrap', function (env) {
+		if (env.type !== 'code-block') {
+			return;
+		}
+
+		var codeLang = '';
+		for (var i = 0, l = env.classes.length; i < l; i++) {
+			var cls = env.classes[i];
+			var match = /language-(.+)/.exec(cls);
+			if (match) {
+				codeLang = match[1];
+				break;
+			}
+		}
+
+		var grammar = Prism.languages[codeLang];
+
+		if (!grammar) {
+			if (codeLang && codeLang !== 'none' && Prism.plugins.autoloader) {
+				var id = 'md-' + new Date().valueOf() + '-' + Math.floor(Math.random() * 1e16);
+				env.attributes['id'] = id;
+
+				Prism.plugins.autoloader.loadLanguages(codeLang, function () {
+					var ele = document.getElementById(id);
+					if (ele) {
+						ele.innerHTML = Prism.highlight(ele.textContent, Prism.languages[codeLang], codeLang);
+					}
+				});
+			}
+		} else {
+			env.content = Prism.highlight(textContent(env.content), grammar, codeLang);
+		}
+	});
+
+	var tagPattern = RegExp(Prism.languages.markup.tag.pattern.source, 'gi');
+
+	/**
+	 * A list of known entity names.
+	 *
+	 * This will always be incomplete to save space. The current list is the one used by lowdash's unescape function.
+	 *
+	 * @see {@link https://github.com/lodash/lodash/blob/2da024c3b4f9947a48517639de7560457cd4ec6c/unescape.js#L2}
+	 */
+	var KNOWN_ENTITY_NAMES = {
+		'amp': '&',
+		'lt': '<',
+		'gt': '>',
+		'quot': '"',
+	};
+
+	// IE 11 doesn't support `String.fromCodePoint`
+	var fromCodePoint = String.fromCodePoint || String.fromCharCode;
+
+	/**
+	 * Returns the text content of a given HTML source code string.
+	 *
+	 * @param {string} html
+	 * @returns {string}
+	 */
+	function textContent(html) {
+		// remove all tags
+		var text = html.replace(tagPattern, '');
+
+		// decode known entities
+		text = text.replace(/&(\w{1,8}|#x?[\da-f]{1,8});/gi, function (m, code) {
+			code = code.toLowerCase();
+
+			if (code[0] === '#') {
+				var value;
+				if (code[1] === 'x') {
+					value = parseInt(code.slice(2), 16);
+				} else {
+					value = Number(code.slice(1));
+				}
+
+				return fromCodePoint(value);
+			} else {
+				var known = KNOWN_ENTITY_NAMES[code];
+				if (known) {
+					return known;
+				}
+
+				// unable to decode
+				return m;
+			}
+		});
+
+		return text;
+	}
+
+	Prism.languages.md = Prism.languages.markdown;
+
+}(Prism));
+
+Prism.languages.python = {
+	'comment': {
+		pattern: /(^|[^\\])#.*/,
+		lookbehind: true,
+		greedy: true
+	},
+	'string-interpolation': {
+		pattern: /(?:f|fr|rf)(?:("""|''')[\s\S]*?\1|("|')(?:\\.|(?!\2)[^\\\r\n])*\2)/i,
+		greedy: true,
+		inside: {
+			'interpolation': {
+				// "{" <expression> <optional "!s", "!r", or "!a"> <optional ":" format specifier> "}"
+				pattern: /((?:^|[^{])(?:\{\{)*)\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}]|\{(?!\{)(?:[^{}])+\})+\})+\}/,
+				lookbehind: true,
+				inside: {
+					'format-spec': {
+						pattern: /(:)[^:(){}]+(?=\}$)/,
+						lookbehind: true
+					},
+					'conversion-option': {
+						pattern: /![sra](?=[:}]$)/,
+						alias: 'punctuation'
+					},
+					rest: null
+				}
+			},
+			'string': /[\s\S]+/
+		}
+	},
+	'triple-quoted-string': {
+		pattern: /(?:[rub]|br|rb)?("""|''')[\s\S]*?\1/i,
+		greedy: true,
+		alias: 'string'
+	},
+	'string': {
+		pattern: /(?:[rub]|br|rb)?("|')(?:\\.|(?!\1)[^\\\r\n])*\1/i,
+		greedy: true
+	},
+	'function': {
+		pattern: /((?:^|\s)def[ \t]+)[a-zA-Z_]\w*(?=\s*\()/g,
+		lookbehind: true
+	},
+	'class-name': {
+		pattern: /(\bclass\s+)\w+/i,
+		lookbehind: true
+	},
+	'decorator': {
+		pattern: /(^[\t ]*)@\w+(?:\.\w+)*/m,
+		lookbehind: true,
+		alias: ['annotation', 'punctuation'],
+		inside: {
+			'punctuation': /\./
+		}
+	},
+	'keyword': /\b(?:_(?=\s*:)|and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|exec|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|print|raise|return|try|while|with|yield)\b/,
+	'builtin': /\b(?:__import__|abs|all|any|apply|ascii|basestring|bin|bool|buffer|bytearray|bytes|callable|chr|classmethod|cmp|coerce|compile|complex|delattr|dict|dir|divmod|enumerate|eval|execfile|file|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|intern|isinstance|issubclass|iter|len|list|locals|long|map|max|memoryview|min|next|object|oct|open|ord|pow|property|range|raw_input|reduce|reload|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|unichr|unicode|vars|xrange|zip)\b/,
+	'boolean': /\b(?:False|None|True)\b/,
+	'number': /\b0(?:b(?:_?[01])+|o(?:_?[0-7])+|x(?:_?[a-f0-9])+)\b|(?:\b\d+(?:_\d+)*(?:\.(?:\d+(?:_\d+)*)?)?|\B\.\d+(?:_\d+)*)(?:e[+-]?\d+(?:_\d+)*)?j?(?!\w)/i,
+	'operator': /[-+%=]=?|!=|:=|\*\*?=?|\/\/?=?|<[<=>]?|>[=>]?|[&|^~]/,
+	'punctuation': /[{}[\];(),.:]/
+};
+
+Prism.languages.python['string-interpolation'].inside['interpolation'].inside.rest = Prism.languages.python;
+
+Prism.languages.py = Prism.languages.python;
+
+(function (Prism) {
+	Prism.languages.sass = Prism.languages.extend('css', {
+		// Sass comments don't need to be closed, only indented
+		'comment': {
+			pattern: /^([ \t]*)\/[\/*].*(?:(?:\r?\n|\r)\1[ \t].+)*/m,
+			lookbehind: true,
+			greedy: true
+		}
+	});
+
+	Prism.languages.insertBefore('sass', 'atrule', {
+		// We want to consume the whole line
+		'atrule-line': {
+			// Includes support for = and + shortcuts
+			pattern: /^(?:[ \t]*)[@+=].+/m,
+			greedy: true,
+			inside: {
+				'atrule': /(?:@[\w-]+|[+=])/
+			}
+		}
+	});
+	delete Prism.languages.sass.atrule;
+
+
+	var variable = /\$[-\w]+|#\{\$[-\w]+\}/;
+	var operator = [
+		/[+*\/%]|[=!]=|<=?|>=?|\b(?:and|not|or)\b/,
+		{
+			pattern: /(\s)-(?=\s)/,
+			lookbehind: true
+		}
+	];
+
+	Prism.languages.insertBefore('sass', 'property', {
+		// We want to consume the whole line
+		'variable-line': {
+			pattern: /^[ \t]*\$.+/m,
+			greedy: true,
+			inside: {
+				'punctuation': /:/,
+				'variable': variable,
+				'operator': operator
+			}
+		},
+		// We want to consume the whole line
+		'property-line': {
+			pattern: /^[ \t]*(?:[^:\s]+ *:.*|:[^:\s].*)/m,
+			greedy: true,
+			inside: {
+				'property': [
+					/[^:\s]+(?=\s*:)/,
+					{
+						pattern: /(:)[^:\s]+/,
+						lookbehind: true
+					}
+				],
+				'punctuation': /:/,
+				'variable': variable,
+				'operator': operator,
+				'important': Prism.languages.sass.important
+			}
+		}
+	});
+	delete Prism.languages.sass.property;
+	delete Prism.languages.sass.important;
+
+	// Now that whole lines for other patterns are consumed,
+	// what's left should be selectors
+	Prism.languages.insertBefore('sass', 'punctuation', {
+		'selector': {
+			pattern: /^([ \t]*)\S(?:,[^,\r\n]+|[^,\r\n]*)(?:,[^,\r\n]+)*(?:,(?:\r?\n|\r)\1[ \t]+\S(?:,[^,\r\n]+|[^,\r\n]*)(?:,[^,\r\n]+)*)*/m,
+			lookbehind: true,
+			greedy: true
+		}
+	});
+
+}(Prism));
+
+Prism.languages.scss = Prism.languages.extend('css', {
+	'comment': {
+		pattern: /(^|[^\\])(?:\/\*[\s\S]*?\*\/|\/\/.*)/,
+		lookbehind: true
+	},
+	'atrule': {
+		pattern: /@[\w-](?:\([^()]+\)|[^()\s]|\s+(?!\s))*?(?=\s+[{;])/,
+		inside: {
+			'rule': /@[\w-]+/
+			// See rest below
+		}
+	},
+	// url, compassified
+	'url': /(?:[-a-z]+-)?url(?=\()/i,
+	// CSS selector regex is not appropriate for Sass
+	// since there can be lot more things (var, @ directive, nesting..)
+	// a selector must start at the end of a property or after a brace (end of other rules or nesting)
+	// it can contain some characters that aren't used for defining rules or end of selector, & (parent selector), or interpolated variable
+	// the end of a selector is found when there is no rules in it ( {} or {\s}) or if there is a property (because an interpolated var
+	// can "pass" as a selector- e.g: proper#{$erty})
+	// this one was hard to do, so please be careful if you edit this one :)
+	'selector': {
+		// Initial look-ahead is used to prevent matching of blank selectors
+		pattern: /(?=\S)[^@;{}()]?(?:[^@;{}()\s]|\s+(?!\s)|#\{\$[-\w]+\})+(?=\s*\{(?:\}|\s|[^}][^:{}]*[:{][^}]))/,
+		inside: {
+			'parent': {
+				pattern: /&/,
+				alias: 'important'
+			},
+			'placeholder': /%[-\w]+/,
+			'variable': /\$[-\w]+|#\{\$[-\w]+\}/
+		}
+	},
+	'property': {
+		pattern: /(?:[-\w]|\$[-\w]|#\{\$[-\w]+\})+(?=\s*:)/,
+		inside: {
+			'variable': /\$[-\w]+|#\{\$[-\w]+\}/
+		}
+	}
+});
+
+Prism.languages.insertBefore('scss', 'atrule', {
+	'keyword': [
+		/@(?:content|debug|each|else(?: if)?|extend|for|forward|function|if|import|include|mixin|return|use|warn|while)\b/i,
+		{
+			pattern: /( )(?:from|through)(?= )/,
+			lookbehind: true
+		}
+	]
+});
+
+Prism.languages.insertBefore('scss', 'important', {
+	// var and interpolated vars
+	'variable': /\$[-\w]+|#\{\$[-\w]+\}/
+});
+
+Prism.languages.insertBefore('scss', 'function', {
+	'module-modifier': {
+		pattern: /\b(?:as|hide|show|with)\b/i,
+		alias: 'keyword'
+	},
+	'placeholder': {
+		pattern: /%[-\w]+/,
+		alias: 'selector'
+	},
+	'statement': {
+		pattern: /\B!(?:default|optional)\b/i,
+		alias: 'keyword'
+	},
+	'boolean': /\b(?:false|true)\b/,
+	'null': {
+		pattern: /\bnull\b/,
+		alias: 'keyword'
+	},
+	'operator': {
+		pattern: /(\s)(?:[-+*\/%]|[=!]=|<=?|>=?|and|not|or)(?=\s)/,
+		lookbehind: true
+	}
+});
+
+Prism.languages.scss['atrule'].inside.rest = Prism.languages.scss;
+
+Prism.languages.sql = {
+	'comment': {
+		pattern: /(^|[^\\])(?:\/\*[\s\S]*?\*\/|(?:--|\/\/|#).*)/,
+		lookbehind: true
+	},
+	'variable': [
+		{
+			pattern: /@(["'`])(?:\\[\s\S]|(?!\1)[^\\])+\1/,
+			greedy: true
+		},
+		/@[\w.$]+/
+	],
+	'string': {
+		pattern: /(^|[^@\\])("|')(?:\\[\s\S]|(?!\2)[^\\]|\2\2)*\2/,
+		greedy: true,
+		lookbehind: true
+	},
+	'identifier': {
+		pattern: /(^|[^@\\])`(?:\\[\s\S]|[^`\\]|``)*`/,
+		greedy: true,
+		lookbehind: true,
+		inside: {
+			'punctuation': /^`|`$/
+		}
+	},
+	'function': /\b(?:AVG|COUNT|FIRST|FORMAT|LAST|LCASE|LEN|MAX|MID|MIN|MOD|NOW|ROUND|SUM|UCASE)(?=\s*\()/i, // Should we highlight user defined functions too?
+	'keyword': /\b(?:ACTION|ADD|AFTER|ALGORITHM|ALL|ALTER|ANALYZE|ANY|APPLY|AS|ASC|AUTHORIZATION|AUTO_INCREMENT|BACKUP|BDB|BEGIN|BERKELEYDB|BIGINT|BINARY|BIT|BLOB|BOOL|BOOLEAN|BREAK|BROWSE|BTREE|BULK|BY|CALL|CASCADED?|CASE|CHAIN|CHAR(?:ACTER|SET)?|CHECK(?:POINT)?|CLOSE|CLUSTERED|COALESCE|COLLATE|COLUMNS?|COMMENT|COMMIT(?:TED)?|COMPUTE|CONNECT|CONSISTENT|CONSTRAINT|CONTAINS(?:TABLE)?|CONTINUE|CONVERT|CREATE|CROSS|CURRENT(?:_DATE|_TIME|_TIMESTAMP|_USER)?|CURSOR|CYCLE|DATA(?:BASES?)?|DATE(?:TIME)?|DAY|DBCC|DEALLOCATE|DEC|DECIMAL|DECLARE|DEFAULT|DEFINER|DELAYED|DELETE|DELIMITERS?|DENY|DESC|DESCRIBE|DETERMINISTIC|DISABLE|DISCARD|DISK|DISTINCT|DISTINCTROW|DISTRIBUTED|DO|DOUBLE|DROP|DUMMY|DUMP(?:FILE)?|DUPLICATE|ELSE(?:IF)?|ENABLE|ENCLOSED|END|ENGINE|ENUM|ERRLVL|ERRORS|ESCAPED?|EXCEPT|EXEC(?:UTE)?|EXISTS|EXIT|EXPLAIN|EXTENDED|FETCH|FIELDS|FILE|FILLFACTOR|FIRST|FIXED|FLOAT|FOLLOWING|FOR(?: EACH ROW)?|FORCE|FOREIGN|FREETEXT(?:TABLE)?|FROM|FULL|FUNCTION|GEOMETRY(?:COLLECTION)?|GLOBAL|GOTO|GRANT|GROUP|HANDLER|HASH|HAVING|HOLDLOCK|HOUR|IDENTITY(?:COL|_INSERT)?|IF|IGNORE|IMPORT|INDEX|INFILE|INNER|INNODB|INOUT|INSERT|INT|INTEGER|INTERSECT|INTERVAL|INTO|INVOKER|ISOLATION|ITERATE|JOIN|KEYS?|KILL|LANGUAGE|LAST|LEAVE|LEFT|LEVEL|LIMIT|LINENO|LINES|LINESTRING|LOAD|LOCAL|LOCK|LONG(?:BLOB|TEXT)|LOOP|MATCH(?:ED)?|MEDIUM(?:BLOB|INT|TEXT)|MERGE|MIDDLEINT|MINUTE|MODE|MODIFIES|MODIFY|MONTH|MULTI(?:LINESTRING|POINT|POLYGON)|NATIONAL|NATURAL|NCHAR|NEXT|NO|NONCLUSTERED|NULLIF|NUMERIC|OFF?|OFFSETS?|ON|OPEN(?:DATASOURCE|QUERY|ROWSET)?|OPTIMIZE|OPTION(?:ALLY)?|ORDER|OUT(?:ER|FILE)?|OVER|PARTIAL|PARTITION|PERCENT|PIVOT|PLAN|POINT|POLYGON|PRECEDING|PRECISION|PREPARE|PREV|PRIMARY|PRINT|PRIVILEGES|PROC(?:EDURE)?|PUBLIC|PURGE|QUICK|RAISERROR|READS?|REAL|RECONFIGURE|REFERENCES|RELEASE|RENAME|REPEAT(?:ABLE)?|REPLACE|REPLICATION|REQUIRE|RESIGNAL|RESTORE|RESTRICT|RETURN(?:ING|S)?|REVOKE|RIGHT|ROLLBACK|ROUTINE|ROW(?:COUNT|GUIDCOL|S)?|RTREE|RULE|SAVE(?:POINT)?|SCHEMA|SECOND|SELECT|SERIAL(?:IZABLE)?|SESSION(?:_USER)?|SET(?:USER)?|SHARE|SHOW|SHUTDOWN|SIMPLE|SMALLINT|SNAPSHOT|SOME|SONAME|SQL|START(?:ING)?|STATISTICS|STATUS|STRIPED|SYSTEM_USER|TABLES?|TABLESPACE|TEMP(?:ORARY|TABLE)?|TERMINATED|TEXT(?:SIZE)?|THEN|TIME(?:STAMP)?|TINY(?:BLOB|INT|TEXT)|TOP?|TRAN(?:SACTIONS?)?|TRIGGER|TRUNCATE|TSEQUAL|TYPES?|UNBOUNDED|UNCOMMITTED|UNDEFINED|UNION|UNIQUE|UNLOCK|UNPIVOT|UNSIGNED|UPDATE(?:TEXT)?|USAGE|USE|USER|USING|VALUES?|VAR(?:BINARY|CHAR|CHARACTER|YING)|VIEW|WAITFOR|WARNINGS|WHEN|WHERE|WHILE|WITH(?: ROLLUP|IN)?|WORK|WRITE(?:TEXT)?|YEAR)\b/i,
+	'boolean': /\b(?:FALSE|NULL|TRUE)\b/i,
+	'number': /\b0x[\da-f]+\b|\b\d+(?:\.\d*)?|\B\.\d+\b/i,
+	'operator': /[-+*\/=%^~]|&&?|\|\|?|!=?|<(?:=>?|<|>)?|>[>=]?|\b(?:AND|BETWEEN|DIV|ILIKE|IN|IS|LIKE|NOT|OR|REGEXP|RLIKE|SOUNDS LIKE|XOR)\b/i,
+	'punctuation': /[;[\]()`,.]/
+};
+

--- a/addons/html_editor/static/src/core/selection_plugin.js
+++ b/addons/html_editor/static/src/core/selection_plugin.js
@@ -468,6 +468,7 @@ export class SelectionPlugin extends Plugin {
         const documentSelection =
             selection?.anchorNode && selection?.focusNode
                 ? Object.freeze({
+                      isCollapsed: selection.isCollapsed,
                       anchorNode: selection.anchorNode,
                       anchorOffset: selection.anchorOffset,
                       focusNode: selection.focusNode,

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.js
@@ -1,0 +1,345 @@
+/* global Prism */
+import {
+    applyObjectPropertyDifference,
+    getEmbeddedProps,
+    StateChangeManager,
+} from "@html_editor/others/embedded_component_utils";
+import { Component, onMounted, useEffect, useRef, useState, onWillDestroy } from "@odoo/owl";
+import { loadBundle } from "@web/core/assets";
+import { newlinesToLineBreaks } from "../../plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
+
+const LANGUAGES = {
+    plaintext: "Plain Text",
+    markdown: "Markdown",
+    javascript: "Javascript",
+    typescript: "Typescript",
+    jsdoc: "JSDoc",
+    java: "Java",
+    python: "Python",
+    html: "HTML",
+    xml: "XML",
+    svg: "SVG",
+    json: "JSON",
+    css: "CSS",
+    sass: "SASS",
+    scss: "SCSS",
+    sql: "SQL",
+    diff: "Diff",
+};
+export const DEFAULT_LANGUAGE_ID = "plaintext";
+
+export class EmbeddedSyntaxHighlightingComponent extends Component {
+    static template = "html_editor.EmbeddedSyntaxHighlighting";
+
+    static props = {
+        initialValue: { type: String },
+        autofocus: { type: Boolean },
+        codeToolbar: { type: Object },
+        onTextareaFocus: { type: Function },
+        addHistoryStep: { type: Function },
+        getPreValue: { type: Function },
+        host: { type: Object },
+    };
+
+    setup() {
+        super.setup();
+        this.loadPrism();
+        this.state = useState({
+            isActive: false,
+            host: this.props.host,
+        });
+        this.preRef = useRef("pre");
+        this.textareaRef = useRef("textarea");
+
+        onMounted(() => {
+            this.pre = this.preRef.el;
+            this.textarea = this.textareaRef.el;
+            this.document = this.textarea.ownerDocument;
+
+            // Activate and focus the textarea if required.
+            if (this.props.autofocus) {
+                this.state.isActive = true;
+                if (this.textarea !== this.document.activeElement) {
+                    this.textarea.focus();
+                    this.props.onTextareaFocus();
+                }
+            }
+
+            // Set the initial values and highlight the pre.
+            this.initialValue =
+                this.state.host.dataset.syntaxHighlightingValue || this.props.initialValue;
+            this.initialLanguageId = this.state.host.dataset.languageId || DEFAULT_LANGUAGE_ID;
+            this.commitToHost(
+                {
+                    value: this.initialValue,
+                    languageId: this.initialLanguageId,
+                },
+                false
+            ).then((didHighlight) => !didHighlight && this.highlight());
+
+            // Ensure the values of the dataset and the content match.
+            this.observer = new MutationObserver((mutations) => {
+                if (mutations.some((mutation) => mutation.oldValue !== null)) {
+                    // Prevent UNDO from returning to a state where the dataset
+                    // was not yet defined.
+                    if (!("syntaxHighlightingValue" in this.state.host.dataset)) {
+                        this.state.host.dataset.syntaxHighlightingValue = this.initialValue;
+                    }
+                    if (!("languageId" in this.state.host.dataset)) {
+                        this.state.host.dataset.languageId = this.initialLanguageId;
+                    }
+                    this.highlight();
+                }
+            });
+            this.observer.observe(this.state.host, {
+                attributeFilter: ["data-syntax-highlighting-value", "data-language-id"],
+                attributeOldValue: true,
+            });
+        });
+        onWillDestroy(() => {
+            this.observer?.disconnect();
+        });
+
+        // Activate/deactivate the code toolbar.
+        useEffect(
+            () => {
+                this.props.codeToolbar.close();
+                if (this.state.isActive) {
+                    this.openCodeToolbar();
+                }
+            },
+            () => [this.state.isActive]
+        );
+    }
+
+    /**
+     * Load the Prism library. This function exists only so it can be overridden
+     * in tests.
+     */
+    loadPrism() {
+        return loadBundle("html_editor.assets_prism");
+    }
+
+    openCodeToolbar() {
+        this.props.codeToolbar.open({
+            target: this.state.host,
+            props: {
+                target: this.state.host,
+                prismSource: this.textarea,
+                languages: LANGUAGES,
+                onLanguageChange: this.onLanguageChange.bind(this),
+            },
+        });
+    }
+
+    /**
+     * Set the value and/or the language ID in the host's dataset so they can be
+     * saved. If anything changed, highlight the pre and add a history step
+     * (unless `addStep` is false).
+     *
+     * @param {{ value?: string, languageId?: string }} values
+     * @param {boolean} [addStep = true]
+     * @returns {Promise<boolean>} true if anything changed.
+     */
+    async commitToHost(values, addStep = true) {
+        let hasChanged = false;
+        if ("value" in values && this.state.host.dataset.syntaxHighlightingValue !== values.value) {
+            hasChanged = true;
+            this.state.host.dataset.syntaxHighlightingValue = values.value;
+        }
+        if ("languageId" in values && this.state.host.dataset.languageId !== values.languageId) {
+            hasChanged = true;
+            this.state.host.dataset.languageId = values.languageId;
+        }
+        if (hasChanged) {
+            await this.highlight();
+            if (addStep) {
+                this.props.addHistoryStep();
+            }
+        }
+        return hasChanged;
+    }
+
+    /**
+     * Get the saved value or language ID from the host's dataset.
+     *
+     * @param {"value" | "languageId"} key
+     * @returns {string | undefined}
+     */
+    getFromHostDataset(key) {
+        return this.state.host.dataset[key == "value" ? "syntaxHighlightingValue" : key];
+    }
+
+    /**
+     * Use the Prism library to highlight the pre using the value and language
+     * stored on the host's dataset. Ensure the values (pre, host, textarea)
+     * match and commit the value if it changed in the process.
+     *
+     * @param {boolean} [focus = this.document.activeElement === this.textarea]
+     */
+    async highlight(focus = this.document.activeElement === this.textarea) {
+        if (!window.Prism) {
+            await this.loadPrism();
+            if (!window.Prism) {
+                console.error("The Prism library couldn't be found.");
+                return;
+            }
+        }
+        const languageId = this.getFromHostDataset("languageId");
+        // We need a temporary element because directly changing the HTML of the
+        // PRE, or using replaceChildren both mess up the history by not
+        // recording the removal of the contents.
+        const fakeElement = this.document.createElement("pre");
+        fakeElement.innerHTML = Prism.highlight(
+            this.getFromHostDataset("value"),
+            Prism.languages[languageId],
+            languageId
+        );
+
+        // Post-process highlighted HTML.
+        newlinesToLineBreaks(fakeElement, this.document);
+
+        // Replace the PRE's contents with the highlighted ones.
+        [...this.pre.childNodes].forEach((child) => child.remove());
+        [...fakeElement.childNodes].forEach((child) => this.pre.append(child));
+
+        // Ensure the values match.
+        const preValue = this.props.getPreValue(this.pre);
+        if (this.textarea.value !== preValue) {
+            this.textarea.value = preValue;
+        }
+        if (focus) {
+            this.textarea.focus({ preventScroll: true });
+            this.props.onTextareaFocus();
+        }
+        await this.commitToHost({ value: this.textarea.value });
+    }
+
+    onInput() {
+        this.textarea.focus();
+        this.props.onTextareaFocus();
+        this.commitToHost({ value: this.textarea.value });
+    }
+
+    /**
+     * Handle tabulation in the textarea.
+     *
+     * @param {KeyboardEvent} ev
+     */
+    onKeydown(ev) {
+        if (ev.key === "Tab") {
+            ev.preventDefault();
+            const tabSize = +getComputedStyle(this.textarea).tabSize || 4;
+            const tab = " ".repeat(tabSize);
+            const { selectionStart, selectionEnd } = this.textarea;
+            const collapsed = selectionStart === selectionEnd;
+            let start = this.textarea.value.slice(0, selectionStart).lastIndexOf("\n");
+            start = start === -1 ? 0 : start;
+            let newValue = "";
+            let spacesRemovedAtStart = 0;
+            if (ev.shiftKey) {
+                // Remove tabs.
+                let end = this.textarea.value
+                    .slice(selectionEnd, this.textarea.value.length)
+                    .indexOf("\n");
+                end = end === -1 ? 0 : end;
+                end = selectionEnd + end;
+                // From 0 to the last \n before selection start.
+                newValue = this.textarea.value.slice(0, start);
+                // From the last \n before selection start to selection end.
+                const regex = new RegExp(`(\n|^)( |\u00A0){1,${tabSize}}`, "g");
+                const startSlice = this.textarea.value.slice(start, selectionStart);
+                const cleanStartSlice = startSlice.replace(regex, "$1");
+                spacesRemovedAtStart = startSlice.length - cleanStartSlice.length;
+                newValue += cleanStartSlice;
+                newValue += this.textarea.value
+                    .slice(selectionStart, selectionEnd)
+                    .replace(regex, "$1");
+                newValue += this.textarea.value.slice(selectionEnd, end).replace(regex, "$1");
+                // From selection end to end.
+                newValue += this.textarea.value.slice(end, this.textarea.value.length);
+            } else {
+                // Insert tabs.
+                if (collapsed && /\S/.test(this.textarea.value.slice(start, selectionStart))) {
+                    newValue =
+                        this.textarea.value.slice(0, selectionStart) +
+                        tab +
+                        this.textarea.value.slice(selectionStart, this.textarea.value.length);
+                } else {
+                    // From 0 to the last \n before selection start.
+                    newValue = start ? this.textarea.value.slice(0, start) : tab;
+                    // From the last \n before selection start to selection end.
+                    newValue += this.textarea.value
+                        .slice(start, selectionEnd)
+                        .replaceAll("\n", `\n${tab}`);
+                    // From selection end to end.
+                    newValue += this.textarea.value.slice(selectionEnd, this.textarea.value.length);
+                }
+            }
+            const insertedChars = newValue.length - this.textarea.value.length;
+            this.textarea.value = newValue;
+            const newStart = selectionStart + (ev.shiftKey ? -spacesRemovedAtStart : tabSize);
+            const newEnd = collapsed ? newStart : selectionEnd + insertedChars;
+            this.textarea.setSelectionRange(newStart, newEnd, this.textarea.selectionDirection);
+            this.commitToHost({ value: this.textarea.value });
+        }
+    }
+
+    /**
+     * Ensure the pre and textarea's scrolls match so they remain aligned.
+     */
+    onScroll() {
+        this.pre.scrollTop = this.textarea.scrollTop;
+        this.pre.scrollLeft = this.textarea.scrollLeft;
+    }
+
+    onHover() {
+        const isLanguageSelectorOpen = !!this.document.querySelector(
+            ".dropdown-menu.o_language_selector"
+        );
+        if (!isLanguageSelectorOpen) {
+            this.state.isActive = true;
+        }
+    }
+
+    onLeave(ev) {
+        const isLanguageSelectorOpen = !!this.document.querySelector(
+            ".dropdown-menu.o_language_selector"
+        );
+        if (!isLanguageSelectorOpen && !ev.relatedTarget?.closest?.(".o_code_toolbar")) {
+            this.state.isActive = false;
+        }
+    }
+
+    /**
+     * Change the language when selecting a new one via the code toolbar.
+     *
+     * @param {string} languageId
+     */
+    onLanguageChange(languageId) {
+        if (this.getFromHostDataset("languageId") !== languageId) {
+            this.props.codeToolbar.close();
+            this.textarea.focus();
+            this.props.onTextareaFocus();
+            this.commitToHost({ languageId }).then(() => {
+                this.openCodeToolbar();
+            });
+        }
+    }
+}
+
+export const syntaxHighlightingEmbedding = {
+    name: "syntaxHighlighting",
+    Component: EmbeddedSyntaxHighlightingComponent,
+    getProps: (host) => ({ host, ...getEmbeddedProps(host) }),
+    getStateChangeManager: (config) =>
+        new StateChangeManager(
+            Object.assign(config, {
+                propertyUpdater: {
+                    value: (state, previous, next) => {
+                        applyObjectPropertyDifference(state, "value", previous.value, next.value);
+                    },
+                },
+            })
+        ),
+};

--- a/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
+++ b/addons/html_editor/static/src/others/embedded_components/backend/syntax_highlighting/syntax_highlighting.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <!-- syntax highlighting template -->
+    <t t-name="html_editor.EmbeddedSyntaxHighlighting">
+        <pre t-ref="pre"/>
+        <textarea t-ref="textarea" class="o_prism_source" contenteditable="true"
+            t-on-input="onInput"
+            t-on-scroll="onScroll"
+            t-on-keydown="onKeydown"
+            t-on-mouseover="onHover" t-on-pointerdown="onHover"
+            t-on-mouseleave="onLeave" t-on-pointerleave="onLeave"
+            t-on-focus="props.onTextareaFocus"></textarea>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
+++ b/addons/html_editor/static/src/others/embedded_components/embedding_sets.js
@@ -8,6 +8,7 @@ import {
 import { toggleBlockEmbedding } from "@html_editor/others/embedded_components/core/toggle_block/toggle_block";
 import { videoEmbedding } from "@html_editor/others/embedded_components/backend/video/video";
 import { readonlyVideoEmbedding } from "@html_editor/others/embedded_components/core/video/readonly_video";
+import { syntaxHighlightingEmbedding } from "@html_editor/others/embedded_components/backend/syntax_highlighting/syntax_highlighting";
 
 export const MAIN_EMBEDDINGS = [
     fileEmbedding,
@@ -15,6 +16,7 @@ export const MAIN_EMBEDDINGS = [
     toggleBlockEmbedding,
     videoEmbedding,
     captionEmbedding,
+    syntaxHighlightingEmbedding,
 ];
 
 export const READONLY_MAIN_EMBEDDINGS = [
@@ -23,4 +25,5 @@ export const READONLY_MAIN_EMBEDDINGS = [
     toggleBlockEmbedding,
     readonlyVideoEmbedding,
     captionEmbedding,
+    syntaxHighlightingEmbedding,
 ];

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.js
@@ -1,0 +1,30 @@
+import { Component, useEffect, useState } from "@odoo/owl";
+import { CopyButton } from "@web/core/copy_button/copy_button";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+
+export class CodeToolbar extends Component {
+    static template = "html_editor.CodeToolbar";
+    static props = {
+        target: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        prismSource: { validate: (el) => el.nodeType === Node.ELEMENT_NODE },
+        languages: { type: Object },
+        onLanguageChange: { type: Function },
+    };
+    static components = { Dropdown, DropdownItem, CopyButton };
+
+    setup() {
+        super.setup();
+        this.state = useState({
+            language: this.props.target.dataset.languageId,
+        });
+        useEffect(
+            () => this.props.onLanguageChange(this.state.language),
+            () => [this.state.language]
+        );
+    }
+
+    selectLanguage(language) {
+        this.state.language = language;
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.scss
@@ -1,0 +1,19 @@
+.o_code_toolbar {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 3px 4px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+
+    button {
+        display: inline-flex;
+        align-items: center;
+        height: 20px;
+        padding: 0 3px 0 0;
+        font-size: 12px;
+        --btn-hover-bg: #{$o-gray-200};
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/code_toolbar.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="html_editor.CodeToolbar">
+        <div class="o_code_toolbar">
+            <div data-prevent-closing-overlay="true">
+                <Dropdown menuClass="'o_language_selector'">
+                    <button class="btn" t-att-title="props.languages[state.language]" name="language">
+                        <span class="px-1" t-esc="props.languages[state.language]"/>
+                        <i class="fa fa-caret-down"></i>
+                    </button>
+                    <t t-set-slot="content">
+                        <t t-foreach="Object.entries(props.languages)" t-as="language" t-key="language[0]">
+                            <DropdownItem
+                                attrs="{ name: language[1] }"
+                                onSelected="() => this.selectLanguage(language[0])" t-on-pointerdown.prevent="() => {}">
+                                <t t-esc="language[1]"/>
+                            </DropdownItem>
+                        </t>
+                    </t>
+                </Dropdown>
+                <CopyButton content="() => props.prismSource.value" copyText.translate="Copy" successText.translate="Code copied to the clipboard."/>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_blueprint.xml
@@ -1,0 +1,6 @@
+<templates>
+    <t t-name="html_editor.EmbeddedSyntaxHighlightingBlueprint">
+        <div t-att-data-embedded-props="embeddedProps" data-embedded="syntaxHighlighting"
+            data-oe-protected="true" contenteditable="false" class="o_syntax_highlighting"/>
+    </t>
+</templates>

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.js
@@ -1,0 +1,155 @@
+import { Plugin } from "@html_editor/plugin";
+import { CodeToolbar } from "./code_toolbar";
+import { renderToElement } from "@web/core/utils/render";
+import { withSequence } from "@html_editor/utils/resource";
+import { descendants, lastLeaf } from "@html_editor/utils/dom_traversal";
+import { fillEmpty } from "@html_editor/utils/dom";
+
+const CODE_BLOCK_CLASS = "o_syntax_highlighting";
+const CODE_BLOCK_SELECTOR = `div.${CODE_BLOCK_CLASS}`;
+
+export const newlinesToLineBreaks = (element, doc = element.ownerDocument || document) => {
+    // 1. Replace \n with <br>.
+    for (const node of descendants(element).filter((node) => node.nodeType === Node.TEXT_NODE)) {
+        let newline = node.textContent.indexOf("\n");
+        while (newline !== -1) {
+            node.before(doc.createTextNode(node.textContent.slice(0, newline)));
+            node.before(doc.createElement("BR"));
+            node.textContent = node.textContent.slice(newline + 1);
+            newline = node.textContent.indexOf("\n");
+        }
+        if (!node.textContent) {
+            node.remove(); // Prevent empty trailing text node that would become the last leaf.
+        }
+    }
+    // 2. Handle trailing BRs. Eg, <span>ab\n</span> -> <span>ab</span><br><br>
+    const trailingBr = lastLeaf(element);
+    if (trailingBr?.nodeName === "BR") {
+        element.append(trailingBr); // <span>ab<br></span> -> <span>ab</span><br>
+        trailingBr.after(doc.createElement("BR")); // <br></pre> -> <br><br></pre>
+    }
+    // 3. Fill empty.
+    fillEmpty(element);
+};
+
+export class SyntaxHighlightingPlugin extends Plugin {
+    static id = "syntaxHighlighting";
+    static dependencies = [
+        "overlay",
+        "history",
+        "selection",
+        "protectedNode",
+        "embeddedComponents",
+    ];
+    resources = {
+        mount_component_handlers: this.setupNewCodeBlock.bind(this),
+        normalize_handlers: (root) => this.addCodeBlocks(root, true),
+        post_undo_handlers: () => this.addCodeBlocks(this.editable, true),
+        post_redo_handlers: () => this.addCodeBlocks(this.editable, true),
+        clean_for_save_handlers: withSequence(0, ({ root }) => this.cleanForSave(root)),
+        // Ensure focus can be preserved within the textarea:
+        is_node_editable_predicates: (node) => node?.classList?.contains("o_prism_source"),
+    };
+
+    setup() {
+        /** @type {import("@html_editor/core/overlay_plugin").Overlay} */
+        this.codeToolbar = this.dependencies.overlay.createOverlay(CodeToolbar, {
+            positionOptions: {
+                position: "top-fit",
+                flip: false,
+            },
+            closeOnPointerdown: false,
+        });
+        this.addDomListener(this.document, "scroll", this.codeToolbar.close, true);
+        this.addCodeBlocks();
+    }
+
+    cleanForSave(root) {
+        for (const codeBlock of root.querySelectorAll("div.o_syntax_highlighting")) {
+            // Save only the `<pre>` element, with information to rebuild the
+            // embedded component, so the saved DOM is independent of this plugin.
+            const pre = codeBlock.querySelector("pre");
+            const value = codeBlock.dataset.syntaxHighlightingValue;
+            pre.dataset.languageId = codeBlock.dataset.languageId;
+            codeBlock.before(pre);
+            codeBlock.remove();
+            // Remove highlighting.
+            pre.textContent = value;
+            newlinesToLineBreaks(pre);
+        }
+    }
+
+    /**
+     * Take all `<pre>` element in the given `root` that aren't in an embedded
+     * syntax highlighting block, and replace them with an embedded syntax
+     * highlighting block. If `preserveFocus` is true, set the currently
+     * targeted `<pre>` element to be focused.
+     *
+     * @param {Element} [root = this.editable]
+     * @param {boolean} [preserveFocus = false]
+     */
+    addCodeBlocks(root = this.editable, preserveFocus = false) {
+        const targetedNodes = this.dependencies.selection.getTargetedNodes();
+        const nonEmbeddedPres = [...root.querySelectorAll("pre")].filter(
+            (pre) => !pre.closest(CODE_BLOCK_SELECTOR)
+        );
+        for (const pre of nonEmbeddedPres) {
+            const isPreInSelection = !targetedNodes.some((node) => !pre.contains(node));
+            const codeBlock = renderToElement("html_editor.EmbeddedSyntaxHighlightingBlueprint", {
+                embeddedProps: JSON.stringify({
+                    initialValue: this.getPreValue(pre),
+                    autofocus: preserveFocus && isPreInSelection,
+                }),
+            });
+            // Transfer the data from the `<pre>` element back to the embedded
+            // component (see `cleanForSave`).
+            if (pre.hasAttribute("data-language-id")) {
+                codeBlock.dataset.languageId = pre.dataset.languageId;
+            }
+            pre.before(codeBlock);
+            if (isPreInSelection) {
+                // Removing the pre will make us lose the selection. The DOM
+                // would try to set it in the root, which would get corrected,
+                // preventing us from directly writing inside the textarea.
+                this.document.getSelection().removeAllRanges();
+            }
+            pre.remove();
+        }
+    }
+
+    /**
+     * Return the given `<pre>` element's inner text, cleaned of any zero-width
+     * characters or trailing invisible newline characters (a trailing `<br>` in
+     * the element's HTML is invisible but results in an visible `\n` in its
+     * `innerText` property, which would be visible if kept).
+     *
+     * @param {HTMLPreElement} pre
+     * @returns {string}
+     */
+    getPreValue(pre) {
+        // Trailing br gives \n in innerText but should not be visible.
+        const trailingBrs = pre.innerHTML.match(/(<br>)+$/)?.length || 0;
+        return pre.innerText
+            .slice(0, pre.innerText.length - (trailingBrs > 1 ? trailingBrs - 1 : trailingBrs))
+            .replace(/[\u200B\uFEFF]/g, "");
+    }
+
+    setupNewCodeBlock({ name, props }) {
+        if (name === "syntaxHighlighting") {
+            let initialValue = props.initialValue || "";
+            if (props.host.hasAttribute("data-syntax-highlighting-value")) {
+                // Preserve any saved value as initial value of the current
+                // editing session.
+                initialValue = props.host.dataset.syntaxHighlightingValue;
+            }
+            Object.assign(props, {
+                codeToolbar: this.codeToolbar,
+                autofocus: props.autofocus || false,
+                initialValue,
+                onTextareaFocus: () => this.dependencies.history.stageFocus(),
+                getPreValue: (pre) => this.getPreValue(pre),
+                addHistoryStep: () => this.dependencies.history.addStep(),
+            });
+        }
+    }
+}

--- a/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
+++ b/addons/html_editor/static/src/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin.scss
@@ -1,0 +1,31 @@
+.o_syntax_highlighting {
+    position: relative;
+    padding: 0;
+    margin: 0;
+    tab-size: 4;
+    font: 13px / 19.5px SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+    pre, textarea.o_prism_source {
+        margin: 0px 0px 16px;
+        padding: 8px 16px;
+    }
+
+    pre {
+        font: inherit;
+        tab-size: inherit;
+        white-space: pre;
+    }
+
+    textarea.o_prism_source {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        caret-color: black;
+        color: transparent;
+        border: 0;
+        outline: none;
+        background: transparent;
+        resize: none;
+    }
+}

--- a/addons/html_editor/static/src/plugin_sets.js
+++ b/addons/html_editor/static/src/plugin_sets.js
@@ -68,6 +68,7 @@ import { EmbeddedVideoPlugin } from "@html_editor/others/embedded_components/plu
 import { EmbeddedYoutubePlugin } from "./others/embedded_components/plugins/video_plugin/embedded_youtube_plugin";
 import { CaptionPlugin } from "@html_editor/others/embedded_components/plugins/caption_plugin/caption_plugin";
 import { EmbeddedFilePlugin } from "@html_editor/others/embedded_components/plugins/embedded_file_plugin/embedded_file_plugin";
+import { SyntaxHighlightingPlugin } from "@html_editor/others/embedded_components/plugins/syntax_highlighting_plugin/syntax_highlighting_plugin";
 import { QWebPlugin } from "./others/qweb_plugin";
 import { EditorVersionPlugin } from "./core/editor_version_plugin";
 import { ImagePostProcessPlugin } from "./main/media/image_post_process_plugin";
@@ -202,6 +203,7 @@ export const EMBEDDED_COMPONENT_PLUGINS = [
     EmbeddedYoutubePlugin,
     CaptionPlugin,
     EmbeddedFilePlugin,
+    SyntaxHighlightingPlugin,
 ];
 
 export const NO_EMBEDDED_COMPONENTS_FALLBACK_PLUGINS = [FilePlugin, VideoPlugin, YoutubePlugin];

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -7,6 +7,9 @@ import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
 import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 /**
  * content of the "deleteBackward" sub suite in editor.test.js
@@ -802,79 +805,220 @@ describe("Selection collapsed", () => {
     });
 
     describe("Pre", () => {
-        test("should delete a character in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>a[]cd</pre>",
+        describe("with syntax highlighting", () => {
+            const configWithEmbeddings = {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+                resources: { embedded_components: MAIN_EMBEDDINGS },
+            };
+            const testDeleteInCodeBlock = (selectionStart) => async (editor) => {
+                // Set the given selection in the textarea.
+                const textarea = editor.editable.querySelector("textarea");
+                textarea.focus();
+                textarea.setSelectionRange(selectionStart, selectionStart, "forward");
+                // Trigger native delete backward.
+                await editor.document.execCommand("delete", false, null);
+                // Wait for the input event to resolve so the content is
+                // highlighted and the focus is in the textarea.
+                await animationFrame();
+            };
+
+            beforeEach(patchPrism);
+
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd</pre>",
+                    contentBeforeEdit: { highlightedValue: "abcd" },
+                    stepFunction: testDeleteInCodeBlock(2),
+                    contentAfterEdit: { highlightedValue: "acd", textareaRange: 1 },
+                    contentAfter: `<pre data-language-id="plaintext">acd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd</pre>",
+                    contentBeforeEdit: { highlightedValue: "     abcd" },
+                    stepFunction: testDeleteInCodeBlock(7), // ab[]cd
+                    contentAfterEdit: {
+                        highlightedValue: "     acd",
+                        textareaRange: 6,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">     acd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd     </pre>",
+                    contentBeforeEdit: { highlightedValue: "abcd     " },
+                    stepFunction: testDeleteInCodeBlock(2),
+                    contentAfterEdit: {
+                        highlightedValue: "acd     ",
+                        textareaRange: 1,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">acd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd     </pre>",
+                    contentBeforeEdit: { highlightedValue: "     abcd     " },
+                    stepFunction: testDeleteInCodeBlock(7), // ab[]cd
+                    contentAfterEdit: {
+                        highlightedValue: "     acd     ",
+                        textareaRange: 6,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">     acd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    stepFunction: testDeleteInCodeBlock(3), // "   []  ab"
+                    contentAfterEdit: {
+                        highlightedValue: "    ab",
+                        textareaRange: 2,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab\ncd</pre>",
+                    contentBeforeEdit: { highlightedValue: "ab\ncd" },
+                    stepFunction: testDeleteInCodeBlock(3), // ab\n[]cd
+                    contentAfterEdit: { highlightedValue: "abcd", textareaRange: 2 },
+                    contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(5)(editor); // "     []ab"
+                        await testDeleteInCodeBlock(4)(editor); // "    []ab"
+                        await testDeleteInCodeBlock(3)(editor); // "   []ab"
+                        await testDeleteInCodeBlock(2)(editor); // "  []ab"
+                        await testDeleteInCodeBlock(1)(editor); // " []ab"
+                    },
+                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 0 },
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab     </pre>",
+                    contentBeforeEdit: { highlightedValue: "ab     " },
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(7)(editor); // "ab     []"
+                        await testDeleteInCodeBlock(6)(editor); // "ab    []"
+                        await testDeleteInCodeBlock(5)(editor); // "ab   []"
+                        await testDeleteInCodeBlock(4)(editor); // "ab  []"
+                        await testDeleteInCodeBlock(3)(editor); // "ab []"
+                    },
+                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 2 },
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
             });
         });
-
-        test("should delete a character in a pre (space before)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>     a[]cd</pre>",
+        describe("without syntax highlighting", () => {
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>a[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd     </pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>a[]cd     </pre>",
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>     a[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space before and after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd     </pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>     a[]cd     </pre>",
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd     </pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>a[]cd     </pre>",
+                });
             });
-        });
 
-        test("should delete a space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>   []  ab</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>  []  ab</pre>",
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd     </pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>     a[]cd     </pre>",
+                });
             });
-        });
 
-        test("should delete a newline in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab\n[]cd</pre>",
-                stepFunction: deleteBackward,
-                contentAfter: "<pre>ab[]cd</pre>",
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>   []  ab</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>  []  ab</pre>",
+                });
             });
-        });
 
-        test("should delete all leading space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>     []ab</pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                },
-                contentAfter: "<pre>[]ab</pre>",
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab\n[]cd</pre>",
+                    stepFunction: deleteBackward,
+                    contentAfter: "<pre>ab[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete all trailing space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab     []</pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                    deleteBackward(BasicEditor);
-                },
-                contentAfter: "<pre>ab[]</pre>",
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     []ab</pre>",
+                    stepFunction: async (editor) => {
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                    },
+                    contentAfter: "<pre>[]ab</pre>",
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab     []</pre>",
+                    stepFunction: async (editor) => {
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                        deleteBackward(editor);
+                    },
+                    contentAfter: "<pre>ab[]</pre>",
+                });
             });
         });
     });

--- a/addons/html_editor/static/tests/delete/backward.test.js
+++ b/addons/html_editor/static/tests/delete/backward.test.js
@@ -8,7 +8,11 @@ import { unformat } from "../_helpers/format";
 import { getContent, setSelection } from "../_helpers/selection";
 import { deleteBackward, insertText, tripleClick, undo } from "../_helpers/user_actions";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
-import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+} from "../_helpers/syntax_highlighting";
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 /**
@@ -828,9 +832,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: { highlightedValue: "abcd" },
+                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
                     stepFunction: testDeleteInCodeBlock(2),
-                    contentAfterEdit: { highlightedValue: "acd", textareaRange: 1 },
+                    contentAfterEdit: highlightedPre({ value: "acd", textareaRange: 1 }),
                     contentAfter: `<pre data-language-id="plaintext">acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -840,12 +844,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd</pre>",
-                    contentBeforeEdit: { highlightedValue: "     abcd" },
+                    contentBeforeEdit: highlightedPre({ value: "     abcd" }),
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
-                    contentAfterEdit: {
-                        highlightedValue: "     acd",
-                        textareaRange: 6,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "     acd", textareaRange: 6 }),
                     contentAfter: `<pre data-language-id="plaintext">     acd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -855,12 +856,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd     </pre>",
-                    contentBeforeEdit: { highlightedValue: "abcd     " },
+                    contentBeforeEdit: highlightedPre({ value: "abcd     " }),
                     stepFunction: testDeleteInCodeBlock(2),
-                    contentAfterEdit: {
-                        highlightedValue: "acd     ",
-                        textareaRange: 1,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "acd     ", textareaRange: 1 }),
                     contentAfter: `<pre data-language-id="plaintext">acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -870,12 +868,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd     </pre>",
-                    contentBeforeEdit: { highlightedValue: "     abcd     " },
+                    contentBeforeEdit: highlightedPre({ value: "     abcd     " }),
                     stepFunction: testDeleteInCodeBlock(7), // ab[]cd
-                    contentAfterEdit: {
-                        highlightedValue: "     acd     ",
-                        textareaRange: 6,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "     acd     ", textareaRange: 6 }),
                     contentAfter: `<pre data-language-id="plaintext">     acd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -885,12 +880,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
                     stepFunction: testDeleteInCodeBlock(3), // "   []  ab"
-                    contentAfterEdit: {
-                        highlightedValue: "    ab",
-                        textareaRange: 2,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "    ab", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -900,9 +892,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab\ncd</pre>",
-                    contentBeforeEdit: { highlightedValue: "ab\ncd" },
+                    contentBeforeEdit: highlightedPre({ value: "ab\ncd" }),
                     stepFunction: testDeleteInCodeBlock(3), // ab\n[]cd
-                    contentAfterEdit: { highlightedValue: "abcd", textareaRange: 2 },
+                    contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -912,7 +904,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(5)(editor); // "     []ab"
                         await testDeleteInCodeBlock(4)(editor); // "    []ab"
@@ -920,7 +912,7 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(2)(editor); // "  []ab"
                         await testDeleteInCodeBlock(1)(editor); // " []ab"
                     },
-                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 0 },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 0 }),
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -930,7 +922,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab     </pre>",
-                    contentBeforeEdit: { highlightedValue: "ab     " },
+                    contentBeforeEdit: highlightedPre({ value: "ab     " }),
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(7)(editor); // "ab     []"
                         await testDeleteInCodeBlock(6)(editor); // "ab    []"
@@ -938,7 +930,7 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(4)(editor); // "ab  []"
                         await testDeleteInCodeBlock(3)(editor); // "ab []"
                     },
-                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 2 },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -5,7 +5,11 @@ import { getContent } from "../_helpers/selection";
 import { deleteForward, insertText, tripleClick } from "../_helpers/user_actions";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { animationFrame } from "@odoo/hoot-dom";
-import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+} from "../_helpers/syntax_highlighting";
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 /**
@@ -748,9 +752,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: { highlightedValue: "abcd" },
+                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd"
-                    contentAfterEdit: { highlightedValue: "abd", textareaRange: 2 },
+                    contentAfterEdit: highlightedPre({ value: "abd", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -760,12 +764,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd</pre>",
-                    contentBeforeEdit: { highlightedValue: "     abcd" },
+                    contentBeforeEdit: highlightedPre({ value: "     abcd" }),
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd"
-                    contentAfterEdit: {
-                        highlightedValue: "     abd",
-                        textareaRange: 7,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "     abd", textareaRange: 7 }),
                     contentAfter: `<pre data-language-id="plaintext">     abd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -775,12 +776,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd     </pre>",
-                    contentBeforeEdit: { highlightedValue: "abcd     " },
+                    contentBeforeEdit: highlightedPre({ value: "abcd     " }),
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]cd     "
-                    contentAfterEdit: {
-                        highlightedValue: "abd     ",
-                        textareaRange: 2,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "abd     ", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -790,12 +788,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     abcd     </pre>",
-                    contentBeforeEdit: { highlightedValue: "     abcd     " },
+                    contentBeforeEdit: highlightedPre({ value: "     abcd     " }),
                     stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd     "
-                    contentAfterEdit: {
-                        highlightedValue: "     abd     ",
-                        textareaRange: 7,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "     abd     ", textareaRange: 7 }),
                     contentAfter: `<pre data-language-id="plaintext">     abd     </pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -805,12 +800,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
                     stepFunction: testDeleteInCodeBlock(2), // "  []   ab"
-                    contentAfterEdit: {
-                        highlightedValue: "    ab",
-                        textareaRange: 2,
-                    },
+                    contentAfterEdit: highlightedPre({ value: "    ab", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -820,9 +812,9 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab\ncd</pre>",
-                    contentBeforeEdit: { highlightedValue: "ab\ncd" },
+                    contentBeforeEdit: highlightedPre({ value: "ab\ncd" }),
                     stepFunction: testDeleteInCodeBlock(2), // "ab[]\ncd"
-                    contentAfterEdit: { highlightedValue: "abcd", textareaRange: 2 },
+                    contentAfterEdit: highlightedPre({ value: "abcd", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -832,7 +824,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>     ab</pre>",
-                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    contentBeforeEdit: highlightedPre({ value: "     ab" }),
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(0)(editor); // "[]     ab"
                         await testDeleteInCodeBlock(0)(editor); // "[]    ab"
@@ -840,7 +832,7 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(0)(editor); // "[]  ab"
                         await testDeleteInCodeBlock(0)(editor); // "[] ab"
                     },
-                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 0 },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 0 }),
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -850,7 +842,7 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>ab     </pre>",
-                    contentBeforeEdit: { highlightedValue: "ab     " },
+                    contentBeforeEdit: highlightedPre({ value: "ab     " }),
                     stepFunction: async (editor) => {
                         await testDeleteInCodeBlock(2)(editor); // "ab[]     "
                         await testDeleteInCodeBlock(2)(editor); // "ab[]    "
@@ -858,7 +850,7 @@ describe("Selection collapsed", () => {
                         await testDeleteInCodeBlock(2)(editor); // "ab[]  "
                         await testDeleteInCodeBlock(2)(editor); // "ab[] "
                     },
-                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 2 },
+                    contentAfterEdit: highlightedPre({ value: "ab", textareaRange: 2 }),
                     contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/delete/forward.test.js
+++ b/addons/html_editor/static/tests/delete/forward.test.js
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "@odoo/hoot";
+import { beforeEach, describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
 import { getContent } from "../_helpers/selection";
 import { deleteForward, insertText, tripleClick } from "../_helpers/user_actions";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { animationFrame } from "@odoo/hoot-dom";
+import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 /**
  * content of the "deleteForward" sub suite in editor.test.js
@@ -722,79 +726,219 @@ describe("Selection collapsed", () => {
     });
 
     describe("Pre", () => {
-        test("should delete a character in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd</pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>ab[]d</pre>",
+        describe("with syntax highlighting", () => {
+            const configWithEmbeddings = {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+                resources: { embedded_components: MAIN_EMBEDDINGS },
+            };
+            const testDeleteInCodeBlock = (selectionStart) => async (editor) => {
+                // Set the given selection in the textarea.
+                const textarea = editor.editable.querySelector("textarea");
+                textarea.focus();
+                textarea.setSelectionRange(selectionStart, selectionStart, "forward");
+                // Trigger native delete backward.
+                await editor.document.execCommand("forwardDelete", false, null);
+                // Wait for the input event to resolve so the content is
+                // highlighted and the focus is in the textarea.
+                await animationFrame();
+            };
+            beforeEach(patchPrism);
+
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd</pre>",
+                    contentBeforeEdit: { highlightedValue: "abcd" },
+                    stepFunction: testDeleteInCodeBlock(2), // "ab[]cd"
+                    contentAfterEdit: { highlightedValue: "abd", textareaRange: 2 },
+                    contentAfter: `<pre data-language-id="plaintext">abd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd</pre>",
+                    contentBeforeEdit: { highlightedValue: "     abcd" },
+                    stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd"
+                    contentAfterEdit: {
+                        highlightedValue: "     abd",
+                        textareaRange: 7,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">     abd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd     </pre>",
+                    contentBeforeEdit: { highlightedValue: "abcd     " },
+                    stepFunction: testDeleteInCodeBlock(2), // "ab[]cd     "
+                    contentAfterEdit: {
+                        highlightedValue: "abd     ",
+                        textareaRange: 2,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">abd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     abcd     </pre>",
+                    contentBeforeEdit: { highlightedValue: "     abcd     " },
+                    stepFunction: testDeleteInCodeBlock(7), // "     ab[]cd     "
+                    contentAfterEdit: {
+                        highlightedValue: "     abd     ",
+                        textareaRange: 7,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">     abd     </pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    stepFunction: testDeleteInCodeBlock(2), // "  []   ab"
+                    contentAfterEdit: {
+                        highlightedValue: "    ab",
+                        textareaRange: 2,
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">    ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab\ncd</pre>",
+                    contentBeforeEdit: { highlightedValue: "ab\ncd" },
+                    stepFunction: testDeleteInCodeBlock(2), // "ab[]\ncd"
+                    contentAfterEdit: { highlightedValue: "abcd", textareaRange: 2 },
+                    contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>     ab</pre>",
+                    contentBeforeEdit: { highlightedValue: "     ab" },
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(0)(editor); // "[]     ab"
+                        await testDeleteInCodeBlock(0)(editor); // "[]    ab"
+                        await testDeleteInCodeBlock(0)(editor); // "[]   ab"
+                        await testDeleteInCodeBlock(0)(editor); // "[]  ab"
+                        await testDeleteInCodeBlock(0)(editor); // "[] ab"
+                    },
+                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 0 },
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>ab     </pre>",
+                    contentBeforeEdit: { highlightedValue: "ab     " },
+                    stepFunction: async (editor) => {
+                        await testDeleteInCodeBlock(2)(editor); // "ab[]     "
+                        await testDeleteInCodeBlock(2)(editor); // "ab[]    "
+                        await testDeleteInCodeBlock(2)(editor); // "ab[]   "
+                        await testDeleteInCodeBlock(2)(editor); // "ab[]  "
+                        await testDeleteInCodeBlock(2)(editor); // "ab[] "
+                    },
+                    contentAfterEdit: { highlightedValue: "ab", textareaRange: 2 },
+                    contentAfter: `<pre data-language-id="plaintext">ab</pre>[]`,
+                    config: configWithEmbeddings,
+                });
             });
         });
-
-        test("should delete a character in a pre (space before)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd</pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>     ab[]d</pre>",
+        describe("without syntax highlighting", () => {
+            test("should delete a character in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd</pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>ab[]d</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd     </pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>ab[]d     </pre>",
+            test("should delete a character in a pre (space before)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd</pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>     ab[]d</pre>",
+                });
             });
-        });
 
-        test("should delete a character in a pre (space before and after)", async () => {
-            await testEditor({
-                contentBefore: "<pre>     ab[]cd     </pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>     ab[]d     </pre>",
+            test("should delete a character in a pre (space after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd     </pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>ab[]d     </pre>",
+                });
             });
-        });
 
-        test("should delete a space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>  []   ab</pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>  []  ab</pre>",
+            test("should delete a character in a pre (space before and after)", async () => {
+                await testEditor({
+                    contentBefore: "<pre>     ab[]cd     </pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>     ab[]d     </pre>",
+                });
             });
-        });
 
-        test("should delete a newline in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]\ncd</pre>",
-                stepFunction: deleteForward,
-                contentAfter: "<pre>ab[]cd</pre>",
+            test("should delete a space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>  []   ab</pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>  []  ab</pre>",
+                });
             });
-        });
 
-        test("should delete all leading space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>[]     ab</pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                },
-                contentAfter: "<pre>[]ab</pre>",
+            test("should delete a newline in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]\ncd</pre>",
+                    stepFunction: deleteForward,
+                    contentAfter: "<pre>ab[]cd</pre>",
+                });
             });
-        });
 
-        test("should delete all trailing space in a pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]     </pre>",
-                stepFunction: async (BasicEditor) => {
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                    deleteForward(BasicEditor);
-                },
-                contentAfter: "<pre>ab[]</pre>",
+            test("should delete all leading space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>[]     ab</pre>",
+                    stepFunction: async (BasicEditor) => {
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                    },
+                    contentAfter: "<pre>[]ab</pre>",
+                });
+            });
+
+            test("should delete all trailing space in a pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]     </pre>",
+                    stepFunction: async (BasicEditor) => {
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                        deleteForward(BasicEditor);
+                    },
+                    contentAfter: "<pre>ab[]</pre>",
+                });
             });
         });
     });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -7,7 +7,11 @@ import { unformat } from "../_helpers/format";
 import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 import { findInSelection } from "@html_editor/utils/selection";
-import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import {
+    compareHighlightedContent,
+    highlightedPre,
+    patchPrism,
+} from "../_helpers/syntax_highlighting";
 import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 describe("Selection collapsed", () => {
@@ -139,14 +143,12 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abcd</pre>",
-                    contentBeforeEdit: {
-                        highlightedValue: "abcd",
-                    },
+                    contentBeforeEdit: highlightedPre({ value: "abcd" }),
                     stepFunction: testEnterInCodeBlock(2), // "ab[]cd"
-                    contentAfterEdit: {
-                        highlightedValue: "ab\ncd",
+                    contentAfterEdit: highlightedPre({
+                        value: "ab\ncd",
                         textareaRange: 3, // "ab\n[]cd"
-                    },
+                    }),
                     contentAfter: `<pre data-language-id="plaintext">ab<br>cd</pre>[]`,
                     config: configWithEmbeddings,
                 });
@@ -155,15 +157,13 @@ describe("Selection collapsed", () => {
                 await testEditor({
                     compareFunction: compareHighlightedContent,
                     contentBefore: "<pre>abc</pre>",
-                    contentBeforeEdit: {
-                        highlightedValue: "abc",
-                    },
+                    contentBeforeEdit: highlightedPre({ value: "abc" }),
                     stepFunction: testEnterInCodeBlock(3), // "abc[]"
-                    contentAfterEdit: {
-                        preValue: "abc<br><br>",
-                        highlightedValue: "abc\n",
+                    contentAfterEdit: highlightedPre({
+                        value: "abc\n",
+                        preHtml: "abc<br><br>",
                         textareaRange: 4, // "abc\n[]"
-                    },
+                    }),
                     contentAfter: `<pre data-language-id="plaintext">abc<br><br></pre>[]`,
                     config: configWithEmbeddings,
                 });

--- a/addons/html_editor/static/tests/insert/paragraph_break.test.js
+++ b/addons/html_editor/static/tests/insert/paragraph_break.test.js
@@ -1,12 +1,14 @@
-import { describe, test } from "@odoo/hoot";
-import { waitFor } from "@odoo/hoot-dom";
+import { beforeEach, describe, test } from "@odoo/hoot";
+import { animationFrame, waitFor } from "@odoo/hoot-dom";
 import { tick } from "@odoo/hoot-mock";
 import { testEditor } from "../_helpers/editor";
 import { insertText, splitBlock } from "../_helpers/user_actions";
 import { unformat } from "../_helpers/format";
-import { MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
 import { QWebPlugin } from "@html_editor/others/qweb_plugin";
 import { findInSelection } from "@html_editor/utils/selection";
+import { compareHighlightedContent, patchPrism } from "../_helpers/syntax_highlighting";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
 
 describe("Selection collapsed", () => {
     describe("Basic", () => {
@@ -115,472 +117,528 @@ describe("Selection collapsed", () => {
     });
 
     describe("Pre", () => {
-        test("should insert a line break within the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab[]cd</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>ab<br>[]cd</pre>",
+        describe("with syntax highlighting", () => {
+            const configWithEmbeddings = {
+                Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+                resources: { embedded_components: MAIN_EMBEDDINGS },
+            };
+            const testEnterInCodeBlock = (selectionStart) => async (editor) => {
+                // Set the given selection in the textarea.
+                const textarea = editor.editable.querySelector("textarea");
+                textarea.focus();
+                textarea.setSelectionRange(selectionStart, selectionStart, "forward");
+                // Trigger native paragraph break.
+                await editor.document.execCommand("insertParagraph", false, null);
+                // Wait for the input event to resolve so the content is
+                // highlighted and the focus is in the textarea.
+                await animationFrame();
+            };
+            beforeEach(patchPrism);
+
+            test("should insert a line break within the pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abcd</pre>",
+                    contentBeforeEdit: {
+                        highlightedValue: "abcd",
+                    },
+                    stepFunction: testEnterInCodeBlock(2), // "ab[]cd"
+                    contentAfterEdit: {
+                        highlightedValue: "ab\ncd",
+                        textareaRange: 3, // "ab\n[]cd"
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">ab<br>cd</pre>[]`,
+                    config: configWithEmbeddings,
+                });
+            });
+            test("should insert a new line at the end of the pre", async () => {
+                await testEditor({
+                    compareFunction: compareHighlightedContent,
+                    contentBefore: "<pre>abc</pre>",
+                    contentBeforeEdit: {
+                        highlightedValue: "abc",
+                    },
+                    stepFunction: testEnterInCodeBlock(3), // "abc[]"
+                    contentAfterEdit: {
+                        preValue: "abc<br><br>",
+                        highlightedValue: "abc\n",
+                        textareaRange: 4, // "abc\n[]"
+                    },
+                    contentAfter: `<pre data-language-id="plaintext">abc<br><br></pre>[]`,
+                    config: configWithEmbeddings,
+                });
             });
         });
-        test("should insert a line break within the pre containing inline element", async () => {
-            await testEditor({
-                contentBefore: "<pre>a<strong>b[]c</strong>d</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>a<strong>b<br>[]c</strong>d</pre>",
+        describe("without syntax highlighting", () => {
+            test("should insert a line break within the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab[]cd</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>ab<br>[]cd</pre>",
+                });
             });
-        });
-        test("should insert a line break within the pre containing inline elementd", async () => {
-            await testEditor({
-                contentBefore: "<pre><em>a<strong>b[]c</strong>d</em></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><em>a<strong>b<br>[]c</strong>d</em></pre>",
+            test("should insert a line break within the pre containing inline element", async () => {
+                await testEditor({
+                    contentBefore: "<pre>a<strong>b[]c</strong>d</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>a<strong>b<br>[]c</strong>d</pre>",
+                });
+            });
+            test("should insert a line break within the pre containing inline elementd", async () => {
+                await testEditor({
+                    contentBefore: "<pre><em>a<strong>b[]c</strong>d</em></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><em>a<strong>b<br>[]c</strong>d</em></pre>",
+                });
+            });
+
+            test("should insert a new paragraph after the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>abc[]</pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>abc</pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after the pre containing inline element", async () => {
+                await testEditor({
+                    contentBefore: "<pre>ab<strong>c[]</strong></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre>ab<strong>c</strong></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after the pre containing inline elements", async () => {
+                await testEditor({
+                    contentBefore: "<pre><em>ab<strong>c[]</strong></em></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><em>ab<strong>c</strong></em></pre><p>[]<br></p>",
+                });
+            });
+
+            test("should be able to break out of an empty pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre>[]<br></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><br></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new line within the pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre><p>abc</p><p>def[]</p></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
+                });
+            });
+            test("should insert a new line after pre", async () => {
+                await testEditor({
+                    contentBefore: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<pre><p>abc</p><p>def</p></pre><p>[]<br></p>",
+                });
+            });
+            test("should insert a new paragraph after a pre tag with rtl direction", async () => {
+                await testEditor({
+                    contentBefore: `<pre dir="rtl">ab[]</pre>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<pre dir="rtl">ab</pre><p dir="rtl">[]<br></p>`,
+                });
+            });
+            test("should insert a new paragraph after a pre tag with rtl direction (2)", async () => {
+                await testEditor({
+                    contentBefore: `<pre><p dir="rtl">abc</p><p dir="rtl">[]<br></p></pre>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<pre><p dir="rtl">abc</p></pre><p dir="rtl">[]<br></p>`,
+                });
             });
         });
 
-        test("should insert a new paragraph after the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>abc[]</pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>abc</pre><p>[]<br></p>",
+        describe("Consecutive", () => {
+            test("should duplicate an empty paragraph twice", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]<br></p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+                });
+                // TODO this cannot actually be tested currently as a
+                // backspace/delete in that case is not even detected
+                // (no input event to rollback)
+                // await testEditor({
+                //     contentBefore: '<p>[<br>]</p>',
+                //     stepFunction: async (editor) => {
+                //         splitBlock(editor);
+                //         splitBlock(editor);
+                //     },
+                //     contentAfter: '<p><br></p><p><br></p><p>[]<br></p>',
+                // });
+                await testEditor({
+                    contentBefore: "<p><br>[]</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+                });
             });
-        });
-        test("should insert a new paragraph after the pre containing inline element", async () => {
-            await testEditor({
-                contentBefore: "<pre>ab<strong>c[]</strong></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre>ab<strong>c</strong></pre><p>[]<br></p>",
+
+            test("should insert two empty paragraphs before a paragraph", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]abc</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p><br></p><p><br></p><p>[]abc</p>",
+                });
             });
-        });
-        test("should insert a new paragraph after the pre containing inline elements", async () => {
-            await testEditor({
-                contentBefore: "<pre><em>ab<strong>c[]</strong></em></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><em>ab<strong>c</strong></em></pre><p>[]<br></p>",
+
+            test("should split a paragraph in three", async () => {
+                await testEditor({
+                    contentBefore: "<p>ab[]cd</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>ab</p><p><br></p><p>[]cd</p>",
+                });
+            });
+
+            test("should split a paragraph in four", async () => {
+                await testEditor({
+                    contentBefore: "<p>ab[]cd</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>ab</p><p><br></p><p><br></p><p>[]cd</p>",
+                });
+            });
+
+            test("should insert two empty paragraphs after a paragraph", async () => {
+                await testEditor({
+                    contentBefore: "<p>abc[]</p>",
+                    stepFunction: async (editor) => {
+                        splitBlock(editor);
+                        splitBlock(editor);
+                    },
+                    contentAfter: "<p>abc</p><p><br></p><p>[]<br></p>",
+                });
             });
         });
 
-        test("should be able to break out of an empty pre", async () => {
-            await testEditor({
-                contentBefore: "<pre>[]<br></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><br></pre><p>[]<br></p>",
+        describe("Format", () => {
+            test("should split a paragraph before a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p>abc[]<b>def</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p>abc</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to []<b>
+                    contentBefore: "<p>abc<b>[]def</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p>abc</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p>abc <b>[]def</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's after a
+                    // <br>).
+                    contentAfter: "<p>abc&nbsp;</p><p><b>[]def</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p>abc<b>[] def </b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's before a
+                    // <br>).
+                    // JW cAfter: '<p>abc</p><p><b>[]&nbsp;def</b></p>',
+                    contentAfter: "<p>abc</p><p><b>[]&nbsp;def </b></p>",
+                });
             });
-        });
-        test("should insert a new line within the pre", async () => {
-            await testEditor({
-                contentBefore: "<pre><p>abc</p><p>def[]</p></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
-            });
-        });
-        test("should insert a new line after pre", async () => {
-            await testEditor({
-                contentBefore: "<pre><p>abc</p><p>def</p><p>[]<br></p></pre>",
-                stepFunction: splitBlock,
-                contentAfter: "<pre><p>abc</p><p>def</p></pre><p>[]<br></p>",
-            });
-        });
-        test("should insert a new paragraph after a pre tag with rtl direction", async () => {
-            await testEditor({
-                contentBefore: `<pre dir="rtl">ab[]</pre>`,
-                stepFunction: splitBlock,
-                contentAfter: `<pre dir="rtl">ab</pre><p dir="rtl">[]<br></p>`,
-            });
-        });
-        test("should insert a new paragraph after a pre tag with rtl direction (2)", async () => {
-            await testEditor({
-                contentBefore: `<pre><p dir="rtl">abc</p><p dir="rtl">[]<br></p></pre>`,
-                stepFunction: splitBlock,
-                contentAfter: `<pre><p dir="rtl">abc</p></pre><p dir="rtl">[]<br></p>`,
-            });
-        });
-    });
 
-    describe("Consecutive", () => {
-        test("should duplicate an empty paragraph twice", async () => {
-            await testEditor({
-                contentBefore: "<p>[]<br></p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
+            test("should split a paragraph after a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>abc</b>[]def</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: "<p><b>abc</b></p><p>[]def</p>",
+                    contentAfter: "<p><b>abc</b></p><p>[]def</p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to </b>[]
+                    contentBefore: "<p><b>abc[]</b>def</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]def</p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc[]</b> def</p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>&nbsp;def</p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]&nbsp;def</p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc []</b>def</p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible (because it's before a
+                    // <br>).
+                    contentAfterEdit: `<p><b>abc&nbsp;</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
+                    contentAfter: "<p><b>abc&nbsp;</b></p><p>[]def</p>",
+                });
             });
-            // TODO this cannot actually be tested currently as a
-            // backspace/delete in that case is not even detected
-            // (no input event to rollback)
-            // await testEditor({
-            //     contentBefore: '<p>[<br>]</p>',
-            //     stepFunction: async (editor) => {
-            //         splitBlock(editor);
-            //         splitBlock(editor);
-            //     },
-            //     contentAfter: '<p><br></p><p><br></p><p>[]<br></p>',
-            // });
-            await testEditor({
-                contentBefore: "<p><br>[]</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]<br></p>",
-            });
-        });
 
-        test("should insert two empty paragraphs before a paragraph", async () => {
-            await testEditor({
-                contentBefore: "<p>[]abc</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p><br></p><p><br></p><p>[]abc</p>",
+            test("should split a paragraph at the beginning of a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p>[]<b>abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
+                    contentAfter: "<p><br></p><p><b>[]abc</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>[]abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
+                    contentAfter: "<p><br></p><p><b>[]abc</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>[] abc</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[] abc</b></p>`,
+                    // The space should have been parsed away.
+                    // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
+                    contentAfter: "<p><br></p><p><b>[] abc</b></p>",
+                });
             });
-        });
 
-        test("should split a paragraph in three", async () => {
-            await testEditor({
-                contentBefore: "<p>ab[]cd</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>ab</p><p><br></p><p>[]cd</p>",
+            test("should split a paragraph within a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>ab[]cd</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<p><b>ab</b></p><p><b>[]cd</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>ab []cd</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfter: "<p><b>ab&nbsp;</b></p><p><b>[]cd</b></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>ab[] cd</b></p>",
+                    stepFunction: splitBlock,
+                    // The space is converted to a non-breaking
+                    // space so it is visible.
+                    contentAfter: "<p><b>ab</b></p><p><b>[]&nbsp;cd</b></p>",
+                });
             });
-        });
 
-        test("should split a paragraph in four", async () => {
-            await testEditor({
-                contentBefore: "<p>ab[]cd</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>ab</p><p><br></p><p><br></p><p>[]cd</p>",
+            test("should split a paragraph at the end of a format node", async () => {
+                await testEditor({
+                    contentBefore: "<p><b>abc</b>[]</p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
+                await testEditor({
+                    // That selection is equivalent to </b>[]
+                    contentBefore: "<p><b>abc[]</b></p>",
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
+                await testEditor({
+                    contentBefore: "<p><b>abc[] </b></p>",
+                    stepFunction: splitBlock,
+                    // The space should have been parsed away.
+                    contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
+                    contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
+                });
             });
-        });
 
-        test("should insert two empty paragraphs after a paragraph", async () => {
-            await testEditor({
-                contentBefore: "<p>abc[]</p>",
-                stepFunction: async (editor) => {
-                    splitBlock(editor);
-                    splitBlock(editor);
-                },
-                contentAfter: "<p>abc</p><p><br></p><p>[]<br></p>",
-            });
-        });
-    });
-
-    describe("Format", () => {
-        test("should split a paragraph before a format node", async () => {
-            await testEditor({
-                contentBefore: "<p>abc[]<b>def</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p>abc</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                // That selection is equivalent to []<b>
-                contentBefore: "<p>abc<b>[]def</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p>abc</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p>abc <b>[]def</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's after a
-                // <br>).
-                contentAfter: "<p>abc&nbsp;</p><p><b>[]def</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p>abc<b>[] def </b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's before a
-                // <br>).
-                // JW cAfter: '<p>abc</p><p><b>[]&nbsp;def</b></p>',
-                contentAfter: "<p>abc</p><p><b>[]&nbsp;def </b></p>",
-            });
-        });
-
-        test("should split a paragraph after a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>abc</b>[]def</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: "<p><b>abc</b></p><p>[]def</p>",
-                contentAfter: "<p><b>abc</b></p><p>[]def</p>",
-            });
-            await testEditor({
-                // That selection is equivalent to </b>[]
-                contentBefore: "<p><b>abc[]</b>def</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]def</p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc[]</b> def</p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfterEdit: `<p><b>abc</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>&nbsp;def</p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]&nbsp;def</p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc []</b>def</p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible (because it's before a
-                // <br>).
-                contentAfterEdit: `<p><b>abc&nbsp;</b></p><p><b data-oe-zws-empty-inline="">[]\u200b</b>def</p>`,
-                contentAfter: "<p><b>abc&nbsp;</b></p><p>[]def</p>",
-            });
-        });
-
-        test("should split a paragraph at the beginning of a format node", async () => {
-            await testEditor({
-                contentBefore: "<p>[]<b>abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
-                contentAfter: "<p><br></p><p><b>[]abc</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>[]abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[]abc</b></p>`,
-                contentAfter: "<p><br></p><p><b>[]abc</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>[] abc</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b data-oe-zws-empty-inline="">\u200b</b></p><p><b>[] abc</b></p>`,
-                // The space should have been parsed away.
-                // JW cAfter: '<p><br></p><p><b>[]abc</b></p>',
-                contentAfter: "<p><br></p><p><b>[] abc</b></p>",
-            });
-        });
-
-        test("should split a paragraph within a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>ab[]cd</b></p>",
-                stepFunction: splitBlock,
-                contentAfter: "<p><b>ab</b></p><p><b>[]cd</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>ab []cd</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfter: "<p><b>ab&nbsp;</b></p><p><b>[]cd</b></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>ab[] cd</b></p>",
-                stepFunction: splitBlock,
-                // The space is converted to a non-breaking
-                // space so it is visible.
-                contentAfter: "<p><b>ab</b></p><p><b>[]&nbsp;cd</b></p>",
-            });
-        });
-
-        test("should split a paragraph at the end of a format node", async () => {
-            await testEditor({
-                contentBefore: "<p><b>abc</b>[]</p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-            await testEditor({
-                // That selection is equivalent to </b>[]
-                contentBefore: "<p><b>abc[]</b></p>",
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-            await testEditor({
-                contentBefore: "<p><b>abc[] </b></p>",
-                stepFunction: splitBlock,
-                // The space should have been parsed away.
-                contentAfterEdit: `<p><b>abc</b></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><b data-oe-zws-empty-inline="">[]\u200b</b></p>`,
-                contentAfter: "<p><b>abc</b></p><p>[]<br></p>",
-            });
-        });
-
-        async function splitBlockA(editor) {
-            // splitBlock in an <a> tag will open the linkPopover which will take the focus.
-            // So we need to wait for it to open and put the selection back into the editor.
-            splitBlock(editor);
-            const editableSelection = editor.shared.selection.getSelectionData().editableSelection;
-            if (findInSelection(editableSelection, "a:not([href])")) {
-                await waitFor(".o-we-linkpopover");
+            async function splitBlockA(editor) {
+                // splitBlock in an <a> tag will open the linkPopover which will take the focus.
+                // So we need to wait for it to open and put the selection back into the editor.
+                splitBlock(editor);
+                const editableSelection =
+                    editor.shared.selection.getSelectionData().editableSelection;
+                if (findInSelection(editableSelection, "a:not([href])")) {
+                    await waitFor(".o-we-linkpopover");
+                }
+                editor.shared.selection.focusEditable();
+                await tick();
             }
-            editor.shared.selection.focusEditable();
-            await tick();
-        }
 
-        // @todo: re-evaluate this possibly outdated comment:
-        // skipping these tests cause with the link isolation the cursor can be put
-        // inside/outside the link so the user can choose where to insert the line break
-        // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
-        test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
+            // @todo: re-evaluate this possibly outdated comment:
+            // skipping these tests cause with the link isolation the cursor can be put
+            // inside/outside the link so the user can choose where to insert the line break
+            // see `anchor.nodeName === "A" && brEls.includes(anchor.firstChild)` in line_break_plugin.js
+            test("should insert line breaks outside the edges of an anchor in unbreakable", async () => {
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable">ab<a href="http://test.test/">[]cd</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable">ab<br><a href="http://test.test/">[]cd</a></div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
+                });
+                await testEditor({
+                    contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
+                    stepFunction: splitBlockA,
+                    contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
+                });
             });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">a[]b</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">a<br>[]b</a></div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br><br>[]</div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/">ab[]</a>cd</div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/">ab</a><br>[]cd</div>`,
-            });
-            await testEditor({
-                contentBefore: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab[]</a></div>`,
-                stepFunction: splitBlockA,
-                contentAfter: `<div class="oe_unbreakable"><a href="http://test.test/" style="display: block;">ab</a>[]<br></div>`,
-            });
-        });
 
-        test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
-                contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
+            test("should insert a paragraph break outside the starting edge of an anchor at start of block", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">[]ab</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p><br></p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]ab\ufeff</a>\ufeff</p>',
+                    contentAfter: '<p><br></p><p><a href="http://test.test/">[]ab</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
-            await testEditor({
-                contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
-                contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
+            test("should insert a paragraph break outside the starting edge of an anchor after some text", async () => {
+                await testEditor({
+                    contentBefore: '<p>ab<a href="http://test.test/">[]cd</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>ab</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]cd\ufeff</a>\ufeff</p>',
+                    contentAfter: '<p>ab</p><p><a href="http://test.test/">[]cd</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break in the middle of an anchor", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
-                contentAfter:
-                    '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
+            test("should insert a paragraph break in the middle of an anchor", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">a[]b</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>\ufeff<a href="http://test.test/">\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a href="http://test.test/" class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
+                    contentAfter:
+                        '<p><a href="http://test.test/">a</a></p><p><a href="http://test.test/">[]b</a></p>',
+                });
             });
-        });
-        test("should insert a paragraph break outside the ending edge of an anchor", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
+            test("should insert a paragraph break outside the ending edge of an anchor", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">ab[]</a></p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit: `<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                    contentAfter: `<p><a href="http://test.test/">ab</a></p><p>[]<br></p>`,
+                });
             });
-        });
-        test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
-            await testEditor({
-                contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
-                stepFunction: splitBlockA,
-                contentAfterEdit:
-                    '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
-                contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
-            });
-        });
-    });
-
-    describe("With attributes", () => {
-        test("should insert an empty paragraph before a paragraph with a span with a class", async () => {
-            await testEditor({
-                contentBefore: '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
-                stepFunction: splitBlock,
-                contentAfter:
-                    '<p><span class="a">ab</span></p><p><span class="b">\u200b</span><br></p><p><span class="b">[]cd</span></p>',
+            test("should insert a paragraph break outside the ending edge of an anchor (2)", async () => {
+                await testEditor({
+                    contentBefore: '<p><a href="http://test.test/">ab[]</a>cd</p>',
+                    stepFunction: splitBlockA,
+                    contentAfterEdit:
+                        '<p>\ufeff<a href="http://test.test/">\ufeffab\ufeff</a>\ufeff</p><p>[]cd</p>',
+                    contentAfter: '<p><a href="http://test.test/">ab</a></p><p>[]cd</p>',
+                });
             });
         });
 
-        test("should split a paragraph with a span with a bold in two", async () => {
-            await testEditor({
-                contentBefore: '<p><span class="a"><b>ab[]cd</b></span></p>',
-                stepFunction: splitBlock,
-                contentAfter:
-                    '<p><span class="a"><b>ab</b></span></p><p><span class="a"><b>[]cd</b></span></p>',
+        describe("With attributes", () => {
+            test("should insert an empty paragraph before a paragraph with a span with a class", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<p><span class="a">ab</span></p><p><span class="b">[]cd</span></p>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<p><span class="a">ab</span></p><p><span class="b">\u200b</span><br></p><p><span class="b">[]cd</span></p>',
+                });
+            });
+
+            test("should split a paragraph with a span with a bold in two", async () => {
+                await testEditor({
+                    contentBefore: '<p><span class="a"><b>ab[]cd</b></span></p>',
+                    stepFunction: splitBlock,
+                    contentAfter:
+                        '<p><span class="a"><b>ab</b></span></p><p><span class="a"><b>[]cd</b></span></p>',
+                });
+            });
+
+            test("should split a paragraph at its end, with a paragraph after it, and both have the same class", async () => {
+                await testEditor({
+                    contentBefore: '<p class="a">a[]</p><p class="a"><br></p>',
+                    stepFunction: splitBlock,
+                    contentAfter: '<p class="a">a</p><p class="a">[]<br></p><p class="a"><br></p>',
+                });
             });
         });
 
-        test("should split a paragraph at its end, with a paragraph after it, and both have the same class", async () => {
-            await testEditor({
-                contentBefore: '<p class="a">a[]</p><p class="a"><br></p>',
-                stepFunction: splitBlock,
-                contentAfter: '<p class="a">a</p><p class="a">[]<br></p><p class="a"><br></p>',
+        describe("POC extra tests", () => {
+            test("should insert a paragraph after an empty h1", async () => {
+                await testEditor({
+                    contentBefore: "<h1>[]<br></h1>",
+                    stepFunction: splitBlock,
+                    contentAfter: "<h1><br></h1><p>[]<br></p>",
+                });
             });
-        });
-    });
 
-    describe("POC extra tests", () => {
-        test("should insert a paragraph after an empty h1", async () => {
-            await testEditor({
-                contentBefore: "<h1>[]<br></h1>",
-                stepFunction: splitBlock,
-                contentAfter: "<h1><br></h1><p>[]<br></p>",
+            test("should insert a paragraph after an empty h1 with styles and a zero-width space", async () => {
+                await testEditor({
+                    contentBefore:
+                        '<h1><font style="color: red;" data-oe-zws-empty-inline="">[]\u200B</font></h1>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit:
+                        '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font></h1>' +
+                        `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: "<h1><br></h1><p>[]<br></p>",
+                });
             });
-        });
 
-        test("should insert a paragraph after an empty h1 with styles and a zero-width space", async () => {
-            await testEditor({
-                contentBefore:
-                    '<h1><font style="color: red;" data-oe-zws-empty-inline="">[]\u200B</font></h1>',
-                stepFunction: splitBlock,
-                contentAfterEdit:
-                    '<h1><font style="color: red;" data-oe-zws-empty-inline="">\u200b</font></h1>' +
-                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: "<h1><br></h1><p>[]<br></p>",
+            test("should insert a new paragraph after an h1 with style", async () => {
+                await testEditor({
+                    contentBefore: `<h1 style="color: red">ab[]</h1>`,
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<h1 style="color: red">ab</h1><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
+                    contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
+                });
+            });
+            test("should insert a new paragraph after a heading tag with rtl direction", async () => {
+                await testEditor({
+                    contentBefore: `<h1 dir="rtl">ab[]</h1>`,
+                    stepFunction: splitBlock,
+                    contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
+                });
             });
         });
-
-        test("should insert a new paragraph after an h1 with style", async () => {
-            await testEditor({
-                contentBefore: `<h1 style="color: red">ab[]</h1>`,
-                stepFunction: splitBlock,
-                contentAfterEdit: `<h1 style="color: red">ab</h1><p o-we-hint-text='Type "/" for commands' class="o-we-hint">[]<br></p>`,
-                contentAfter: `<h1 style="color: red">ab</h1><p>[]<br></p>`,
-            });
-        });
-        test("should insert a new paragraph after a heading tag with rtl direction", async () => {
-            await testEditor({
-                contentBefore: `<h1 dir="rtl">ab[]</h1>`,
-                stepFunction: splitBlock,
-                contentAfter: `<h1 dir="rtl">ab</h1><p dir="rtl">[]<br></p>`,
-            });
-        });
-    });
-    describe("Styles", () => {
-        test("should split a paragraph at the end of style node", async () => {
-            await testEditor({
-                contentBefore: '<p><font style="color: red;">abc[]</font></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
-            });
-            await testEditor({
-                contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
-                contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
-            });
-            await testEditor({
-                contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
-                stepFunction: splitBlock,
-                contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span></p>`,
-                contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
+        describe("Styles", () => {
+            test("should split a paragraph at the end of style node", async () => {
+                await testEditor({
+                    contentBefore: '<p><font style="color: red;">abc[]</font></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><font style="color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: `<p><font style="color: red;">abc</font></p><p>[]<br></p>`,
+                });
+                await testEditor({
+                    contentBefore: '<p><font style="background-color: red;">abc[]</font></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><font style="background-color: red;">abc</font></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><font style="background-color: red;" data-oe-zws-empty-inline="">[]\u200b</font></p>`,
+                    contentAfter: `<p><font style="background-color: red;">abc</font></p><p>[]<br></p>`,
+                });
+                await testEditor({
+                    contentBefore: '<p><span style="font-size: 36px;">abc[]</span></p>',
+                    stepFunction: splitBlock,
+                    contentAfterEdit: `<p><span style="font-size: 36px;">abc</span></p><p o-we-hint-text='Type "/" for commands' class="o-we-hint"><span style="font-size: 36px;" data-oe-zws-empty-inline="">[]\u200b</span></p>`,
+                    contentAfter: `<p><span style="font-size: 36px;">abc</span></p><p>[]<br></p>`,
+                });
             });
         });
     });

--- a/addons/html_editor/static/tests/syntax_highlighting.test.js
+++ b/addons/html_editor/static/tests/syntax_highlighting.test.js
@@ -1,0 +1,1051 @@
+import { beforeEach, expect, test } from "@odoo/hoot";
+import { getContent } from "./_helpers/selection";
+import { animationFrame, click, pointerUp, press, queryOne, waitFor } from "@odoo/hoot-dom";
+import { insertText, splitBlock } from "./_helpers/user_actions";
+import {
+    compareHighlightedContent,
+    patchPrism,
+    testTextareaRange,
+} from "./_helpers/syntax_highlighting";
+import { patchWithCleanup } from "@web/../tests/web_test_helpers";
+import { browser } from "@web/core/browser/browser";
+import { setupEditor, testEditor } from "./_helpers/editor";
+import { EMBEDDED_COMPONENT_PLUGINS, MAIN_PLUGINS } from "@html_editor/plugin_sets";
+import { MAIN_EMBEDDINGS } from "@html_editor/others/embedded_components/embedding_sets";
+
+const insertPre = async (editor) => {
+    await insertText(editor, "/code");
+    await animationFrame();
+    expect(".active .o-we-command-name").toHaveText("Code");
+    await press("enter");
+    await animationFrame();
+};
+
+const changeLanguage = async (textarea, from, to) => {
+    await click(textarea);
+    // Code Toolbar should open.
+    await waitFor(`.o_code_toolbar button[name='language'][title='${from}']`);
+    await click(`.o_code_toolbar button[name='language'][title='${from}']`);
+    // Language selector dropdown should open.
+    await waitFor(`.o_language_selector .o-dropdown-item[name='${to}']`);
+    await click(`.o_language_selector .o-dropdown-item[name='${to}']`);
+    // Code Toolbar should show the new language name.
+    await waitFor(`.o_code_toolbar button[name='language'][title='${to}']`);
+};
+
+const configWithEmbeddings = {
+    Plugins: [...MAIN_PLUGINS, ...EMBEDDED_COMPONENT_PLUGINS],
+    resources: { embedded_components: MAIN_EMBEDDINGS },
+};
+
+beforeEach(patchPrism);
+
+test("starting edition with a pre activates syntax highlighting", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit: { highlightedValue: "some code" },
+        stepFunction: async () => press(["ctrl", "z"]),
+        contentAfterEdit: { highlightedValue: "some code" }, // Undo did nothing.
+        contentAfter: `<pre data-language-id="plaintext">some code</pre>`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("starting edition with a pre activates syntax highlighting (with dataset values)", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: `<pre data-language-id="javascript">Hello world!</pre>`,
+        // The DIV should now be filled with a highlighted pre and a textarea,
+        // the respective values of which match the dataset.
+        contentBeforeEdit: {
+            highlightedValue: "Hello world!",
+            language: "javascript",
+        },
+        stepFunction: async (editor) => {
+            await press(["ctrl", "z"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                {
+                    highlightedValue: "Hello world!",
+                    language: "javascript",
+                },
+                "Undo should have done nothing.",
+                editor
+            );
+            await click("textarea");
+            await press("a");
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                {
+                    highlightedValue: "Hello world!a",
+                    language: "javascript",
+                    textareaRange: 13, // "Hello world!a[]"
+                },
+                "Should have written at the end of the textarea.",
+                editor
+            );
+            await press(["ctrl", "z"]);
+            await press(["ctrl", "z"]);
+        },
+        contentAfterEdit: {
+            highlightedValue: "Hello world!",
+            language: "javascript",
+            textareaRange: 12, // "Hello world![]"
+        }, // Undo did nothing.
+        contentAfter: `<pre data-language-id="javascript">Hello world!</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting a code block activates syntax highlighting plugin, typing triggers highlight", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p>[]abc</p>",
+        stepFunction: async (editor) => {
+            await insertPre(editor);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                {
+                    highlightedValue: "abc",
+                    textareaRange: 3,
+                },
+                "The syntax highlighting wrapper was inserted, the paragraph's content is its value and the selection in at the end of the textarea.",
+                editor
+            );
+            await press("d");
+        },
+        contentAfterEdit: {
+            highlightedValue: "abcd",
+            textareaRange: 4,
+        }, // The change of value in the textarea is reflected in the pre.
+        contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting an empty code block activates syntax highlighting plugin with an empty textarea", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p><br>[]</p>",
+        stepFunction: insertPre,
+        contentAfterEdit: {
+            highlightedValue: "",
+            textareaRange: 0,
+        },
+        contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("inserting a code block in an empty paragraph with a style placeholder activates syntax highlighting plugin with an empty textarea", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<p><br>[]</p>",
+        stepFunction: async (editor) => {
+            await press(["ctrl", "b"]);
+            expect(getContent(editor.editable)).toBe(
+                `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                { message: "The style placeholder was inserted." }
+            );
+            splitBlock(editor);
+            expect(getContent(editor.editable)).toBe(
+                `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>` +
+                    `<p o-we-hint-text='Type "/" for commands' class="o-we-hint"><strong data-oe-zws-empty-inline="">[]\u200B</strong></p>`,
+                { message: "The paragraph was split." }
+            );
+            await insertPre(editor);
+        },
+        contentAfterEdit: [
+            `<p><strong data-oe-zws-empty-inline="">\u200B</strong></p>`,
+            {
+                highlightedValue: "", // There should be no content (the zws is stripped)
+                textareaRange: 0,
+            },
+        ],
+        contentAfter: "<p><br></p>" + `<pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test.tags();
+test("changing languages in a code block changes its highlighting", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>some code</pre>",
+        contentBeforeEdit: { highlightedValue: "some code", language: "plaintext" },
+        stepFunction: async () => {
+            await changeLanguage(queryOne("textarea"), "Plain Text", "Javascript");
+        },
+        contentAfterEdit: {
+            highlightedValue: "some code",
+            language: "javascript",
+            textareaRange: 9,
+        },
+        contentAfter: `<pre data-language-id="javascript">some code</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("should fill an empty pre", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>abc</pre>",
+        contentBeforeEdit: { highlightedValue: "abc" },
+        stepFunction: async () => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+            textarea.select();
+            await press("backspace");
+        },
+        contentAfterEdit: { highlightedValue: "", textareaRange: 0 }, // Note: the BR is outside the highlight.
+        contentAfter: `<pre data-language-id="plaintext"><br></pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("the textarea should never contains zws", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>a\u200bb\ufeffc</pre>",
+        contentBeforeEdit: { highlightedValue: "abc" },
+        stepFunction: async () => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+        },
+        contentAfterEdit: { highlightedValue: "abc", textareaRange: 3 },
+        contentAfter: `<pre data-language-id="plaintext">abc</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test.tags();
+test("can copy content with the copy button", async () => {
+    patchWithCleanup(browser.navigator.clipboard, {
+        async writeText(text) {
+            expect.step(text);
+        },
+    });
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>abc</pre>",
+        contentBeforeEdit: { highlightedValue: "abc" },
+        stepFunction: async (editor) => {
+            const textarea = queryOne("textarea");
+            await click(textarea);
+            testTextareaRange(editor, { el: textarea, value: "abc", range: 3 });
+            await animationFrame();
+            await waitFor(".o_code_toolbar");
+            // Copy "abc".
+            await click(".o_code_toolbar .o_clipboard_button");
+            expect.verifySteps(["abc"]);
+            // Change text.
+            await click(textarea);
+            testTextareaRange(editor, { el: textarea, value: "abc", range: 3 });
+            await press("d");
+            testTextareaRange(editor, { el: textarea, value: "abcd", range: 4 });
+            // Copy "abcd"
+            await click(".o_code_toolbar .o_clipboard_button");
+            expect.verifySteps(["abcd"]);
+            textarea.focus();
+        },
+        contentAfterEdit: {
+            highlightedValue: "abcd",
+            textareaRange: 4,
+        },
+        contentAfter: `<pre data-language-id="plaintext">abcd</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("tab in code block inserts 4 spaces", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>code</pre>",
+        contentBeforeEdit: { highlightedValue: "code" },
+        stepFunction: async () => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(2, 2); // "co[]de"
+            await press("tab");
+        },
+        contentAfterEdit: {
+            highlightedValue: `co    de`,
+            textareaRange: 6, // "co    []de"
+        },
+        contentAfter: `<pre data-language-id="plaintext">co    de</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("tab in selection in code block indents each selected line", async () => {
+    const valueAfter = "    a\n    b c\n     d";
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>a<br>b c<br> d</pre>",
+        contentBeforeEdit: { highlightedValue: "a\nb c\n d" },
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(1, 7); // "a[\nb c\n ]d"
+            await press("tab");
+        },
+        contentAfterEdit: {
+            highlightedValue: valueAfter,
+            textareaRange: [5, 19], // "    a[\n    b c\n     ]d"
+        },
+        contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
+            "\n",
+            "<br>"
+        )}</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("shift+tab in code block outdents the current line", async () => {
+    const valueAfter = "    some\nco    de\n    for you";
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>    some<br>       co    de<br>    for you</pre>",
+        contentBeforeEdit: { highlightedValue: "    some\n       co    de\n    for you" },
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(22, 22); // "    some\n       co    []de\n    for you"
+            await press(["shift", "tab"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                [
+                    {
+                        highlightedValue: `    some\n   co    de\n    for you`,
+                        textareaRange: 18, // "    some\n   co    []de\n    for you"
+                    },
+                ],
+                "The content was outdented a first time.",
+                editor
+            );
+            await press(["shift", "tab"]);
+        },
+        contentAfterEdit: {
+            highlightedValue: valueAfter,
+            textareaRange: 15, // "    some\nco    []de\n    for you"
+        },
+        contentAfter: `<pre data-language-id="plaintext">${valueAfter.replaceAll(
+            "\n",
+            "<br>"
+        )}</pre>[]`,
+        config: configWithEmbeddings,
+    });
+});
+
+test("shift+tab in selection in code block outdents each selected line", async () => {
+    await testEditor({
+        compareFunction: compareHighlightedContent,
+        contentBefore: "<pre>    a<br>    b c<br>     d</pre>",
+        contentBeforeEdit: { highlightedValue: "    a\n    b c\n     d" },
+        stepFunction: async (editor) => {
+            await click("textarea");
+            const textarea = queryOne("textarea");
+            textarea.setSelectionRange(5, 19); // "a[\nb c\n ]d"
+            await press(["shift", "tab"]);
+            await compareHighlightedContent(
+                getContent(editor.editable),
+                {
+                    highlightedValue: "a\nb c\n d",
+                    textareaRange: [1, 7], // "a[\nb c\n ]d"
+                },
+                "The content was outdented a first time.",
+                editor
+            );
+            // Remove the last remaining leading space.
+            await press(["shift", "tab"]);
+        },
+        contentAfterEdit: {
+            highlightedValue: "a\nb c\nd",
+            textareaRange: [1, 6], // "a[\nb c\n]d"
+        },
+        config: configWithEmbeddings,
+        contentAfter: `<pre data-language-id="plaintext">a<br>b c<br>d</pre>[]`,
+    });
+});
+
+test.tags("focus required");
+test("can switch between code blocks without issues", async () => {
+    const { editor } = await setupEditor(`<p>ab</p><pre>de</pre><p>gh</p><pre>jk</pre>`, {
+        config: configWithEmbeddings,
+    });
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            {
+                highlightedValue: "de",
+            },
+            "<p>gh</p>",
+            { highlightedValue: "jk" },
+        ],
+        "The content was highlighted",
+        editor
+    );
+    const [p1, textarea1, p2, textarea2] = editor.document.querySelectorAll("p, textarea");
+    await click(textarea1);
+    testTextareaRange(editor, { el: textarea1, value: "de", range: 2 });
+    await click(textarea2);
+    testTextareaRange(editor, { el: textarea2, value: "jk", range: 2 });
+    // Action 1: insert "l" in second pre.
+    await press("l");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            {
+                highlightedValue: "de",
+            },
+            "<p>gh</p>",
+            {
+                highlightedValue: "jkl",
+                textareaRange: 3,
+            },
+        ],
+        `1. Inserted "l" into the second pre and highlighted it.`,
+        editor
+    );
+    await click(textarea1);
+    testTextareaRange(editor, { el: textarea1, value: "de", range: 2 });
+    // Action 2: insert "f" in first pre.
+    await press("f");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            {
+                highlightedValue: "def",
+                textareaRange: 3,
+            },
+            "<p>gh</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `2. Inserted "f" into the first pre and highlighted it.`,
+        editor
+    );
+    await click(p1);
+    editor.shared.selection.setCursorEnd(p1);
+    // Action 3: insert "c" in first paragraph.
+    await insertText(editor, "c");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc[]</p>",
+            {
+                highlightedValue: "def",
+            },
+            "<p>gh</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `3. Inserted "c" into the first paragraph.`,
+        editor
+    );
+    await click(p2);
+    editor.shared.selection.setCursorEnd(p2);
+    // Action 4: insert "i" in second paragraph.
+    await insertText(editor, "i");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            {
+                highlightedValue: "def",
+            },
+            "<p>ghi[]</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `4. Inserted "i" into the second paragraph.`,
+        editor
+    );
+    // Action 5: change the language of first textarea.
+    await changeLanguage(textarea1, "Plain Text", "Javascript");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            {
+                highlightedValue: "def",
+                language: "javascript",
+                textareaRange: 3,
+            },
+            "<p>ghi</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `5. Changed the language of the first textarea to "javascript".`,
+        editor
+    );
+    // Action 6: change the language of second textarea.
+    await changeLanguage(textarea2, "Plain Text", "Python");
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            {
+                highlightedValue: "def",
+                language: "javascript",
+            },
+            "<p>ghi</p>",
+            {
+                highlightedValue: "jkl",
+                language: "python",
+                textareaRange: 3,
+            },
+        ],
+        `6. Changed the language of the second textarea to "python".`,
+        editor
+    );
+
+    // UNDO
+    // ----
+
+    // UNDO action 6: change the language of second textarea.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            { highlightedValue: "def", language: "javascript" },
+            "<p>ghi</p>",
+            { highlightedValue: "jkl", textareaRange: 3 },
+        ],
+        // TODO: is it correct to not move the focus?
+        `Undo 6 changed back the language of the second textarea to "plaintext" (without losing the current focus, editor).`,
+        editor
+    );
+    // UNDO action 5: change the language of first textarea.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            { highlightedValue: "def", textareaRange: 3 },
+            "<p>ghi</p>",
+            { highlightedValue: "jkl" },
+        ],
+        // TODO: is it correct to move the focus?
+        `Undo 5 changed back the language of the first textarea to "plaintext" (and move the focus to the last focused textarea, editor).`,
+        editor
+    );
+    // UNDO action 4: insert "i" in second paragraph.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        ["<p>abc</p>", { highlightedValue: "def" }, "<p>gh[]</p>", { highlightedValue: "jkl" }],
+        `Undo 4 removed the "i" from the second paragraph.`,
+        editor
+    );
+    // UNDO action 3: insert "c" in first paragraph.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        ["<p>ab[]</p>", { highlightedValue: "def" }, "<p>gh</p>", { highlightedValue: "jkl" }],
+        `Undo 3 removed the "c" from the first paragraph.`,
+        editor
+    );
+    // UNDO action 2: insert "f" in first pre.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            { highlightedValue: "de", textareaRange: 2 },
+            "<p>gh</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `Undo 2 removed the "f" from the first pre and un-highlighted it.`,
+        editor
+    );
+    // UNDO action 1: insert "l" in second pre.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            { highlightedValue: "de" },
+            "<p>gh</p>",
+            { highlightedValue: "jk", textareaRange: 2 },
+        ],
+        `Undo 1 removed the "l" from the second pre and un-highlighted it.`,
+        editor
+    );
+    // UNDO nothing.
+    await press(["ctrl", "z"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            { highlightedValue: "de" },
+            "<p>gh</p>",
+            { highlightedValue: "jk", textareaRange: 2 },
+        ],
+        "Undo did nothing.",
+        editor
+    );
+
+    // REDO
+    // ----
+
+    // REDO action 1: insert "l" in second pre.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            { highlightedValue: "de" },
+            "<p>gh</p>",
+            { highlightedValue: "jkl", textareaRange: 3 },
+        ],
+        `Redo 1 reinserted "l" into the second pre and re-highlighted it.`,
+        editor
+    );
+    // REDO action 2: insert "f" in first pre.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>ab</p>",
+            { highlightedValue: "def", textareaRange: 3 },
+            "<p>gh</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `Redo 2 reinserted "f" into the first pre and re-highlighted it.`,
+        editor
+    );
+    // REDO action 3: insert "c" in first paragraph.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        ["<p>abc[]</p>", { highlightedValue: "def" }, "<p>gh</p>", { highlightedValue: "jkl" }],
+        `Redo 3 reinserted "c" into the first paragraph.`,
+        editor
+    );
+    // REDO action 4: insert "i" in second paragraph.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        ["<p>abc</p>", { highlightedValue: "def" }, "<p>ghi[]</p>", { highlightedValue: "jkl" }],
+        `Redo 4 reinserted "i" into the second paragraph.`,
+        editor
+    );
+    // REDO action 5: change the language of first textarea.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            {
+                highlightedValue: "def",
+                language: "javascript",
+                textareaRange: 3,
+            },
+            "<p>ghi</p>",
+            { highlightedValue: "jkl" },
+        ],
+        `Redo 5 changed back the language of the first textarea to "javascript".`,
+        editor
+    );
+    // REDO action 6: change the language of second textarea.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            { highlightedValue: "def", language: "javascript" },
+            "<p>ghi</p>",
+            {
+                highlightedValue: "jkl",
+                language: "python",
+                textareaRange: 3,
+            },
+        ],
+        `Redo 6 changed back the language of the second textarea to "python".`,
+        editor
+    );
+    // REDO nothing.
+    await press(["ctrl", "y"]);
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            "<p>abc</p>",
+            { highlightedValue: "def", language: "javascript" },
+            "<p>ghi</p>",
+            {
+                highlightedValue: "jkl",
+                language: "python",
+                textareaRange: 3,
+            },
+        ],
+        "Redo did nothing.",
+        editor
+    );
+});
+
+test.tags("focus required");
+test("multiple ctrl+z in a highlighted code block undo changes in the block and any other changes before (all redone with ctrl+y or ctrl+shift+z)", async () => {
+    const { editor } = await setupEditor(`<pre>some code</pre><p>hell[]</p>`, {
+        config: configWithEmbeddings,
+    });
+
+    // Perform a series of actions to undo later.
+    // ------------------------------------------
+
+    const actions = [];
+    const listActions = (...actionNumbers) =>
+        actionNumbers
+            .map((actionNumber) => `${actionNumber}. ${actions[actionNumber - 1]}`)
+            .join("\n");
+
+    // Perform a series of actions to undo later.
+    // ------------------------------------------
+
+    // Write in the P.
+    actions.push("type: insert 'o' into the paragraph", "type: insert '!' into the paragraph");
+    await insertText(editor, "o!"); // <wrapper><pre>some code</pre></wrapper><p>hello![]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+            },
+            "<p>hello![]</p>",
+        ],
+        listActions(1, 2),
+        editor
+    );
+    // Change the language -> code gets highlighted.
+    actions.push("language: change the language to javascript and highlight the code");
+    const textarea = queryOne("textarea");
+    await changeLanguage(textarea, "Plain Text", "Javascript"); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+                language: "javascript",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        listActions(3),
+        editor
+    );
+    // Write in the TEXTAREA.
+    actions.push("type: insert 'n' into the pre", "type: insert 'o' into the pre");
+    await click("textarea");
+    await press("n"); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press("o"); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeno",
+                language: "javascript",
+                textareaRange: 11,
+            },
+            "<p>hello!</p>",
+        ],
+        listActions(4, 5),
+        editor
+    );
+    actions.push(
+        "type: remove 'o' from the pre",
+        "type: remove 'n' from the pre",
+        "type: insert 'y' into the pre",
+        "type: insert 'e' into the pre",
+        "type: insert 's' into the pre"
+    );
+    await press("Backspace"); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press("Backspace"); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await press("y"); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press("e"); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press("s"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+                language: "javascript",
+                textareaRange: 12,
+            },
+            "<p>hello!</p>",
+        ],
+        listActions(6, 7, 8, 9, 10),
+        editor
+    );
+    // Write in the P again.
+    actions.push("type: insert 'o' into the paragraph", "type: insert 'k' into the paragraph");
+    editor.shared.selection.setCursorEnd(queryOne("p"));
+    await pointerUp("p");
+    await insertText(editor, "ok"); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok[]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+                language: "javascript",
+            },
+            "<p>hello!ok[]</p>",
+        ],
+        listActions(11, 12),
+        editor
+    );
+    // Write in the TEXTAREA again.
+    actions.push("type: insert 'h' into the pre");
+    await click("textarea");
+    await press("h"); // <wrapper><highlight><pre>some codeyesh</pre></highlight></wrapper><p>hello!ok[]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyesh",
+                language: "javascript",
+                textareaRange: 13,
+            },
+            "<p>hello!ok</p>",
+        ],
+        listActions(13),
+        editor
+    );
+
+    // Undo everything.
+    // ----------------
+
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+                language: "javascript",
+                textareaRange: 12,
+            },
+            "<p>hello!ok</p>",
+        ],
+        `undo:\n${listActions(13)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!o[]</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello![]</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+                language: "javascript",
+            },
+            "<p>hello![]</p>",
+        ],
+        `undo:\n${listActions(12, 11)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+                language: "javascript",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        `undo:\n${listActions(10, 9, 8)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeno",
+                language: "javascript",
+                textareaRange: 11,
+            },
+            "<p>hello!</p>",
+        ],
+        `undo:\n${listActions(7, 6)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+
+                language: "javascript",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        `undo:\n${listActions(5, 4)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        `undo:\n${listActions(3)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hello</p>
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hell</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+            },
+            "<p>hell[]</p>",
+        ],
+        `undo:\n${listActions(2, 1)}`,
+        editor
+    );
+    await press(["ctrl", "z"]); // <wrapper><pre>some code</pre></wrapper><p>hell</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+            },
+            "<p>hell[]</p>",
+        ],
+        "undo: should have done nothing",
+        editor
+    );
+
+    // Redo everything.
+    // ----------------
+
+    await press(["ctrl", "y"]); // <wrapper><pre>some code</pre></wrapper><p>hello</p>
+    await press(["ctrl", "y"]); // <wrapper><pre>some code</pre></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [{ highlightedValue: "some code" }, "<p>hello![]</p>"],
+        `redo:\n${listActions(1, 2)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+                language: "javascript",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        `redo:\n${listActions(3)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeno</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeno",
+
+                language: "javascript",
+                textareaRange: 11,
+            },
+            "<p>hello!</p>",
+        ],
+        `redo:\n${listActions(4, 5)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some coden</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some code</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some code",
+                language: "javascript",
+                textareaRange: 9,
+            },
+            "<p>hello!</p>",
+        ],
+        `redo:\n${listActions(6, 7)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codey</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeye</pre></highlight></wrapper><p>hello!</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+
+                language: "javascript",
+                textareaRange: 12,
+            },
+            "<p>hello!</p>",
+        ],
+        `redo:\n${listActions(8, 9, 10)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!o</p>
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyes",
+
+                language: "javascript",
+            },
+            "<p>hello!ok[]</p>",
+        ],
+        `redo:\n${listActions(11, 12)}`,
+        editor
+    );
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyesh",
+
+                language: "javascript",
+                textareaRange: 13,
+            },
+            "<p>hello!ok</p>",
+        ],
+        `redo:\n${listActions(13)}`,
+        editor
+    );
+    await press(["ctrl", "shift", "z"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await press(["ctrl", "y"]); // <wrapper><highlight><pre>some codeyes</pre></highlight></wrapper><p>hello!ok</p>
+    await compareHighlightedContent(
+        getContent(editor.editable),
+        [
+            {
+                highlightedValue: "some codeyesh",
+
+                language: "javascript",
+                textareaRange: 13,
+            },
+            "<p>hello!ok</p>",
+        ],
+        "redo: should have done nothing",
+        editor
+    );
+});

--- a/addons/web/tooling/_eslintignore
+++ b/addons/web/tooling/_eslintignore
@@ -77,6 +77,8 @@ web_gantt/static/tests/legacy/**/*
 # Whitelist html_editor
 !addons/html_editor
 !addons/html_editor/**/*
+# but blacklist the Prism library
+addons/html_editor/static/lib/prismjs/*
 
 # Whitelist html_builder
 !addons/html_builder

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -80,6 +80,7 @@ safe_attrs = defs.safe_attrs | frozenset(
      'data-ai-field', 'data-ai-record-id',
      'data-heading-link-id',
      'data-mimetype-before-conversion',
+     'data-language-id', 'data-syntax-highlighting-value'
      ])
 SANITIZE_TAGS = {
     # allow new semantic HTML5 tags


### PR DESCRIPTION
This integrates the PrismJS library to provide syntax highlighting to code blocks. Whenever a `pre` element is in the editor, it gets wrapped into a `contenteditable=false` container, with an invisible editable `textarea` element overlayed on top of the `pre`. Whenever the contents of the `textarea` change, they pass through the library to get highlighted in the `pre`. A special toolbar appears at the top of the code block, for the user to pick a language and copy the code in plain text.

task-4585835

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
