### PR TITLE
[REV] website, *: temporarily disable form property fields

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -22,16 +22,6 @@ odoo.define('website.s_website_form', function (require) {
          */
         start: function () {
             if (this.editableMode) {
-                // TODO: Improve this. Since the form behavior was handled using
-                // two separate public widgets, and the "data-for" values were
-                // removed (on destroy before saving), we still need to restore
-                // them in edit mode in the case of a simple widget refresh.
-                this.dataForValues = wUtils.getParsedDataFor(this.$target[0].id, this.$target[0].ownerDocument);
-                for (const fieldEl of this._getDataForFields()) {
-                    if (!fieldEl.getAttribute("value")) {
-                        fieldEl.setAttribute("value", this.dataForValues[fieldEl.name]);
-                    }
-                }
                 // We do not initialize the datetime picker in edit mode but want the dates to be formated
                 const dateTimeFormat = time.getLangDatetimeFormat();
                 const dateFormat = time.getLangDateFormat();
@@ -46,21 +36,8 @@ odoo.define('website.s_website_form', function (require) {
             return this._super(...arguments);
         },
         /**
-         * @override
-         */
-        destroy() {
-            if (this.editableMode) {
-                // The "data-for" values are always correctly added to the form
-                // on the form widget start. But if we make any change to it in
-                // "edit" mode, we need to be sure it will not be saved with
-                // the new values.
-                for (const fieldEl of this._getDataForFields()) {
-                    fieldEl.removeAttribute("value");
-                }
-            }
-            this._super(...arguments);
-        },
-        /**
+         * TODO: remove in master (kept for compatibility).
+         *
          * @private
          */
         _getDataForFields() {
@@ -276,18 +253,8 @@ odoo.define('website.s_website_form', function (require) {
             // All 'hidden if' fields start with d-none
             this.$target[0].querySelectorAll('.s_website_form_field_hidden_if:not(.d-none)').forEach(el => el.classList.add('d-none'));
 
-            // Prevent "data-for" values removal on destroy, they are still used
-            // in edit mode to keep the form linked to its predefined server
-            // values (e.g., the default `job_id` value on the application form
-            // for a given job).
-            const dataForValues = wUtils.getParsedDataFor(this.$target[0].id, document) || {};
-            const initialValuesToReset = new Map(
-                [...this.initialValues.entries()].filter(
-                    ([input]) => !dataForValues[input.name] || input.name === "email_to"
-                )
-            );
             // Reset the initial default values.
-            for (const [fieldEl, initialValue] of initialValuesToReset.entries()) {
+            for (const [fieldEl, initialValue] of this.initialValues.entries()) {
                 if (initialValue) {
                     fieldEl.setAttribute('value', initialValue);
                 } else {

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -120,9 +120,7 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         content: 'Verify that the job_id field has kept its default value',
         trigger: "body",
         run: () => {
-            const doc = document.querySelector(".o_iframe:not(.o_ignore_in_tour)").contentDocument;
-            const id = doc.querySelector('[data-oe-model="hr.job"]').dataset.oeId;
-            if (!doc.querySelector(`input[name="job_id"][value="${id}"]`)) {
+            if (!document.querySelector('.o_iframe:not(.o_ignore_in_tour)').contentDocument.querySelector('input[name="job_id"][value="FAKE_JOB_ID_DEFAULT_VAL"]')) {
                 console.error('The job_id field has lost its default value');
             }
         }


### PR DESCRIPTION
The fix from [1] allowed to have model-related custom property fields in website
forms by preventing the removal of data-for values when switching to edit mode.

This commit also preserved a diff from an old fix that became optional later
(see [full explanation]) which led to form default values being lost when fields
also have `data-for` values.

This commit is reverting [1] temporarily until the merge of [2].

[1]: https://github.com/odoo/odoo/commit/ca433f38dbfe379dc9e0b823c7862eaec1a7ed9d
[2]: https://github.com/odoo/odoo/pull/211083
[full explanation]: https://github.com/odoo/odoo/pull/211083#pullrequestreview-2899441967

task-3922573
opw-4794903