### PR TITLE
[FIX] web: fix concurrency test failing randomly

### DIFF
--- a/addons/web/static/tests/webclient/actions/concurrency.test.js
+++ b/addons/web/static/tests/webclient/actions/concurrency.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@odoo/hoot";
-import { queryAll, queryAllTexts } from "@odoo/hoot-dom";
+import { queryAll, queryAllTexts, runAllTimers } from "@odoo/hoot-dom";
 import { animationFrame, Deferred } from "@odoo/hoot-mock";
 import { Component, onWillStart, xml } from "@odoo/owl";
 import {
@@ -28,6 +28,7 @@ import { SearchBar } from "@web/search/search_bar/search_bar";
 import { useSetupAction } from "@web/search/action_hook";
 import { WebClient } from "@web/webclient/webclient";
 import { browser } from "@web/core/browser/browser";
+import { router } from "@web/core/browser/router";
 
 const { ResCompany, ResPartner, ResUsers } = webModels;
 const actionRegistry = registry.category("actions");
@@ -759,8 +760,23 @@ test("doing browser back temporarily disables the UI", async () => {
     await mountWithCleanup(WebClient);
 
     await getService("action").doAction(4);
-    await contains(".o_kanban_record").click();
     await getService("action").doAction(8);
+    await runAllTimers(); // wait for the update of the router
+    expect(router.current).toEqual({
+        action: 8,
+        actionStack: [
+            {
+                action: 4,
+                displayName: "Partners Action 4",
+                view_type: "kanban",
+            },
+            {
+                action: 8,
+                displayName: "Favorite Ponies",
+                view_type: "list",
+            },
+        ],
+    });
 
     def = new Deferred();
     browser.history.back();


### PR DESCRIPTION
This commit fixes an action service concurrency test that fails randomly. The way the test was written was prone to errors as we didn't wait for the router to be updated before doing browser back. As a matter of fact, we even asserted that we went 2 actions back in the breadcrumbs, whereas it should be only one as we did one browser.history.back().

runbot error~163078

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
