### PR TITLE
[FIX] website, web_editor: fix confusing overlay action buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -191,6 +191,24 @@ var SnippetEditor = publicWidget.Widget.extend({
         // a flickering when not needed.
         this.$target.on('transitionend.snippet_editor, animationend.snippet_editor', this.postAnimationCover);
 
+        // TODO: remove in master, handle the same in respective template.
+        const overlayButtonsTooltips = {
+            "div.o_front_back.o_send_back": _t("Send back"),
+            "div.o_front_back.o_bring_front": _t("Bring forward"),
+            "div.o_move_handle.fa-arrows": _t("Drag and move"),
+            "button.oe_snippet_remove.fa-trash": _t("Delete"),
+        };
+
+        for (const [selector, tooltip] of Object.entries(overlayButtonsTooltips)) {
+            const buttonEl = this.el.querySelector(selector);
+            if (buttonEl) {
+                Object.assign(buttonEl.dataset, {
+                    tooltip,
+                    tooltipPosition: "top"
+                });
+            }
+        }
+
         return Promise.all(defs).then(() => {
             this.__isStartedResolveFunc(this);
         });

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5798,11 +5798,27 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
      * @override
      */
     start: function () {
-        var $buttons = this.$el.find('we-button');
+        // TODO: remove in master, handle the same in respective template.
+        const tooltips = {
+            move_up_opt: _t("Move up"),
+            move_down_opt: _t("Move down"),
+            move_left_opt: _t("Move left"),
+            move_right_opt: _t("Move right"),
+        };
+        const buttonEls = this.el.querySelectorAll("we-button");
+        for (const buttonEl of buttonEls) {
+            const tooltip = tooltips[buttonEl.dataset.name];
+            if (tooltip) {
+                Object.assign(buttonEl.dataset, {
+                    tooltip,
+                    tooltipPosition: "top"
+                });
+            }
+        }
         var $overlayArea = this.$overlay.find('.o_overlay_move_options');
         // Putting the arrows side by side.
-        $overlayArea.prepend($buttons[1]);
-        $overlayArea.prepend($buttons[0]);
+        $overlayArea.prepend(buttonEls[1]);
+        $overlayArea.prepend(buttonEls[0]);
 
         // Needed for compatibility (with already dropped snippets).
         // If the target is a column, check if all the columns are either mobile


### PR DESCRIPTION
The overlay action buttons for sending a snippet to the back or front in the website editor were unclear. This commit adds tooltips to these buttons, providing better clarity on their functionality.

Steps to reproduce issue:
1. Drop a text block using website editor.
2. Click on the text-block and increase the number of columns to 3.
3. Convert to grid mode.
4. Now click on the text-block and check the action buttons for send back and bring front.

Before this commit:
- It was confusing to identify which button would send the snippet to the back or bring it to the front. Additionally, the icons were insufficient in conveying the button's purpose

After this commit:
- Tooltips have been added to the overlay action buttons, providing clear descriptions of their functions. Additionally, tooltips have been added to the rest of the overlay action buttons.

task-4497684

