### PR TITLE
[IMP] purchase_stock: contacts as vendors in replenish wizard

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -1065,11 +1065,7 @@ class ProductProduct(models.Model):
             }
             return [vals.get(key, record[key]) for key in sort_key]
         sellers = self._get_filtered_sellers(partner_id=partner_id, quantity=quantity, date=date, uom_id=uom_id, params=params)
-        res = self.env['product.supplierinfo']
-        for seller in sellers:
-            if not res or res.partner_id == seller.partner_id:
-                res |= seller
-        return res and res.sorted(sort_function)[:1]
+        return sellers.sorted(sort_function)[:1]
 
     def _get_product_price_context(self, combination):
         self.ensure_one()

--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -164,3 +164,23 @@ class TestSeller(TransactionCase):
         vendors.write({'product_id': False})
         self.assertEqual(vendors, self.product_consu.seller_ids,
             "Setting the product_id to False shouldn't affect seller_ids.")
+
+    def test_51_seller_ids(self):
+        """Test vendor selection when using select_seller with Partner_id False"""
+
+        self.env['product.supplierinfo'].create([
+            {
+                'partner_id': self.asustec.id,
+                'product_tmpl_id': self.product_consu.product_tmpl_id.id,
+                'price': 170,
+                'sequence': 1,
+            }, {
+                'partner_id': self.camptocamp.id,
+                'product_tmpl_id': self.product_consu.product_tmpl_id.id,
+                'price': 10,  # Wow so cheap
+                'sequence': 2,
+            }
+        ])
+
+        price = self.product_consu._select_seller(partner_id=False, quantity=1).price
+        self.assertEqual(price, 10, "Should select cheapest vendor with partner_id false")

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -352,10 +352,11 @@ class PurchaseOrderLine(models.Model):
         if values.get('product_description_variants'):
             line_description = values['product_description_variants']
         supplier = values.get('supplier')
-        if not values.get('force_uom') and supplier.product_uom_id != product_uom:
+        if not values.get('force_uom') and supplier and supplier.product_uom_id != product_uom:
             product_qty = product_uom._compute_quantity(product_qty, supplier.product_uom_id)
             product_uom = supplier.product_uom_id
-        res = self.with_context(procurement_values=values)._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, supplier.partner_id, po)
+        partner = values.get('procurement_partner')
+        res = self.with_context(procurement_values=values)._prepare_purchase_order_line(product_id, product_qty, product_uom, company_id, partner, po)
         # We need to keep the vendor name set in _prepare_purchase_order_line. To avoid redundancy
         # in the line name, we add the line_description only if different from the product name.
         # This way, we shoud not lose any valuable information.

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -261,8 +261,8 @@ class StockWarehouseOrderpoint(models.Model):
     def _get_default_supplier(self):
         self.ensure_one()
         if self.show_supplier and self.product_id:
-            return self._get_default_rule()._get_matching_supplier(
-                self.product_id, self.qty_to_order, self.product_uom, self.company_id, {}
+            return self._get_default_rule()._pick_supplier(
+                self.company_id, self.product_id, qty=self.qty_to_order, uom=self.product_uom
             )
         else:
             return self.env['product.supplierinfo']

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -631,7 +631,7 @@ class TestReorderingRule(TransactionCase):
                     "rule_id": warehouse.buy_pull_id,
                     "group_id": False,
                     "route_ids": [],
-                    "supplierinfo_name": secondary_vendor,
+                    "procurement_partner": secondary_vendor,
                 }
             )])
         po_line = self.env["purchase.order.line"].search(

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -30,10 +30,24 @@ class TestReplenishWizard(PurchaseTestCommon):
             'price': cls.product1_price,
         })
 
+        cls.vendor1, cls.vendor2 = cls.env['res.partner'].create([
+            {'name': 'vendor1', 'email': 'from.test@example.com'},
+            {'name': 'vendor2', 'email': 'from.test2@example.com'}
+        ])
+
         # Additional Values required by the replenish wizard
         cls.uom_unit = cls.env.ref('uom.product_uom_unit')
         cls.uom_pack_6 = cls.env.ref('uom.product_uom_pack_6')
         cls.wh = cls.env['stock.warehouse'].search([('company_id', '=', cls.env.user.id)], limit=1)
+
+    def _get_purchase_order_from_replenishment(self, replenish_wizard):
+        notification = replenish_wizard.launch_replenishment()
+        links = notification.get("params", {}).get("links")
+        url = links and links[0].get("url", "") or ""
+        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
+
+        assert (purchase_order_id and model_name == 'purchase.order'), "replenishment didn't return a link to a purchase order"
+        return self.env[model_name].browse(int(purchase_order_id))
 
     def test_replenish_buy_1(self):
         """ Set a quantity to replenish via the "Buy" route and check if
@@ -51,16 +65,10 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': self.product_uom_qty,
             'warehouse_id': self.wh.id,
         })
-        genrated_picking = replenish_wizard.launch_replenishment()
-        links = genrated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
 
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-        self.assertTrue(last_po_id, 'Purchase Order not found')
-        order_line = last_po_id.order_line.search([('product_id', '=', self.product1.id)])
+        self.assertTrue(po, 'Purchase Order not found')
+        order_line = po.order_line.search([('product_id', '=', self.product1.id)])
         self.assertTrue(order_line, 'The product is not in the Purchase Order')
         self.assertEqual(order_line.product_qty, self.product_uom_qty, 'Quantities does not match')
         self.assertEqual(order_line.price_unit, self.product1_price, 'Prices does not match')
@@ -79,22 +87,22 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
 
-        supplierinfo1 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor1.id,
-            'min_qty': 1,
-            'price': 140,
-            'sequence': 1,
-        })
-        supplierinfo2 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor1.id,
-            'min_qty': 10,
-            'price': 100,
-            'sequence': 2,
-        })
+        self.env['product.supplierinfo'].create([
+            {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor1.id,
+                'min_qty': 1,
+                'price': 140,
+                'sequence': 1,
+            }, {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor1.id,
+                'min_qty': 10,
+                'price': 100,
+                'sequence': 2,
+            }
+        ])
 
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=product_to_buy.product_tmpl_id.id).create({
             'product_id': product_to_buy.id,
@@ -103,16 +111,9 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
-        genrated_picking = replenish_wizard.launch_replenishment()
-        links = genrated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
-
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-        self.assertEqual(last_po_id.partner_id, vendor1)
-        self.assertEqual(last_po_id.order_line.price_unit, 100)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+        self.assertEqual(po.partner_id, self.vendor1)
+        self.assertEqual(po.order_line.price_unit, 100)
 
     def test_chose_supplier_2(self):
         """ Choose supplier based on the ordered quantity and minimum price
@@ -129,30 +130,28 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
-        vendor2 = self.env['res.partner'].create({'name': 'vendor2', 'email': 'from.test2@example.com'})
 
-        supplierinfo1 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor1.id,
-            'min_qty': 1,
-            'price': 140,
-            'sequence': 1,
-        })
-        supplierinfo2 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor2.id,
-            'min_qty': 10,
-            'price': 90,
-            'sequence': 2,
-        })
-        supplierinfo3 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor1.id,
-            'min_qty': 10,
-            'price': 100,
-            'sequence': 3,
-        })
+        self.env['product.supplierinfo'].create([
+            {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor1.id,
+                'min_qty': 1,
+                'price': 140,
+                'sequence': 1,
+            }, {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor2.id,
+                'min_qty': 10,
+                'price': 90,
+                'sequence': 2,
+            }, {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor1.id,
+                'min_qty': 10,
+                'price': 100,
+                'sequence': 3,
+            }
+        ])
 
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=product_to_buy.product_tmpl_id.id).create({
             'product_id': product_to_buy.id,
@@ -161,16 +160,9 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
-        genrated_picking = replenish_wizard.launch_replenishment()
-        links = genrated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
-
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-        self.assertEqual(last_po_id.partner_id, vendor1)
-        self.assertEqual(last_po_id.order_line.price_unit, 100)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+        self.assertEqual(po.partner_id, vendor1)
+        self.assertEqual(po.order_line.price_unit, 100)
 
     def test_chose_supplier_3(self):
         """ Choose supplier based on the ordered quantity and minimum price
@@ -186,21 +178,20 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
-        vendor2 = self.env['res.partner'].create({'name': 'vendor2', 'email': 'from.test2@example.com'})
 
-        supplierinfo1 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor1.id,
-            'price': 50,
-            'sequence': 2,
-        })
-        supplierinfo2 = self.env['product.supplierinfo'].create({
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'partner_id': vendor2.id,
-            'price': 50,
-            'sequence': 1,
-        })
+        self.env['product.supplierinfo'].create([
+            {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor1.id,
+                'price': 50,
+                'sequence': 2,
+            }, {
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'partner_id': self.vendor2.id,
+                'price': 50,
+                'sequence': 1,
+            }
+        ])
 
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=product_to_buy.product_tmpl_id.id).create({
             'product_id': product_to_buy.id,
@@ -209,16 +200,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
-        genrated_picking = replenish_wizard.launch_replenishment()
-        links = genrated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
-
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-
-        self.assertEqual(last_po_id.partner_id, vendor2)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+        self.assertEqual(po.partner_id, self.vendor2)
 
     def test_chose_supplier_4(self):
         """ Choose supplier based on the ordered quantity and minimum price
@@ -235,25 +218,26 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
-        supplierinfo1 = self.env['product.supplierinfo'].create({
-            'partner_id': vendor1.id,
-            'price': 100,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 2
-        })
-        supplierinfo2 = self.env['product.supplierinfo'].create({
-            'partner_id': vendor1.id,
-            'price': 60,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 10
-        })
-        supplierinfo3 = self.env['product.supplierinfo'].create({
-            'partner_id': vendor1.id,
-            'price': 80,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 5
-        })
+
+        self.env['product.supplierinfo'].create([
+            {
+                'partner_id': self.vendor1.id,
+                'price': 100,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 2
+            }, {
+                'partner_id': self.vendor1.id,
+                'price': 60,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 10
+            }, {
+                'partner_id': self.vendor1.id,
+                'price': 80,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 5
+            }
+        ])
+
         replenish_wizard = self.env['product.replenish'].with_context(default_product_tmpl_id=product_to_buy.product_tmpl_id.id).create({
             'product_id': product_to_buy.id,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
@@ -261,17 +245,10 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 10,
             'warehouse_id': self.wh.id,
         })
-        genrated_picking = replenish_wizard.launch_replenishment()
-        links = genrated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
 
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-
-        self.assertEqual(last_po_id.partner_id, vendor1)
-        self.assertEqual(last_po_id.order_line.price_unit, 60)
+        self.assertEqual(po.partner_id, self.vendor1)
+        self.assertEqual(po.order_line.price_unit, 60)
 
     def test_chose_supplier_5(self):
         """ Choose supplier based on discounted price
@@ -299,17 +276,11 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 1,
             'warehouse_id': self.wh.id,
         })
-        generated_picking = replenish_wizard.launch_replenishment()
-        links = generated_picking.get("params", {}).get("links")
-        url = links and links[0].get("url", "") or ""
-        purchase_order_id, model_name = self.url_extract_rec_id_and_model(url)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
 
-        last_po_id = False
-        if purchase_order_id and model_name:
-            last_po_id = self.env[model_name].browse(int(purchase_order_id))
-        self.assertEqual(last_po_id.partner_id, self.vendor)
-        self.assertEqual(last_po_id.order_line.price_unit, 110)
-        self.assertEqual(last_po_id.order_line.discount, 20.0)
+        self.assertEqual(po.partner_id, self.vendor)
+        self.assertEqual(po.order_line.price_unit, 110)
+        self.assertEqual(po.order_line.discount, 20.0)
 
     def test_supplier_delay(self):
         product_to_buy = self.env['product.product'].create({
@@ -317,21 +288,21 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor1 = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
-        supplier_delay = self.env['product.supplierinfo'].create({
-            'partner_id': vendor1.id,
-            'price': 100,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 2,
-            'delay': 3
-        })
-        supplier_no_delay = self.env['product.supplierinfo'].create({
-            'partner_id': vendor1.id,
-            'price': 100,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 2,
-            'delay' : 0
-        })
+        supplier_delay, supplier_no_delay = self.env['product.supplierinfo'].create([
+            {
+                'partner_id': self.vendor1.id,
+                'price': 100,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 2,
+                'delay': 3
+            }, {
+                'partner_id': self.vendor2.id,
+                'price': 100,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 2,
+                'delay': 0
+            }
+        ])
         with freeze_time("2023-01-01"):
             wizard = self.env['product.replenish'].create({
                 'product_id': product_to_buy.id,
@@ -352,21 +323,23 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
-        supplier1 = self.env['product.supplierinfo'].create({
-            'partner_id': vendor.id,
-            'price': 100,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 2,
-            'delay': 0
-        })
-        supplier2 = self.env['product.supplierinfo'].create({
-            'partner_id': vendor.id,
-            'price': 100,
-            'product_tmpl_id': product_to_buy.product_tmpl_id.id,
-            'min_qty': 2,
-            'delay' : 0
-        })
+
+        supplier1, supplier2 = self.env['product.supplierinfo'].create([
+            {
+                'partner_id': self.vendor1.id,
+                'price': 100,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 2,
+                'delay': 0
+            },
+            {
+                'partner_id': self.vendor2.id,
+                'price': 100,
+                'product_tmpl_id': product_to_buy.product_tmpl_id.id,
+                'min_qty': 2,
+                'delay': 0
+            }
+        ])
         self.env.company.days_to_purchase = 0
 
         with freeze_time("2023-01-01"):
@@ -391,9 +364,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'is_storable': True,
             'route_ids': [Command.link(self.route_buy.id)],
         })
-        vendor = self.env['res.partner'].create({'name': 'vendor1', 'email': 'from.test@example.com'})
         supplier = self.env['product.supplierinfo'].create({
-            'partner_id': vendor.id,
+            'partner_id': self.vendor.id,
             'price': 100,
             'product_tmpl_id': product_to_buy.product_tmpl_id.id,
             'min_qty': 2,
@@ -414,15 +386,11 @@ class TestReplenishWizard(PurchaseTestCommon):
             self.assertEqual(fields.Datetime.from_string('2023-01-08 00:00:00'), wizard.date_planned)
 
     def test_unit_price_expired_price_list(self):
-        vendor = self.env['res.partner'].create({
-            'name': 'Contact',
-            'type': 'contact',
-        })
         product = self.env['product.product'].create({
             'name': 'Product',
             'standard_price': 60,
             'seller_ids': [(0, 0, {
-                'partner_id': vendor.id,
+                'partner_id': self.vendor.id,
                 'price': 1.0,
                 'date_end': '2019-01-01',
             })],
@@ -437,13 +405,10 @@ class TestReplenishWizard(PurchaseTestCommon):
             'warehouse_id': self.wh.id,
             'route_id': self.route_buy.id,
         })
-        replenish_wizard.launch_replenishment()
-        last_po_id = self.env['purchase.order'].search([
-            ('origin', 'ilike', '%Manual Replenishment%'),
-        ])[-1]
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
 
-        self.assertEqual(last_po_id.partner_id, vendor)
-        self.assertEqual(last_po_id.order_line.price_unit, 0)
+        self.assertEqual(po.partner_id, self.vendor)
+        self.assertEqual(po.order_line.price_unit, 0)
 
     def test_correct_supplier(self):
         self.env['stock.warehouse'].search([], limit=1).reception_steps = 'two_steps'
@@ -451,20 +416,17 @@ class TestReplenishWizard(PurchaseTestCommon):
             'name': 'Product',
             'route_ids': [Command.set([self.route_buy.id])],
         })
-        partner_a, partner_b = self.env['res.partner'].create([
-            {'name': "partner_a"},
-            {'name': "partner_b"},
-        ])
+
         self.env['product.supplierinfo'].create([{
-            'partner_id': partner_a.id,
+            'partner_id': self.vendor1.id,
             'product_id': product.id,
             'price': 1.0,
         }, {
-            'partner_id': partner_b.id,
+            'partner_id': self.vendor2.id,
             'product_id': product.id,
             'price': 10.0,
         }, {
-            'partner_id': partner_b.id,
+            'partner_id': self.vendor2.id,
             'product_id': product.id,
             'price': 100.0,
         }])
@@ -476,12 +438,9 @@ class TestReplenishWizard(PurchaseTestCommon):
             'quantity': 1,
             'warehouse_id': self.wh.id,
             'route_id': self.route_buy.id,
-            'supplier_id': product.seller_ids[2].id  # partner_b price 100$
+            'partner_id': self.vendor2.id,  # vendor2 price 100$
         })
-        replenish_wizard.launch_replenishment()
-        po = self.env['purchase.order'].search([
-            ('partner_id', '=', partner_b.id)
-        ])
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
         self.assertEqual(po.amount_untaxed, 10, "best price is 10$")
 
     def test_delete_buy_route_and_replenish(self):
@@ -533,10 +492,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
             'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
         })
-        replenish_wizard.launch_replenishment()
-        po = self.env['purchase.order'].search([
-            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
-        ], order='id DESC', limit=1)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+
         self.assertEqual(po.order_line.product_qty, 10, 'Generated PO line must respect the requested quantity from the wizard')
         self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
         self.assertEqual(po.order_line.price_unit, 1, 'Generated PO line must respect the supplier price of UoM "Unit"')
@@ -551,10 +508,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
             'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
         })
-        replenish_wizard.launch_replenishment()
-        po = self.env['purchase.order'].search([
-            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
-        ], order='id DESC', limit=1)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+
         self.assertEqual(po.order_line.product_qty, 15, 'Generated PO line must respect the requested quantity from the wizard')
         self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
         self.assertEqual(po.order_line.price_unit, 1, 'Generated PO line must respect the supplier price of UoM "Unit"')
@@ -569,10 +524,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
             'supplier_id': self.fuzzy_drink.seller_ids[1].id,  # pricelist with uom "Pack of 6"
         })
-        replenish_wizard.launch_replenishment()
-        po = self.env['purchase.order'].search([
-            ('partner_id', '=', self.fuzzy_drink.seller_ids[1].partner_id.id)
-        ], order='id DESC', limit=1)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+
         self.assertEqual(po.order_line.product_qty, 1, 'Generated PO line must respect the requested quantity from the wizard')
         self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
         self.assertEqual(po.order_line.price_unit, 6, 'Generated PO line must respect the supplier price of UoM "Unit" because the quantity doesn\'t match the "Pack of 6" pricelist')
@@ -587,10 +540,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'route_id': self.env.ref('purchase_stock.route_warehouse0_buy').id,
             'supplier_id': self.fuzzy_drink.seller_ids[0].id,  # pricelist with uom "Unit"
         })
-        replenish_wizard.launch_replenishment()
-        po = self.env['purchase.order'].search([
-            ('partner_id', '=', self.fuzzy_drink.seller_ids[0].partner_id.id)
-        ], order='id DESC', limit=1)
+        po = self._get_purchase_order_from_replenishment(replenish_wizard)
+
         self.assertEqual(po.order_line.product_qty, 2, 'Generated PO line must respect the requested quantity from the wizard')
         self.assertEqual(po.order_line.product_uom_id, replenish_wizard.product_uom_id, 'Generated PO line must respect the requested UOM from the wizard')
         self.assertEqual(po.order_line.price_unit, 5, 'Generated PO line must respect the supplier price of UoM "Pack of 6" because the quantity matches the "Pack of 6" pricelist')

--- a/addons/purchase_stock/tests/test_replenish_wizard.py
+++ b/addons/purchase_stock/tests/test_replenish_wizard.py
@@ -123,7 +123,7 @@ class TestReplenishWizard(PurchaseTestCommon):
         1)seq1 vendor1 140 min qty 1
         2)seq2 vendor2 90  min qty 10
         3)seq3 vendor1 100 min qty 10
-        -> 3) should be chosen
+        -> 2) should be chosen
         """
         product_to_buy = self.env['product.product'].create({
             'name': "Furniture Service",
@@ -161,8 +161,8 @@ class TestReplenishWizard(PurchaseTestCommon):
             'warehouse_id': self.wh.id,
         })
         po = self._get_purchase_order_from_replenishment(replenish_wizard)
-        self.assertEqual(po.partner_id, vendor1)
-        self.assertEqual(po.order_line.price_unit, 100)
+        self.assertEqual(po.partner_id, self.vendor2)
+        self.assertEqual(po.order_line.price_unit, 90)
 
     def test_chose_supplier_3(self):
         """ Choose supplier based on the ordered quantity and minimum price

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -6,11 +6,12 @@
         <field name="inherit_id" ref="stock.view_product_replenish"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='route_id']" position="after">
-                <label for="supplier_id" invisible="not show_vendor"/>
-                <div class="o_row">
-                    <field name="show_vendor" invisible="1"/>
-                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
-                </div>
+                <field name="partner_id"
+                    required="show_vendor"
+                    invisible="not show_vendor"
+                    context="{'product_id': product_id, 'highlight_supplier': 1}"
+                    options="{'no_open': 1, 'no_create': 0, 'no_quick_create':1}"
+                />
             </xpath>
         </field>
     </record>

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -75,9 +75,8 @@ class ProductReplenish(models.TransientModel):
             res['warehouse_id'] = warehouse.id
         if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
             res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
-            if not res['route_id']:
-                if product_tmpl_id.route_ids:
-                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
+            if not res['route_id'] and product_tmpl_id.route_ids:
+                res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
         return res
 
     def _get_date_planned(self, route_id, **kwargs):
@@ -114,17 +113,6 @@ class ProductReplenish(models.TransientModel):
             return act_window_close
         except UserError as error:
             raise UserError(error)
-
-    # TODO: to remove in master
-    def _prepare_orderpoint_values(self):
-        values = {
-            'location_id': self.warehouse_id.lot_stock_id.id,
-            'product_id': self.product_id.id,
-            'qty_to_order': self.quantity,
-        }
-        if self.route_id:
-            values['route_id'] = self.route_id.id
-        return values
 
     def _prepare_run_values(self):
         values = {

--- a/addons/stock/wizard/product_replenish_views.xml
+++ b/addons/stock/wizard/product_replenish_views.xml
@@ -28,10 +28,10 @@
                                 widget="many2one_uom"
                                 options="{'no_open': 1, 'no_create': 1, 'quantity_field': 'quantity'}"/>
                         </div>
-                        <field name="date_planned"/>
                         <field name="warehouse_id"
                             groups="stock.group_stock_multi_warehouses"/>
                         <field name="route_id" domain="[('id', 'in', allowed_route_ids)]"/>
+                        <field name="date_planned"/>
                     </group>
                 </group>
                 <footer>

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -14,12 +14,6 @@ class StockRule(models.Model):
         """
         return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_groupby(procurement)
 
-    def _get_partner_id(self, values, rule):
-        route = self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False)
-        if route and rule.route_id == route:
-            return False
-        return super()._get_partner_id(values, rule)
-
     def _compute_picking_type_code_domain(self):
         super()._compute_picking_type_code_domain()
         for rule in self:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As a procurement specialist, when using the replenish wizard with a buy route, I can only use vendors in the product pricelist. However, I should be able to order a replenishment from any partner (and as is already the case, if the PO is confirmed this partner will be added to vendor list automatically) .

Additionally, it would be better if the partner was pre-selected for me, based on the best pricelist, if they are any.  

Current behavior before PR:

To replenish a product from a partner that is not in vendor pricelist from the replenish wizard, currently I must either add him to the pricelist or make a purchase order. I must always choose a supplier myself (no defaults).

Desired behavior after PR is merged:

1 Allow replenishement from any partner in the replenishement wizard, by changing the supplier search box from vendor list only to vendor first, in blue, and then all partners in normal display.
2 Allow to create and edit partner from the supplier search box (no-quick create)
3 Default "best" vendor pre-selected if buy route + the product has any pricelists

Note the task is split in 4 commits:

Commit 1: Refactoring tests so test diffs are clearer on other commits (plus fix one test to make it more resilient)
Commit 2: Fixing a bug on product.product _select_vendor method 
Commit 3: Change run_buy to allow for partners not vendors  using `procurement_partner` key.
Commit 4: Use `procurement_partner` key to allow replenishing from non vendor partners
 
Entreprise PR: https://github.com/odoo/enterprise/pull/87279
task: [4314668](https://www.odoo.com/odoo/project/966/tasks/4314668)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
