### PR TITLE
[IMP] account_accountant: demo data in python instead of xml

### DIFF
--- a/addons/account/demo/account_demo.py
+++ b/addons/account/demo/account_demo.py
@@ -83,7 +83,7 @@ class AccountChartTemplate(models.AbstractModel):
 
         # the invoice_extract acts like a placeholder for the OCR to be ran and doesn't contain
         # any lines yet
-        for move in invoices.filtered(lambda m: m.state == 'draft'):
+        for move in invoices:
             try:
                 move.action_post()
             except (UserError, ValidationError):


### PR DESCRIPTION
Backport of https://github.com/odoo/enterprise/pull/86477

which improves what was done in commits

- https://github.com/odoo/odoo/commit/ebd6b5f374303dcdfcc69fa64522c1b83bd7fe58
- https://github.com/odoo/enterprise/commit/37cc5e067ff8d1e45edbd9a167a2d801c658739c

since it avoids reloading the demo data twice by hooking on `_install_demo`.

Instead, we just call our own function to create the demo data once in the accountant module.

This commit therefore only reverts ebd6b5f374303dcdfcc69fa64522c1b83bd7fe58

Enterprise PR: https://github.com/odoo/enterprise/pull/87204