### PR TITLE
[FIX] mail: better visual of discuss sidebar and chat hub options

### DIFF
--- a/addons/im_livechat/static/tests/chat_hub_compact.test.js
+++ b/addons/im_livechat/static/tests/chat_hub_compact.test.js
@@ -24,8 +24,8 @@ test("Do not open chat windows automatically when chat hub is compact", async ()
         create_uid: serverState.publicUserId,
     });
     await start();
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']");
-    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
+    await click("button[title='Chat Options']");
+    await click(".o-dropdown-item", { text: "Hide all conversations" });
     await contains(".o-mail-ChatHub-bubbleBtn .fa-comments");
     await withGuest(guestId, () =>
         rpc("/mail/message/post", {

--- a/addons/mail/static/src/core/common/chat_hub.js
+++ b/addons/mail/static/src/core/common/chat_hub.js
@@ -9,9 +9,10 @@ import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { ChatBubble } from "./chat_bubble";
 import { isMobileOS } from "@web/core/browser/feature_detection";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 
 export class ChatHub extends Component {
-    static components = { ChatBubble, ChatWindow, Dropdown };
+    static components = { ChatBubble, ChatWindow, Dropdown, DropdownItem };
     static props = [];
     static template = "mail.ChatHub";
 

--- a/addons/mail/static/src/core/common/chat_hub.scss
+++ b/addons/mail/static/src/core/common/chat_hub.scss
@@ -95,15 +95,22 @@
     border: $border-width solid transparent !important;
 
     &.o-bubblesHover {
-        opacity: 50%;
+        border-color: mix($o-gray-200, $o-gray-300) !important;
+
+        i {
+            opacity: 50%;
+        }
     }
 
     &:hover {
         border-color: $o-gray-300 !important;
-        opacity: 75%;
     }
     &.show {
-        opacity: 100% !important;
         border-color: mix($o-gray-300, $o-gray-400) !important;
+    }
+    &:hover, &.show {
+        i {
+            opacity: 100%;
+        }
     }
 }

--- a/addons/mail/static/src/core/common/chat_hub.xml
+++ b/addons/mail/static/src/core/common/chat_hub.xml
@@ -11,13 +11,13 @@
         <div class="o-mail-ChatHub-bubbles position-fixed d-flex flex-column align-content-start justify-content-end align-items-center" t-attf-style="top: {{position.top}}; left: {{position.left}}; right: {{position.right}}; bottom: {{position.bottom}}" t-att-class="{ 'o-liftUp': busMonitoring.hasConnectionIssues, 'o-mobile': isMobileOS }" t-ref="bubbles">
             <div class="d-flex flex-column align-content-start justify-content-end align-items-center gap-1">
                 <Dropdown t-if="(chatHub.showConversations and !chatHub.compact) or position.dragged" state="options" position="'top-end'" menuClass="'d-flex flex-column bg-100 shadow-sm m-0 p-0 mb-1 border-secondary'">
-                    <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn oi oi-ellipsis-h bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"/>
+                    <button class="o-mail-ChatHub-bubbleBtn btn o-mail-ChatHub-optionsBtn bg-100 mt-1 fs-3" t-att-class="{ 'opacity-0': !bubblesHover.isHover and !position.dragged and !options.isOpen and !isMobileOS, 'o-bubblesHover': (bubblesHover.isHover or position.dragged) and !isMobileOS, 'o-active': bubblesHover.isHover or options.isOpen }" title="Chat Options"><i class="oi oi-ellipsis-h"/></button>
                     <t t-set-slot="content">
                         <t t-if="chatHub.showConversations and !chatHub.compact">
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</button>
-                            <button class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</button>
+                            <DropdownItem class="'o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal px-2'" onSelected="() => chatHub.hideAll()"><i class="fa fa-fw fa-eye-slash"></i>Hide all conversations</DropdownItem>
+                            <DropdownItem class="'o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal px-2'" onSelected="() => chatHub.closeAll()"><i class="oi fa-fw oi-close"></i>Close all conversations</DropdownItem>
                         </t>
-                        <button t-if="position.dragged" class="o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal" t-on-click="resetPosition"><i class="fa fa-fw fa-undo"></i>Reset initial position</button>
+                        <DropdownItem t-if="position.dragged" class="'o-mail-ChatHub-option btn border-0 d-flex align-items-center gap-2 rounded-0 fw-normal px-2'" onSelected="resetPosition"><i class="fa fa-fw fa-undo"></i>Reset initial position</DropdownItem>
                     </t>
                 </Dropdown>
                 <t t-if="store.chatHub.compact" t-call="mail.ChatHub.compactButton"/>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -43,12 +43,9 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebarChannel-actions button {
     opacity: 35%;
+    --border-opacity: .15;
 
-    &:hover {
-        opacity: 100%;
-    }
-
-    &.o-showingActions {
+    &:hover, &.o-showingActions {
         opacity: 100%;
         --border-opacity: .25;
     }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -188,7 +188,7 @@
             'ms-1': thread.importantCounter > 0,
         }">
             <Dropdown state="showingActions" position="'right-start'" menuClass="'o-mail-DiscussSidebar-floatingMenu bg-100 border border-secondary my-0 min-w-0 p-0 o-rounded-bubble mx-1'">
-                <button class="btn me-1 btn-light rounded-circle d-flex o-px-0_5 py-1 align-items-center justify-content-center" t-att-class="{ 'o-showingActions border-dark o-mail-discussSidebarBgColor shadow-sm': showingActions.isOpen, 'bg-transparent border-transparent': !showingActions.isOpen }" t-att-title="actionsTitle">
+                <button class="btn me-1 btn-light rounded-circle d-flex o-px-0_5 py-1 align-items-center justify-content-center o-mail-discussSidebarBgColor border-dark" t-att-class="{ 'o-showingActions shadow-sm': showingActions.isOpen }" t-att-title="actionsTitle">
                     <i role="img" class="oi oi-fw oi-lg oi-ellipsis-h"/>
                 </button>
                 <t t-set-slot="content">

--- a/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
+++ b/addons/mail/static/tests/chat_bubble/chat_bubble.test.js
@@ -305,8 +305,8 @@ test("Can close all chat windows at once", async () => {
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
     await contains(".o-mail-ChatBubble", { text: "+13" });
     await hover(".o-mail-ChatHub-hiddenBtn");
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']");
-    await click("button.o-mail-ChatHub-option", { text: "Close all conversations" });
+    await click("button[title='Chat Options']");
+    await click(".o-dropdown-item", { text: "Close all conversations" });
     await contains(".o-mail-ChatBubble", { count: 0 });
     assertChatHub({});
 });
@@ -323,8 +323,8 @@ test("Can compact chat hub", async () => {
     await contains(".o-mail-ChatBubble", { count: 8 }); // max reached
     await contains(".o-mail-ChatBubble", { text: "+13" });
     await hover(".o-mail-ChatHub-hiddenBtn");
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']");
-    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
+    await click("button[title='Chat Options']");
+    await click(".o-dropdown-item", { text: "Hide all conversations" });
     await contains(".o-mail-ChatBubble i.fa.fa-comments");
     await click(".o-mail-ChatBubble i.fa.fa-comments");
     await contains(".o-mail-ChatBubble", { count: 8 });
@@ -342,8 +342,8 @@ test("Compact chat hub is crosstab synced", async () => {
     await contains(".o-mail-ChatBubble", { count: 2, target: env1 });
     await contains(".o-mail-ChatBubble", { count: 2, target: env2 });
     await hover(".o-mail-ChatBubble:eq(0)", { target: env1 });
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']", { target: env1 });
-    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations", target: env1 });
+    await click("button[title='Chat Options']", { target: env1 });
+    await click(".o-dropdown-item", { text: "Hide all conversations", target: env1 });
     await contains(".o-mail-ChatBubble .fa-comments", { target: env1 });
     await contains(".o-mail-ChatBubble .fa-comments", { target: env2 });
 });
@@ -516,8 +516,8 @@ test("Open chat window from messaging menu with chat hub compact", async () => {
     setupChatHub({ folded: [chatId] });
     await start();
     await openFormView("res.partner", serverState.partnerId);
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']");
-    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
+    await click("button[title='Chat Options']");
+    await click(".o-dropdown-item", { text: "Hide all conversations" });
     await contains(".o-mail-ChatHub-compact");
     await click(".o_menu_systray i[aria-label='Messages']");
     await click(".o-mail-NotificationItem", { text: "John" });
@@ -549,8 +549,8 @@ test("Open chat window from command palette with chat hub compact", async () => 
     });
     setupChatHub({ folded: [chatId] });
     await start();
-    await click("button.oi.oi-ellipsis-h[title='Chat Options']");
-    await click("button.o-mail-ChatHub-option", { text: "Hide all conversations" });
+    await click("button[title='Chat Options']");
+    await click(".o-dropdown-item", { text: "Hide all conversations" });
     await contains(".o-mail-ChatHub-compact");
     await triggerHotkey("control+k");
     await insertText(".o_command_palette_search input", "@");


### PR DESCRIPTION
Discuss sidebar options button was too shy on action mouse-hover when not active. This commit improves the mouse-hover effect.

The chat hub options button had global opacity when not being used, which made it hard to see when there's content below. The hover effect was also lacking. This commit improves to have opacity change only on icon and not background, and the hover effect is made more obvious.

Chat hub options were not dropdown items, thus keyboard navigation didn't work. Discuss dropdown menu use dropdown item for keyboard navigation, so this was weird to be a rare menu without it. This commit turned the buttons into `<DropdownItem>`.

Before / After (discuss sidebar options)
![before-ds](https://github.com/user-attachments/assets/bc61540e-b3e4-4785-8009-b4410dbed1f0) ![after-ds](https://github.com/user-attachments/assets/89512d99-9183-408b-85b5-96c6c1d8150b)

Before / After (chat hub options)
![before-ch](https://github.com/user-attachments/assets/f57e885e-5023-408c-af93-c54b277626bf) ![after-ch](https://github.com/user-attachments/assets/7cd93b78-11f1-452f-bf27-d77da34cdaa2)
