### PR TITLE
[FIX] l10n_ro_edi_stock: exclude internal pickings from EDI check

### DIFF
--- a/addons/l10n_ro_edi_stock/models/stock_picking.py
+++ b/addons/l10n_ro_edi_stock/models/stock_picking.py
@@ -363,7 +363,7 @@ class Picking(models.Model):
     @api.depends('company_id.account_fiscal_country_id.code')
     def _compute_l10n_ro_edi_stock_enable(self):
         for picking in self:
-            picking.l10n_ro_edi_stock_enable = picking.company_id.account_fiscal_country_id.code == 'RO'
+            picking.l10n_ro_edi_stock_enable = picking.picking_type_code != 'internal' and picking.company_id.account_fiscal_country_id.code == 'RO'
 
     @api.depends('l10n_ro_edi_stock_enable', 'state', 'l10n_ro_edi_stock_state')
     def _compute_l10n_ro_edi_stock_enable_send(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Currently, the l10n_ro_edi_stock_enable flag may be set for all stock pickings, including internal transfers. This leads to unnecessary EDI processing for pickings that are not relevant for EDI (e.g., internal movements within the company).

Current behavior before PR:

The system does not explicitly exclude pickings of type 'internal' from EDI logic. As a result, internal transfers may trigger EDI processing even though they are not intended for such flows.
Additionally, at line 508, the existing match-case logic processes only 'outgoing' and 'incoming' types:

 
```
match data['picking_type_id'].code:
    case 'outgoing':
        partner = data['picking_type_id'].warehouse_id.partner_id if location == 'start' else data['partner_id']
    case 'incoming':
        partner = data['picking_type_id'].warehouse_id.partner_id if location == 'end' else data['partner_id']
    case _other:
        errors.append(_("Invalid picking type %(type_code)s", type_code=_other))
        continue
```

Since 'internal' is not handled explicitly, it is treated as an invalid type, resulting in misleading error messages and unnecessary processing.

Desired behavior after PR is merged:

The PR introduces a condition to exclude pickings with picking_type_code = 'internal' from EDI processing. This prevents the l10n_ro_edi_stock_enable flag from being set for irrelevant pickings and avoids the generation of errors for valid internal movements.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
