### PR TITLE
[FIX] account: Auto-Check on Post logic when posting move

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4912,7 +4912,8 @@ class AccountMove(models.Model):
                 validation_msgs.add(_("A line of this move is using a deprecated account, you cannot post it."))
 
             # If the field autocheck_on_post is set, we want the checked field on the move to be checked
-            move.checked = move.journal_id.autocheck_on_post
+            if move.journal_id.autocheck_on_post:
+                move.checked = move.journal_id.autocheck_on_post
 
         if validation_msgs:
             msg = "\n".join([line for line in validation_msgs])

--- a/doc/cla/corporate/ahkio-consulting.md
+++ b/doc/cla/corporate/ahkio-consulting.md
@@ -1,0 +1,15 @@
+Finland, 2025-06-06
+
+Ahkio Consulting Oy agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Johan Tötterman johan@ahkio.com https://github.com/juppe
+
+List of contributors:
+
+Johan Tötterman johan@ahkio.com https://github.com/juppe


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Posting an account move will unconditionally overwrite any value in the `checked` field to the value of the `journal_id.autocheck_on_post` field. I.e. whatever the user has selected in the `checked` will be overwritten. This PR will change the functionality to work as the original comment for the feature states.


Current behavior before PR:
The `checked` field on an account move is always updated to the value of the `journal_id.autocheck_on_post` field, when posting an account move.


Desired behavior after PR is merged:
The checked field on an account move is updated to the value of the  journal_id.autocheck_on_post, when posting a move, only when the journal_id.autocheck_on_post is `True`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
