### PR TITLE
[IMP] payment: save live/test information on transactions

### DIFF
--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -87,6 +87,11 @@ class PaymentTransaction(models.Model):
         readonly=True,
         index=True,
     )
+    is_live = fields.Boolean(
+        string="Production Environment",
+        help="Whether the transaction happened in a production environment. False for transactions"
+             " created before this tracking was implemented.",
+    )
     source_transaction_id = fields.Many2one(
         string="Source Transaction",
         comodel_name='payment.transaction',
@@ -177,6 +182,8 @@ class PaymentTransaction(models.Model):
 
             if not values.get('reference'):
                 values['reference'] = self._compute_reference(provider.code, **values)
+
+            values['is_live'] = provider.state == 'enabled'
 
             # Duplicate partner values.
             partner = self.env['res.partner'].browse(values['partner_id'])

--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -12,6 +12,16 @@ from odoo.addons.payment.tests.common import PaymentCommon
 @tagged('-at_install', 'post_install')
 class TestPaymentTransaction(PaymentCommon):
 
+    def test_is_live_when_created_by_enabled_provider(self):
+        self.provider.state = 'enabled'
+        tx = self._create_transaction('redirect')
+        self.assertTrue(tx.is_live)
+
+    def test_is_not_live_when_created_by_test_provider(self):
+        self.provider.state = 'test'  # Will work with anything other than 'enabled'
+        tx = self._create_transaction('redirect')
+        self.assertFalse(tx.is_live)
+
     def test_capture_allowed_for_authorized_users(self):
         """ Test that users who have access to a transaction can capture it. """
         if not self.env.ref('account.group_account_invoice', raise_if_not_found=False):

--- a/addons/payment/views/payment_transaction_views.xml
+++ b/addons/payment/views/payment_transaction_views.xml
@@ -38,6 +38,7 @@
                             <field name="token_id" invisible="not token_id"/>
                             <field name="create_date"/>
                             <field name="last_state_change"/>
+                            <field name="is_live"/>
                             <field name="is_post_processed" groups="base.group_no_one"/>
                         </group>
                         <group name="transaction_partner">
@@ -81,6 +82,7 @@
                 <field name="amount"/>
                 <field name="state"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
+                <field name="is_live" optional="hide"/>
             </list>
         </field>
     </record>
@@ -113,10 +115,20 @@
                 <field name="provider_id"/>
                 <field name="partner_id"/>
                 <field name="partner_name"/>
+                <filter
+                    string="Production Environment"
+                    name="live_transactions"
+                    domain="[('is_live', '=', True)]"
+                />
                 <group>
                     <filter string="Provider" name="provider_id" context="{'group_by': 'provider_id'}"/>
                     <filter string="Partner" name="partner_id" context="{'group_by': 'partner_id'}"/>
                     <filter string="Status" name="state" context="{'group_by': 'state'}"/>
+                    <filter
+                        string="Production Environment"
+                        name="is_live"
+                        context="{'group_by': 'is_live'}"
+                    />
                     <filter string="Company" name="company" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>
                 </group>
             </search>


### PR DESCRIPTION
This commit saves to the payment transactions a flag indicating whether the transaction was made on a live transaction or not in order to compute better statistics on the number of live transactions per provider and their total amount.

task-4818740