### PR TITLE
[IMP] sale_project: unlink project from product when switching it to non-billable

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -166,6 +166,27 @@ class ProjectProject(models.Model):
             total = project.real_cost + revenue_per_account.get(project.account_id, 0)
             project.real_cost_ratio = 100 * (project.real_cost / total) if total else 0
 
+    def _fetch_linked_products(self, project_ids, limit=None):
+        return self.env["product.template"].search([
+            ("service_tracking", "!=", "no"),
+            "|",
+                ("project_id", "in", project_ids),
+                ("project_template_id", "in", project_ids),
+        ], limit=limit)
+
+    def _fetch_linked_sale_orders(self, project_ids, limit=None):
+        return self.env["sale.order"].search([("project_id", "in", project_ids)], limit=limit)
+
+    def check_allow_billable_projects(self):
+        """ return if the project is linked to product or sales order """
+        self.ensure_one()
+        return bool(self._fetch_linked_products(self.ids, limit=1) or
+                    self._fetch_linked_sale_orders(self.ids, limit=1))
+
+    def _unlink_billable_products(self):
+        linked_product_ids = self._fetch_linked_products(self.ids)
+        linked_product_ids.write({'project_id': False, 'project_template_id': False})
+
     def action_customer_preview(self):
         self.ensure_one()
         return {
@@ -196,6 +217,12 @@ class ProjectProject(models.Model):
             elif project.sudo().reinvoiced_sale_order_id and not project.sudo().reinvoiced_sale_order_id.project_id:
                 project.sudo().reinvoiced_sale_order_id.project_id = project.id
         return projects
+
+    def write(self, vals):
+        project = super().write(vals)
+        if vals.get('allow_billable') is False:
+            self._unlink_billable_products()
+        return project
 
     def _get_sale_orders_domain(self, all_sale_orders):
         return [("id", "in", all_sale_orders.ids)]

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -153,6 +153,27 @@ class ProjectProject(models.Model):
         for project in self:
             project.actual_margin = margin_per_account.get(project.account_id, 0.0)
 
+    def _fetch_linked_products(self, project_ids, limit=None):
+        return self.env["product.template"].search([
+            ("service_tracking", "!=", "no"),
+            "|",
+                ("project_id", "in", project_ids),
+                ("project_template_id", "in", project_ids),
+        ], limit=limit)
+
+    def _fetch_linked_sale_orders(self, project_ids, limit=None):
+        return self.env["sale.order"].search([("project_id", "in", project_ids)], limit=limit)
+
+    def check_allow_billable_projects(self):
+        """ return if the project is linked to product or sales order """
+        self.ensure_one()
+        return bool(self._fetch_linked_products(self.ids, limit=1) or
+                    self._fetch_linked_sale_orders(self.ids, limit=1))
+
+    def _unlink_billable_products(self):
+        linked_product_ids = self._fetch_linked_products(self.ids)
+        linked_product_ids.write({'project_id': False, 'project_template_id': False})
+
     def action_customer_preview(self):
         self.ensure_one()
         return {
@@ -203,6 +224,8 @@ class ProjectProject(models.Model):
 
     def write(self, vals):
         project = super().write(vals)
+        if vals.get('allow_billable') is False:
+            self._unlink_billable_products()
         if sol_id := vals.get('sale_line_id'):
             self._ensure_sale_order_linked([sol_id])
         return project

--- a/addons/sale_project/static/src/views/project_form/project_project_form_controller.js
+++ b/addons/sale_project/static/src/views/project_form/project_project_form_controller.js
@@ -1,0 +1,36 @@
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ProjectProjectFormController } from "@project/views/project_form/project_project_form_controller";
+
+patch(ProjectProjectFormController.prototype, {
+    async onWillSaveRecord(record, changes) {
+        let linkedProject = false;
+
+        if ("allow_billable" in record._changes && record._changes.allow_billable === false) {
+            linkedProject = await record.model.orm.call(
+                record.resModel,
+                "check_allow_billable_projects",
+                [[record.resId]],
+            );
+        }
+
+        if (linkedProject) {
+            const confirmation = await new Promise((resolve) => {
+                this.env.services.dialog.add(ConfirmationDialog, {
+                    title: _t("Confirmation Required"),
+                    body: _t("Making this project non-billable will unlink it from any products that create tasks in it or use it as a template. Are you sure you want to continue?"),
+                    confirm: async () => resolve(true),
+                    cancel: async () => resolve(false),
+                });
+            });
+
+            if (!confirmation) {
+                record.update({ allow_billable: true });
+                return false;
+            }
+        }
+
+        return super.onWillSaveRecord(...arguments);
+    },
+});


### PR DESCRIPTION
### Before
 When switching a project to non-billable, the products linked to it remain linked with that project.

### After
When a project is switched to non-billable, if there are products linked to that project

1. A warning message will appear if the project is linked to a sales order, not just products.
2. Upon saving, it will unlink all products related to that project.

---

task-4797542