### PR TITLE
[FIX] point_of_sale: prevent traceback when printing mobile self-order

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -207,6 +207,9 @@ class PosConfig(models.Model):
         static_records = {}
 
         for model, ids in records.items():
+            if not len(ids):
+                static_records[model] = []
+                continue
             static_records[model] = self.env[model]._read_pos_record(ids, self.id)
 
         self._notify('SYNCHRONISATION', {


### PR DESCRIPTION
**Configuration:**
- Restaurant mode
- Self-order mode: "QR + Ordering"
- Pay after: "Each order"
- Online payment is enabled for self-order

**Steps:**
- Open the restaurant UI in one tab.
- Open the self-order UI in another tab.
- Process a self-order with successful online payment.
- Switch to the restaurant tab — a server traceback appears.

**cause:**
- The `notify_synchronisation` method attempted to read POS records with empty record IDs, causing the traceback.

**Fix:**
- Skip processing records with empty IDs before making server calls.

Task-4858105
