### PR TITLE
[18.0][FIX] mail: allow model specific logic on templates on unsaved activity plans

### DIFF
--- a/addons/mail/views/mail_activity_plan_views.xml
+++ b/addons/mail/views/mail_activity_plan_views.xml
@@ -66,7 +66,8 @@
                         </group>
                         <notebook>
                             <page string="Activities To Create">
-                                <field name="template_ids" nolabel="1">
+                                <!-- Pass on the model to ensure the correct dynamic selection (in e.g. hr) on unsaved plans -->
+                                <field name="template_ids" nolabel="1" context="{'default_res_model': res_model}">
                                     <list>
                                         <field name="company_id" column_invisible="1"/>
                                         <field name="note" column_invisible="1"/>


### PR DESCRIPTION
_Description of the issue/feature this PR addresses:_

When setting up a new activity template on a new activity plan, HR specific values for 'Assignment' such as Coach or Manager are not available.

_Current behavior before PR:_

As an HR manager, go to menu HR -> Configuration -> Activity Plan. Click 'New'. Under Activities To Create, click 'Add a line'. Under 'Assignment', the only options available are Ask at launch and Default user.

<img src="https://github.com/user-attachments/assets/97be6790-b450-42c6-910a-07483c30e175" width=50% height=50%>

Cancel the 'Create Activities' popup. Give the plan a name and save it. Again, under Activities To Create, click 'Add a line'. Only now are HR specific options (Coach, Manager etc) available under 'Assignment'.

_Desired behavior after PR is merged:_

HR specific values for 'Assignment' are immediately availalbe when setting up a new plan for the Employee model.

![image](https://github.com/user-attachments/assets/391da1c1-c1ed-495a-a25f-48941554791a)

_Technical solution:_

Pass the plan's model as the default model for new templates so that the related field is populated with a value that unlocks the HR specific values before first saving the plan.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
