### PR TITLE
[FIX] website_sale: don't add a product in GMC if it's not available for sale

### DIFF
--- a/addons/website_sale/models/product_product.py
+++ b/addons/website_sale/models/product_product.py
@@ -249,13 +249,13 @@ class ProductProduct(models.Model):
                 'link': format_product_link(product.website_url),
                 **product._prepare_gmc_identifier(),
                 **product._prepare_gmc_image_links(base_url),
-                **product._prepare_gmc_price_info(),
+                **price_info,
                 **product._prepare_gmc_shipping_info(delivery_methods_sudo, all_countries),
                 **product._prepare_gmc_stock_info(),
                 **product._prepare_gmc_additional_info(),
             }
             for product in self
-            if product._is_variant_possible()
+            if product._is_variant_possible() and (price_info := product._prepare_gmc_price_info())
         }
 
     def _prepare_gmc_identifier(self):


### PR DESCRIPTION
Currently an error is generated when the user tries to open the
XML file of the product feed to Google.

Steps to produce:
- Go to settings and enable `Google Merchant Center Data Source`
- In settings, enable `Prevent Sale of Zero-Priced Product`
- Create a product with a 0 price and publish the website
- Go to website settings and click the `Copy file link` button from 
 `Google Merchant Center Data Source`
- Open copied link  >>>  error generated

error: `XPathEvalError: Undefined namespace prefix`

This is because the method `_prepare_gmc_price_info` tries to add a `price`
key in the dict of the product in GMC XML, but to prevent sale when the product
has a zero price, it does not add a price to the GMC info at code [line](https://github.com/odoo/odoo/blob/2efb56381c4030aee246074e1318aa1c35d40eec/addons/website_sale/models/product_product.py#L305-L306).

This commit will fix the above issue by not adding product into GMC info when
the price is available in the product.

sentry-6658754370