### PR TITLE
[FIX] spreadsheet: Fix groups of week that spread over two years

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_helpers.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_helpers.js
@@ -19,7 +19,11 @@ export const pivotFormulaRegex = /^=.*PIVOT/;
 export function formatDate(interval, value) {
     const output = FORMATS[interval].display;
     const input = FORMATS[interval].out;
-    const date = moment(value, input);
+    
+    let date = moment(value, input);
+    if (interval === "week") {
+        date = date.endOf("week");
+    }
     return date.isValid() ? date.format(output) : _t("None");
 }
 

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -456,7 +456,10 @@ export class SpreadsheetPivotModel extends PivotModel {
                 }
                 const fOut = FORMATS[aggregateOperator]["out"];
                 // eslint-disable-next-line no-undef
-                const date = moment(value);
+                let date = moment(value);
+                if (aggregateOperator === "week") {
+                    date = date.endOf("week");
+                }
                 return date.isValid() ? date.format(fOut) : false;
             }
             return this._sanitizeValue(group[groupBy]);


### PR DESCRIPTION
When grouping by week/days in a pivot, some issues can be seen for dates which week is between two years (for instance 12/30/2024 is both part of the last week of 2024 and the first week of 2025). Currently, such a date is assigned to week 1 of 2024 in a spreadsheet pivot, which is false and also messes up the group by of the first week of 2024.

Technically, it's an issue with the date formatting "WW/YYYY" because the two parts are decorellated.
Following the ISO calendar rules, the year of the date is obviously 2024 but the week of 12/30/2024 is 1 only because we consider it part of 2025. Since both parts of the information are gathered independently, we end up with this misleading formatted value.

Task-4853825

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
