### PR TITLE
[FIX] product: fix error when saving vendor pricelist

### DIFF
--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -114,7 +114,7 @@ class ProductSupplierinfo(models.Model):
         self._sanitize_vals(vals)
         res = super().write(vals)
         for supplier in self:
-            if not supplier.product_uom_id:
+            if supplier.product_tmpl_id and not supplier.product_uom_id:
                 supplier.product_uom_id = supplier.product_tmpl_id.uom_id
         return res
 

--- a/addons/product/tests/test_seller.py
+++ b/addons/product/tests/test_seller.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.fields import Command
-from odoo.tests import tagged, TransactionCase
+from odoo.tests import Form, tagged, TransactionCase
 from odoo.tools import float_compare
 
 
@@ -149,3 +149,15 @@ class TestSeller(TransactionCase):
         vendors.write({'product_id': False})
         self.assertEqual(vendors, self.product_consu.seller_ids,
             "Setting the product_id to False shouldn't affect seller_ids.")
+
+    def test_supplierinfo_without_uom_and_product_template(self):
+        supplier_info = self.env['product.supplierinfo'].create({
+            'partner_id': self.asustec.id,
+        })
+
+        with Form(supplier_info.with_context(visible_product_tmpl_id=False)) as supplier_info_form:
+            supplier_info_form.product_tmpl_id = self.product_consu.product_tmpl_id
+            supplier_info_form.product_uom_id = self.env['uom.uom']
+            supplier_info_form.product_tmpl_id = self.env['product.template']
+        self.assertFalse(supplier_info_form.product_uom_id)
+        self.assertFalse(supplier_info_form.product_tmpl_id)


### PR DESCRIPTION
When the user saves the vendor pricelist after removing both the UoM and
the product template, a traceback appears.

Steps to reproduce the error:
- Install ``purchase`` module
- Enable ``Units of Measure & Packagings`` from settings
- Go to Purchase > Configuration > Vendor Pricelists > New > Add Vendor > Save
- Now add any Product > remove the uom and product > Save

Traceback:
```
RecursionError: maximum recursion depth exceeded
```

https://github.com/odoo/odoo/blob/06733a16cff904887c8a5ec9e2d2ba591f252636/addons/product/models/product_supplierinfo.py#L117-L118
When the user removes both the product and UoM from a vendor pricelist,
the condition becomes true, and attempts to reassign
the product UoM from ``supplier.product_tmpl_id.uom_id``.

However, since ``product_tmpl_id`` is also cleared, this causes repeated
assignments and eventually triggers a RecursionError during write operations.

sentry-6666831551

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
