### PR TITLE
[IMP] im_livechat: identify agents who requested help

### DIFF
--- a/addons/im_livechat/report/im_livechat_report_channel.py
+++ b/addons/im_livechat/report/im_livechat_report_channel.py
@@ -62,6 +62,16 @@ class Im_LivechatReportChannel(models.Model):
     chatbot_answers_path = fields.Char("Chatbot Answers", readonly=True)
     chatbot_answers_path_str = fields.Char("Chatbot Answers (String)", readonly=True)
     session_expertises = fields.Char("Expertises used in this session", readonly=True)
+    agent_requesting_help_history = fields.Many2one(
+        "im_livechat.channel.member.history",
+        related="channel_id.livechat_agent_requesting_help_history",
+        readonly=True,
+    )
+    agent_providing_help_history = fields.Many2one(
+        "im_livechat.channel.member.history",
+        related="channel_id.livechat_agent_providing_help_history",
+        readonly=True,
+    )
 
     @property
     def _unknown_chatbot_answer_name(self):

--- a/addons/im_livechat/report/im_livechat_report_channel_views.xml
+++ b/addons/im_livechat/report/im_livechat_report_channel_views.xml
@@ -69,6 +69,8 @@
             <field name="arch" type="xml">
                 <search string="Search report">
                     <field name="partner_id"/>
+                    <field name="agent_requesting_help_history"/>
+                    <field name="agent_requesting_help_history"/>
                     <field name="livechat_channel_id" string="Channel"/>
                     <field name="country_id" string="Country"/>
                     <field name="chatbot_script_id"/>
@@ -93,6 +95,8 @@
                     <group expand="0" string="Group By...">
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_operator" string="Agent" domain="[]" context="{'group_by': 'partner_id'}"/>
+                        <filter name="group_by_agent_requesting_help" domain="[]" context="{'group_by': 'agent_requesting_help_history'}"/>
+                        <filter name="group_by_agent_providing_help" domain="[]" context="{'group_by': 'agent_providing_help_history'}"/>
                         <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
                         <filter name="group_by_outcome" string="Status" domain="[]" context="{'group_by':'session_outcome'}"/>

--- a/addons/im_livechat/views/discuss_channel_views.xml
+++ b/addons/im_livechat/views/discuss_channel_views.xml
@@ -8,6 +8,8 @@
             <field name="arch" type="xml">
                 <search string="Search history">
                     <field name="livechat_agent_partner_ids" string="Agent"/>
+                    <field name="livechat_agent_requesting_help_history"/>
+                    <field name="livechat_agent_providing_help_history"/>
                     <field name="country_id" string="Country"/>
                     <field name="livechat_customer_partner_ids" string="Customer"/>
                     <filter name="filter_my_sessions" domain="[('livechat_operator_id.user_ids', '=', uid)]" string="My Sessions"/>
@@ -29,6 +31,8 @@
                     <group expand="0" string="Group By...">
                         <filter name="group_by_channel" string="Channel" domain="[]" context="{'group_by':'livechat_channel_id'}"/>
                         <filter name="group_by_agent" string="Agent" domain="[]" context="{'group_by':'livechat_agent_partner_ids'}"/>
+                        <filter name="group_by_agent_requesting_help" domain="[]" context="{'group_by': 'livechat_agent_requesting_help_history'}"/>
+                        <filter name="group_by_agent_providing_help" domain="[]" context="{'group_by': 'livechat_agent_providing_help_history'}"/>
                         <filter name="group_by_rating" string="Rating" domain="[]" context="{'group_by':'rating_last_text'}"/>
                         <filter name="group_by_country" string="Country" domain="[]" context="{'group_by':'country_id'}"/>
                         <filter name="group_by_customer_partner" string="Customer" domain="[]" context="{'group_by':'livechat_customer_partner_ids'}"/>
@@ -46,6 +50,8 @@
                 <list js_class="im_livechat.discuss_channel_list" sample="1" string="History" create="false" default_order="create_date desc">
                     <field name="create_date" string="Date"/>
                     <field name="livechat_agent_history_ids" string="Agents" widget="many2many_tags_avatar" optional="show"/>
+                    <field name="livechat_agent_requesting_help_history" widget="many2one_avatar"/>
+                    <field name="livechat_agent_providing_help_history" widget="many2one_avatar"/>
                     <field name="livechat_bot_history_ids" string="Bot" widget="many2many_tags_avatar" optional="show"/>
                     <field name="livechat_customer_history_ids" string="Customer" widget="many2many_tags_avatar" optional="show"/>
                     <field name="country_id" optional="show"/>


### PR DESCRIPTION
This commit introduces the ability to distinguish live chat sessions where agents requested help, who made the request, and who responded. This is achieved by leveraging the channel member history instead of relying on the `livechat_operator_id` field.

Indeed, the `livechat_operator_id` field is unreliable: it's assigned at the start of the session but can change later (e.g., during chatbot forwarding), mixes bot and agents... It was introduced before the member history model and is planned for removal.

task-4826560

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
