### PR TITLE
[IMP] account, l10n_*_edi: Add missing XML generation tests

### DIFF
--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -8,11 +8,14 @@ from odoo.addons.product.tests.common import ProductCommon
 
 import json
 import base64
+import logging
 from contextlib import contextmanager
 from functools import wraps
 from lxml import etree
 from unittest import SkipTest
 from unittest.mock import patch
+
+_logger = logging.getLogger(__name__)
 
 
 class AccountTestInvoicingCommon(ProductCommon):
@@ -650,13 +653,14 @@ class AccountTestInvoicingCommon(ProductCommon):
         attrib_wo_ns = {k: v for k, v in node.attrib.items() if '}' not in k}
         full_path = f'{path}/{tag_wo_ns}'
         return {
+            'node': node,
             'tag': tag_wo_ns,
             'full_path': full_path,
             'namespace': None if len(tag_split) < 2 else tag_split[0],
             'text': (node.text or '').strip(),
             'attrib': attrib_wo_ns,
             'children': [
-                self._turn_node_as_dict_hierarchy(child_node, path=path)
+                self._turn_node_as_dict_hierarchy(child_node, path=full_path)
                 for child_node in node.getchildren()
             ],
         }
@@ -697,9 +701,19 @@ class AccountTestInvoicingCommon(ProductCommon):
                 )
 
             # Check children.
+            children = [child['tag'] for child in node_dict['children']]
+            expected_children = [child['tag'] for child in expected_node_dict['children']]
+            if children != expected_children:
+                for child in node_dict['children']:
+                    if child['tag'] not in expected_children:
+                        _logger.warning('Non-expected child: \n%s', etree.tostring(child['node']).decode())
+                for child in expected_node_dict['children']:
+                    if child['tag'] not in children:
+                        _logger.warning('Missing child: \n%s', etree.tostring(child['node']).decode())
+
             self.assertEqual(
-                [child['tag'] for child in node_dict['children']],
-                [child['tag'] for child in expected_node_dict['children']],
+                children,
+                expected_children,
                 f"Number of children elements for node {node_dict['full_path']} is different.",
             )
 

--- a/addons/l10n_anz_ubl_pint/tests/__init__.py
+++ b/addons/l10n_anz_ubl_pint/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_anz_ubl_pint

--- a/addons/l10n_anz_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_anz_ubl_pint/tests/expected_xmls/invoice.xml
@@ -1,0 +1,139 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@aunz-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/18-19/0001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>NZD</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>AUD</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/18-19/0001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0151">11225459588</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Henry Lawson Drive</cbc:StreetName>
+        <cbc:CityName>Home Rule</cbc:CityName>
+        <cbc:PostalZone>2850</cbc:PostalZone>
+        <cbc:CountrySubentity>Western Australia</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>AU</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>11225459588</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0151">11225459588</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+61 412 345 678</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0088">9429047488083</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Victoria Street</cbc:StreetName>
+        <cbc:CityName>Hamilton</cbc:CityName>
+        <cbc:PostalZone>3247</cbc:PostalZone>
+        <cbc:CountrySubentity>West Coast</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>NZ</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>49098576</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID schemeID="0088">49098576</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+64 21 123 4567</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>Victoria Street</cbc:StreetName>
+        <cbc:CityName>Hamilton</cbc:CityName>
+        <cbc:PostalZone>3247</cbc:PostalZone>
+        <cbc:CountrySubentity>West Coast</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>NZ</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/18-19/0001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="NZD">200.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="NZD">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="NZD">200.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="AUD">100.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="NZD">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="NZD">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="NZD">2200.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="NZD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="NZD">2200.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="NZD">2000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="NZD">2000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_anz_ubl_pint/tests/test_anz_ubl_pint.py
+++ b/addons/l10n_anz_ubl_pint/tests/test_anz_ubl_pint.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import file_open
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestAnzUBLPint(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('au')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.other_currency = cls.setup_other_currency('NZD')
+
+        # TIN number is required
+        cls.company_data['company'].write({
+            'vat': '11225459588',
+            'street': 'Henry Lawson Drive',
+            'zip': '2850',
+            'city': 'Home Rule',
+            'state_id': cls.env.ref('base.state_au_8').id,
+            'phone': '+61 412 345 678',
+        })
+        cls.partner_a.write({
+            'vat': '49098576',
+            'company_registry': '9429047488083',
+            'street': 'Victoria Street',
+            'zip': '3247',
+            'city': 'Hamilton',
+            'state_id': cls.env.ref('base.state_nz_wtc').id,
+            'country_id': cls.env.ref('base.nz').id,
+            'phone': '+64 21 123 4567',
+        })
+
+        cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
+        cls.startClassPatcher(freeze_time(cls.fakenow))
+
+    def test_invoice(self):
+        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a)
+        invoice.action_post()
+
+        actual_xml, errors = self.env['account.edi.xml.pint_anz']._export_invoice(invoice)
+        self.assertFalse(errors)
+
+        with file_open('l10n_anz_ubl_pint/tests/expected_xmls/invoice.xml', 'rb') as f:
+            expected_xml = f.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_xml),
+            self.get_xml_tree_from_string(expected_xml),
+        )

--- a/addons/l10n_jp_ubl_pint/tests/__init__.py
+++ b/addons/l10n_jp_ubl_pint/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_jp_ubl_pint

--- a/addons/l10n_jp_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_jp_ubl_pint/tests/expected_xmls/invoice.xml
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@jp-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>JPY</cbc:TaxCurrencyCode>
+  <cac:InvoicePeriod>
+    <cbc:StartDate>2019-01-01</cbc:StartDate>
+    <cbc:EndDate>2019-01-01</cbc:EndDate>
+  </cac:InvoicePeriod>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0221">7482543580381</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>池上通り</cbc:StreetName>
+        <cbc:CityName>品川区</cbc:CityName>
+        <cbc:PostalZone>140-0004</cbc:PostalZone>
+        <cbc:CountrySubentity>Yamanashi</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>JP</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>7482543580381</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+81 90-1234-5678</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0221">T7000012050002</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3F 星和池袋ビル</cbc:StreetName>
+        <cbc:CityName>豊島区</cbc:CityName>
+        <cbc:PostalZone>170-0013</cbc:PostalZone>
+        <cbc:CountrySubentity>Tokyo</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>JP</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>T7000012050002</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+81 3-5798-5555</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>3F 星和池袋ビル</cbc:StreetName>
+        <cbc:CityName>豊島区</cbc:CityName>
+        <cbc:PostalZone>170-0013</cbc:PostalZone>
+        <cbc:CountrySubentity>Tokyo</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>JP</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">100.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">100.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="JPY">50</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="JPY">500</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="JPY">50</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">1100.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="USD">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="USD">1100.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>S</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_jp_ubl_pint/tests/test_jp_ubl_pint.py
+++ b/addons/l10n_jp_ubl_pint/tests/test_jp_ubl_pint.py
@@ -1,0 +1,56 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import file_open
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestJpUBLPint(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('jp')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.other_currency = cls.setup_other_currency('USD')
+
+        # TIN number is required
+        cls.company_data['company'].write({
+            'vat': '7482543580381',
+            'street': '池上通り',
+            'zip': '140-0004',
+            'city': '品川区',
+            'state_id': cls.env.ref('base.state_jp_jp-19').id,
+            'phone': '+81 90-1234-5678',
+        })
+        cls.partner_a.write({
+            'vat': 'T7000012050002',
+            'street': '3F 星和池袋ビル',
+            'zip': '170-0013',
+            'city': '豊島区',
+            'state_id': cls.env.ref('base.state_jp_jp-13').id,
+            'country_id': cls.env.ref('base.jp').id,
+            'phone': '+81 3-5798-5555',
+        })
+
+        cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
+        cls.startClassPatcher(freeze_time(cls.fakenow))
+
+    def test_invoice(self):
+        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a)
+        invoice.action_post()
+
+        actual_xml, errors = self.env['account.edi.xml.pint_jp']._export_invoice(invoice)
+        self.assertFalse(errors)
+
+        with file_open('l10n_jp_ubl_pint/tests/expected_xmls/invoice.xml', 'rb') as f:
+            expected_xml = f.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_xml),
+            self.get_xml_tree_from_string(expected_xml),
+        )

--- a/addons/l10n_my_edi/tests/expected_xmls/bill_import.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/bill_import.xml
@@ -1,0 +1,175 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:ID>BILL/2019/01/0001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">11</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>E12345678912</cbc:ID>
+    <cbc:DocumentType>CustomsImportForm</cbc:DocumentType>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">800.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+      <cbc:Percent>0.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Name>Exempt Customer</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">800.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">800.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">800.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">800.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">800.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">800.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>E</cbc:ID>
+          <cbc:Name>Exempt Customer</cbc:Name>
+          <cbc:Percent>0.0</cbc:Percent>
+          <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Name>Exempt Customer</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">800.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">800.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/credit_note.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/credit_note.xml
@@ -1,0 +1,174 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:ID>RINV/2024/00001</cbc:ID>
+  <cbc:IssueDate>2024-07-15</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">02</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:BillingReference>
+    <cac:InvoiceDocumentReference>
+      <cbc:ID>INV/2019/00001</cbc:ID>
+      <cbc:UUID>12345678912345678912345678</cbc:UUID>
+    </cac:InvoiceDocumentReference>
+  </cac:BillingReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:TaxExchangeRate>
+    <cbc:SourceCurrencyCode>EUR</cbc:SourceCurrencyCode>
+    <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
+    <cbc:CalculationRate>0.5</cbc:CalculationRate>
+  </cac:TaxExchangeRate>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2200.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">2200.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">0.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="EUR">2000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice.xml
@@ -1,0 +1,166 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1100.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1100.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">1000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_foreigner.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_foreigner.xml
@@ -1,0 +1,165 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">EI00000000020</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">NA</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_b</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Alabama</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>AL</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">USA</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_b</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_b</cbc:Name>
+        <cbc:Telephone>+60123456785</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">EI00000000020</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">NA</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Alabama</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>AL</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">USA</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_b</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1100.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1100.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">1000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_import.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_import.xml
@@ -1,0 +1,166 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1100.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1100.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">1000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_multicurrency.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_multicurrency.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxExchangeRate>
+    <cbc:SourceCurrencyCode>EUR</cbc:SourceCurrencyCode>
+    <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
+    <cbc:CalculationRate>0.5</cbc:CalculationRate>
+  </cac:TaxExchangeRate>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2200.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">2200.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="EUR">2000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_optional_fields.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_optional_fields.xml
@@ -1,0 +1,190 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>CFR</cbc:ID>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>E12345678912</cbc:ID>
+    <cbc:DocumentType>K2</cbc:DocumentType>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="SST">A01-2345-67891012</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TTX">123-4567-89012345</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="SST">A01-2345-67891013</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="SST">A01-2345-67891013</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxExchangeRate>
+    <cbc:SourceCurrencyCode>EUR</cbc:SourceCurrencyCode>
+    <cbc:TargetCurrencyCode>MYR</cbc:TargetCurrencyCode>
+    <cbc:CalculationRate>0.5</cbc:CalculationRate>
+  </cac:TaxExchangeRate>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2200.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">2200.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="EUR">2000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_tax_exempt.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_tax_exempt.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">EI00000000020</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">NA</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_b</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Alabama</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>AL</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">USA</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_b</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_b</cbc:Name>
+        <cbc:Telephone>+60123456785</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">EI00000000020</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">NA</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Alabama</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>AL</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">USA</cbc:IdentificationCode>
+          <cbc:Name>United States</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_b</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: 30% Advance End of Following Month</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+      <cbc:Percent>0.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Name>Exempt Customer</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">1000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1000.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1000.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">1000.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>E</cbc:ID>
+          <cbc:Name>Exempt Customer</cbc:Name>
+          <cbc:Percent>0.0</cbc:Percent>
+          <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:CommodityClassification>
+        <cbc:ItemClassificationCode listID="CLASS">001</cbc:ItemClassificationCode>
+      </cac:CommodityClassification>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>E</cbc:ID>
+        <cbc:Name>Exempt Customer</cbc:Name>
+        <cbc:Percent>0.0</cbc:Percent>
+        <cbc:TaxExemptionReason>Exempt Customer</cbc:TaxExemptionReason>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">1000.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_edi/tests/expected_xmls/invoice_with_so.xml
+++ b/addons/l10n_my_edi/tests/expected_xmls/invoice_with_so.xml
@@ -1,0 +1,163 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:ID>INV/2024/00001</cbc:ID>
+  <cbc:IssueDate>2024-07-15</cbc:IssueDate>
+  <cbc:IssueTime>10:00:00Z</cbc:IssueTime>
+  <cbc:InvoiceTypeCode listVersionID="1.1">01</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cbc:BuyerReference>MY-REF</cbc:BuyerReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:IndustryClassificationCode name="Growing of maize">01111</cbc:IndustryClassificationCode>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563200</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234567</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that one street, 5</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryParty>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TIN">C2584563201</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="BRN">202001234568</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PostalAddress>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cbc:CountrySubentityCode>01</cbc:CountrySubentityCode>
+        <cac:AddressLine>
+          <cbc:Line>that other street, 3</cbc:Line>
+        </cac:AddressLine>
+        <cac:Country>
+          <cbc:IdentificationCode listID="ISO3166-1" listAgencyID="6">MYS</cbc:IdentificationCode>
+          <cbc:Name>Malaysia</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+      </cac:PartyLegalEntity>
+    </cac:DeliveryParty>
+  </cac:Delivery>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="MYR">100.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+      <cbc:Percent>10.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">100.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">100.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">110.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">110.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">100.00</cbc:LineExtensionAmount>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="MYR">100.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="MYR">10.00</cbc:TaxAmount>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cbc:ID>01</cbc:ID>
+          <cbc:Percent>10.0</cbc:Percent>
+          <cac:TaxScheme>
+            <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>01</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID schemeID="UN/ECE 5153" schemeAgencyID="6">OTH</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">100.0</cbc:PriceAmount>
+    </cac:Price>
+    <cac:ItemPriceExtension>
+      <cbc:Amount currencyID="MYR">100.00</cbc:Amount>
+    </cac:ItemPriceExtension>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_ubl_pint/tests/__init__.py
+++ b/addons/l10n_my_ubl_pint/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_my_ubl_pint

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml
@@ -1,0 +1,118 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@my-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>MYR</cbc:DocumentCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that one street, 5</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>NA</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>NA</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563201</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">0.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="MYR">0.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="MYR">1000.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="MYR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="MYR">1000.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="MYR">1000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="MYR">1000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
+++ b/addons/l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml
@@ -1,0 +1,140 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@my-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>MYR</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that one street, 5</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>A01-2345-67891012</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563200</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+60123456789</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>A01-2345-67891013</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>C2584563201</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+60123456786</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>Main city</cbc:CityName>
+        <cbc:CountrySubentity>Johor</cbc:CountrySubentity>
+        <cac:Country>
+          <cbc:IdentificationCode>MY</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">200.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>T</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="MYR">100.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2200.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">2200.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>T</cbc:ID>
+        <cbc:Percent>10.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
+++ b/addons/l10n_my_ubl_pint/tests/test_my_ubl_pint.py
@@ -1,0 +1,80 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import file_open
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestMyUBLPint(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('my')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.other_currency = cls.setup_other_currency('EUR')
+
+        # TIN number is required
+        cls.company_data['company'].write({
+            'vat': 'C2584563200',
+            'state_id': cls.env.ref('base.state_my_jhr').id,
+            'street': 'that one street, 5',
+            'city': 'Main city',
+            'phone': '+60123456789',
+        })
+        cls.partner_a.write({
+            'vat': 'C2584563201',
+            'country_id': cls.env.ref('base.my').id,
+            'state_id': cls.env.ref('base.state_my_jhr').id,
+            'street': 'that other street, 3',
+            'city': 'Main city',
+            'phone': '+60123456786',
+        })
+
+        cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
+        cls.startClassPatcher(freeze_time(cls.fakenow))
+
+    def test_invoice_no_taxes(self):
+        invoice = self.init_invoice('out_invoice', products=self.product_a, taxes=[])
+        invoice.action_post()
+
+        actual_xml, errors = self.env['account.edi.xml.pint_my']._export_invoice(invoice)
+        self.assertFalse(errors)
+
+        with file_open('l10n_my_ubl_pint/tests/expected_xmls/invoice_no_taxes.xml', 'rb') as f:
+            expected_xml = f.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_xml),
+            self.get_xml_tree_from_string(expected_xml),
+        )
+
+    def test_invoice_with_sst(self):
+        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a)
+
+        invoice.write({
+            'invoice_incoterm_id': self.env.ref('account.incoterm_CFR').id,
+        })
+
+        self.company_data['company'].write({
+            'sst_registration_number': 'A01-2345-67891012',
+            'ttx_registration_number': '123-4567-89012345',
+        })
+        self.partner_a.commercial_partner_id.sst_registration_number = 'A01-2345-67891013'
+
+        invoice.action_post()
+
+        actual_xml, errors = self.env['account.edi.xml.pint_my']._export_invoice(invoice)
+        self.assertFalse(errors)
+
+        with file_open('l10n_my_ubl_pint/tests/expected_xmls/invoice_with_sst.xml', 'rb') as f:
+            expected_xml = f.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_xml),
+            self.get_xml_tree_from_string(expected_xml),
+        )

--- a/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
+++ b/addons/l10n_sg_ubl_pint/models/account_edi_xml_pint_sg.py
@@ -66,7 +66,7 @@ class AccountEdiXmlUBLPINTSG(models.AbstractModel):
             )
             # [BR-53-GST-SG]-If the GST accounting currency code (BT-6-GST) is present, then the Invoice total GST amount (BT-111-GST),
             # Invoice total including GST amount and Invoice Total excluding GST amount in accounting currency shall be provided.
-            additional_document_reference_list.append([{
+            additional_document_reference_list.extend([{
                 'id': invoice.company_id.currency_id.name,
                 'document_description': amount,
                 'document_type_code': code,

--- a/addons/l10n_sg_ubl_pint/tests/__init__.py
+++ b/addons/l10n_sg_ubl_pint/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_sg_ubl_pint

--- a/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
+++ b/addons/l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml
@@ -1,0 +1,146 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2">
+  <cbc:CustomizationID>urn:peppol:pint:billing-1@sg-1</cbc:CustomizationID>
+  <cbc:ProfileID>urn:peppol:bis:billing</cbc:ProfileID>
+  <cbc:ID>INV/2019/00001</cbc:ID>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2019-01-01</cbc:IssueDate>
+  <cbc:DueDate>2019-01-01</cbc:DueDate>
+  <cbc:InvoiceTypeCode>380</cbc:InvoiceTypeCode>
+  <cbc:DocumentCurrencyCode>EUR</cbc:DocumentCurrencyCode>
+  <cbc:TaxCurrencyCode>SGD</cbc:TaxCurrencyCode>
+  <cac:OrderReference>
+    <cbc:ID>INV/2019/00001</cbc:ID>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>SGD</cbc:ID>
+    <cbc:DocumentTypeCode>sgdtotal-excl-gst</cbc:DocumentTypeCode>
+    <cbc:DocumentDescription>1000.0</cbc:DocumentDescription>
+  </cac:AdditionalDocumentReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>SGD</cbc:ID>
+    <cbc:DocumentTypeCode>sgdtotal-incl-gst</cbc:DocumentTypeCode>
+    <cbc:DocumentDescription>1090.0</cbc:DocumentDescription>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cbc:EndpointID schemeID="0195">201131415A</cbc:EndpointID>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Tyersall Avenue</cbc:StreetName>
+        <cbc:CityName>Central Singapore</cbc:CityName>
+        <cbc:PostalZone>248048</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>197401143C</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+65 9123 4567</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyName>
+        <cbc:Name>partner_a</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_a</cbc:RegistrationName>
+        <cbc:CompanyID>S16FC0121D</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:Name>partner_a</cbc:Name>
+        <cbc:Telephone>+65 9123 4589</cbc:Telephone>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:Delivery>
+    <cac:DeliveryLocation>
+      <cac:Address>
+        <cbc:StreetName>that other street, 3</cbc:StreetName>
+        <cbc:CityName>East Singapore</cbc:CityName>
+        <cbc:PostalZone>248050</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>SG</cbc:IdentificationCode>
+        </cac:Country>
+      </cac:Address>
+    </cac:DeliveryLocation>
+  </cac:Delivery>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="mutually defined">ZZZ</cbc:PaymentMeansCode>
+    <cbc:PaymentID>INV/2019/00001</cbc:PaymentID>
+  </cac:PaymentMeans>
+  <cac:PaymentTerms>
+    <cbc:Note>Payment terms: Immediate Payment</cbc:Note>
+  </cac:PaymentTerms>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="EUR">180.00</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="EUR">2000.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="EUR">180.00</cbc:TaxAmount>
+      <cac:TaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>9.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="SGD">90.00</cbc:TaxAmount>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="EUR">2000.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="EUR">2180.00</cbc:TaxInclusiveAmount>
+    <cbc:PrepaidAmount currencyID="EUR">0.00</cbc:PrepaidAmount>
+    <cbc:PayableAmount currencyID="EUR">2180.00</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">1.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="EUR">2000.00</cbc:LineExtensionAmount>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+      <cac:ClassifiedTaxCategory>
+        <cbc:ID>SR</cbc:ID>
+        <cbc:Percent>9.0</cbc:Percent>
+        <cac:TaxScheme>
+          <cbc:ID>GST</cbc:ID>
+        </cac:TaxScheme>
+      </cac:ClassifiedTaxCategory>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="EUR">2000.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
+++ b/addons/l10n_sg_ubl_pint/tests/test_sg_ubl_pint.py
@@ -1,0 +1,63 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from datetime import datetime
+
+from freezegun import freeze_time
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tools import file_open
+from odoo.tests import tagged
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestSgUBLPint(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('sg')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.other_currency = cls.setup_other_currency('EUR')
+
+        # TIN number is required
+        cls.company_data['company'].write({
+            'vat': '197401143C',
+            'l10n_sg_unique_entity_number': '201131415A',
+            'street': 'Tyersall Avenue',
+            'zip': '248048',
+            'city': 'Central Singapore',
+            'phone': '+65 9123 4567',
+        })
+        cls.partner_a.write({
+            'vat': 'S16FC0121D',
+            'country_id': cls.env.ref('base.sg').id,
+            'street': 'that other street, 3',
+            'zip': '248050',
+            'city': 'East Singapore',
+            'phone': '+65 9123 4589',
+        })
+        cls.tax_9 = cls.env['account.tax'].create({
+            'name': '9% GST',
+            'amount_type': 'percent',
+            'amount': 9,
+            'type_tax_use': 'sale',
+            'country_id': cls.env.ref('base.sg').id,
+            'ubl_cii_tax_category_code': 'SR',
+        })
+
+        cls.fakenow = datetime(2024, 7, 15, 10, 00, 00)
+        cls.startClassPatcher(freeze_time(cls.fakenow))
+
+    def test_invoice(self):
+        invoice = self.init_invoice('out_invoice', currency=self.other_currency, products=self.product_a, taxes=self.tax_9)
+        invoice.action_post()
+
+        actual_xml, errors = self.env['account.edi.xml.pint_sg']._export_invoice(invoice)
+        self.assertFalse(errors)
+
+        with file_open('l10n_sg_ubl_pint/tests/expected_xmls/invoice.xml', 'rb') as f:
+            expected_xml = f.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(actual_xml),
+            self.get_xml_tree_from_string(expected_xml),
+        )

--- a/addons/l10n_tr_nilvera/models/res_partner.py
+++ b/addons/l10n_tr_nilvera/models/res_partner.py
@@ -44,18 +44,19 @@ class ResPartner(models.Model):
 
     @api.depends('vat', 'invoice_edi_format')
     def _compute_nilvera_customer_status_and_alias_id(self):
-        if not modules.module.current_test:
-            for partner in self:
-                if partner.vat and partner.invoice_edi_format == 'ubl_tr':
-                    try:
-                        partner.check_nilvera_customer()
-                    except UserError:
-                        # In case of an internet connection issue, exit silently.
-                        continue
-                else:
-                    # Reset the alias if no VAT or UBL format changed.
-                    partner.l10n_tr_nilvera_customer_status = 'not_checked'
-                    partner.l10n_tr_nilvera_customer_alias_id = False
+        if modules.module.current_test:
+            return
+        for partner in self:
+            if partner.vat and partner.invoice_edi_format == 'ubl_tr':
+                try:
+                    partner.check_nilvera_customer()
+                except UserError:
+                    # In case of an internet connection issue, exit silently.
+                    continue
+            else:
+                # Reset the alias if no VAT or UBL format changed.
+                partner.l10n_tr_nilvera_customer_status = 'not_checked'
+                partner.l10n_tr_nilvera_customer_alias_id = False
 
     def check_nilvera_customer(self):
         self.ensure_one()

--- a/addons/l10n_tr_nilvera/models/res_partner.py
+++ b/addons/l10n_tr_nilvera/models/res_partner.py
@@ -1,7 +1,7 @@
 import logging
 import urllib.parse
 
-from odoo import api, fields, models
+from odoo import api, fields, models, modules
 from odoo.exceptions import UserError
 from odoo.addons.l10n_tr_nilvera.lib.nilvera_client import _get_nilvera_client
 
@@ -44,17 +44,18 @@ class ResPartner(models.Model):
 
     @api.depends('vat', 'invoice_edi_format')
     def _compute_nilvera_customer_status_and_alias_id(self):
-        for partner in self:
-            if partner.vat and partner.invoice_edi_format == 'ubl_tr':
-                try:
-                    partner.check_nilvera_customer()
-                except UserError:
-                    # In case of an internet connection issue, exit silently.
-                    continue
-            else:
-                # Reset the alias if no VAT or UBL format changed.
-                partner.l10n_tr_nilvera_customer_status = 'not_checked'
-                partner.l10n_tr_nilvera_customer_alias_id = False
+        if not modules.module.current_test:
+            for partner in self:
+                if partner.vat and partner.invoice_edi_format == 'ubl_tr':
+                    try:
+                        partner.check_nilvera_customer()
+                    except UserError:
+                        # In case of an internet connection issue, exit silently.
+                        continue
+                else:
+                    # Reset the alias if no VAT or UBL format changed.
+                    partner.l10n_tr_nilvera_customer_status = 'not_checked'
+                    partner.l10n_tr_nilvera_customer_alias_id = False
 
     def check_nilvera_customer(self):
         self.ensure_one()

--- a/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_xml_ubl_tr

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml
@@ -1,0 +1,181 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>EARSIVFATURA</cbc:ProfileID>
+  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+  <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ELEKTRONIK</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    <cbc:DocumentTypeCode>SEND_TYPE</cbc:DocumentTypeCode>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+      <cac:Person>
+        <cbc:FirstName>partner_1</cbc:FirstName>
+        <cbc:FamilyName>​</cbc:FamilyName>
+      </cac:Person>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+      <cbc:Percent>-4.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>KDV Tevkifatı</cbc:Name>
+          <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="TRY">153.12</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="TRY">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="TRY">153.12</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+        <cbc:Percent>-4.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>KDV Tevkifatı</cbc:Name>
+            <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml
@@ -1,0 +1,188 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>EARSIVFATURA</cbc:ProfileID>
+  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:PricingCurrencyCode>USD</cbc:PricingCurrencyCode>
+  <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AdditionalDocumentReference>
+    <cbc:ID>ELEKTRONIK</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+    <cbc:DocumentTypeCode>SEND_TYPE</cbc:DocumentTypeCode>
+  </cac:AdditionalDocumentReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+      <cac:Person>
+        <cbc:FirstName>partner_1</cbc:FirstName>
+        <cbc:FamilyName>​</cbc:FamilyName>
+      </cac:Person>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PricingExchangeRate>
+    <cbc:SourceCurrencyCode>USD</cbc:SourceCurrencyCode>
+    <cbc:TargetCurrencyCode>TRY</cbc:TargetCurrencyCode>
+    <cbc:CalculationRate>40.0</cbc:CalculationRate>
+    <cbc:Date>2025-03-03</cbc:Date>
+  </cac:PricingExchangeRate>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">21.12</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">-5.28</cbc:TaxAmount>
+      <cbc:Percent>-4.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>KDV Tevkifatı</cbc:Name>
+          <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">153.12</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="USD">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="USD">153.12</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:Amount currencyID="USD">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="USD">21.12</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="USD">-5.28</cbc:TaxAmount>
+        <cbc:Percent>-4.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>KDV Tevkifatı</cbc:Name>
+            <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml
@@ -1,0 +1,176 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:DocumentCurrencyCode>TRY</cbc:DocumentCurrencyCode>
+  <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+      <cac:Person>
+        <cbc:FirstName>partner_1</cbc:FirstName>
+        <cbc:FamilyName>​</cbc:FamilyName>
+      </cac:Person>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+      <cbc:Percent>-4.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>KDV Tevkifatı</cbc:Name>
+          <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="TRY">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="TRY">153.12</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="TRY">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="TRY">153.12</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="TRY">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:Amount currencyID="TRY">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="TRY">21.12</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="TRY">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="TRY">-5.28</cbc:TaxAmount>
+        <cbc:Percent>-4.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>KDV Tevkifatı</cbc:Name>
+            <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="TRY">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
+++ b/addons/l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml
@@ -1,0 +1,183 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Invoice xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">
+  <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+  <cbc:CustomizationID>TR1.2</cbc:CustomizationID>
+  <cbc:ProfileID>TEMELFATURA</cbc:ProfileID>
+  <cbc:ID>EIN998833000000000</cbc:ID>
+  <cbc:CopyIndicator>false</cbc:CopyIndicator>
+  <cbc:UUID>___ignore___</cbc:UUID>
+  <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  <cbc:InvoiceTypeCode>SATIS</cbc:InvoiceTypeCode>
+  <cbc:Note>3 products</cbc:Note>
+  <cbc:DocumentCurrencyCode>USD</cbc:DocumentCurrencyCode>
+  <cbc:PricingCurrencyCode>USD</cbc:PricingCurrencyCode>
+  <cbc:LineCountNumeric>4</cbc:LineCountNumeric>
+  <cac:OrderReference>
+    <cbc:ID>EIN/998833/0</cbc:ID>
+    <cbc:IssueDate>2025-03-03</cbc:IssueDate>
+  </cac:OrderReference>
+  <cac:AccountingSupplierParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="VKN">3297552117</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>company_1_data</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>3281. Cadde</cbc:StreetName>
+        <cbc:CitySubdivisionName>İç Anadolu Bölgesi</cbc:CitySubdivisionName>
+        <cbc:CityName>Düzce</cbc:CityName>
+        <cbc:PostalZone>06810</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>company_1_data</cbc:RegistrationName>
+        <cbc:CompanyID>3297552117</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>company_1_data</cbc:Name>
+        <cbc:Telephone>+90 501 234 56 78</cbc:Telephone>
+        <cbc:ElectronicMail>info@company.trexample.com</cbc:ElectronicMail>
+      </cac:Contact>
+    </cac:Party>
+  </cac:AccountingSupplierParty>
+  <cac:AccountingCustomerParty>
+    <cac:Party>
+      <cac:PartyIdentification>
+        <cbc:ID schemeID="TCKN">17291716060</cbc:ID>
+      </cac:PartyIdentification>
+      <cac:PartyName>
+        <cbc:Name>partner_1</cbc:Name>
+      </cac:PartyName>
+      <cac:PostalAddress>
+        <cbc:StreetName>Gökhane Sokak No:1</cbc:StreetName>
+        <cbc:CitySubdivisionName>Sincan/Ankara</cbc:CitySubdivisionName>
+        <cbc:CityName>Ankara</cbc:CityName>
+        <cbc:PostalZone>06934</cbc:PostalZone>
+        <cac:Country>
+          <cbc:IdentificationCode>TR</cbc:IdentificationCode>
+          <cbc:Name>Türkiye</cbc:Name>
+        </cac:Country>
+      </cac:PostalAddress>
+      <cac:PartyTaxScheme>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+        <cac:TaxScheme>
+          <cbc:ID>NOT_EU_VAT</cbc:ID>
+        </cac:TaxScheme>
+      </cac:PartyTaxScheme>
+      <cac:PartyLegalEntity>
+        <cbc:RegistrationName>partner_1</cbc:RegistrationName>
+        <cbc:CompanyID>17291716060</cbc:CompanyID>
+      </cac:PartyLegalEntity>
+      <cac:Contact>
+        <cbc:ID>___ignore___</cbc:ID>
+        <cbc:Name>partner_1</cbc:Name>
+        <cbc:Telephone>+90 509 876 54 32</cbc:Telephone>
+        <cbc:ElectronicMail>info@tr_partner.com</cbc:ElectronicMail>
+      </cac:Contact>
+      <cac:Person>
+        <cbc:FirstName>partner_1</cbc:FirstName>
+        <cbc:FamilyName>​</cbc:FamilyName>
+      </cac:Person>
+    </cac:Party>
+  </cac:AccountingCustomerParty>
+  <cac:PaymentMeans>
+    <cbc:PaymentMeansCode name="credit transfer">30</cbc:PaymentMeansCode>
+    <cbc:PaymentDueDate>2025-03-05</cbc:PaymentDueDate>
+    <cac:PayeeFinancialAccount>
+      <cbc:ID>TR0123456789</cbc:ID>
+    </cac:PayeeFinancialAccount>
+  </cac:PaymentMeans>
+  <cac:PricingExchangeRate>
+    <cbc:SourceCurrencyCode>USD</cbc:SourceCurrencyCode>
+    <cbc:TargetCurrencyCode>TRY</cbc:TargetCurrencyCode>
+    <cbc:CalculationRate>40.0</cbc:CalculationRate>
+    <cbc:Date>2025-03-03</cbc:Date>
+  </cac:PricingExchangeRate>
+  <cac:TaxTotal>
+    <cbc:TaxAmount currencyID="USD">21.12</cbc:TaxAmount>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
+      <cbc:Percent>20.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+          <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+    <cac:TaxSubtotal>
+      <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+      <cbc:TaxAmount currencyID="USD">-5.28</cbc:TaxAmount>
+      <cbc:Percent>-4.0</cbc:Percent>
+      <cac:TaxCategory>
+        <cac:TaxScheme>
+          <cbc:Name>KDV Tevkifatı</cbc:Name>
+          <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+        </cac:TaxScheme>
+      </cac:TaxCategory>
+    </cac:TaxSubtotal>
+  </cac:TaxTotal>
+  <cac:LegalMonetaryTotal>
+    <cbc:LineExtensionAmount currencyID="USD">132.00</cbc:LineExtensionAmount>
+    <cbc:TaxExclusiveAmount currencyID="USD">132.00</cbc:TaxExclusiveAmount>
+    <cbc:TaxInclusiveAmount currencyID="USD">153.12</cbc:TaxInclusiveAmount>
+    <cbc:AllowanceTotalAmount currencyID="USD">0.00</cbc:AllowanceTotalAmount>
+    <cbc:PayableAmount currencyID="USD">153.12</cbc:PayableAmount>
+  </cac:LegalMonetaryTotal>
+  <cac:InvoiceLine>
+    <cbc:ID>1</cbc:ID>
+    <cbc:InvoicedQuantity unitCode="C62">3.0</cbc:InvoicedQuantity>
+    <cbc:LineExtensionAmount currencyID="USD">132.00</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:Amount currencyID="USD">18.00</cbc:Amount>
+    </cac:AllowanceCharge>
+    <cac:TaxTotal>
+      <cbc:TaxAmount currencyID="USD">21.12</cbc:TaxAmount>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="USD">26.40</cbc:TaxAmount>
+        <cbc:Percent>20.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>Gerçek Usulde KDV</cbc:Name>
+            <cbc:TaxTypeCode>0015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+      <cac:TaxSubtotal>
+        <cbc:TaxableAmount currencyID="USD">132.00</cbc:TaxableAmount>
+        <cbc:TaxAmount currencyID="USD">-5.28</cbc:TaxAmount>
+        <cbc:Percent>-4.0</cbc:Percent>
+        <cac:TaxCategory>
+          <cac:TaxScheme>
+            <cbc:Name>KDV Tevkifatı</cbc:Name>
+            <cbc:TaxTypeCode>9015</cbc:TaxTypeCode>
+          </cac:TaxScheme>
+        </cac:TaxCategory>
+      </cac:TaxSubtotal>
+    </cac:TaxTotal>
+    <cac:Item>
+      <cbc:Description>product_a</cbc:Description>
+      <cbc:Name>product_a</cbc:Name>
+    </cac:Item>
+    <cac:Price>
+      <cbc:PriceAmount currencyID="USD">50.0</cbc:PriceAmount>
+    </cac:Price>
+  </cac:InvoiceLine>
+</Invoice>

--- a/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
+++ b/addons/l10n_tr_nilvera_einvoice/tests/test_xml_ubl_tr.py
@@ -1,0 +1,132 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+from odoo import Command
+from odoo.tools import file_open
+from freezegun import freeze_time
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUBLTR(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('tr')
+    @freeze_time('2025-03-05')
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company_data['company'].partner_id.write({
+            'vat': '3297552117',
+            'street': '3281. Cadde',
+            'zip': '06810',
+            'city': 'İç Anadolu Bölgesi',
+            'state_id': cls.env.ref('base.state_tr_81').id,
+            'country_id': cls.env.ref('base.tr').id,
+            'email': 'info@company.trexample.com',
+            'phone': '+90 501 234 56 78',
+            'bank_ids': [(0, 0, {'acc_number': 'TR0123456789'})],
+        })
+
+        cls.partner_1 = cls.env['res.partner'].create({
+            'name': 'partner_1',
+            'vat': '17291716060',
+            'street': 'Gökhane Sokak No:1',
+            'zip': '06934',
+            'city': 'Sincan/Ankara',
+            'state_id': cls.env.ref('base.state_tr_06').id,
+            'country_id': cls.env.ref('base.tr').id,
+            'email': 'info@tr_partner.com',
+            'phone': '+90 509 876 54 32',
+            'bank_ids': [(0, 0, {'acc_number': 'TR9876543210'})],
+            'invoice_edi_format': 'ubl_tr',
+            'l10n_tr_nilvera_customer_status': 'einvoice',  # Pretend that the customer status has been checked
+        })
+
+        cls.tax_20 = cls.env['account.chart.template'].ref('tr_s_wh_20_2_10')
+
+        # The rate of 1 USD = 40 TRY is meant to simplify tests
+        usd = cls.env.ref('base.USD')
+        cls.env['res.currency.rate'].search([
+            ('company_id', '=', cls.company_data['company'].id),
+            ('currency_id', '=', usd.id),
+        ]).unlink()
+        cls.env['res.currency.rate'].create({
+            'name': '2019-01-01',
+            'rate': 0.025,
+            'currency_id': usd.id,
+            'company_id': cls.company_data['company'].id,
+        })
+
+    def _generate_invoice_xml(self, **kwargs):
+        invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'company_id': self.company_data['company'].id,
+            'partner_id': self.partner_1.id,
+            'name': 'EIN/998833/0',
+            'invoice_date': '2025-03-03',
+            'narration': '3 products',
+            'invoice_line_ids': [
+                Command.create({
+                    'product_id': self.product_a.id,
+                    'price_unit': 50.00,
+                    'quantity': 3,
+                    'discount': 12,
+                    'tax_ids': [Command.set(self.tax_20.ids)],
+                }),
+            ],
+            **kwargs,
+        })
+        invoice.action_post()
+        generated_xml = self.env['account.edi.xml.ubl.tr']._export_invoice(invoice)[0]
+        return generated_xml
+
+    def test_xml_invoice_einvoice(self):
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_invoice_xml()
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_xml),
+            self.get_xml_tree_from_string(expected_xml)
+        )
+
+    def test_xml_invoice_einvoice_multicurrency(self):
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_invoice_xml(currency_id=self.env.ref('base.USD').id)
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_einvoice_multicurrency.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_xml),
+            self.get_xml_tree_from_string(expected_xml)
+        )
+
+    def test_xml_invoice_earchive(self):
+        self.partner_1.l10n_tr_nilvera_customer_status = 'earchive'
+
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_invoice_xml()
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_xml),
+            self.get_xml_tree_from_string(expected_xml)
+        )
+
+    def test_xml_invoice_earchive_multicurrency(self):
+        self.partner_1.l10n_tr_nilvera_customer_status = 'earchive'
+
+        with freeze_time('2025-03-05'):
+            generated_xml = self._generate_invoice_xml(currency_id=self.env.ref('base.USD').id)
+
+        with file_open('l10n_tr_nilvera_einvoice/tests/expected_xmls/invoice_earchive_multicurrency.xml', 'rb') as expected_xml_file:
+            expected_xml = expected_xml_file.read()
+
+        self.assertXmlTreeEqual(
+            self.get_xml_tree_from_string(generated_xml),
+            self.get_xml_tree_from_string(expected_xml)
+        )


### PR DESCRIPTION
This adds XML generation tests for the following UBL formats:
- Turkey (Nilvera)
- Malaysia
- ANZ, JP, MY and SG PINT formats.

Additionally, we improve error reporting in the `assertXmlTreeEqual` method.

Enterprise PR: https://github.com/odoo/enterprise/pull/87222

task-4242065