### PR TITLE
[FIX] stock: fix move lines order on delivery slips

### DIFF
--- a/addons/mrp/report/report_deliveryslip.xml
+++ b/addons/mrp/report/report_deliveryslip.xml
@@ -28,7 +28,7 @@
 
     <template id="stock_report_delivery_kit_sections">
         <!-- get all kits-related SML, including subkits -->
-        <t t-set="all_kits_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type == 'phantom')"/>
+        <t t-set="all_kits_move_lines" t-value="o.move_ids.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type == 'phantom')"/>
         <!-- do another map to get unique top level kits -->
         <t t-set="boms" t-value="has_kits.mapped('move_id.bom_line_id.bom_id')"/>
         <t t-foreach="boms" t-as="bom">
@@ -66,7 +66,7 @@
     <!-- No kit section is expected to only be called in no packages case -->
     <template id="stock_report_delivery_no_kit_section">
         <!-- Do another section for kit-less products if they exist -->
-        <t t-set="no_kit_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type != 'phantom')"/>
+        <t t-set="no_kit_move_lines" t-value="o.move_ids.move_line_ids.filtered(lambda l: l.move_id.bom_line_id.bom_id.type != 'phantom')"/>
         <t t-if="no_kit_move_lines">
             <tr t-att-class="'fw-bold o_line_section'">
                 <td colspan="99">

--- a/addons/stock/report/report_deliveryslip.xml
+++ b/addons/stock/report/report_deliveryslip.xml
@@ -113,7 +113,7 @@
                                 <t t-set="packages" t-value="o.move_line_ids.mapped('result_package_id')"/>
                                 <t t-foreach="packages" t-as="package">
                                     <t t-call="stock.stock_report_delivery_package_section_line"/>
-                                    <t t-set="package_move_lines" t-value="o.move_line_ids.filtered(lambda l: l.result_package_id == package)"/>
+                                    <t t-set="package_move_lines" t-value="o.move_ids.move_line_ids.filtered(lambda l: l.result_package_id == package)"/>
                                     <!-- If printing lots/serial numbers => keep products in original lines -->
                                     <t t-if="has_serial_number">
                                         <tr t-foreach="package_move_lines" t-as="move_line">
@@ -127,8 +127,8 @@
                                     </t>
                                 </t>
                                 <!-- Make sure we do another section for package-less products if they exist -->
-                                <t t-set="move_lines" t-value="o.move_line_ids.filtered(lambda l: not l.result_package_id)"/>
-                                <t t-set="aggregated_lines" t-value="o.move_line_ids._get_aggregated_product_quantities(except_package=True)"/>
+                                <t t-set="move_lines" t-value="o.move_ids.move_line_ids.filtered(lambda l: not l.result_package_id)"/>
+                                <t t-set="aggregated_lines" t-value="o.move_ids.move_line_ids._get_aggregated_product_quantities(except_package=True)"/>
                                 <t t-if="move_lines or aggregated_lines" name="no_package_move_lines">
                                     <t t-call="stock.stock_report_delivery_no_package_section_line" name="no_package_section"/>
                                     <t t-if="has_serial_number">
@@ -145,13 +145,13 @@
                             <t t-else="">
                                 <!-- If printing lots/serial numbers => keep products in original lines -->
                                 <t t-if="has_serial_number">
-                                    <tr t-foreach="o.move_line_ids" t-as="move_line">
+                                    <tr t-foreach="o.move_ids.move_line_ids" t-as="move_line">
                                         <t t-call="stock.stock_report_delivery_has_serial_move_line"/>
                                     </tr>
                                 </t>
                                 <!-- If not printing lots/serial numbers => merge lines with same product -->
                                 <t t-else="" name="aggregated_move_lines">
-                                    <t t-set="aggregated_lines" t-value="o.move_line_ids._get_aggregated_product_quantities()"/>
+                                    <t t-set="aggregated_lines" t-value="o.move_ids.move_line_ids._get_aggregated_product_quantities()"/>
                                     <t t-call="stock.stock_report_delivery_aggregated_move_lines"/>
                                 </t>
                             </t>


### PR DESCRIPTION
**Steps to reproduce:**
- Add 2 products in a delivery
- Add the second's product move lines before the first one.
- Validate and print delivery slip

**Issue:**
We iterate the `move_line_ids` directly which means if
we have a new move line for a move with a lower id, it
will push the product to the end of the delivery slip.

  **Example:**
  If we have `stock.move(1,)` with `stock.move_line(52,)` and
  `stock.move(2,)` with `stock.move_line(51,)`.

`stock.move_line(51,)` will be printed first, which introduces
a change in the order of the delivery slip.

**Fix:**
Iterate on `move_ids` and access `move_line_ids` through it,
to print `move_lines_ids` in the same order of the `move_id`.

Task: 4570203


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
