### PR TITLE
[FIX] mail: rounder discuss app and chat window main composer

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -7,7 +7,8 @@
     <t t-set="compact" t-value="props.mode === 'compact'"/>
     <t t-set="normal" t-value="props.mode === 'normal'"/>
     <t t-set="extended" t-value="props.mode === 'extended'"/>
-    <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex rounded-3'"/>
+    <t t-set="roundedClass" t-value="env.inChatter or props.composer.message ? 'o-rounded-bubble' : 'rounded-4'"/>
+    <t t-set="actionsContainerClass" t-value="'o-mail-Composer-actions d-flex ' + roundedClass"/>
     <div t-ref="root">
         <div class="o-mail-Composer d-grid flex-shrink-0 pt-0"
                 t-att-class="{
@@ -41,8 +42,9 @@
                 <i class="fa fa-lg fa-times-circle rounded-circle p-0 ms-1 cursor-pointer" title="Stop replying" t-on-click="() => (props.composer.replyToMessage = undefined)"/>
             </div>
             <div class="o-mail-Composer-coreMain d-flex flex-nowrap align-items-start flex-grow-1" t-att-class="{ 'flex-column' : extended or props.composer.message }">
-                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary rounded-3 shadow-sm"
+                <div class="o-mail-Composer-inputContainer o-mail-Composer-bg d-flex flex-grow-1 border border-secondary shadow-sm"
                     t-att-class="{
+                        [roundedClass]: true,
                         'o-iosPwa': isIosPwa,
                         'align-self-stretch' : extended,
                         'w-100': props.composer.message,
@@ -58,7 +60,11 @@
                         </Dropdown>
                     </div>
                     <div class="position-relative flex-grow-1">
-                        <t t-set="inputClasses" t-value="{'o-mail-Composer-inputStyle form-control border-0 rounded-3': true, 'ps-2': partitionedActions.other.length === 0}"/>
+                        <t t-set="inputClasses" t-value="{
+                            [roundedClass]: true,
+                            'o-mail-Composer-inputStyle form-control border-0': true,
+                            'ps-2': partitionedActions.other.length === 0
+                        }"/>
                         <textarea class="o-mail-Composer-input o-mail-Composer-bg shadow-none overflow-auto text-body"
                             t-att-class="inputClasses"
                             t-ref="textarea"


### PR DESCRIPTION
Floating UI elements look prettier with significant roundness. Composer in discuss app and chat window have this "floating" look, so making it rounder feels better.

This roundness doesn't work in chatter (form view + chatter buttons are slightly rounded) and when editing a message (composer inside a rounded message), so in these exceptional cases the roundness is reduced.

Before / After
![Screenshot 2025-06-06 at 14 58 06](https://github.com/user-attachments/assets/29fec81c-38d1-4429-a733-05506ebad997) ![Screenshot 2025-06-06 at 14 57 57](https://github.com/user-attachments/assets/3ee9b2aa-b615-4348-b9ac-e0e7a9470701)
