### PR TITLE
[DRAFT][IMP] hr_holidays: Overview see everybody in my teams filter

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report_calendar.xml
+++ b/addons/hr_holidays/report/hr_leave_report_calendar.xml
@@ -56,7 +56,7 @@
                 <field name="employee_id"/>
                 <field name="department_id"/>
                 <field name="job_id"/>
-                <filter name="my_team" string="My Team" domain="['|', ('employee_id.user_id', '=', uid), ('employee_id.parent_id.user_id', '=', uid)]"/>
+                <filter name="my_team" string="My Team" domain="['|', ('employee_id.user_id', '=', uid), ('employee_id.parent_id.user_id', '=', uid)]" context="{'leave_report_show_all_resources': True}"/>
                 <filter string="My Department" name="department"
                         domain="[('employee_id.member_of_department', '=', True)]"
                         help="My Department"/>


### PR DESCRIPTION
### Before:
- In gantt view we were only showing the employee who has a timeoff present.

### After:
- Added the `get_gantt_data` method to display all employees in the time off overview, even if they have no time off, when the filter is checked from the default filter.

task-4852912

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
