### PR TITLE
[FIX] base: patch lxml to allow multiple data urls

### DIFF
--- a/odoo/_monkeypatches/__init__.py
+++ b/odoo/_monkeypatches/__init__.py
@@ -25,6 +25,8 @@ def patch_all():
     patch_pytz()
     from .literal_eval import patch_literal_eval
     patch_literal_eval()
+    from .lxml import patch_lxml
+    patch_lxml()
     from .num2words import patch_num2words
     patch_num2words()
     from .stdnum import patch_stdnum

--- a/odoo/_monkeypatches/lxml.py
+++ b/odoo/_monkeypatches/lxml.py
@@ -1,0 +1,13 @@
+import lxml.html.clean
+import re
+
+from importlib.metadata import version
+
+from odoo.tools import parse_version
+
+
+def patch_lxml():
+    # between these versions having a couple data urls in a style attribute
+    # or style node removes the attribute or node erroneously
+    if parse_version("4.6.0") <= parse_version(version('lxml')) < parse_version("5.2.0"):
+        lxml.html.clean._find_image_dataurls = re.compile(r'data:image/(.+?);base64,').findall


### PR DESCRIPTION
In lxml from 4.6.0 to 5.2.0:

[1] introduces an issue where "style" tags will always be cleaned if
there is more than one data url inside it (the regex is too greedy) in
4.6.0

[2] fixes the issue in the lxml_html_clean module version 0.1.1 which is
the dependency that replaces lxml.html.clean from lxml 5.2.0 and up

We apply the fix from [2] in odoo directly. With many checks to ensure
we don't override any potential deviation from the original regex.

The issue only appear from 18.0 onwards, as that's when "email_outgoing"
sanitation started being applied [3]

[1]: https://github.com/lxml/lxml/commit/73778681f14359fe6d16644e69aaca276eba525a
[2]: https://github.com/fedora-python/lxml_html_clean/commit/97402b5f6e94583c8f1c3f6070ef19ce1df90da8
[3]: https://github.com/odoo/odoo/commit/24731938f75358fd3c72b91465b72ab80d62d208

runbot-105525
