### PR TITLE
[FIX] repair: fix delivered quantity of sol generated by repair order

### DIFF
--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -120,7 +120,9 @@ class StockMove(models.Model):
                 'order_id': move.repair_id.sale_order_id.id,
                 'product_id': move.product_id.id,
                 'product_uom_qty': product_qty, # When relying only on so_line compute method, the sol quantity is only updated on next sol creation
+                'product_uom': move.product_uom.id,
                 'move_ids': [Command.link(move.id)],
+                'qty_delivered': move.quantity if move.state == 'done' else 0.0,
             })
             if move.repair_id.under_warranty:
                 so_line_vals[-1]['price_unit'] = 0.0

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -852,3 +852,30 @@ class TestRepair(common.TransactionCase):
         self.assertFalse(copied_without_access.create_repair)
         copied_with_access = product_templ.copy().with_user(mitchell_user)
         self.assertTrue(copied_with_access.create_repair)
+
+    def test_delivered_qty_of_generated_so(self):
+        """
+        Test that checks that `qty_delivered` of the generated SOL is correctly set when the repair is done.
+        """
+        repair_order = self.env['repair.order'].create({
+            'product_id': self.product_storable_order_repair.id,
+            'product_uom': self.product_storable_order_repair.uom_id.id,
+            'partner_id': self.res_partner_1.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.product_consu_order_repair.id,
+                    'product_uom_qty': 1.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                })
+            ],
+        })
+        repair_order.action_validate()
+        repair_order.action_repair_start()
+        repair_order.action_repair_end()
+        self.assertEqual(repair_order.state, 'done')
+        self.assertEqual(repair_order.move_ids.quantity, 1.0)
+        repair_order.action_create_sale_order()
+        sale_order = repair_order.sale_order_id
+        sale_order.action_confirm()
+        self.assertEqual(sale_order.order_line.qty_delivered, 1.0)


### PR DESCRIPTION
Steps to reproduce:
- Create a repair order.
- Add a stock move to it with any quantity.
- Confirm, start and end the repair order. Make sure that quantity done is positive.
- Generate a sale order from the repair order.
- Confirm the sale order.

Expected result:
`qty_delivered` of the generated sale order line should be the same as the quantity done of the move in the repair order.

Current result:
`qty_delivered` is zero.

* Same as https://github.com/odoo/odoo/pull/181639

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
