### PR TITLE
[IMP] website_livechat: send falsy visitor data for LC channels

### DIFF
--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -48,7 +48,7 @@ class DiscussChannel(models.Model):
                     Store.One("partner_id", [Store.One("country_id", ["code"])]),
                     Store.One("website_id", ["name"]),
                 ],
-                predicate=lambda channel: channel.livechat_visitor_id
+                predicate=lambda channel: channel.channel_type == "livechat"
                 and self.livechat_visitor_id.has_access("read"),
             ),
             "requested_by_operator",

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -365,6 +365,19 @@ class TestLivechatBasicFlowHttpCase(HttpCaseWithUserDemo, TestLivechatCommon):
         )
         self.assertEqual(result["Store"]["livechat_available"], False)
 
+    def test_livechat_visitor_to_store(self):
+        """Test livechat_visitor_id is sent with livechat channels data even when there is no
+        visitor."""
+        self.target_visitor = None
+        channel_info = self.make_jsonrpc_request(
+            "/im_livechat/get_session",
+            {
+                "anonymous_name": "whatever",
+                "channel_id": self.livechat_channel.id,
+            },
+        )["store_data"]["discuss.channel"][0]
+        self.assertEqual(channel_info["livechat_visitor_id"], False)
+
 
 @tests.tagged('post_install', '-at_install')
 class TestLivechatBasicFlowHttpCaseMobile(HttpCaseWithUserDemo, TestLivechatCommon):


### PR DESCRIPTION
Send the livechat_visitor_id with livechat channels data even there is no visitor to ensure synced data on the server and client in case of removing the visitor.

follow up to #208848

