### PR TITLE
[FIX] html_editor: normalize tab width rounding in tests

### DIFF
--- a/addons/html_editor/static/tests/_helpers/tabs.js
+++ b/addons/html_editor/static/tests/_helpers/tabs.js
@@ -76,7 +76,7 @@ export function oeTab(size, contenteditable = true) {
     return (
         `<span class="oe-tabs"` +
         (contenteditable ? "" : ' contenteditable="false"') +
-        (size ? ` style="width: ${size.toFixed(1)}px;"` : "") +
+        (size ? ` style="width: ${Number(size.toFixed(1))}px;"` : "") +
         `>\u0009</span>\u200B`
     );
 }


### PR DESCRIPTION
Description of the issue this PR addresses:
- Trailing zeros in tab width styles cause test mismatches with browser-normalized values.

Current behavior before PR:
- Tests may use widths like "24.0px" which differ from browser output "24px".

Desired behavior after PR is merged:
- Tab widths use Number() conversion to match browser formatting and avoid test mismatches.

task-4853029

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
