### PR TITLE
[FIX] web: support missing first date in daterange

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -194,7 +194,8 @@ export class DateTimeField extends Component {
      * @param {number} valueIndex
      */
     getFormattedValue(valueIndex) {
-        const value = this.values[valueIndex];
+        const values = this.values;
+        const value = values[valueIndex];
         if (!value) {
             return "";
         }
@@ -202,7 +203,7 @@ export class DateTimeField extends Component {
         if (this.field.type === "date") {
             return formatDate(value, { condensed });
         }
-        if (showTime && valueIndex === 1 && this.values[0].hasSame(value, "day")) {
+        if (showTime && valueIndex === 1 && values[0] && values[0].hasSame(value, "day")) {
             return formatDateTime(value, {
                 format: showSeconds ? localization.timeFormat : localization.shortTimeFormat,
             });

--- a/addons/web/static/tests/views/fields/daterange_field.test.js
+++ b/addons/web/static/tests/views/fields/daterange_field.test.js
@@ -1322,3 +1322,20 @@ test("daterange in readonly with same dates but different hours", async () => {
         message: "end date only shows time since it has the same day as start date",
     });
 });
+
+test("daterange in list view with missing first date", async () => {
+    Partner._records[0].datetime_end = Partner._records[0].datetime;
+    Partner._records[0].datetime = false;
+
+    await mountView({
+        type: "list",
+        resModel: "partner",
+        arch: /* xml */ `
+            <list multi_edit="1">
+                <field name="datetime_end" widget="daterange" options="{'start_date_field': 'datetime'}" />
+            </list>
+        `,
+    });
+
+    expect(".o_field_daterange[name=datetime_end]").toHaveText("02/08/2017 15:30");
+});


### PR DESCRIPTION
Before this commit, a datetime field in range mode displayed in read- only (e.g. in a list) would crash if it had an end date but no start date.

This was due to a missing check to ensure the existence of a start date before rendering a specially formatted date value.

This commit solves this issue by adding the aforementioned check.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
