### PR TITLE
[FIX] account_payment: exclude cancelled invoices from reconciliation

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -195,6 +195,7 @@ class PaymentTransaction(models.Model):
             invoices = self.source_transaction_id.invoice_ids
         else:
             invoices = self.invoice_ids
+        invoices = invoices.filtered(lambda inv: inv.state != 'cancel')
         if invoices:
             invoices.filtered(lambda inv: inv.state == 'draft').action_post()
 


### PR DESCRIPTION
Steps to reproduce:
1. Create an invoice.
2. Register a payment in the 'pending' state.
3. Cancel the invoice.
4. Confirm the payment (set payment state to 'done').
5. Run the 'post-process transactions' cron job and check the logs.
→ Error occurs during reconciliation due to the cancelled invoice.

Issue:
cancelled invoices were being considered during the reconciliation process,
leading to errors.

Solution:
This fix ensures that only posted invoices are considered during the
reconciliation process.
