### PR TITLE
[IMP] spreadsheet: returns coherent date values for ODOO.FILTER.VALUE

### DIFF
--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper.test.js
@@ -1,6 +1,6 @@
 /** @ts-check */
 import { describe, expect, test } from "@odoo/hoot";
-import { getRelativeDateDomain } from "@spreadsheet/global_filters/helpers";
+import { getDateDomain, getRelativeDateFromTo } from "@spreadsheet/global_filters/helpers";
 import {
     getDateDomainDurationInDays,
     assertDateDomainEqual,
@@ -9,6 +9,11 @@ import {
 describe.current.tags("headless");
 
 const { DateTime } = luxon;
+
+function getRelativeDateDomain(now, offset, rangeType, fieldName, fieldType) {
+    const { from, to } = getRelativeDateFromTo(now, offset, rangeType);
+    return getDateDomain(from, to, fieldName, fieldType);
+}
 
 test("getRelativeDateDomain > year_to_date (year to date)", async function () {
     const now = DateTime.fromISO("2022-05-16");

--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze.test.js
@@ -194,10 +194,11 @@ test("a new sheet is added for global filters", async function () {
 test("global filters and their display value are exported", async function () {
     const { model } = await createModelWithDataSource();
     await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
+    const year = new Date().getFullYear().toString();
     const data = await freezeOdooData(model);
     expect(data.globalFilters.length).toBe(1);
     expect(data.globalFilters[0].label).toBe("This Year");
-    expect(data.globalFilters[0].value).toBe(new Date().getFullYear().toString());
+    expect(data.globalFilters[0].value).toBe(`1/1/${year}, 12/31/${year}`);
 });
 
 test("from/to global filters are exported", async function () {


### PR DESCRIPTION
Before this commit, the ODOO.FILTER.VALUE for date values was returning something different depending on the type of the date filter:
- `fixedPeriod`: returns the name of the period, not translated (e.g. "Q4 2024") => This one was used in pivot formula.
- `relative`: returns the name of the period, translated (e.g. "Last 7 days") => Unusable in formulas
- `fromTo`: returns the two values, the date from and the date to (with a date format)

This commit makes sure that the ODOO.FILTER.VALUE for date values returns the same values for all types of date filters, which is two cells, the first one being the date from and the second one being the date to. (One of them, or both, can be empty.)

This is done for different reasons:
- To have a coherent behavior for ODOO.FILTER.VALUE for date values
- To remove the need to have a restriction on the date filter (restrict filter to only month, or only quarter, or only year) to be able to use
- ODOO.FILTER.VALUE can now be used in any formula

This commit could break some existing dashboards, that relied on the previous behavior of ODOO.FILTER.VALUE for date values. One could use this king of formula to restore the previous behavior (example for quarter):

```
A1: =ODOO.FILTER.VALUE('My Filter');
B1: =TEXTJOIN(" ",,CONCAT("Q",QUARTER(A1)),YEAR(A1))
```

Task: 4854841

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
