### PR TITLE
[FIX] account: Added missing patch

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1135,7 +1135,7 @@ class AccountChartTemplate(models.AbstractModel):
                 "match_partner": True,
             },
             "reconcile_bill": {
-                "name": 'Create Bill',
+                "name": _('Create Bill'),
                 "sequence": 5,
                 "rule_type": 'writeoff_button',
                 'counterpart_type': 'purchase',


### PR DESCRIPTION
If customers migrate to version 18 from a lower version, 'Create Bill' record newly introduced so it just create but not translated.

**Before fix:**
```
test_18=# select id,name from account_reconcile_model;
 id |                                                            name                                                            
----+----------------------------------------------------------------------------------------------------------------------------
  3 | {"en_US": "Line with Bank Fees", "es_AR": "Línea con comisiones bancarias"}
  1 | {"en_US": "Invoices/Bills Perfect Match", "es_AR": "Coincidencia perfecta de facturas"}
  2 | {"en_US": "Invoices/Bills Partial Match if Underpaid", "es_AR": "Coincidencia parcial si hay pagos parciales en facturas"}
  4 | {"en_US": "Create Bill"}
  5 | {"en_US": "Internal Transfers", "es_AR": "Transferencias internas"}
```

**After Fix:**
```
test_18=# select id,name from account_reconcile_model;
 id |                                                            name                                                            
----+----------------------------------------------------------------------------------------------------------------------------
  1 | {"en_US": "Invoices/Bills Perfect Match", "es_AR": "Coincidencia perfecta de facturas"}
  2 | {"en_US": "Invoices/Bills Partial Match if Underpaid", "es_AR": "Coincidencia parcial si hay pagos parciales en facturas"}
  5 | {"en_US": "Internal Transfers", "es_AR": "Transferencias internas"}
  3 | {"en_US": "Line with Bank Fees", "es_AR": "Línea con comisiones bancarias"}
  4 | {"en_US": "Create Bill", "es_AR": "Crear factura"}
```
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
