### PR TITLE
[FIX] mail: display help message when no favorite GIFs are present

### DIFF
--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.js
@@ -61,7 +61,6 @@ export class GifPicker extends Component {
             "scroller",
             () => {
                 if (!this.state.showCategories) {
-                    this.state.loadingGif = true;
                     if (!this.showFavorite) {
                         this.search();
                     } else {
@@ -114,7 +113,6 @@ export class GifPicker extends Component {
                     return;
                 }
                 this.clear();
-                this.state.loadingGif = true;
                 this.search();
                 if (this.searchTerm) {
                     this.closeCategories();

--- a/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/gif_picker.xml
@@ -70,7 +70,7 @@
                     <div t-if="state.loadingGif" class="text-center fs-6 h-100 d-flex flex-column justify-content-center">
                         <i class="fa fa-spin fa-circle-o-notch"/>
                     </div>
-                    <div t-elif="showFavorite and state.evenGif.gifs.length === 0 and state.oddGif.gifs.length === 0" class="d-flex flex-column h-100 align-items-center justify-content-center text-center text-muted gap-2">
+                    <div t-elif="showFavorite and state.evenGif.gifs.size === 0 and state.oddGif.gifs.size === 0" class="d-flex flex-column h-100 align-items-center justify-content-center text-center text-muted gap-2">
                         <i class="o-discuss-GifPicker-noFavoritesIcon fa fa-star fs-1"/>
                         <span class="fs-5">So uhh... maybe go favorite some GIFs?</span>
                     </div>

--- a/addons/mail/static/tests/gif_picker/gif_picker_tests.js
+++ b/addons/mail/static/tests/gif_picker/gif_picker_tests.js
@@ -250,3 +250,19 @@ QUnit.test(
         await contains(".o-discuss-Gif", { count: 8 });
     }
 );
+
+QUnit.test("Show help when no favorite GIF", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "" });
+    const { openDiscuss } = await start({
+        mockRPC(route) {
+            if (route === "/discuss/gif/categories") {
+                return rpc.categories;
+            }
+        }
+    });
+    openDiscuss(channelId);
+    await click("button[aria-label='GIFs']");
+    await click(".o-discuss-GifPicker div[aria-label='list-item']", { text: "Favorites" });
+    await contains("span", { text: "So uhh... maybe go favorite some GIFs?" });
+});


### PR DESCRIPTION
**Current behavior before PR:**

When the user opened the Favorite category with no favorite GIFs, nothing was shown. This was caused by using `.length` on Map objects (`evenGif.gifs` and `oddGif.gifs`) , which should have been `.size`. (since #131344 )

**Desired behavior after PR is merged:**

Help message is correctly displayed when no favorite GIFs are available.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
