### PR TITLE
[FIX] html_builder: fix editing of button links

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -37,6 +37,7 @@
             ('include', 'web._assets_primary_variables'),
             'web/static/src/scss/bootstrap_overridden.scss',
             'html_builder/static/src/**/*.inside.scss',
+            'html_editor/static/src/main/link/link.scss',
         ],
         'html_builder.assets_edit_frontend': [
             ('include', 'website.assets_edit_frontend'),


### PR DESCRIPTION
**Problem**
Before this commit, the html builder behaviour differs from the one of
the html editor in two points:
1. The text in button links can't be edited on Firefox.
2. The links are not highlighted when selected.

This happens because the styles of [1] are not applied in html_builder.
The buttons miss `user-select` and  `cursor` CSS rules. Apparently,
without these rules, Firefox does not throw a `selectionchange` event
when the buttons are clicked, and this breaks their editing.
The links miss the styles `background-color`, `color`, `border` and
`margin` required to produce the highlight effect on selection.

**Solution**
After this commit, file [1] is included in the bundle
"html_builder.inside_builder_style".

[1] /html_editor/static/src/main/link/link.scss
