### PR TITLE
[FIX] hr_homeworking: prevent error when date is missing in location setup

### DIFF
--- a/addons/hr_homeworking/wizard/homework_location_wizard.py
+++ b/addons/hr_homeworking/wizard/homework_location_wizard.py
@@ -22,10 +22,12 @@ class HomeworkLocationWizard(models.TransientModel):
     @api.depends('date')
     def _compute_day_week_string(self):
         for record in self:
-            record.day_week_string = record.date.strftime("%A")
+            record.day_week_string = record.date.strftime("%A") if record.date else ''
 
     def set_employee_location(self):
         self.ensure_one()
+        if not self.date:
+            return
         default_employee_id = self.env.context.get('default_employee_id') or self.env.user.employee_id.id
         employee_id = self.env['hr.employee'].browse(self.employee_id.id or default_employee_id)
         employee_location = self.env['hr.employee.location'].search([


### PR DESCRIPTION
Currently, an error occurs if the date is missing when setting a work location via the calendar.

**Steps to reproduce:**
- Install the `hr` module.
- Activate the **Remote Work** feature from the employee settings.
- Open the Calendar (Month view), hover over a date, and click **Set Location** (or location icon).
- Remove the date in the wizard and unfocus the field.

**Error:**
`AttributeError - 'bool' object has no attribute 'strftime'`

This error occurs when the `date` field is `False`, and `_compute_day_week_string` attempts to call `strftime()` on a boolean value - [1].

After addressing the compute function issue, saving the record without a date results in another issue during employee location setup, where `weekday()` is called on a boolean - [2].

[1] - https://github.com/odoo/odoo/blob/e787d0a642bd710a8a80f8abc660c3ff4a385740/addons/hr_homeworking/wizard/homework_location_wizard.py#L25
[2] - https://github.com/odoo/odoo/blob/e787d0a642bd710a8a80f8abc660c3ff4a385740/addons/hr_homeworking/wizard/homework_location_wizard.py#L35

This commit prevent the computation if the `date` field is not set.

Sentry - 6658596690