### PR TITLE
[FIX] pos_restaurant: fix ParseError while loading demo data

### DIFF
--- a/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
+++ b/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml
@@ -611,7 +611,7 @@
             <field name="uom_id" ref="uom.product_uom_unit"/>
             <field name="image_1920" type="base64" file="pos_restaurant/static/img/sushi-combo.png"/>
             <field name="combo_ids" eval="[(6, 0, [ref('drink_combo'), ref('sushi_choice')])]"/>
-            <field name="categ_id" ref="point_of_sale.product_category_food"/>
+            <field name="categ_id" eval="ref('point_of_sale.product_category_food', raise_if_not_found=False)"/>
             <field name="pos_categ_ids" eval="[(6, 0, [ref('food')])]"/>
             <field name="taxes_id" eval="[(5,)]"/>
             <field name="supplier_taxes_id" eval="[(5,)]"/>


### PR DESCRIPTION
A ParseError is raised when the system attempts to assign a product category to the `sushi_drink_combo` product, in cases where food product category have have been manually removed before loading the demo data.


- new demo data has been added : odoo/odoo@94734feba5670b23acf73a2ad485efe3d480efc0
- `raise_if_not_found` conditions has been added for all demo data : odoo/odoo@e6430737bdcea0162e4a3d5ee82e9ab6caa697e9

Steps to reproduce:

1. Install the `point_of_sale` module without demo data.
2. Navigate to Inventory -> Configuration -> Categories.
3. Delete food category.
4. Navigate to Point of Sale → Load Restaurant Sample Data.
5. An error is triggered during the process.

Error: 
```python
odoo.tools.convert.ParseError: while parsing /home/odoo/odoo/codebase/odoo/saas-18.3/addons/pos_restaurant/data/scenarios/restaurant_demo_data.xml:605, somewhere inside
```
This issue occurs because `sushi_drink_combo` also references a missing product category. As with previous products, this change ensures a fallback to prevent failure when no categories exist.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
