### PR TITLE
[FIX] website, web_editor: fix confusing overlay action buttons

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -192,6 +192,22 @@ var SnippetEditor = publicWidget.Widget.extend({
         // a flickering when not needed.
         this.$target.on('transitionend.snippet_editor, animationend.snippet_editor', this.postAnimationCover);
 
+        // TODO: remove in master, handle the same in respective template.
+        const overlayButtonsTooltips = {
+            "div.o_front_back.o_send_back": _t("Send back"),
+            "div.o_front_back.o_bring_front": _t("Bring forward"),
+            "div.o_move_handle.fa-arrows": _t("Drag and move"),
+            "button.o_snippet_replace.fa-exchange": _t("Exchange with another block"),
+            "button.oe_snippet_remove.fa-trash": _t("Delete"),
+        };
+
+        for (const [selector, tooltip] of Object.entries(overlayButtonsTooltips)) {
+            const buttonEl = this.el.querySelector(selector);
+            if(buttonEl) {
+                buttonEl.dataset.tooltip = tooltip;
+            }
+        }
+
         return Promise.all(defs).then(() => {
             this.__isStartedResolveFunc(this);
         });
@@ -354,6 +370,11 @@ var SnippetEditor = publicWidget.Widget.extend({
         if (handleEReadonlyEl) {
             handleEReadonlyEl.style.width = $(targetEl).hasScrollableContent() ? 0 : '';
         }
+        const optionsOverlay = this.el.querySelector(".o_overlay_options_wrap");
+        const tooltipPosition = this.el.classList.contains("o_top_cover") ? "bottom" : "top";
+        optionsOverlay.querySelectorAll("[data-tooltip]").forEach((el) => {
+            el.dataset.tooltipPosition = tooltipPosition
+        });
     },
     /**
      * DOMElements have a default name which appears in the overlay when they

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5812,11 +5812,24 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
      * @override
      */
     start: function () {
-        var $buttons = this.$el.find('we-button');
+        // TODO: remove in master, handle the same in respective template.
+        const tooltips = {
+            move_up_opt: _t("Move up"),
+            move_down_opt: _t("Move down"),
+            move_left_opt: _t("Move left"),
+            move_right_opt: _t("Move right"),
+        };
+        const buttonEls = this.el.querySelectorAll("we-button");
+        for (const buttonEl of buttonEls) {
+            const tooltip = tooltips[buttonEl.dataset.name];
+            if (buttonEl) {
+                buttonEl.dataset.tooltip = tooltip;
+            }
+        }
         var $overlayArea = this.$overlay.find('.o_overlay_move_options');
         // Putting the arrows side by side.
-        $overlayArea.prepend($buttons[1]);
-        $overlayArea.prepend($buttons[0]);
+        $overlayArea.prepend(buttonEls[1]);
+        $overlayArea.prepend(buttonEls[0]);
 
         // Needed for compatibility (with already dropped snippets).
         // If the target is a column, check if all the columns are either mobile


### PR DESCRIPTION
The overlay action buttons for sending a snippet to the back or front in the website editor were unclear. This commit adds tooltips to these buttons, providing better clarity on their functionality.

Steps to reproduce issue:
1. Drop a text block using website editor.
2. Click on the text-block and increase the number of columns to 3.
3. Convert to grid mode.
4. Now click on the text-block and check the action buttons for send back and bring front.

Before this PR:
- It was confusing to identify which button would send the snippet to the back or bring it to the front. Additionally, the icons were
insufficient in conveying the button's purpose
- Tooltips sometimes cover the entire block above the overlay action buttons.

After this PR:
- Tooltips have been added to the overlay action buttons, providing clear descriptions of their functions. Additionally, tooltips have been added to the rest of the overlay action buttons.
- Added a mechanism to change the position of the tooltip (top/bottom) based on the position of the overlay buttons.

task-4497684
