### PR TITLE
[FIX] survey: show survey title as page name

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -4,6 +4,7 @@
     <!-- Main survey layout -->
     <template id="survey.layout" name="Survey Layout" inherit_id="web.frontend_layout" primary="True">
         <xpath expr="//head" position="before">
+            <t t-if="survey" t-set="title" t-value="survey.title"/>
             <!--TODO DBE Fix me : If one day, there is a survey_livechat bridge module, put this in that module-->
             <t t-set="no_livechat" t-value="True"/>
         </xpath>


### PR DESCRIPTION
Before this commit, the page title of surveys (and their related pages) would be the `name` of the template, which looked e.g. like this: "Survey: main page (take survey)" in the browser tab.

This commit fixes that by using the survey title as the page title whenever it is available.