### PR TITLE
[FIX] web: list view: date(time) column widths in bold

### DIFF
--- a/addons/web/static/src/views/list/column_width_hook.js
+++ b/addons/web/static/src/views/list/column_width_hook.js
@@ -141,8 +141,9 @@ function computeOptimalDateWidths() {
     const datetimeSpans = div.querySelectorAll(".datetimes span");
     const datetimeWidths = [...datetimeSpans].map((span) => span.getBoundingClientRect().width);
     document.body.removeChild(div);
-    _dateFieldWidth = Math.ceil(Math.max(...dateWidths)) + 1;
-    _datetimeFieldWidth = Math.ceil(Math.max(...datetimeWidths)) + 1;
+    // add a 5% margin to cope with potential bold decorations
+    _dateFieldWidth = Math.ceil(Math.max(...dateWidths) * 1.05);
+    _datetimeFieldWidth = Math.ceil(Math.max(...datetimeWidths) * 1.05);
 }
 
 /**

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -886,7 +886,7 @@ test("list daterange: column widths", async () => {
 
     expect(".o_data_row").toHaveCount(1);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 183, 300, 277]);
+    expect(columnWidths).toEqual([40, 187, 310, 263]);
 });
 
 test("list daterange: column widths (fancy format)", async () => {
@@ -925,7 +925,7 @@ test("list daterange: column widths (fancy format)", async () => {
         "",
     ]);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 361, 527, 100]);
+    expect(columnWidths).toEqual([40, 375, 549, 100]);
 });
 
 test("list daterange: column widths (show_time=false)", async () => {
@@ -952,7 +952,7 @@ test("list daterange: column widths (show_time=false)", async () => {
     expect(".o_data_row").toHaveCount(1);
     expect(queryAllTexts(".o_data_cell")).toEqual(["02/08/2017\n02/09/2017", ""]);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 183, 577]);
+    expect(columnWidths).toEqual([40, 187, 573]);
 });
 
 test("list daterange: column widths (no record)", async () => {
@@ -978,7 +978,7 @@ test("list daterange: column widths (no record)", async () => {
 
     expect(".o_data_row").toHaveCount(0);
     const columnWidths = queryAllProperties(".o_list_table thead th", "offsetWidth");
-    expect(columnWidths).toEqual([40, 183, 300, 277]);
+    expect(columnWidths).toEqual([40, 187, 310, 263]);
 });
 
 test("always range: related end date, both start date and end date empty", async () => {

--- a/addons/web/static/tests/views/fields/datetime_field.test.js
+++ b/addons/web/static/tests/views/fields/datetime_field.test.js
@@ -658,5 +658,5 @@ test("list datetime: column widths (show_time=false)", async () => {
     });
 
     expect(queryAllTexts(".o_data_row:eq(0) .o_data_cell")).toEqual(["02/08/2017", "partner,1"]);
-    expect(queryAllProperties(".o_list_table thead th", "offsetWidth")).toEqual([40, 81, 679]);
+    expect(queryAllProperties(".o_list_table thead th", "offsetWidth")).toEqual([40, 83, 677]);
 });

--- a/addons/web/static/tests/views/list/column_widths.test.js
+++ b/addons/web/static/tests/views/list/column_widths.test.js
@@ -153,7 +153,7 @@ test(`width computation: no record, lot of fields`, async () => {
                 <field name="currency_id"/>
             </list>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 83, 144, 114, 100]);
 });
 
 test(`width computation: no record, few fields`, async () => {
@@ -220,7 +220,7 @@ test(`width computation: with records, lot of fields`, async () => {
                 <field name="currency_id"/>
             </list>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 83, 144, 114, 100]);
 });
 
 test(`width computation: with records, lot of fields, grouped`, async () => {
@@ -243,7 +243,7 @@ test(`width computation: with records, lot of fields, grouped`, async () => {
         groupBy: ["int_field"],
     });
     expect(`.o_resize`).toHaveCount(9);
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 81, 139, 114, 45]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 89, 102, 83, 144, 114, 45]);
 });
 
 test(`width computation: with records, few fields`, async () => {
@@ -272,7 +272,7 @@ test(`width computation: with records, no relative fields`, async () => {
                 <field name="date"/>
             </list>`,
     });
-    expect(getColumnWidths()).toEqual([40, 203, 174, 196, 186]);
+    expect(getColumnWidths()).toEqual([40, 203, 174, 196, 188]);
 });
 
 test(`width computation: with records, very long text field`, async () => {
@@ -318,7 +318,7 @@ test(`width computation: with records, lot of fields, long texts`, async () => {
                 <field name="currency_id"/>
             </list>`,
     });
-    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 102, 81, 89, 139, 114, 100]);
+    expect(getColumnWidths()).toEqual([40, 29, 89, 80, 102, 83, 89, 144, 114, 100]);
 });
 
 test(`width computation: editable list, overflowing table`, async () => {
@@ -481,7 +481,7 @@ test(`width computation: date and datetime with fancy formats`, async () => {
         "Wed, 25 January 2017",
         "Mon, 12 December 2016 11:55:05 AM",
     ]);
-    expect(getColumnWidths()).toEqual([40, 325, 170, 265]);
+    expect(getColumnWidths()).toEqual([40, 307, 177, 276]);
 });
 
 test(`width computation: date and datetime with fancy formats (2)`, async () => {
@@ -514,7 +514,7 @@ test(`width computation: date and datetime with fancy formats (2)`, async () => 
         "2017aJana25",
         "2016aDeca12 115505aAM",
     ]);
-    expect(getColumnWidths()).toEqual([40, 470, 99, 191]);
+    expect(getColumnWidths()).toEqual([40, 459, 103, 198]);
 });
 
 test(`width computation: width attribute in arch and overflowing table`, async () => {
@@ -537,7 +537,7 @@ test(`width computation: width attribute in arch and overflowing table`, async (
             </list>
         `,
     });
-    expect(getColumnWidths()).toEqual([40, 139, 210, 411]);
+    expect(getColumnWidths()).toEqual([40, 144, 210, 406]);
 });
 
 test(`width computation: no record, nameless and stringless buttons`, async () => {
@@ -1219,20 +1219,20 @@ test(`freeze widths: toggle optional fields`, async () => {
         `,
     });
 
-    expect(getColumnWidths()).toEqual([40, 81, 507, 139, 32]);
+    expect(getColumnWidths()).toEqual([40, 83, 500, 144, 32]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input:eq(0)").click();
-    expect(getColumnWidths()).toEqual([40, 81, 405, 102, 140, 32]);
+    expect(getColumnWidths()).toEqual([40, 83, 397, 102, 145, 32]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 81, 544, 102, 32]);
+    expect(getColumnWidths()).toEqual([40, 83, 542, 102, 32]);
 
     await contains(".dropdown-item input:eq(2)").click();
-    expect(getColumnWidths()).toEqual([40, 81, 89, 102, 455, 32]);
+    expect(getColumnWidths()).toEqual([40, 83, 89, 102, 453, 32]);
 
     await contains(".dropdown-item input:eq(1)").click();
-    expect(getColumnWidths()).toEqual([40, 81, 89, 103, 140, 315, 32]);
+    expect(getColumnWidths()).toEqual([40, 83, 89, 103, 145, 308, 32]);
 });
 
 test(`freeze widths: x2many, add first record`, async () => {
@@ -1329,16 +1329,16 @@ test(`freeze widths: x2many, toggle optional field`, async () => {
             </form>`,
     });
 
-    expect(getColumnWidths()).toEqual([92, 644, 32]);
+    expect(getColumnWidths()).toEqual([94, 642, 32]);
 
     // create a record to store the current widths, but discard it directly to keep
     // the list empty (otherwise, the browser automatically computes the optimal widths)
     await contains(".o_field_x2many_list_row_add a").click();
-    expect(getColumnWidths()).toEqual([92, 644, 32]);
+    expect(getColumnWidths()).toEqual([94, 642, 32]);
 
     await contains(".o_optional_columns_dropdown_toggle").click();
     await contains(".dropdown-item input").click();
-    expect(getColumnWidths()).toEqual([92, 563, 80, 32]);
+    expect(getColumnWidths()).toEqual([94, 561, 80, 32]);
 });
 
 // manually resize columns


### PR DESCRIPTION
This commit is a followup of [1] where we compute the minimum required width for date and datetime fields in list views. However, it didn't take into account decorations that could be applied to list views, in particular `decoration-bf`, which may, for certain fonts, increase the width of date values. We tested all languages, on different systems (thus different standard fonts), and an increase of 5% of the computed width is enough on those systems to display date and datetimes without an ellipsis, even in bold.

[1] odoo/odoo#210584

No task, issue reported on our prod

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
