### PR TITLE
[IMP] pos_self_order: skip payment confirmation screen

### DIFF
--- a/addons/pos_online_payment/controllers/payment_portal.py
+++ b/addons/pos_online_payment/controllers/payment_portal.py
@@ -289,6 +289,8 @@ class PaymentPortal(payment_portal.PaymentPortal):
         tx_sudo._process_pos_online_payment()
 
         rendering_context['state'] = 'success'
+        if exit_route:
+            return request.redirect(exit_route)
         return self._render_pay_confirmation(rendering_context)
 
     def _render_pay_confirmation(self, rendering_context):


### PR DESCRIPTION
Before:
=
- A payment confirmation screen used to appear after a successful transaction.

After:
=
- The flow now skips the payment confirmation screen and moves directly to the next Screen.

Task: 4836123