### PR TITLE
[FIX] mail: improve discuss sidebar actions style

### DIFF
--- a/addons/hr/static/src/core/web/thread_actions.js
+++ b/addons/hr/static/src/core/web/thread_actions.js
@@ -12,6 +12,7 @@ threadActionsRegistry.add("open-hr-profile", {
         );
     },
     icon: "fa fa-fw fa-id-card",
+    iconLarge: "fa fa-lg fa-fw fa-id-card",
     name: _t("Open Profile"),
     async open(component) {
         component.actionService.doAction({

--- a/addons/im_livechat/static/src/embed/common/thread_actions.js
+++ b/addons/im_livechat/static/src/embed/common/thread_actions.js
@@ -9,6 +9,7 @@ threadActionsRegistry.add("restart", {
         return component.thread?.chatbot?.canRestart;
     },
     icon: "fa fa-fw fa-refresh",
+    iconLarge: "fa fa-lg fa-fw fa-refresh",
     name: _t("Restart Conversation"),
     open(component) {
         component.thread.chatbot.restart();

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -121,38 +121,44 @@
 <t t-name="mail.ThreadActionsAsDropdownContent">
     <t t-if="quick?.length > 0">
         <t t-set="groupBefore" t-value="true"/>
-        <t t-foreach="quick" t-as="action" t-key="action.id">
-            <t t-call="mail.ThreadActionsAsDropdownContent.action">
-                <t t-set="action" t-value="action"/>
+        <div class="d-flex flex-column rounded-3" t-att-class="{ 'border border-secondary shadow-sm o-border-opacity-50': !env.inChatWindow }">
+            <t t-foreach="quick" t-as="action" t-key="action.id">
+                <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                    <t t-set="action" t-value="action"/>
+                </t>
             </t>
-        </t>
+        </div>
     </t>
     <t t-else="" t-set="groupBefore" t-value="false"/>
     <t t-if="group?.length > 0">
         <hr t-if="groupBefore" class="mx-2 my-1"/>
         <t t-set="groupBefore" t-value="true"/>
         <t t-foreach="group" t-as="group" t-key="group_index">
-            <t t-foreach="group" t-as="action" t-key="action.id">
-                <t t-call="mail.ThreadActionsAsDropdownContent.action">
-                    <t t-set="action" t-value="action"/>
+            <div class="d-flex flex-column rounded-3" t-att-class="{ 'border border-secondary shadow-sm o-border-opacity-50': !env.inChatWindow }">
+                <t t-foreach="group" t-as="action" t-key="action.id">
+                    <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                        <t t-set="action" t-value="action"/>
+                    </t>
                 </t>
-            </t>
+            </div>
             <hr t-if="!group_last" class="mx-2 my-1"/>
         </t>
     </t>
     <t t-else="" t-set="groupBefore" t-value="false"/>
     <t t-if="other?.length">
         <hr t-if="groupBefore" class="mx-2 my-1"/>
-        <t t-foreach="other" t-as="action" t-key="action.id">
-            <t t-call="mail.ThreadActionsAsDropdownContent.action">
-                <t t-set="action" t-value="action"/>
+        <div class="d-flex flex-column rounded-3" t-att-class="{ 'border border-secondary shadow-sm o-border-opacity-50': !env.inChatWindow }">
+            <t t-foreach="other" t-as="action" t-key="action.id">
+                <t t-call="mail.ThreadActionsAsDropdownContent.action">
+                    <t t-set="action" t-value="action"/>
+                </t>
             </t>
-        </t>
+        </div>
     </t>
 </t>
 
 <t t-name="mail.ThreadActionsAsDropdownContent.action">
-    <DropdownItem class="'btn d-flex align-items-baseline m-0 rounded-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command p-2' : 'rounded-4 px-2 py-1 smaller')" onSelected="() => action.onSelect()">
+    <DropdownItem class="'btn d-flex align-items-baseline m-0 ' + (env.inChatWindow ? 'o-mail-ChatWindow-command rounded-0 p-2' : ('rounded-3 px-2 py-1 bg-200 smaller ' + (!action_first ? 'rounded-top-0' : !action_last ? 'rounded-bottom-0' : '')))" onSelected="() => action.onSelect()">
         <i t-att-class="action.icon"/>
         <span t-att-class="{ 'mx-2': env.inChatWindow, 'mx-1': !env.inChatWindow }" t-attf-class="{{ action.nameClass }}" t-out="action.name"/>
     </DropdownItem>

--- a/addons/mail/static/src/core/common/composer.scss
+++ b/addons/mail/static/src/core/common/composer.scss
@@ -32,11 +32,11 @@
     }
 
     .o-mail-Composer-mainActions {
-        margin-top: map-get($spacers, 1) * 5 / 4;
+        margin-top: map-get($spacers, 1);
     }
 
     &.o-chatWindow .o-mail-Composer-mainActions {
-        margin-top: map-get($spacers, 1) / 2;
+        margin-top: map-get($spacers, 1) / 4;
     }
 
     &:not(.o-focused) {
@@ -54,12 +54,12 @@
 
     button {
         &.o-small {
-            margin: map-get($spacers, 1) / 2 !important;
-            padding: map-get($spacers, 1) / 2 !important;
+            margin: 0 !important;
+            padding: map-get($spacers, 1) !important;
         }
         &.o-large {
-            padding: map-get($spacers, 1) !important;
-            margin: map-get($spacers, 1) !important;
+            margin: 0 !important;
+            padding: map-get($spacers, 2) !important;
         }
         &:disabled {
             opacity: 25% !important;

--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -21,6 +21,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
     background-color: $body-bg !important;
 }
 
+.o-border-opacity-50 {
+    --border-opacity: 0.5;
+}
+
 .o-discuss-badge {
     &, & .o-innerBadge {
         --o-discuss-badge-bg: #{$o-success}; // sync with --o-navbar-badge-bg
@@ -45,7 +49,7 @@ $o-discuss-talkingColor: lighten($success, 10%);
 }
 
 .o-discuss-separator {
-    opacity: $hr-opacity / 3;
+    opacity: $hr-opacity / 2;
 }
 
 .o-discuss-badge, .o-discuss-badgeShape {
@@ -104,6 +108,10 @@ $o-discuss-talkingColor: lighten($success, 10%);
 .o-py-1_5 {
     padding-top: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
     padding-bottom: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
+}
+
+.o-p-1_5 {
+    padding: map-get($spacers, 1) + map-get($spacers, 1) / 2 !important;
 }
 
 .o-pt-0_5 {

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,6 +1,5 @@
 .o-mail-Message.o-card {
     background-color: mix($gray-100, $gray-200);
-    --border-opacity: .15;
 }
 
 .o-mail-Message-actions {

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -216,7 +216,7 @@ export class Message extends Component {
     get attClass() {
         return {
             [this.props.className]: true,
-            "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-secondary shadow-sm rounded-3":
+            "o-card p-2 ps-1 mx-1 mt-1 mb-1 border border-dark shadow-sm rounded-3":
                 this.props.asCard,
             "pt-1": !this.props.asCard && !this.props.squashed,
             "o-pt-0_5": !this.props.asCard && this.props.squashed,

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -3,7 +3,7 @@
 
     &.o-card {
         background-color: $o-view-background-color;
-        --border-opacity: .5;
+        --border-opacity: .075;
     }
 
     &.o-highlighted {

--- a/addons/mail/static/src/core/common/message_card_list.scss
+++ b/addons/mail/static/src/core/common/message_card_list.scss
@@ -1,6 +1,6 @@
 .o-mail-MessageCardList {
     .card {
-        --border-opacity: .35;
+        --border-opacity: .075;
     }
 
     .card-body {

--- a/addons/mail/static/src/core/common/message_card_list.xml
+++ b/addons/mail/static/src/core/common/message_card_list.xml
@@ -2,8 +2,8 @@
 <templates xml:space="preserve">
     <t t-name="mail.MessageCardList">
         <div class="o-mail-MessageCardList d-flex flex-column" t-att-class="{ 'justify-content-center flex-grow-1': props.messages.length === 0 }" t-ref="message-list">
-            <div class="card mb-2 rounded-3 border-secondary" t-foreach="props.messages" t-as="message" t-key="message.id">
-                <div class="card-body ps-0 py-2 rounded-3 shadow-sm">
+            <div class="card mb-2 rounded-3 border-dark shadow-sm" t-foreach="props.messages" t-as="message" t-key="message.id">
+                <div class="card-body ps-0 py-2 rounded-3">
                     <div class="position-absolute top-0 end-0 z-1 mx-2 my-1 d-flex align-items-center">
                         <a role="button" class="o-mail-MessageCard-jump rounded bg-400 badge opacity-0" t-att-class="{ 'opacity-100 py-1 px-2': ui.isSmall }" t-on-click="() => this.onClickJump(message)">Jump</a>
                         <button t-if="props.mode === 'pin'" class="btn btn-link text-reset ms-2 p-0 opacity-25 opacity-100-hover" t-att-class="{ 'fs-5': ui.isSmall }" title="Unpin" t-on-click="message.unpin">

--- a/addons/mail/static/src/core/common/thread_actions.js
+++ b/addons/mail/static/src/core/common/thread_actions.js
@@ -11,7 +11,8 @@ threadActionsRegistry
         condition(component) {
             return component.props.chatWindow;
         },
-        icon: "fa fa-fw fa-minus",
+        icon: "oi oi-fw oi-minus",
+        iconLarge: "oi oi-fw fa-lg oi-minus",
         name(component) {
             return !component.props.chatWindow?.isOpen ? _t("Open") : _t("Fold");
         },
@@ -33,6 +34,7 @@ threadActionsRegistry
             );
         },
         icon: "fa fa-fw fa-pencil",
+        iconLarge: "fa fa-lg fa-fw fa-pencil",
         name: _t("Rename Thread"),
         open(component) {
             component.state.editingName = true;
@@ -45,6 +47,7 @@ threadActionsRegistry
             return component.props.chatWindow;
         },
         icon: "oi fa-fw oi-close",
+        iconLarge: "oi fa-lg fa-fw oi-close",
         name: _t("Close Chat Window (ESC)"),
         open(component) {
             component.close();

--- a/addons/mail/static/src/core/common/thread_icon.js
+++ b/addons/mail/static/src/core/common/thread_icon.js
@@ -19,10 +19,12 @@ export class ThreadIcon extends Component {
         thread: { type: Thread },
         size: { optional: true, validate: (size) => ["small", "medium", "large"].includes(size) },
         className: { type: String, optional: true },
+        title: { type: Boolean, optional: true },
     };
     static defaultProps = {
         size: "medium",
         className: "",
+        title: true,
     };
 
     setup() {

--- a/addons/mail/static/src/core/common/thread_icon.xml
+++ b/addons/mail/static/src/core/common/thread_icon.xml
@@ -20,9 +20,9 @@
             </t>
             <div t-elif="props.thread.channel_type === 'group'" class="o-mail-ThreadIcon fa fa-fw fa-users" t-att-class="largeClass" title="Grouped Chat"/>
             <t t-elif="props.thread.model === 'mail.box'">
-                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass" title="Inbox"/>
-                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass" title="Favorites"/>
-                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="largeClass" title="History"/>
+                <div t-if="props.thread.id === 'inbox'" class="fa fa-fw fa-inbox" t-att-class="largeClass"/>
+                <div t-elif="props.thread.id === 'starred'" class="fa fa-fw fa-star-o" t-att-class="largeClass"/>
+                <div t-elif="props.thread.id === 'history'" class="fa fa-fw fa-history" t-att-class="largeClass"/>
             </t>
         </div>
     </t>

--- a/addons/mail/static/src/core/public_web/discuss.xml
+++ b/addons/mail/static/src/core/public_web/discuss.xml
@@ -47,7 +47,7 @@
                         </t>
                     </div>
                     <div class="o-mail-Discuss-headerActions flex-shrink-0 d-flex align-items-center ms-1">
-                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
+                        <span t-if="partitionedActions.quick.length" class="o-mail-Discuss-headerActionsGroup btn-group o-rounded-bubble shadow-sm">
                             <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.quick" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -55,7 +55,7 @@
                         </span>
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
-                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
+                        <span t-if="partitionedActions.other.length" class="o-mail-Discuss-headerActionsGroup btn-group o-rounded-bubble shadow-sm">
                          <t t-set="groupBefore" t-value="true"/>
                             <t t-foreach="partitionedActions.other" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                 <t t-set="action" t-value="action"/>
@@ -64,7 +64,7 @@
                         <t t-else="" t-set="groupBefore" t-value="false"/>
                         <span t-if="groupBefore" class="text-muted align-self-stretch ms-2 me-1"/>
                         <t t-foreach="partitionedActions.group.slice().reverse()" t-as="group" t-key="group_index">
-                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group rounded-3 shadow-sm">
+                            <span t-if="group.length" class="o-mail-Discuss-headerActionsGroup btn-group o-rounded-bubble shadow-sm">
                                 <t t-foreach="group" t-as="action" t-key="action.id" t-call="mail.Discuss.action">
                                     <t t-set="action" t-value="action"/>
                                 </t>
@@ -112,7 +112,12 @@
 </t>
 
 <t t-name="mail.Discuss.action">
-    <button class="btn px-1 btn-group-item btn-secondary bg-inherit m-0 border-0" t-attf-class="{{ action.isActive ? 'o-isActive' : '' }}" t-att-disabled="action.disabledCondition" t-att-title="action.name" t-att-name="action.id" t-on-click="() => action.onSelect()">
+    <button class="btn px-1 btn-group-item btn-secondary bg-inherit m-0 border-0" t-attf-class="{{ action.isActive ? 'o-isActive' : '' }}" t-att-disabled="action.disabledCondition" t-att-title="action.name" t-att-name="action.id" t-on-click="() => action.onSelect()" t-att-class="{
+        'o-rounded-start-bubble': action_first,
+        'o-rounded-end-bubble': action_last,
+        'rounded-start-0': !action_first,
+        'rounded-end-0': !action_last,
+    }">
         <i t-if="action.iconLarge" t-att-class="action.iconLarge"/> <span t-if="action.text" t-esc="action.text"/>
     </button>
 </t>

--- a/addons/mail/static/src/core/public_web/thread_actions.js
+++ b/addons/mail/static/src/core/public_web/thread_actions.js
@@ -8,6 +8,7 @@ threadActionsRegistry.add("leave", {
         !(component.env.inChatWindow && !component.ui.isSmall) &&
         (component.thread?.canLeave || component.thread?.canUnpin),
     icon: "fa fa-fw fa-sign-out text-danger",
+    iconLarge: "fa fa-fw fa-lg fa-sign-out text-danger",
     name: (component) =>
         component.thread.canLeave ? _t("Leave Channel") : _t("Unpin Conversation"),
     nameClass: "text-danger",

--- a/addons/mail/static/src/core/web/thread_actions.js
+++ b/addons/mail/static/src/core/web/thread_actions.js
@@ -48,6 +48,7 @@ threadActionsRegistry
             component.actionService = useService("action");
         },
         icon: "fa fa-fw fa-expand",
+        iconLarge: "fa fa-lg fa-fw fa-expand",
         name: _t("Open Form View"),
         open(component) {
             component.actionService.doAction({

--- a/addons/mail/static/src/discuss/core/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/common/thread_actions.js
@@ -192,6 +192,7 @@ threadActionsRegistry
             !component.thread?.mute_until_dt,
         open: (component) => component.thread.markAsRead(),
         icon: "fa fa-fw fa-check",
+        iconLarge: "fa fa-lg fa-fw fa-check",
         name: _t("Mark Read"),
         partition: false,
         sidebarSequence: 10,

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.scss
@@ -24,12 +24,6 @@ $o-mail-DiscussSidebarChannel-borderOpacity: .05;
 
 .o-mail-DiscussSidebar-floatingMenu {
     max-width: 250px !important;
-    --border-opacity: 0.5;
-}
-
-.o-mail-DiscussSidebarChannel-floatingName {
-    --border-opacity: 0.5;
-    background-color: var(---mail-DiscussSidebarChannel-floatingNameBgColor, mix($gray-100, $gray-200));
 }
 
 .o-mail-DiscussSidebar-item {

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_categories.xml
@@ -70,7 +70,7 @@
             <div class="o-mail-DiscussSidebarCategory-actions" t-att-class="{ 'd-flex flex-column align-items-start pt-1': store.discuss.isSidebarCompact, 'btn-group btn-group-sm ms-1 o-gap-0_5': !store.discuss.isSidebarCompact }">
                 <t name="action-group">
                     <t t-foreach="actions" t-as="action" t-key="action_index">
-                        <button class="btn w-100 o-opacity-35 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
+                        <button class="btn w-100 opacity-50 opacity-100-hover" t-on-click="() => action.onSelect()" t-att-class="{ 'd-flex align-items-center px-1 py-0 gap-1 text-start smaller btn-secondary shadow-sm': store.discuss.isSidebarCompact, 'btn-light bg-transparent rounded-3 p-0 border-transparent': !store.discuss.isSidebarCompact }" t-attf-class="#{action.class}" t-att-title="store.discuss.isSidebarCompact ? '' : action.label" t-att-data-hotkey="action.hotkey">
                             <i role="img" class="fa-fw fa-lg" t-att-class="action.icon"/>
                             <span t-if="store.discuss.isSidebarCompact" class="text-muted" t-esc="action.label"/>
                         </button>
@@ -87,7 +87,7 @@
                     <t t-call="mail.DiscussSidebarChannel.main"/>
                     <t t-set-slot="content">
                         <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                            <span class="o-mail-DiscussSidebarChannel-floatingName fw-bolder user-select-none text-truncate d-inline-block p-2 shadow-sm border-bottom border-secondary" t-esc="thread.displayName"/>
+                            <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
                             <DiscussSidebarChannelActions thread="thread"/>
                         </div>
                     </t>
@@ -107,7 +107,7 @@
             <t t-call="mail.DiscussSidebarSubchannel.main"/>
             <t t-set-slot="content">
                 <div class="overflow-hidden d-flex flex-column" t-ref="floating">
-                    <span class="o-mail-DiscussSidebarChannel-floatingName fw-bolder user-select-none text-truncate d-inline-block p-2 shadow-sm border-bottom border-secondary" t-esc="thread.displayName"/>
+                    <span class="fw-bolder user-select-none text-truncate d-inline-block p-2 pb-0" t-esc="thread.displayName"/>
                     <DiscussSidebarChannelActions thread="thread"/>
                 </div>
             </t>

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.dark.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.dark.scss
@@ -1,0 +1,4 @@
+
+.o-mail-DiscussSidebarChannelActions {
+    --mail-DiscussSidebarChannelActions-activeBgColor: #{$gray-300};
+}

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.scss
@@ -1,11 +1,13 @@
 .o-mail-DiscussSidebarChannelActions {
     .o-dropdown-item {
-        opacity: 75%;
+        opacity: 65%;
         &.focus {
             opacity: 100%;
+            outline: 1px solid $gray-300;
+            background-color: var(--mail-DiscussSidebarChannelActions-activeBgColor, $white) !important;
         }
     }
     hr {
-        opacity: 10%;
+        opacity: 0%;
     }
 }

--- a/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
+++ b/addons/mail/static/src/discuss/core/public_web/discuss_sidebar_channel_actions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebarChannelActions">
-        <div class="o-mail-DiscussSidebarChannelActions d-flex flex-column o-gap-0_5" t-att-class="{ 'px-1 pt-1 pb-2': store.discuss.isSidebarCompact, 'p-1': !store.discuss.isSidebarCompact }">
+        <div class="o-mail-DiscussSidebarChannelActions d-flex flex-column o-gap-0_5" t-att-class="{ 'p-2': store.discuss.isSidebarCompact, 'o-p-1_5': !store.discuss.isSidebarCompact }">
             <t t-call="mail.ThreadActionsAsDropdownContent">
                 <t t-set="group" t-value="threadActions.sidebarActions"/>
             </t>

--- a/addons/mail/static/src/discuss/core/web/thread_actions.js
+++ b/addons/mail/static/src/discuss/core/web/thread_actions.js
@@ -19,6 +19,7 @@ threadActionsRegistry
             component.actionService = useService("action");
         },
         icon: "fa fa-fw fa-expand",
+        iconLarge: "fa fa-lg fa-fw fa-expand",
         name: _t("Open in Discuss"),
         shouldClearBreadcrumbs(component) {
             return false;
@@ -50,6 +51,7 @@ threadActionsRegistry
             });
         },
         icon: "fa fa-fw fa-gear",
+        iconLarge: "fa fa-lg fa-fw fa-gear",
         name: _t("Advanced Settings"),
         partition: false,
         setup(action) {


### PR DESCRIPTION
Discuss app sidebar channel action style was not pretty: it feels too crowded, with visual separator and colored header with conversation name in compact

This commit makes style look simpler and matches discuss header action.

This commit also makes a few somewhat related changes:
- discuss header actions slightly more rounded
- fix some discuss header actions that didn't have "large" icon
- discuss sidebar floating menu have more visible borders
- message in card layout have more visible borders
- date section separator lines are more visible
- no title on mouse-hover mailbox icon
- composer quick actions have bigger clickable area