### PR TITLE
[PERF] core: disable gc when starting

### DIFF
--- a/odoo/init.py
+++ b/odoo/init.py
@@ -14,6 +14,9 @@ assert sys.version_info > MIN_PY_VERSION, f"Outdated python version detected, Od
 from . import _monkeypatches
 _monkeypatches.patch_init()
 
+from .tools.gc import gc_set_timing
+gc_set_timing(enable=True)
+
 # ----------------------------------------------------------
 # Shortcuts
 # Expose them at the `odoo` namespace level

--- a/odoo/orm/registry.py
+++ b/odoo/orm/registry.py
@@ -15,7 +15,7 @@ import typing
 import warnings
 from collections import defaultdict, deque
 from collections.abc import Mapping
-from contextlib import closing, contextmanager, nullcontext
+from contextlib import closing, contextmanager, nullcontext, ExitStack
 from functools import partial
 from operator import attrgetter
 
@@ -26,6 +26,7 @@ from odoo.tools import (
     SQL,
     OrderedSet,
     config,
+    gc,
     lazy_classproperty,
     remove_accents,
     sql,
@@ -149,6 +150,7 @@ class Registry(Mapping[str, type["BaseModel"]]):
         registry: Registry = object.__new__(cls)
         registry.init(db_name)
         registry.new = registry.init = registry.registries = None  # type: ignore
+        first_registry = not cls.registries
 
         # Initializing a registry will call general code which will in
         # turn call Registry() to obtain the registry being initialized.
@@ -160,12 +162,17 @@ class Registry(Mapping[str, type["BaseModel"]]):
             registry.setup_signaling()
             # This should be a method on Registry
             from odoo.modules.loading import load_modules, reset_modules_state  # noqa: PLC0415
+            exit_stack = ExitStack()
             try:
+                if upgrade_modules or install_modules:
+                    update_module = True
                 if new_db_demo is None:
                     new_db_demo = config['with_demo']
+                if first_registry and not update_module:
+                    exit_stack.enter_context(gc.disabling_gc())
                 load_modules(
                     registry,
-                    update_module=update_module or bool(upgrade_modules or install_modules),
+                    update_module=update_module,
                     upgrade_modules=upgrade_modules,
                     install_modules=install_modules,
                     new_db_demo=new_db_demo,
@@ -173,6 +180,8 @@ class Registry(Mapping[str, type["BaseModel"]]):
             except Exception:
                 reset_modules_state(db_name)
                 raise
+            finally:
+                exit_stack.close()
         except Exception:
             _logger.error('Failed to load registry')
             del cls.registries[db_name]     # pylint: disable=unsupported-delete-operation

--- a/odoo/service/server.py
+++ b/odoo/service/server.py
@@ -57,7 +57,7 @@ except ImportError:
 from odoo import api, sql_db
 from odoo.modules.registry import Registry
 from odoo.release import nt_service_name
-from odoo.tools import config, osutil, OrderedSet, profiler
+from odoo.tools import config, gc, osutil, OrderedSet, profiler
 from odoo.tools.cache import log_ormcache_stats
 from odoo.tools.misc import stripped_sys_argv, dumpstacks
 from .db import list_dbs
@@ -1353,18 +1353,21 @@ class WorkerCron(Worker):
 server = None
 server_phoenix = False
 
+
 def load_server_wide_modules():
     from odoo.modules.module import load_openerp_module  # noqa: PLC0415
-    for m in config['server_wide_modules']:
-        try:
-            load_openerp_module(m)
-        except Exception:
-            msg = ''
-            if m == 'web':
-                msg = """
-The `web` module is provided by the addons found in the `openerp-web` project.
-Maybe you forgot to add those addons in your addons_path configuration."""
-            _logger.exception('Failed to load server-wide module `%s`.%s', m, msg)
+    with gc.disabling_gc():
+        for m in config['server_wide_modules']:
+            try:
+                load_openerp_module(m)
+            except Exception:
+                msg = ''
+                if m == 'web':
+                    msg = """
+    The `web` module is provided by the addons found in the `openerp-web` project.
+    Maybe you forgot to add those addons in your addons_path configuration."""
+                _logger.exception('Failed to load server-wide module `%s`.%s', m, msg)
+
 
 def _reexec(updated_modules=None):
     """reexecute openerp-server process with (nearly) the same arguments"""

--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -1,0 +1,39 @@
+""" Garbage collector tools
+
+## Reference
+https://github.com/python/cpython/blob/main/InternalDocs/garbage_collector.md
+
+## TLDR cpython
+
+Objects have reference counts, but we need garbage collection for cyclic
+references.  All allocated objects are split into collections (aka generations).
+There is also one permanent generation that is never collected (see
+``gc.freeze``).
+
+The GC is triggered by the number of created objects. For the first collection,
+at every allocation and deallocation, a counter is respectively increased and
+decreased. Once it reaches a threshold, that collection is automatically
+collected. Other thresolds indicate that every X collections, the next
+collection is collected.
+
+Default thresolds are 700, 10, 10.
+"""
+import contextlib
+import gc
+import logging
+
+_logger = logging.getLogger('gc')
+
+
+@contextlib.contextmanager
+def disabling_gc():
+    """Disable gc in the context manager."""
+    if not gc.isenabled():
+        yield False
+        return
+    gc.disable()
+    _logger.debug('disabled, counts %s', gc.get_count())
+    yield True
+    counts = gc.get_count()
+    gc.enable()
+    _logger.debug('enabled, counts %s', counts)

--- a/odoo/tools/gc.py
+++ b/odoo/tools/gc.py
@@ -21,8 +21,70 @@ Default thresolds are 700, 10, 10.
 import contextlib
 import gc
 import logging
+from time import thread_time_ns as _gc_time
 
 _logger = logging.getLogger('gc')
+_gc_start: int = 0
+_gc_init_stats = gc.get_stats()
+_gc_timings = [0, 0, 0]
+
+
+def _to_ms(ns):
+    return round(ns / 1_000_000, 2)
+
+
+def _timing_gc_callback(event, info):
+    """Called before and after each run of the gc, see gc_set_timing."""
+    global _gc_start  # noqa: PLW0603
+    gen = info['generation']
+    if event == 'start':
+        _gc_start = _gc_time()
+        if gen == 2 and _logger.isEnabledFor(logging.DEBUG):
+            _logger.debug("info %s, starting collection of gen2", gc_info())
+    else:
+        timing = _gc_time() - _gc_start
+        _gc_timings[gen] += timing
+        _gc_start = 0
+        if gen > 0:
+            _logger.debug("collected %s in %.2fms", info, _to_ms(timing))
+
+
+def gc_set_timing(*, enable: bool):
+    """Enable or disable timing callback.
+
+    This collects information about how much time is spent by the GC.
+    It logs GC times (at debug level) for collections bigger than 0.
+    The overhead is under a microsecond.
+    """
+    if _timing_gc_callback in gc.callbacks:
+        if enable:
+            return
+        gc.callbacks.remove(_timing_gc_callback)
+    elif enable:
+        global _gc_init_stats, _gc_timings  # noqa: PLW0603
+        _gc_init_stats = gc.get_stats()
+        _gc_timings = [0, 0, 0]
+        gc.callbacks.append(_timing_gc_callback)
+
+
+def gc_info():
+    """Return a dict with stats about the garbage collector."""
+    stats = gc.get_stats()
+    times = []
+    cumulative_time = sum(_gc_timings) or 1
+    for info, info_init, time in zip(stats, _gc_init_stats, _gc_timings):
+        count = info['collections'] - info_init['collections']
+        times.append({
+            'avg_time': time // count if count > 0 else 0,
+            'time': _to_ms(time),
+            'pct': round(time / cumulative_time, 3)
+        })
+    return {
+        'cumulative_time': _to_ms(cumulative_time),
+        'time': times if _timing_gc_callback in gc.callbacks else (),
+        'count': stats,
+        'thresholds': (gc.get_count(), gc.get_threshold()),
+    }
 
 
 @contextlib.contextmanager

--- a/odoo/tools/profiler.py
+++ b/odoo/tools/profiler.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from contextlib import nullcontext
+from contextlib import nullcontext, ExitStack
 from datetime import datetime
-import gc
 import json
 import logging
 import sys
@@ -16,6 +14,8 @@ from psycopg2 import OperationalError
 
 from odoo import tools
 from odoo.tools import SQL
+
+from .gc import disabling_gc
 
 
 _logger = logging.getLogger(__name__)
@@ -558,6 +558,7 @@ class Profiler:
         self.sub_profilers = []
         self.entry_count_limit = int(self.params.get("entry_count_limit",0)) # the limit could be set using a smarter way
         self.done = False
+        self.exit_stack = ExitStack()
 
         if db is ...:
             # determine database from current thread
@@ -604,8 +605,8 @@ class Profiler:
             self.description = f"{frame.f_code.co_name} ({code.co_filename}:{frame.f_lineno})"
         if self.params:
             self.init_thread.profiler_params = self.params
-        if self.disable_gc and gc.isenabled():
-            gc.disable()
+        if self.disable_gc:
+            self.exit_stack.enter_context(disabling_gc())
         self.start_time = real_time()
         self.start_cpu_time = real_cpu_time()
         for collector in self.collectors:
@@ -654,8 +655,7 @@ class Profiler:
         except OperationalError:
             _logger.exception("Could not save profile in database")
         finally:
-            if self.disable_gc:
-                gc.enable()
+            self.exit_stack.close()
             if self.params:
                 del self.init_thread.profiler_params
             if self.log:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
During loading of the registry, we import a lot of modules nad may create small objects which can trigger the gc. Instead of letting it happen, we can temporarly disable the gc during normal loading of the registry; during install/updates we need to collect objects because data initialization may create a lot of them.

We add a module in tools to ease tracking how much time is spent by the GC. Details in commit messages.

Performance:
```bash
# shows a total improvement of over 5% (tested with 160 installed modules)
time for i in {1..25}; do odoo-bin -d odoo --stop-after-init ;done
```

Typical gc pause when starting. That file is no bigger than others.
![image](https://github.com/user-attachments/assets/0d2f2098-ad6d-4ecd-ba4e-b5f0ab3f8b3a)

GC cumulated time in ms during --stop-after-init.
|Modules| master | set_thresholds | disable - this PR |
|----|----|----|----|
|base (19) | 55 | 35 | 25 |
|mid (117) | 230 | 90 | 70 |
|big (303) | 505 | 310 | 120 |


task-4856492



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
