### PR TITLE
[FIX] mail: more shadow on chat windows

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -3,7 +3,7 @@
 
 <t t-name="mail.ChatWindow">
     <t t-set="partitionedActions" t-value="threadActions.partition"/>
-    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column shadow-sm bg-100"
+    <div class="o-mail-ChatWindow fixed-bottom overflow-hidden d-flex flex-column shadow bg-100"
         t-att-style="style"
         t-att-class="attClass"
         t-on-keydown="onKeydown"


### PR DESCRIPTION
Before this commit, when there was some content under chat windows, this was hard to read chat window conversations and content below.

This happens because the chat windows lack visual separation from the content below: everything looked flat.

There was a slight `.shadow-sm` on chat window but it barely contributed to separation with background. This commit fixes it by using stronger `.shadow` instead.

Before
![Screenshot 2025-06-06 at 17 42 26](https://github.com/user-attachments/assets/743e3b76-779b-419d-81d3-21ac0d4041c4)

After
![Screenshot 2025-06-06 at 17 42 08](https://github.com/user-attachments/assets/4bde2a1a-5fbb-46f3-85b7-a3e48c9da10b)