### PR TITLE
[FIX] hr_homeworking_calendar: make date field required on location setup

### DIFF
--- a/addons/hr_homeworking_calendar/wizard/homework_location_wizard.py
+++ b/addons/hr_homeworking_calendar/wizard/homework_location_wizard.py
@@ -16,13 +16,13 @@ class HomeworkLocationWizard(models.TransientModel):
     employee_name = fields.Char(related="employee_id.name")
     user_can_edit = fields.Boolean(compute='_compute_user_can_edit')
     weekly = fields.Boolean(default=False)
-    date = fields.Date(string="Date")
+    date = fields.Date(string="Date", required=True)
     day_week_string = fields.Char(compute="_compute_day_week_string")
 
     @api.depends('date')
     def _compute_day_week_string(self):
         for record in self:
-            record.day_week_string = record.date.strftime("%A")
+            record.day_week_string = record.date.strftime("%A") if record.date else ''
 
     @api.depends('date')
     def _compute_user_can_edit(self):


### PR DESCRIPTION
Currently, an error occurs if the date is not provided when setting a location via the calendar, as the `date` field is optional, but its absence causes issues in the computation flow.

**Steps to reproduce:**
- Install the `hr_homeworking_calendar` module.
- Open the Calendar (Month view), hover over a date, and click **Set Location** (or location icon).
- Remove the date from the opened wizard and unfocus the field.

**Error:**
`AttributeError - 'bool' object has no attribute 'strftime'`

This error occurs when the `date` field is `False`, and `_compute_day_week_string` attempts to call `strftime()` on a boolean value - [1].

After addressing the compute function issue, saving the record without a date results in another issue during employee location setup, where `weekday()` is called on a boolean - [2].

[1] - https://github.com/odoo/odoo/blob/65a3557f79a146cea0755318cbbe08e793959218/addons/hr_homeworking_calendar/wizard/homework_location_wizard.py#L25
[2] - https://github.com/odoo/odoo/blob/65a3557f79a146cea0755318cbbe08e793959218/addons/hr_homeworking_calendar/wizard/homework_location_wizard.py#L39

This commit makes the `date` field required in the model to prevent such runtime errors.

Sentry - 6658596690