### PR TITLE
[FIX] sale: fetch all linked combo lines correctly

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -919,7 +919,7 @@ class SaleOrder(models.Model):
     def _onchange_order_line(self):
         for index, line in enumerate(self.order_line):
             if line.product_type == 'combo' and line.selected_combo_items:
-                linked_lines = line._get_linked_lines()
+                linked_lines = line._get_all_linked_lines()
                 selected_combo_items = json.loads(line.selected_combo_items)
                 if (
                     selected_combo_items

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -1556,6 +1556,20 @@ class SaleOrderLine(models.Model):
     def has_valued_move_ids(self):
         return self.move_ids
 
+    def _get_all_linked_lines(self, visited=None):
+        if visited is None:
+            visited = set()
+        all_linked_lines = self.env['sale.order.line']
+        linked_lines = self._get_linked_lines()
+
+        for line in linked_lines:
+            if line.id in visited:
+                continue
+            visited.add(line.id)
+            all_linked_lines |= line
+            all_linked_lines |= line._get_all_linked_lines(visited=visited)
+        return all_linked_lines
+
     def _get_linked_line(self):
         """ Return the linked line of this line, if any.
 

--- a/addons/sale/static/tests/tours/sale_combo_nested_combo_lines_deleted.js
+++ b/addons/sale/static/tests/tours/sale_combo_nested_combo_lines_deleted.js
@@ -1,0 +1,41 @@
+import { registry } from '@web/core/registry';
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+import comboConfiguratorTourUtils from '@sale/js/tours/combo_configurator_tour_utils';
+import tourUtils from '@sale/js/tours/tour_utils';
+
+registry
+    .category('web_tour.tours')
+    .add('sale_combo_nested_combo_lines_deleted', {
+        url: '/odoo',
+        steps: () => [
+            ...stepUtils.goToAppSteps('sale.sale_menu_root', "Open the sales app"),
+            ...tourUtils.createNewSalesOrder(),
+            ...tourUtils.selectCustomer("Test Partner"),
+            ...tourUtils.addProduct("Combo product"),
+            comboConfiguratorTourUtils.selectComboItem("Product A1"),
+            ...comboConfiguratorTourUtils.saveConfigurator(),
+            {
+                content: "Click to activate the row containing Product A1",
+                trigger: '.o_form_view .o_list_view tbody tr:contains("Product A1") td.o_data_cell',
+                run: 'click'
+            },
+            {
+                content: "Edit and replace with Combo Product",
+                trigger: '.o_list_view tbody tr td[name="product_template_id"] input',
+                run: 'edit Combo Product',
+            },
+            {
+                content: "Select Combo Product from dropdown",
+                trigger: '.ui-autocomplete .ui-menu-item:contains("Combo Product")',
+                run: 'click',
+            },
+            comboConfiguratorTourUtils.selectComboItem("Product A1"),
+            ...comboConfiguratorTourUtils.saveConfigurator(),
+            {
+                content: "Click delete on Desk Organizer line",
+                trigger: '.o_list_view tbody tr:has(td span:contains("Combo Product")) .o_list_record_remove button[name="delete"]',
+                run: 'click',
+            },
+            ...stepUtils.saveForm(),
+        ],
+    });

--- a/addons/sale/tests/test_sale_combo_configurator.py
+++ b/addons/sale/tests/test_sale_combo_configurator.py
@@ -170,3 +170,25 @@ class TestSaleComboConfigurator(HttpCase, SaleCommon):
             'name': combo_name,
             'combo_item_ids': [Command.create({'product_id': product.product_variant_id.id})],
         })
+
+    def test_sale_combo_configurator_nested_lines_deleted(self):
+        if self.env['ir.module.module']._get('sale_management').state != 'installed':
+            self.skipTest("Sale App is not installed, Sale menu is not accessible.")
+
+        combo_a = self.env['product.combo'].create({
+            'name': "Combo A",
+            'combo_item_ids': [
+                Command.create({'product_id': self._create_product(name="Product A1").id}),
+            ],
+        })
+        self._create_product(
+            name="Combo product",
+            list_price=25,
+            type='combo',
+            combo_ids=[
+                Command.link(combo_a.id),
+            ],
+        )
+        self.start_tour(
+            '/', 'sale_combo_nested_combo_lines_deleted', login='salesman'
+        )


### PR DESCRIPTION
Currently, an error occurs when a combo product is added to a sales order, and one of its combo items is replaced with another combo product, then the original parent combo product is deleted.

Steps to reproduce:
- Create a sales order and add a combo product to it.
- Modify one of the combo items by replacing it with another combo product.
- Delete the original parent combo product from the order lines and save.

Error:
`ValueError: Expected singleton: sale.order.line()`

The error occurs because the parent combo item is deleted, which causes `line.virtual_id` to become False. As a result, the filter [1] returns no matching records, and ensure_one() fails by raising a singleton error due to receiving zero records.

This happens because the function [2] called from onchange in `sales_order` [3] that performs all the changes only checks the first level of combo items and doesn’t handle cases where those items are also combo products with their own linked items.

This commit fixes the error by properly deleting all nested combo items in the sales order, ensuring no leftover items from nested combos remain that could cause errors.

[1] - https://github.com/odoo/odoo/blob/7bb84621b773cdd7e9984222d61d70d622f8ac43/addons/sale/models/sale_order_line.py#L1567-L1569
[2] - https://github.com/odoo/odoo/blob/57b4056798b9a380027fd3da1c4f3965249a4509/addons/sale/models/sale_order_line.py#L1572-L1591
[3] - https://github.com/odoo/odoo/blob/7bb84621b773cdd7e9984222d61d70d622f8ac43/addons/sale/models/sale_order.py#L922

sentry-6653847384

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
