### PR TITLE
[FIX] pos_self_order*: prevent prep order on unsuccessful payments

### DIFF
--- a/addons/pos_online_payment_self_order/models/pos_config.py
+++ b/addons/pos_online_payment_self_order/models/pos_config.py
@@ -21,3 +21,9 @@ class PosConfig(models.Model):
         payment_methods = self._get_self_ordering_payment_methods_data(self.self_order_online_payment_method_id)
         res['pos_payment_methods'] += payment_methods
         return res
+
+    def has_valid_self_payment_method(self):
+        res = super().has_valid_self_payment_method()
+        if self.self_ordering_mode == 'mobile':
+            return res or bool(self.self_order_online_payment_method_id)
+        return res or any(pm.is_online_payment for pm in self.payment_method_ids)

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -369,6 +369,16 @@ class PosConfig(models.Model):
     def get_kiosk_url(self):
         return self.self_ordering_url
 
+    def _supported_kiosk_payment_terminal(self):
+        return ['adyen', 'razorpay', 'stripe']
+
+    def has_valid_self_payment_method(self):
+        """ Checks if the POS config has a valid payment method (terminal or online). """
+        self.ensure_one()
+        if self.self_ordering_mode == 'mobile':
+            return False
+        return any(pm.use_payment_terminal in self._supported_kiosk_payment_terminal() for pm in self.payment_method_ids)
+
     @api.model
     def load_onboarding_kiosk_scenario(self):
         if not bool(self.env.company.chart_template):

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -70,3 +70,15 @@ class PosOrder(models.Model):
         if self.state == 'paid':
             email_values['attachment_ids'] = self._get_mail_attachments(self.name, ticket_image, basic_image)
         mail_template.send_mail(self.id, force_send=True, email_values=email_values)
+
+    def _send_payment_result(self, payment_result):
+        self.ensure_one()
+        self.config_id._notify('PAYMENT_STATUS', {
+            'payment_result': payment_result,
+            'data': {
+                'pos.order': self.read(self._load_pos_self_data_fields(self.config_id.id), load=False),
+                'pos.order.line': self.lines.read(self._load_pos_self_data_fields(self.config_id.id), load=False),
+            }
+        })
+        if payment_result == 'Success':
+            self._send_order()

--- a/addons/pos_self_order/static/src/app/services/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/services/self_order_service.js
@@ -261,9 +261,7 @@ export class SelfOrder extends Reactive {
             orderAccessToken: access_token || this.currentOrder.access_token,
             screenMode: screen_mode,
         });
-        if (device === "kiosk") {
-            this.printKioskChanges(access_token);
-        }
+        this.printKioskChanges(access_token);
     }
     hasPaymentMethod() {
         return this.filterPaymentMethods(this.models["pos.payment.method"].getAll()).length > 0;

--- a/addons/pos_self_order_adyen/controllers/main.py
+++ b/addons/pos_self_order_adyen/controllers/main.py
@@ -43,14 +43,7 @@ class PosSelfAdyenController(PosAdyenController):
                 'pos_order_id': order.id
             })
             order.action_pos_order_paid()
-            order._send_order()
 
         if order.config_id.self_ordering_mode == 'kiosk':
-            order.config_id._notify('PAYMENT_STATUS', {
-                'payment_result': payment_result,
-                'data': {
-                    'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                }
-            })
+            order._send_payment_result(payment_result)
         return request.make_json_response('[accepted]') # https://docs.adyen.com/point-of-sale/design-your-integration/choose-your-architecture/cloud/#guarantee

--- a/addons/pos_self_order_razorpay/controllers/orders.py
+++ b/addons/pos_self_order_razorpay/controllers/orders.py
@@ -61,10 +61,4 @@ class PosSelfOrderControllerRazorpay(PosSelfOrderController):
         return razorpay_cancel_response
 
     def call_bus_service(self, order, payment_result):
-        order.config_id._notify('PAYMENT_STATUS', {
-            'payment_result': payment_result,
-            'data': {
-                'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-            }
-        })
+        order._send_payment_result(payment_result)

--- a/addons/pos_self_order_stripe/controllers/orders.py
+++ b/addons/pos_self_order_stripe/controllers/orders.py
@@ -44,18 +44,6 @@ class PosSelfOrderControllerStripe(PosSelfOrderController):
             order.action_pos_order_paid()
 
             if order.config_id.self_ordering_mode == 'kiosk':
-                order.config_id._notify('PAYMENT_STATUS', {
-                    'payment_result': 'Success',
-                    'data': {
-                        'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                        'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    }
-                })
+                order._send_payment_result('Success')
         else:
-            order.config_id._notify('PAYMENT_STATUS', {
-                'payment_result': 'fail',
-                'data': {
-                    'pos.order': order.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                    'pos.order.line': order.lines.read(order._load_pos_self_data_fields(order.config_id.id), load=False),
-                }
-            })
+            order._send_payment_result('fail')


### PR DESCRIPTION
pos_self_order*: pos_online_payment_self_order, pos_self_order_adyen, pos_self_order_razorpay, pos_self_order_stripe

Ensure self-orders are sent to the preparation display only after a successful payment, 
when a valid payment method is configured.

**Issue 1: Orders sent for preparation before successful payment**

**Steps:**
- Configure the kiosk with an online or terminal payment method.
- Open the kiosk, add products, and proceed to payment.

**Issue:**
- Preparation orders were being sent even if the payment was not completed.

**Fix:**
- Restrict preparation flow to only orders with a successful payment when a valid payment method is configured.

---
**Issue 2: Orders not sent for preparation in mobile mode without the online method**
- Allow unpaid orders to be sent for preparation only in mobile mode when no online payment method is configured.

Task-4845410

Related: https://github.com/odoo/enterprise/pull/87173