### PR TITLE
[IMP] im_livechat: day of week filter considers first day from language settings

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
-from odoo.tools import SQL
+from odoo.tools import get_lang, Query, SQL
 
 
 class Im_LivechatReportChannel(models.Model):
@@ -238,6 +238,13 @@ class Im_LivechatReportChannel(models.Model):
                 for answer_id in id_list
             )
         return result
+
+    def _read_group_orderby(self, order: str, groupby_terms: dict[str, SQL], query: Query) -> SQL:
+        groupby_terms = dict(groupby_terms)
+        if "day_number" in groupby_terms:
+            first_week_day = int(get_lang(self.env, self.env.context.get('tz')).week_start)
+            groupby_terms["day_number"] = SQL("mod(7 - %s + (%s)::int, 7)", first_week_day, groupby_terms["day_number"])
+        return super()._read_group_orderby(order, groupby_terms, query)
 
     @api.model
     def action_open_discuss_channel_list_view(self, report_channels_domain=()):

--- a/addons/im_livechat/tests/test_im_livechat_report.py
+++ b/addons/im_livechat/tests/test_im_livechat_report.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import datetime, timedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 
@@ -108,4 +109,35 @@ class TestImLivechatReport(TestImLivechatCommon):
             f"/odoo/action-{report_action.id}?view_type=pivot",
             "im_livechat_report_pivot_redirect_tour",
             login="operator_1",
+        )
+
+    def test_day_of_week_ordered_by_lang_week_start(self):
+        agent = new_test_user(self.env, login="test_agent", groups="im_livechat.im_livechat_group_manager")
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Test Support", "user_ids": [agent.id]}
+        )
+        today_dt = datetime.now()
+        for i in range(1, 8):
+            date = today_dt + timedelta(days=i)
+            with freeze_time(date):
+                channel_id = self.make_jsonrpc_request(
+                    "/im_livechat/get_session",
+                    {"anonymous_name": f"Visitor_{i}", "channel_id": livechat_channel.id},
+                )["channel_id"]
+                channel = self.env["discuss.channel"].browse(channel_id)
+                self._create_message(channel, channel.livechat_operator_id, date)
+        en_lang = self.env["res.lang"]._activate_lang("en_US")
+        report_model = self.env["im_livechat.report.channel"].with_user(agent)
+        result = report_model.formatted_read_group(domain=[], groupby=["day_number"])
+        expected_order = ["0", "1", "2", "3", "4", "5", "6"]
+        actual_order = [group["day_number"] for group in result]
+        self.assertEqual(actual_order, expected_order)
+        en_lang.week_start = "6"
+        result = report_model.formatted_read_group(domain=[], groupby=["day_number"])
+        expected_order = ["6", "0", "1", "2", "3", "4", "5"]
+        actual_order = [group["day_number"] for group in result]
+        self.assertEqual(
+            actual_order,
+            expected_order,
+            f"Days should be ordered starting from Saturday. Got {actual_order}, expected {expected_order}"
         )


### PR DESCRIPTION
**Current behavior before PR**:

The "Day of Week" group by in the Live Chat report always treats Sunday as the start of the week, ignoring the "First Day of Week" configured in the user's language settings.

**Desired behavior after PR is merged**:

"Day of Week" group by now correctly takes into account the user's configured "First Day of Week", as set in their language settings.

**task**-[4808640](https://www.odoo.com/odoo/project.task/4808640)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
