### PR TITLE
[FIX] web: fix boolean property field test failing randomly

### DIFF
--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -15351,7 +15351,6 @@ test(`Properties: boolean`, async () => {
     expect(`.o_field_cell.o_boolean_cell`).toHaveCount(3);
 
     await contains(`.o_field_cell.o_boolean_cell`).click();
-    await contains(`.o_field_cell.o_boolean_cell input`).click();
     await contains(`.o_list_button_save`).click();
     expect(`.o_field_cell.o_boolean_cell input:first`).not.toBeChecked();
     expect.verifySteps(["web_save"]);


### PR DESCRIPTION
This commit fixes a test involving a boolean property field in list view that randomly fails. The problem was that we clicked twice to toggle the boolean value: once on the cell (I assume that it was done to switch the row in edition), and one on the checkbox to toggle it. However, boolean fields in list views don't require the row to be in edition to be toggled. So the first click already toggled the value, and the second click toggled it again, **sometimes** (I guess that's the non deterministic part, it was a question of timing there).

So this commit fixes the issue by removing one of the 2 clicks.

runbot error~224053

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
