### PR TITLE
[IMP] account: Specify a grouping key for base lines with no tax

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4284,7 +4284,8 @@ class AccountMove(models.Model):
         }
 
         def total_grouping_function(base_line, tax_data):
-            return not filter_tax_values_to_apply or filter_tax_values_to_apply(base_line, tax_data)
+            if tax_data:
+                return not filter_tax_values_to_apply or filter_tax_values_to_apply(base_line, tax_data)
 
         # Report the total amounts.
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, total_grouping_function)

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -2062,9 +2062,7 @@ class AccountTax(models.Model):
         by tax is not enough because some details should be excluded, aggregated together or just moved into a separated section
         having another grouping key.
 
-        In case the base_line has no tax, the detail is added under the 'None' grouping key.
-        It's needed when you need to add some tax details plus the total base amount at the same time.
-        So when iterating on the result of this method, take care of the 'None' grouping key.
+        In case the base_line has no tax, the grouping_function is called with an empty tax_data to get the grouping key for the line.
 
         Don't forget to call '_add_tax_details_in_base_lines' and '_round_base_lines_tax_details' before calling this method.
 
@@ -2105,39 +2103,37 @@ class AccountTax(models.Model):
 
         tax_details = base_line['tax_details']
         taxes_data = tax_details['taxes_data']
-        for tax_data in taxes_data:
+        # If there are no taxes, we pass None to the grouping function.
+        for tax_data in (taxes_data or [None]):
             grouping_key = grouping_function(base_line, tax_data)
             if isinstance(grouping_key, dict):
                 grouping_key = frozendict(grouping_key)
             already_accounted = grouping_key in values_per_grouping_key
             values = values_per_grouping_key[grouping_key]
             values['grouping_key'] = grouping_key
-            values['taxes_data'].append(tax_data)
 
             # Base amount.
             if not already_accounted:
-                values['base_amount_currency'] += tax_data['base_amount_currency']
-                values['base_amount'] += tax_data['base_amount']
-                values['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
-                values['raw_base_amount'] += tax_data['raw_base_amount']
                 values['total_excluded_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
                 values['total_excluded'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
+                if tax_data:
+                    values['base_amount_currency'] += tax_data['base_amount_currency']
+                    values['base_amount'] += tax_data['base_amount']
+                    values['raw_base_amount_currency'] += tax_data['raw_base_amount_currency']
+                    values['raw_base_amount'] += tax_data['raw_base_amount']
+                else:
+                    values['base_amount_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
+                    values['base_amount'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
+                    values['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
+                    values['raw_base_amount'] += tax_details['raw_total_excluded']
 
             # Tax amount.
-            values['tax_amount_currency'] += tax_data['tax_amount_currency']
-            values['tax_amount'] += tax_data['tax_amount']
-            values['raw_tax_amount_currency'] += tax_data['raw_tax_amount_currency']
-            values['raw_tax_amount'] += tax_data['raw_tax_amount']
-
-        if not taxes_data:
-            values = values_per_grouping_key[None]
-            values['grouping_key'] = None
-            values['base_amount_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
-            values['base_amount'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
-            values['raw_base_amount_currency'] += tax_details['raw_total_excluded_currency']
-            values['raw_base_amount'] += tax_details['raw_total_excluded']
-            values['total_excluded_currency'] += tax_details['total_excluded_currency'] + tax_details['delta_total_excluded_currency']
-            values['total_excluded'] += tax_details['total_excluded'] + tax_details['delta_total_excluded']
+            if tax_data:
+                values['tax_amount_currency'] += tax_data['tax_amount_currency']
+                values['tax_amount'] += tax_data['tax_amount']
+                values['raw_tax_amount_currency'] += tax_data['raw_tax_amount_currency']
+                values['raw_tax_amount'] += tax_data['raw_tax_amount']
+                values['taxes_data'].append(tax_data)
 
         return values_per_grouping_key
 
@@ -2279,7 +2275,7 @@ class AccountTax(models.Model):
 
         # Global tax values.
         def global_grouping_function(base_line, tax_data):
-            return True
+            return True if tax_data else None
 
         base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, global_grouping_function)
         values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
@@ -2302,7 +2298,7 @@ class AccountTax(models.Model):
         })
 
         def tax_group_grouping_function(base_line, tax_data):
-            return tax_data['tax'].tax_group_id
+            return tax_data['tax'].tax_group_id if tax_data else None
 
         base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, tax_group_grouping_function)
         values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)

--- a/addons/account/static/src/helpers/account_tax.js
+++ b/addons/account/static/src/helpers/account_tax.js
@@ -1015,6 +1015,9 @@ export const accountTaxHelpers = {
         const subtotals = {};
 
         const tax_group_grouping_function = (base_line, tax_data) => {
+            if (!tax_data) {
+                return;
+            }
             return {
                 grouping_key: tax_data.tax.tax_group_id.id,
                 raw_grouping_key: tax_data.tax.tax_group_id,
@@ -1209,7 +1212,8 @@ export const accountTaxHelpers = {
         const tax_details = base_line.tax_details;
         const taxes_data = tax_details.taxes_data;
 
-        for (const tax_data of taxes_data) {
+        // If there are no taxes, we pass an empty object to the grouping function.
+        for (const tax_data of (taxes_data.length !== 0 ? taxes_data : [null])) {
             const generated_grouping_key = grouping_function(base_line, tax_data);
             let raw_grouping_key = generated_grouping_key;
             let grouping_key = generated_grouping_key;
@@ -1217,7 +1221,7 @@ export const accountTaxHelpers = {
             // There is no FrozenDict in javascript.
             // When the key is a record, it can't be jsonified so this is a trick to provide both the
             // raw_grouping_key (to be jsonified) from the grouping_key (to be added to the values).
-            if (typeof raw_grouping_key === 'object' && ("raw_grouping_key" in raw_grouping_key)) {
+            if (raw_grouping_key && typeof raw_grouping_key === "object" && "raw_grouping_key" in raw_grouping_key) {
                 raw_grouping_key = generated_grouping_key.raw_grouping_key;
                 grouping_key = generated_grouping_key.grouping_key;
             }
@@ -1230,10 +1234,6 @@ export const accountTaxHelpers = {
             // Base amount
             if(!(grouping_key in values_per_grouping_key)){
                 values_per_grouping_key[grouping_key] = {
-                    base_amount_currency: tax_data.base_amount_currency,
-                    base_amount: tax_data.base_amount,
-                    raw_base_amount_currency: tax_data.raw_base_amount_currency,
-                    raw_base_amount: tax_data.raw_base_amount,
                     tax_amount_currency: 0.0,
                     tax_amount: 0.0,
                     raw_tax_amount_currency: 0.0,
@@ -1243,32 +1243,30 @@ export const accountTaxHelpers = {
                     taxes_data: [],
                     grouping_key: raw_grouping_key
                 };
+                const values = values_per_grouping_key[grouping_key];
+
+                if (tax_data) {
+                    values.base_amount_currency = tax_data.base_amount_currency;
+                    values.base_amount = tax_data.base_amount;
+                    values.raw_base_amount_currency = tax_data.raw_base_amount_currency;
+                    values.raw_base_amount = tax_data.raw_base_amount;
+                } else {
+                    values.base_amount_currency = tax_details.total_excluded_currency + tax_details.delta_total_excluded_currency;
+                    values.base_amount = tax_details.total_excluded + tax_details.delta_total_excluded;
+                    values.raw_base_amount_currency = tax_details.raw_total_excluded_currency;
+                    values.raw_base_amount = tax_details.raw_total_excluded;
+                }
             }
             const values = values_per_grouping_key[grouping_key];
-            values.taxes_data.push(tax_data);
 
             // Tax amount
-            values.tax_amount_currency += tax_data.tax_amount_currency;
-            values.tax_amount += tax_data.tax_amount;
-            values.raw_tax_amount_currency += tax_data.raw_tax_amount_currency;
-            values.raw_tax_amount += tax_data.raw_tax_amount;
-        }
-
-        if (!taxes_data.length) {
-            values_per_grouping_key[null] = {
-                base_amount_currency: tax_details.total_excluded_currency + tax_details.delta_total_excluded_currency,
-                base_amount: tax_details.total_excluded + tax_details.delta_total_excluded,
-                raw_base_amount_currency: tax_details.raw_total_excluded_currency,
-                raw_base_amount: tax_details.raw_total_excluded,
-                total_excluded_currency: tax_details.total_excluded_currency + tax_details.delta_total_excluded_currency,
-                total_excluded: tax_details.total_excluded + tax_details.delta_total_excluded,
-                tax_amount_currency: 0.0,
-                tax_amount: 0.0,
-                raw_tax_amount_currency: 0.0,
-                raw_tax_amount: 0.0,
-                taxes_data: [],
-                grouping_key: null
-            };
+            if (tax_data) {
+                values.tax_amount_currency += tax_data.tax_amount_currency;
+                values.tax_amount += tax_data.tax_amount;
+                values.raw_tax_amount_currency += tax_data.raw_tax_amount_currency;
+                values.raw_tax_amount += tax_data.raw_tax_amount;
+                values.taxes_data.push(tax_data);
+            }
         }
 
         return values_per_grouping_key;

--- a/addons/l10n_account_withholding_tax/models/account_withholding_line.py
+++ b/addons/l10n_account_withholding_tax/models/account_withholding_line.py
@@ -470,6 +470,8 @@ class AccountWithholdingLine(models.AbstractModel):
         existing_withholding_line_map = self.grouped(key=lambda l: l._get_grouping_key())
 
         def grouping_function(base_line_data, tax_data):
+            if not tax_data:
+                return None
             account = company.withholding_tax_base_account_id or base_line_data['account_id']
             tax = tax_data['tax']
             # Note: keep this aligned with _get_grouping_key

--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -379,6 +379,8 @@ class AccountMove(models.Model):
         base_lines, _tax_lines = self._get_rounded_base_and_tax_lines()
 
         def grouping_function(base_line, tax_data):
+            if not tax_data:
+                return None
             tax_group = tax_data['tax'].tax_group_id
             skip = False
             name = None

--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -224,6 +224,8 @@ class AccountEdiFormat(models.Model):
         # Tax amounts per line.
 
         def grouping_function_base_line(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
             code_split = tax.l10n_eg_eta_code.split('_')
             return {
@@ -238,14 +240,16 @@ class AccountEdiFormat(models.Model):
         # Tax amounts for the whole document.
 
         def grouping_function_global(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
             code_split = tax.l10n_eg_eta_code.split('_')
             return {
                 'tax_type': code_split[0].upper(),
             }
-            
+
         def grouping_function_total_amount(base_line, tax_data):
-            return True
+            return True if tax_data else None
 
         base_lines_aggregated_values_total_amount = AccountTax._aggregate_base_lines_tax_details(base_lines, grouping_function_total_amount)
         values_per_grouping_key_total_amount = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values_total_amount)

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -421,7 +421,7 @@ class AccountMove(models.Model):
         AccountTax._round_base_lines_tax_details(base_lines, self.company_id, tax_lines=tax_lines)
 
         def grouping_function(base_line, tax_data):
-            return tax_data['tax']
+            return tax_data['tax'] if tax_data else None
 
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, grouping_function)
         for base_line, aggregated_values in base_lines_aggregated_values:

--- a/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
+++ b/addons/l10n_es_edi_tbai/models/l10n_es_edi_tbai_document.py
@@ -529,6 +529,8 @@ class L10nEsEdiTbaiDocument(models.Model):
         AccountTax = self.env['account.tax']
 
         def tax_details_info_grouping_function(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
 
             return {
@@ -562,7 +564,7 @@ class L10nEsEdiTbaiDocument(models.Model):
 
         # Aggregate the base lines again (with no grouping) to add the base amount to the total.
         def totals_grouping_function(base_line, tax_data):
-            return True
+            return True if tax_data else None
 
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, totals_grouping_function)
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)
@@ -581,6 +583,8 @@ class L10nEsEdiTbaiDocument(models.Model):
         AccountTax = self.env['account.tax']
 
         def tax_details_info_grouping_function(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
 
             return {
@@ -620,7 +624,7 @@ class L10nEsEdiTbaiDocument(models.Model):
 
         # Aggregate the base lines again (with no grouping) to add the base amount to the total.
         def totals_grouping_function(base_line, tax_data):
-            return True
+            return True if tax_data else None
 
         base_lines_aggregated_values = AccountTax._aggregate_base_lines_tax_details(base_lines, totals_grouping_function)
         values_per_grouping_key = AccountTax._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -88,7 +88,7 @@ class AccountTax(models.Model):
             return {
                 **get_base_line_grouping_key(base_line),
                 'l10n_in_tax_type': tax_data['tax'].l10n_in_tax_type,
-            }
+            } if tax_data else None
 
         base_lines_aggregated_values = self._aggregate_base_lines_tax_details(base_lines, grouping_function)
         values_per_grouping_key = self._aggregate_base_lines_aggregated_values(base_lines_aggregated_values)

--- a/addons/l10n_in/static/src/helpers/hsn_summary.js
+++ b/addons/l10n_in/static/src/helpers/hsn_summary.js
@@ -56,10 +56,10 @@ patch(accountTaxHelpers, {
 
         // Tax amounts.
         function grouping_function(base_line, tax_data) {
-            return {
+            return tax_data ? {
                 ...get_base_line_grouping_key(base_line),
                 l10n_in_tax_type: tax_data.tax.l10n_in_tax_type,
-            };
+            } : null;
         }
 
         const base_lines_aggregated_values = this.aggregate_base_lines_tax_details(base_lines, grouping_function);

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -416,6 +416,8 @@ class AccountMove(models.Model):
 
     @api.model
     def _l10n_it_edi_grouping_function_base_lines(self, base_line, tax_data):
+        if not tax_data:
+            return None
         tax = tax_data['tax']
         return {
             'tax_amount_field': -23.0 if tax.amount == -11.5 else tax.amount,
@@ -425,6 +427,8 @@ class AccountMove(models.Model):
 
     @api.model
     def _l10n_it_edi_grouping_function_tax_lines(self, base_line, tax_data):
+        if not tax_data:
+            return None
         tax = tax_data['tax']
 
         if tax._l10n_it_is_split_payment():
@@ -447,6 +451,8 @@ class AccountMove(models.Model):
 
     @api.model
     def _l10n_it_edi_grouping_function_total(self, base_line, tax_data):
+        if not tax_data:
+            return None
         skip = tax_data['is_reverse_charge'] or self._l10n_it_edi_is_neg_split_payment(tax_data)
         return not skip
 

--- a/addons/l10n_it_edi_withholding/models/account_move.py
+++ b/addons/l10n_it_edi_withholding/models/account_move.py
@@ -70,6 +70,8 @@ class AccountMove(models.Model):
         # Withholding tax amounts.
 
         def grouping_function_withholding(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
             return {
                 'tax_amount_field': -23.0 if tax.amount == -11.5 else tax.amount,
@@ -97,6 +99,8 @@ class AccountMove(models.Model):
         # Pension fund.
 
         def grouping_function_pension_funds(base_line, tax_data):
+            if not tax_data:
+                return None
             tax = tax_data['tax']
             flatten_taxes = base_line['tax_ids'].flatten_taxes_hierarchy()
             vat_tax = flatten_taxes.filtered(lambda t: t._l10n_it_filter_kind('vat') and t.amount >= 0)[:1]

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -304,6 +304,8 @@ class SaleOrder(models.Model):
         AccountTax._round_base_lines_tax_details(base_lines, self.company_id)
 
         def grouping_function(base_line, tax_data):
+            if not tax_data:
+                return None
             return {
                 'taxes': base_line['discount_taxes'],
                 'skip': (


### PR DESCRIPTION
At the moment, the tax aggregators always give a base line with no tax the `None` grouping key.

Sometimes, we want base lines with no tax to be grouped as if they had a particular tax, such as an exempt one.

This commit extends the aggregator behaviour so that for base lines with no tax, the grouping function is called with an empty tax_data dict, and the returned grouping key is used to group the base line.

Enterprise PR: https://github.com/odoo/enterprise/pull/87223

task-4242065