### PR TITLE
[REF] html_builder: improve loading css in snippet dialog

### DIFF
--- a/addons/html_builder/__manifest__.py
+++ b/addons/html_builder/__manifest__.py
@@ -42,9 +42,13 @@
             ('include', 'website.assets_edit_frontend'),
         ],
         'html_builder.iframe_add_dialog': [
-            ('include', 'web.assets_frontend'),
+            ('include', 'web._assets_helpers'),
+            ('include', 'web._assets_frontend_helpers'),
+            'web/static/src/scss/pre_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables.scss',
+            'web/static/lib/bootstrap/scss/_variables-dark.scss',
+            'web/static/lib/bootstrap/scss/_maps.scss',
             'html_builder/static/src/snippets/snippet_viewer.scss',
-            'website/static/src/snippets/**/*.edit.scss',
         ],
         'web.assets_unit_tests': [
             'html_builder/static/tests/**/*',

--- a/addons/html_builder/static/src/snippets/add_snippet_dialog.js
+++ b/addons/html_builder/static/src/snippets/add_snippet_dialog.js
@@ -55,10 +55,13 @@ export class AddSnippetDialog extends Component {
             });
             root.mount(iframeDocument.body);
 
-            await loadBundle("html_builder.iframe_add_dialog", {
-                targetDoc: iframeDocument,
-                js: false,
-            });
+            await Promise.all([
+                loadBundle("web.assets_frontend", { targetDoc: iframeDocument, js: false }),
+                loadBundle("html_builder.iframe_add_dialog", {
+                    targetDoc: iframeDocument,
+                    js: false,
+                }),
+            ]);
             this.state.showIframe = true;
         });
 


### PR DESCRIPTION
Before this commit, the snippet dialog would load all frontend css in a special bundle. This is not necessary, since we already have the web.assets_frontend somewhere in cache, so loading that css in a different bundle means that the server has to process it an extra time.

With this commit, the iframe dialog bundle only contains the required new css, and we simply load the web.assets_frontend bundle separately. This makes the dialog quicker to load.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
