### PR TITLE
[FIX] l10n_it: Set English default for tax group subtotal labels

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -46,6 +46,7 @@ class AccountTaxGroup(models.Model):
         string="Preceding Subtotal",
         help="If set, this value will be used on documents as the label of a subtotal excluding this tax group before displaying it. " \
              "If not set, the tax group will be displayed after the 'Untaxed amount' subtotal.",
+        translate=True,
     )
 
     @api.model

--- a/addons/l10n_it/data/account.tax.group.csv
+++ b/addons/l10n_it/data/account.tax.group.csv
@@ -1,12 +1,12 @@
 id,name,country_id/id,preceding_subtotal
-tax_group_iva_2,IVA 2%,base.it,Imponibile
-tax_group_iva_4,IVA 4%,base.it,Imponibile
-tax_group_iva_5,IVA 5%,base.it,Imponibile
-tax_group_iva_10,IVA 10%,base.it,Imponibile
-tax_group_iva_12,IVA 12%,base.it,Imponibile
-tax_group_iva_21,IVA 21%,base.it,Imponibile
-tax_group_iva_20,IVA 20%,base.it,Imponibile
-tax_group_iva_22,IVA 22%,base.it,Imponibile
-tax_group_imp_esc_art_15,Imponibile Escluso Art.15,base.it,Imponibile
-tax_group_fuori,Fuori Campo IVA,base.it,Imponibile
-tax_group_split_payment,Scissione dei Pagamenti,base.it,Scissione dei Pagamenti Esclusa
+tax_group_iva_2,IVA 2%,base.it,Taxable
+tax_group_iva_4,IVA 4%,base.it,Taxable
+tax_group_iva_5,IVA 5%,base.it,Taxable
+tax_group_iva_10,IVA 10%,base.it,Taxable
+tax_group_iva_12,IVA 12%,base.it,Taxable
+tax_group_iva_21,IVA 21%,base.it,Taxable
+tax_group_iva_20,IVA 20%,base.it,Taxable
+tax_group_iva_22,IVA 22%,base.it,Taxable
+tax_group_imp_esc_art_15,Imponibile Escluso Art.15,base.it,Taxable
+tax_group_fuori,Fuori Campo IVA,base.it,Taxable
+tax_group_split_payment,Scissione dei Pagamenti,base.it,Split Payments Excluded

--- a/addons/l10n_it/i18n/it.po
+++ b/addons/l10n_it/i18n/it.po
@@ -1,0 +1,624 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * l10n_it
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-10 14:03+0000\n"
+"PO-Revision-Date: 2025-06-10 14:03+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_chart_template
+msgid "Account Chart Template"
+msgstr "Modello piano dei conti"
+
+#. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_report_expression
+msgid "Accounting Report Expression"
+msgstr "Espressione rendiconto contabile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
+msgid "Altre operazioni"
+msgstr "Altre operazioni"
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_report_vat_balance
+msgid "Balance"
+msgstr "Saldo"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_1
+msgid ""
+"Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in "
+"caso di superamento di 1/3"
+msgstr "Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in caso di superamento di 1/3)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_conto_corrente_iva
+msgid "Conto corrente IVA"
+msgstr "Conto corrente IVA"
+
+#. module: l10n_it
+#: model_terms:account.fiscal.position,note:l10n_it.1_intra
+#: model_terms:account.fiscal.position,note:l10n_it.2_intra
+msgid ""
+"Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, "
+"l’applicazione dell’IVA è a carico del destinatario."
+msgstr "Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, l’applicazione dell’IVA è a carico del destinatario."
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_fuori
+msgid "Fuori Campo IVA"
+msgstr "Fuori Campo IVA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_iva
+msgid "IVA"
+msgstr "IVA"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_10
+msgid "IVA 10%"
+msgstr "IVA 10%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_12
+msgid "IVA 12%"
+msgstr "IVA 12%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_2
+msgid "IVA 2%"
+msgstr "IVA 2%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_20
+msgid "IVA 20%"
+msgstr "IVA 20%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_21
+msgid "IVA 21%"
+msgstr "IVA 21%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_22
+msgid "IVA 22%"
+msgstr "IVA 22%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_4
+msgid "IVA 4%"
+msgstr "IVA 4%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_5
+msgid "IVA 5%"
+msgstr "IVA 5%"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_imp_esc_art_15
+msgid "Imponibile Escluso Art.15"
+msgstr "Imponibile Escluso Art.15"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_operazione_imponibile
+msgid "Operazione Imponibile"
+msgstr "Operazione Imponibile"
+
+#. module: l10n_it
+#: model_terms:account.fiscal.position,note:l10n_it.1_split_payment_fiscal_position
+#: model_terms:account.fiscal.position,note:l10n_it.2_split_payment_fiscal_position
+msgid ""
+"Operazione soggetta a split payment – il cedente non incassa l’Iva ai sensi "
+"dell’ex art.17-ter del D.P.R. 633/1972, l’acquirente è obbligato al "
+"versamento all’Agenzia delle Entrate."
+msgstr "Operazione soggetta a split payment – il cedente non incassa l’Iva ai sensi dell’ex art.17-ter del D.P.R. 633/1972, l’acquirente è obbligato al versamento all’Agenzia delle Entrate."
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
+msgid ""
+"Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili "
+"commerciali e professional"
+msgstr "Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili commerciali e professionali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_reverse_charge_iva
+msgid "Reverse Charge"
+msgstr "Inversione contabile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_saldi_riporti_e_interessi
+msgid "Saldi, riporti e interessi"
+msgstr "Saldi, riporti e interessi"
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_split_payment
+msgid "Scissione dei Pagamenti"
+msgstr "Scissione dei Pagamenti"
+
+#. module: l10n_it
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_split_payment
+msgid "Split Payments Excluded"
+msgstr "Scissione Pagamenti Esclusa"
+
+#. module: l10n_it
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_fuori
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_imp_esc_art_15
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_10
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_12
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_2
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_20
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_21
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_22
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_4
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_5
+msgid "Taxable"
+msgstr "Imponibile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
+msgid "Totale imponibile e imposta"
+msgstr "Totale imponibile e imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover
+msgid "Turnover"
+msgstr "Fatturato"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_report_vat
+msgid "VAT Report"
+msgstr "Rendiconto IVA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve1
+msgid ""
+"VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 2%"
+msgstr "VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 2%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve10
+msgid ""
+"VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di "
+"compensazione 10%"
+msgstr "VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 10%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve11
+msgid ""
+"VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di "
+"compensazione 12,3%"
+msgstr "VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 12,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve2
+msgid ""
+"VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 4%"
+msgstr "VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve20
+msgid "VE20 - Operazioni imponibili aliquota 4%"
+msgstr "VE20 - Operazioni imponibili aliquota 4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve21
+msgid "VE21 - Operazioni imponibili aliquota 5%"
+msgstr "VE21 - Operazioni imponibili aliquota 5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve22
+msgid "VE22 - Operazioni imponibili aliquota 10%"
+msgstr "VE22 - Operazioni imponibili aliquota 10%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve23
+msgid "VE23 - Operazioni imponibili aliquota 22%"
+msgstr "VE23 - Operazioni imponibili aliquota 22%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve24
+msgid "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
+msgstr "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve25
+msgid "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
+msgstr "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve26
+msgid "VE26 - Totale VE24 e VE25"
+msgstr "VE26 - Totale VE24 e VE25"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve3
+msgid ""
+"VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 6,4%"
+msgstr "VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 6,4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30
+msgid "VE30 - Operazioni che concorrono alla formazione del plafond"
+msgstr "VE30 - Operazioni che concorrono alla formazione del plafond"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_I
+msgid "VE30_I - Totale"
+msgstr "VE30_I - Totale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_ii
+msgid "VE30_II - Esportazioni"
+msgstr "VE30_II - Esportazioni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_iii
+msgid "VE30_III - Cessioni intracomunitarie"
+msgstr "VE30_III - Cessioni intracomunitarie"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_iv
+msgid "VE30_IV - Cessioni verso San Marino"
+msgstr "VE30_IV - Cessioni verso San Marino"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_v
+msgid "VE30_V - Operazioni assimilate"
+msgstr "VE30_V - Operazioni assimilate"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve31
+msgid "VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
+msgstr "VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve32
+msgid "VE32 - Altre operazioni non imponibili"
+msgstr "VE32 - Altre operazioni non imponibili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve33
+msgid "VE33 - Operazioni esenti (art.10"
+msgstr "VE33 - Operazioni esenti (art.10)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve34
+msgid ""
+"VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a "
+"7-septies"
+msgstr "VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a 7-septies"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35
+msgid "VE35 - Operazioni con applicazione del reverse charge interno"
+msgstr "VE35 - Operazioni con applicazione del reverse charge interno"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_I
+msgid "VE35_I - Total"
+msgstr "VE35_I - Totale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_ii
+msgid "VE35_II - Cessioni di rottami e altri materiali di recupero"
+msgstr "VE35_II - Cessioni di rottami e altri materiali di recupero"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_iii
+msgid "VE35_III - Cessioni di oro e argento puro"
+msgstr "VE35_III - Cessioni di oro e argento puro"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_iv
+msgid "VE35_IV - Subappalto nel settore edile"
+msgstr "VE35_IV - Subappalto nel settore edile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_ix
+msgid "VE35_IX - Operazioni settore energetico"
+msgstr "VE35_IX - Operazioni settore energetico"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_v
+msgid "VE35_V - Cessioni di fabbricati strumentali"
+msgstr "VE35_V - Cessioni di fabbricati strumentali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_vi
+msgid "VE35_VI - Cessioni di telefoni cellulari"
+msgstr "VE35_VI - Cessioni di telefoni cellulari"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_vii
+msgid "VE35_VII - Cessioni di prodotti elettronici"
+msgstr "VE35_VII - Cessioni di prodotti elettronici"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_viii
+msgid "VE35_VIII - Prestazioni comparto edile e settori connessi"
+msgstr "VE35_VIII - Prestazioni comparto edile e settori connessi"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve36
+msgid ""
+"VE36 - Operazioni non soggette all\"imposta effettuate nei confronti dei "
+"terremotati"
+msgstr "VE36 - Operazioni non soggette all'imposta effettuate nei confronti dei terremotati"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37
+msgid ""
+"VE37 - Operazioni effettuate nell\"anno ma con imposta esigibile negli anni "
+"successivi"
+msgstr "VE37 - Operazioni effettuate nell'anno ma con imposta esigibile negli anni successivi"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37_I
+msgid "VE37_I - Total"
+msgstr "VE37_I - Totale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37_ii
+msgid "VE37_II - ex art. 32-bis, DL n. 83/2012"
+msgstr "VE37_II - ex art. 32-bis, DL n. 83/2012"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve38
+msgid "VE38 - Operazioni nei confronti di soggetti di cui all\"art.17-ter"
+msgstr "VE38 - Operazioni nei confronti di soggetti di cui all'art.17-ter"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve39
+msgid ""
+"VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta "
+"esigibile nel 2022"
+msgstr "VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta esigibile nel 2022"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve4
+msgid ""
+"VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 7,3%"
+msgstr "VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve40
+msgid "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
+msgstr "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve5
+msgid ""
+"VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 7,5%"
+msgstr "VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve6
+msgid ""
+"VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,3%"
+msgstr "VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve7
+msgid ""
+"VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,5%"
+msgstr "VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve8
+msgid ""
+"VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,8%"
+msgstr "VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,8%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve9
+msgid ""
+"VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 9,5%"
+msgstr "VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 9,5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj1
+msgid "VJ1 - Acquisti di beni dalla Città del Vaticano e da San Marino"
+msgstr "VJ1 - Acquisti di beni dalla Città del Vaticano e da San Marino"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj10
+msgid "VJ10 - Importazioni di rottami e altri materiali di recupero"
+msgstr "VJ10 - Importazioni di rottami e altri materiali di recupero"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj11
+msgid "VJ11 - Importazioni di oro industriale e argento puro"
+msgstr "VJ11 - Importazioni di oro industriale e argento puro"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj12
+msgid "VJ12 - Subappalto di servizi in campo edile"
+msgstr "VJ12 - Subappalto di servizi in campo edile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj13
+msgid "VJ13 - Acquisti di fabbricati o porzioni di fabbricati strumentali"
+msgstr "VJ13 - Acquisti di fabbricati o porzioni di fabbricati strumentali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj14
+msgid "VJ14 - Acquisti di telefoni cellulari"
+msgstr "VJ14 - Acquisti di telefoni cellulari"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj15
+msgid "VJ15 - Acquisti di prodotti elettronici"
+msgstr "VJ15 - Acquisti di prodotti elettronici"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj16
+msgid "VJ16 - Prestazioni di servizi in campo edile"
+msgstr "VJ16 - Prestazioni di servizi in campo edile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj17
+msgid "VJ17 - Acquiti di beni e servizi del settore energetico"
+msgstr "VJ17 - Acquisti di beni e servizi del settore energetico"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj18
+msgid ""
+"VJ18 - acquisti effettuati dalle pubbliche amministrazioni titolari di "
+"partita IVA"
+msgstr "VJ18 - acquisti effettuati dalle pubbliche amministrazioni titolari di partita IVA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj19
+msgid "VJ19 - Totale quadro VJ"
+msgstr "VJ19 - Totale quadro VJ"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj2
+msgid "VJ2 - Estrazione di beni da depositi Iva"
+msgstr "VJ2 - Estrazione di beni da depositi Iva"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj3
+msgid ""
+"VJ3 - Acquisti di beni giá presenti in Italia o servizi, da soggetti non "
+"residenti"
+msgstr "VJ3 - Acquisti di beni giá presenti in Italia o servizi, da soggetti non residenti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj4
+msgid ""
+"VJ4 - Compensi corrisposti ai rivenditori di biglietti di viaggio ed ai "
+"rivenditori di documenti di sosta "
+msgstr "VJ4 - Compensi corrisposti ai rivenditori di biglietti di viaggio ed ai rivenditori di documenti di sosta "
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj5
+msgid ""
+"VJ5 - Provvigioni corrisposte dalle agenzie di viaggio ai propri "
+"intermediari"
+msgstr "VJ5 - Provvigioni corrisposte dalle agenzie di viaggio ai propri intermediari"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj6
+msgid "VJ6 - Acquisti di rottami e altri materiali di recupero"
+msgstr "VJ6 - Acquisti di rottami e altri materiali di recupero"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj7
+msgid "VJ7 - Acquisti di oro industriale e argento puro effettuati in Italia"
+msgstr "VJ7 - Acquisti di oro industriale e argento puro effettuati in Italia"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj8
+msgid "VJ8 - Acquisti di oro da investimento effettuati in Italia"
+msgstr "VJ8 - Acquisti di oro da investimento effettuati in Italia"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj9
+msgid "VJ9 - Acquisti intracomunitari di beni"
+msgstr "VJ9 - Acquisti intracomunitari di beni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp10
+msgid "VP10 - Versamenti auto UE"
+msgstr "VP10 - Versamenti auto UE"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp11
+msgid "VP11 - Credito d'imposta"
+msgstr "VP11 - Credito d'imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp12
+msgid "VP12 - Interessi dovuti per liquidazioni trimestrali"
+msgstr "VP12 - Interessi dovuti per liquidazioni trimestrali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp13
+msgid "VP13 - Acconto dovuto"
+msgstr "VP13 - Acconto dovuto"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14
+msgid "VP14 - IVA da versare"
+msgstr "VP14 - IVA da versare"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14a
+msgid "VP14a - IVA da versare (debito)"
+msgstr "VP14a - IVA da versare (debito)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14b
+msgid "VP14b - IVA da versare (credito)"
+msgstr "VP14b - IVA da versare (credito)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp2
+msgid "VP2 - Totale operazioni attive"
+msgstr "VP2 - Totale operazioni attive"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp3
+msgid "VP3 - Totale operazioni passive"
+msgstr "VP3 - Totale operazioni passive"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp4
+msgid "VP4 - IVA esigibile"
+msgstr "VP4 - IVA esigibile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp5
+msgid "VP5 - IVA detraibile"
+msgstr "VP5 - IVA detraibile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6
+msgid "VP6 - IVA dovuta"
+msgstr "VP6 - IVA dovuta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6a
+msgid "VP6a - IVA dovuta (debito)"
+msgstr "VP6a - IVA dovuta (debito)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6b
+msgid "VP6b - IVA dovuta (credito)"
+msgstr "VP6b - IVA dovuta (credito)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp7
+msgid "VP7 - Debito periodo precedente non superiore 25,82"
+msgstr "VP7 - Debito periodo precedente non superiore 25,82"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp8
+msgid "VP8 - Credito periodo precedente"
+msgstr "VP8 - Credito periodo precedente"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp9
+msgid "VP9 - Credito anno precedente"
+msgstr "VP9 - Credito anno precedente"

--- a/addons/l10n_it/i18n/l10n_it.pot
+++ b/addons/l10n_it/i18n/l10n_it.pot
@@ -1,0 +1,624 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_it
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-10 14:01+0000\n"
+"PO-Revision-Date: 2025-06-10 14:01+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_report_expression
+msgid "Accounting Report Expression"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
+msgid "Altre operazioni"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_report_vat_balance
+msgid "Balance"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_1
+msgid ""
+"Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in "
+"caso di superamento di 1/3"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_conto_corrente_iva
+msgid "Conto corrente IVA"
+msgstr ""
+
+#. module: l10n_it
+#: model_terms:account.fiscal.position,note:l10n_it.1_intra
+#: model_terms:account.fiscal.position,note:l10n_it.2_intra
+msgid ""
+"Fattura emessa ai sensi dell’art. 17, comma 2 del DPR 26/10/1972 n. 633, "
+"l’applicazione dell’IVA è a carico del destinatario."
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_fuori
+msgid "Fuori Campo IVA"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_iva
+msgid "IVA"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_10
+msgid "IVA 10%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_12
+msgid "IVA 12%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_2
+msgid "IVA 2%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_20
+msgid "IVA 20%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_21
+msgid "IVA 21%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_22
+msgid "IVA 22%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_4
+msgid "IVA 4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_iva_5
+msgid "IVA 5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_imp_esc_art_15
+msgid "Imponibile Escluso Art.15"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_operazione_imponibile
+msgid "Operazione Imponibile"
+msgstr ""
+
+#. module: l10n_it
+#: model_terms:account.fiscal.position,note:l10n_it.1_split_payment_fiscal_position
+#: model_terms:account.fiscal.position,note:l10n_it.2_split_payment_fiscal_position
+msgid ""
+"Operazione soggetta a split payment – il cedente non incassa l’Iva ai sensi "
+"dell’ex art.17-ter del D.P.R. 633/1972, l’acquirente è obbligato al "
+"versamento all’Agenzia delle Entrate."
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
+msgid ""
+"Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili "
+"commerciali e professional"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_reverse_charge_iva
+msgid "Reverse Charge"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_saldi_riporti_e_interessi
+msgid "Saldi, riporti e interessi"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,name:l10n_it.tax_group_split_payment
+msgid "Scissione dei Pagamenti"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_split_payment
+msgid "Split Payments Excluded"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_fuori
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_imp_esc_art_15
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_10
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_12
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_2
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_20
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_21
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_22
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_4
+#: model:account.tax.group,preceding_subtotal:l10n_it.tax_group_iva_5
+msgid "Taxable"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
+msgid "Totale imponibile e imposta"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover
+msgid "Turnover"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_report_vat
+msgid "VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve1
+msgid ""
+"VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 2%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve10
+msgid ""
+"VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di "
+"compensazione 10%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve11
+msgid ""
+"VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di "
+"compensazione 12,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve2
+msgid ""
+"VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve20
+msgid "VE20 - Operazioni imponibili aliquota 4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve21
+msgid "VE21 - Operazioni imponibili aliquota 5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve22
+msgid "VE22 - Operazioni imponibili aliquota 10%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve23
+msgid "VE23 - Operazioni imponibili aliquota 22%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve24
+msgid "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve25
+msgid "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve26
+msgid "VE26 - Totale VE24 e VE25"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve3
+msgid ""
+"VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 6,4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30
+msgid "VE30 - Operazioni che concorrono alla formazione del plafond"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_I
+msgid "VE30_I - Totale"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_ii
+msgid "VE30_II - Esportazioni"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_iii
+msgid "VE30_III - Cessioni intracomunitarie"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_iv
+msgid "VE30_IV - Cessioni verso San Marino"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve30_v
+msgid "VE30_V - Operazioni assimilate"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve31
+msgid "VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve32
+msgid "VE32 - Altre operazioni non imponibili"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve33
+msgid "VE33 - Operazioni esenti (art.10"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve34
+msgid ""
+"VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a "
+"7-septies"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35
+msgid "VE35 - Operazioni con applicazione del reverse charge interno"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_I
+msgid "VE35_I - Total"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_ii
+msgid "VE35_II - Cessioni di rottami e altri materiali di recupero"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_iii
+msgid "VE35_III - Cessioni di oro e argento puro"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_iv
+msgid "VE35_IV - Subappalto nel settore edile"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_ix
+msgid "VE35_IX - Operazioni settore energetico"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_v
+msgid "VE35_V - Cessioni di fabbricati strumentali"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_vi
+msgid "VE35_VI - Cessioni di telefoni cellulari"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_vii
+msgid "VE35_VII - Cessioni di prodotti elettronici"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve35_viii
+msgid "VE35_VIII - Prestazioni comparto edile e settori connessi"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve36
+msgid ""
+"VE36 - Operazioni non soggette all\"imposta effettuate nei confronti dei "
+"terremotati"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37
+msgid ""
+"VE37 - Operazioni effettuate nell\"anno ma con imposta esigibile negli anni "
+"successivi"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37_I
+msgid "VE37_I - Total"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve37_ii
+msgid "VE37_II - ex art. 32-bis, DL n. 83/2012"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve38
+msgid "VE38 - Operazioni nei confronti di soggetti di cui all\"art.17-ter"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve39
+msgid ""
+"VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta "
+"esigibile nel 2022"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve4
+msgid ""
+"VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 7,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve40
+msgid "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve5
+msgid ""
+"VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 7,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve6
+msgid ""
+"VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve7
+msgid ""
+"VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve8
+msgid ""
+"VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 8,8%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_ve9
+msgid ""
+"VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
+" 9,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj1
+msgid "VJ1 - Acquisti di beni dalla Città del Vaticano e da San Marino"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj10
+msgid "VJ10 - Importazioni di rottami e altri materiali di recupero"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj11
+msgid "VJ11 - Importazioni di oro industriale e argento puro"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj12
+msgid "VJ12 - Subappalto di servizi in campo edile"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj13
+msgid "VJ13 - Acquisti di fabbricati o porzioni di fabbricati strumentali"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj14
+msgid "VJ14 - Acquisti di telefoni cellulari"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj15
+msgid "VJ15 - Acquisti di prodotti elettronici"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj16
+msgid "VJ16 - Prestazioni di servizi in campo edile"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj17
+msgid "VJ17 - Acquiti di beni e servizi del settore energetico"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj18
+msgid ""
+"VJ18 - acquisti effettuati dalle pubbliche amministrazioni titolari di "
+"partita IVA"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj19
+msgid "VJ19 - Totale quadro VJ"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj2
+msgid "VJ2 - Estrazione di beni da depositi Iva"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj3
+msgid ""
+"VJ3 - Acquisti di beni giá presenti in Italia o servizi, da soggetti non "
+"residenti"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj4
+msgid ""
+"VJ4 - Compensi corrisposti ai rivenditori di biglietti di viaggio ed ai "
+"rivenditori di documenti di sosta "
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj5
+msgid ""
+"VJ5 - Provvigioni corrisposte dalle agenzie di viaggio ai propri "
+"intermediari"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj6
+msgid "VJ6 - Acquisti di rottami e altri materiali di recupero"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj7
+msgid "VJ7 - Acquisti di oro industriale e argento puro effettuati in Italia"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj8
+msgid "VJ8 - Acquisti di oro da investimento effettuati in Italia"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vj9
+msgid "VJ9 - Acquisti intracomunitari di beni"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp10
+msgid "VP10 - Versamenti auto UE"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp11
+msgid "VP11 - Credito d'imposta"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp12
+msgid "VP12 - Interessi dovuti per liquidazioni trimestrali"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp13
+msgid "VP13 - Acconto dovuto"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14
+msgid "VP14 - IVA da versare"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14a
+msgid "VP14a - IVA da versare (debito)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp14b
+msgid "VP14b - IVA da versare (credito)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp2
+msgid "VP2 - Totale operazioni attive"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp3
+msgid "VP3 - Totale operazioni passive"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp4
+msgid "VP4 - IVA esigibile"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp5
+msgid "VP5 - IVA detraibile"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6
+msgid "VP6 - IVA dovuta"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6a
+msgid "VP6a - IVA dovuta (debito)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp6b
+msgid "VP6b - IVA dovuta (credito)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp7
+msgid "VP7 - Debito periodo precedente non superiore 25,82"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp8
+msgid "VP8 - Credito periodo precedente"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_report_line_vp9
+msgid "VP9 - Credito anno precedente"
+msgstr ""


### PR DESCRIPTION
The Italian localization defined 'preceding_subtotal' in tax group records using the Italian term "Imponibile" as the default value. This caused the label for untaxed amounts in invoices, sale orders, and purchase orders to always appear in Italian, regardless of the system or partner language.

Since this field is translatable, the correct approach is to define the default in English (e.g., "Untaxed Amount") and provide Italian translations via .po files.

This commit removes the hardcoded Italian values, enabling proper language-sensitive display of tax totals.

task-4853046

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
