### PR TITLE
[REF] im_livechat: clean get_session

### DIFF
--- a/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
+++ b/addons/test_discuss_full/tests/test_livechat_hr_holidays.py
@@ -5,10 +5,11 @@ from dateutil.relativedelta import relativedelta
 from odoo import Command, fields
 from odoo.tests.common import tagged
 from odoo.addons.mail.tests.common import MailCommon
+from odoo.addons.im_livechat.tests.common import TestGetOperatorCommon
 
 
 @tagged("post_install", "-at_install")
-class TestLivechatHrHolidays(MailCommon):
+class TestLivechatHrHolidays(MailCommon, TestGetOperatorCommon):
     """Tests for bridge between im_livechat and hr_holidays modules."""
 
     @classmethod
@@ -47,8 +48,6 @@ class TestLivechatHrHolidays(MailCommon):
                 "user_ids": [Command.link(self.user_employee.id)],
             }
         )
-        self.env["discuss.channel"].create(
-            livechat_channel._get_livechat_discuss_channel_vals(anonymous_name="Visitor")
-        )
+        self._create_chat(livechat_channel, self.user_employee)
         self.assertEqual(self.user_employee.im_status, "leave_online")
         self.assertFalse(livechat_channel.available_operator_ids)

--- a/addons/website_livechat/models/im_livechat_channel.py
+++ b/addons/website_livechat/models/im_livechat_channel.py
@@ -6,12 +6,10 @@ from odoo import api, models
 class Im_LivechatChannel(models.Model):
     _inherit = 'im_livechat.channel'
 
-    def _get_livechat_discuss_channel_vals(self, anonymous_name, previous_operator_id=None, chatbot_script=None, user_id=None, country_id=None, lang=None):
+    def _get_livechat_discuss_channel_vals(self, anonymous_name, agent=None, bot=None, country_id=None):
         discuss_channel_vals = super()._get_livechat_discuss_channel_vals(
-            anonymous_name, previous_operator_id, chatbot_script, user_id=user_id, country_id=country_id, lang=lang
+            anonymous_name, agent=agent, bot=bot, country_id=country_id
         )
-        if not discuss_channel_vals:
-            return False
         visitor_sudo = self.env['website.visitor']._get_visitor_from_request()
         if visitor_sudo:
             discuss_channel_vals['livechat_visitor_id'] = visitor_sudo.id


### PR DESCRIPTION
Live chat agents want to distinguish between agents who requested help, were assigned to help, or were just present. Until now, the only field related to the agent’s identity was `livechat_operator_id`.

However, this field is unreliable: it’s not consistently updated during escalations, sometimes changes during chatbot processing, and mixes real agents with bots.

This commit prepares for its removal. Agent-related information will instead be derived from the member history. Over time, `get_session` has become messy. Adding more complexity is not ideal. This commit simplifies `get_session` by separating agent/bot assignment from channel value computation.

part of task-4826560