### PR TITLE
[FIX] mail: correct chat window ratio on Safari

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.js
+++ b/addons/mail/static/src/core/common/chat_window.js
@@ -91,12 +91,11 @@ export class ChatWindow extends Component {
     }
 
     get style() {
-        const maxHeight = !this.ui.isSmall ? "max-height: 95vh;" : "";
         const textDirection = localization.direction;
         const offsetFrom = textDirection === "rtl" ? "left" : "right";
         const visibleOffset = this.ui.isSmall ? 0 : this.props.right;
         const oppositeFrom = offsetFrom === "right" ? "left" : "right";
-        return `${offsetFrom}: ${visibleOffset}px; ${oppositeFrom}: auto; ${maxHeight}`;
+        return `${offsetFrom}: ${visibleOffset}px; ${oppositeFrom}: auto;`;
     }
 
     onKeydown(ev) {

--- a/addons/mail/static/src/core/common/chat_window.scss
+++ b/addons/mail/static/src/core/common/chat_window.scss
@@ -4,7 +4,7 @@
     z-index: $zindex-dropdown + 1;
     &:not(.o-mobile) {
         --border-opacity: .15;
-        aspect-ratio: 9 / 15;
+        height: Min(95vh, $o-mail-ChatWindow-width * 15 / 9)
     }
     outline: none;
 }


### PR DESCRIPTION
Before this commit, chat window size on Safari sometimes look off.

The intended sizing is 380px in width and 9/15 ratio, with height being limited by 95vh.

Safari `aspect-ratio` has strange behavior: instead of shrinking just the height from max-height, it gives too much priority on enforcing the aspect-ratio, thus the chat window becomes thinner and thinner the less vertical space there are.

This commit fixes the issue by replacing the `aspect-ratio` style by a max-height that is computed with ratio and 95vh.