### PR TITLE
[FIX] web_editor, website: snippet oriented fixings

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -10,7 +10,7 @@
                     Show optimized images
                 </label>
             </div>
-            <select t-if="showSearchServiceSelect" class="o_input o_we_search_select form-select" t-on-change="ev => props.changeSearchService(ev.target.value)">
+            <select t-if="showSearchServiceSelect" class="o_input o_we_search_select form-select pe-5" t-on-change="ev => props.changeSearchService(ev.target.value)">
                 <option t-att-selected="props.searchService === 'all'" value="all">All</option>
                 <option t-att-selected="props.searchService === 'database'" value="database">My Images</option>
                 <option t-if="props.useMediaLibrary" t-att-selected="props.searchService === 'media-library'" value="media-library">Illustrations</option>

--- a/addons/web_editor/static/src/components/media_dialog/search_media.js
+++ b/addons/web_editor/static/src/components/media_dialog/search_media.js
@@ -26,6 +26,6 @@ export class SearchMedia extends Component {
 }
 SearchMedia.template = xml`
 <div class="position-relative mw-lg-25 flex-grow-1 me-auto">
-    <input type="text" class="o_we_search o_input form-control" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
+    <input type="text" class="o_we_search o_input form-control pe-4" t-att-placeholder="props.searchPlaceholder.trim()" t-model="state.input" t-ref="autofocus"/>
     <i class="oi oi-search input-group-text position-absolute end-0 top-50 me-n3 px-2 py-1 translate-middle bg-transparent border-0" title="Search" role="img" aria-label="Search"/>
 </div>`;


### PR DESCRIPTION
## [FIX] website: prevent blurry countdown canvas and text on zoom [Commit 1]
Steps to reproduce:
- Go to Website -> Edit Mode
- Add a Countdown snippet (size: "Small")
- Save and zoom in/out, the countdown canvas and text appears blurry

The countdown was rendered at a low resolution, which caused it to blur
when zooming. This fix updates the canvas to draw at the proper
resolution so the countdown remains sharp at any zoom level.


## [FIX] web_editor: prevent text overlap with icon [Commit 2]
Steps to reproduce:
- Go to Website -> Edit Mode
- Add a Image snippet
- Enter a long text in search bar:

Issue:
1. Text overlaps with search icon.
2. Selecting the "Photos (via Unsplash)" option causes the text to
overlap the dropdown icon.

The fix adjusts the end padding to provide sufficient spacing between
the text and the icons.

task-[4771268](https://www.odoo.com/odoo/project/974/tasks/4771268)