### PR TITLE
[FIX] sale_project: add project to all analytic distribution lines

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -148,7 +148,11 @@ class SaleOrderLine(models.Model):
                 if accounts_to_add := project._get_analytic_accounts().filtered(
                     lambda account: account.root_plan_id not in applied_root_plans
                 ):
-                    line.analytic_distribution |= {",".join(str(account_id.id) for account_id in accounts_to_add): 100}
+                    # project account is added to each analytic distribution line
+                    line.analytic_distribution = {
+                        f"{account_ids},{','.join(map(str, accounts_to_add.ids))}": percentage
+                        for account_ids, percentage in line.analytic_distribution.items()
+                    }
             else:
                 line.analytic_distribution = project._get_analytic_distribution()
 

--- a/addons/sale_project/tests/test_sale_project.py
+++ b/addons/sale_project/tests/test_sale_project.py
@@ -111,6 +111,10 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             'project_id': project.id,
         })
 
+        # Create additional analytic plans at setup to avoid adding fields in project.project between tests
+        cls.analytic_plan_1 = cls.env['account.analytic.plan'].create({'name': 'Sale Project Plan 1'})
+        cls.analytic_plan_2 = cls.env['account.analytic.plan'].create({'name': 'Sale Project Plan 2'})
+
     def test_task_create_sol_ui(self):
         self.start_tour('/odoo', 'task_create_sol_tour', login='admin')
 
@@ -536,18 +540,35 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
         })
         self.assertEqual(sale_order.order_line.analytic_distribution, analytic_distribution_manual)
         sale_order.action_confirm()
-        expected_analytic_distribution = analytic_distribution_manual | {str(sale_order.order_line.project_id.account_id.id): 100}
+        expected_analytic_distribution = {f"{self.analytic_account_sale.id},{sale_order.order_line.project_id.account_id.id}": 100}
         self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
 
     def test_project_on_sol_with_analytic_distribution_model(self):
         """ If a line has a distribution coming from an analytic distribution model, and the sale order has a project,
             both the project account and the accounts from the ADM should still be in the line after confirmation.
+            The Project account should appear on all lines if there are several Analytic Distribution Models applying.
         """
-        distribution_model = self.env['account.analytic.distribution.model'].create({
+        # We create one distribution model with two accounts in one line, based on product
+        # and a second model with a different plan, based on partner
+        analytic_account_1 = self.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 1',
+            'plan_id': self.analytic_plan_1.id,
+        })
+        analytic_account_2 = self.env['account.analytic.account'].create({
+            'name': 'Analytic Account - Plan 2',
+            'plan_id': self.analytic_plan_2.id,
+        })
+        distribution_model_product = self.env['account.analytic.distribution.model'].create({
             'product_id': self.product_a.id,
+            'analytic_distribution': {','.join([str(analytic_account_1.id), str(analytic_account_2.id)]): 100},
+            'company_id': self.company.id,
+        })
+        distribution_model_partner = self.env['account.analytic.distribution.model'].create({
+            'partner_id': self.partner.id,
             'analytic_distribution': {self.analytic_account_sale.id: 100},
             'company_id': self.company.id,
         })
+
         project = self.env['project.project'].create({
             'name': 'Project Test',
             'account_id': self.analytic_account.id,
@@ -563,12 +584,18 @@ class TestSaleProject(HttpCase, TestSaleProjectCommon):
             ],
         })
 
-        expected_analytic_distribution = distribution_model.analytic_distribution | {str(project.account_id.id): 100}
+        expected_analytic_distribution = {
+            f"{analytic_account_1.id},{analytic_account_2.id},{project.account_id.id}": 100,
+            f"{self.analytic_account_sale.id},{project.account_id.id}": 100,
+        }
         self.assertEqual(sale_order.order_line.analytic_distribution, expected_analytic_distribution)
 
         # If the project is removed from the SO, only the product's analytic distribution is still in the line
         sale_order.project_id = None
-        self.assertEqual(sale_order.order_line.analytic_distribution, distribution_model.analytic_distribution)
+        self.assertEqual(
+            sale_order.order_line.analytic_distribution,
+            distribution_model_product.analytic_distribution | distribution_model_partner.analytic_distribution
+        )
 
         # If project is added and the SO is confirmed, both analytic distributions are in the line
         sale_order.project_id = project


### PR DESCRIPTION
1. Have sales and project installed
2. Create a service product which creates a project on order
3. Set up a distribution model for this service
4. Create a sales order with this service. Confirm it.
5. The project account is added to the analytic distribution in a separate line

In odoo/odoo#199763, `_compute_analytic_distribution()` in the SO line was changed to add both project account and ditribution model accounts in the analytic distribution. However, the project account should not have its own line and should instead be added to all lines coming from Analytical Distribution Models.

no-task

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
