### PR TITLE
[IMP] iot_box_image: ngrok as a service

### DIFF
--- a/addons/hw_posbox_homepage/controllers/homepage.py
+++ b/addons/hw_posbox_homepage/controllers/homepage.py
@@ -5,6 +5,7 @@ import logging
 import netifaces
 import platform
 import re
+import requests
 import subprocess
 import threading
 import time
@@ -266,6 +267,31 @@ class IotBoxOwlHomePage(http.Controller):
             'message': 'IoT Handlers cleared successfully',
         })
 
+    @http.route('/hw_posbox_homepage/is_ngrok_enabled', auth="none", type="http")
+    def is_ngrok_enabled(self):
+        # Check if the service exists for retro-compatibility TODO: remove in v18.4
+        p = subprocess.run(
+            ['systemctl', 'is-active', 'odoo-ngrok.service'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if p.returncode != 0:
+            return json.dumps({
+                'enabled': subprocess.call(['pgrep', 'ngrok']) != 1
+            })
+
+        try:
+            response = requests.get("http://localhost:4040/api/tunnels", timeout=5)
+            response.raise_for_status()
+            response.json()
+        except (requests.exceptions.RequestException, ValueError):
+            # if the request fails or the response is not valid JSON,
+            # it means ngrok is not enabled or not running
+            return json.dumps({'enabled': False})
+
+        return json.dumps({'enabled': True})
+
     # ---------------------------------------------------------- #
     # POST methods                                               #
     # -> Never use json.dumps() it will be done automatically    #
@@ -316,16 +342,67 @@ class IotBoxOwlHomePage(http.Controller):
 
         return res_payload
 
-    @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="jsonrpc", methods=['POST'], cors='*')
+    @http.route('/hw_posbox_homepage/enable_ngrok', auth="none", type="jsonrpc", methods=['POST'])
     def enable_remote_connection(self, auth_token):
-        if subprocess.call(['pgrep', 'ngrok']) == 1:
-            subprocess.Popen(['sudo', 'systemd-run', 'ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22'])
+        # check if the service exists for retro-compatibility TODO: remove in v18.4
+        p = subprocess.run(
+            ['systemctl', 'is-active', 'odoo-ngrok.service'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if p.returncode != 0:
+            subprocess.Popen(
+                ['sudo', 'systemd-run', 'ngrok', 'tcp', '--authtoken', auth_token, '--log', '/tmp/ngrok.log', '22']
+            )
+            return {'status': 'success'}
 
-        return {
-            'status': 'success',
-            'auth_token': auth_token,
-            'message': 'Ngrok tunnel is now enabled',
-        }
+        # if the service exists, we only update the authtoken
+        with helpers.writable():
+            p = subprocess.run(
+                ['ngrok', 'config', 'add-authtoken', auth_token, '--config', '/home/pi/ngrok.yml'],
+                check=False,
+            )
+        if p.returncode == 0:
+            subprocess.run(
+                ['sudo', 'systemctl', 'restart', 'odoo-ngrok.service'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            return {'status': 'success'}
+
+        return {'status': 'failure'}
+
+    @http.route('/hw_posbox_homepage/disable_ngrok', auth="none", type="jsonrpc", methods=['POST'])
+    def disable_remote_connection(self):
+        # check if the service exists for retro-compatibility TODO: remove in v18.4
+        p = subprocess.run(
+            ['systemctl', 'is-active', 'odoo-ngrok.service'],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if p.returncode != 0:
+            subprocess.run(
+                ['sudo', 'pkill', 'ngrok'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False
+            )
+            return {'status': 'success'}
+
+        with helpers.writable():
+            p = subprocess.run(
+                ['ngrok', 'config', 'add-authtoken', '""', '--config', '/home/pi/ngrok.yml'], check=False
+            )
+        if p.returncode == 0:
+            subprocess.run(
+                ['sudo', 'systemctl', 'stop', 'odoo-ngrok.service'],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            return {'status': 'success'}
+
+        return {'status': 'failure'}
 
     @http.route('/hw_posbox_homepage/update_hostname', auth="none", type="jsonrpc", methods=['POST'], cors='*')
     def update_hostname(self, hostname):

--- a/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
+++ b/addons/hw_posbox_homepage/static/src/app/components/dialog/RemoteDebugDialog.js
@@ -4,7 +4,7 @@ import useStore from "../../hooks/useStore.js";
 import { LoadingFullScreen } from "../LoadingFullScreen.js";
 import { BootstrapDialog } from "./BootstrapDialog.js";
 
-const { Component, xml, useState } = owl;
+const { Component, xml, onWillStart, useState } = owl;
 
 export class RemoteDebugDialog extends Component {
     static props = {};
@@ -17,7 +17,24 @@ export class RemoteDebugDialog extends Component {
             loading: false,
             ngrok: false,
             ngrokToken: "",
+            loadingNgrok: false,
         });
+
+        onWillStart(async () => {
+            await this.isNgrokEnabled();
+        });
+    }
+
+    async isNgrokEnabled() {
+        try {
+            const data = await this.store.rpc({ url: "/hw_posbox_homepage/is_ngrok_enabled" });
+            this.state.ngrok = data.enabled;
+            if (!this.state.ngrok) {
+                this.state.ngrokToken = "";
+            }
+        } catch {
+            console.warn("Error while fetching data");
+        }
     }
 
     async generatePassword() {
@@ -35,43 +52,57 @@ export class RemoteDebugDialog extends Component {
         }
     }
 
-    async connectToRemoteDebug() {
+    async enableNgrok() {
         if (!this.state.ngrokToken) {
             return;
         }
-
+        this.state.loadingNgrok = true;
         try {
-            const data = await this.store.rpc({
+            await this.store.rpc({
                 url: "/hw_posbox_homepage/enable_ngrok",
                 method: "POST",
                 params: {
                     auth_token: this.state.ngrokToken,
                 },
             });
-
-            if (data.status === "success") {
-                this.state.ngrok = true;
-            }
+            // Wait 2 seconds to let odoo-ngrok service start
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            await this.isNgrokEnabled();
         } catch {
             console.warn("Error while enabling remote debugging");
         }
+        this.state.loadingNgrok = false;
+    }
+
+    async disableNgrok() {
+        this.state.loadingNgrok = true;
+        try {
+            await this.store.rpc({
+                url: "/hw_posbox_homepage/disable_ngrok",
+                method: "POST",
+            });
+            // Wait 2 seconds to let odoo-ngrok service stop
+            await new Promise((resolve) => setTimeout(resolve, 2000));
+            await this.isNgrokEnabled();
+        } catch {
+            console.warn("Error while disabling remote debugging");
+        }
+        this.state.loadingNgrok = false;
     }
 
     static template = xml`
-        <LoadingFullScreen t-if="this.state.waitRestart">
-            <t t-set-slot="body">
-                Processing your request, please wait...
-            </t>
-        </LoadingFullScreen>
-
         <BootstrapDialog identifier="'remote-debug-configuration'" btnName="'Remote debug'">
             <t t-set-slot="header">
                 Remote Debugging
             </t>
             <t t-set-slot="body">
-                <div class="alert alert-warning fs-6" role="alert">
+                <div t-if="!state.ngrok" class="alert alert-warning fs-6" role="alert">
                     This allows someone who give a ngrok authtoken to gain remote access to your IoT Box,
                     and thus your entire local network. Only enable this for someone you trust.
+                </div>
+                <div t-else="" class="alert alert-danger fs-6" role="alert">
+                    Your IoT Box is currently accessible from the internet. 
+                    The owner of the ngrok authtoken can access both the IoT Box and your local network.
                 </div>
                 <div class="d-flex flex-row gap-2 mb-4">
                     <input placeholder="Password" t-att-value="this.state.password" class="form-control" readonly="readonly" />
@@ -83,13 +114,22 @@ export class RemoteDebugDialog extends Component {
                     </button>
                 </div>
                 <input t-model="this.state.ngrokToken" placeholder="Authentication token" class="form-control" />
-                <div t-if="this.state.ngrok" class="alert alert-success fs-6 mt-2" role="alert">
-                    Your IoT Box is now accessible from the internet.
-                </div>
             </t>
             <t t-set-slot="footer">
-                <button type="submit" class="btn btn-secondary btn-sm" t-on-click="connectToRemoteDebug">Enable remote debugging</button>
-                <button type="button" class="btn btn-primary btn-sm" data-bs-dismiss="modal">Close</button>
+                <button
+                    type="submit"
+                    class="btn btn-sm"
+                    t-att-class="state.ngrok ? 'btn-primary' : 'btn-secondary'"
+                    t-on-click="state.ngrok ? disableNgrok : enableNgrok"
+                >
+                    <div t-if="state.loadingNgrok" class="spinner-border spinner-border-sm" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <t t-else="">
+                        <t t-esc="state.ngrok ? 'Disable remote debugging' : 'Enable remote debugging'" />
+                    </t>
+                </button>
+                <button type="button" t-att-class="'btn btn-sm btn-' + (state.ngrok ? 'secondary' : 'primary')" data-bs-dismiss="modal">Close</button>
             </t>
         </BootstrapDialog>
     `;

--- a/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
+++ b/addons/iot_box_image/overwrite_before_init/etc/init_image.sh
@@ -318,6 +318,7 @@ systemctl disable cups-browsed.service
 systemctl enable labwc.service
 systemctl enable odoo.service
 systemctl enable odoo-led-manager.service
+systemctl enable odoo-ngrok.service
 
 # create dirs for ramdisks
 create_ramdisk_dir () {

--- a/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo-ngrok.service
+++ b/addons/iot_box_image/overwrite_before_init/etc/systemd/system/odoo-ngrok.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Odoo Service to ensure ngrok is running
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/bin/ngrok tcp 22 --config /home/pi/ngrok.yml
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
We introduce a new systemd service that automatically starts on boot, trying to enable a remote access using ngrok. This will fail most of the time as users don't configure a ngrok token.

When one is configured, the tunnel will open. When we'll remove it, we'll stop the service and its automatic startup will fail again on next boot.

task: 4848368
