### PR TITLE
[FIX] l10n_in_edi: regenerate invoice PDF to fix IRN section

### DIFF
--- a/addons/l10n_in_edi/models/account_move_send.py
+++ b/addons/l10n_in_edi/models/account_move_send.py
@@ -58,5 +58,7 @@ class AccountMoveSend(models.AbstractModel):
                         ),
                         'errors': [error] if not isinstance(error, list) else error,
                     }
+                elif invoice.invoice_pdf_report_id:
+                    invoice.write({'invoice_pdf_report_file': False})
                 if self._can_commit():
                     self._cr.commit()


### PR DESCRIPTION
Steps To Regenerate
- Make a customer invoice along with E-invoicing feature on and any valid tax.
- When sending invoice without selecting E-invoicing, creates a normal PDF
  without IRN.
- If later E-invoicing was selected for the same and sent, it still reused
  the old existing PDF without updating the IRN section.

In this commit
The old generated invoice PDF is cleared so that a new one is generated
with IRN and the invoice record is updated accordingly.

taskId-4844613