### PR TITLE
[FIX] account,account_edi_ubl_cii: UBL related cash rounding issues

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3249,7 +3249,8 @@ class AccountMove(models.Model):
     # -------------------------------------------------------------------------
 
     def _get_tax_lines_to_aggregate(self):
-        return self.line_ids.filtered(lambda x: x.display_type == 'tax')
+        # Note: We need to include cash rounding lines created by the 'biggest_tax' strategy too.
+        return self.line_ids.filtered('tax_repartition_line_id')
 
     def _prepare_invoice_aggregated_taxes(self, filter_invl_to_apply=None, filter_tax_values_to_apply=None, grouping_key_generator=None):
         self.ensure_one()

--- a/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
+++ b/addons/account_edi_ubl_cii/data/ubl_20_templates.xml
@@ -284,6 +284,9 @@
             <cbc:PrepaidAmount
                 t-att-currencyID="vals['currency'].name"
                 t-out="format_float(vals.get('prepaid_amount'), vals.get('currency_dp'))"/>
+            <cbc:PayableRoundingAmount
+                t-att-currencyID="vals['currency'].name"
+                t-out="format_float(vals.get('payable_rounding_amount'), vals.get('currency_dp'))"/>
             <cbc:PayableAmount
                 t-att-currencyID="vals['currency'].name"
                 t-out="format_float(vals.get('payable_amount'), vals.get('currency_dp'))"/>

--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -500,6 +500,37 @@ class AccountEdiCommon(models.AbstractModel):
             ]
         return []
 
+    def _import_rounding_amount(self, invoice, rounding_node, qty_factor):
+        """
+        Add an invoice line representing the rounding amount given in the document.
+        - The amount is assumed to be in document currency
+        """
+        currency = invoice.currency_id
+        rounding_amount_currency = currency.round(qty_factor * float(rounding_node.text) if rounding_node is not None else 0.0)
+
+        if invoice.currency_id.is_zero(rounding_amount_currency):
+            return []
+
+        inverse_rate = abs(invoice.amount_total_signed) / invoice.amount_total if invoice.amount_total else 0
+        rounding_amount = invoice.company_id.currency_id.round(rounding_amount_currency * inverse_rate)
+
+        invoice.line_ids.create([{
+            'display_type': 'product',
+            'name': _('Rounding'),
+            'quantity': 1,
+            'product_id': False,
+            'price_unit': rounding_amount_currency,
+            'balance': invoice.direction_sign * rounding_amount,
+            'company_id': invoice.company_id.id,
+            'move_id': invoice.id,
+            'tax_ids': False,
+        }])
+
+        formatted_amount = formatLang(self.env, rounding_amount_currency, currency_obj=currency)
+        return [
+            _("A rounding amount of %s was detected.", formatted_amount),
+        ]
+
     def _import_fill_invoice_line_values(self, tree, xpath_dict, invoice_line, qty_factor):
         """
         Read the xml invoice, extract the invoice line values, compute the odoo values

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -232,6 +232,126 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
         self.assertEqual(attachment.name[-12:], "ubl_bis3.xml")
         self._assert_imported_invoice_from_etree(refund, attachment)
 
+    def test_export_import_cash_rounding(self):
+        cash_rounding_line = self.env['account.cash.rounding'].create({
+            'name': '1.0 Line',
+            'rounding': 1.00,
+            'strategy': 'add_invoice_line',
+            'profit_account_id': self.company_data['default_account_revenue'].copy().id,
+            'loss_account_id': self.company_data['default_account_expense'].copy().id,
+            'rounding_method': 'HALF-UP',
+        })
+
+        cash_rounding_tax = self.env['account.cash.rounding'].create({
+            'name': '1.0 Tax',
+            'rounding': 1.00,
+            'strategy': 'biggest_tax',
+            'rounding_method': 'HALF-UP',
+        })
+
+        test_data = [
+            {
+                'invoice_cash_rounding_id': False,
+                'expected_xml_values': {
+                    '{*}TaxTotal/{*}TaxAmount': '14.70',
+                    '{*}LegalMonetaryTotal/{*}TaxExclusiveAmount': '70.00',
+                    '{*}LegalMonetaryTotal/{*}TaxInclusiveAmount': '84.70',
+                    '{*}LegalMonetaryTotal/{*}PrepaidAmount': '0.00',
+                    '{*}LegalMonetaryTotal/{*}PayableRoundingAmount': None,
+                    '{*}LegalMonetaryTotal/{*}PayableAmount': '84.70',
+                },
+                'expected_rounding_invoice_line_values': None,
+            },
+            {
+                'invoice_cash_rounding_id': cash_rounding_tax,
+                'expected_xml_values': {
+                    '{*}TaxTotal/{*}TaxAmount': '15.00',
+                    '{*}LegalMonetaryTotal/{*}TaxExclusiveAmount': '70.00',
+                    '{*}LegalMonetaryTotal/{*}TaxInclusiveAmount': '85.00',
+                    '{*}LegalMonetaryTotal/{*}PrepaidAmount': '0.00',
+                    '{*}LegalMonetaryTotal/{*}PayableRoundingAmount': None,
+                    '{*}LegalMonetaryTotal/{*}PayableAmount': '85.00',
+                },
+                'expected_rounding_invoice_line_values': None,
+            },
+            {
+                'invoice_cash_rounding_id': cash_rounding_line,
+                'expected_xml_values': {
+                    '{*}TaxTotal/{*}TaxAmount': '14.70',
+                    '{*}LegalMonetaryTotal/{*}TaxExclusiveAmount': '70.00',
+                    '{*}LegalMonetaryTotal/{*}TaxInclusiveAmount': '84.70',
+                    '{*}LegalMonetaryTotal/{*}PrepaidAmount': '0.00',
+                    '{*}LegalMonetaryTotal/{*}PayableRoundingAmount': '0.30',
+                    '{*}LegalMonetaryTotal/{*}PayableAmount': '85.00',
+                },
+                # We create an invoice line for the rounding amount.
+                # (This adjusts the base amount of the invoice.)
+                'expected_rounding_invoice_line_values': {
+                    'display_type': 'product',
+                    'name': 'Rounding',
+                    'quantity': 1,
+                    'product_id': False,
+                    'price_unit': 0.30,
+                    'balance': -0.15,
+                }
+            },
+        ]
+        for test in test_data:
+            cash_rounding_method = test['invoice_cash_rounding_id']
+            with self.subTest(sub_test_name=f"cash rounding method: {cash_rounding_method.name if cash_rounding_method else 'None'}"):
+                invoice = self._generate_move(
+                    seller=self.partner_1,
+                    buyer=self.partner_2,
+                    move_type='out_invoice',
+                    currency_id=self.currency_data['currency'].id,
+                    invoice_cash_rounding_id=cash_rounding_method.id if cash_rounding_method else False,
+                    invoice_line_ids=[
+                        {
+                            'product_id': self.product_a.id,
+                            'quantity': 1,
+                            'price_unit': 70.00,
+                            'tax_ids': [Command.set([self.tax_21.id])],
+                        },
+                    ],
+                )
+
+                attachment = invoice.ubl_cii_xml_id
+                self.assertTrue(attachment)
+
+                xml_content = base64.b64decode(attachment.with_context(bin_size=False).datas)
+                xml_etree = self.get_xml_tree_from_string(xml_content)
+
+                for path, text in test['expected_xml_values'].items():
+                    with self.subTest(sub_test_name=f"cash rounding method: {cash_rounding_method.name if cash_rounding_method else 'None'}", path=path):
+                        node = xml_etree.find(path)
+                        if text is None:
+                            self.assertTrue(node is None)
+                        else:
+                            self.assertEqual(node.text, text)
+
+                # Check that importing yields the expected results.
+
+                # For the 'add_invoice_line' strategy we create a dedicated invoice line for the cash rounding.
+                rounding_invoice_line_values = test['expected_rounding_invoice_line_values']
+                if rounding_invoice_line_values:
+                    invoice.button_draft()
+                    invoice.invoice_cash_rounding_id = False  # Do not round twice
+                    invoice.invoice_line_ids.create([{
+                        'company_id': invoice.company_id.id,
+                        'move_id': invoice.id,
+                        'partner_id': invoice.partner_id.id,
+                        **rounding_invoice_line_values,
+                    }])
+                    invoice.action_post()
+
+                self._assert_imported_invoice_from_etree(invoice, attachment)
+
+                # Check that importing a bill yields the expected results.
+
+                bill = self.company_data['default_journal_purchase']._create_document_from_attachment(attachment.ids)
+                self.assertTrue(bill)
+                self.assert_same_invoice(invoice, bill, partner_id=self.partner_1.id)
+
     def test_encoding_in_attachment_ubl(self):
         invoice = self._generate_move(
             seller=self.partner_1,


### PR DESCRIPTION
Currently these problems can appear when an invoice is cash rounded.
1. In case we use the "Modify tax amount" (`biggest_tax`) cash rounding strategy:
   The rounding amount is added to the taxes in Odoo but not in the UBL XML
   - This affects everything that uses `_prepare_invoice_aggregated_taxes`
     (and not just UBL XML)
2. The generated UBL XML is invalid (for any rounding strategy).
   See below for details.
3. The import of the exported UBL XML does not yield back the same invoice
   (even after fixing the export / the previous 2 problems).

Also there are some problems with the correction of tax values
of imported UBL XML (`correct_invoice_tax_amount`).
(They probably do not cause issues in practice but would after this
fix. We adapt the correction as part of the fix for (3).)

#### Runbot: How to generate problematic XML
1. Select BE Company CoA
2. Enable Cash Rounding in the settings
3. Create a cash rounding method
   (in the settings where cash rounding can be enabled):
   - precision `1.00`
   - strategy: any
   - profit / loss account: any
4. Create an invoice
   - Set a Belgian partner (e.g. "BE Company CoA" is okay)
   - Set the the cash rounding method from step 2
   - Single Line with price=70.00€ and a 21% tax
5. The total should be 85.00 € (84.70 € w/o the rounding)
   In the journal items there should be the following
   non payment term items:
   - 70.00€ base
   - 14.70€ tax
   -  0.30€ rounding (depending on the cash rounding strategy the tax is set or not)
6. Confirm & Send (with BIS Billing 3.0)
7. Look at the UBL BIS 3 XML in the `Invoice` element
   - `TaxTotal/TaxAmount`: 14.70€
   - `TaxTotal/TaxSubtotal/TaxableAmount`: 70.00€
   - `TaxTotal/TaxSubtotal/TaxAmount`: 14.70€
   - `LegalMonetaryTotal/TaxExclusiveAmount`: 70.00€
   - `LegalMonetaryTotal/TaxInclusiveAmount`: 85.00€
   - `LegalMonetaryTotal/PayableAmount`: 85.00€
8. This fails validation `BR-CO-15`:
   ```
     Invoice total amount with VAT (BT-112)
   = Invoice total amount without VAT (BT-109) + Invoice total VAT amount (BT-110).
   ```
   (`LegalMonetaryTotal/TaxInclusiveAmount` = `LegalMonetaryTotal/TaxExclusiveAmount` + `TaxTotal/TaxAmount`)

   Since the cash rounding is included in `LegalMonetaryTotal/TaxInclusiveAmount` but not in
   `TaxTotal/TaxAmount` (or `LegalMonetaryTotal/TaxExclusiveAmount`)

#### Tax value correction details (with examples)

Currently we try to fix the tax amounts after importing an invoice.
The function we use for that (`_correct_invoice_tax_amount`) has the following issues:
- We look for `TaxTotal/TaxSubtotal` elements anywhere.
  But i.e. such elements can also exist inside `InvoiceLine` elements.
  Example:
  - module `l10n_dk_oioubl` file `test_xml_oioubl_dk.py`
  - function `test_oioubl_import_exemple_file_4` / XML file 'external/BASPRO_01_01_00_Invoice_v2p1.xml'
- The tax total parsed from the document may need to be inverted.
  E.g. credit notes can be given as an invoice with negative amounts.
  See function `_get_import_document_amount_sign`.
  Example:
  - module `l10n_account_edi_ubl_cii` file `test_xml_ubl_be.py`
  - function `test_import_invoice_xml_open_peppol_examples` / XML file 'bis3_invoice_negative_amounts.xml'
- We compare the tax total from the document only with a single line of that tax.
  But there can be multiple lines for a single tax. We have to use the sum of all those lines for the comparison.
  Example:
  - module `l10n_account_edi_ubl_cii` file `test_xml_ubl_au.py`
  - function `test_export_import_invoice` / XML file 'from_odoo/a_nz_out_invoice.xml'

#### The fix

This commit does the following to fix that
1. We include cash rounding lines belonging to a tax in the tax computation for the UBL XML export
   (or rather everything any tax computation done with `_prepare_invoice_aggregated_taxes`).
2. After fixing (1) we only have to fix the "Add a rounding line" (`add_invoice_line`) strategy.
   This is as follows
   - Subtract the cash rounding from the `LegalMonetaryTotal/TaxInclusiveAmount`
   - Add node `LegalMonetaryTotal/PayableRoundingAmount` with the value of the cash rounding
3. Cases
   - `add_invoice_line`: We create a dedicated invoice line with the amount found in node
     `LegalMonetaryTotal/PayableRoundingAmount` (if it is present).
   - `biggest_tax`: We update the amount on the tax line to match the value found in the XML.
     (Currently we only do this if the difference is not greater than '0.05')

The fixes for the tax value correction on import are also needed for 3./`biggest_tax`.

#### Runbot: example XML after the fix

The export in the example then looks like this for the different cash rounding strategies
- `add_invoice_line`
  - `TaxTotal/TaxAmount`: 14.70€
  - `TaxTotal/TaxSubtotal/TaxableAmount`: 70.00€
  - `TaxTotal/TaxSubtotal/TaxAmount`: 14.70€
  - `LegalMonetaryTotal/TaxExclusiveAmount`: 70.00€
  - `LegalMonetaryTotal/TaxInclusiveAmount`: 84.70€
  - `LegalMonetaryTotal/PayableRoundingAmount`: 0.30€
  - `LegalMonetaryTotal/PayableAmount`: 85.00€

  The validation for the `LegalMonetaryTotal/PayableAmount` is still
  okay since (in the example) it is just `LegalMonetaryTotal/TaxInclusiveAmount` + `LegalMonetaryTotal/PayableRoundingAmount`.
- `biggest_tax`
  - `TaxTotal/TaxAmount`: 15.00€
  - `TaxTotal/TaxSubtotal/TaxableAmount`: 70.00€
  - `TaxTotal/TaxSubtotal/TaxAmount`: 15.00€
  - `LegalMonetaryTotal/TaxExclusiveAmount`: 70.00€
  - `LegalMonetaryTotal/TaxInclusiveAmount`: 85.00€
  - `LegalMonetaryTotal/PayableRoundingAmount`: (not exported)
  - `LegalMonetaryTotal/PayableAmount`: 85.00€

#### References

Also see
- https://docs.peppol.eu/poacc/billing/3.0/bis/#_rounding
- https://docs.peppol.eu/poacc/billing/3.0/bis/#_calculation_of_totals

task-4854592