### PR TITLE
[FIX] mail: opening chat window in mobile should focus thread

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -22,6 +22,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
 import { Typing } from "@mail/discuss/typing/common/typing";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /**
  * @typedef {Object} Props
@@ -61,6 +62,7 @@ export class ChatWindow extends Component {
         this.threadActions = useThreadActions();
         this.actionsMenuButtonHover = useHover("actionsMenuButton");
         this.parentChannelHover = useHover("parentChannel");
+        this.isMobileOS = isMobileOS();
 
         useChildSubEnv({
             closeActionPanel: () => this.threadActions.activeAction?.close(),

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -102,13 +102,13 @@
                     <t t-component="threadActions.activeAction.component" t-props="{ ...threadActions.activeAction.componentProps, thread }"/>
                 </div>
                 <t t-elif="thread">
-                    <Thread isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
+                    <Thread autofocus="isMobileOS ? props.chatWindow.autofocus : undefined" isInChatWindow="true" thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" jumpToNewMessage="props.chatWindow.jumpToNewMessage" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
                     <div t-if="thread.hasOtherMembersTyping" class="d-flex bg-inherit position-relative">
                         <div class="o-mail-ChatWindow-typing d-flex px-2 position-absolute bottom-0 start-0 w-100 bg-inherit align-items-center">
                             <Typing channel="thread" size="'medium'"/>
                         </div>
                     </div>
-                    <Composer t-if="thread.composer" composer="thread.composer" autofocus="props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
+                    <Composer t-if="thread.composer" composer="thread.composer" autofocus="isMobileOS ? undefined : props.chatWindow.autofocus" mode="'compact'" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="composerType"/>
                 </t>
             </t>
         </div>

--- a/addons/mail/static/src/core/common/chat_window_model.js
+++ b/addons/mail/static/src/core/common/chat_window_model.js
@@ -1,5 +1,4 @@
 import { Record } from "@mail/core/common/record";
-import { isMobileOS } from "@web/core/browser/feature_detection";
 
 /** @typedef {{ thread?: import("models").Thread }} ChatWindowData */
 
@@ -81,7 +80,7 @@ export class ChatWindow extends Record {
         if (notifyState) {
             this.store.chatHub.save();
         }
-        if (focus && !isMobileOS()) {
+        if (focus) {
             this.focus({ jumpToNewMessage });
         }
     }

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -44,6 +44,7 @@ const PRESENT_MESSAGE_THRESHOLD = 10;
 export class Thread extends Component {
     static components = { Message, Transition, DateSection };
     static props = [
+        "autofocus?",
         "showDates?",
         "isInChatWindow?",
         "jumpPresent?",
@@ -134,6 +135,14 @@ export class Thread extends Component {
             this.updateShowJumpPresent()
         );
         this.setupScroll();
+        useEffect(
+            (focus) => {
+                if (focus && this.state.mountedAndLoaded) {
+                    this.root.el.focus();
+                }
+            },
+            () => [this.props.autofocus + this.props.thread.autofocus, this.state.mountedAndLoaded]
+        );
         useEffect(
             () => {
                 this.computeJumpPresentPosition();

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Thread">
-    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusin="onFocusin" t-on-focusout="onFocusout">
+    <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-5': env.inChatter?.aside, 'pb-4': !env.inChatter?.aside, 'px-2': !env.inChatter and !props.isInChatWindow, 'o-focused': state.isFocused }" t-att-data-transient="props.thread.isTransient" t-ref="messages" tabindex="-1" t-on-focusin="onFocusin" t-on-focusout="onFocusout">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -57,6 +57,7 @@ export class Thread extends Record {
         return thread;
     }
 
+    autofocus = 0;
     /** @type {number} */
     id;
     /** @type {string} */

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -12,7 +12,7 @@ import {
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
-import { disableAnimations, tick } from "@odoo/hoot-mock";
+import { disableAnimations, mockUserAgent, tick } from "@odoo/hoot-mock";
 import {
     asyncStep,
     Command,
@@ -258,6 +258,7 @@ test("sidebar and banner counters display same value", async () => {
 });
 
 test("mobile: mark as read when opening chat", async () => {
+    mockUserAgent("android");
     const pyEnv = await startServer();
     const bobPartnerId = pyEnv["res.partner"].create({ name: "bob" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -281,6 +282,8 @@ test("mobile: mark as read when opening chat", async () => {
     await contains(".o-mail-NotificationItem:has(.badge:contains(1))", { text: "bob" });
     await click(".o-mail-NotificationItem", { text: "bob" });
     await contains(".o-mail-Message");
+    await contains(".o-mail-Thread.o-focused");
+    await contains(".o-mail-Composer:not(.o-focused)");
     await click(".o-mail-ChatWindow-command[title*='Close Chat Window']");
     await contains(".o-mail-NotificationItem:has(.badge:contains(1))", { text: "bob", count: 0 });
 });


### PR DESCRIPTION
Before this commit, when opening a discuss conversation in mobile, the conversation was not focused.

This was intended behaviour not long ago because focusing conversation meant focusing the composer, which is ok in desktop but in mobile this opens the soft-keyboard which is not good.

Since https://github.com/odoo/odoo/pull/211720 a thread can be focused without focus on composer. This has been introduced to improve the behaviour of mark as read.

This commit re-introduces the focus on opening conversation in mobile. In desktop it focuses the composer, but in mobile this focuses the thread. Thanks to this, the conversation is marked as read when opening conversation in mobile, as expected, without opening the soft-keyboard.

Before / After
![before](https://github.com/user-attachments/assets/08f33739-6895-463f-8e19-7bbbbf5b08e6) ![after](https://github.com/user-attachments/assets/db0153fa-ce3a-4ae8-88e2-291c3a0de0ed)
