### PR TITLE
[FIX] hr_timesheet: prevent error on unarchiving company

### DIFF
--- a/addons/hr_timesheet/models/ir_http.py
+++ b/addons/hr_timesheet/models/ir_http.py
@@ -16,6 +16,8 @@ class IrHttp(models.AbstractModel):
             company_ids = self.env.user.company_ids
 
             for company in company_ids:
+                if company.id not in result["user_companies"]["allowed_companies"]:
+                    result["user_companies"]["allowed_companies"][company.id] = {}
                 result["user_companies"]["allowed_companies"][company.id].update({
                     "timesheet_uom_id": company.timesheet_encode_uom_id.id,
                     "timesheet_uom_factor": company.project_time_mode_id._compute_quantity(


### PR DESCRIPTION
Currently, on unarchiving a company, raises an error when hr_timesheet is installed

**Steps to Reproduce:**
- Install `hr_timesheet` module.
- Create a company, archive it and then unarchive it.

**Error:**
`KeyError: 2`

**Root Cause:**
since https://github.com/odoo/odoo/commit/22e9d822e8cab08114c006eb8c4054c4de0c40f2, the `session_info` method relies on `user_companies` at [1], which fetches only active company IDs via `_get_company_ids()`. When a company is unarchived, its ID is missing in the `allowed_companies` dictionary at [2], causing a KeyError.

[1]- https://github.com/odoo/odoo/blob/d3482e32f7dbe273125de84f1bbc434ac3c9ffc3/addons/web/models/ir_http.py#L146

[2]- https://github.com/odoo/odoo/blob/d3482e32f7dbe273125de84f1bbc434ac3c9ffc3/addons/web/models/ir_http.py#L153

**Solution:**
Add a check to initialize missing keys in the `allowed_companies` dictionary before updating it.

Sentry-6251348500