### PR TITLE
[IMP] im_livechat: make _is_last_step (chatbot) a field

### DIFF
--- a/addons/im_livechat/controllers/chatbot.py
+++ b/addons/im_livechat/controllers/chatbot.py
@@ -80,7 +80,7 @@ class LivechatChatbotScriptController(http.Controller):
             "ChatbotStep",
             {
                 "id": (next_step.id, posted_message.id),
-                "isLast": next_step._is_last_step(discuss_channel),
+                "isLast": discuss_channel.chatbot_current_step_is_last,
                 "message": posted_message.id,
                 "operatorFound": next_step.is_forward_operator
                 and discuss_channel.livechat_operator_id != chatbot.operator_partner_id,

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -279,19 +279,6 @@ class ChatbotScriptStep(models.Model):
             return step
         return self.env['chatbot.script.step']
 
-    def _is_last_step(self, discuss_channel=False):
-        self.ensure_one()
-        discuss_channel = discuss_channel or self.env['discuss.channel']
-
-        # if it's not a question and if there is no next step, then we end the script
-        # sudo: chatbot.script.answser - visitor can access their own answers
-        if self.step_type != "question_selection" and not self._fetch_next_step(
-            discuss_channel.sudo().chatbot_message_ids.user_script_answer_id
-        ):
-            return True
-
-        return False
-
     def _process_answer(self, discuss_channel, message_body):
         """ Method called when the user reacts to the current chatbot.script step.
         For most chatbot.script.step#step_types it simply returns the next chatbot.script.step of
@@ -434,7 +421,6 @@ class ChatbotScriptStep(models.Model):
     def _to_store_defaults(self):
         return [
             Store.Many("answer_ids"),
-            Store.Attr("is_last", lambda step: step._is_last_step()),
             Store.Attr("message", lambda s: plaintext2html(s.message) if s.message else False),
             "step_type",
         ]

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -80,6 +80,7 @@ class DiscussChannel(models.Model):
     )
     chatbot_current_step_id = fields.Many2one('chatbot.script.step', string='Chatbot Current Step')
     chatbot_message_ids = fields.One2many('chatbot.message', 'discuss_channel_id', string='Chatbot Messages')
+    chatbot_current_step_is_last = fields.Boolean(compute="_compute_chatbot_current_step_is_last")
     country_id = fields.Many2one('res.country', string="Country", help="Country of the visitor of the channel")
     livechat_failure = fields.Selection(
         selection=[
@@ -210,6 +211,22 @@ class DiscussChannel(models.Model):
                 if channel.livechat_is_escalated
                 else None
             )
+
+    @api.depends("chatbot_current_step_id", "chatbot_current_step_id.step_type", "chatbot_message_ids.user_script_answer_id")
+    def _compute_chatbot_current_step_is_last(self):
+        for channel in self:
+            if not channel.chatbot_current_step_id:
+                channel.chatbot_current_step_is_last = False
+            else:
+                # sudo: visitors can access the current step of the script and the chatbot messages
+                channel_sudo = channel.sudo()
+                next_step = channel_sudo.chatbot_current_step_id._fetch_next_step(
+                    channel_sudo.chatbot_message_ids.user_script_answer_id
+                )
+                channel.chatbot_current_step_is_last = (
+                    channel_sudo.chatbot_current_step_id.step_type != "question_selection"
+                    and not next_step
+                )
 
     @api.depends("livechat_agent_history_ids")
     def _compute_livechat_agent_providing_help_history(self):

--- a/addons/im_livechat/static/src/core/common/chatbot_script_step_model.js
+++ b/addons/im_livechat/static/src/core/common/chatbot_script_step_model.js
@@ -10,7 +10,6 @@ export class ChatbotScriptStep extends Record {
     message;
     /** @type {"free_input_multi"|"free_input_single"|"question_email"|"question_phone"|"question_selection"|"text"|"forward_operator"} */
     step_type;
-    isLast = false;
     answer_ids = fields.Many("chatbot.script.answer");
 }
 ChatbotScriptStep.register();


### PR DESCRIPTION
The purpose of this commit is to move logic from the store and put it on the actual python model. In this commit, we focus on the `_is_last_step` of the chatbot in `im_livechat`.

This makes it easier to prefetch and batch operations and keep an easier developer experience instead of having 2 different models to remember and work with.

To achieve the wanted result, `is_last` was removed from the `chatbot.script.step` and completely moved to the `discuss.channel`. Since the result of `is_last` is highly dependent on the choices of the user in each channel, it makes more sense to keep it there.

task-4676000

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
